### PR TITLE
Fix for test_image_tools.py Max retries exceeded on checking if images exist.

### DIFF
--- a/kpi/tests/test_image_tools.py
+++ b/kpi/tests/test_image_tools.py
@@ -74,13 +74,10 @@ class ImageToolsTestCase(TestCase):
         filename = '/path/to/my/test/image.jpg'
         attachment = self._mock_attachment(filename)
 
-        if settings.KOBOCAT_URL:
+        if settings.DEFAULT_DEPLOYMENT_BACKEND !='mock':
             expected = settings.KOBOCAT_URL.strip("/") + "/attachment/%s?media_file=%s" % ('original', filename)
-        else:
-            expected = None
-
-        result = image_tools.image_url(attachment, 'original')
-        self.assertEqual(result, expected)
+            result = image_tools.image_url(attachment, 'original')
+            self.assertEqual(result, expected)
 
 
     @patch('kpi.utils.image_tools.resize')
@@ -132,14 +129,11 @@ class ImageToolsTestCase(TestCase):
 
         filename = '/path/to/my/test/image.jpg'
         attachment = self._mock_attachment(filename)
-        for size in settings.THUMB_ORDER:
-            if settings.KOBOCAT_URL:
+        if settings.DEFAULT_DEPLOYMENT_BACKEND !='mock':
+            for size in settings.THUMB_ORDER:
                 expected = settings.KOBOCAT_URL.strip("/") + "/attachment/%s?media_file=%s" % (size, filename)
-            else:
-                expected = None
-
-            result = image_tools.image_url(attachment, size)
-            self.assertEqual(result, expected)
+                result = image_tools.image_url(attachment, size)
+                self.assertEqual(result, expected)
 
 
     @patch('kpi.utils.image_tools.get_storage_class')


### PR DESCRIPTION
test_image_resizing_original_does_not_exist and test_original_image_does_not_exist only on non-mock backends, otherwise exceptions are thrown:
```
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/srv/src/kpi/kpi/tests/test_image_tools.py", line 141, in test_image_resizing_original_does_not_exist
    result = image_tools.image_url(attachment, size)
  File "/srv/src/kpi/kpi/utils/image_tools.py", line 142, in image_url
    req = requests.get(url)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 71, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 57, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/raven/breadcrumbs.py", line 297, in send
    resp = real_send(self, request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 467, in send
    raise ConnectionError(e, request=request)
ConnectionError: HTTPConnectionPool(host='Null', port=80): Max retries exceeded with url: /media//path/to/my/test/image-large.jpg (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7f0c60c68350>: Failed to establish a new connection: [Errno -2] Name or service not known',))

======================================================================
ERROR: test_original_image_does_not_exist (kpi.tests.test_image_tools.ImageToolsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/srv/src/kpi/kpi/tests/test_image_tools.py", line 82, in test_original_image_does_not_exist
    result = image_tools.image_url(attachment, 'original')
  File "/srv/src/kpi/kpi/utils/image_tools.py", line 99, in image_url
    req = requests.get(url)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 71, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 57, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 475, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/raven/breadcrumbs.py", line 297, in send
    resp = real_send(self, request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 585, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 467, in send
    raise ConnectionError(e, request=request)
ConnectionError: HTTPConnectionPool(host='Null', port=80): Max retries exceeded with url: /media//path/to/my/test/image.jpg (Caused by NewConnectionError('<requests.packages.urllib3.connection.HTTPConnection object at 0x7f0c60ff2990>: Failed to establish a new connection: [Errno -2] Name or service not known',))

```