### PR TITLE
Remove double slash added to ENKETO_SERVER

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -334,7 +334,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         }
         try:
             response = requests.post(
-                u'{}/{}'.format(
+                u'{}{}'.format(
                     settings.ENKETO_SERVER, settings.ENKETO_SURVEY_ENDPOINT),
                 # bare tuple implies basic auth
                 auth=(settings.ENKETO_API_TOKEN, ''),


### PR DESCRIPTION
A trailing slash is added to `ENKETO_SERVER` in the settings module. Another one is introduced between the domain and path, resulting in a double slash. This PR fixes #1225