### PR TITLE
Actually include `django-guardian` requirement

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -22,6 +22,7 @@ dj-static==0.0.6
 django-braces==1.11.0
 django-debug-toolbar==1.6
 django-extensions==1.7.6
+django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -23,6 +23,7 @@ dj-static==0.0.6
 django-braces==1.8.1
 django-debug-toolbar==1.4
 django-extensions==1.6.7
+django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -12,6 +12,9 @@
 python-digest==1.7
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
 
+# django-guardian must match KoBoCAT's version
+django-guardian==1.4.1
+
 # Regular PyPI packages
 Django<1.9
 Markdown

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -22,6 +22,7 @@ dj-static==0.0.6
 django-braces==1.8.1
 django-debug-toolbar==1.4
 django-extensions==1.6.7
+django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3


### PR DESCRIPTION
Should have been included with 12ced2a