### PR TITLE
Use `login_required` decorator on `switch_builder` view

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -1,18 +1,14 @@
-from rest_framework.decorators import api_view
-from rest_framework.response import Response
 from .models import FormBuilderPreference
 from django.http import HttpResponseRedirect
 from django.core.management import call_command
+from django.contrib.auth.decorators import login_required
 
 
-@api_view(['GET'])
+@login_required
 def switch_builder(request):
     '''
     very un-restful, but for ease of testing, a quick 'GET' is hard to beat
     '''
-    if not request.user.is_authenticated():
-        raise exceptions.NotAuthenticated()
-
     if 'beta' in request.GET:
         beta_val = request.GET.get('beta') == '1'
         (pref, created) = FormBuilderPreference.objects.get_or_create(


### PR DESCRIPTION
Fixes 500 when unauthenticated people try to opt into the beta
