### PR TITLE
fix #1429: restore context router for FormSidebar, needed by XLS upload

### DIFF
--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -92,6 +92,10 @@ class FormSidebar extends Reflux.Component {
 
 };
 
+FormSidebar.contextTypes = {
+  router: PropTypes.object
+};
+
 reactMixin(FormSidebar.prototype, searches.common);
 reactMixin(FormSidebar.prototype, mixins.droppable);
 


### PR DESCRIPTION
Fixes a bug yours truly introduced in PR #1421. 