### PR TITLE
clone and compile the locale messages into docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ RUN ln -s "${NODE_PATH}" "${KPI_SRC_DIR}/node_modules" && \
 ENV DJANGO_SETTINGS_MODULE kobo_playground.settings
 RUN python manage.py collectstatic --noinput
 
+RUN git clone https://github.com/kobotoolbox/form-builder-translations.git locale
+RUN python manage.py compilemessages
 
 #################################################################
 # Persist the log directory, email directory, and Whoosh index. #

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,11 @@ RUN ln -s "${NODE_PATH}" "${KPI_SRC_DIR}/node_modules" && \
 ENV DJANGO_SETTINGS_MODULE kobo_playground.settings
 RUN python manage.py collectstatic --noinput
 
+
+############################
+# Clone locales repository #
+############################
+RUN rm -rf locale
 RUN git clone https://github.com/kobotoolbox/form-builder-translations.git locale
 RUN python manage.py compilemessages
 


### PR DESCRIPTION
Next iteration needs:
* Review where in the Dockerfile this should take place
* Some way to specify the `DJANGO_LANGUAGE_CODES` environment variable