### PR TITLE
Fix display issues with skip logic

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.SkipLogic.coffee
+++ b/jsapp/xlform/src/view.rowDetail.SkipLogic.coffee
@@ -145,7 +145,7 @@ module.exports = do ->
     render: () ->
       super()
 
-      # HACK disable placeholder option on load and after change
+      # disable placeholder option onLoad and onChange
       if @$el.val() isnt PLACEHOLDER_VALUE
         @disable_placeholder_option()
       @$el.on('change', @disable_placeholder_option.bind(@))
@@ -186,6 +186,9 @@ module.exports = do ->
 
           operators
       })
+
+      # workaround for missing elements when toggling skiplogic back and forth
+      target.find('.skiplogic__expressionselect.select2-container').show()
 
       if @value
         @val @value
@@ -283,6 +286,8 @@ module.exports = do ->
     attach_to: (target) ->
       target.find('.skiplogic__responseval').remove()
       super(target)
+      # workaround for missing elements when toggling skiplogic back and forth
+      target.find('.skiplogic__responseval.select2-container').show()
 
     bind_event: (handler) ->
       super 'change', handler


### PR DESCRIPTION
This fixes one of the problems from #1812 (the `8.c. You can change the question to "Select question from list" causing a JS error`). Now you can't select the placeholder value, which was possible in some cases before.

<img width="345" alt="screen shot 2018-06-07 at 19 55 08" src="https://user-images.githubusercontent.com/2521888/41118715-135a1c86-6a91-11e8-82a6-4ffa92b9670a.png">
