### PR TITLE
Revert prettier code-formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,0 @@
-locale
-node_modules
-static
-package.json
-package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,0 @@
-singleQuote: true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "font-awesome": "^4.4.0",
-    "husky": "^0.14.3",
     "immutable": "^3.4.7",
     "jquery": "^3.3.1",
     "jquery-ui": "1.12.1",
@@ -60,8 +59,6 @@
     "opn": "^3.0.2",
     "postcss": "^5.2.15",
     "postcss-loader": "^1.3.3",
-    "prettier": "^1.12.1",
-    "pretty-quick": "^1.4.1",
     "q": "^1.4.1",
     "react": "^15.6.0",
     "react-autobind": "^1.0.6",
@@ -99,8 +96,7 @@
     "watch": "node webpack/dev.server.js",
     "test-server": "node webpack/test.server.js",
     "test": "webpack --config webpack/test.config.js --progress --colors && mocha-phantomjs test/tests.html",
-    "copy-fonts": "python ./scripts/copy_fonts.py",
-    "precommit": "pretty-quick --staged"
+    "copy-fonts": "python ./scripts/copy_fonts.py"
   },
   "repository": "https://github.com/kobotoolbox/kpi.git",
   "author": "alex.dorey@kobotoolbox.org, esmail.fadae@kobotoolbox.org, john.milner@kobotoolbox.org",


### PR DESCRIPTION
Reverts https://github.com/kobotoolbox/kpi/pull/1778. 

Prettier's pre-commit hook makes formatting changes to whole files (as soon as anything on the file is edited). That means that we would quickly lose the line-by-line `git blame` history (or make it extremely complicated to access). 

After discussions with John, we decided to revert Prettier. We may revisit this in the future, but we would certainly look for something that's less drastic. 