### PR TITLE
Fix a reports bug with "grouped by" graphs missing data

### DIFF
--- a/jsapp/js/components/reportViewItem.es6
+++ b/jsapp/js/components/reportViewItem.es6
@@ -140,6 +140,7 @@ class ReportViewItem extends React.Component {
   loadChart() {
     var canvas = ReactDOM.findDOMNode(this.refs.canvas);
     var opts = this.buildChartOptions();
+
     if (this.itemChart) {
       this.itemChart.destroy();
       this.itemChart = new Chart(canvas, opts);
@@ -205,6 +206,7 @@ class ReportViewItem extends React.Component {
     var datasets = [];
 
     if (data.values != undefined) {
+
       if (data.responseLabels) {
         data.responseLabels.forEach(function(r, i){
           data.responseLabels[i] = _this.truncateLabel(r);

--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -488,7 +488,7 @@ class ReportContents extends React.Component {
         }
       }
 
-      if (_type == 'select_one' || _type == 'select_multiple') {
+      if (_type === 'select_one' || _type === 'select_multiple') {
         let question = asset.content.survey.find(z => z.name === _qn || z.$autoname === _qn);
         let resps = reportData[i].data.responses;
         if (resps) {

--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -488,7 +488,7 @@ class ReportContents extends React.Component {
         }
       }
 
-      if (this.props.parentState.translations && (_type == 'select_one' || _type == 'select_multiple')) {
+      if (_type == 'select_one' || _type == 'select_multiple') {
         let question = asset.content.survey.find(z => z.name === _qn || z.$autoname === _qn);
         let resps = reportData[i].data.responses;
         if (resps) {
@@ -526,6 +526,10 @@ class ReportContents extends React.Component {
         {
           reportData.map((rowContent, i)=>{
             var label = (rowContent.row.label && rowContent.row.label[tnslIndex]) ? rowContent.row.label[tnslIndex] : t('Unlabeled');
+
+            if (!rowContent.data.provided)
+              return false;
+
             return (
                 <bem.ReportView__item key={i}>
                   <ReportViewItem
@@ -679,7 +683,7 @@ class ReportStyleSettings extends React.Component {
                           onChange={this.groupDataBy}
                           checked={reportStyle.groupDataBy === val ? true : false}
                           id={'groupby-' + i} />
-                          {this.props.parentState.translations ? row.label[reportStyle.translationIndex] : row.label}
+                          {translations ? row.label[reportStyle.translationIndex] : row.label}
                       </label>
                     );
                   })


### PR DESCRIPTION
Fixes #1753, forms without translations would not have correct disaggregated reports (due to a bug introduced in a PR a few weeks ago). 

Also changes the way the reports behaves when a questions has 0 responses. Reports now do NOT include those questions. 