### PR TITLE
Hotfix

### DIFF
--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -67,8 +67,8 @@ def xlsform_to_kpi_content_schema(xlsform):
     # Remove the __version__ calculate question
     content['survey'] = [
         row for row in content['survey'] if not (
-            'calculation' in row and row.get('type') == 'calculate' and
-            row['name'] == '__version__'
+            'calculation' in row and row.get('type', None) == 'calculate' and
+            row.get('name', None) == '__version__'
         )
     ]
     # a temporary fix to the problem of list_name alias

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -181,6 +181,14 @@ class FormpackXLSFormUtils(object):
             if '$kuid' not in row:
                 row['$kuid'] = random_id(9)
 
+    def _strip_kuids(self, content):
+        # this is important when stripping out kobo-specific types because the
+        # $kuid field in the xform prevents cascading selects from rendering
+        for row in content['survey']:
+            row.pop('$kuid', None)
+        for row in content.get('choices', []):
+            row.pop('$kuid', None)
+
     def _link_list_items(self, content):
         arr = content['survey']
         if len(arr) > 0:
@@ -247,8 +255,8 @@ class XlsExportable(object):
         if not kobo_specific_types:
             self._expand_kobo_qs(content)
             self._autoname(content)
-            self._assign_kuids(content)
             self._populate_fields_with_autofields(content)
+            self._strip_kuids(content)
         content = OrderedDict(content)
         self._xlsform_structure(content, ordered=True)
         return content
@@ -598,7 +606,6 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
             _source = {}
         self._standardize(_source)
         self._strip_empty_rows(_source)
-        self._assign_kuids(_source)
         self._autoname(_source)
         self._remove_empty_expressions(_source)
         _settings = _source.get('settings', {})
@@ -637,6 +644,7 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
         source_copy = copy.deepcopy(source)
         self._expand_kobo_qs(source_copy)
         self._populate_fields_with_autofields(source_copy)
+        self._strip_kuids(source_copy)
 
         warnings = []
         details = {}

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -33,12 +33,9 @@ class AssetVersion(models.Model):
     class Meta:
         ordering = ['-date_modified']
 
-    def save(self, *args, **kwargs):
-        if self.deployed and self.deployed_content is None:
-            self.deployed_content = self._deployed_content()
-        super(AssetVersion, self).save(*args, **kwargs)
-
     def _deployed_content(self):
+        if self.deployed_content is not None:
+            return self.deployed_content
         legacy_names = self._reversion_version is not None
         if legacy_names:
             return to_xlsform_structure(self.version_content,
@@ -49,7 +46,7 @@ class AssetVersion(models.Model):
 
     def to_formpack_schema(self):
         return {
-            'content': self.deployed_content or self._deployed_content(),
+            'content': self._deployed_content(),
             'version': self.uid,
             'version_id_key': '__version__',
         }

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -10,6 +10,8 @@ from reversion.models import Version
 from ..fields import KpiUidField
 from ..utils.kobo_to_xlsform import to_xlsform_structure
 
+from formpack.utils.expand_content import expand_content
+
 DEFAULT_DATETIME = datetime.datetime(2010, 1, 1)
 
 
@@ -46,7 +48,7 @@ class AssetVersion(models.Model):
 
     def to_formpack_schema(self):
         return {
-            'content': self._deployed_content(),
+            'content': expand_content(self._deployed_content()),
             'version': self.uid,
             'version_id_key': '__version__',
         }

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -1,3 +1,6 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
 import re
 from collections import OrderedDict
 
@@ -8,6 +11,37 @@ from django.test import TestCase
 from kpi.models import Asset
 from kpi.models import Collection
 from kpi.models.object_permission import get_all_objects_for_user
+
+# move this into a fixture file?
+# note: this is not a very robust example of a cascading select
+CASCADE_CONTENT = {u'survey': [{u'type': u'select_one',
+                                u'select_from_list_name': u'country',
+                                u'label': [u'country'],
+                                u'required': True},
+                               {u'type': u'select_one',
+                                u'select_from_list_name': u'region',
+                                u'label': [u'region'],
+                                u'choice_filter': u'country=${country}',
+                                u'required': True},
+                               {u'type': u'select_one',
+                                u'select_from_list_name': u'town',
+                                u'label': [u'region'],
+                                u'choice_filter': u'region=${region}',
+                                u'required': True}],
+                   u'choices': [{u'label': [u'France'],
+                                 u'list_name': u'country',
+                                 u'name': u'france'},
+                                {u'country': u'france',
+                                 u'label': [u'\xcele-de-France'],
+                                 u'list_name': u'region',
+                                 u'name': u'ile-de-france'},
+                                {u'region': u'ile-de-france',
+                                 u'label': [u'Paris'],
+                                 u'list_name': u'town',
+                                 u'name': u'paris'}],
+                   u'translated': [u'label'],
+                   u'translations': [None]}
+
 
 class AssetsTestCase(TestCase):
     fixtures = ['test_data']
@@ -249,13 +283,6 @@ class AssetSettingsTests(AssetsTestCase):
         self.assertTrue('form_title' not in settings)
         self.assertEqual(a1.name, 'abcxyz')
 
-    def test_surveys_exported_to_xml_have_id_string_and_title(self):
-        a1 = Asset.objects.create(content=self._content('abcxyz'),
-                                  owner=self.user,
-                                  asset_type='survey')
-        export = a1.snapshot
-        self.assertTrue('<h:title>abcxyz</h:title>' in export.xml)
-        self.assertTrue('<data id="xid_stringx">' in export.xml)
 
 
 class AssetScoreTestCase(TestCase):
@@ -287,6 +314,37 @@ class AssetScoreTestCase(TestCase):
         _snapshot = a1.snapshot
         self.assertNotEqual(_snapshot.xml, '')
         self.assertNotEqual(_snapshot.details['status'], 'failure')
+
+
+class AssetSnapshotXmlTestCase(TestCase):
+    def test_cascading_select_xform(self):
+        asset = Asset.objects.create(asset_type='survey',
+                                     content=CASCADE_CONTENT)
+        # kuids automatically populated by asset.save()
+        survey_kuids = [row.get('$kuid') for row in asset.content.get('survey')]
+        choices_kuids = [row.get('$kuid') for row in asset.content.get('choices')]
+        self.assertTrue(None not in survey_kuids)
+        self.assertTrue(None not in choices_kuids)
+        # asset.snapshot.xml generates a document that does not have any
+        # "$kuid" or "<$kuid>x</$kuid>" elements
+        _xml = asset.snapshot.xml
+
+        # as is in every xform:
+        self.assertTrue('<instance>' in _xml)
+        # specific to this cascading select form:
+        self.assertTrue('<instance id="town">' in _xml)
+        self.assertTrue('<instance id="region">' in _xml)
+        self.assertTrue('<instance id="country">' in _xml)
+
+        self.assertTrue('$kuid' not in _xml)
+
+    def test_surveys_exported_to_xml_have_id_string_and_title(self):
+        a1 = Asset.objects.create(content=self._content('abcxyz'),
+                                  owner=self.user,
+                                  asset_type='survey')
+        export = a1.snapshot
+        self.assertTrue('<h:title>abcxyz</h:title>' in export.xml)
+        self.assertTrue('<data id="xid_stringx">' in export.xml)
 
 
 # TODO: test values of "valid_xlsform_content"

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -316,7 +316,7 @@ class AssetScoreTestCase(TestCase):
         self.assertNotEqual(_snapshot.details['status'], 'failure')
 
 
-class AssetSnapshotXmlTestCase(TestCase):
+class AssetSnapshotXmlTestCase(AssetSettingsTests):
     def test_cascading_select_xform(self):
         asset = Asset.objects.create(asset_type='survey',
                                      content=CASCADE_CONTENT)

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -16,13 +16,13 @@ class AssetContentAnalyzer(object):
 
     def get_summary(self):
         row_count = 0
-        languages = set()
         geo = False
         labels = []
         metas = set()
         types = set()
         summary_errors = []
         keys = OrderedDict()
+        naming_conflicts = []
         if not self.survey:
             return {}
 
@@ -30,6 +30,8 @@ class AssetContentAnalyzer(object):
             # pyxform's csv_to_dict() returns an OrderedDict, so we have to be
             # more tolerant than `type(row) == dict`
             if isinstance(row, dict):
+                if '$given_name' in row:
+                    naming_conflicts.append(row['$given_name'])
                 _type = row.get('type')
                 _label = row.get('label')
                 if _type in GEO_TYPES:
@@ -57,4 +59,6 @@ class AssetContentAnalyzer(object):
             'labels': labels[0:5],
             'columns': filter(lambda k: not k.startswith('$'), keys.keys()),
         }
+        if len(naming_conflicts) > 0:
+            summary['naming_conflicts'] = naming_conflicts
         return summary

--- a/kpi/utils/autoname.py
+++ b/kpi/utils/autoname.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, defaultdict
 
 from kpi.utils.sluggify import (sluggify, sluggify_label, is_valid_nodeName)
 
-
+from formpack.utils.json_hash import json_hash
 
 
 
@@ -51,8 +51,7 @@ def autoname_fields__depr(surv_content):
             if 'label' in surv_row:
                 next_name = sluggify_valid_xml__depr(surv_row['label'])
             else:
-                raise ValueError('Label cannot be translated: %s' %
-                                 json.dumps(surv_row))
+                next_name = 'unnamable_row_{}'.format(json_hash(surv_row))
             while next_name in kuid_names.values():
                 next_name = _increment(next_name)
             if 'kuid' not in surv_row:


### PR DESCRIPTION
* could be paired with a notification on surveys which have had an assigned name be renamed. (e.g. two questions named `or_other_response`.
* fixes some issues which were preventing reports from loading