### PR TITLE
Asset endpoint lists available Enketo URLs

### DIFF
--- a/kobo_playground/settings.py
+++ b/kobo_playground/settings.py
@@ -245,6 +245,10 @@ ENKETO_PREVIEW_URI = 'webform/preview' if ENKETO_VERSION == 'legacy' else 'previ
 # around before purging it.
 KOBO_SURVEY_PREVIEW_EXPIRATION = os.environ.get('KOBO_SURVEY_PREVIEW_EXPIRATION', 24)
 
+ENKETO_API_TOKEN = os.environ.get('ENKETO_API_TOKEN', 'enketorules')
+# http://apidocs.enketo.org/v2/
+ENKETO_SURVEY_ENDPOINT = 'api/v2/survey/all'
+
 ''' Celery configuration '''
 if os.environ.get('SKIP_CELERY', 'False') == 'True':
     # helpful for certain debugging

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -76,6 +76,10 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             string=url
         )
 
+    @property
+    def backend_response(self):
+        return self.asset._deployment_data['backend_response']
+
     def to_csv_io(self, asset_xls_io, id_string):
         ''' Convert the output of `Asset.to_xls_io()` or
         `Asset.to_versioned_xls_io()` into a CSV appropriate for KC's
@@ -182,8 +186,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     @property
     def timestamp(self):
         try:
-            return self.asset._deployment_data['backend_response'][
-                'date_modified']
+            return self.backend_response['date_modified']
         except KeyError:
             return None
 
@@ -253,9 +256,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         '''
         if active is None:
             active = self.active
-        url = self.external_to_internal_url(
-            self.asset._deployment_data['backend_response']['url'])
-        id_string = self.asset._deployment_data['backend_response']['id_string']
+        url = self.external_to_internal_url(self.backend_response['url'])
+        id_string = self.backend_response['id_string']
         csv_io = self.to_csv_io(self.asset.to_versioned_xls_io(), id_string)
         valid_xlsform_csv_repr = csv_io.getvalue()
         payload = {
@@ -285,7 +287,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # self.asset._deployment_data.update(...)
         # self.asset.save()
         url = self.external_to_internal_url(
-            self.asset._deployment_data['backend_response']['url'])
+            self.backend_response['url'])
         payload = {
             u'downloadable': bool(active)
         }
@@ -298,7 +300,28 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
     def delete(self):
         url = self.external_to_internal_url(
-            self.asset._deployment_data['backend_response']['url'])
+            self.backend_response['url'])
         self._kobocat_request('DELETE', url, None)
         self.asset._deployment_data = {}
         self.asset.save()
+
+    def get_enketo_survey_links(self):
+        data = {
+            'server_url': u'{}/{}'.format(
+                settings.KOBOCAT_URL.rstrip('/'),
+                self.asset.owner.username
+            ),
+            'form_id': self.backend_response['id_string']
+        }
+        response = requests.post(
+            u'{}/{}'.format(
+                settings.ENKETO_SERVER, settings.ENKETO_SURVEY_ENDPOINT),
+            # bare tuple implies basic auth
+            auth=(settings.ENKETO_API_TOKEN, ''),
+            data=data
+        )
+        links = response.json()
+        for discard in ('enketo_id', 'code'):
+            try: del links[discard]
+            except KeyError: pass
+        return links

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -21,3 +21,14 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         self.store_data({
                 'active': bool(active),
             })
+
+    def get_enketo_survey_links(self):
+        # `self` is a demo Enketo form, but there's no guarantee it'll be
+        # around forever.
+        return {
+            'url': 'https://enke.to/::self',
+            'iframe_url': 'https://enke.to/i/::self',
+            'offline_url': 'https://enke.to/_/#self',
+            'preview_url': 'https://enke.to/preview/::self',
+            'preview_iframe_url': 'https://enke.to/preview/i/::self',
+        }

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -548,7 +548,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_deployment__links(self, obj):
         if obj.has_deployment and obj.deployment.active:
-            dev_link = "https://ee.kobotoolbox.org/x/#YYES"
+            dev_link = "{}/enter-data".format(obj.deployment.identifier)
             return dict([[dd, dev_link] for dd in
                         ["online_offline",
                          "online_only_single",

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -548,12 +548,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_deployment__links(self, obj):
         if obj.has_deployment and obj.deployment.active:
-            dev_link = "{}/enter-data".format(obj.deployment.identifier)
-            return dict([[dd, dev_link] for dd in
-                        ["online_offline",
-                         "online_only_single",
-                         "online_only_multi"]]
-                        )
+            return obj.deployment.get_enketo_survey_links()
         else:
             return {}
 
@@ -666,7 +661,6 @@ class AssetListSerializer(AssetSerializer):
                   'deployed_version_id',
                   'deployment__identifier',
                   'deployment__active',
-                  'deployment__links',
                   'permissions',
                   )
 

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -385,6 +385,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     deployed_versions = serializers.SerializerMethodField()
     deployment__identifier = serializers.SerializerMethodField()
     deployment__active = serializers.SerializerMethodField()
+    deployment__links = serializers.SerializerMethodField()
 
     class Meta:
         model = Asset
@@ -405,6 +406,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                   'deployed_version_id',
                   'deployed_versions',
                   'deployment__identifier',
+                  'deployment__links',
                   'deployment__active',
                   'content',
                   'downloads',
@@ -544,6 +546,17 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def get_deployment__active(self, obj):
         return obj.has_deployment and obj.deployment.active
 
+    def get_deployment__links(self, obj):
+        if obj.has_deployment and obj.deployment.active:
+            dev_link = "https://ee.kobotoolbox.org/x/#YYES"
+            return dict([[dd, dev_link] for dd in
+                        ["online_offline",
+                         "online_only_single",
+                         "online_only_multi"]]
+                        )
+        else:
+            return {}
+
     def _content(self, obj):
         return json.dumps(obj.content)
 
@@ -653,6 +666,7 @@ class AssetListSerializer(AssetSerializer):
                   'deployed_version_id',
                   'deployment__identifier',
                   'deployment__active',
+                  'deployment__links',
                   'permissions',
                   )
 


### PR DESCRIPTION
Closes #705. **NOTE**: `ENKETO_API_TOKEN` now must be specified in the environment.

Available only on the detail view (not the list view). Returns all available Enketo survey URLs per http://apidocs.enketo.org/v2/#/post-survey-all. Some link types listed in the placeholder are not being returned by https://ee.kobotoolbox.org/api/v2/survey/all, and trying to request them specifically (e.g. https://ee.kobotoolbox.org/api/v2/survey/single) returns a 405. Perhaps an Enketo configuration change is required to enable more types of surveys.