### PR TITLE
Notify users when survey save has failed

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -342,8 +342,9 @@ actions.resources.updateAsset.listen(function(uid, values){
       actions.resources.updateAsset.completed(asset);
       notify(t('successfully updated'));
     })
-    .fail(function(...args){
-      actions.resources.updateAsset.failed(...args);
+    .fail(function(resp){
+      actions.resources.updateAsset.failed(resp);
+      notify(t('save failed'));
     });
 });
 

--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -344,7 +344,6 @@ actions.resources.updateAsset.listen(function(uid, values){
     })
     .fail(function(resp){
       actions.resources.updateAsset.failed(resp);
-      notify(t('save failed'));
     });
 });
 

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -6,6 +6,7 @@ const update_states = {
   UNSAVED_CHANGES: -1,
   UP_TO_DATE: true,
   PENDING_UPDATE: false,
+  SAVE_FAILED: 'SAVE_FAILED',
 };
 
 const AVAILABLE_FORM_STYLES = [

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -9,6 +9,7 @@ import SurveyScope from '../models/surveyScope';
 import cascadeMixin from './cascadeMixin';
 import AssetNavigator from './assetNavigator';
 import {Link, hashHistory} from 'react-router';
+import alertify from 'alertifyjs';
 
 import {
   surveyToValidJson,
@@ -333,14 +334,23 @@ export default assign({
           });
         })
         .catch((resp) => {
+          var errorMsg = `${t('Your changes could not be saved, likely because of a lost internet connection.')}&nbsp;
+                         ${t('Keep this window open and try saving again while using a better connection.')}`;
+          if (resp.statusText != 'error')
+            errorMsg = resp.statusText;
+
+          alertify.defaults.theme.ok = "ajs-cancel";
+          let dialog = alertify.dialog('alert');
+          let opts = {
+            title: t('Error saving form'),
+            message: errorMsg,
+            label: t('Dismiss'),
+          };
+          dialog.set(opts).show();
+
           this.setState({
-            surveySaveFail: {
-              error: resp.statusText,
-              uid: params.uid,
-              name: params.name,
-              content: params.content,
-            },
-            asset_updated: update_states.SAVE_FAILED,
+            surveySaveFail: true,
+            asset_updated: update_states.SAVE_FAILED
           });
         });
     }
@@ -389,7 +399,7 @@ export default assign({
     if (this.editorState === 'new') {
       ooo.saveButtonText = t('create');
     } else if (this.state.surveySaveFail) {
-      ooo.saveButtonText = t('save failed (retry)');
+      ooo.saveButtonText = `${t('save')} (${t('retry')}) `;
     } else {
       ooo.saveButtonText = t('save');
     }
@@ -653,29 +663,6 @@ export default assign({
               {this.renderSaveAndPreviewButtons()}
 
               <bem.FormBuilder__contents>
-                {this.state.surveySaveFail ?
-                  <bem.FormMeta m='message'>
-                    <bem.FormMeta__content>
-                      <h3>
-                      {
-                        t('save failed')
-                      }
-                      </h3>
-                      <p>
-                        {this.state.surveySaveFail.error == 'error' ?
-                          t('Lost internet connection?')
-                          :
-                          this.state.surveySaveFail.error
-                        }
-                      </p>
-                      <p>
-                        {t('If you would like to save changes, please do not close' +
-                           ' this tab. Retry saving from a better connection until' +
-                           ' you see the "succesfully updated" message.')}
-                      </p>
-                    </bem.FormMeta__content>
-                  </bem.FormMeta>
-                :null}
 
                 { isSurvey ?
                   <FormSettingsBox survey={this.app.survey} {...this.state} />

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -262,6 +262,25 @@
     }
   }
 
+  &.formBuilder-header__button--savefailed {
+    background-color: #b32a2a;
+
+    // forcefully override mdl-lite colors
+    &:hover, &:focus:not(:active) {
+      background-color: #b32a2a;
+    }
+
+    > i {
+      @extend .fa-exclamation-circle;
+      font-size: 22px;
+      line-height: 39px;
+      display: inline-block;
+    }
+    > i + span {
+      display: none;
+    }
+  }
+
   &.formBuilder-header__button--saveneeded:after {
     content: '*';
     color: white;
@@ -304,7 +323,6 @@
   margin:8px 75px;
   margin-bottom: 16px;
   margin-right: 60px;
-
 }
 
 .form-meta__button--metasummary {

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -262,26 +262,7 @@
     }
   }
 
-  &.formBuilder-header__button--savefailed {
-    background-color: #b32a2a;
-
-    // forcefully override mdl-lite colors
-    &:hover, &:focus:not(:active) {
-      background-color: #b32a2a;
-    }
-
-    > i {
-      @extend .fa-exclamation-circle;
-      font-size: 22px;
-      line-height: 39px;
-      display: inline-block;
-    }
-    > i + span {
-      display: none;
-    }
-  }
-
-  &.formBuilder-header__button--saveneeded:after {
+  &.formBuilder-header__button--savefailed:after, &.formBuilder-header__button--saveneeded:after {
     content: '*';
     color: white;
   }

--- a/jsapp/scss/components/_kobo.modal.scss
+++ b/jsapp/scss/components/_kobo.modal.scss
@@ -148,7 +148,7 @@
 
 .alertify .ajs-dimmer {
   background-color: #FFF;
-  opacity: 0.4;
+  opacity: 0.55;
 }
 
 .alertify .ajs-dialog {
@@ -224,6 +224,9 @@
     }
     &.ajs-cancel {
       @extend .mdl-button--colored;
+      &:focus, &:focus:not(:active) {
+        background: transparent;
+      }
     }
   }
 }


### PR DESCRIPTION
* shows an updated button and a message telling the user not to close the tab.
* displays a brief alertify message if the survey is scrolled.

* Note: falls short of saving the changes (e.g. to localStorage) which could prevent data loss but could also lead to privacy leaks of things stored in the browser.

Closes #1109