### PR TITLE
Resolve import filename confusion

### DIFF
--- a/kpi/model_utils.py
+++ b/kpi/model_utils.py
@@ -43,7 +43,11 @@ def _load_library_content(structure):
         block_name = row.get('block', None)
         grouped[block_name].append((row, row_tags,))
 
-    collection = Collection.objects.create(owner=structure['owner'], name=structure['name'])
+    collection_name = structure['name']
+    if not collection_name:
+        collection_name = 'Collection'
+    collection = Collection.objects.create(
+        owner=structure['owner'], name=collection_name)
 
     for block_name, rows in grouped.items():
         if block_name is None:

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -311,7 +311,8 @@ class ImportTaskViewSet(viewsets.ReadOnlyModelViewSet):
             encoded_substr = encoded_str[encoded_str.index('base64') + 7:]
             itask_data = {
                 'base64Encoded': encoded_substr,
-                'filename': request.POST.get('filename', None),
+                # NOTE: 'filename' here comes from 'name' (!) in the POST data
+                'filename': request.POST.get('name', None),
                 'destination': request.POST.get('destination', None),
             }
             import_task = ImportTask.objects.create(user=request.user, data=itask_data)


### PR DESCRIPTION
Don't lose the filename during import. Use 'Collection' as the default name for an imported library when no filename is provided.
