### PR TITLE
Fixes to SL and validation gatekeeper regex

### DIFF
--- a/jsapp/xlform/src/model.skipLogicParser.coffee
+++ b/jsapp/xlform/src/model.skipLogicParser.coffee
@@ -11,22 +11,17 @@ log_equiv = (i1, i2, i3)->
 ###
 
 module.exports = do ->
-  # /^\${(\w+)}\s*(=|!=|<|>|<=|>=)\s*\'?((?:date\(\'\d{4}-\d{2}-\d{2}\'\)|[\s\w]+|-?\d+)\.?\d*)\'?/
   equalityCriterionPattern = ///
-      ^\${(\w+)}\s*
-        (=|!=|<|>|<=|>=)
-        \s*\'?
-        (
-          (?:
-            date\(\'\d{4}-\d{2}-\d{2}\'\)
-          |
-            [\s\w]+
-          |
-            -?\d+
-          )
-          \.?\d*
-        )
-      \'?
+      ^\${(\w+)}\s*                      # question reference in the format of ${name}
+      (!=|<=|>=|=|<|>)\s*                # operator (careful: if < is listed before <=, the = will be treated as part of the value)
+      (                                  # start of the value group
+        (?:                              #   start of a non-matching group
+          date\(\'\d{4}-\d{2}-\d{2}\'\)) #     something resembling a date: date('xxxx-xx-xx')
+        |                                #   or
+          (?:-?(?:\d+\.\d+|\.\d+|\d+.?)) #     a signed integer or decimal
+        |                                #   or
+          (?:\'[^']+\')                  #     a string surrounded by single quotes (careful: the quotes are included in the match!)
+      )                                  # end of the value group
     ///
 
   # /\${(\w+)}\s*((?:=|!=)\s*(?:NULL|''))/i

--- a/jsapp/xlform/src/model.validationLogicParser.coffee
+++ b/jsapp/xlform/src/model.validationLogicParser.coffee
@@ -1,20 +1,17 @@
 $factory = require('./model.validationLogicParserFactory')
 
 module.exports = do ->
-  # /(\.)\s*(=|!=|<|>|<=|>=)\s*\'?((?:date\(\'\d{4}-\d{2}-\d{2}\'\)|[\s\w]+|-?\d+)\.?\d*)\'?/
   equalityCriterionPattern = ///
-      (\.)\s*
-      (=|!=|<|>|<=|>=)\s*
-      \'?
-      (
-        (?:
-          date\(\'\d{4}-\d{2}-\d{2}\'\)
-        |
-          [\s\w]+|-?\d+
-        )
-        \.?\d*
-      )
-      \'?
+      (\.)\s*                            # always a leading dot
+      (!=|<=|>=|=|<|>)\s*                # operator (careful: if < is listed before <=, the = will be treated as part of the value)
+      (                                  # start of the value group
+        (?:                              #   start of a non-matching group
+          date\(\'\d{4}-\d{2}-\d{2}\'\)) #     something resembling a date: date('xxxx-xx-xx')
+        |                                #   or
+          (?:-?(?:\d+\.\d+|\.\d+|\d+.?)) #     a signed integer or decimal
+        |                                #   or
+          (?:\'[^']+\')                  #     a string surrounded by single quotes (careful: the quotes are included in the match!)
+      )                                  # end of the value group
     ///
 
   # /(\.)\s*((?:=|!=)\s*(?:NULL|''))/i

--- a/jsapp/xlform/src/model.validationLogicParserFactory.js
+++ b/jsapp/xlform/src/model.validationLogicParserFactory.js
@@ -31,7 +31,11 @@ module.exports = (function(){
             };
 
             if (matches[3]) {
-                res.response_value = matches[3].replace(/date\('(\d{4}-\d{2}-\d{2})'\)/, '$1');
+                // strip surrounding single quotes, if any
+                var response_value = matches[3].replace(/^'([^']*)'$/, "$1");
+                // extract xxxx-xx-xx from date('xxxx-xx-xx')
+                response_value = response_value.replace(/date\('(\d{4}-\d{2}-\d{2})'\)/, '$1');
+                res.response_value = response_value;
             }
 
             return res;


### PR DESCRIPTION
Closes #208, but still doesn't address following situation:
- User has an integer field called 'age'
- User writes manual validation criteria `${age} >= 18.5`
- Gatekeeper regex allows 18.5 as a valid possible value
- Backbone validation rejects 18.5 because it's not an integer
- Form builder does not fall back on hand-code box
- Form builder silently erases 18.5; "response value" is now blank
- Saving the form now removes the validation criteria altogether
