### PR TITLE
Increase UWSGI processes from 2 to 4

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -13,7 +13,7 @@ mount              = $(KPI_PREFIX)=$(KPI_SRC_DIR)/kobo_playground/wsgi.py
 
 # process related settings
 master = true
-processes = 2
+processes = 4
 
 # Manage Celery.
 smart-attach-daemon = /tmp/celery.pid celery -A kobo_playground worker --beat --loglevel=info --logfile $(KPI_LOGS_DIR)/celery.log --pidfile=/tmp/celery.pid


### PR DESCRIPTION
Hopefully preempts timeouts such as those seen on OCHA's KC.
Mirrors @teodorescuserban's change to OCHA's KPI