### PR TITLE
Validate `source` in `test_create_asset_snapshot()`

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -248,7 +248,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 raise Exception('The identifier is not properly formatted.')
 
         url = self.external_to_internal_url(u'{}/api/v1/forms'.format(server))
-        csv_io = self.to_csv_io(self.asset.to_versioned_xls_io(), id_string)
+        csv_io = self.to_csv_io(self.asset.to_xls_io(versioned=True), id_string)
         valid_xlsform_csv_repr = csv_io.getvalue()
         payload = {
             u'text_xls_form': valid_xlsform_csv_repr,
@@ -272,7 +272,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             active = self.active
         url = self.external_to_internal_url(self.backend_response['url'])
         id_string = self.backend_response['id_string']
-        csv_io = self.to_csv_io(self.asset.to_versioned_xls_io(), id_string)
+        csv_io = self.to_csv_io(self.asset.to_xls_io(versioned=True), id_string)
         valid_xlsform_csv_repr = csv_io.getvalue()
         payload = {
             u'text_xls_form': valid_xlsform_csv_repr,

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -564,6 +564,13 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
         return self.source
 
     def save(self, *args, **kwargs):
+        if self.asset is not None:
+            if self.asset_version is None:
+                self.asset_version = self.asset.latest_version
+            if self.source is None:
+                self.source = self.asset_version.version_content
+            if self.owner is None:
+                self.owner = self.asset.owner
         _note = self.details.pop('note', None)
         _source = copy.deepcopy(self.source)
         if _source is None:
@@ -606,13 +613,14 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
                                      u'name': u'prepended_note',
                                      u'label': _label})
 
-        self._expand_kobo_qs(source)
-        self._populate_fields_with_autofields(source)
+        source_copy = copy.deepcopy(source)
+        self._expand_kobo_qs(source_copy)
+        self._populate_fields_with_autofields(source_copy)
 
         warnings = []
         details = {}
         try:
-            xml = FormPack({'content': source},
+            xml = FormPack({'content': source_copy},
                                 root_node_name=root_node_name,
                                 id_string=id_string,
                                 title=form_title)[0].to_xml(warnings=warnings)

--- a/kpi/tests/test_asset_snapshots.py
+++ b/kpi/tests/test_asset_snapshots.py
@@ -36,6 +36,7 @@ class CreateAssetSnapshots(AssetSnapshotsTestCase):
         ae = AssetSnapshot.objects.create(asset=self.asset)
         ae_count2 = AssetSnapshot.objects.count()
         self.assertTrue(len(ae.uid) > 0)
+        self.assertEqual(ae.source, self.asset.content)
         self.assertEqual(ae_count + 1, ae_count2)
 
     def test_create_assetless_snapshot(self):

--- a/kpi/tests/test_asset_snapshots.py
+++ b/kpi/tests/test_asset_snapshots.py
@@ -36,7 +36,8 @@ class CreateAssetSnapshots(AssetSnapshotsTestCase):
         ae = AssetSnapshot.objects.create(asset=self.asset)
         ae_count2 = AssetSnapshot.objects.count()
         self.assertTrue(len(ae.uid) > 0)
-        self.assertEqual(ae.source, self.asset.content)
+        self.assertEqual(ae.source, self.asset.latest_version.version_content)
+        self.assertEqual(ae.owner, self.asset.owner)
         self.assertEqual(ae_count + 1, ae_count2)
 
     def test_create_assetless_snapshot(self):


### PR DESCRIPTION
When an `AssetSnapshot` is created from an `Asset`, make sure that the
`AssetSnapshot`'s `source` matches the `Asset`'s `content`