### PR TITLE
Make legacy deployments tolerate stopped service

### DIFF
--- a/fabfile/legacy.py
+++ b/fabfile/legacy.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from fabric.api import cd, env, prefix, run
+from fabric.api import cd, env, prefix, run, settings
 
 def kobo_workon(venv_name):
     return prefix('kobo_workon %s' % venv_name)
@@ -99,7 +99,10 @@ def deploy_ref(deployment_name, ref, force=False):
         run("date > LAST_UPDATE.txt")
 
     run("sudo restart kpi_celeryd")
-    run("sudo restart kpi_sync_kobocat_xforms_celeryd")
+    with settings(warn_only=True):
+        # Job is often stopped, which triggers a non-zero return code from
+        # `restart` and fails the whole deployment
+        run("sudo restart kpi_sync_kobocat_xforms_celeryd")
     run("sudo service uwsgi reload")
 
 


### PR DESCRIPTION
`sync_kobocat_xforms`, issuing a warning instead of aborting