### PR TITLE
darken user avatar backgrounds, to avoid having white on white

### DIFF
--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -169,7 +169,7 @@ export function isLibrary(router) {
 
 export function stringToColor(str, prc) {
   // Higher prc = lighter color, lower = darker
-  var prc = typeof prc === 'number' ? prc : 0.1;
+  var prc = typeof prc === 'number' ? prc : -15;
   var hash = function(word) {
       var h = 0;
       for (var i = 0; i < word.length; i++) {


### PR DESCRIPTION
fixes #1552

see screenshot below for the difference, especially for user `cdcvte`

![cdcvte](https://user-images.githubusercontent.com/368961/36043041-f36ce284-0d9b-11e8-8df4-affb0f5f14f1.jpg)
