### PR TITLE
Redirect to other builder by prefix

### DIFF
--- a/hub/middleware.py
+++ b/hub/middleware.py
@@ -7,28 +7,36 @@ class OtherFormBuilderRedirectMiddleware(object):
     If the user prefers to use another form builder, redirect to it
     '''
     THIS_BUILDER = FormBuilderPreference.KPI
-    PREFERENCE_TO_URL = {
-        FormBuilderPreference.KPI: settings.KPI_URL,
-        FormBuilderPreference.DKOBO: settings.DKOBO_URL,
+    PREFERENCE_TO_PREFIX = {
+        FormBuilderPreference.KPI: settings.KPI_PREFIX,
+        FormBuilderPreference.DKOBO: settings.DKOBO_PREFIX,
     }
 
     def _redirect_if_necessary(self, request, preferred_builder):
         try:
-            preferred_url = self.PREFERENCE_TO_URL[preferred_builder]
+            preferred_prefix = self.PREFERENCE_TO_PREFIX[preferred_builder]
         except KeyError:
             # Ignore invalid preference
             return
-        if not request.build_absolute_uri().startswith(preferred_url):
-            return HttpResponseRedirect(preferred_url)
+        prefix_length = max(1, len(request.path) - len(request.path_info))
+        prefix = request.path[:prefix_length]
+        if prefix != preferred_prefix:
+            try:
+                # Requires Django 1.7
+                scheme = request.scheme
+            except:
+                scheme = 'https' if request.is_secure() else 'http'
+            return HttpResponseRedirect(u'{}://{}{}'.format(
+                scheme, request.get_host(), preferred_prefix))
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         ''' Using process_view instead of process_request allows the resolver
         to run and return 404 when appropriate, instead of blindly returning
         302 for all requests '''
         preferred_builder = self.THIS_BUILDER
-        if not settings.KPI_URL or not settings.DKOBO_URL \
+        if not settings.KPI_PREFIX or not settings.DKOBO_PREFIX \
                 or request.user.is_anonymous():
-            # Do not attempt to redirect if the necessary URLs are not
+            # Do not attempt to redirect if the necessary prefixes are not
             # configured or the user is anonymous
             return
         try:
@@ -36,5 +44,5 @@ class OtherFormBuilderRedirectMiddleware(object):
                 request.user.formbuilderpreference.preferred_builder
         except FormBuilderPreference.DoesNotExist:
             # Ignore missing preference
-            pass    
+            pass
         return self._redirect_if_necessary(request, preferred_builder)

--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -135,12 +135,14 @@ USE_TZ = True
 STATIC_ROOT = 'staticfiles'
 STATIC_URL = '/static/'
 
-# KPI_URL should be set in the environment when running in a subdirectory
-KPI_URL = os.environ.get('KPI_URL', False)
-if KPI_URL:
-    STATIC_URL = KPI_URL + STATIC_URL
+# Following the uWSGI mountpoint convention, this should have a leading slash
+# but no trailing slash
+KPI_PREFIX = os.environ.get('KPI_PREFIX', False)
+# KPI_PREFIX should be set in the environment when running in a subdirectory
+if KPI_PREFIX and KPI_PREFIX != '/':
+    STATIC_URL = '{}/{}'.format(KPI_PREFIX, STATIC_URL)
     from django.conf.global_settings import LOGIN_URL
-    LOGIN_URL = KPI_URL + LOGIN_URL
+    LOGIN_URL = '{}/{}'.format(KPI_PREFIX, LOGIN_URL)
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'jsapp'),
@@ -176,7 +178,9 @@ USE_MINIFIED_SCRIPTS = os.environ.get('KOBO_USE_MINIFIED_SCRIPTS', False)
 TRACKJS_TOKEN = os.environ.get('TRACKJS_TOKEN')
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL', False)
 KOBOCAT_INTERNAL_URL = os.environ.get('KOBOCAT_INTERNAL_URL', False)
-DKOBO_URL = os.environ.get('DKOBO_URL', False)
+# Following the uWSGI mountpoint convention, this should have a leading slash
+# but no trailing slash
+DKOBO_PREFIX = os.environ.get('DKOBO_PREFIX', False)
 
 ''' Haystack search settings '''
 HAYSTACK_CONNECTIONS = {


### PR DESCRIPTION
Requires new `KPI_PREFIX` and `DKOBO_PREFIX` environment variables
