### PR TITLE
Skipping content-type checking in the browser

### DIFF
--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -849,7 +849,9 @@ var dmix = {
       throw new Error(errMsg);
     }
     const VALID_ASSET_UPLOAD_FILE_TYPES = [
+      'application/xls',
       'application/vnd.ms-excel',
+      'application/vnd.openxmlformats',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     ];
     var file = files[0];

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -858,10 +858,8 @@ var dmix = {
     if (VALID_ASSET_UPLOAD_FILE_TYPES.indexOf(file.type) === -1) {
       var err = `Invalid filetype: '${file.type}'`;
       console.error(err);
-      alertify.error(err);
-    } else {
-      this.dropFiles(files);
     }
+    this.dropFiles(files);
   },
   summaryDetails () {
     return (


### PR DESCRIPTION
The goal was to prevent random (and large) files from being uploaded, but this `content-type` check has prevented a number of valid spreadsheet submissions out in the wild.