### PR TITLE
form editor header icon back click navigation

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -433,7 +433,10 @@ export default assign({
         <bem.FormBuilderHeader>
           <bem.FormBuilderHeader__row m={['first', allButtonsDisabled ? 'disabled' : null]}>
 
-            <bem.FormBuilderHeader__cell m={'project-icon'} onClick={this.navigateBack}>
+            <bem.FormBuilderHeader__cell m={'project-icon'}
+              data-tip={t('Return to list')}
+              className="left-tooltip"
+              onClick={this.safeNavigateToFormsList}>
               <i className="k-icon-projects" />
             </bem.FormBuilderHeader__cell>
             <bem.FormBuilderHeader__cell m={'name'} >
@@ -460,7 +463,7 @@ export default assign({
 
               <bem.FormBuilderHeader__close m={[{
                     'close-warning': this.needsSave(),
-                  }]} onClick={this.navigateBack}>
+                  }]} onClick={this.safeNavigateToForm}>
                 <i className="k-icon-close"></i>
               </bem.FormBuilderHeader__close>
 
@@ -668,22 +671,17 @@ export default assign({
       enketopreviewError: false,
     });
   },
-  navigateBack() {
-    var backRoute = this.state.backRoute;
-    if (this.state.backRoute == '/forms') {
-      backRoute = `/forms/${this.state.asset_uid}`;
-    }
-
+  safeNavigateToRoute(route) {
     if (!this.needsSave()) {
-      hashHistory.push(backRoute);
+      hashHistory.push(route);
     } else {
       let dialog = alertify.dialog('confirm');
       let opts = {
-        title: t('you have unsaved changes. leave form without saving?'),
+        title: t('You have unsaved changes. Leave form without saving?'),
         message: '',
         labels: {ok: t('Yes, leave form'), cancel: t('Cancel')},
         onok: (evt, val) => {
-          hashHistory.push(backRoute);
+          hashHistory.push(route);
         },
         oncancel: () => {
           dialog.destroy();
@@ -691,6 +689,16 @@ export default assign({
       };
       dialog.set(opts).show();
     }
+  },
+  safeNavigateToFormsList() {
+    this.safeNavigateToRoute('/forms/');
+  },
+  safeNavigateToForm() {
+    var backRoute = this.state.backRoute;
+    if (this.state.backRoute == '/forms') {
+      backRoute = `/forms/${this.state.asset_uid}`;
+    }
+    this.safeNavigateToRoute(backRoute);
   },
 
   render () {

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -433,7 +433,7 @@ export default assign({
         <bem.FormBuilderHeader>
           <bem.FormBuilderHeader__row m={['first', allButtonsDisabled ? 'disabled' : null]}>
 
-            <bem.FormBuilderHeader__cell m={'project-icon'} >
+            <bem.FormBuilderHeader__cell m={'project-icon'} onClick={this.navigateBack}>
               <i className="k-icon-projects" />
             </bem.FormBuilderHeader__cell>
             <bem.FormBuilderHeader__cell m={'name'} >

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -149,6 +149,13 @@
       text-align: center;
       vertical-align: middle;
       height: 75px;
+      cursor: pointer;
+      
+      @extend .mdl-button, .mdl-button--icon;
+      
+      &:hover {
+          background-color: darken($cool-green, 10%);
+      }
 
       i {
         color: #FFF;

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -150,8 +150,7 @@
       vertical-align: middle;
       height: 75px;
       cursor: pointer;
-      
-      @extend .mdl-button, .mdl-button--icon;
+      transition: background-color 0.2s, color 0.2s;
       
       &:hover {
           background-color: darken($cool-green, 10%);

--- a/jsapp/scss/components/_kobo.tooltips.scss
+++ b/jsapp/scss/components/_kobo.tooltips.scss
@@ -68,10 +68,19 @@
   }
 
   // right aligned tooltips
-
   .right-tooltip [data-tip]:after,
   .right-tooltip[data-tip]:after {
-    transform: translate(-95%, 0);
+    left: auto;
+    right: calc(50% - 10px);
+    transform: translate(0);
+  }
+
+  // left aligned tooltips
+  .left-tooltip [data-tip]:after,
+  .left-tooltip[data-tip]:after {
+    left: calc(50% - 10px);
+    right: auto;
+    transform: translate(0);
   }
 
   // more actions in asset-row adjustment


### PR DESCRIPTION
closes #1688 

@pmusaraj Q1: I noticed that you can go back by clicking "x" on the right side - maybe instead of adding click event to the icon on the left, we want to improve the visibility of "x"-close button?

Q2: I can add an left-pointing arrow to appear on hover to emphasise the fact it's "go back" button. What do you think?