### PR TITLE
remove unused script tag in registration form

### DIFF
--- a/kpi/templates/registration/registration_form.html
+++ b/kpi/templates/registration/registration_form.html
@@ -1,43 +1,31 @@
-{% extends "registration.html" %}
-{% load staticfiles %}
-
-{% block content %}
+{% extends "registration.html" %} {% load staticfiles %} {% block content %}
 <div class="registration__bg">
 
-  <form action="." method="post" class="registration registration--register">
-    <div class="registration--logo"><a href="/"><img src="{% static 'img/kobologo.svg' %}"/></a></div>
+    <form action="." method="post" class="registration registration--register">
+        <div class="registration--logo">
+            <a href="/"><img src="{% static 'img/kobologo.svg' %}" /></a>
+        </div>
 
-    <div class="registration__first-half">
-      {% csrf_token%}
-      {{ form.as_p }}
-      <input type="submit" value="Create Account" class="registration__action" />
-      <div class="registration__footer">
-        or <a href="{% url 'auth_login' %}">login</a>
-      </div>
-    </div>
+        <div class="registration__first-half">
+            {% csrf_token%} {{ form.as_p }}
+            <input type="submit" value="Create Account" class="registration__action" />
+            <div class="registration__footer">
+                or <a href="{% url 'auth_login' %}">login</a>
+            </div>
+        </div>
 
-    <div class="registration__second-half">
-      {% if welcome_message %}
-        {{ welcome_message|safe }}
-      {% else %}
-        <p>KoBoToolbox is an integrated set of tools for building forms and collecting interview responses. It is built by the Harvard Humanitarian Initiative for easy and reliable use in difficult field settings, such as humanitarian emergencies or post-conflict environments.</p>
-        <p>You can download and install KoBoToolbox on <a href="http://support.kobotoolbox.org/customer/portal/articles/1691108-install-kobotoolbox-on-your-own-server">your own server</a> or <a href="http://support.kobotoolbox.org/customer/portal/articles/1691105-using-kobotoolbox-offline">on your own computer</a>.</p>
-      {% endif %}
-    </div>
-    <div style="clear:both;"></div>
-  </form>
+        <div class="registration__second-half">
+            {% if welcome_message %} {{ welcome_message|safe }} {% else %}
+            <p>KoBoToolbox is an integrated set of tools for building forms and collecting interview responses. It is built by the Harvard Humanitarian Initiative for easy and reliable use in difficult field settings, such as humanitarian emergencies or
+                post-conflict environments.</p>
+            <p>You can download and install KoBoToolbox on <a href="http://support.kobotoolbox.org/customer/portal/articles/1691108-install-kobotoolbox-on-your-own-server">your own server</a> or <a href="http://support.kobotoolbox.org/customer/portal/articles/1691105-using-kobotoolbox-offline">on your own computer</a>.</p>
+            {% endif %}
+        </div>
+        <div style="clear:both;"></div>
+    </form>
 
-  <div class="registration__credit"><a href="https://flic.kr/p/9v4mC5" title="Muhkjar refugee camp" target="_blank">Photo</a> by UNAMID / <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/" target="_blank">by-nc-nd</a></div>
+    <div class="registration__credit"><a href="https://flic.kr/p/9v4mC5" title="Muhkjar refugee camp" target="_blank">Photo</a> by UNAMID / <a href="https://creativecommons.org/licenses/by-nc-nd/2.0/" target="_blank">by-nc-nd</a></div>
 </div>
 
-<script>
-  $(function () {
-    $('form.registration input#id_username').attr('placeholder', 'Username');
-    $('form.registration input#id_email').attr('placeholder', 'Email');
-    $('form.registration input#id_password1').attr('placeholder', 'Password');
-    $('form.registration input#id_password2').attr('placeholder', 'Repeat Password');
-    $('form.registration p label').addClass('hidden');
-  });
-</script>
 
 {% endblock %}


### PR DESCRIPTION
The registration page has an extraneous jquery script that seems to be from a much older version.  Jquery is not being loaded on this page causing the script to no run and gives an error in the console.  This is visible in both live versions here:
[kf.kobotoolbox.org](https://kf.kobotoolbox.org/forms/accounts/register/)
[kobo.humanitarianresponse.info](https://kobo.humanitarianresponse.info/forms/accounts/register/)
