### PR TITLE
Fix formbuilder in wide screens, closes #1490

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -103,8 +103,9 @@ class App extends React.Component {
           }
           <bem.PageWrapper m={{
               'fixed-drawer': this.state.pageState.showFixedDrawer,
-              'header-hidden': (this.isFormBuilder() || this.state.pageState.headerHidden),
-              'drawer-hidden': (this.isFormBuilder() || this.state.pageState.drawerHidden),
+              'header-hidden': this.state.pageState.headerHidden,
+              'drawer-hidden': this.state.pageState.drawerHidden,
+              'in-formbuilder': this.isFormBuilder()
                 }} className="mdl-layout mdl-layout--fixed-header">
               { this.state.pageState.modal &&
                 <Modal params={this.state.pageState.modal} />

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -8,10 +8,6 @@
   max-width: 1440px;
   margin: 0 auto;
   overflow: hidden;
-
-  &.page-wrapper--header-hidden.page-wrapper--drawer-hidden {
-    max-width: 100%;
-  }
 }
 
 .mdl-layout__content {
@@ -40,6 +36,16 @@
       margin-right: 0px;
       height: calc(100% - 76px);
     }
+  }
+}
+
+// full screen overrides (for expanded reports, table, maps, etc.)
+.mdl-layout.page-wrapper--header-hidden.page-wrapper--drawer-hidden {
+  max-width: 100%;
+
+  .mdl-layout__content.page-wrapper__content--form-landing {
+    box-shadow: none;
+    height: calc(100% - 40px);
   }
 }
 
@@ -79,7 +85,7 @@
 }
 
 // Focus mode for form builder, disable drawer, header
-.mdl-layout.page-wrapper--header-hidden.mdl-layout.page-wrapper--drawer-hidden {
+.mdl-layout.page-wrapper--in-formbuilder {
   .mdl-layout__content {
     margin: 0px;
     width: 100%;

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -1,6 +1,6 @@
 // FORM BUILDER MAIN LAYOUT
 @media screen and (min-width: 1400px) {
-  .page-wrapper--header-hidden.page-wrapper--drawer-hidden {
+  .page-wrapper--in-formbuilder {
     &:before {
       content: ' ';
       width: 100%;


### PR DESCRIPTION
The new table/map views have an expanded display feature. For that case, it makes sense to have tables/maps/reports take up 100% of the viewport. For the formbuilder, though, we still would like to limit the width to 1440px. This PR restores the max-width to the formbuilder, without affecting tables/maps/reports. 

This is now deployed on `unu`. 