### PR TITLE
redirecting dkobo library URL to dkobo

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -14,6 +14,7 @@ import {
   DefaultRoute,
   Link,
   Route,
+  Redirect,
   RouteHandler,
   NotFoundRoute,
   run,
@@ -2702,6 +2703,7 @@ Demo.collection = React.createClass({
 
 var routes = (
   <Route name="home" path="/" handler={App}>
+    <Redirect from="library/questions" to="library" />
     <Route name="library" handler={LibrarySearchableList}>
     </Route>
 


### PR DESCRIPTION
Alternative to kobocat-template#76, which would break links to dkobo's
library
