### PR TITLE
Allow login using a one-time key

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -22,13 +22,15 @@ def switch_builder(request):
             else FormBuilderPreference.DKOBO
         pref.save()
     if 'migrate' in request.GET:
+        # TODO: don't start these tasks for if they're already running for this
+        # particular user
         call_command(
             'import_survey_drafts_from_dkobo',
             username=request.user.username,
             quiet=True # squelches `print` statements
         )
         # Create/update KPI assets to match the user's KC forms
-        sync_kobocat_xforms.delay(username=request.user.username)
+        sync_kobocat_xforms(username=request.user.username)
 
     return HttpResponseRedirect('/')
 

--- a/hub/views.py
+++ b/hub/views.py
@@ -10,7 +10,7 @@ from kpi.tasks import sync_kobocat_xforms
 from .models import FormBuilderPreference, ExtraUserDetail
 
 # The `api_view` decorator allows authentication via DRF
-@api_view
+@api_view(['GET'])
 @login_required
 def switch_builder(request):
     '''

--- a/hub/views.py
+++ b/hub/views.py
@@ -4,11 +4,13 @@ from django.db import transaction
 from django.http import HttpResponseRedirect
 from registration.backends.default.views import RegistrationView
 from registration.forms import RegistrationForm
+from rest_framework.decorators import api_view
 
 from kpi.tasks import sync_kobocat_xforms
 from .models import FormBuilderPreference, ExtraUserDetail
 
-
+# The `api_view` decorator allows authentication via DRF
+@api_view
 @login_required
 def switch_builder(request):
     '''

--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -177,6 +177,13 @@ REST_FRAMEWORK = {
     'URL_FIELD_NAME': 'url',
     'DEFAULT_PAGINATION_CLASS': 'kpi.serializers.Paginated',
     'PAGE_SIZE': 100,
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        # SessionAuthentication and BasicAuthentication would be included by
+        # default
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ],
 }
 
 TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (

--- a/kpi/migrations/0012_onetimeauthenticationkey.py
+++ b/kpi/migrations/0012_onetimeauthenticationkey.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import kpi.models.authorized_application
+import django.core.validators
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('kpi', '0011_explode_asset_deployments'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OneTimeAuthenticationKey',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(default=kpi.models.authorized_application._generate_random_key, max_length=60, validators=[django.core.validators.MinLengthValidator(60)])),
+                ('expiry', models.DateTimeField(default=kpi.models.authorized_application.ten_minutes_from_now)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/kpi/models/__init__.py
+++ b/kpi/models/__init__.py
@@ -5,5 +5,6 @@ from kpi.models.object_permission import ObjectPermission, ObjectPermissionMixin
 from kpi.models.import_task import ImportTask
 from kpi.models.tag_uid import TagUid
 from kpi.models.authorized_application import AuthorizedApplication
+from kpi.models.authorized_application import OneTimeAuthenticationKey
 
 import kpi.signals

--- a/kpi/models/authorized_application.py
+++ b/kpi/models/authorized_application.py
@@ -1,3 +1,4 @@
+import datetime
 from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
@@ -19,11 +20,27 @@ class AuthorizedApplication(models.Model):
         validators=[MinLengthValidator(KEY_LENGTH)],
         default=_generate_random_key
     )
+
     def __unicode__(self):
         return self.name
 
+
+def ten_minutes_from_now():
+    return datetime.datetime.now() + datetime.timedelta(minutes=10)
+
+class OneTimeAuthenticationKey(models.Model):
+    user = models.ForeignKey('auth.User')
+    key = models.CharField(
+        max_length=KEY_LENGTH,
+        validators=[MinLengthValidator(KEY_LENGTH)],
+        default=_generate_random_key
+    )
+    expiry = models.DateTimeField(default=ten_minutes_from_now)
+
+
 class ApplicationTokenAuthentication(TokenAuthentication):
     model = AuthorizedApplication
+
     def authenticate_credentials(self, key):
         ''' Mostly duplicated from TokenAuthentication, except that we return
         an AnonymousUser '''

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -23,6 +23,7 @@ from .models import ObjectPermission
 from .models.object_permission import get_anonymous_user
 from .models.asset import ASSET_TYPES
 from .models import TagUid
+from .models import OneTimeAuthenticationKey
 from .forms import USERNAME_REGEX, USERNAME_MAX_LENGTH
 from .forms import USERNAME_INVALID_MESSAGE
 
@@ -904,3 +905,11 @@ class AuthorizedApplicationUserSerializer(serializers.BaseSerializer):
         if len(validation_errors):
             raise exceptions.ValidationError(validation_errors)
         return validated_data
+
+
+class OneTimeAuthenticationKeySerializer(serializers.ModelSerializer):
+    username = serializers.SlugRelatedField(
+        slug_field='username', source='user', queryset=User.objects.all())
+    class Meta:
+        model = OneTimeAuthenticationKey
+        fields = ('username', 'key', 'expiry')

--- a/kpi/urls.py
+++ b/kpi/urls.py
@@ -14,9 +14,10 @@ from kpi.views import (
     ObjectPermissionViewSet,
     SitewideMessageViewSet,
     AuthorizedApplicationUserViewSet,
+    OneTimeAuthenticationKeyViewSet,
 )
 
-from kpi.views import current_user, home
+from kpi.views import current_user, home, one_time_login
 from kpi.views import authorized_application_authenticate_user
 from kpi.forms import RegistrationForm
 from hub.views import switch_builder
@@ -31,9 +32,11 @@ router.register(r'permissions', ObjectPermissionViewSet)
 router.register(r'imports', ImportTaskViewSet)
 router.register(r'sitewide_messages', SitewideMessageViewSet)
 
-router.register(r'authorized-application/users',
+router.register(r'authorized_application/users',
                 AuthorizedApplicationUserViewSet,
-                base_name='authorized-applications')
+                base_name='authorized_applications')
+router.register(r'authorized_application/one_time_authentication_keys',
+                OneTimeAuthenticationKeyViewSet)
 
 
 # Apps whose translations should be available in the client code.
@@ -54,9 +57,10 @@ urlpatterns = [
     url(r'^accounts/', include('registration.backends.default.urls')),
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(
-        r'^authorized-application/authenticate-user/$',
+        r'^authorized_application/authenticate_user/$',
         authorized_application_authenticate_user
     ),
+    url(r'^authorized_application/one_time_login/$', one_time_login),
     url(r'^hub/switch_builder$', switch_builder, name='toggle-preferred-builder'),
     # Translation catalog for client code.
     url(r'^jsi18n/$', javascript_catalog, js_info_dict, name='javascript-catalog'),


### PR DESCRIPTION
**Do not deploy** without also deploying accompanying EquityTool changes (https://github.com/kobotoolbox/reports/pull/81)

* Backend of an authorized client app can POST to KPI to create a one-time key
* Frontend of client app can use key to establish a KPI (+KC) session
* Users do not have to re-enter credentials
* The one-time keys are valid for one use only (really!)
* The one-time keys expire after 10 minutes if not used earlier
* Replace `authorized-application` with more standard `authorized_application` in URLs