### PR TITLE
Revert django-reversion; standardize package names

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "jquery": "~2.1.0",
-    "sinon": "http://sinonjs.org/releases/sinon-1.10.3.js",
     "underscore": "~1.6.0",
     "backbone": "~1.1.2",
     "requirejs": "~2.1.11",

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements/dev_requirements.txt requirements/dev_requirements.in
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@1.4#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@1b5e8bab8c1327db6b7e37ad578359f3a97124d3#egg=formpack
 -e git+https://github.com/kobotoolbox/pyxform.git@6dfff060fc2ad6c575c6a7d953c381d2180e6833#egg=pyxform
 amqp==2.1.4
 anyjson==0.3.3
@@ -35,23 +35,24 @@ django-ses==0.8.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1
 django-webpack-loader==0.4.1
-Django==1.8.17            # via django-debug-toolbar, django-haystack, django-jsonbfield, django-oauth-toolkit, django-reversion, django-toolbelt, jsonfield
+django==1.8.17
 djangorestframework==3.5.4
 docutils==0.13.1          # via statistics
+drf-extensions==0.3.1
 enum34==1.1.6             # via cryptography
-Fabric==1.13.1
+fabric==1.13.1
 funcsigs==1.0.2           # via begins
 functools32==3.2.3.post2  # via jsonschema
 gunicorn==19.6.0
 idna==2.2                 # via cryptography
 ipaddress==1.0.18         # via cryptography
-Jinja2==2.9.5             # via pyexcelerate
+jinja2==2.9.5             # via pyexcelerate
 jsonfield==1.0.3
 jsonschema==2.5.1
 kombu==4.0.2
 lxml==2.3.4
-Markdown==2.6.8
-MarkupSafe==0.23          # via jinja2
+markdown==2.6.8
+markupsafe==0.23          # via jinja2
 ndg-httpsclient==0.4.2
 oauthlib==1.1.2
 packaging==16.8           # via setuptools
@@ -62,7 +63,7 @@ py==1.4.32                # via pytest
 pyasn1==0.2.2
 pycparser==2.17           # via cffi
 PyExcelerate==0.6.7
-Pygments==2.2.0
+pygments==2.2.0
 pymongo==3.4.0
 pyopenssl==16.2.0
 pyparsing==2.1.10         # via packaging
@@ -80,9 +81,9 @@ static3==0.7.0
 statistics==1.0.3.5
 tabulate==0.7.7
 unicodecsv==0.14.1
-uWSGI==2.0.14
+uwsgi==2.0.14
 vine==1.1.3               # via amqp
-Werkzeug==0.11.15
+werkzeug==0.11.15
 whitenoise==3.3.0
 Whoosh==2.7.4
 xlrd==0.8.0

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -30,7 +30,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.11.0
 django-registration-redux==1.3
-django-reversion==2.0.8
+django-reversion==1.10.2
 django-ses==0.8.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1

--- a/requirements/external_services.txt
+++ b/requirements/external_services.txt
@@ -32,7 +32,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.10.0
 django-registration-redux==1.3
-django-reversion==2.0.8
+django-reversion==1.10.2
 django-ses==0.7.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1

--- a/requirements/external_services.txt
+++ b/requirements/external_services.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements/external_services.txt requirements/external_services.in
 #
-
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
 -e git+https://github.com/kobotoolbox/formpack.git@1b5e8bab8c1327db6b7e37ad578359f3a97124d3#egg=formpack
 -e git+https://github.com/kobotoolbox/pyxform.git@6dfff060fc2ad6c575c6a7d953c381d2180e6833#egg=pyxform
@@ -41,7 +40,6 @@ django==1.8.13
 djangorestframework==3.3.3
 docutils==0.12            # via statistics
 drf-extensions==0.3.1
-ecdsa==0.13               # via paramiko
 enum34==1.1.6             # via cryptography
 funcsigs==1.0.2           # via begins
 functools32==3.2.3.post2  # via jsonschema
@@ -59,7 +57,6 @@ ndg-httpsclient==0.4.2
 newrelic==2.78.0.57
 oauthlib==1.0.3
 packaging==16.8           # via setuptools
-paramiko==1.17.0          # via fabric
 path.py==8.1.2
 psycopg2==2.6.1
 py==1.4.31                # via pytest

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -32,12 +32,12 @@ django-registration-redux==1.3 # DO NOT UPGRADE TO 1.4 WITHOUT TESTING!
 django-ses
 django-toolbelt
 django-webpack-loader
-django_haystack
+django-haystack
 django-loginas==0.2.3
-django_markitup
-django_mptt
-django_reversion
-django_taggit
+django-markitup
+django-mptt
+django-reversion
+django-taggit
 djangorestframework
 drf-extensions
 gunicorn
@@ -48,7 +48,7 @@ oauthlib
 psycopg2
 pymongo
 pytest-django
-python_dateutil
+python-dateutil
 pytz
 requests
 shortuuid

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -38,6 +38,7 @@ django-webpack-loader==0.3.0
 django==1.8.13
 djangorestframework==3.3.3
 docutils==0.12            # via statistics
+drf-extensions==0.3.1
 enum34==1.1.6             # via cryptography
 funcsigs==1.0.2           # via begins
 functools32==3.2.3.post2  # via jsonschema

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.10.0
 django-registration-redux==1.3
-django-reversion==2.0.8
+django-reversion==1.10.2
 django-ses==0.7.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1


### PR DESCRIPTION
* django-reversion>=2.0.0 requires a long migration; avoid for now
* Package names in `.in` files must match PyPI exactly for `pip-compile` version pinning to work properly; some requirements were listed with underscores while their PyPI names had dashes

Fixes #1169 
