### PR TITLE
Fix issue #1817: tags not working

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -112,7 +112,8 @@ class App extends React.Component {
           name='APP_SHORTCUTS'
           handler={this._handleShortcuts}
           className="mdl-wrapper"
-          global>
+          global
+          isolate>
 
           { !this.isFormBuilder() && !this.state.pageState.headerHidden &&
             <div className="k-header__bar" />


### PR DESCRIPTION
Due to event propagations blocked by react-shortcuts.