### PR TITLE
pull latest translations when deploying kpi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "locale"]
 	path = locale
 	url = https://github.com/kobotoolbox/form-builder-translations
+	branch = master

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN python manage.py collectstatic --noinput
 #####################################
 
 RUN git submodule init && \
-    git submodule update && \
+    git submodule update --remote && \
     python manage.py compilemessages
 
 


### PR DESCRIPTION
* The `branch = master` in `.gitmodules` is redundant.
* The `--remote` flag overrides whatever is in the kpi repo and pulls the latest from the remote
