### PR TITLE
Upgraded cryptography, uwsgi, pyopenssl - see #1798

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -17,7 +17,7 @@ botocore==1.8.22          # via boto3, s3transfer
 celery==4.0.2
 cffi==1.9.1               # via cryptography
 cookies==2.2.1            # via responses
-cryptography==1.7.2       # via paramiko, pyopenssl
+cryptography==2.2.2       # via paramiko, pyopenssl
 cssselect==1.0.3          # via pyquery
 cyordereddict==1.0.0
 dj-database-url==0.4.2
@@ -72,7 +72,7 @@ pyasn1==0.2.2
 pycparser==2.17           # via cffi
 pygments==2.2.0
 pymongo==3.4.0
-pyopenssl==16.2.0
+pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
 pytest==3.0.6             # via pytest-django
@@ -89,7 +89,7 @@ static3==0.7.0
 statistics==1.0.3.5
 tabulate==0.7.7
 unicodecsv==0.14.1
-uwsgi==2.0.14
+uwsgi==2.0.17
 vine==1.1.3               # via amqp
 werkzeug==0.11.15
 whitenoise==3.3.1

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -18,7 +18,7 @@ celery==3.1.23
 cffi==1.8.3               # via cryptography
 contextlib2==0.5.4        # via raven
 cookies==2.2.1            # via responses
-cryptography==1.5.2       # via pyopenssl
+cryptography==2.2.2       # via pyopenssl
 cssselect==1.0.3          # via pyquery
 cyordereddict==1.0.0
 dj-database-url==0.4.1
@@ -72,7 +72,7 @@ pyasn1==0.1.9
 pycparser==2.14           # via cffi
 pygments==2.1.3
 pymongo==3.3.0
-pyopenssl==16.1.0
+pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
 pytest==3.0.3             # via pytest-django
@@ -92,7 +92,7 @@ tabulate==0.7.5
 transifex-client==0.11
 unicodecsv==0.14.1
 urllib3==1.15.1           # via transifex-client
-uwsgi==2.0.13
+uwsgi==2.0.17
 whitenoise==3.3.1
 whoosh==2.7.4
 xlrd==1.1.0

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -17,7 +17,7 @@ botocore==1.8.22          # via boto3, s3transfer
 celery==3.1.23
 cffi==1.8.3               # via cryptography
 cookies==2.2.1            # via responses
-cryptography==1.5.2       # via pyopenssl
+cryptography==2.2.2       # via pyopenssl
 cssselect==1.0.3          # via pyquery
 cyordereddict==1.0.0
 dj-database-url==0.4.1
@@ -70,7 +70,7 @@ pyasn1==0.1.9
 pycparser==2.14           # via cffi
 pygments==2.1.3
 pymongo==3.3.0
-pyopenssl==16.1.0
+pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
 pytest==3.0.3             # via pytest-django
@@ -87,7 +87,7 @@ static3==0.7.0
 statistics==1.0.3.5
 tabulate==0.7.5
 unicodecsv==0.14.1
-uwsgi==2.0.13
+uwsgi==2.0.17
 whitenoise==3.3.1
 whoosh==2.7.4
 xlrd==1.1.0


### PR DESCRIPTION
It was necessary to upgrade cryptography, uwsgi and pyopenssl. They all don't compile anymore when OpenSSL is upgraded in the base OS.

Fixes #1798 