### PR TITLE
Allow asset/collection lookup when `KPI_PREFIX='/'`.

### DIFF
--- a/kpi/models/import_task.py
+++ b/kpi/models/import_task.py
@@ -21,8 +21,8 @@ from rest_framework import exceptions
 def _resolve_url_to_asset_or_collection(item_path):
     if item_path.startswith(('http', 'https')):
         item_path = urlparse.urlparse(item_path).path
-        if settings.KPI_PREFIX:
-            item_path = item_path.replace(settings.KPI_PREFIX, '')
+        if settings.KPI_PREFIX and (settings.KPI_PREFIX != '/'):
+            item_path = item_path.lstrip(settings.KPI_PREFIX)
     match = resolve(item_path)
     uid = match.kwargs.get('uid')
     if match.url_name == 'asset-detail':

--- a/kpi/models/import_task.py
+++ b/kpi/models/import_task.py
@@ -21,8 +21,9 @@ from rest_framework import exceptions
 def _resolve_url_to_asset_or_collection(item_path):
     if item_path.startswith(('http', 'https')):
         item_path = urlparse.urlparse(item_path).path
-        if settings.KPI_PREFIX and (settings.KPI_PREFIX != '/'):
-            item_path = item_path.lstrip(settings.KPI_PREFIX)
+        if settings.KPI_PREFIX and (settings.KPI_PREFIX != '/') and \
+                item_path.startswith(settings.KPI_PREFIX):
+            item_path = item_path.replace(settings.KPI_PREFIX, '', 1)
     match = resolve(item_path)
     uid = match.kwargs.get('uid')
     if match.url_name == 'asset-detail':


### PR DESCRIPTION
Technically, this was tested on top of #1010.