### PR TITLE
Fixes #860, added django-digest.

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'oauth2_provider',
     'markitup',
+    'django_digest'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -461,4 +462,3 @@ else:
 MONGO_CONNECTION = MongoClient(
     MONGO_CONNECTION_URL, j=True, tz_aware=True)
 MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
-

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,11 @@
 # Formpack
 -e git+https://github.com/kobotoolbox/formpack.git@1.4#egg=formpack
 
+# More up-to-date version of django-digest than PyPI seems to have.
+# Also, python-digest is an unlisted dependency thereof.
+python-digest==1.7
+-e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
+
 # Regular PyPI packages
 Django<1.9
 Fabric
@@ -24,12 +29,13 @@ django-debug-toolbar
 django-extensions
 django-jsonbfield
 django-oauth-toolkit
-django-registration-redux
+django-registration-redux==1.3 # DO NOT UPGRADE TO 1.4 WITHOUT TESTING!
 django-ses
 django-toolbelt
 django-webpack-loader
 django_cachebuster
 django_haystack
+django-loginas==0.2.3
 django_markitup
 django_mptt
 django_reversion

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+-e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
 -e git+https://github.com/kobotoolbox/formpack.git@1.4#egg=formpack
 -e git+https://github.com/kobotoolbox/pyxform.git@6dfff060fc2ad6c575c6a7d953c381d2180e6833#egg=pyxform
 amqp==1.4.9
@@ -25,10 +26,11 @@ django-debug-toolbar==1.4
 django-extensions==1.6.7
 django-haystack==2.5.0
 django-jsonbfield==0.1.0
+django-loginas==0.2.3
 django-markitup==2.3.1
 django-mptt==0.8.6
 django-oauth-toolkit==0.10.0
-django-registration-redux==1.3 # DO NOT UPGRADE TO 1.4 WITHOUT TESTING!
+django-registration-redux==1.3
 django-reversion==1.10.2
 django-ses==0.7.1
 django-taggit==0.21.3
@@ -49,7 +51,6 @@ Jinja2==2.8               # via pyexcelerate
 jsonfield==1.0.3
 jsonschema==2.5.1
 kombu==3.0.35
-django-loginas==0.2.3
 lxml==2.3.4
 Markdown==2.6.6
 MarkupSafe==0.23          # via jinja2
@@ -70,6 +71,7 @@ pyquery==1.2.11
 pytest-django==3.0.0
 pytest==3.0.3             # via pytest-django
 python-dateutil==2.5.3
+python-digest==1.7
 pytz==2016.4
 raven==5.16.0
 requests==2.10.0


### PR DESCRIPTION
So now, a user unable to log into Enketo or the Collect app may
restore their access by changing their password (even to the same
password) within KPI.

Misc: Also pinned version for django-registration-redux where
pip-compile won't overwrite it.