### PR TITLE
Conditionally configure Sentry for Celery

### DIFF
--- a/kobo_playground/celery.py
+++ b/kobo_playground/celery.py
@@ -4,8 +4,6 @@ import os
 import celery
 
 from django.conf import settings
-from raven.contrib.celery import register_signal, register_logger_signal
-from raven.contrib.django.raven_compat.models import client as raven_client
 
 # Attempt to determine the project name from the directory containing this file
 PROJECT_NAME = os.path.basename(os.path.dirname(__file__))
@@ -14,14 +12,19 @@ PROJECT_NAME = os.path.basename(os.path.dirname(__file__))
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{}.settings'.format(
     PROJECT_NAME))
 
-# Log to Sentry from Celery jobs per
-# https://docs.getsentry.com/hosted/clients/python/integrations/celery/
-class Celery(celery.Celery):
-    def on_configure(self):
-        # register a custom filter to filter out duplicate logs
-        register_logger_signal(raven_client)
-        # hook into the Celery error handler
-        register_signal(raven_client)
+Celery = celery.Celery
+if hasattr(settings, 'RAVEN_CONFIG'):
+    from raven.contrib.celery import register_signal, register_logger_signal
+    from raven.contrib.django.raven_compat.models import client as raven_client
+    # Log to Sentry from Celery jobs per
+    # https://docs.getsentry.com/hosted/clients/python/integrations/celery/
+    class RavenCelery(celery.Celery):
+        def on_configure(self):
+            # register a custom filter to filter out duplicate logs
+            register_logger_signal(raven_client)
+            # hook into the Celery error handler
+            register_signal(raven_client)
+    Celery = RavenCelery
 
 app = Celery(PROJECT_NAME)
 # Using a string here means the worker will not have to


### PR DESCRIPTION
Don't do it unless Raven is present and configured. This follows the [`settings.py` convention](https://github.com/kobotoolbox/kpi/blob/f3ea80c4e7ca93b0cee46bbaa68cbc6e616e89cd/kobo_playground/settings.py#L354).