### PR TITLE
Add two env. vars. to control sync_kobocat_xforms

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -330,15 +330,19 @@ CELERYBEAT_SCHEDULE = {
 }
 
 if 'KOBOCAT_URL' in os.environ:
-    # Create/update KPI assets to match KC forms
-    SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES = int(os.environ.get('SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES',
-                                                            '30'))
-    CELERYBEAT_SCHEDULE['sync-kobocat-xforms'] = {
-        'task': 'kpi.tasks.sync_kobocat_xforms',
-        'schedule': timedelta(minutes=SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES),
-        'options': {'queue': 'sync_kobocat_xforms_queue',
-                    'expires': SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES /2. * 60},
-    }
+    SYNC_KOBOCAT_XFORMS = (os.environ.get('SYNC_KOBOCAT_XFORMS', 'True') == 'True')
+    SYNC_KOBOCAT_PERMISSIONS = (
+        os.environ.get('SYNC_KOBOCAT_PERMISSIONS', 'True') == 'True')
+    if SYNC_KOBOCAT_XFORMS:
+        # Create/update KPI assets to match KC forms
+        SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES = int(
+            os.environ.get('SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES', '30'))
+        CELERYBEAT_SCHEDULE['sync-kobocat-xforms'] = {
+            'task': 'kpi.tasks.sync_kobocat_xforms',
+            'schedule': timedelta(minutes=SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES),
+            'options': {'queue': 'sync_kobocat_xforms_queue',
+                        'expires': SYNC_KOBOCAT_XFORMS_PERIOD_MINUTES /2. * 60},
+        }
 
 '''
 Distinct projects using Celery need their own queues. Example commands for

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -293,6 +293,11 @@ def _sync_form_metadata(asset, xform, changes):
 
 
 def _sync_permissions(asset, xform):
+    # Returns a list of affected users' usernames
+
+    if not settings.SYNC_KOBOCAT_PERMISSIONS:
+        return []
+
     # Get all applicable KC permissions set for this xform
     xform_user_perms = UserObjectPermission.objects.filter(
         permission_id__in=PERMISSIONS_MAP.keys(),


### PR DESCRIPTION
* `SYNC_KOBOCAT_XFORMS`: defaults to `True`; set to `False` to disable sync
    altogether
* `SYNC_KOBOCAT_PERMISSIONS`: defaults to `True`; set to `False` to disable
    permissions sync without affecting other KC synchronization, i.e. restore
    pre-#1210 behavior