### PR TITLE
Tell KC's API to return JSON

### DIFF
--- a/kpi/models/asset_deployment.py
+++ b/kpi/models/asset_deployment.py
@@ -71,7 +71,7 @@ def deploy_asset(user, asset, form_id):
     valid_xlsform_csv_repr = foo.getvalue()
     payload = {u'text_xls_form': valid_xlsform_csv_repr}
 
-    url = kobocat_url('/api/v1/forms', internal=True)
+    url = kobocat_url('/api/v1/forms?format=json', internal=True)
     try:
         response = requests.post(url, headers=headers, data=payload)
         status_code = response.status_code


### PR DESCRIPTION
Does needing this mean I set up [KC's DRF renderers](https://github.com/kobotoolbox/kobocat/blob/docker_local_django-1.8/onadata/settings/common.py#L267) incorrectly?
