### PR TITLE
Add `/environment/` endpoint with settings for

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -115,6 +115,10 @@ MIDDLEWARE_CLASSES = (
 CONSTANCE_CONFIG = {
     'REGISTRATION_OPEN': (True, 'Whether or not to allow registration of new '
                                 'accounts'),
+    'TERMS_OF_SERVICE_URL': ('http://www.kobotoolbox.org/terms',
+                            'URL for terms of service document'),
+    'PRIVACY_POLICY_URL': ('http://www.kobotoolbox.org/privacy',
+                          'URL for privacy policy'),
 }
 # Tell django-constance to use a database model instead of Redis
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'

--- a/kpi/tests/test_api_environment.py
+++ b/kpi/tests/test_api_environment.py
@@ -1,0 +1,24 @@
+import constance
+from rest_framework.test import APITestCase
+from django.core.urlresolvers import reverse
+from rest_framework import status
+
+class EnvironmentTests(APITestCase):
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.url = reverse('environment')
+
+    def test_anonymous_forbidden(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authenticated_succeeds(self):
+        expected_dict = {
+            'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,
+            'privacy_policy_url': constance.config.PRIVACY_POLICY_URL,
+        }
+        self.client.login(username='admin', password='pass')
+        response = self.client.get(self.url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.data, expected_dict)

--- a/kpi/tests/test_api_environment.py
+++ b/kpi/tests/test_api_environment.py
@@ -8,17 +8,18 @@ class EnvironmentTests(APITestCase):
 
     def setUp(self):
         self.url = reverse('environment')
-
-    def test_anonymous_forbidden(self):
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_authenticated_succeeds(self):
-        expected_dict = {
+        self.expected_dict = {
             'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,
             'privacy_policy_url': constance.config.PRIVACY_POLICY_URL,
         }
+
+    def test_anonymous_succeeds(self):
+        response = self.client.get(self.url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.data, self.expected_dict)
+
+    def test_authenticated_succeeds(self):
         self.client.login(username='admin', password='pass')
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertDictEqual(response.data, expected_dict)
+        self.assertDictEqual(response.data, self.expected_dict)

--- a/kpi/urls.py
+++ b/kpi/urls.py
@@ -22,6 +22,7 @@ from kpi.views import (
     OneTimeAuthenticationKeyViewSet,
     UserCollectionSubscriptionViewSet,
     TokenView,
+    EnvironmentView,
 )
 
 from kpi.views import home, one_time_login, browser_tests
@@ -94,6 +95,7 @@ urlpatterns = [
     url(r'^jsi18n/$', javascript_catalog, js_info_dict, name='javascript-catalog'),
     # url(r'^.*', home),
     url(r'^token/$', TokenView.as_view(), name='token'),
+    url(r'^environment/$', EnvironmentView.as_view(), name='environment'),
     url(r'^private-media/', include(private_storage.urls)),
     # Statistics for superusers
     url(r'^superuser_stats/user_report/$',

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -33,7 +33,6 @@ from rest_framework.decorators import renderer_classes
 from rest_framework.decorators import detail_route
 from rest_framework.decorators import authentication_classes
 from rest_framework.parsers import MultiPartParser
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.authtoken.models import Token
@@ -1015,7 +1014,6 @@ class TokenView(APIView):
 
 class EnvironmentView(APIView):
     ''' GET-only view for certain server-provided configuration data '''
-    permission_classes = (IsAuthenticated,)
     def get(self, request, *args, **kwargs):
         return Response({
             'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -33,12 +33,14 @@ from rest_framework.decorators import renderer_classes
 from rest_framework.decorators import detail_route
 from rest_framework.decorators import authentication_classes
 from rest_framework.parsers import MultiPartParser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.authtoken.models import Token
 from rest_framework.views import APIView
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
+import constance
 from taggit.models import Tag
 
 from .filters import KpiAssignedObjectPermissionsFilter
@@ -1009,3 +1011,13 @@ class TokenView(APIView):
             token = get_object_or_404(Token, user=user)
             token.delete()
         return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+
+class EnvironmentView(APIView):
+    ''' GET-only view for certain server-provided configuration data '''
+    permission_classes = (IsAuthenticated,)
+    def get(self, request, *args, **kwargs):
+        return Response({
+            'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,
+            'privacy_policy_url': constance.config.PRIVACY_POLICY_URL,
+        })


### PR DESCRIPTION
terms of service and privacy policy URLs. This is the back-end work for #1709 