### PR TITLE
Include django-oauth-toolkit

### DIFF
--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = (
     'taggit',
     'rest_framework',
     'rest_framework.authtoken',
+    'oauth2_provider',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/kpi/urls.py
+++ b/kpi/urls.py
@@ -42,4 +42,5 @@ urlpatterns = [
     url(r'^accounts/logout/', 'django.contrib.auth.views.logout',
         {'next_page': '/'}),
     url(r'^accounts/', include('registration.backends.default.urls')),
+    url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ django-cachebuster==0.2.1
 django-ses==0.7.0
 raven==5.5.0
 django-markitup==2.2.2
+django-oauth-toolkit==0.9.0


### PR DESCRIPTION
Requires `manage.py migrate oauth2_provider --fake` when sharing a database with Django < 1.7
