### PR TITLE
use polyfill for fs.copyFileSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react": "^7.8.2",
     "file-loader": "^1.1.11",
     "font-awesome": "^4.4.0",
+    "fs-copy-file-sync": "^1.1.1",
     "immutable": "^3.4.7",
     "jquery": "^3.3.1",
     "jquery-ui": "1.12.1",

--- a/scripts/generate_icons.js
+++ b/scripts/generate_icons.js
@@ -1,5 +1,7 @@
 const webfontsGenerator = require('webfonts-generator');
 const fs = require('fs');
+// Node version on Docker is too old to have fs.copyFileSync, thus polyfill:
+const copyFileSync = require('fs-copy-file-sync');
 const sourceDir = 'jsapp/svg-icons/';
 const destDir = 'jsapp/fonts/';
 
@@ -60,7 +62,7 @@ webfontsGenerator(
       throw new Error('Fail!', error);
     } else {
       try {
-        fs.copyFileSync(`${destDir}k-icons.css`, `${destDir}_k-icons.scss`);
+        copyFileSync(`${destDir}k-icons.css`, `${destDir}_k-icons.scss`);
         console.info('Copied k-icons.css to _k-icons.scss in fonts folder.');
       } catch(e){
         console.warn(


### PR DESCRIPTION
Fixes problem of generating icon fonts on docker machine