### PR TITLE
Really simple `kind` field on Collections and SurveyAssets

### DIFF
--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -45,6 +45,10 @@ class Collection(ObjectPermissionMixin, MPTTModel):
     tags = TaggableManager()
     permissions = GenericRelation(ObjectPermission)
 
+    @property
+    def kind(self):
+        return self._meta.model_name
+
     class Meta:
         permissions = (
             # change_, add_, and delete_collection are provided automatically

--- a/kpi/models/survey_asset.py
+++ b/kpi/models/survey_asset.py
@@ -43,6 +43,10 @@ class SurveyAsset(ObjectPermissionMixin, models.Model):
 
     objects = SurveyAssetManager()
 
+    @property
+    def kind(self):
+        return self._meta.model_name
+
     class Meta:
         ordering = ('date_created',)
         permissions = (

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -217,6 +217,7 @@ class SurveyAssetSerializer(serializers.HyperlinkedModelSerializer):
                     'content',
                     'xform_link',
                     'uid',
+                    'kind',
                     'xls_link',
                     'name', 'tags',
                     'permissions',)
@@ -320,6 +321,7 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
         model = Collection
         fields = ('name',
                     'uid',
+                    'kind',
                     'url',
                     'parent',
                     'children',


### PR DESCRIPTION
This will return `collection` and `surveyasset`. I'm happy to replace with `"kobo#collection"` and  `"kobo#asset"` if you'd prefer those, @dorey.
