### PR TITLE
`kc_reader` utility

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -28,5 +28,9 @@ class BaseDeploymentBackend:
         return self.asset._deployment_data.get('version', None)
 
     @property
+    def submission_count(self):
+        return self._submission_count()
+
+    @property
     def mongo_userform_id(self):
         return None

--- a/kpi/deployment_backends/kc_reader/shadow_models.py
+++ b/kpi/deployment_backends/kc_reader/shadow_models.py
@@ -1,0 +1,78 @@
+from django.contrib.auth.models import User
+from django.db import models
+from django.db import ProgrammingError
+
+
+class ReadOnlyModelError(ValueError):
+    pass
+
+
+class _ReadOnlyModel(models.Model):
+    class Meta:
+        abstract = True
+
+    def save(self, *args, **kwargs):
+        raise ReadOnlyModelError('Cannot save read-only-model')
+
+    def delete(self, *args, **kwargs):
+        raise ReadOnlyModelError('Cannot delete read-only-model')
+
+
+class LazyModelGroup:
+    @property
+    def XForm(self):
+        if not hasattr(self, '_XForm'):
+            self._define()
+        return self._XForm
+
+    @property
+    def Instance(self):
+        if not hasattr(self, '_Instance'):
+            self._define()
+        return self._Instance
+
+    def _define(self):
+        class _ReadOnlyXform(_ReadOnlyModel):
+            class Meta:
+                managed = False
+                db_table = 'logger_xform'
+                verbose_name = 'xform'
+                verbose_name_plural = 'xforms'
+
+            xml = models.TextField()
+            user = models.ForeignKey(User, null=True)
+            id_string = models.SlugField()
+            date_created = models.DateTimeField()
+            date_modified = models.DateTimeField()
+            uuid = models.CharField(max_length=249, default=u'')
+
+        class _ReadOnlyInstance(_ReadOnlyModel):
+            class Meta:
+                managed = False
+                db_table = 'logger_instance'
+                verbose_name = 'instance'
+                verbose_name_plural = 'instances'
+
+            xml = models.TextField()
+            user = models.ForeignKey(User, null=True)
+            xform = models.ForeignKey(_ReadOnlyXform, related_name='instances')
+            date_created = models.DateTimeField()
+            date_modified = models.DateTimeField()
+            deleted_at = models.DateTimeField(null=True, default=None)
+            status = models.CharField(max_length=20,
+                                      default=u'submitted_via_web')
+            uuid = models.CharField(max_length=249, default=u'')
+        self._XForm = _ReadOnlyXform
+        self._Instance = _ReadOnlyInstance
+
+_models = LazyModelGroup()
+
+
+def safe_kc_read(func):
+    def _wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ProgrammingError as e:
+            raise ProgrammingError('kc_reader error accessing kobocat '
+                                   'tables: {}'.format(e.message))
+    return _wrapper

--- a/kpi/deployment_backends/kc_reader/utils.py
+++ b/kpi/deployment_backends/kc_reader/utils.py
@@ -1,0 +1,68 @@
+from django.contrib.auth.models import User
+from django.db import models
+from django.db import ProgrammingError
+
+
+class __ReadOnlyModelError(ValueError):
+    pass
+
+
+class __ReadOnlyModel:
+    def save(self, *args, **kwargs):
+        raise __ReadOnlyModelError('Cannot save read-only-model')
+
+    def delete(self, *args, **kwargs):
+        raise __ReadOnlyModelError('Cannot delete read-only-model')
+
+
+class _ReadOnlyXform(models.Model,
+                      __ReadOnlyModel):
+    class Meta:
+        db_table = 'logger_xform'
+        verbose_name = 'xform'
+        verbose_name_plural = 'xforms'
+
+    xml = models.TextField()
+    user = models.ForeignKey(User, null=True)
+    id_string = models.SlugField()
+    date_created = models.DateTimeField()
+    date_modified = models.DateTimeField()
+    deleted_at = models.DateTimeField(null=True, default=None)
+    status = models.CharField(max_length=20,
+                              default=u'submitted_via_web')
+    uuid = models.CharField(max_length=249, default=u'')
+
+
+class __ReadOnlyInstance(models.Model,
+                         __ReadOnlyModel):
+    class Meta:
+        db_table = 'logger_instance'
+        verbose_name = 'instance'
+        verbose_name_plural = 'instances'
+
+    xml = models.TextField()
+    user = models.ForeignKey(User, null=True)
+    xform = models.ForeignKey(_ReadOnlyXform, related_name='instances')
+    date_created = models.DateTimeField()
+    date_modified = models.DateTimeField()
+    deleted_at = models.DateTimeField(null=True, default=None)
+    status = models.CharField(max_length=20,
+                              default=u'submitted_via_web')
+    uuid = models.CharField(max_length=249, default=u'')
+
+
+def wrap_kc_reader_call(func):
+    def _wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ProgrammingError as e:
+            raise ProgrammingError('kc_reader error accessing kobocat '
+                                   'tables: {}'.format(e.message))
+    return _wrapper
+
+
+@wrap_kc_reader_call
+def instance_count(xform_id_string, user_id, version_id=None):
+    return __ReadOnlyInstance.objects.filter(xform__user_id=user_id,
+                                             xform__id_string=xform_id_string,
+                                             ).count()

--- a/kpi/deployment_backends/kc_reader/utils.py
+++ b/kpi/deployment_backends/kc_reader/utils.py
@@ -1,68 +1,9 @@
-from django.contrib.auth.models import User
-from django.db import models
-from django.db import ProgrammingError
+from .shadow_models import _models, safe_kc_read
 
 
-class __ReadOnlyModelError(ValueError):
-    pass
-
-
-class __ReadOnlyModel:
-    def save(self, *args, **kwargs):
-        raise __ReadOnlyModelError('Cannot save read-only-model')
-
-    def delete(self, *args, **kwargs):
-        raise __ReadOnlyModelError('Cannot delete read-only-model')
-
-
-class _ReadOnlyXform(models.Model,
-                      __ReadOnlyModel):
-    class Meta:
-        db_table = 'logger_xform'
-        verbose_name = 'xform'
-        verbose_name_plural = 'xforms'
-
-    xml = models.TextField()
-    user = models.ForeignKey(User, null=True)
-    id_string = models.SlugField()
-    date_created = models.DateTimeField()
-    date_modified = models.DateTimeField()
-    deleted_at = models.DateTimeField(null=True, default=None)
-    status = models.CharField(max_length=20,
-                              default=u'submitted_via_web')
-    uuid = models.CharField(max_length=249, default=u'')
-
-
-class __ReadOnlyInstance(models.Model,
-                         __ReadOnlyModel):
-    class Meta:
-        db_table = 'logger_instance'
-        verbose_name = 'instance'
-        verbose_name_plural = 'instances'
-
-    xml = models.TextField()
-    user = models.ForeignKey(User, null=True)
-    xform = models.ForeignKey(_ReadOnlyXform, related_name='instances')
-    date_created = models.DateTimeField()
-    date_modified = models.DateTimeField()
-    deleted_at = models.DateTimeField(null=True, default=None)
-    status = models.CharField(max_length=20,
-                              default=u'submitted_via_web')
-    uuid = models.CharField(max_length=249, default=u'')
-
-
-def wrap_kc_reader_call(func):
-    def _wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except ProgrammingError as e:
-            raise ProgrammingError('kc_reader error accessing kobocat '
-                                   'tables: {}'.format(e.message))
-    return _wrapper
-
-
-@wrap_kc_reader_call
-def instance_count(xform_id_string, user_id, version_id=None):
-    return __ReadOnlyInstance.objects.filter(xform__user_id=user_id,
-                                             xform__id_string=xform_id_string,
-                                             ).count()
+@safe_kc_read
+def instance_count(xform_id_string, user_id):
+    return _models.Instance.objects.filter(deleted_at__isnull=True,
+                                           xform__user_id=user_id,
+                                           xform__id_string=xform_id_string,
+                                           ).count()

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -16,6 +16,7 @@ from rest_framework import exceptions, status
 from rest_framework.authtoken.models import Token
 
 from base_backend import BaseDeploymentBackend
+from .kc_reader.utils import instance_count
 
 
 class KobocatDeploymentException(exceptions.APIException):
@@ -355,7 +356,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         id_string = _deployment_data['backend_response']['id_string']
         # avoid migrations from being created for kc_reader mocked models
         # there should be a better way to do this, right?
-        from .kc_reader.utils import instance_count
         return instance_count(xform_id_string=id_string,
                               user_id=self.asset.owner.pk,
                               )

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -349,3 +349,13 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             except KeyError:
                 pass
         return links
+
+    def _submission_count(self):
+        _deployment_data = self.asset._deployment_data
+        id_string = _deployment_data['backend_response']['id_string']
+        # avoid migrations from being created for kc_reader mocked models
+        # there should be a better way to do this, right?
+        from .kc_reader.utils import instance_count
+        return instance_count(xform_id_string=id_string,
+                              user_id=self.asset.owner.pk,
+                              )

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -32,3 +32,6 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             'preview_url': 'https://enke.to/preview/::self',
             # 'preview_iframe_url': 'https://enke.to/preview/i/::self',
         }
+
+    def _submission_count(self):
+        return 0

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -391,6 +391,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     deployment__identifier = serializers.SerializerMethodField()
     deployment__active = serializers.SerializerMethodField()
     deployment__links = serializers.SerializerMethodField()
+    deployment__submission_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Asset
@@ -413,6 +414,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                   'deployment__identifier',
                   'deployment__links',
                   'deployment__active',
+                  'deployment__submission_count',
                   'report_styles',
                   'content',
                   'downloads',
@@ -534,6 +536,11 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             return obj.deployment.get_enketo_survey_links()
         else:
             return {}
+
+    def get_deployment__submission_count(self, obj):
+        if not obj.has_deployment:
+            return 0
+        return obj.deployment.submission_count
 
     def _content(self, obj):
         return json.dumps(obj.content)


### PR DESCRIPTION
* adds a `kc_reader` utility To perform read-only queries on KC tables for xforms and submissions.
* models will only be accessed through getter methods such as [`instance_count`](https://github.com/kobotoolbox/kpi/commit/e7339314cc1d379399437ecb88cbda4ab5b7c72d#diff-05d181aad038e404fe4e7982db4949b4R65)

todo:
find a way to prevent django from auto-creating migrations