### PR TITLE
closes #950

### DIFF
--- a/kpi/utils/autoname.py
+++ b/kpi/utils/autoname.py
@@ -38,6 +38,8 @@ def autoname_fields__depr(surv_content):
                 continue
             if 'label' in surv_row:
                 next_name = sluggify_valid_xml__depr(surv_row['label'])
+            elif surv_row.get('type') == 'group':
+                next_name = sluggify_valid_xml__depr('Grp')
             else:
                 raise ValueError('Label cannot be translated: %s' %
                                  json.dumps(surv_row))


### PR DESCRIPTION
This might not ever be used because this autoname method
is being deprecated. But if we need to bring it back, this
will allow forms to be deployed that have been failing in
the past.

(Resolves sentry kpi issue 1191)