### PR TITLE
Use consistent working directory for `pip-sync`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN if ! diff "${KPI_SRC_DIR}/dependencies/apt_requirements.txt" /srv/tmp/base__
 ###########################
 
 COPY ./dependencies/pip/external_services.txt "${KPI_SRC_DIR}/dependencies/pip/"
+WORKDIR ${PIP_DIR}/
 # Only install if the current version of `dependencies/pip/external_services.txt` differs from the one used in the base image.
 RUN if ! diff "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" /srv/tmp/base__external_services.txt; then \
         pip-sync "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" 1>/dev/null \
@@ -42,6 +43,7 @@ RUN if ! diff "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" /srv/tmp/b
 ##########################################
 
 COPY ./package.json "${KPI_SRC_DIR}/"
+WORKDIR ${KPI_SRC_DIR}/
 # Only install if the current version of `package.json` differs from the one used in the base image.
 RUN if ! diff "${KPI_SRC_DIR}/package.json" /srv/tmp/base_package.json; then \
         # Try error-prone `npm install` step twice.

--- a/Dockerfile.koboform_base
+++ b/Dockerfile.koboform_base
@@ -7,6 +7,7 @@ FROM kobotoolbox/base-kobos:latest
 ENV KPI_SRC_DIR=/srv/src/kpi \
     KPI_NODE_PATH=/srv/node_modules \
     BOWER_COMPONENTS_DIR=/srv/bower_components
+    PIP_DIR=/srv/pip
 
 
 ###############################
@@ -31,6 +32,7 @@ RUN bash /tmp/setup_6.x.bash && \
 # Install `pip` packages. #
 ###########################
 
+WORKDIR ${PIP_DIR}/
 RUN pip install --quiet --upgrade pip && \
     pip install --quiet pip-tools
 COPY ./dependencies/pip/external_services.txt /srv/tmp/base__external_services.txt

--- a/Dockerfile.koboform_base
+++ b/Dockerfile.koboform_base
@@ -6,7 +6,7 @@ FROM kobotoolbox/base-kobos:latest
 
 ENV KPI_SRC_DIR=/srv/src/kpi \
     KPI_NODE_PATH=/srv/node_modules \
-    BOWER_COMPONENTS_DIR=/srv/bower_components
+    BOWER_COMPONENTS_DIR=/srv/bower_components \
     PIP_DIR=/srv/pip
 
 


### PR DESCRIPTION
Fixes #1567.

@pmusaraj, can you try this out and merge if it fixes your problem? It wasn't necessary when I tested locally, but if anything doesn't cooperate, you could also rebuild the base image by running `docker build -t kobotoolbox/koboform_base:latest -f Dockerfile.koboform_base .` inside your `kpi` source directory.