### PR TITLE
Gracefully handle missing translations in matrixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 script:
   - gulp copy
   - npm run build
-  - coverage run --source='hub,kpi,kobo' --omit='*/tests/*,*/migrations/*,*/management/commands/*' manage.py test
+  - coverage run --source='hub,kpi,kobo' --omit='*/tests/*,*/migrations/*,*/management/commands/*' pytest
   - npm run test
 after_script:
   - coverage xml && python-codacy-coverage -r coverage.xml

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -72,7 +72,7 @@ pygments==2.1.3
 pymongo==3.3.0
 pyopenssl==16.1.0
 pyquery==1.4.0
-pytest-django==3.0.0
+pytest-django==3.1.2
 pytest==3.0.3             # via pytest-django
 python-dateutil==2.6.0
 python-digest==1.7

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -70,7 +70,7 @@ pygments==2.1.3
 pymongo==3.3.0
 pyopenssl==16.1.0
 pyquery==1.4.0
-pytest-django==3.0.0
+pytest-django==3.1.2
 pytest==3.0.3             # via pytest-django
 python-dateutil==2.6.0
 python-digest==1.7

--- a/docker/run_tests.bash
+++ b/docker/run_tests.bash
@@ -3,5 +3,5 @@ set -e
 
 source /etc/profile
 
-python manage.py test
+pytest
 npm run test

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -107,6 +107,12 @@ MIDDLEWARE_CLASSES = (
     'hub.middleware.OtherFormBuilderRedirectMiddleware',
 )
 
+# Warn developers to use `pytest` instead of `./manage.py test`
+class DoNotUseRunner(object):
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError('Please run tests with `pytest` instead')
+TEST_RUNNER = __name__ + '.DoNotUseRunner'
+
 # used in kpi.models.sitewide_messages
 MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': False})
 

--- a/kpi/utils/xlsform_preprocessors/kobomatrix_handler.py
+++ b/kpi/utils/xlsform_preprocessors/kobomatrix_handler.py
@@ -112,7 +112,7 @@ class KoboMatrixGroupHandler(GroupHandler):
 
     def _format_all_labels(self, labels, template):
         return [
-            template.format(_l) for _l in labels
+            template.format(_l) if _l is not None else None for _l in labels
         ]
 
     def _header(self, name, items_label, cols,
@@ -173,13 +173,16 @@ class KoboMatrixGroupHandler(GroupHandler):
                 _appearance.append('horizontal-compact')
             else:
                 _appearance.append('no-label')
+            _labels = []
+            for _label in col.get('label'):
+                if _label is not None:
+                    _labels.append('-'.join([_item_name, _label]))
+                else:
+                    _labels.append(None)
             out = {'type': _type,
                    'name': '_'.join([_base_name, col['name']]),
                    'appearance': ' '.join(_appearance),
-                   'label': self._format_all_labels([
-                       '-'.join([_item_name, _label])
-                       for _label in col.get('label')
-                   ], self.span_wrap),
+                   'label': self._format_all_labels(_labels, self.span_wrap),
                    'required': col.get('required', False),
                    }
             for key in ['relevant', 'constraint', 'required']:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = kobo kpi


### PR DESCRIPTION
Fixes #1565. Also switches to testing with `pytest`, in order to run asset content tests that were previously skipped silently.