### PR TITLE
Automatically run `sync_kobocat_xforms`

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseRedirect
 from registration.backends.default.views import RegistrationView
 from registration.forms import RegistrationForm
 
+from kpi.tasks import sync_kobocat_xforms
 from .models import FormBuilderPreference, ExtraUserDetail
 
 
@@ -26,6 +27,8 @@ def switch_builder(request):
             username=request.user.username,
             quiet=True # squelches `print` statements
         )
+        # Create/update KPI assets to match the user's KC forms
+        sync_kobocat_xforms.delay(username=request.user.username)
 
     return HttpResponseRedirect('/')
 

--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -236,11 +236,6 @@ KOBO_SURVEY_PREVIEW_EXPIRATION = os.environ.get('KOBO_SURVEY_PREVIEW_EXPIRATION'
 ''' Celery configuration '''
 from datetime import timedelta
 CELERYBEAT_SCHEDULE = {
-    # Create/update KPI assets to match KC forms
-    'sync-kobocat-xforms': {
-        'task': 'kpi.tasks.sync_kobocat_xforms',
-        'schedule': timedelta(minutes=30)
-    },
     # Update the Haystack index twice per day to catch any stragglers that
     # might have gotten past haystack.signals.RealtimeSignalProcessor
     #'update-search-index': {
@@ -248,6 +243,14 @@ CELERYBEAT_SCHEDULE = {
     #    'schedule': timedelta(hours=12)
     #},
 }
+
+if KOBOCAT_URL:
+    # Create/update KPI assets to match KC forms
+    CELERYBEAT_SCHEDULE['sync-kobocat-xforms'] = {
+        'task': 'kpi.tasks.sync_kobocat_xforms',
+        'schedule': timedelta(minutes=30),
+    }
+
 '''
 Distinct projects using Celery need their own queues. Example commands for
 RabbitMQ queue creation:

--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -234,16 +234,20 @@ ENKETO_PREVIEW_URI = 'webform/preview' if ENKETO_VERSION == 'legacy' else 'previ
 KOBO_SURVEY_PREVIEW_EXPIRATION = os.environ.get('KOBO_SURVEY_PREVIEW_EXPIRATION', 24)
 
 ''' Celery configuration '''
-# Uncomment to enable failsafe search indexing
-#from datetime import timedelta
-#CELERYBEAT_SCHEDULE = {
-#    # Update the Haystack index twice per day to catch any stragglers that
-#    # might have gotten past haystack.signals.RealtimeSignalProcessor
-#    'update-search-index': {
-#        'task': 'kpi.tasks.update_search_index',
-#        'schedule': timedelta(hours=12)
-#    },
-#}
+from datetime import timedelta
+CELERYBEAT_SCHEDULE = {
+    # Create/update KPI assets to match KC forms
+    'sync-kobocat-xforms': {
+        'task': 'kpi.tasks.sync_kobocat_xforms',
+        'schedule': timedelta(minutes=30)
+    },
+    # Update the Haystack index twice per day to catch any stragglers that
+    # might have gotten past haystack.signals.RealtimeSignalProcessor
+    #'update-search-index': {
+    #    'task': 'kpi.tasks.update_search_index',
+    #    'schedule': timedelta(hours=12)
+    #},
+}
 '''
 Distinct projects using Celery need their own queues. Example commands for
 RabbitMQ queue creation:

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -1,11 +1,12 @@
+import StringIO
 import datetime
+import dateutil.parser
 import io
 import json
+import logging
 import re
 import requests
 import xlwt
-import StringIO
-import dateutil.parser
 from optparse import make_option
 from pyxform import xls2json_backends
 
@@ -182,9 +183,9 @@ class Command(BaseCommand):
                             time_diff_str = '-{}'.format(-time_diff)
                         else:
                             time_diff_str = '+{}'.format(time_diff)
-                        # If the timestamps are close enough, we assume the KC
-                        # form content was not updated since the last KPI
-                        # deployment
+                        # If KC timestamp is not sufficiently ahead of the KPI
+                        # timestamp, we assume the KC form content was not
+                        # updated since the last KPI deployment
                         if time_diff <= TIMESTAMP_DIFFERENCE_TOLERANCE:
                             print_tabular(
                                 'NOOP',
@@ -201,13 +202,16 @@ class Command(BaseCommand):
                     response = kc_forms_api_request(
                         token, xform.pk, xlsform=True)
                     if response.status_code != 200:
-                        print_tabular(
+                        error_information = [
                             'FAIL',
                             user.username,
                             xform.id_string,
-                            'unable to load xls ({})'.format(
+                            u'unable to load xls ({})'.format(
                                 response.status_code)
-                        )
+                        ]
+                        print_tabular(*error_information)
+                        logging.warning(u'sync_kobocat_xforms: {}'.format(
+                            u', '.join(error_information)))
                         continue
                     # Convert the xlsform to KPI JSON
                     xls_io = io.BytesIO(response.content)
@@ -218,13 +222,16 @@ class Command(BaseCommand):
                     # Get the form data from KC
                     response = kc_forms_api_request(token, xform.pk)
                     if response.status_code != 200:
-                        print_tabular(
+                        error_information = [
                             'FAIL',
                             user.username,
                             xform.id_string,
                             'unable to load form data ({})'.format(
                                 response.status_code)
-                        )
+                        ]
+                        print_tabular(*error_information)
+                        logging.error(u'sync_kobocat_xforms: {}'.format(
+                            u', '.join(error_information)))
                         continue
                     deployment_data = response.json()
                     with transaction.atomic():
@@ -277,12 +284,15 @@ class Command(BaseCommand):
                                 asset.uid,
                             )
                 except Exception as e:
-                    print_tabular(
+                    error_information = [
                         'FAIL',
                         user.username,
                         xform.id_string,
                         repr(e)
-                    )
+                    ]
+                    print_tabular(*error_information)
+                    logging.exception(u'sync_kobocat_xforms: {}'.format(
+                        u', '.join(error_information)))
 
         _set_auto_field_update(Asset, "date_created", True)
         _set_auto_field_update(Asset, "date_modified", True)

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -12,6 +12,7 @@ from pyxform import xls2json_backends
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import get_storage_class
 from django.core.management.base import BaseCommand
 from django.db import models, transaction
@@ -123,6 +124,11 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
+        if not settings.KOBOCAT_URL or not settings.KOBOCAT_INTERNAL_URL:
+            raise ImproperlyConfigured(
+                'Both KOBOCAT_URL and KOBOCAT_INTERNAL_URL must be '
+                'configured before using this command'
+            )
         if options.get('quiet'):
             # Do not output anything
             def print_str(string): pass

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -11,3 +11,7 @@ def update_search_index():
 def import_in_background(import_task_uid):
     import_task = ImportTask.objects.get(uid=import_task_uid)
     import_task.run()
+
+@shared_task
+def sync_kobocat_xforms(username=None, quiet=True):
+    call_command('sync_kobocat_xforms', username=username, quiet=quiet)


### PR DESCRIPTION
* Every 30 minutes for all users;
* Whenever a user opts into KPI, for that user only.

Failures should be logged to Sentry via the standard Python logging facility.