### PR TITLE
Deploy to Docker-based production via Fabric

### DIFF
--- a/fabfile/docker.py
+++ b/fabfile/docker.py
@@ -1,19 +1,44 @@
-import json
 import os
+import re
+import json
+import tempfile
 
-from fabric.api import cd, env, run, sudo, hide, settings
+from fabric.api import (
+    abort,
+    cd,
+    env,
+    hide,
+    lcd,
+    local,
+    prompt,
+    run,
+    settings,
+    sudo,
+)
 from fabric.contrib import files
 
 
 SERVICE_NAME = 'kpi'
 GIT_REPO = 'https://github.com/kobotoolbox/{}.git'.format(SERVICE_NAME)
 DOCKER_HUB_REPO = 'kobotoolbox/{}'.format(SERVICE_NAME)
+DOCKER_COMPOSE_IMAGE_UPDATE_PATTERN = re.compile(
+    r'^( *image: *){}.*$'.format(DOCKER_HUB_REPO)
+)
 CONTAINER_SRC_DIR_ENV_VAR = '{}_SRC_DIR'.format(SERVICE_NAME.upper())
 UPDATE_STATIC_FILE = '{}/LAST_UPDATE.txt'.format(SERVICE_NAME)
-# These must be defined in deployments.json
-REQUIRED_SETTINGS = (
-    'build_root', # Temporary location for cloning repo; deleted at end
+# These may be defined in deployments.json
+DEPLOYMENT_SETTINGS = (
+    'host_string', # user@host for SSH connection
     'docker_config_path', # Location must house `docker_compose.yml`
+    ####### For deploying pre-built images #######
+    'docker_git_compose_file', # YML file to update with tag being deployed
+    'docker_git_repo', # Git repo housing Docker Compose YML file
+    'docker_git_branch', # Branch to update when committing YML change
+    'docker_compose_command', # Docker Compose invocation to use when deploying
+                              # (include options like `-f`, but do not include
+                              # commands like `up`)
+    ####### For building images from source in situ #######
+    'build_root', # Temporary location for cloning repo; deleted at end
     'static_path' # `UPDATE_STATIC_FILE` will be written here
 )
 
@@ -39,22 +64,114 @@ def sudo_no_pty(*args, **kwargs):
     return sudo(*args, **kwargs)
 
 
-def setup_env(deployment_name, required_settings=REQUIRED_SETTINGS):
+def setup_env(deployment_name):
     deployment = DEPLOYMENTS.get(deployment_name, {})
 
     if deployment_name in IMPORTED_DEPLOYMENTS:
         deployment.update(IMPORTED_DEPLOYMENTS[deployment_name])
 
+    unrecognized_settings = set(deployment.keys()) - set(DEPLOYMENT_SETTINGS)
+    if unrecognized_settings:
+        raise Exception('Unrecognized deployment settings in {}: {}'.format(
+            deployments_file, ','.join(unrecognized_settings))
+        )
     env.update(deployment)
 
+
+def check_required_settings(required_settings):
     for required_setting in required_settings:
         if required_setting not in env:
             raise Exception('Please define {} in {} and try again'.format(
                 required_setting, deployments_file))
 
 
-def deploy(deployment_name, branch='master'):
+def deploy(deployment_name, tag_or_branch):
     setup_env(deployment_name)
+    if 'docker_git_repo' in env:
+        check_required_settings((
+            'docker_git_compose_file',
+            'docker_git_repo',
+            'docker_git_branch',
+            'docker_compose_command',
+        ))
+        commit_pull_and_deploy(tag_or_branch)
+    else:
+        check_required_settings((
+            'build_root',
+            'docker_config_path',
+            'static_path',
+        ))
+        build_and_deploy(tag_or_branch)
+
+
+def commit_pull_and_deploy(tag):
+    # Clone the Docker configuration in a local temporary directory
+    local_tmpdir = tempfile.mkdtemp(prefix='fab-deploy')
+    local_compose_file = os.path.join(
+        local_tmpdir, env.docker_git_compose_file)
+    with lcd(local_tmpdir):
+        local("git clone --quiet --depth=1 --branch='{}' '{}' .".format(
+            env.docker_git_branch, env.docker_git_repo)
+        )
+        # Update the image tag used by Docker Compose
+        image_name = '{}:{}'.format(DOCKER_HUB_REPO, tag)
+        updated_compose_image = False
+        with open(local_compose_file, 'r') as f:
+            compose_file_lines = f.readlines()
+        with open(local_compose_file, 'w') as f:
+            for line in compose_file_lines:
+                matches = re.match(DOCKER_COMPOSE_IMAGE_UPDATE_PATTERN, line)
+                if not matches:
+                    f.write(line)
+                    continue
+                else:
+                    # https://docs.python.org/2/library/os.html#os.linesep
+                    f.write('{prefix}{image_name}\n'.format(
+                        prefix=matches.group(1), image_name=image_name)
+                    )
+                    updated_compose_image = True
+        if not updated_compose_image:
+            raise Exception(
+                'Failed to update image to {} in Docker Compose '
+                'configuration'.format(image_name)
+            )
+        # Did we actually make a change?
+        if local('git diff', capture=True):
+            # Commit the change
+            local("git add '{}'".format(local_compose_file))
+            local("git commit -am 'Updated {service} to {tag}'".format(
+                service=SERVICE_NAME, tag=tag)
+            )
+            # Push the commit
+            local('git show')
+            response = prompt(
+                'OK to push the above commit to {} branch of {}? (y/n)'.format(
+                    env.docker_git_branch, env.docker_git_repo)
+            )
+            if response != 'y':
+                abort('Push cancelled')
+            local("git push origin '{}'".format(env.docker_git_branch))
+        # Make a note of the commit to verify later that it's pulled to the
+        # remote server
+        pushed_config_commit = local("git show --no-patch", capture=True)
+
+    # Deploy to the remote server
+    with cd(env.docker_config_path):
+        run('git pull')
+        pulled_config_commit = run_no_pty("git show --no-patch")
+        if pulled_config_commit != pushed_config_commit:
+            raise Exception(
+                'The configuration commit on the remote server does not match '
+                'what was pushed locally. Please make sure {} is checked out '
+                'on the remote server.'.format(env.docker_git_branch)
+            )
+        run_no_pty("{doco} pull '{service}'".format(
+            doco=env.docker_compose_command, service=SERVICE_NAME)
+        )
+        run("{doco} up -d".format(doco=env.docker_compose_command))
+
+
+def build_and_deploy(branch):
     build_dir = os.path.join(env.build_root, SERVICE_NAME)
     with cd(build_dir):
         # Start from scratch
@@ -86,7 +203,7 @@ def deploy(deployment_name, branch='master'):
         files.append(UPDATE_STATIC_FILE, running_commit.decode('utf-8'), use_sudo=True)
     if running_commit != cloned_commit:
         raise Exception(
-            'The running commit does not match the tip of the cloned'
+            'The running commit does not match the tip of the cloned '
             'branch! Make sure docker-compose.yml is set to build from '
             '{}'.format(build_dir)
         )
@@ -103,7 +220,8 @@ def publish_docker_image(tag, deployment_name='_image_builder'):
                 )
             )
 
-    setup_env(deployment_name, required_settings=('host_string', 'build_root'))
+    setup_env(deployment_name)
+    check_required_settings(('build_root',))
     build_dir = os.path.join(env.build_root, SERVICE_NAME, tag)
     image_name = '{}:{}'.format(DOCKER_HUB_REPO, tag)
 
@@ -127,7 +245,7 @@ def publish_docker_image(tag, deployment_name='_image_builder'):
             commit_inside_image = _get_commit_from_docker_image(image_name)
             if commit_inside_image != cloned_commit:
                 raise Exception(
-                    'The code inside the built image does not match the'
+                    'The code inside the built image does not match the '
                     'specified tag. This script is probably broken.'
                 )
     # Push the image to Docker Hub


### PR DESCRIPTION
Closes #1713. You will need something like this in your `deployments.json`:
```json
  "PROD": {
    "host_string": "ubuntu@ec2.kobotoolbox.org",
    "docker_git_repo": "git@github.com:kobotoolbox/kobo-docker",
    "docker_git_branch": "multi_compose",
    "docker_git_compose_file": "docker-compose.frontend.yml",
    "docker_config_path": "/home/ubuntu/kobo-docker",
    "docker_compose_command":
        "docker-compose -f docker-compose.frontend.yml -f docker-compose.frontend.tmp.override.yml"
  },
```
The example above assumes you have SSH access to `docker_git_repo` on your local machine.