### PR TITLE
Do not assume that all exceptions have a `response`

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -286,7 +286,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 'version': self.asset.version_id,
             })
         except KobocatDeploymentException as e:
-            if e.response.status_code == 404:
+            if hasattr(e, 'response') and e.response.status_code == 404:
                 # Whoops, the KC project we thought we were going to overwrite
                 # is gone! Try a standard deployment instead
                 return self.connect(self.identifier, active)


### PR DESCRIPTION
If we encounter an unexpected exception, we want to [re-raise](https://github.com/kobotoolbox/kpi/blob/b87c49ca8c7fb95d3917135ca71683a21a89c9b9/kpi/deployment_backends/kobocat_backend.py#L293) that original exception, not accidentally raise an `AttributeError` instead :blush: