### PR TITLE
Log warning when object has no search index

### DIFF
--- a/kpi/haystack_utils.py
+++ b/kpi/haystack_utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import haystack
+import logging
 from django.apps import apps as kpi_apps
 from django.db import models
 from django.conf import settings
@@ -15,6 +16,8 @@ def update_object_in_search_index(obj):
             type(obj))
     except haystack.exceptions.NotHandled:
         # There's nothing to update because this type of object is not indexed
+        logging.warning(
+            'No search index for type {}'.format(type(obj)), exc_info=True)
         return
     index.update_object(obj)
 


### PR DESCRIPTION
While reindexing manually, I noticed silent failures for `Asset`s I'd fetched using `only()` (see https://github.com/django-haystack/django-haystack/issues/405).

[Some `Asset`s have been reported missing](https://www.flowdock.com/app/kobotoolbox/kobo/threads/eyKDdbMvDHxZvkShi6fxGp3uTNi) from the search index. Though I doubt this logging will reveal anything interesting during normal use, it shouldn't hurt.