### PR TITLE
Rudimentiary permissions sync from KC

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -318,6 +318,15 @@ if 'KOBOCAT_URL' in os.environ:
     # Create/update KPI assets to match KC forms
     SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES = int(os.environ.get('SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES',
                                                             '30'))
+    # Create view permission in KPI when KC form is shared? Default is False.
+    # WARNING: this is a one-way operation! Users will retain their
+    # `view_asset` permission in KPI even if their KC access is revoked.
+    # This setting affects only the periodic task run by Celery. When using the
+    # management command, refer to `--grant-kpi-view-permission`
+    SYNC_KOBOCAT_XFORMS_GRANT_KPI_VIEW_PERMISSION = os.environ.get(
+        'SYNC_KOBOCAT_XFORMS_GRANT_KPI_VIEW_PERMISSION', 'False'
+    ).lower() == 'true'
+
     CELERYBEAT_SCHEDULE['sync-kobocat-xforms'] = {
         'task': 'kpi.tasks.sync_kobocat_xforms',
         'schedule': timedelta(minutes=SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES),

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from celery import shared_task
 from django.core.management import call_command
+from django.conf import settings
 from .models import ImportTask
 
 @shared_task
@@ -14,4 +15,10 @@ def import_in_background(import_task_uid):
 
 @shared_task
 def sync_kobocat_xforms(username=None, quiet=True):
-    call_command('sync_kobocat_xforms', username=username, quiet=quiet)
+    call_command(
+        'sync_kobocat_xforms',
+        username=username,
+        quiet=quiet,
+        grant_kpi_view=getattr(
+            settings, 'SYNC_KOBOCAT_XFORMS_GRANT_KPI_VIEW_PERMISSION', False)
+    )


### PR DESCRIPTION
Enabled with `--grant-kpi-view-permission` argument to `sync_kobocat_xforms` management command or `SYNC_KOBOCAT_XFORMS_GRANT_KPI_VIEW_PERMISSION`, which governs the periodic Celery task's behavior.

WARNING: this is a one-way operation! Users will retain their `view_asset` permission in KPI even if their KC access is revoked.

Currently testing on https://kf.tri.kbtdev.org. Closes #1161 