### PR TITLE
Add asset deployment identifier to search index

### DIFF
--- a/kpi/search_indexes.py
+++ b/kpi/search_indexes.py
@@ -62,6 +62,13 @@ class AssetIndex(indexes.SearchIndex, indexes.Indexable, FieldPreparersMixin):
     owner__username__exact = indexes.MultiValueField()
     parent__name__exact = indexes.MultiValueField()
     parent__uid = indexes.MultiValueField()
+    deployment__identifier = indexes.MultiValueField()
+
+    def prepare_deployment__identifier(self, obj):
+        if not obj.has_deployment:
+            return None
+        return self._escape_comma_space(obj.deployment.identifier)
+
     def get_model(self):
         return Asset
 


### PR DESCRIPTION
* Requires `./manage.py rebuild_index` (must be rebuild, not just update, because of the change to Whoosh schema);
* Allows easily finding the KPI asset that corresponds to a given KC project, e.g. `http://lxkobo:8000/assets/?q=deployment__identifier:"http://lxkobo:8001/jnm/forms/project-name"`