### PR TITLE
Hotfix for missing form meta fields

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -684,6 +684,7 @@ export default assign({
   },
 
   render () {
+    console.log(this.constructor.name);
     var isSurvey = this.app && this.constructor.name === 'FormPage';
     var docTitle = this.state.name || t('Untitled');
     return (

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -684,8 +684,7 @@ export default assign({
   },
 
   render () {
-    console.log(this.constructor.name);
-    var isSurvey = this.app && this.constructor.name === 'FormPage';
+    var isSurvey = this.app && this.state.backRoute === '/forms';
     var docTitle = this.state.name || t('Untitled');
     return (
         <DocumentTitle title={`${docTitle} | KoboToolbox`}>


### PR DESCRIPTION
As reported in the support channel in Flowdock, the form meta fields are missing. Confirmed on our prod, OCHA, as well as on a recent dev site. 

This fix was tested on `kvar`.