### PR TITLE
configurable support details

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -4,6 +4,7 @@ import {
   log,
   t,
   notify,
+  replaceSupportEmail,
 } from './utils';
 
 var Reflux = require('reflux');
@@ -413,7 +414,7 @@ actions.resources.deployAsset.failed.listen(function(data, dialog_or_alert){
       msg = t('please check your connection and try again.');
     }
     failure_message = `
-      <p>${t('if this problem persists, contact support@kobotoolbox.org')}</p>
+      <p>${replaceSupportEmail(t('if this problem persists, contact support@kobotoolbox.org'))}</p>
       <p>${msg}</p>
     `;
   } else if(!!data.responseJSON.xform_id_string){
@@ -422,7 +423,7 @@ actions.resources.deployAsset.failed.listen(function(data, dialog_or_alert){
     failure_message = `
       <p>${t('your form id was not valid:')}</p>
       <p><pre>${data.responseJSON.xform_id_string}</pre></p>
-      <p>${t('if this problem persists, contact support@kobotoolbox.org')}</p>
+      <p>${replaceSupportEmail(t('if this problem persists, contact support@kobotoolbox.org'))}</p>
     `;
   } else if(!!data.responseJSON.detail) {
     failure_message = `

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -23,6 +23,7 @@ import {
   getAnonymousUserPermission,
   anonUsername,
   isLibrary,
+  supportUrl,
 } from '../utils';
 
 import SidebarFormsList from '../lists/sidebarForms';
@@ -106,10 +107,12 @@ var Drawer = React.createClass({
                   <i className="k-icon k-icon-github" />
                   {t('source')}
                 </a>
-                <a href='http://support.kobotoolbox.org/' className='k-drawer__link' target="_blank">
-                  <i className="k-icon k-icon-help" />
-                  {t('help')}
-                </a>
+                { stores.session.currentAccount ?
+                  <a href={supportUrl()} className='k-drawer__link' target="_blank">
+                    <i className="k-icon k-icon-help" />
+                    {t('help')}
+                  </a>
+                : null}
               </div>
             </div>
           </bem.Drawer>

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -9,6 +9,7 @@ import {
   t,
   notify,
   assign,
+  setSupportDetails,
 } from './utils';
 
 function changes(orig_obj, new_obj) {
@@ -367,6 +368,9 @@ var sessionStore = Reflux.createStore({
       if ('downtimeNoticeSeen' in window.localStorage) {
         localStorage.removeItem('downtimeNoticeSeen');
       }
+    }
+    if (acct.support) {
+      setSupportDetails(acct.support)
     }
     var nestedArrToChoiceObjs = function (_s) {
       return {

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -136,6 +136,31 @@ if (window.gettext) {
 export function t(str) {
   return _gettext(str);
 };
+
+
+// these values may appear in transifex (esp. email) and need to
+// be replaced in all the translations before removing this hard
+// coded value.
+const originalSupportEmail = 'support@kobotoolbox.org';
+const originalSupportUrl = 'http://support.kobotoolbox.org';
+
+let supportDetails = {
+  url: originalSupportUrl,
+  email: originalSupportEmail,
+};
+
+export function setSupportDetails(details) {
+  assign(supportDetails, details);
+}
+
+export function replaceSupportEmail(str) {
+  return str.replace(originalSupportEmail, supportDetails.email);
+}
+
+export function supportUrl() {
+  return supportDetails.url;
+}
+
 export function currentLang() {
   return cookie.load(LANGUAGE_COOKIE_NAME) || 'en';
 }

--- a/jsapp/xlform/src/view.row.templates.coffee
+++ b/jsapp/xlform/src/view.row.templates.coffee
@@ -1,5 +1,6 @@
 module.exports = do ->
   _t = require('utils').t
+  replaceSupportEmail = require('utils').replaceSupportEmail
 
   expandingSpacerHtml = """
       <div class="survey__row__spacer  row clearfix expanding-spacer-between-rows expanding-spacer-between-rows--depr">
@@ -234,7 +235,7 @@ module.exports = do ->
     """
     <div class="card card--error">
       #{_t("Row could not be displayed:")} <pre>#{atts}</pre>
-      <em>#{_t("This question could not be imported. Please re-create it manually. Please contact us at support@kobotoolbox.org so we can fix this bug!")}</em>
+      <em>#{replaceSupportEmail(_t("This question could not be imported. Please re-create it manually. Please contact us at support@kobotoolbox.org so we can fix this bug!"))}</em>
     </div>
     #{expandingSpacerHtml}
     """

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -226,9 +226,6 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 TRACKJS_TOKEN = os.environ.get('TRACKJS_TOKEN')
 GOOGLE_ANALYTICS_TOKEN = os.environ.get('GOOGLE_ANALYTICS_TOKEN')
 
-KOBO_SUPPORT_URL = os.environ.get('KOBO_SUPPORT_URL', 'http://support.kobotoolbox.org/')
-KOBO_SUPPORT_EMAIL = os.environ.get('KOBO_SUPPORT_EMAIL', 'support@kobotoolbox.org')
-
 # replace this with the pointer to the kobocat server, if it exists
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL', 'http://kobocat/')
 KOBOCAT_INTERNAL_URL = os.environ.get('KOBOCAT_INTERNAL_URL',
@@ -377,6 +374,9 @@ if os.environ.get('EMAIL_USE_TLS'):
 if os.environ.get('DEFAULT_FROM_EMAIL'):
     DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
     SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
+KOBO_SUPPORT_URL = os.environ.get('KOBO_SUPPORT_URL', 'http://support.kobotoolbox.org/')
+KOBO_SUPPORT_EMAIL = os.environ.get('KOBO_SUPPORT_EMAIL') or os.environ.get('DEFAULT_FROM_EMAIL', 'support@kobotoolbox.org')
 
 if os.environ.get('AWS_ACCESS_KEY_ID'):
     AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -226,6 +226,9 @@ TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
 TRACKJS_TOKEN = os.environ.get('TRACKJS_TOKEN')
 GOOGLE_ANALYTICS_TOKEN = os.environ.get('GOOGLE_ANALYTICS_TOKEN')
 
+KOBO_SUPPORT_URL = os.environ.get('KOBO_SUPPORT_URL', 'http://support.kobotoolbox.org/')
+KOBO_SUPPORT_EMAIL = os.environ.get('KOBO_SUPPORT_EMAIL', 'support@kobotoolbox.org')
+
 # replace this with the pointer to the kobocat server, if it exists
 KOBOCAT_URL = os.environ.get('KOBOCAT_URL', 'http://kobocat/')
 KOBOCAT_INTERNAL_URL = os.environ.get('KOBOCAT_INTERNAL_URL',

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -745,6 +745,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField()
     server_time = serializers.SerializerMethodField()
     projects_url = serializers.SerializerMethodField()
+    support = serializers.SerializerMethodField()
     gravatar = serializers.SerializerMethodField()
     languages = serializers.SerializerMethodField()
     extra_details = WritableJSONField(source='extra_details.data')
@@ -761,6 +762,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             'email',
             'server_time',
             'projects_url',
+            'support',
             'is_superuser',
             'gravatar',
             'is_staff',
@@ -777,6 +779,12 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_projects_url(self, obj):
         return '/'.join((settings.KOBOCAT_URL, obj.username))
+
+    def get_support(self, obj):
+        return {
+            'email': settings.KOBO_SUPPORT_EMAIL,
+            'url': settings.KOBO_SUPPORT_URL,
+        }
 
     def get_gravatar(self, obj):
         return gravatar_url(obj.email)


### PR DESCRIPTION
* configurable support URL in KPI sidebar
* configurable support email in coffeescript code
* note: works around existing transifex strings with
  hardcoded support URL 

closes #1162