### PR TITLE
Autoname arabic bug

### DIFF
--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -3,6 +3,7 @@
 # 😬
 
 from kpi.models import Asset
+from kpi.utils.sluggify import sluggify_label
 from pprint import pprint
 from collections import OrderedDict
 import pytest
@@ -302,6 +303,15 @@ def _score_item(_r):
         r.pop('$autoname', False),
         u' '.join(sorted(r.keys())),
     ]
+
+
+def test_sluggify_arabic():
+    # this "_" value will get replaced with something else by `autoname`
+    ll = sluggify_label(u'مرحبا بالعالم')
+    assert ll == '_'
+
+    ll = sluggify_label(u'بالعالم')
+    assert ll == '_'
 
 
 def test_rank_to_xlsform_structure():

--- a/kpi/utils/autoname.py
+++ b/kpi/utils/autoname.py
@@ -132,7 +132,7 @@ def autoname_fields_in_place(surv_content, destination_key):
                 _name = sluggify_label(_label,
                                        other_names=other_names.keys(),
                                        characterLimit=40)
-                if _name != '_':
+                if _name not in ['', '_']:
                     _assign_row_to_name(row, _name)
                     continue
 

--- a/kpi/utils/sluggify.py
+++ b/kpi/utils/sluggify.py
@@ -61,7 +61,7 @@ def sluggify(_str, _opts):
         else:
             regex = '\W+'
         _str = re.sub(regex, '_', _str)
-        if re.search('_$', _str):
+        if _str != '_' and re.search('_$', _str):
             _str = re.sub('_$', '', _str)
 
     if opts['characterLimit']:


### PR DESCRIPTION
* When an arabic word has no spaces, it behaves differently because of `sluggify_label()`
* Fixes that bug

Fixes #1167
Possibly related to #1054 