### PR TITLE
#527: Lets user close form without saving. OK closes the form, Cancel closes the alert.

### DIFF
--- a/jsapp/js/editorMixins/existingForm.es6
+++ b/jsapp/js/editorMixins/existingForm.es6
@@ -33,9 +33,9 @@ export default {
     if (!this.needsSave()) {
       this.transitionTo('form-landing', {assetid: this.props.params.assetid});
     } else {
-      customConfirmAsync(t('you have unsaved changes. would you like to save?'))
+      customConfirmAsync(t('you have unsaved changes. leave form without saving?'))
         .done(() => {
-          this.saveForm();
+          this.transitionTo('form-landing', {assetid: this.props.params.assetid});
         });
     }
   },

--- a/jsapp/js/editorMixins/newForm.es6
+++ b/jsapp/js/editorMixins/newForm.es6
@@ -27,8 +27,8 @@ export default {
     if (!this.needsSave()) {
       this.transitionTo(this.listRoute);
     } else {
-      customConfirmAsync(t('you have unsaved changes. would you like to save?'))
-        .fail(() => {
+      customConfirmAsync(t('you have unsaved changes. leave form without saving?'))
+        .done(() => {
           this.transitionTo(this.listRoute);
         });
     }


### PR DESCRIPTION
Fixes #527

Could be refined further after #528 (ui review)

After discussing with @jnm, we agree:

- Ask "Close form without saving?"
  - **OK**: Close the form without saving
  - **Cancel**: Stay on the form without saving

We wanted to avoid people hitting `Cancel` and losing their work.
