### PR TITLE
Fix migration `0015` by removing `save()` args

### DIFF
--- a/kpi/management/commands/populate_assetversions.py
+++ b/kpi/management/commands/populate_assetversions.py
@@ -39,7 +39,7 @@ def populate_assetversions(_Asset, _AssetVersion, _ReversionVersion,
     _cur = _Asset.objects.filter(asset_type='survey')
     if filter_usernames:
         _cur = _cur.filter(owner__username__in=filter_usernames)
-    asset_ids = _cur.order_by('date_modified').values_list('id', flat=True)
+    asset_ids = _cur.order_by('-date_modified').values_list('id', flat=True)
 
     for _i in xrange(0, len(asset_ids)):
         _create_versions_for_asset_id(asset_ids[_i], _AssetVersion, _ReversionVersion)

--- a/kpi/migrations/0015_assetversion.py
+++ b/kpi/migrations/0015_assetversion.py
@@ -36,6 +36,7 @@ def copy_reversion_to_assetversion(apps, schema_editor):
         populate_assetversions(apps.get_model('kpi', 'Asset'),
                                apps.get_model('kpi', 'AssetVersion'),
                                apps.get_model('reversion', 'Version'),
+                               historical_models=True,
                                )
 
 

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -27,15 +27,13 @@ class AssetContentAnalyzer(object):
             return {}
 
         for row in self.survey:
-            # pyxform's csv_to_dict() returns an OrderedDict, so we have to be
-            # more tolerant than `type(row) == dict`
             if isinstance(row, dict):
                 _type = row.get('type')
                 _label = row.get('label')
                 if _type in GEO_TYPES:
                     geo = True
 
-                if not _type or _type.startswith('end'):
+                if not _type or isinstance(_type, dict) or _type.startswith('end'):
                     summary_errors.append(row)
                     continue
                 if _type in META_TYPES:


### PR DESCRIPTION
Don't try to call `asset.save(adjust_content=False, create_version=False)` when running in a migration; just do `asset.save()`. There's no content-adjusting or version-creating code in the stock method anyway