### PR TITLE
Enclose tags between double quotes in search queries

### DIFF
--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -112,7 +112,7 @@ function SearchContext(opts={}) {
         if (searchParams.tags && searchParams.tags.length > 0) {
           paramGroups.push(
               searchParams.tags.map(function(t){
-                return `tag:${t.value}`
+                return `tag:"${t.value}"`
               }).join(' AND ')
             );
         }


### PR DESCRIPTION
Whoosh [`FieldnameTagger`](https://bitbucket.org/mchaput/whoosh/src/c9ad870378a0f5167182349b64fc3e09c6ca12df/src/whoosh/qparser/plugins.py?at=default#plugins.py-372) doesn't do what we'd expect for queries like `?q=tag:ki-type:camp-leaders`.

```
In : p.parse(u'tag:ki-type:camp-leaders')
Out: And([Term(u'tag', u'ki-'), Term('text', u'type'), Term('text', u'camp'), Term('text', u'leader')])
```

However, `?q=tag:context:camp-leaders` does work as expected. Given the confusing behavior, **this PR assumes it's always best to enclose tag names in double quotes**, e.g. `?q=tag:"ki-type:camp-leaders"`. Maybe that means we should also replace double quotes with dashes in all tag names?
