### PR TITLE
Fix missing import

### DIFF
--- a/kpi/models/import_task.py
+++ b/kpi/models/import_task.py
@@ -5,7 +5,7 @@ from shortuuid import ShortUUID
 from jsonfield import JSONField
 import requests
 from pyxform import xls2json_backends
-from ..models import Collection
+from ..models import Collection, Asset
 from ..model_utils import create_assets, _load_library_content
 from ..zip_importer import HttpContentParse
 


### PR DESCRIPTION
The missing import would have affected survey or block XLS imports (failing line: https://github.com/kobotoolbox/kpi/blob/47e55fcf641bc586b13e24e8a94bb6b53c62ef26/kpi/models/import_task.py#L122). Resulting exception was seen in the staging Celery log.
