### PR TITLE
Remove `deployed_versions` from asset list serializer

### DIFF
--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -651,7 +651,6 @@ class AssetListSerializer(AssetSerializer):
                   'version_id',
                   'has_deployment',
                   'deployed_version_id',
-                  'deployed_versions',
                   'deployment__identifier',
                   'deployment__active',
                   'permissions',


### PR DESCRIPTION
It's very expensive and kills the performance of the asset list view. It's only
needed on the detail serializer.