### PR TITLE
Fix #1468: trim label length for report charts

### DIFF
--- a/jsapp/js/components/reportViewItem.es6
+++ b/jsapp/js/components/reportViewItem.es6
@@ -165,11 +165,12 @@ class ReportViewItem extends React.Component {
     }
 
     var datasets = [];
+
     if (data.values != undefined) {
       data.responses = data.values[0][1].responses;
       data.graphLabels = [];
       data.responses.forEach(function(r, i){
-        data.graphLabels[i] = r.length > 20 ? r.substring(0,17) + '...' : r;
+        data.graphLabels[i] = r.length > 25 ? r.substring(0,22) + '...' : r;
       });
       var allPercentages = [];
       data.values.forEach(function(val, i){
@@ -187,10 +188,12 @@ class ReportViewItem extends React.Component {
     } else {
       maxPercentage = Math.max.apply(Math, data.percentages);
       datasets.push({data: data.percentages});
+      data.responses.forEach(function(r, i){
+        data.responses[i] = r.length > 25 ? r.substring(0,22) + '...' : r;
+      });
     }
 
     maxPercentage = maxPercentage < 85 ? ((parseInt(maxPercentage/10, 10)+1)*10) : 100;
-
     var opts = {
       type: chartType,
       data: {
@@ -198,6 +201,7 @@ class ReportViewItem extends React.Component {
           datasets: datasets
       },
       options: {
+        responsive: true,
         events: [''],
         legend: {
           display: showLegend

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bower": "^1.4.1",
     "browser-sync": "^2.10.1",
     "chai": "^3.4.1",
-    "chart.js": "^2.1.6",
+    "chart.js": "^2.7.1",
     "classnames": "^2.1.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.10.0",


### PR DESCRIPTION
At the same time: enable responsiveness for the charts and update chart.js to the latest version in `package.json`. 