### PR TITLE
Preserving AssetVersion uid aliases

### DIFF
--- a/kpi/management/commands/remove_duplicate_assetversions.py
+++ b/kpi/management/commands/remove_duplicate_assetversions.py
@@ -82,7 +82,7 @@ def find_original_and_duplicate_versions(version_pks, asset_pk):
     duplicate_version_pks = []
     for (digest, matches) in digests_to_first_version_pks.items():
         if len(matches) > 1:
-            duplicates_of[matches[0]]['pk'] = [m['uid'] for m in matches[1:]]
+            duplicates_of[matches[0]['pk']] = [m['uid'] for m in matches[1:]]
             duplicate_version_pks = duplicate_version_pks + [
                 m['pk'] for m in matches[1:]
             ]
@@ -206,6 +206,9 @@ class Command(BaseCommand):
                     # There are FKs (e.g. from `AssetSnapshot`) that require
                     # Django to take the slow path for cascade deletion
                     start = 0
+                    for (pk, uid_aliases) in duplicate_uids.iteritems():
+                        AssetVersion.objects.filter(id=pk).update(
+                            uid_aliases=uid_aliases)
                     while True:
                         this_batch_version_pks = pks_to_delete[
                             start:start + batch_size]

--- a/kpi/management/commands/remove_duplicate_assetversions.py
+++ b/kpi/management/commands/remove_duplicate_assetversions.py
@@ -33,8 +33,7 @@ def find_original_and_duplicate_versions(version_pks, asset_pk):
         belong. This is required as a safety check.
     '''
     version_pks = sorted(version_pks)
-    digests_to_first_version_pks = {}
-    duplicate_version_pks = []
+    digests_to_first_version_pks = defaultdict(list)
 
     start = 0
     batch_size = 1
@@ -66,10 +65,10 @@ def find_original_and_duplicate_versions(version_pks, asset_pk):
                 version.deployed
             ), sort_keys=True)
             digest = md5(serialized).digest()
-            if digest in digests_to_first_version_pks:
-                duplicate_version_pks.append(version.pk)
-            else:
-                digests_to_first_version_pks[digest] = version.pk
+            digests_to_first_version_pks[digest].append({
+                'pk': version.pk,
+                'uid': version.uid,
+                })
 
         start += batch_size
 
@@ -79,10 +78,20 @@ def find_original_and_duplicate_versions(version_pks, asset_pk):
             batch_size = min(batch_size, MAX_BATCH_SIZE)
             batch_size_guessed = True
 
+    duplicates_of = {}
+    duplicate_version_pks = []
+    for (digest, matches) in digests_to_first_version_pks.items():
+        if len(matches) > 1:
+            duplicates_of[matches[0]]['pk'] = [m['uid'] for m in matches[1:]]
+            duplicate_version_pks = duplicate_version_pks + [
+                m['pk'] for m in matches[1:]
+            ]
+
     return (
-        digests_to_first_version_pks.values(),
+        duplicates_of.keys(),
         duplicate_version_pks,
-        batch_size
+        duplicates_of,
+        batch_size,
     )
 
 
@@ -167,7 +176,7 @@ class Command(BaseCommand):
                 currently_deployed_pk = AssetVersion.objects.filter(
                     uid=currently_deployed_uid).values_list('pk', flat=True)
 
-                original_version_pks, duplicate_version_pks, \
+                original_version_pks, duplicate_version_pks, duplicate_uids, \
                     batch_size = find_original_and_duplicate_versions(
                         versions_for_assets[asset_pk], asset_pk)
                 pks_to_delete = duplicate_version_pks

--- a/kpi/migrations/0017_assetversion_uid_aliases_20170608.py
+++ b/kpi/migrations/0017_assetversion_uid_aliases_20170608.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+import jsonbfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kpi', '0016_asset_settings'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assetversion',
+            name='uid_aliases',
+            field=jsonbfield.fields.JSONField(null=True),
+        ),
+    ]

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -28,6 +28,7 @@ class AssetVersion(models.Model):
                                               on_delete=models.SET_NULL,
                                               )
     version_content = JSONBField()
+    uid_aliases = JSONBField(null=True)
     deployed_content = JSONBField(null=True)
     _deployment_data = JSONBField(default=False)
     deployed = models.BooleanField(default=False)


### PR DESCRIPTION
* In the fix for #1302, we are purging a number of `AssetVersion` records which may still be referenced by submissions coming in.
* This will keep a record of those IDs in a new `JSONBField`.