### PR TITLE
Fiz dropzone Firefox issue

### DIFF
--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -315,8 +315,8 @@ export class ProjectSettings extends React.Component {
               <Dropzone onDrop={this.onDrop.bind(this)}
                             multiple={false}
                             className='dropzone'
-                            activeClassName='dropzone-active'
-                            rejectClassName='dropzone-reject'
+                            activeClassName='dropzone--active'
+                            rejectClassName='dropzone--reject'
                             accept={validFileTypes()}>
                 <i className="k-icon-xls-file" />
                 {t(' Drag and drop the XLSForm file here or click to browse')}

--- a/jsapp/js/components/searchcollectionlist.es6
+++ b/jsapp/js/components/searchcollectionlist.es6
@@ -196,7 +196,7 @@ class SearchCollectionList extends Reflux.Component {
           disableClick
           multiple
           className="dropzone"
-          activeClassName="dropzone-active"
+          activeClassName="dropzone--active"
           accept={validFileTypes()}
         >
           <bem.List m={display} onScroll={this.handleScroll}>

--- a/jsapp/js/components/searchcollectionlist.es6
+++ b/jsapp/js/components/searchcollectionlist.es6
@@ -197,7 +197,8 @@ class SearchCollectionList extends Reflux.Component {
           multiple
           className="dropzone"
           activeClassName="dropzone-active"
-          accept={validFileTypes()}>
+          accept={validFileTypes()}
+        >
           <bem.List m={display} onScroll={this.handleScroll}>
             {
               (()=>{

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -686,24 +686,35 @@ span.svg-icon {
   }
 }
 
-.dropzone-active {
+.dropzone {
   position: relative;
   min-height: calc(100% - 4px);
 
-  &:after {
-    width: calc(100% - 4px);
-    height: calc(100% - 4px);
+  &::after {
     position: absolute;
-    left: 0;
     top: 0;
+    right: 4px;
+    bottom: 4px;
+    left: 0;
     content: '';
     background: rgba(255, 255, 255, 0.7);
     border: 2px solid $cool-blue;
     z-index: 1;
+    opacity: 0;
+    visibility: hidden;
+    transition: 0.2s;
   }
 
-  .dropzone-active-overlay {
-    display: block;
+  &.dropzone-active {
+    &::after {
+      opacity: 1;
+      visibility: visible;
+      transition: 0.2s;
+    }
+
+    .dropzone-active-overlay {
+      display: block;
+    }
   }
 }
 

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -693,8 +693,8 @@ span.svg-icon {
   &::after {
     position: absolute;
     top: 0;
-    right: 4px;
-    bottom: 4px;
+    right: 0;
+    bottom: 0;
     left: 0;
     content: '';
     background: rgba(255, 255, 255, 0.7);
@@ -705,7 +705,7 @@ span.svg-icon {
     transition: 0.2s;
   }
 
-  &.dropzone-active {
+  &.dropzone--active {
     &::after {
       opacity: 1;
       visibility: visible;

--- a/jsapp/scss/components/_kobo.modal.scss
+++ b/jsapp/scss/components/_kobo.modal.scss
@@ -439,11 +439,13 @@
       border-color: $cool-blue;
     }
 
-    &.dropzone-active {
+    &::after {display: none;}
+
+    &.dropzone--active {
       border-color: $cool-blue;
     }
 
-    &.dropzone-reject {
+    &.dropzone--reject {
       border-color: $cool-red;
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-debounce-input": "^3.1.0",
     "react-document-title": "^2.0.2",
     "react-dom": "^16.4.0",
-    "react-dropzone": "^4.1.0",
+    "react-dropzone": "^4.2.11",
     "react-hot-loader": "3.1.0",
     "react-mixin": "^3.0.5",
     "react-router": "^3.2.1",


### PR DESCRIPTION
fixes #1792

The problem was with `onDragLeave` not being called after `onDragEnter` on the `Dropzone` area. I managed to discover that replacing `display: none` with transitioning opacity works.