### PR TITLE
Fixes related to deployment versions

### DIFF
--- a/hub/utils/xls_to_ss_structure.py
+++ b/hub/utils/xls_to_ss_structure.py
@@ -5,6 +5,7 @@ from __future__ import (unicode_literals, print_function,
 
 from collections import OrderedDict
 
+import datetime
 import pyxform
 import xlrd
 import re

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -500,33 +500,28 @@ var dmix = {
                   {t('not deployed')}
                 </bem.AssetView__deployment>
               :
-                this.state.deployed_version_id === 0 ?
-                  <bem.AssetView__deployment>
-                    {t('unknown version deployed')}
-                  </bem.AssetView__deployment>
-                :
-                  this.state.deployed_versions.map((item) => {
-                    return (
-                      <bem.AssetView__deployment>
-                        {t('version ___').replace('___', item.version_id)}
-                        {' | '}
-                        {
-                          item.version_id === this.state.deployed_version_id ?
-                              t('current live version')
-                          : [
-                            t('previously deployed ___')
-                              .replace('___', formatTime(item.date_deployed)),
-                            ' | ',
-                            <bem.AssetView__plainlink m='clone'
-                                data-version-id={item.version_id}
-                                onClick={this.saveCloneAs}>
-                              {t('clone')}
-                            </bem.AssetView__plainlink>
-                          ]
-                        }
-                      </bem.AssetView__deployment>
-                    );
-                  })
+                this.state.deployed_versions.map((item) => {
+                  return (
+                    <bem.AssetView__deployment>
+                      {[
+                        t('version ___').replace('___', item.version_id),
+                        ' | ',
+                        t('deployed ___')
+                          .replace('___', formatTime(item.date_deployed)),
+                        ' | ',
+                        item.version_id === this.state.deployed_version_id ?
+                          t('current live version')
+                        :
+                          <bem.AssetView__plainlink m='clone'
+                              data-version-id={item.version_id}
+                              onClick={this.saveCloneAs}>
+                            {t('clone')}
+                          </bem.AssetView__plainlink>
+                      ]}
+                    </bem.AssetView__deployment>
+                  );
+                }
+              )
             }
           </bem.AssetView__deployments>
         </bem.AssetView__row>

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -497,6 +497,13 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         if asset.has_deployment:
             asset_deployments_by_version_id[asset.deployment.version] = \
                 asset.deployment
+            # The currently deployed version may be unknown, but we still want
+            # to pass its timestamp to the serializer
+            if asset.deployment.version == 0:
+                # Temporary attributes for later use by the serializer
+                asset._static_version_id = 0
+                asset._date_deployed = asset.deployment.timestamp
+                deployed_versioned_assets.append(asset)
         # Record all previous deployments
         for version in asset.versions():
             historical_asset = version.object_version.object


### PR DESCRIPTION
* `0011_explode_asset_deployments` migration preserves asset timestamps
* `sync_kobocat_xforms` management command has more useful output and exception handling
* List of deployed versions no longer indicates "unknown version deployed"; instead, it shows "version 0" and the accurate timestamp
* All deployed version show a timestamp, including the currently active one
* Fix missing import in `xls_to_ss_structure.py`