### PR TITLE
Minor environment updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "moment": "^2.10.3",
     "ms": "^0.7.1",
     "node-sass": "^4.5.1",
+    "object-assign": "^4.1.1",
     "postcss": "^6.0.22",
     "postcss-loader": "^2.1.5",
     "prop-types": "^15.6.1",

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -7,6 +7,7 @@ var publicPath = 'http://localhost:3000/static/compiled/';
 
 module.exports = WebpackCommon({
   mode: "development",
+  entry: {app: ['react-hot-loader/patch', './jsapp/js/main.es6']},
   output: {
     library: 'KPI',
     path: path.resolve(__dirname, '../jsapp/compiled/'),

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -5,6 +5,7 @@ const WebpackCommon = require('./webpack.common');
 
 module.exports = WebpackCommon({
   mode: "production",
+  entry: {app: './jsapp/js/main.es6'},
   output: {
     path: path.resolve(__dirname, '../jsapp/compiled/'),
     publicPath: publicPath,

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -4,7 +4,6 @@ const BundleTracker = require('webpack-bundle-tracker');
 var merge = require('lodash.merge');
 
 var defaultOptions = {
-  entry: {app: ['react-hot-loader/patch', './jsapp/js/main.es6']},
   module: {
     rules: [
       {
@@ -19,7 +18,7 @@ var defaultOptions = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ["env","es2015","react"],
+            presets: ["env","react"],
             plugins: ["add-module-exports", "react-hot-loader/babel"]
           }
         }


### PR DESCRIPTION
This branch has a few small changes: 

- add `object-assign` library explicitly, since we still use it in our .es6 files
- remove `es2015` preset in webpack builds, the `env` preset covers all year-based Babel presets (see http://babeljs.io/docs/en/env/)
- set `entry` webpack option separately for production and dev builds (removes unneeded `react-hot-loader` parameter in the production build)

These changes should also help with image builds, I had some issues with both `es2015` and `object-assign` when building on our test servers. 