### PR TITLE
i18n-related fixes

### DIFF
--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -387,27 +387,7 @@ var Reports = React.createClass({
                 onClick={this.toggleReportGraphSettings}>
           {t('Graph Settings')}
         </button>
- 
-        <button className="mdl-button mdl-js-button is-edge"
-                id="report-language">
-          {t('Language')}
-          <i className="fa fa-caret-down"></i>
-        </button>
- 
-        <ul className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect"
-            htmlFor="report-language">
-          <li>
-            <a className="mdl-menu__item">
-              {t('Test link 1')}
-            </a>
-          </li>
-          <li>
-            <a className="mdl-menu__item">
-              {t('Test link 2')}
-            </a>
-          </li>
-        </ul> 
- 
+  
         {groupByList.length > 1 && 
           <button className="mdl-button mdl-js-button"
                   id="report-groupby">
@@ -432,25 +412,6 @@ var Reports = React.createClass({
 
           </ul> 
         }
-
-        <button className="mdl-button mdl-js-button is-edge"
-                id="report-viewall">
-          {t('View All')}
-          <i className="fa fa-caret-down"></i>
-        </button>
-        <ul className="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect"
-            htmlFor="report-viewall">
-          <li>
-            <a className="mdl-menu__item">
-              {t('Test view all 1')}
-            </a>
-          </li>
-          <li>
-            <a className="mdl-menu__item">
-              {t('Test view all 2')}
-            </a>
-          </li>
-        </ul> 
 
         <button className="mdl-button mdl-js-button mdl-button--icon report-button__expand"
                 onClick={this.toggleExpandedReports} 

--- a/jsapp/js/i18nMissingStrings.es6
+++ b/jsapp/js/i18nMissingStrings.es6
@@ -1,0 +1,50 @@
+// This file is a workaround to keep a record strings that don't get extracted by gettext.
+// It is not loaded or invoked by the app.
+
+import {
+  t,
+} from './utils';
+
+test = t("Add another condition");
+
+test = t("Question should match all of these criteria");
+test = t("Question should match any of these criteria");
+test = t("Click to add another response...");
+test = t("AUTOMATIC");
+test = t("Skip Logic");
+test = t("Question Options");
+test = t("Validation Criteria");
+test = t("Response Type");
+test = t("A constraint message to be read in case of error:");
+test = t("Row could not be displayed:");
+#~ "This question could not be imported. Please re-create it manually. Please contact us at support@kobotoolbox.org so we can fix this bug!");
+test = t("Add Question");
+test = t("or");
+test = t("Import XLS");
+#~ "This question will only be displayed if the following conditions apply");
+test = t("Save and Exit");
+test = t("Show All Responses");
+test = t("Question Library");
+test = t("Form ID");
+test = t("Unique form name");
+test = t("Web form style (Optional)");
+test = t("This allows using different Enketo styles, e.g. 'theme-grid'");
+test = t("Multiple pages + Grid theme");
+test = t("Version (Optional)");
+test = t("A version ID of the form");
+test = t("Hidden meta questions to include in your form to help with analysis");
+test = t("Meta questions for collecting with cell phones");
+test = t("This form is currently empty.");
+#~ "You can add questions, notes, prompts, or other fields by clicking on the '+' sign below.");
+test = t("Vertical");
+test = t("Donut");
+test = t("Area");
+test = t("Horizontal");
+test = t("Pie");
+test = t("Line");
+test = t("Draft");
+
+test = t("This question could not be imported. Please re-create it manually. Please contact us at support@kobotoolbox.org so we can fix this bug!");
+
+test = t("This question will only be displayed if the following conditions apply");
+test = t("You can add questions, notes, prompts, or other fields by clicking on the '+' sign below.");

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -158,6 +158,7 @@ $headerAccountTextColor: #dbedf7;
         line-height: 36px;
         vertical-align: middle;
         font-size: 16px;
+        text-transform: capitalize;
         i {
             font-size: 24px;
             width: 30px;


### PR DESCRIPTION
Related to: https://github.com/kobotoolbox/form-builder-translations/pull/1 

Changes include: 

- cleanup of test strings in Reports
- added .es6 file to allow gettext to index strings that it would otherwise ignore (gettext has issues with multiline strings in JS files)
- capitalize language names in dropdown via CSS
