### PR TITLE
Dot notation in question names table fix

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -279,7 +279,8 @@ export class DataTable extends React.Component {
 
             return lbl;
           },
-  	  	accessor: key,
+        id: key,
+        accessor: a => a[key],
         index: index,
         question: q,
         filterable: false,

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -280,7 +280,7 @@ export class DataTable extends React.Component {
             return lbl;
           },
         id: key,
-        accessor: a => a[key],
+        accessor: row => row[key],
         index: index,
         question: q,
         filterable: false,


### PR DESCRIPTION
Modify react-table column accessor to accomodate dot notation in the row's object property name. Should go together with https://github.com/kobotoolbox/kobocat/issues/420 