### PR TITLE
Rename SurveyAsset.collection to SurveyAsset.parent

### DIFF
--- a/kpi/highlighters.py
+++ b/kpi/highlighters.py
@@ -16,8 +16,8 @@ HTML_HEADER = '''\
 class XFormFormatter(HtmlFormatter):
     def _wrap_full(self, inner, outfile):
         yield 0, (HTML_HEADER %
-                  dict(title= self.options.get('title', ''),
-                       styledefs= self.get_style_defs('body'),))
+                  dict(title=self.options.get('title', ''),
+                       styledefs=self.get_style_defs('body'),))
         yield 0, self.options.get('header', '')
         for t, line in inner:
             yield t, line

--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -21,7 +21,7 @@ class CollectionManager(models.Manager):
         if assets:
             new_assets = []
             for asset in assets:
-                asset['collection'] = created
+                asset['parent'] = created
                 new_assets.append(SurveyAsset.objects.create(**asset))
             # bulk_create comes with a number of caveats
             # SurveyAsset.objects.bulk_create(new_assets)

--- a/kpi/models/survey_asset.py
+++ b/kpi/models/survey_asset.py
@@ -35,7 +35,7 @@ class SurveyAsset(models.Model):
     date_modified = models.DateTimeField(auto_now=True)
     content = JSONField(null=True)
     asset_type = models.CharField(choices=SURVEY_ASSET_TYPES, max_length=20, default='text')
-    collection = models.ForeignKey('Collection', related_name='survey_assets', null=True)
+    parent = models.ForeignKey('Collection', related_name='survey_assets', null=True)
     owner = models.ForeignKey('auth.User', related_name='survey_assets', null=True)
     editors_can_change_permissions = models.BooleanField(default=True)
     uid = models.CharField(max_length=SURVEY_ASSET_UID_LENGTH, default='')
@@ -86,14 +86,14 @@ class SurveyAsset(models.Model):
             inherited=True
         ).delete()
         # Is there anything to inherit?
-        if self.collection is not None:
+        if self.parent is not None:
             # All our parent's effective permissions become our inherited
             # permissions.
             mangle_perm = lambda x: re.sub('_collection$', '_surveyasset', x)
             # Store translations in a dictionary here to minimize invocations of
             # the Django machinery
             translate_perm = {}
-            for user_id, permission_id in self.collection._effective_perms():
+            for user_id, permission_id in self.parent._effective_perms():
                 try:
                     translated_id = translate_perm[permission_id]
                 except KeyError:

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -101,13 +101,13 @@ class SurveyAssetSerializer(serializers.HyperlinkedModelSerializer):
     content = SurveyAssetContentField(style={'base_template': 'muted_readonly_content_field.html'})
     tags = serializers.SerializerMethodField('_get_tag_names')
     version_count = serializers.SerializerMethodField('_version_count')
-    collection = TaggedHyperlinkedRelatedField(lookup_field='uid', queryset=Collection.objects.all(),
+    parent = TaggedHyperlinkedRelatedField(lookup_field='uid', queryset=Collection.objects.all(),
                                                 view_name='collection-detail', required=False)
 
     class Meta:
         model = SurveyAsset
         lookup_field = 'uid'
-        fields = ('url', 'parent', 'owner', 'collection',
+        fields = ('url', 'parent', 'owner', 'parent',
                     'settings',
                     'assetType',
                     'date_created',
@@ -120,7 +120,7 @@ class SurveyAssetSerializer(serializers.HyperlinkedModelSerializer):
                     'xls_link',
                     'name', 'tags', )
         extra_kwargs = {
-            'collection': {
+            'parent': {
                 'lookup_field': 'uid',
             },
         }
@@ -128,7 +128,7 @@ class SurveyAssetSerializer(serializers.HyperlinkedModelSerializer):
     def get_fields(self, *args, **kwargs):
         fields = super(SurveyAssetSerializer, self).get_fields(*args, **kwargs)
         user = self.context['request'].user
-        fields['collection'].queryset = fields['collection'].queryset.filter(owner=user)
+        fields['parent'].queryset = fields['parent'].queryset.filter(owner=user)
         return fields
 
     def _version_count(self, obj):
@@ -158,7 +158,7 @@ class SurveyAssetSerializer(serializers.HyperlinkedModelSerializer):
 
 class SurveyAssetListSerializer(SurveyAssetSerializer):
     class Meta(SurveyAssetSerializer.Meta):
-        fields = ('url', 'owner', 'collection',
+        fields = ('url', 'owner', 'parent',
                     'assetType', 'name', 'tags',)
 
 

--- a/kpi/tests/test_api_collections.py
+++ b/kpi/tests/test_api_collections.py
@@ -27,15 +27,15 @@ class CollectionsTests(APITestCase):
         self.assertEqual(response.data['name'], 'my collection')
 
     def test_collection_detail(self):
-        url= reverse('collection-detail', kwargs={'uid': self.coll.uid})
-        response= self.client.get(url, format='json')
+        url = reverse('collection-detail', kwargs={'uid': self.coll.uid})
+        response = self.client.get(url, format='json')
         self.assertEqual(response.data['name'], 'test collection')
 
     def test_collection_delete(self):
-        url= reverse('collection-detail', kwargs={'uid': self.coll.uid})
-        response= self.client.delete(url)
+        url = reverse('collection-detail', kwargs={'uid': self.coll.uid})
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        response= self.client.get(url)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 class AnonymousCollectionsTest(APITestCase):

--- a/kpi/tests/test_api_survey_assets.py
+++ b/kpi/tests/test_api_survey_assets.py
@@ -80,12 +80,12 @@ class ObjectRelationshipsTests(APITestCase):
         coll_req1 = self.client.get(reverse('collection-detail', args=[self.coll.uid]))
         self.assertEqual(len(coll_req1.data['survey_assets']), 0)
 
-        self.surv.collection = self.coll
+        self.surv.parent = self.coll
         self.surv.save()
 
         surv_req2 = self.client.get(reverse('surveyasset-detail', args=[self.surv.uid]))
-        self.assertIn('collection', surv_req2.data)
-        self.assertIn(self.coll.uid, surv_req2.data['collection'])
+        self.assertIn('parent', surv_req2.data)
+        self.assertIn(self.coll.uid, surv_req2.data['parent'])
 
         coll_req2 = self.client.get(reverse('collection-detail', args=[self.coll.uid]))
         self.assertEqual(len(coll_req2.data['survey_assets']), 1)
@@ -97,9 +97,9 @@ class ObjectRelationshipsTests(APITestCase):
         * assigning a collection to the survey returns a HTTP 200 code.
         * a follow up query on the asset shows that the collection is now set
         '''
-        self.assertEqual(self.surv.collection, None)
+        self.assertEqual(self.surv.parent, None)
         surv_url = reverse('surveyasset-detail', args=[self.surv.uid])
-        patch_req = self.client.patch(surv_url, data={'collection': reverse('collection-detail', args=[self.coll.uid])})
+        patch_req = self.client.patch(surv_url, data={'parent': reverse('collection-detail', args=[self.coll.uid])})
         self.assertEqual(patch_req.status_code, status.HTTP_200_OK)
         req = self.client.get(surv_url)
-        self.assertIn('/collections/%s' % (self.coll.uid), req.data['collection'])
+        self.assertIn('/collections/%s' % (self.coll.uid), req.data['parent'])

--- a/kpi/tests/test_collections.py
+++ b/kpi/tests/test_collections.py
@@ -45,7 +45,7 @@ class CreateCollectionTests(TestCase):
         right now, this does make it easy to delete survey_assets within a
         collection.
         '''
-        initial_asset_count= SurveyAsset.objects.count()
+        initial_asset_count = SurveyAsset.objects.count()
         asset = self.coll.survey_assets.create(name='test', content=[
                 {'type': 'text', 'label': 'Q1', 'name': 'q1'},
                 {'type': 'text', 'label': 'Q2', 'name': 'q2'},
@@ -71,8 +71,8 @@ class CreateCollectionTests(TestCase):
         self.assertEqual(SurveyAsset.objects.count(), 0)
 
     def test_create_collection_with_survey_assets(self):
-        initial_asset_count= SurveyAsset.objects.count()
-        initial_collection_count= Collection.objects.count()
+        initial_asset_count = SurveyAsset.objects.count()
+        initial_collection_count = Collection.objects.count()
         self.assertTrue(Collection.objects.count() >= 1)
         Collection.objects.create(name='test_collection', owner=self.user, survey_assets=[
                 {

--- a/kpi/tests/test_survey_assets.py
+++ b/kpi/tests/test_survey_assets.py
@@ -69,7 +69,7 @@ class ShareSurveyAssetsTest(SurveyAssetsTestCase):
         # Make a copy of self.survey_asset and put it inside self.coll
         self.sa_in_coll = self.survey_asset
         self.sa_in_coll.pk = None
-        self.sa_in_coll.collection = self.coll
+        self.sa_in_coll.parent = self.coll
         self.sa_in_coll.save()
 
     def grant_and_revoke_standalone(self, user, perm):


### PR DESCRIPTION
Still fails the same tests as before, namely:

```
ERROR: test_add_survey_asset_to_collection (kpi.tests.test_api_survey_assets.ObjectRelationshipsTests)
TemplateDoesNotExist: rest_framework/horizontal/json_field.html
ERROR: test_collection_can_have_survey_asset (kpi.tests.test_api_survey_assets.ObjectRelationshipsTests)
TemplateDoesNotExist: rest_framework/horizontal/json_field.html
ERROR: test_can_update_survey_asset_settings (kpi.tests.test_api_survey_assets.SurveyAssetsDetailApiTests)
NotImplementedError: SurveyAssetContentField.to_internal_value() must be implemented.
ERROR: test_survey_asset_exists (kpi.tests.test_api_survey_assets.SurveyAssetsDetailApiTests)
NotImplementedError: SurveyAssetContentField.to_internal_value() must be implemented.
ERROR: test_create_survey_asset (kpi.tests.test_api_survey_assets.SurveyAssetsListApiTests)
NotImplementedError: SurveyAssetContentField.to_internal_value() must be implemented.
```
