### PR TITLE
Expose git info

### DIFF
--- a/jsapp/js/bem.es6
+++ b/jsapp/js/bem.es6
@@ -232,6 +232,9 @@ bem.collectionFilter = BEM('collection-filter');
 
 bem.PrintOnly = BEM('print-only');
 
+bem.GitRev = BEM('git-rev');
+bem.GitRev__item = bem.GitRev.__('item', '<div>');
+
 bem.create = BEM;
 
 export default bem;

--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -15,6 +15,7 @@ import {
   assign,
   currentLang,
   LANGUAGE_COOKIE_NAME,
+  notify
 } from '../utils';
 import searches from '../searches';
 import cookie from 'react-cookie';
@@ -248,6 +249,23 @@ var MainHeader = React.createClass({
           <span>{t('not logged in')}</span>
     );
   },
+  renderGitRevInfo () {
+    if (stores.session.currentAccount && stores.session.currentAccount.git_rev) {
+      var gitRev = stores.session.currentAccount.git_rev;
+      return (
+        <bem.GitRev>
+          <bem.GitRev__item>
+            branch: {gitRev.branch}
+          </bem.GitRev__item>
+          <bem.GitRev__item>
+            commit: {gitRev.short}
+          </bem.GitRev__item>
+        </bem.GitRev>
+      );
+    }
+
+    return false;
+  },
   toggleFixedDrawer() {
     stores.pageState.toggleFixedDrawer();
   },
@@ -466,6 +484,7 @@ var MainHeader = React.createClass({
               {this.renderFormViewHeader()}
             </bem.FormView__header>
           }
+          {this.renderGitRevInfo()}
         </header>
       );
   },

--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -15,7 +15,6 @@ import {
   assign,
   currentLang,
   LANGUAGE_COOKIE_NAME,
-  notify
 } from '../utils';
 import searches from '../searches';
 import cookie from 'react-cookie';

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -544,3 +544,26 @@ a.form-view__tab {
         }
     }
 }
+
+.git-rev {
+    display: none;
+}
+
+@media screen and (min-width: 768px) {
+    .git-rev {
+        display: block;
+        position: fixed;
+        bottom: 0px;
+        left: 256px;
+        z-index:100;
+        .git-rev__item {
+            color: white;
+            opacity: 0.75;
+            background: darken($cool-green, 10%);
+            margin-right:5px;
+            padding:6px 12px;
+            display: inline-block;
+            font-size: 12px;
+        }
+    }
+}

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 from datetime import timedelta
 import multiprocessing
 import os
+import subprocess
 
 from django.conf import global_settings
 from django.conf.global_settings import LANGUAGES as _available_langs
@@ -443,6 +444,25 @@ if 'RAVEN_DSN' in os.environ:
             },
         },
     }
+
+
+''' Try to identify the running codebase. Based upon
+https://github.com/tblobaum/git-rev/blob/master/index.js '''
+GIT_REV = {}
+for git_rev_key, git_command in (
+        ('short', ('git', 'rev-parse', '--short', 'HEAD')),
+        ('long', ('git', 'rev-parse', 'HEAD')),
+        ('branch', ('git', 'rev-parse', '--abbrev-ref', 'HEAD')),
+        ('tag', ('git', 'describe', '--exact-match', '--tags')),
+):
+    try:
+        GIT_REV[git_rev_key] = subprocess.check_output(
+            git_command, stderr=subprocess.STDOUT).strip()
+    except (OSError, subprocess.CalledProcessError) as e:
+        GIT_REV[git_rev_key] = False
+if GIT_REV['branch'] == 'HEAD':
+    GIT_REV['branch'] = False
+
 
 ''' Since this project handles user creation but shares its database with
 KoBoCAT, we must handle the model-level permission assignment that would've

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -462,6 +462,9 @@ for git_rev_key, git_command in (
         GIT_REV[git_rev_key] = False
 if GIT_REV['branch'] == 'HEAD':
     GIT_REV['branch'] = False
+# Only superusers will be able to see this information unless
+# EXPOSE_GIT_REV=TRUE is set in the environment
+EXPOSE_GIT_REV = os.environ.get('EXPOSE_GIT_REV', '').upper() == 'TRUE'
 
 
 ''' Since this project handles user creation but shares its database with

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -767,7 +767,11 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         return settings.LANGUAGES
 
     def get_git_rev(self, obj):
-        return settings.GIT_REV
+        request = self.context.get('request', False)
+        if settings.EXPOSE_GIT_REV or (request and request.user.is_superuser):
+            return settings.GIT_REV
+        else:
+            return False
 
     def to_representation(self, obj):
         if obj.is_anonymous():

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -732,6 +732,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     extra_details = WritableJSONField(source='extra_details.data')
     current_password = serializers.CharField(write_only=True, required=False)
     new_password = serializers.CharField(write_only=True, required=False)
+    git_rev = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -750,6 +751,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             'extra_details',
             'current_password',
             'new_password',
+            'git_rev',
         )
 
     def get_server_time(self, obj):
@@ -763,6 +765,9 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_languages(self, obj):
         return settings.LANGUAGES
+
+    def get_git_rev(self, obj):
+        return settings.GIT_REV
 
     def to_representation(self, obj):
         if obj.is_anonymous():


### PR DESCRIPTION
Expose git info to js app, allows us to identify current branch and commit for a) superusers and b) environments where EXPOSE_GIT_REV = true (used in dev environments, for example). 