### PR TITLE
Optimize library imports and collection deletions

### DIFF
--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -191,7 +191,7 @@ HAYSTACK_CONNECTIONS = {
 }
 # If this causes performance trouble, see
 # http://django-haystack.readthedocs.org/en/latest/best_practices.html#use-of-a-queue-for-a-better-user-experience
-HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+HAYSTACK_SIGNAL_PROCESSOR = 'kpi.signals.HaystackSignalProcessor'
 
 # Enketo settings copied from dkobo.
 ENKETO_SERVER = os.environ.get('ENKETO_URL') or os.environ.get('ENKETO_SERVER', 'https://enketo.org')

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -1,15 +1,15 @@
-import django.db.models
+import contextlib
+import haystack
+from  django.db import models
 from django.dispatch import receiver
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
-from django.conf import settings
 from taggit.models import Tag, TaggedItem
-from haystack import connections
-from haystack.exceptions import NotHandled
-from models import Collection, Asset, TagUid
+from .models import Collection, Asset, TagUid
 from .model_utils import grant_default_model_level_perms
+from .model_utils import update_object_in_search_index
 
-@receiver(django.db.models.signals.post_save, sender=User)
+@receiver(models.signals.post_save, sender=User)
 def default_permissions_post_save(sender, instance, created, raw, **kwargs):
     '''
     Users must have both model-level and object-level permissions to satisfy
@@ -26,40 +26,81 @@ def default_permissions_post_save(sender, instance, created, raw, **kwargs):
         return
     grant_default_model_level_perms(instance)
 
-@receiver(django.db.models.signals.post_save, sender=Tag)
+@receiver(models.signals.post_save, sender=Tag)
 def tag_uid_post_save(sender, instance, created, raw, **kwargs):
     ''' Make sure we have a TagUid object for each newly-created Tag '''
     if raw or not created:
         return
     TagUid.objects.get_or_create(tag=instance)
 
-def _update_object_in_index(obj):
-    '''
-    If a search index exists for the type of `obj`, update it. Otherwise, do
-    nothing
-    '''
-    try:
-        index = connections['default'].get_unified_index().get_index(type(obj))
-    except NotHandled:
-        # There's nothing to update because this type of object is not indexed
-        return
-    index.update_object(obj)
+class HaystackSignalProcessor(haystack.signals.BaseSignalProcessor):
+    """
+    Allows for observing when saves/deletes fire & automatically updates the
+    search engine appropriately.
+    """
+    HAYSTACK_SIGNAL_MODELS = (Asset, Collection, Tag)
+    def setup(self):
+        for model in self.HAYSTACK_SIGNAL_MODELS:
+            models.signals.post_save.connect(self.handle_save, sender=model)
+            models.signals.post_delete.connect(
+                self.handle_delete, sender=model)
 
-@receiver(django.db.models.signals.post_save, sender=TaggedItem)
-def tagged_item_post_save(sender, instance, created, raw, **kwargs):
-    '''
-    TaggedItem is the through model for the tag-to-object M2M relationship.
-    When a TaggedItem is saved, we need to update the search index for the tag
-    itself, as well as the tagged item
-    '''
-    if raw:
-        return
-    # Update the search index for the tag itself
-    _update_object_in_index(instance.tag)
-    # Update the search index for the tagged object
-    _update_object_in_index(instance.content_object)
+        models.signals.post_save.connect(
+            self.handle_tagged_item_save, sender=TaggedItem)
+        models.signals.post_delete.connect(
+            self.handle_tagged_item_delete, sender=TaggedItem)
 
-@receiver(django.db.models.signals.post_delete, sender=TaggedItem)
-def tagged_item_post_delete(sender, instance, **kwargs):
-    _update_object_in_index(instance.tag)
-    _update_object_in_index(instance.content_object)
+    def teardown(self):
+        for model in self.HAYSTACK_SIGNAL_MODELS:
+            models.signals.post_save.disconnect(
+                self.handle_save, sender=model)
+            models.signals.post_delete.disconnect(
+                self.handle_delete, sender=model)
+
+        models.signals.post_save.disconnect(
+            self.handle_tagged_item_save, sender=TaggedItem)
+        models.signals.post_delete.disconnect(
+            self.handle_tagged_item_delete, sender=TaggedItem)
+
+    def handle_save(self, sender, instance, **kwargs):
+        if not getattr(instance, '_allow_signal_handler_to_index', True):
+            # We were instructed to skip indexing here, probably because this
+            # save is part of a bulk operation
+            return
+        return super(HaystackSignalProcessor, self).handle_save(
+            sender, instance, **kwargs)
+
+    def handle_delete(self, sender, instance, **kwargs):
+        if not getattr(instance, '_allow_signal_handler_to_index', True):
+            # We were instructed to skip indexing here, probably because this
+            # delete is part of a bulk operation
+            return
+        return super(HaystackSignalProcessor, self).handle_delete(
+            sender, instance, **kwargs)
+
+    def handle_tagged_item_save(sender, instance, created, raw, **kwargs):
+        '''
+        TaggedItem is the through model for the tag-to-object M2M relationship.
+        When a TaggedItem is saved, we need to update the search index for the tag
+        itself, as well as the tagged item
+        '''
+        if raw:
+            # Since we touch other objects, we cannot run when the database is
+            # not yet consistent
+            return
+        # Update the search index for the tag itself
+        update_object_in_search_index(instance.tag)
+        # Update the search index for the tagged object
+        update_object_in_search_index(instance.content_object)
+
+    def handle_tagged_item_delete(sender, instance, **kwargs):
+        update_object_in_search_index(instance.tag)
+        update_object_in_search_index(instance.content_object)
+
+    @contextlib.contextmanager
+    def defer(self):
+        ''' Do not perform any automatic, real-time Haystack indexing for
+        operations performed inside the body of the `with` block '''
+        self.teardown()
+        yield
+        self.setup()

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -208,6 +208,9 @@ class CollectionViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
 
+    def perform_destroy(self, instance):
+        instance.delete_with_deferred_indexing()
+
     def get_serializer_class(self):
         if self.action == 'list':
             return CollectionListSerializer


### PR DESCRIPTION
Closes #489.
`questionbank_irc_13.xlsx` now imports in about 7 minutes on my laptop. Creating new objects takes up the first ~4 minutes of the import, and indexing for Haystack/Whoosh takes the remaining ~3 minutes. Deleting the resulting collection takes about 90 seconds. I have **not** moved deletion into a Celery job, but that might be worth doing soon.
