### PR TITLE
Collection sharing modal routes back to library

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -1257,7 +1257,7 @@ var CollectionSharing = React.createClass({
     this.listenTo(stores.userExists, this.userExistsStoreChange);
   },
   routeBack () {
-    this.transitionTo('collections');
+    this.transitionTo('library');
   },
   userExistsStoreChange (checked, result) {
     var inpVal = this.usernameFieldValue();

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -5,6 +5,7 @@ import {Navigation} from 'react-router';
 import Dropzone from '../libs/dropzone';
 import Select from 'react-select';
 import mdl from '../libs/rest_framework/material';
+import alertify from 'alertifyjs';
 
 import {dataInterface} from '../dataInterface';
 import actions from '../actions';
@@ -209,6 +210,11 @@ var Drawer = React.createClass({
           actions.permissions.setCollectionDiscoverability(
             collection.uid, discoverable
           );
+        }).catch((jqxhr) => {
+          // maybe publicPerm was already removed
+          if (jqxhr.status !== 404) {
+            alertify.error(t('unexpected error removing public permission'));
+          }
         });
       } else {
         var discovDeferred = actions.permissions.setCollectionDiscoverability(


### PR DESCRIPTION
Fixes #656 
Additional fix for the following:

1. User selects collection;
1. User clicks 'make public';
1. User clicks 'sharing';
1. User toggles off 'link sharing';
1. User closes sharing modal;
1. User clicks 'make private' for previously mentioned collection;
1. Operation fails because 'make private' tries to remove an anonymous `view_collection` permission that no longer exists.