### PR TITLE
Fix #1730: do not refresh asset list when deleting an asset

### DIFF
--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -328,7 +328,6 @@ mixins.clickAssets = {
         let onok = (evt, val) => {
           actions.resources.deleteAsset({uid: uid}, {
             onComplete: ()=> {
-              this.refreshSearch && this.refreshSearch();
               notify(`${assetTypeLabel} ${t('deleted permanently')}`);
               $('.alertify-toggle input').prop("checked", false);
             }

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -80,7 +80,6 @@ function SearchContext(opts={}) {
     },
     onDeleteAssetCompleted (asset) {
       var filterOutDeletedAsset = ({listName}) => {
-        // TODO: look into why sometimes this.state[listName] is not defined
         if (this.state[listName] != undefined) {
           let uid = asset.uid;
           let listLength = this.state[listName].length;
@@ -94,7 +93,22 @@ function SearchContext(opts={}) {
           }
         }
       };
+      var filterOutDeletedAssetFromCategorizedList = () => {
+        let list = this.state.defaultQueryCategorizedResultsLists;
+        if (list != undefined) {
+          var l = {};
+          for (var category in list) {
+            l[category] = list[category].filter(function(result){
+              return result.uid !== asset.uid;
+            });
+          }
+          let o = {};
+          o.defaultQueryCategorizedResultsLists = l;
+          this.update(o);
+        }
+      };
       filterOutDeletedAsset({listName: 'defaultQueryResultsList'});
+      filterOutDeletedAssetFromCategorizedList();
       if (this.state.searchResultsList && this.state.searchResultsList.length > 0) {
         filterOutDeletedAsset({listName: 'searchResultsList'});
       }

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -95,7 +95,7 @@ function SearchContext(opts={}) {
       };
       var filterOutDeletedAssetFromCategorizedList = () => {
         let list = this.state.defaultQueryCategorizedResultsLists;
-        if (list != undefined) {
+        if (list) {
           var l = {};
           for (var category in list) {
             l[category] = list[category].filter(function(result){


### PR DESCRIPTION
Instead, update the list of categorized results in the search store. Fixes #1730 