### PR TITLE
Form title does not change on redeploy fix

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -294,7 +294,10 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 }
             }
         )
-        payload = {u'downloadable': active}
+        payload = {
+            u'downloadable': active,
+            u'title': self.asset.name
+        }
         files = {'xls_file': (u'{}.xls'.format(id_string), xls_io)}
         try:
             json_response = self._kobocat_request(


### PR DESCRIPTION
The title was missing in the payload which is sent to KC API.