### PR TITLE
modified form sharing view to check usernames onChange and onKeyUp

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -1225,6 +1225,7 @@ var AssetSharing = React.createClass({
                   ref='usernameInput'
                   placeholder={t('Enter a username')}
                   onKeyUp={this.usernameCheck}
+                  onChange={this.usernameCheck}
               />
               <button className={btnKls}>
                 <i className="fa fa-fw fa-lg fa-plus" />


### PR DESCRIPTION
When sharing a form and selecting a user from the dropdown instead of typing, usernameCheck was not firing. 