### PR TITLE
don't display unused button as it obstructs other UI elements

### DIFF
--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -137,9 +137,6 @@ class Drawer extends Reflux.Component {
       stores.serverEnvironment,
     ];
   }
-  toggleFixedDrawer() {
-    stores.pageState.toggleFixedDrawer();
-  }
   render () {
     return (
       <bem.Drawer className='k-drawer'>
@@ -149,9 +146,6 @@ class Drawer extends Reflux.Component {
         </nav>
 
         <div className="drawer__sidebar">
-          <button className="mdl-button mdl-button--icon k-drawer__close" onClick={this.toggleFixedDrawer}>
-            <i className="k-icon-close"></i>
-          </button>
           { this.isLibrary()
             ? <LibrarySidebar />
             : <FormSidebar />

--- a/jsapp/scss/components/_kobo.drawer.scss
+++ b/jsapp/scss/components/_kobo.drawer.scss
@@ -69,10 +69,6 @@
   height: 100%;
   padding: 20px 14px;
 
-  .k-drawer__close {
-    display: none;
-  }
-
   .form-sidebar__wrapper, .collections-wrapper {
     height: 100%;
   }

--- a/jsapp/scss/components/_kobo.drawer.scss
+++ b/jsapp/scss/components/_kobo.drawer.scss
@@ -101,23 +101,6 @@
   .mdl-layout__content {
     margin-left: 0px;
   }
-
-  .drawer__sidebar {
-    .k-drawer__close {
-      font-size: 16px;
-      opacity: 1;
-      position: absolute;
-      right: 8px;
-      top: 8px;
-      display: block;
-      color: $layout-drawer-nav-link-color;
-
-      &:hover {
-        background-color: transparent;
-        opacity: 0.6;
-      }
-    }
-  }
 }
 
 @media screen and (min-width: 768px) and (max-width: 999px) {


### PR DESCRIPTION
On smaller screens (`< 999px`) we applied styles to the button that was not visible, but was covering other UI elements (esp. "Projects" menu item). We already set `display: none` to it on default, so I guess someone forgot about the `@media` styles? 

See screenshot:

<img width="697" alt="screen shot 2018-06-04 at 10 50 26" src="https://user-images.githubusercontent.com/2521888/40908062-f86ad396-67e5-11e8-81c7-b2128dfaea4b.png">
