### PR TITLE
Save form style

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -137,6 +137,7 @@ var FormSettingsBox = React.createClass({
     });
   },
   onStyleChange (evt) {
+    // todo: test if this function is obsolete
     var newStyle = evt.target.value;
     this.props.survey.settings.set('style', newStyle);
     this.setState({
@@ -214,10 +215,9 @@ export default assign({
   surveyStateChanged (state) {
     this.setState(state);
   },
-  onStyleChange (value) {
-    var newStyle = value;
+  onStyleChange ({value}) {
     this.setState({
-      settings__style: newStyle,
+      settings__style: value,
     });
   },
   onSurveyChange: _.debounce(function () {

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -5,6 +5,7 @@
 import re
 import copy
 import json
+import logging
 import StringIO
 from collections import OrderedDict
 
@@ -795,11 +796,19 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
                 u'warnings': warnings,
             })
         except Exception as err:
+            err_message = unicode(err)
+            logging.error('Failed to generate xform for asset', extra={
+                'src': source,
+                'id_string': id_string,
+                'uid': self.uid,
+                'message': err_message,
+                'warnings': warnings,
+            })
             xml = ''
             details.update({
                 u'status': u'failure',
                 u'error_type': type(err).__name__,
-                u'error': unicode(err),
+                u'error': err_message,
                 u'warnings': warnings,
             })
         return (xml, details)


### PR DESCRIPTION
The style switcher was saving the form style as an object (with the `label` value as well).

* fix that so now the style is saved as a string
* set up logging on `AssetSnapshot` to capture errors on XML generation