### PR TITLE
Upgrade reversion to 2.0.8. Read WARNING below!

### DIFF
--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -30,7 +30,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.11.0
 django-registration-redux==1.3
-django-reversion==1.10.2
+django-reversion==2.0.8
 django-ses==0.8.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1

--- a/requirements/external_services.txt
+++ b/requirements/external_services.txt
@@ -31,7 +31,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.10.0
 django-registration-redux==1.3
-django-reversion==1.10.2
+django-reversion==2.0.8
 django-ses==0.7.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ django-markitup==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==0.10.0
 django-registration-redux==1.3
-django-reversion==1.10.2
+django-reversion==2.0.8
 django-ses==0.7.1
 django-taggit==0.22.0
 django-toolbelt==0.0.1


### PR DESCRIPTION
If your database is large, the migration included in this update of
django-reversion will be slow. For example, on a database with 3.3 million rows
in the `reversion_version` table, the migration takes about 20 minutes. This
can be reduced to around 7 minutes on the same size of database by checking out
commit e822bb1 (from https://github.com/etianen/django-reversion/pull/611).