### PR TITLE
Taking potential KOBOCAT_ROOT_URI_PREFIX into account - fixes #1748

### DIFF
--- a/jsapp/js/components/submission.es6
+++ b/jsapp/js/components/submission.es6
@@ -143,7 +143,10 @@ class Submission extends React.Component {
 
     var kc_server = document.createElement('a');
     kc_server.href = this.props.asset.deployment__identifier;
-    var kc_base = kc_server.origin;
+    // if this has more components than /{username}/forms/{uid}, it's safe to assume kobocat is running under a
+    // KOBOCAT_ROOT_URI_PREFIX
+    const kc_prefix = kc_server.pathname.split('/').length > 4 ? '/' + kc_server.pathname.split('/')[1] : '';
+    var kc_base = `${kc_server.origin}${kc_prefix}`;
 
     // build media attachment URL using the KC endpoint
     attachmentUrl = `${kc_base}/attachment/original?media_file=${encodeURI(filename)}`;


### PR DESCRIPTION
This fixes #1748 by checking the number of path components in the kobocat form identifier URL.