### PR TITLE
Clean up library routes; split drawer component

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -1055,7 +1055,9 @@ var FormSharing = React.createClass({
   },
   routeBack () {
     var params = this.context.router.getCurrentParams();
-    this.transitionTo('form-landing', {assetid: params.assetid});
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    var baseName = isLibrary ? 'library-' : '';
+    this.transitionTo(`${baseName}form-landing`, {assetid: params.assetid});
   },
   userExistsStoreChange (checked, result) {
     var inpVal = this.usernameFieldValue();
@@ -1447,7 +1449,7 @@ var FormEnketoPreview = React.createClass({
       if (asset.asset_type === 'survey') {
         bcRoot = {'label': t('Projects'), 'to': 'forms'};
       } else {
-        bcRoot = {'label': t('Library List'), 'to': 'library'};
+        bcRoot = {'label': t('Library'), 'to': 'library'};
       }
       stores.pageState.setHeaderBreadcrumb([
         bcRoot,
@@ -1478,7 +1480,9 @@ var FormEnketoPreview = React.createClass({
   },
   routeBack () {
     var params = this.context.router.getCurrentParams();
-    this.transitionTo('form-landing', {assetid: params.assetid});
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    var baseName = isLibrary ? 'library-' : '';
+    this.transitionTo(`${baseName}form-landing`, {assetid: params.assetid});
   },
   render () {
     if (this.state.error) {
@@ -1732,22 +1736,36 @@ Demo.collection = React.createClass({
   }
 });
 
+var formRouteChildren = (baseName) => {
+  if (baseName === undefined) {
+    baseName = '';
+  }
+  return [
+    <Route name={`${baseName}form-download`} path="download" handler={FormDownload} />,
+    <Route name={`${baseName}form-json`} path="json" handler={FormJson} />,
+    <Route name={`${baseName}form-xform`} path="xform" handler={FormXform} />,
+    <Route name={`${baseName}form-sharing`} path="sharing" handler={FormSharing} />,
+    <Route name={`${baseName}form-preview-enketo`} path="preview" handler={FormEnketoPreview} />,
+    <Route name={`${baseName}form-edit`} path="edit" handler={FormPage} />
+  ];
+}
+
 var routes = (
   <Route name="home" path="/" handler={App}>
-    <Route name="library" handler={LibrarySearchableList}>
+    <Route name="library">
+      <Route name="library-new-form" path="new" handler={AddToLibrary} />
+      <Route name="library-form-landing" path="/library/:assetid">
+        {formRouteChildren('library-')}
+        <DefaultRoute handler={FormLanding} />
+      </Route>
+      <DefaultRoute handler={LibrarySearchableList} />
     </Route>
 
     <Route name="forms" handler={Forms}>
       <Route name="new-form" path="new" handler={NewForm} />
-      <Route name="add-to-library" path="add-to-library" handler={AddToLibrary} />
 
       <Route name="form-landing" path="/forms/:assetid">
-        <Route name="form-download" path="download" handler={FormDownload} />
-        <Route name="form-json" path="json" handler={FormJson} />
-        <Route name="form-xform" path="xform" handler={FormXform} />
-        <Route name="form-sharing" path="sharing" handler={FormSharing} />
-        <Route name="form-preview-enketo" path="preview" handler={FormEnketoPreview} />
-        <Route name='form-edit' path="edit" handler={FormPage} />
+        {formRouteChildren()}
         <DefaultRoute handler={FormLanding} />
       </Route>
 

--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -48,6 +48,7 @@ import {
   log,
   t,
   assign,
+  isLibrary,
 } from './utils';
 
 mixins.permissions = {
@@ -153,9 +154,10 @@ class ItemDropdown extends React.Component {
 
 class ItemDropdownItem extends React.Component {
   render () {
+    var baseName = isLibrary(this.context.router) ? 'library-' : '';
     return (
           <li>
-            <Link to='form-edit'
+            <Link to={`${baseName}form-edit`}
                   params={{assetid: this.props.uid}}>
               <i className={classNames('fa', 'fa-sm', this.props.faIcon)} />
               &nbsp;
@@ -1055,8 +1057,7 @@ var FormSharing = React.createClass({
   },
   routeBack () {
     var params = this.context.router.getCurrentParams();
-    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
-    var baseName = isLibrary ? 'library-' : '';
+    var baseName = isLibrary(this.context.router) ? 'library-' : '';
     this.transitionTo(`${baseName}form-landing`, {assetid: params.assetid});
   },
   userExistsStoreChange (checked, result) {
@@ -1480,8 +1481,7 @@ var FormEnketoPreview = React.createClass({
   },
   routeBack () {
     var params = this.context.router.getCurrentParams();
-    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
-    var baseName = isLibrary ? 'library-' : '';
+    var baseName = isLibrary(this.context.router) ? 'library-' : '';
     this.transitionTo(`${baseName}form-landing`, {assetid: params.assetid});
   },
   render () {

--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -12,6 +12,7 @@ import {
   anonUsername,
   t,
   assign,
+  isLibrary,
 } from '../utils';
 
 var AssetTypeIcon = bem.create('asset-type-icon');
@@ -70,8 +71,9 @@ var AssetRow = React.createClass({
     // var perm = this.props.perm;
     var isPublic = this.props.owner__username === anonUsername;
     var _rc = this.props.summary && this.props.summary.row_count;
+    var baseName = isLibrary(this.context.router) ? 'library-' : '';
     var isCollection = this.props.kind === 'collection',
-        hrefTo = isCollection ? 'collection-page' : 'form-landing',
+        hrefTo = isCollection ? 'collection-page' : `${baseName}form-landing`,
         hrefKey = isCollection ? 'uid' : 'assetid',
         hrefParams = {},
         tags = this.props.tags || [];

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -104,8 +104,8 @@ var Drawer = React.createClass({
     this.setStates();
   },
   setStates() {
-    var breadcrumb = this.state.headerBreadcrumb;
-    if (breadcrumb[0] && breadcrumb[0].to == 'library') {
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    if (isLibrary) {
       this.setState({
         headerFilters: 'library',
         searchContext: searches.getSearchContext('library', {
@@ -146,6 +146,7 @@ var Drawer = React.createClass({
       filteredCollectionUid: collectionUid,
       filteredByPublicCollection: publicCollection,
     });
+    this.transitionTo('library');
   },
   clickShowPublicCollections (evt) {
     //TODO: show the collections in the main pane?
@@ -295,7 +296,7 @@ var Drawer = React.createClass({
                     {this.state.headerFilters == 'library' ?
                       <ul htmlFor="sidebar-menu" className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect">
                         <bem.CollectionNav__link key={'new-asset'} m={['new', 'new-block']} className="mdl-menu__item"
-                            href={this.makeHref('add-to-library')}>
+                            href={this.makeHref('library-new-form')}>
                           <i />
                           {t('add to library')}
                         </bem.CollectionNav__link>

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -81,6 +81,133 @@ var Drawer = React.createClass({
     Reflux.connect(stores.session),
     Reflux.connect(stores.pageState)
   ],
+  toggleFixedDrawer() {
+    stores.pageState.toggleFixedDrawer();
+  },
+  render () {
+    return (
+          <bem.Drawer className='k-drawer mdl-shadow--2dp'>
+            <nav className='k-drawer__icons'>
+              <DrawerLink label={t('Projects')} linkto='forms' ki-icon='projects' />
+              <DrawerLink label={t('Library')} linkto='library' ki-icon='library' />
+              { stores.session.currentAccount ?
+                  <DrawerLink label={t('Projects')} active='true' href={stores.session.currentAccount.projects_url} className="is-edge" ki-icon='globe' />
+              : null }
+              <div className="mdl-layout-spacer"></div>
+
+              <div className='k-drawer__icons-bottom'>
+                <DrawerLink label={t('source')} href='https://github.com/kobotoolbox/' ki-icon='github' />
+                <DrawerLink label={t('help')} href='http://support.kobotoolbox.org/' ki-icon='help' />
+              </div>
+            </nav>
+
+            <div className="drawer__sidebar">
+              <button className="mdl-button mdl-button--icon k-drawer__close" onClick={this.toggleFixedDrawer}>
+                <i className="fa fa-close"></i>
+              </button>
+              { isLibrary(this.context.router)
+                ? <LibrarySidebar />
+                : <FormSidebar />
+              }
+            </div>
+
+            <ReactTooltip effect="float" place="bottom" />
+          </bem.Drawer>
+      );
+  },
+  componentDidUpdate() {
+    mdl.upgradeDom();
+  }
+});
+
+var FormSidebar = React.createClass({
+  mixins: [
+    searches.common,
+    mixins.droppable,
+    Navigation,
+    Reflux.connect(stores.session),
+    Reflux.connect(stores.pageState)
+  ],
+  componentDidMount () {
+    this.searchDefault();
+  },
+  getInitialState () {
+    return assign({}, stores.pageState.state);
+  },
+  componentWillMount() {
+    this.setStates();
+  },
+  setStates() {
+    this.setState({
+      headerFilters: 'forms',
+      searchContext: searches.getSearchContext('forms', {
+        filterParams: {
+          assetType: 'asset_type:survey',
+        },
+        filterTags: 'asset_type:survey',
+      })
+    });
+  },
+  render () {
+    return (
+      <div>
+        {this.state.headerBreadcrumb.map((item, n)=>{
+          if (n < 1) {
+            return (
+              <div className="header-breadcrumb__item" key={`bc${n}`}>
+                <i className="k-icon-projects" />
+                {
+                  ('to' in item) ?
+                  <Link to={item.to} params={item.params}>{item.label}</Link>
+                  :
+                  <a href={item.href}>{item.label}</a>
+                }
+              </div>
+            );
+          } else {
+            return '';
+          }
+        })}
+
+        <bem.CollectionNav>
+          <bem.CollectionNav__actions className="k-form-list-actions">
+            <button id="sidebar-menu"
+                    className="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
+              {t('new')}
+            </button>
+            <ul htmlFor="sidebar-menu" className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect">
+              <bem.CollectionNav__link className="mdl-menu__item" m={['new', 'new-block']}
+                  href={this.makeHref('new-form')}>
+                <i />
+                {t('new form')}
+              </bem.CollectionNav__link>
+              <Dropzone onDropFiles={this.dropFiles} params={{destination: false}} fileInput>
+                <bem.CollectionNav__button m={['upload', 'upload-block']} className="mdl-menu__item">
+                  <i className='fa fa-icon fa-cloud fa-fw' />
+                  {t('upload')}
+                </bem.CollectionNav__button>
+              </Dropzone>
+            </ul>
+          </bem.CollectionNav__actions>
+        </bem.CollectionNav>
+        <SidebarFormsList/>
+      </div>
+    );
+  },
+  componentWillReceiveProps() {
+    this.setStates();
+  }
+
+});
+
+var LibrarySidebar = React.createClass({
+  mixins: [
+    searches.common,
+    mixins.droppable,
+    Navigation,
+    Reflux.connect(stores.session),
+    Reflux.connect(stores.pageState)
+  ],
   queryCollections () {
     dataInterface.listCollections().then((collections)=>{
       this.setState({
@@ -105,28 +232,15 @@ var Drawer = React.createClass({
     this.setStates();
   },
   setStates() {
-    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
-    if (isLibrary) {
-      this.setState({
-        headerFilters: 'library',
-        searchContext: searches.getSearchContext('library', {
-          filterParams: {
-            assetType: 'asset_type:question OR asset_type:block',
-          },
-          filterTags: 'asset_type:question OR asset_type:block',
-        })
-      });
-    } else {
-      this.setState({
-        headerFilters: 'forms',
-        searchContext: searches.getSearchContext('forms', {
-          filterParams: {
-            assetType: 'asset_type:survey',
-          },
-          filterTags: 'asset_type:survey',
-        })
-      });
-    }
+    this.setState({
+      headerFilters: 'library',
+      searchContext: searches.getSearchContext('library', {
+        filterParams: {
+          assetType: 'asset_type:question OR asset_type:block',
+        },
+        filterTags: 'asset_type:question OR asset_type:block',
+      })
+    });
   },
   clickFilterByCollection (evt) {
     var data = $(evt.currentTarget).data();
@@ -240,246 +354,193 @@ var Drawer = React.createClass({
       });
     };
   },
-  toggleFixedDrawer() {
-    stores.pageState.toggleFixedDrawer();
-  },
   render () {
     return (
-          <bem.Drawer className='k-drawer mdl-shadow--2dp'>
-            <nav className='k-drawer__icons'>
-              <DrawerLink label={t('Projects')} linkto='forms' ki-icon='projects' />
-              <DrawerLink label={t('Library')} linkto='library' ki-icon='library' />
-              { stores.session.currentAccount ?
-                  <DrawerLink label={t('Projects')} active='true' href={stores.session.currentAccount.projects_url} className="is-edge" ki-icon='globe' />
-              : null }
-              <div className="mdl-layout-spacer"></div>
-
-              <div className='k-drawer__icons-bottom'>
-                <DrawerLink label={t('source')} href='https://github.com/kobotoolbox/' ki-icon='github' />
-                <DrawerLink label={t('help')} href='http://support.kobotoolbox.org/' ki-icon='help' />
-              </div>
-            </nav>
-
-            <div className="drawer__sidebar">
-              <button className="mdl-button mdl-button--icon k-drawer__close" onClick={this.toggleFixedDrawer}>
-                <i className="fa fa-close"></i>
-              </button>
-
-              {this.state.headerBreadcrumb.map((item, n)=>{
-                if (n < 1) {
-                  return (
-                    <div className="header-breadcrumb__item" key={`bc${n}`}>
-                      {item.to == 'library' ?
-                        <i className="k-icon-library" />
-                      :
-                        <i className="k-icon-projects" />
-                      }
-                      {
-                        ('to' in item) ?
-                        <Link to={item.to} params={item.params}>{item.label}</Link>
-                        :
-                        <a href={item.href}>{item.label}</a>
-                      }
-                    </div>
-                  );
-                } else {
-                  return '';
+      <div>
+        {this.state.headerBreadcrumb.map((item, n)=>{
+          if (n < 1) {
+            return (
+              <div className="header-breadcrumb__item" key={`bc${n}`}>
+                <i className="k-icon-library" />
+                {
+                  ('to' in item) ?
+                  <Link to={item.to} params={item.params}>{item.label}</Link>
+                  :
+                  <a href={item.href}>{item.label}</a>
                 }
-              })}
+              </div>
+            );
+          } else {
+            return '';
+          }
+        })}
 
-              <bem.CollectionNav>
-                <bem.CollectionNav__actions className="k-form-list-actions">
-                  <button id="sidebar-menu"
-                          className="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
-                    {t('new')}
-                  </button>
+        <bem.CollectionNav>
+          <bem.CollectionNav__actions className="k-form-list-actions">
+            <button id="sidebar-menu"
+                    className="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
+              {t('new')}
+            </button>
+            <ul htmlFor="sidebar-menu" className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect">
+              <bem.CollectionNav__link key={'new-asset'} m={['new', 'new-block']} className="mdl-menu__item"
+                  href={this.makeHref('library-new-form')}>
+                <i />
+                {t('add to library')}
+              </bem.CollectionNav__link>
+              <bem.CollectionNav__button key={'new-collection'} m={['new', 'new-collection']} className="mdl-menu__item"
+                  onClick={this.createCollection}>
+                <i />
+                {t('new collection')}
+              </bem.CollectionNav__button>
+            </ul>
+          </bem.CollectionNav__actions>
+        </bem.CollectionNav>
 
-                    {this.state.headerFilters == 'library' ?
-                      <ul htmlFor="sidebar-menu" className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect">
-                        <bem.CollectionNav__link key={'new-asset'} m={['new', 'new-block']} className="mdl-menu__item"
-                            href={this.makeHref('library-new-form')}>
-                          <i />
-                          {t('add to library')}
-                        </bem.CollectionNav__link>
-                        <bem.CollectionNav__button key={'new-collection'} m={['new', 'new-collection']} className="mdl-menu__item"
-                            onClick={this.createCollection}>
-                          <i />
-                          {t('new collection')}
-                        </bem.CollectionNav__button>
-                      </ul>
-                    : null }
-                    {this.state.headerFilters == 'forms' ?
-                      <ul htmlFor="sidebar-menu" className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect">
-                        <bem.CollectionNav__link className="mdl-menu__item" m={['new', 'new-block']}
-                            href={this.makeHref('new-form')}>
-                          <i />
-                          {t('new form')}
-                        </bem.CollectionNav__link>
-                        <Dropzone onDropFiles={this.dropFiles} params={{destination: false}} fileInput>
-                          <bem.CollectionNav__button m={['upload', 'upload-block']} className="mdl-menu__item">
-                            <i className='fa fa-icon fa-cloud fa-fw' />
-                            {t('upload')}
-                          </bem.CollectionNav__button>
-                        </Dropzone>
-                      </ul>
-                    : null }
-                </bem.CollectionNav__actions>
-              </bem.CollectionNav>
-
-              { this.state.sidebarCollections && this.state.headerFilters == 'library' &&
-                <bem.CollectionSidebar>
+        { this.state.sidebarCollections &&
+          <bem.CollectionSidebar>
+            <bem.CollectionSidebar__item
+              key='allitems'
+              m={{
+                  toplevel: true,
+                  selected: !this.state.filteredCollectionUid,
+                }} onClick={this.clickFilterByCollection}>
+              <i className="fa fa-caret-down" />
+              <i className="k-icon-folder" />
+              {t('My Library')}
+            </bem.CollectionSidebar__item>
+            {this.state.sidebarCollections.map((collection)=>{
+              var editLink = this.makeHref('collection-page', {uid: collection.uid}),
+                sharingLink = this.makeHref('collection-sharing', {assetid: collection.uid});
+              var iconClass = 'k-icon-folder';
+              switch (collection.access_type) {
+                case 'public':
+                case 'subscribed':
+                  iconClass = 'k-icon-globe';
+                  break;
+                case 'shared':
+                  iconClass = 'k-icon-folder-share';
+              }
+              return (
                   <bem.CollectionSidebar__item
-                    key='allitems'
+                    key={collection.uid}
                     m={{
-                        toplevel: true,
-                        selected: !this.state.filteredCollectionUid,
-                      }} onClick={this.clickFilterByCollection}>
-                    <i className="fa fa-caret-down" />
-                    <i className="k-icon-folder" />
-                    {t('My Library')}
-                  </bem.CollectionSidebar__item>
-                  {this.state.sidebarCollections.map((collection)=>{
-                    var editLink = this.makeHref('collection-page', {uid: collection.uid}),
-                      sharingLink = this.makeHref('collection-sharing', {assetid: collection.uid});
-                    var iconClass = 'k-icon-folder';
-                    switch (collection.access_type) {
-                      case 'public':
-                      case 'subscribed':
-                        iconClass = 'k-icon-globe';
-                        break;
-                      case 'shared':
-                        iconClass = 'k-icon-folder-share';
+                      collection: true,
+                      selected:
+                        this.state.filteredCollectionUid ===
+                          collection.uid &&
+                        !this.state.filteredByPublicCollection,
+                    }}
+                    onClick={this.clickFilterByCollection}
+                    data-collection-uid={collection.uid}
+                  >
+                    <i className={iconClass} />
+                    {collection.name}
+                    { collection.access_type !== 'owned' ?
+                        <bem.CollectionSidebar__itembyline>
+                        {t('by ___').replace('___', collection.owner__username)}
+                        </bem.CollectionSidebar__itembyline>
+                      : null
                     }
-                    return (
-                        <bem.CollectionSidebar__item
-                          key={collection.uid}
-                          m={{
-                            collection: true,
-                            selected:
-                              this.state.filteredCollectionUid ===
-                                collection.uid &&
-                              !this.state.filteredByPublicCollection,
-                          }}
-                          onClick={this.clickFilterByCollection}
-                          data-collection-uid={collection.uid}
-                        >
-                          <i className={iconClass} />
-                          {collection.name}
-                          { collection.access_type !== 'owned' ?
-                              <bem.CollectionSidebar__itembyline>
-                              {t('by ___').replace('___', collection.owner__username)}
-                              </bem.CollectionSidebar__itembyline>
-                            : null
-                          }
-                          <bem.CollectionSidebar__itemactions>
-                            { collection.access_type === 'subscribed' ?
-                                <bem.CollectionSidebar__itemlink href={'#'}
-                                  onClick={this.unsubscribeCollection}
-                                  data-collection-uid={collection.uid}>
-                                  {t('unsubscribe')}
-                                </bem.CollectionSidebar__itemlink>
-                              : [
-                                <bem.CollectionSidebar__itemlink href={'#'}
-                                  onClick={this.deleteCollection}
-                                  data-collection-uid={collection.uid}>
-                                  {t('delete')}
-                                </bem.CollectionSidebar__itemlink>,
-                                <bem.CollectionSidebar__itemlink href={sharingLink}>
-                                  {t('sharing')}
-                                </bem.CollectionSidebar__itemlink>,
-                                <br />,
-                                <bem.CollectionSidebar__itemlink href={'#'}
-                                  onClick={this.renameCollection(collection)
-                                }>
-                                  {t('rename')}
-                                </bem.CollectionSidebar__itemlink>,
-                                collection.access_type === 'owned' ?
-                                  collection.discoverable_when_public ?
-                                    <bem.CollectionSidebar__itemlink href={'#'}
-                                      onClick={
-                                        this.setCollectionDiscoverability(
-                                          false, collection)
-                                    }>
-                                      {t('make private')}
-                                    </bem.CollectionSidebar__itemlink>
-                                  :
-                                    <bem.CollectionSidebar__itemlink href={'#'}
-                                      onClick={
-                                        this.setCollectionDiscoverability(
-                                          true, collection)
-                                    }>
-                                      {t('make public')}
-                                    </bem.CollectionSidebar__itemlink>
-                                : null
-                              ]
-                            }
-                          </bem.CollectionSidebar__itemactions>
-                        </bem.CollectionSidebar__item>
-                      );
-                  })}
-                  <bem.CollectionSidebar__item
-                    key='public'
-                    m={{
-                        toplevel: true,
-                        selected: this.state.showPublicCollections,
-                      }} onClick={this.clickShowPublicCollections}>
-                    <i className="fa fa-caret-down" />
-                    <i className="k-icon-folder" />
-                    {t('Public Collections')}
+                    <bem.CollectionSidebar__itemactions>
+                      { collection.access_type === 'subscribed' ?
+                          <bem.CollectionSidebar__itemlink href={'#'}
+                            onClick={this.unsubscribeCollection}
+                            data-collection-uid={collection.uid}>
+                            {t('unsubscribe')}
+                          </bem.CollectionSidebar__itemlink>
+                        : [
+                          <bem.CollectionSidebar__itemlink href={'#'}
+                            onClick={this.deleteCollection}
+                            data-collection-uid={collection.uid}>
+                            {t('delete')}
+                          </bem.CollectionSidebar__itemlink>,
+                          <bem.CollectionSidebar__itemlink href={sharingLink}>
+                            {t('sharing')}
+                          </bem.CollectionSidebar__itemlink>,
+                          <br />,
+                          <bem.CollectionSidebar__itemlink href={'#'}
+                            onClick={this.renameCollection(collection)
+                          }>
+                            {t('rename')}
+                          </bem.CollectionSidebar__itemlink>,
+                          collection.access_type === 'owned' ?
+                            collection.discoverable_when_public ?
+                              <bem.CollectionSidebar__itemlink href={'#'}
+                                onClick={
+                                  this.setCollectionDiscoverability(
+                                    false, collection)
+                              }>
+                                {t('make private')}
+                              </bem.CollectionSidebar__itemlink>
+                            :
+                              <bem.CollectionSidebar__itemlink href={'#'}
+                                onClick={
+                                  this.setCollectionDiscoverability(
+                                    true, collection)
+                              }>
+                                {t('make public')}
+                              </bem.CollectionSidebar__itemlink>
+                          : null
+                        ]
+                      }
+                    </bem.CollectionSidebar__itemactions>
                   </bem.CollectionSidebar__item>
-                  {this.state.sidebarPublicCollections.map((collection)=>{
-                    var editLink = this.makeHref('collection-page', {uid: collection.uid}),
-                      sharingLink = this.makeHref('collection-sharing', {assetid: collection.uid});
-                    return (
-                        <bem.CollectionSidebar__item
-                          key={collection.uid}
-                          m={{
-                            collection: true,
-                            selected:
-                              this.state.filteredCollectionUid ===
-                                collection.uid &&
-                              this.state.filteredByPublicCollection,
-                          }}
-                          onClick={this.clickFilterByCollection}
-                          data-collection-uid={collection.uid}
-                          data-public-collection={true}
-                        >
-                          <i className="k-icon-globe" />
-                          {collection.name}
-                          <bem.CollectionSidebar__itembyline>
-                          {t('by ___').replace('___', collection.owner__username)}
-                          </bem.CollectionSidebar__itembyline>
-                          <bem.CollectionSidebar__itemactions>
-                            { collection.access_type === 'subscribed' ?
-                                <bem.CollectionSidebar__itemlink href={'#'}
-                                  onClick={this.unsubscribeCollection}
-                                  data-collection-uid={collection.uid}>
-                                  {t('unsubscribe')}
-                                </bem.CollectionSidebar__itemlink>
-                              :
-                                <bem.CollectionSidebar__itemlink href={'#'}
-                                  onClick={this.subscribeCollection}
-                                  data-collection-uid={collection.uid}>
-                                  {t('subscribe')}
-                                </bem.CollectionSidebar__itemlink>
-                            }
-                          </bem.CollectionSidebar__itemactions>
-                        </bem.CollectionSidebar__item>
-                      );
-                  })}
-                </bem.CollectionSidebar>
-              }
-              { this.state.headerFilters == 'forms' &&
-                <SidebarFormsList/>
-              }
-            </div>
-
-            <ReactTooltip effect="float" place="bottom" />
-          </bem.Drawer>
+                );
+            })}
+            <bem.CollectionSidebar__item
+              key='public'
+              m={{
+                  toplevel: true,
+                  selected: this.state.showPublicCollections,
+                }} onClick={this.clickShowPublicCollections}>
+              <i className="fa fa-caret-down" />
+              <i className="k-icon-folder" />
+              {t('Public Collections')}
+            </bem.CollectionSidebar__item>
+            {this.state.sidebarPublicCollections.map((collection)=>{
+              var editLink = this.makeHref('collection-page', {uid: collection.uid}),
+                sharingLink = this.makeHref('collection-sharing', {assetid: collection.uid});
+              return (
+                  <bem.CollectionSidebar__item
+                    key={collection.uid}
+                    m={{
+                      collection: true,
+                      selected:
+                        this.state.filteredCollectionUid ===
+                          collection.uid &&
+                        this.state.filteredByPublicCollection,
+                    }}
+                    onClick={this.clickFilterByCollection}
+                    data-collection-uid={collection.uid}
+                    data-public-collection={true}
+                  >
+                    <i className="k-icon-globe" />
+                    {collection.name}
+                    <bem.CollectionSidebar__itembyline>
+                    {t('by ___').replace('___', collection.owner__username)}
+                    </bem.CollectionSidebar__itembyline>
+                    <bem.CollectionSidebar__itemactions>
+                      { collection.access_type === 'subscribed' ?
+                          <bem.CollectionSidebar__itemlink href={'#'}
+                            onClick={this.unsubscribeCollection}
+                            data-collection-uid={collection.uid}>
+                            {t('unsubscribe')}
+                          </bem.CollectionSidebar__itemlink>
+                        :
+                          <bem.CollectionSidebar__itemlink href={'#'}
+                            onClick={this.subscribeCollection}
+                            data-collection-uid={collection.uid}>
+                            {t('subscribe')}
+                          </bem.CollectionSidebar__itemlink>
+                      }
+                    </bem.CollectionSidebar__itemactions>
+                  </bem.CollectionSidebar__item>
+                );
+            })}
+          </bem.CollectionSidebar>
+        }
+      </div>
       );
-  },
-  componentDidUpdate() {
-    mdl.upgradeDom();
   },
   componentWillReceiveProps() {
     this.setStates();

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -22,6 +22,7 @@ import {
   assign,
   getAnonymousUserPermission,
   anonUsername,
+  isLibrary,
 } from '../utils';
 
 import SidebarFormsList from '../lists/sidebarForms';

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -12,6 +12,7 @@ import {
   notify,
   assign,
   t,
+  isLibrary,
 } from '../utils';
 
 import {
@@ -206,34 +207,30 @@ export default assign({
     this.setBreadcrumb();
   },
   setBreadcrumb (params={}) {
-    let isLibrary;
-    if (params.asset_type) {
-      isLibrary = params.asset_type !== 'survey';
-    } else {
-      this.isLibrary();
-    }
+    let library = isLibrary(this.context.router);
+    var baseName = library ? 'library-' : '';
     let bcData = [
       {
-        'label': isLibrary ? t('Library') : t('Projects'),
-        'to': isLibrary ? 'library' : 'forms',
+        'label': library ? t('Library') : t('Projects'),
+        'to': library ? 'library' : 'forms',
       }
     ];
     if (this.editorState === 'new') {
       bcData.push({
         label: t('new'),
-        to: `${isLibrary ? 'library-' : ''}new-form`,
+        to: `${baseName}new-form`,
       });
     } else {
       let uid = params.asset_uid || this.state.asset_uid || this.props.params.assetid,
           asset_type = params.asset_type || this.state.asset_type || 'asset';
       bcData.push({
         label: t(`view-${asset_type}`),
-        to: `${isLibrary ? 'library-' : ''}form-landing`,
+        to: `${baseName}form-landing`,
         params: {assetid: uid},
       });
       bcData.push({
         label: t(`edit-${asset_type}`),
-        to: `${isLibrary ? 'library-' : ''}form-edit`,
+        to: `${baseName}form-edit`,
         params: {assetid: uid},
       });
     }
@@ -320,13 +317,6 @@ export default assign({
   needsSave () {
     return this.state.asset_updated === update_states.UNSAVED_CHANGES;
   },
-  isLibrary () {
-    if (this.state.asset_type) {
-      return this.state.asset_type !== 'survey';
-    } else {
-      return !!this.context.router.getCurrentPath().match(/library/);
-    }
-  },
   previewForm (evt) {
     if (evt && evt.preventDefault) {
       evt.preventDefault();
@@ -372,10 +362,12 @@ export default assign({
       params.name = this.state.name;
     }
     if (this.editorState === 'new') {
-      params.asset_type = this.isLibrary() ? 'block' : 'survey';
+      var library = isLibrary(this.context.router);
+      var baseName = library ? 'library-' : '';
+      params.asset_type = library ? 'block' : 'survey';
       actions.resources.createResource(params)
         .then((asset) => {
-          this.transitionTo(`${this.isLibrary() ? 'library-' : ''}form-edit`, {assetid: asset.uid});
+          this.transitionTo(`${baseName}form-edit`, {assetid: asset.uid});
         })
     } else {
       // update existing
@@ -430,7 +422,7 @@ export default assign({
         return hasSelect;
       })(); // todo: only true if survey has select questions
       ooo.name = this.state.name;
-      ooo.hasSettings = !this.isLibrary();
+      ooo.hasSettings = !isLibrary(this.context.router);
       ooo.styleValue = this.state.settings__style;
     }
     if (this.editorState === 'new') {
@@ -595,7 +587,7 @@ export default assign({
   },
   renderNotLoadedMessage () {
     if (this.state.surveyLoadError) {
-      var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+      var baseName = isLibrary(this.context.router) ? 'library-' : '';
       return (
           <ErrorMessage>
             <ErrorMessage__strong>
@@ -606,7 +598,7 @@ export default assign({
             </p>
             <div>
               <ErrorMessage__link m="raised"
-                  href={this.makeHref(`${isLibrary ? 'library-' : ''}form-landing`, {
+                  href={this.makeHref(`${baseName}form-landing`, {
                     assetid: this.props.params.assetid,
                   })}>
                 {t('Back')}
@@ -691,7 +683,7 @@ export default assign({
     });
   },
   render () {
-    var isSurvey = this.app && !this.isLibrary();
+    var isSurvey = this.app && !isLibrary(this.context.router);
     return (
         <DocumentTitle title={this.state.name || t('Untitled')}>
           <ui.Panel m={'transparent'}>

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -214,26 +214,26 @@ export default assign({
     }
     let bcData = [
       {
-        'label': isLibrary ? t('Library List') : t('Projects'),
+        'label': isLibrary ? t('Library') : t('Projects'),
         'to': isLibrary ? 'library' : 'forms',
       }
     ];
     if (this.editorState === 'new') {
       bcData.push({
         label: t('new'),
-        to: isLibrary ? 'add-to-library' : 'new-form',
+        to: `${isLibrary ? 'library-' : ''}new-form`,
       });
     } else {
       let uid = params.asset_uid || this.state.asset_uid || this.props.params.assetid,
           asset_type = params.asset_type || this.state.asset_type || 'asset';
       bcData.push({
         label: t(`view-${asset_type}`),
-        to: 'form-landing',
+        to: `${isLibrary ? 'library-' : ''}form-landing`,
         params: {assetid: uid},
       });
       bcData.push({
         label: t(`edit-${asset_type}`),
-        to: 'form-edit',
+        to: `${isLibrary ? 'library-' : ''}form-edit`,
         params: {assetid: uid},
       });
     }
@@ -375,7 +375,7 @@ export default assign({
       params.asset_type = this.isLibrary() ? 'block' : 'survey';
       actions.resources.createResource(params)
         .then((asset) => {
-          this.transitionTo('form-edit', {assetid: asset.uid});
+          this.transitionTo(`${this.isLibrary() ? 'library-' : ''}form-edit`, {assetid: asset.uid});
         })
     } else {
       // update existing
@@ -595,6 +595,7 @@ export default assign({
   },
   renderNotLoadedMessage () {
     if (this.state.surveyLoadError) {
+      var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
       return (
           <ErrorMessage>
             <ErrorMessage__strong>
@@ -605,7 +606,7 @@ export default assign({
             </p>
             <div>
               <ErrorMessage__link m="raised"
-                  href={this.makeHref('form-landing', {
+                  href={this.makeHref(`${isLibrary ? 'library-' : ''}form-landing`, {
                     assetid: this.props.params.assetid,
                   })}>
                 {t('Back')}

--- a/jsapp/js/editorMixins/existingForm.es6
+++ b/jsapp/js/editorMixins/existingForm.es6
@@ -2,6 +2,7 @@ import {
   t,
   log,
   customConfirmAsync,
+  isLibrary,
 } from '../utils';
 
 import stores from '../stores';
@@ -27,8 +28,7 @@ export default {
     });
   },
   navigateBack () {
-    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
-    var routeName = `${isLibrary ? 'library-' : ''}form-landing`;
+    var routeName = `${isLibrary(this.context.router) ? 'library-' : ''}form-landing`;
     if (!this.needsSave()) {
       this.transitionTo(routeName, {assetid: this.props.params.assetid});
     } else {

--- a/jsapp/js/editorMixins/existingForm.es6
+++ b/jsapp/js/editorMixins/existingForm.es6
@@ -27,12 +27,14 @@ export default {
     });
   },
   navigateBack () {
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    var routeName = `${isLibrary ? 'library-' : ''}form-landing`;
     if (!this.needsSave()) {
-      this.transitionTo('form-landing', {assetid: this.props.params.assetid});
+      this.transitionTo(routeName, {assetid: this.props.params.assetid});
     } else {
       customConfirmAsync(t('you have unsaved changes. leave form without saving?'))
         .done(() => {
-          this.transitionTo('form-landing', {assetid: this.props.params.assetid});
+          this.transitionTo(routeName, {assetid: this.props.params.assetid});
         });
     }
   },

--- a/jsapp/js/lists/sidebarForms.es6
+++ b/jsapp/js/lists/sidebarForms.es6
@@ -12,7 +12,8 @@ import SearchCollectionList from '../components/searchcollectionlist';
 import {
   parsePermissions,
   t,
-  assign
+  assign,
+  isLibrary
 } from '../utils';
 
 var SidebarFormsList = React.createClass({
@@ -48,9 +49,10 @@ var SidebarFormsList = React.createClass({
     this.setState(searchStoreState);
   },
   renderMiniAssetRow (resource) {
+    var baseName = isLibrary(this.context.router) ? 'library-' : '';
     return (
         <bem.FormSidebar__item key={resource.uid}>
-          <bem.FormSidebar__itemlink href={this.makeHref('form-landing', {assetid: resource.uid})}>
+          <bem.FormSidebar__itemlink href={this.makeHref(`${baseName}form-landing`, {assetid: resource.uid})}>
             <ui.SidebarAssetName {...resource} />
           </bem.FormSidebar__itemlink>
         </bem.FormSidebar__item>

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -190,17 +190,17 @@ var dmix = {
         <bem.FormView__group m='buttons'>
           <bem.FormView__link m={['edit', {
               disabled: !this.state.userCanEdit,
-                }]} 
+                }]}
               href={this.makeHref('form-edit', {assetid: this.state.uid})}
               data-tip={t('Edit in Form Builder')}>
             <i className="k-icon-edit" />
           </bem.FormView__link>
-          <bem.FormView__link m='preview' 
+          <bem.FormView__link m='preview'
             href={this.makeHref('form-preview-enketo', {assetid: this.state.uid})}
             data-tip={t('Preview')}>
             <i className="k-icon-view" />
           </bem.FormView__link>
-          <bem.FormView__link m={'deploy'} 
+          <bem.FormView__link m={'deploy'}
             onClick={this.deployAsset}
             data-tip={this.state.deployed_version_id === null ? t('deploy') : t('redeploy')}>
             <i className="k-icon-deploy" />
@@ -214,7 +214,7 @@ var dmix = {
                 <i className="k-icon-replace" />
               </bem.FormView__link>
             </Dropzone>
-            <bem.FormView__item m={'more-actions'} 
+            <bem.FormView__item m={'more-actions'}
               onFocus={this.toggleDownloads}
               onBlur={this.toggleDownloads}>
               <bem.FormView__button disabled={!downloadable}>
@@ -284,7 +284,7 @@ var dmix = {
               {t('Delete this project')}
             </a>
           </li>
-        </ul> 
+        </ul>
       </bem.FormView__extras>
       );
   },
@@ -518,7 +518,7 @@ var dmix = {
         {
           key: key,
           value: value,
-          label: label, 
+          label: label,
           desc: desc
         }
       );
@@ -538,10 +538,10 @@ var dmix = {
           <a href="http://support.kobotoolbox.org/customer/en/portal/articles/1653790-collecting-data-through-web-forms"
              className="collect-link collect-link__web"
              target="_blank">
-            {t('Learn more')} 
+            {t('Learn more')}
             <i className="fa fa-arrow-right"></i>
           </a>
-          <bem.FormView__item m={'collect'} 
+          <bem.FormView__item m={'collect'}
             onFocus={this.toggleCollectOptions}
             onBlur={this.toggleCollectOptions}>
             <bem.FormView__button m='collectOptions'>
@@ -552,7 +552,7 @@ var dmix = {
               <bem.PopoverMenu ref='collect-popover'>
                 {deployment__links_list.map((c)=>{
                   return (
-                      <bem.PopoverMenu__link  key={`c-${c.value}`} 
+                      <bem.PopoverMenu__link  key={`c-${c.value}`}
                                               onClick={this.setSelectedCollectOption(c)}
                                               className={this.state.selectedCollectOption.value == c.value ? 'active' : null}>
                         <span className="label">{c.label}</span>
@@ -585,13 +585,13 @@ var dmix = {
           <a href="http://support.kobotoolbox.org/customer/en/portal/articles/1653782-collecting-data-with-kobocollect-on-android"
              className="collect-link collect-link__android"
              target="_blank">
-            {t('Learn more')} 
+            {t('Learn more')}
             <i className="fa fa-arrow-right"></i>
           </a>
 
           <ol>
             <li>
-              {t('Install')} 
+              {t('Install')}
               &nbsp;
               <a href="https://play.google.com/store/apps/details?id=org.koboc.collect.android&hl=en" target="_blank">KoboCollect</a>
               &nbsp;
@@ -655,11 +655,16 @@ var dmix = {
   renderButtons ({deployable}) {
     var downloadable = !!this.state.downloads[0],
         downloads = this.state.downloads;
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    var baseNameHref = (to, params, query) => {
+      var baseName = isLibrary ? 'library-' : '';
+      return this.makeHref(`${baseName}${to}`, params, query);
+    }
 
     return (
         <bem.AssetView__buttons>
           <bem.AssetView__buttoncol>
-            <bem.AssetView__link m='preview' href={this.makeHref('form-preview-enketo', {assetid: this.state.uid})}>
+            <bem.AssetView__link m='preview' href={baseNameHref('form-preview-enketo', {assetid: this.state.uid})}>
               <i />
               {t('preview')}
             </bem.AssetView__link>
@@ -667,7 +672,7 @@ var dmix = {
           <bem.AssetView__buttoncol>
             <bem.AssetView__link m={['edit', {
               disabled: !this.state.userCanEdit,
-                }]} href={this.makeHref('form-edit', {assetid: this.state.uid})}>
+                }]} href={baseNameHref('form-edit', {assetid: this.state.uid})}>
               <i />
               {t('edit')}
             </bem.AssetView__link>
@@ -701,7 +706,7 @@ var dmix = {
             </bem.AssetView__link>
           </bem.AssetView__buttoncol>
           <bem.AssetView__buttoncol>
-            <bem.AssetView__link m='sharing' href={this.makeHref('form-sharing', {assetid: this.state.uid})}>
+            <bem.AssetView__link m='sharing' href={baseNameHref('form-sharing', {assetid: this.state.uid})}>
               <i />
               {t('share')}
             </bem.AssetView__link>
@@ -800,15 +805,15 @@ var dmix = {
   renderDeployments () {
     // var deployed_versions = [
     //     {
-    //       version_id: 1, 
+    //       version_id: 1,
     //       date_deployed: 'June 1 2016',
     //     },
     //     {
-    //       version_id: 2, 
+    //       version_id: 2,
     //       date_deployed: 'June 1 2016',
     //     },
     //     {
-    //       version_id: 3, 
+    //       version_id: 3,
     //       date_deployed: 'June 1 2016',
     //     }
     // ];
@@ -845,7 +850,7 @@ var dmix = {
             </bem.FormView__item>
           </bem.FormView__group>
 
-          {this.state.deployed_versions.length > 0 && 
+          {this.state.deployed_versions.length > 0 &&
             <bem.FormView__group m={["history", this.state.historyExpanded ? 'historyExpanded' : 'historyHidden']}>
               <bem.FormView__group m="history-contents">
                 <bem.FormView__label m='previous-versions'>
@@ -858,7 +863,7 @@ var dmix = {
                       <bem.FormView__item m='version'>
                         {item.version_id}
                         <bem.FormView__group m='buttons'>
-                          <bem.FormView__link m='clone' 
+                          <bem.FormView__link m='clone'
                               data-version-id={item.version_id}
                               data-tip={t('Clone as new project')}
                               onClick={this.saveCloneAs}>
@@ -935,7 +940,7 @@ var dmix = {
         <bem.Loading>
           <bem.Loading__inner>
             <i />
-            {t('loading...')} 
+            {t('loading...')}
           </bem.Loading__inner>
         </bem.Loading>
       </ui.Panel>
@@ -990,7 +995,7 @@ var dmix = {
 
         stores.pageState.setHeaderBreadcrumb([
           {
-            label: isLibrary ? t('Library List') : t('Projects'),
+            label: isLibrary ? t('Library') : t('Projects'),
             to: isLibrary ? 'library' : 'forms',
           },
           {
@@ -1324,6 +1329,11 @@ mixins.clickAssets = {
       evt.preventDefault();
     }
   },
+  baseNameRoute (route) {
+    var isLibrary = !!this.context.router.getCurrentPathname().match(/library/);
+    var baseName = isLibrary ? 'library-' : '';
+    return `${baseName}${route}`;
+  },
   click: {
     collection: {
       sharing: function(uid/*, evt*/){
@@ -1345,7 +1355,7 @@ mixins.clickAssets = {
         this.transitionTo('new-form');
       },
       view: function(uid/*, evt*/){
-        this.transitionTo('form-landing', {assetid: uid});
+        this.transitionTo(this.baseNameRoute('form-landing'), {assetid: uid});
       },
       clone: function(uid/*, evt*/){
         customPromptAsync(t('new name?'))
@@ -1361,10 +1371,10 @@ mixins.clickAssets = {
           });
       },
       download: function(uid/*, evt*/){
-        this.transitionTo('form-download', {assetid: uid});
+        this.transitionTo(this.baseNameRoute('form-download'), {assetid: uid});
       },
       edit: function (uid) {
-        this.transitionTo('form-edit', {assetid: uid});
+        this.transitionTo(this.baseNameRoute('form-edit'), {assetid: uid});
       },
       delete: function(uid/*, evt*/){
         var q_ = t('You are about to permanently delete this form. Are you sure you want to continue?');

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -36,6 +36,8 @@ const clearSearchState = {
   searchResultsSuccess: null,
   searchDebugQuery: false,
   searchResultsCount: 0,
+  parentUid: false,
+  allPublic: false,
 };
 const initialState = assign({
   cleared: false,

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -144,4 +144,8 @@ export var newId = function(prefix='id') {
 
 export var randString = function () {
   return Math.random().toString(36).match(/\.(\S{6}).*/)[1];
+};
+
+export function isLibrary(router) {
+  return !!router.getCurrentPathname().match(/library/);
 }

--- a/jsapp/scss/components/_kobo.drawer.lists.scss
+++ b/jsapp/scss/components/_kobo.drawer.lists.scss
@@ -156,9 +156,10 @@
 .form-sidebar__grouping {
   transition:0.5s all;
   &--visible {
+    max-height:2000px;
   }
   &--collapsed {
-    max-height: 0%;
+    max-height: 0px;
     overflow: hidden;
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "immutable": "^3.4.7",
     "jit-grunt": "^0.9.1",
     "jquery": "^2.1.4",
-    "jquery-ui": "1.11.4",
+    "jquery-ui": "1.10.4",
     "jquery.scrollto": "^2.1.0",
     "json-loader": "^0.5.2",
     "less": "^2.5.1",


### PR DESCRIPTION
Fixes #753 (by cleaning up the routing)
Fixes #754 (by having separate components instead of trying to toggle `searchContext` within a single component)

The `drawer.es6` diff is a little difficult to manage. Basically, where there was once one large `Drawer`, there is now [a small `Drawer` that [loads either the `LibrarySidebar` or `FormSidebar` component depending on the current route](https://github.com/kobotoolbox/kpi/blob/c87bb4dff610a675725b01b0c5a46bfd100a01d8/jsapp/js/components/drawer.es6#L108). [`FormSidebar`](https://github.com/kobotoolbox/kpi/blob/c87bb4dff610a675725b01b0c5a46bfd100a01d8/jsapp/js/components/drawer.es6#L123) and [`LibrarySidebar`](https://github.com/kobotoolbox/kpi/blob/c87bb4dff610a675725b01b0c5a46bfd100a01d8/jsapp/js/components/drawer.es6#L203) should only have methods and render code specific to each (let me know if you spot anything extraneous).