### PR TITLE
Fix issue #1545

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -295,7 +295,8 @@ export class DataTable extends React.Component {
                 var labels = [];
                 values.forEach(function(v) {
                   let choice = choices.find(o => o.list_name == q.select_from_list_name && (o.name === v || o.$autoname == v));
-                  labels.push(choice.label[0]);
+                  if (choice && choice.label && choice.label[0])
+                    labels.push(choice.label[0]);
                 });
 
                 return labels.join(", ");

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -305,7 +305,7 @@ export class DataTable extends React.Component {
                 return formatTimeDate(row.value);
               }
             }
-            return row.value;
+            return typeof(row.value) == "object" ? '' : row.value;
           }
       });
 


### PR DESCRIPTION
Fixes two bugs in table display: 

- blank table when a choice list is missing a label (often caused by a select list with or_other option). 
- blank table when theere is a calculate question, with an object as value (that React Table doesn't know how to render)

Reported by users `cambodia2018` and `tanyalrussell`.