### PR TITLE
Move KC profile sync to serializer, management cmd

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -4,9 +4,6 @@ from django.conf import settings
 from markitup.fields import MarkupField
 from jsonfield import JSONField
 
-from kpi.deployment_backends.kc_reader.utils import get_kc_profile_data
-from kpi.deployment_backends.kc_reader.utils import set_kc_require_auth
-
 
 class SitewideMessage(models.Model):
     slug = models.CharField(max_length=50)
@@ -37,30 +34,6 @@ class FormBuilderPreference(models.Model):
 class ExtraUserDetail(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, related_name='extra_details')
     data = JSONField(default={})
-
-    # @jnm: Can we reassess how to do this and not break tests?
-    '''
-    def __init__(self, *args, **kwargs):
-        result = super(ExtraUserDetail, self).__init__(*args, **kwargs)
-        # Copy data from the user's KC profile, if applicable, one time only.
-        # Do not overwrite any existing data in this object
-        if settings.KOBOCAT_URL and settings.KOBOCAT_INTERNAL_URL:
-            if self.user_id is not None and not self.data.get(
-                    'copied_kc_profile', False):
-                kc_detail = get_kc_profile_data(self.user_id)
-                for k, v in kc_detail.iteritems():
-                    if self.data.get(k, None) is None:
-                        self.data[k] = v
-                        self.data['copied_kc_profile'] = True
-        return result
-    '''
-
-    def save(self, *args, **kwargs):
-        # `require_auth` needs to be written back to KC
-        if settings.KOBOCAT_URL and settings.KOBOCAT_INTERNAL_URL:
-            if self.user_id is not None and 'require_auth' in self.data:
-                set_kc_require_auth(self.user_id, self.data['require_auth'])
-        return super(ExtraUserDetail, self).save(*args, **kwargs)
 
     def __unicode__(self):
         return '{}\'s data: {}'.format(self.user.__unicode__(), repr(self.data))

--- a/kpi/deployment_backends/kc_reader/utils.py
+++ b/kpi/deployment_backends/kc_reader/utils.py
@@ -39,7 +39,9 @@ def get_kc_profile_data(user_id):
         else:
             kc_name = field
         value = getattr(profile, kc_name)
-        if not isinstance(value, basestring):
+        # When a field contains JSON (e.g. `metadata`), it gets loaded as a
+        # `dict`. Convert it back to a string representation
+        if isinstance(value, dict):
             value = json.dumps(value)
         result[field] = value
     return result


### PR DESCRIPTION
* Fixes #821 
* Does not break tests
* Does not prevent KPI user creation when KC tables do not exist
* Assembled in the USA from foreign and domestic components :ok_hand: 