### PR TITLE
Allow async dkobo migrations and notify the user

### DIFF
--- a/hub/views.py
+++ b/hub/views.py
@@ -32,7 +32,10 @@ def switch_builder(request):
             quiet=True # squelches `print` statements
         )
         # Create/update KPI assets to match the user's KC forms
-        sync_kobocat_xforms(username=request.user.username)
+        if 'async' in request.GET:
+            sync_kobocat_xforms.delay(username=request.user.username)
+        else:
+            sync_kobocat_xforms(username=request.user.username)
 
     return HttpResponseRedirect('/')
 

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -1,5 +1,6 @@
 import Reflux from 'reflux';
 import cookie from 'react-cookie';
+import alertify from 'alertifyjs';
 
 import dkobo_xlform from '../xlform/src/_xlform.init';
 import assetParserUtils from './assetParserUtils';
@@ -335,6 +336,28 @@ var sessionStore = Reflux.createStore({
     }
     if (acct.all_languages) {
       acct.all_languages = acct.all_languages.map(nestedArrToChoiceObjs);
+    }
+    if (acct.dkobo_survey_drafts && acct.dkobo_survey_drafts.non_migrated) {
+      let wait_message = t(
+        `It may take several minutes for all of your survey drafts to finish
+        migrating from the legacy form builder. Refresh the page to view
+        newly-migrated drafts.`
+      );
+      let stuck_message = t(
+        `If this message persists longer than a few hours, click here to
+        restart the migration process.`
+      );
+      let notify_content = `${wait_message}<br/>
+        <a href="${acct.dkobo_survey_drafts.migrate_url}">${stuck_message}</a>
+        <small>
+        (${acct.dkobo_survey_drafts.non_migrated}/${acct.dkobo_survey_drafts.total})
+        </small>
+      `;
+      alertify.notify(
+        notify_content,
+        'warning',
+        0 // Persist until the user clicks the close button
+      );
     }
 
     this.trigger({


### PR DESCRIPTION
when any of their SurveyDrafts have not been migrated yet. Pass the `async`
query parameter to `switch_builder`, i.e.
`switch_builder?beta=1&migrate=1&async=1` to have Celery run the migration job
in the background. Running the migration *synchronously* remains the default.
Fixes #1437.