### PR TITLE
Fix XLS uploads for Linux and Windows

### DIFF
--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -222,6 +222,8 @@ export function stringToColor(str, prc) {
 
 export function validFileTypes() {
   const VALID_ASSET_UPLOAD_FILE_TYPES = [
+    '.xls',
+    '.xlsx',
     'application/xls',
     'application/vnd.ms-excel',
     'application/octet-stream',

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-copy-to-clipboard": "^4.2.3",
     "react-document-title": "^2.0.2",
     "react-dom": "^15.6.0",
-    "react-dropzone": "^3.12.2",
+    "react-dropzone": "^4.1.0",
     "react-hot-loader": "^1.3.1",
     "react-hotkey": "^0.7.0",
     "react-mixin": "^3.0.5",


### PR DESCRIPTION
Closes #1363 (again).

Adds `.xls, .xlsx` to valid file types expected by `react-dropzone`. When uploading a file in Chrome/FF/IE on Windows and Linux this should now show the correct list of allowed files by default (without needing to toggle to "All files".) 