### PR TITLE
Improve performance of permissions recalculation; fixes #269

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -197,14 +197,6 @@ class Asset(ObjectPermissionMixin, TagStringMixin, models.Model, XlsExportable):
         with transaction.atomic(), reversion.create_revision():
             super(Asset, self).save(*args, **kwargs)
 
-    def get_descendants_list(self, include_self=False):
-        ''' A asset never has any descendants, but provide this method
-        a la django-mptt to simplify permissions code '''
-        if include_self:
-            return list(self)
-        else:
-            return list()
-
     def get_ancestors_or_none(self):
         # ancestors are ordered from farthest to nearest
         if self.parent is not None:

--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -96,22 +96,9 @@ class Collection(ObjectPermissionMixin, TagStringMixin, MPTTModel):
         else:
             return None
 
-    def get_descendants_list(self, include_self=False):
-        ''' Similar to django-mptt's get_descendants, but returns a list
-        instead of a QuerySet since our descendants are both Assets and
-        Collections '''
-        mixed_descendants = list()
-        if not include_self:
-            # Gather our own child assets, since we won't be included
-            # in the main loop
-            mixed_descendants.extend(list(self.assets.all()))
-        for descendant in self.get_descendants(include_self):
-            # Append each of our descendant collections
-            mixed_descendants.append(descendant)
-            for asset in descendant.assets.all():
-                # Append each descendant collection's child assets
-                mixed_descendants.append(asset)
-        return mixed_descendants
+    def get_mixed_children(self):
+        ''' Returns all children, both Assets and Collections '''
+        return CollectionChildrenQuerySet(self)
 
     def __unicode__(self):
         return self.name
@@ -213,11 +200,14 @@ class CollectionChildrenQuerySet(object):
     def prefetch_related(self, *args, **kwargs):
         return self._apply_to_both('prefetch_related', *args, **kwargs)
 
+    def only(self, *args, **kwargs):
+        return self._apply_to_both('only', *args, **kwargs)
+
     def _apply_to_both(self, method, *args, **kwargs):
         qs = self._clone()
         qs.child_collections = getattr(qs.child_collections, method)(
             *args, **kwargs)
-        qs.child_collections = getattr(qs.child_collections, method)(
+        qs.child_assets = getattr(qs.child_assets, method)(
             *args, **kwargs)
         return qs
 


### PR DESCRIPTION
Still some repetitive queries visible with `manage.py debugsqlshell`, but the time to share the large collection is down to 12 seconds. Memory use is greatly reduced.
