### PR TITLE
Implement share_ permission, cleanup after deletion, and anonymous privileges

### DIFF
--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -64,6 +64,11 @@ ROOT_URLCONF = 'kobo_playground.urls'
 
 WSGI_APPLICATION = 'kobo_playground.wsgi.application'
 
+# What User object should be mapped to AnonymousUser?
+ANONYMOUS_USER_ID = -1
+# Permissions assigned to AnonymousUser are restricted to the following
+ALLOWED_ANONYMOUS_PERMISSIONS = ('view_collection', 'view_surveyasset')
+
 
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases

--- a/kpi/backends.py
+++ b/kpi/backends.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.models import AnonymousUser
 
 class ObjectPermissionBackend(ModelBackend):
     def get_group_permissions(self, user_obj, obj=None):
@@ -14,7 +15,9 @@ class ObjectPermissionBackend(ModelBackend):
         if obj is None or not hasattr(obj, 'has_perm'):
             return super(ObjectPermissionBackend, self
                 ).has_perm(user_obj, obj)
-        if not user_obj.is_active:
+        if not user_obj.is_active and not isinstance(user_obj, AnonymousUser):
+            # Inactive users are denied immediately, except in the case of
+            # AnonymousUsers. They are inactive but require further processing
             return False
         return obj.has_perm(user_obj, perm)
 

--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -2,6 +2,8 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import User
+from django.conf import settings
 
 def perm_parse(perm, obj=None):
     if obj is not None:
@@ -25,6 +27,22 @@ def get_all_objects_for_user(user, klass):
         user=user,
         content_type=ContentType.objects.get_for_model(klass)
     ).values_list('object_id', flat=True))
+
+def get_anonymous_user():
+    ''' Return a real User in the database to represent AnonymousUser. '''
+    try:
+        user = User.objects.get(pk=settings.ANONYMOUS_USER_ID)
+    except User.DoesNotExist:
+        username = getattr(
+            settings,
+            'ANONYMOUS_DEFAULT_USERNAME_VALUE',
+            'AnonymousUser'
+        )
+        user = User.objects.create(
+            pk=settings.ANONYMOUS_USER_ID,
+            username=username
+        )
+    return user
 
 class ObjectPermissionManager(models.Manager):
     def _rewrite_query_args(self, method, content_object, **kwargs):

--- a/kpi/models/survey_asset.py
+++ b/kpi/models/survey_asset.py
@@ -7,9 +7,11 @@ from taggit.models import Tag
 import reversion
 import json
 import copy
-from object_permission import ObjectPermission, perm_parse
-from django.contrib.auth.models import User, Permission
+from object_permission import ObjectPermission, perm_parse, get_anonymous_user
+from django.contrib.auth.models import User, AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.dispatch import receiver
 import re
 
@@ -138,6 +140,11 @@ class SurveyAsset(models.Model):
     def has_perm(self, user_obj, perm):
         ''' Does user_obj have perm on this survey asset? (True/False) '''
         app_label, codename = perm_parse(perm, self)
+        is_anonymous = False
+        if isinstance(user_obj, AnonymousUser):
+            # Get the User database representation for AnonymousUser
+            user_obj = get_anonymous_user()
+            is_anonymous = True
         # share_surveyasset is a special case
         if codename == 'share_surveyasset':
             if user_obj.pk == self.owner.pk:
@@ -147,15 +154,33 @@ class SurveyAsset(models.Model):
             # AND the editors_can_change_permissions flag is set.
             return self.editors_can_change_permissions and self.has_perm(
                 user_obj, 'change_surveyasset')
-        return len(self._effective_perms(
+        # Look for matching permissions
+        result = len(self._effective_perms(
             user_id=user_obj.pk,
             permission__codename=codename
         )) == 1
+        if not result and not is_anonymous:
+            # The user-specific test failed, but does the public have access?
+            result = self.has_perm(AnonymousUser(), perm)
+        if result and is_anonymous:
+            # Is an anonymous user allowed to have this permission?
+            if not codename in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+                return False
+        return result
 
     def assign_perm(self, user_obj, perm, deny=False, defer_recalc=False):
         ''' Assign user_obj the given perm on this survey asset. To break
         inheritance from a parent collection, use deny=True. '''
         app_label, codename = perm_parse(perm, self)
+        if isinstance(user_obj, AnonymousUser):
+            # Is an anonymous user allowed to have this permission?
+            if not codename in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+                raise ValidationError(
+                    'Anonymous users cannot have the permission {}.'.format(
+                        codename)
+                )
+            # Get the User database representation for AnonymousUser
+            user_obj = get_anonymous_user()
         perm_model = Permission.objects.get(
             content_type__app_label=app_label,
             codename=codename
@@ -202,6 +227,9 @@ class SurveyAsset(models.Model):
 
     def remove_perm(self, user_obj, perm, deny=False):
         ''' Revoke perm on this collection from user_obj. '''
+        if isinstance(user_obj, AnonymousUser):
+            # Get the User database representation for AnonymousUser
+            user_obj = get_anonymous_user()
         app_label, codename = perm_parse(perm, self)
         ObjectPermission.objects.filter_for_object(
             self,


### PR DESCRIPTION
- `share_collection` and `share_surveyasset` should now work
  - Still need to block these from `assign_perm` and `remove_perm`, since those methods have no effect on these permissions
- `ObjectPermission` objects should be reaped by `post_delete` signal receivers whenever a `Collection` or `SurveyAsset` is deleted
- `AnonymousUser` gets mapped to a real `User` object so that the standard permissions mechanisms work for URL sharing, etc.
  - There's a setting that limits what permissions an `AnonymousUser` can have—currently only `view_collection` and `view_surveyasset`
