### PR TITLE
Add Docker support to Fabric configuration

### DIFF
--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -1,0 +1,3 @@
+from .docker import deploy
+from .legacy import deploy as deploy_legacy
+from .legacy import deploy_ref as deploy_ref_legacy

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -71,35 +71,39 @@ def setup_env(deployment_name):
 def deploy(deployment_name, branch='master'):
     setup_env(deployment_name)
     build_dir = run("mktemp --tmpdir='{}' -d".format(env.build_root))
-    with cd(build_dir):
-        # Shallow clone the requested branch to a temporary directory
-        run("git clone --quiet --depth=1 --branch='{}' '{}' .".format(
-            branch, GIT_REPO))
-        # Note which commit is at the tip of the cloned branch
-        cloned_commit = run("git show --no-patch")
-        # Build the image
-        run("docker build -t '{}' .".format(IMAGE_NAME))
-        # Clean up
-        run("find -delete")
-    run("rmdir '{}'".format(build_dir))
-    with cd(env.docker_config_path):
-        # Run the new image
-        run("docker-compose stop '{}'".format(SERVICE_NAME))
-        run("docker-compose rm -f --all '{}'".format(SERVICE_NAME))
-        run("docker-compose up -d '{}'".format(SERVICE_NAME))
-        running_commit = run(
-            "docker exec $(docker-compose ps -q '{service}') bash -c '"
-            "cd \"${src_dir_var}\" && git show --no-patch'".format(
-                service=SERVICE_NAME,
-                src_dir_var=CONTAINER_SRC_DIR_ENV_VAR
+    try:
+        with cd(build_dir):
+            # Shallow clone the requested branch to a temporary directory
+            run("git clone --quiet --depth=1 --branch='{}' '{}' .".format(
+                branch, GIT_REPO))
+            # Note which commit is at the tip of the cloned branch
+            cloned_commit = run("git show --no-patch")
+            # Build the image
+            run("docker build -t '{}' .".format(IMAGE_NAME))
+        with cd(env.docker_config_path):
+            # Run the new image
+            run("docker-compose stop '{}'".format(SERVICE_NAME))
+            run("docker-compose rm -f --all '{}'".format(SERVICE_NAME))
+            run("docker-compose up -d '{}'".format(SERVICE_NAME))
+            running_commit = run(
+                "docker exec $(docker-compose ps -q '{service}') bash -c '"
+                "cd \"${src_dir_var}\" && git show --no-patch'".format(
+                    service=SERVICE_NAME,
+                    src_dir_var=CONTAINER_SRC_DIR_ENV_VAR
+                )
             )
-        )
-    with cd(env.static_path):
-        # Write the date and running commit to a publicly-accessible file
-        sudo("(date; echo) > '{}'".format(UPDATE_STATIC_FILE))
-        files.append(UPDATE_STATIC_FILE, running_commit, use_sudo=True)
-    if running_commit != cloned_commit:
-        raise Exception(
-            'The running commit does not match the tip of the cloned branch! '
-            'Make sure docker-compose.yml is set to use {}'.format(IMAGE_NAME)
-        )
+        with cd(env.static_path):
+            # Write the date and running commit to a publicly-accessible file
+            sudo("(date; echo) > '{}'".format(UPDATE_STATIC_FILE))
+            files.append(UPDATE_STATIC_FILE, running_commit, use_sudo=True)
+        if running_commit != cloned_commit:
+            raise Exception(
+                'The running commit does not match the tip of the cloned'
+                'branch! Make sure docker-compose.yml is set to use {}'.format(
+                    IMAGE_NAME)
+            )
+    finally:
+        # Clean up no matter what!
+        with cd(build_dir):
+            run("find -delete")
+        run("rmdir '{}'".format(build_dir))

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -1,0 +1,105 @@
+import os
+import json
+import re
+import requests
+
+from fabric.api import cd, env, run as run_, sudo as sudo_
+from fabric.contrib import files
+
+
+SERVICE_NAME = 'kpi'
+GIT_REPO = 'https://github.com/kobotoolbox/{}.git'.format(SERVICE_NAME)
+IMAGE_NAME = 'fabric/{}:autobuild'.format(SERVICE_NAME)
+CONTAINER_SRC_DIR_ENV_VAR = '{}_SRC_DIR'.format(SERVICE_NAME.upper())
+UPDATE_STATIC_FILE = '{}/LAST_UPDATE.txt'.format(SERVICE_NAME)
+# These must be defined in deployments.json
+REQUIRED_SETTINGS = (
+    'build_root', # Temporary location for cloning repo; deleted at end
+    'docker_config_path', # Location must house `docker_compose.yml`
+    'static_path' # `UPDATE_STATIC_FILE` will be written here
+)
+
+DEPLOYMENTS = {}
+IMPORTED_DEPLOYMENTS = {}
+deployments_file = os.environ.get('DEPLOYMENTS_JSON', 'deployments.json')
+if os.path.exists(deployments_file):
+    with open(deployments_file, 'r') as f:
+        IMPORTED_DEPLOYMENTS = json.load(f)
+else:
+    raise Exception("Cannot find {}".format(deployments_file))
+
+
+def run(*args, **kwargs):
+    # Avoids control characters being returned in the output
+    kwargs['pty'] = False
+    return run_(*args, **kwargs)
+
+
+def sudo(*args, **kwargs):
+    # Avoids control characters being returned in the output
+    kwargs['pty'] = False
+    return sudo_(*args, **kwargs)
+
+
+def check_key_filename(deployment_configs):
+    if 'key_filename' in deployment_configs and \
+       not os.path.exists(deployment_configs['key_filename']):
+        # Maybe the path contains a ~; try expanding that before failing
+        deployment_configs['key_filename'] = os.path.expanduser(
+            deployment_configs['key_filename']
+        )
+        if not os.path.exists(deployment_configs['key_filename']):
+            raise Exception("Cannot find required permissions file: %s" %
+                            deployment_configs['key_filename'])
+
+
+def setup_env(deployment_name):
+    deployment = DEPLOYMENTS.get(deployment_name, {})
+
+    if deployment_name in IMPORTED_DEPLOYMENTS:
+        deployment.update(IMPORTED_DEPLOYMENTS[deployment_name])
+
+    env.update(deployment)
+    check_key_filename(deployment)
+
+    for required_setting in REQUIRED_SETTINGS:
+        if required_setting not in env:
+            raise Exception('Please define {} in {} and try again'.format(
+                required_setting, deployments_file))
+
+
+def deploy(deployment_name, branch='master'):
+    setup_env(deployment_name)
+    build_dir = run("mktemp --tmpdir='{}' -d".format(env.build_root))
+    with cd(build_dir):
+        # Shallow clone the requested branch to a temporary directory
+        run("git clone --quiet --depth=1 --branch='{}' '{}' .".format(
+            branch, GIT_REPO))
+        # Note which commit is at the tip of the cloned branch
+        cloned_commit = run("git show --no-patch")
+        # Build the image
+        run("docker build -t '{}' .".format(IMAGE_NAME))
+        # Clean up
+        run("find -delete")
+    run("rmdir '{}'".format(build_dir))
+    with cd(env.docker_config_path):
+        # Run the new image
+        run("docker-compose stop '{}'".format(SERVICE_NAME))
+        run("docker-compose rm -f --all '{}'".format(SERVICE_NAME))
+        run("docker-compose up -d '{}'".format(SERVICE_NAME))
+        running_commit = run(
+            "docker exec $(docker-compose ps -q '{service}') bash -c '"
+            "cd \"${src_dir_var}\" && git show --no-patch'".format(
+                service=SERVICE_NAME,
+                src_dir_var=CONTAINER_SRC_DIR_ENV_VAR
+            )
+        )
+    with cd(env.static_path):
+        # Write the date and running commit to a publicly-accessible file
+        sudo("(date; echo) > '{}'".format(UPDATE_STATIC_FILE))
+        files.append(UPDATE_STATIC_FILE, running_commit, use_sudo=True)
+    if running_commit != cloned_commit:
+        raise Exception(
+            'The running commit does not match the tip of the cloned branch! '
+            'Make sure docker-compose.yml is set to use {}'.format(IMAGE_NAME)
+        )

--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -1,10 +1,10 @@
-import os
 import json
+import os
 import re
-import requests
 
 from fabric.api import cd, env, run as run_, sudo as sudo_
 from fabric.contrib import files
+import requests
 
 
 SERVICE_NAME = 'kpi'
@@ -49,7 +49,7 @@ def check_key_filename(deployment_configs):
             deployment_configs['key_filename']
         )
         if not os.path.exists(deployment_configs['key_filename']):
-            raise Exception("Cannot find required permissions file: %s" %
+            raise Exception("Cannot find required SSH key file: %s" %
                             deployment_configs['key_filename'])
 
 

--- a/fabfile/legacy.py
+++ b/fabfile/legacy.py
@@ -1,10 +1,10 @@
-import os
-import sys
 import json
+import os
 import re
-import requests
+import sys
 
 from fabric.api import cd, env, prefix, run as run_
+import requests
 
 
 def run(*args, **kwargs):
@@ -49,7 +49,7 @@ def check_key_filename(deployment_configs):
             deployment_configs['key_filename']
         )
         if not os.path.exists(deployment_configs['key_filename']):
-            exit_with_error("Cannot find required permissions file: %s" %
+            exit_with_error("Cannot find required SSH key file: %s" %
                             deployment_configs['key_filename'])
 
 


### PR DESCRIPTION
Builds and deploys a Docker image for the requested branch (`master` by
default). Example: `fab deploy:devel,branch='issue-1063'`

Requires `docker_config_path`, `build_root`, and `static_path` to be set in
`deployments.json`; see example below:

```
"devel": {
  "host_string": "ubuntu@staging.kobo",
  "key_filename": "~/.ssh/secretkey.pem",
  "docker_config_path": "/home/ubuntu/src/kobo-devel",
  "build_root": "/tmp",
  "static_path": "/home/ubuntu/src/kobo-devel/.vols/static"
}
```

**Also renames old, non-Docker commands to `deploy_legacy` and `deploy_ref_legacy`.**