### PR TITLE
Fix issue 1363: XLS upload issues on certain browsers

### DIFF
--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -89,12 +89,6 @@ class AssetRow extends React.Component {
       clearPopover: true,
     });
   }
-  onDrop (files, rejectedFiles) {
-    if (files.length === 0) {
-      return;
-    }
-    this.dropFiles(files, rejectedFiles, {url: this.props.url});
-  }
   render () {
     var selfowned = this.props.owner__username === this.props.currentUsername;
 
@@ -291,9 +285,9 @@ class AssetRow extends React.Component {
                 </bem.PopoverMenu__link>
               }
               { this.props.asset_type && this.props.asset_type === 'survey' && userCanEdit &&
-                <Dropzone onDrop={this.onDrop} 
+                <Dropzone onDrop={this.dropFiles}
                           multiple={false} 
-                          className='dropzone' 
+                          className='dropzone'
                           accept={validFileTypes()}>
                   <bem.PopoverMenu__link
                         m={'refresh'}

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -125,27 +125,6 @@ var dmix = {
       historyExpanded: !this.state.historyExpanded,
     });
   },
-  onDrop (files) {
-    if (files.length === 0) {
-      return;
-    } else if (files.length> 1) {
-      var errMsg = t('Only 1 file can be uploaded in this case');
-      alertify.error(errMsg);
-      throw new Error(errMsg);
-    }
-    const VALID_ASSET_UPLOAD_FILE_TYPES = [
-      'application/xls',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    ];
-    var file = files[0];
-    if (VALID_ASSET_UPLOAD_FILE_TYPES.indexOf(file.type) === -1) {
-      var err = `Invalid filetype: '${file.type}'`;
-      console.error(err);
-    }
-    this.dropFiles(files);
-  },
   summaryDetails () {
     return (
       <pre>
@@ -310,6 +289,11 @@ mixins.droppable = {
         f.call(this, e, file, params);
       };
       reader.readAsDataURL(file);
+    });
+
+    rejectedFiles.map((rej) => {
+      var errMsg = t('Upload error: could not recognize Excel file.');
+      alertify.error(errMsg);
     });
   }
 }; 

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -224,6 +224,7 @@ export function validFileTypes() {
   const VALID_ASSET_UPLOAD_FILE_TYPES = [
     'application/xls',
     'application/vnd.ms-excel',
+    'application/octet-stream',
     'application/vnd.openxmlformats',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   ];

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -227,6 +227,7 @@ export function validFileTypes() {
     'application/octet-stream',
     'application/vnd.openxmlformats',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ''
   ];
   return VALID_ASSET_UPLOAD_FILE_TYPES.join(',');
 }

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -227,7 +227,7 @@ export function validFileTypes() {
     'application/octet-stream',
     'application/vnd.openxmlformats',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    ''
+    '' // Keep this to fix issue with IE Edge sending an empty MIME type
   ];
   return VALID_ASSET_UPLOAD_FILE_TYPES.join(',');
 }


### PR DESCRIPTION
This PR

- removes a duplicate MIME type check (when replacing XLS in the asset row)
- adds two more MIME types to cover cases when browsers misreport the file's MIME type (Chrome on Mac and IE Edge on Windows 10)
- adds alert to user when file type has been rejected by Dropzone

Closes #1363 . 