### PR TITLE
Remove trailing slash before format extension

### DIFF
--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -470,9 +470,10 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def get_downloads(self, obj):
         def _reverse_lookup_format(fmt):
             request = self.context.get('request', None)
-            url = '%s.%s' % (reverse('asset-detail',
-                                     args=(obj.uid,),
-                                     request=request), fmt)
+            obj_url = reverse('asset-detail', args=(obj.uid,), request=request)
+            # The trailing slash must be removed prior to appending the format
+            # extension
+            url = '%s.%s' % (obj_url.rstrip('/'), fmt)
 
             return {'format': fmt,
                     'url': url, }

--- a/kpi/urls.py
+++ b/kpi/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url, include
-from rest_framework.urlpatterns import format_suffix_patterns
 from rest_framework.routers import DefaultRouter
 from rest_framework import renderers
 from registration.backends.default.views import RegistrationView


### PR DESCRIPTION
...since DRF stopped supporting this. Fixes #580.
