### PR TITLE
Fix #1422 by optimizing performance of API asset lists

### DIFF
--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -77,6 +77,7 @@ class LazyModelGroup:
             date_modified = models.DateTimeField()
             uuid = models.CharField(max_length=32, default=u'')
             last_submission_time = models.DateTimeField(blank=True, null=True)
+            num_of_submissions = models.IntegerField(default=0)
 
             @property
             def hash(self):

--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -35,10 +35,13 @@ def _trigger_kc_profile_creation(user):
 
 @safe_kc_read
 def instance_count(xform_id_string, user_id):
-    return _models.Instance.objects.filter(deleted_at__isnull=True,
-                                           xform__user_id=user_id,
-                                           xform__id_string=xform_id_string,
-                                           ).count()
+    try:
+        return _models.XForm.objects.only('num_of_submissions').get(
+            id_string=xform_id_string,
+            user_id=user_id
+        ).num_of_submissions
+    except _models.XForm.DoesNotExist:
+        return 0
 
 @safe_kc_read
 def last_submission_time(xform_id_string, user_id):

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -451,7 +451,7 @@ class Asset(ObjectPermissionMixin,
 
     @property
     def kind(self):
-        return self._meta.model_name
+        return 'asset'
 
     class Meta:
         ordering = ('-date_modified',)

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -16,6 +16,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import MultipleObjectsReturned
 from django.db import models
 from django.db import transaction
+from django.db.models import Prefetch
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 import jsonbfield.fields
@@ -101,7 +102,13 @@ class TagStringMixin:
 
     @property
     def tag_string(self):
-        return ','.join(self.tags.values_list('name', flat=True))
+        try:
+            tag_list = self.prefetched_tags
+        except AttributeError:
+            tag_names = self.tags.values_list('name', flat=True)
+        else:
+            tag_names = [t.name for t in tag_list]
+        return ','.join(tag_names)
 
     @tag_string.setter
     def tag_string(self, value):
@@ -675,9 +682,17 @@ class Asset(ObjectPermissionMixin,
 
     @property
     def version_id(self):
-        latest_version = self.latest_version
-        if latest_version:
-            return latest_version.uid
+        try:
+            latest_versions = self.prefetched_latest_versions
+        except AttributeError:
+            latest_version = self.latest_version
+            if latest_version:
+                return latest_version.uid
+        else:
+            try:
+                return latest_versions[0]
+            except IndexError:
+                return None
 
     @property
     def snapshot(self):
@@ -719,6 +734,41 @@ class Asset(ObjectPermissionMixin,
 
     def __unicode__(self):
         return u'{} ({})'.format(self.name, self.uid)
+
+    @staticmethod
+    def optimize_queryset_for_list(queryset):
+        ''' Used by serializers to improve performance when listing assets '''
+        queryset = queryset.defer(
+            # Avoid pulling these `JSONField`s from the database because:
+            #   * they are stored as plain text, and just deserializing them
+            #     to Python objects is CPU-intensive;
+            #   * they are often huge;
+            #   * we don't need them for list views.
+            'content', 'report_styles'
+        ).select_related(
+            'owner__username',
+        ).prefetch_related(
+            # We previously prefetched `permissions__content_object`, but that
+            # actually pulled the entirety of each permission's linked asset
+            # from the database! For now, the solution is to remove
+            # `content_object` here *and* from
+            # `ObjectPermissionNestedSerializer`.
+            'permissions__permission',
+            'permissions__user',
+            # `Prefetch(..., to_attr='prefetched_list')` stores the prefetched
+            # related objects in a list (`prefetched_list`) that we can use in
+            # other methods to avoid additional queries; see:
+            # https://docs.djangoproject.com/en/1.8/ref/models/querysets/#prefetch-objects
+            Prefetch('tags', to_attr='prefetched_tags'),
+            Prefetch(
+                'asset_versions',
+                queryset=AssetVersion.objects.order_by(
+                    '-date_modified'
+                ).only('uid', 'asset', 'date_modified', 'deployed'),
+                to_attr='prefetched_latest_versions',
+            ),
+        )
+        return queryset
 
 
 class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):

--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -62,7 +62,7 @@ class Collection(ObjectPermissionMixin, TagStringMixin, MPTTModel):
 
     @property
     def kind(self):
-        return self._meta.model_name
+        return 'collection'
 
     class Meta:
         ordering = ('-date_modified',)

--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -198,7 +198,7 @@ class ObjectPermission(models.Model):
 
     @property
     def kind(self):
-        return self._meta.model_name
+        return 'objectpermission'
 
     class Meta:
         unique_together = ('user', 'permission', 'deny', 'inherited',

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -615,9 +615,17 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             # migration has been run
             v_id = obj.deployment.version_id
             try:
-                return asset_versions_uids_only.get(_reversion_version_id=v_id).uid
-            except ObjectDoesNotExist, e:
-                return asset_versions_uids_only.filter(deployed=True).first().uid
+                return asset_versions_uids_only.get(
+                    _reversion_version_id=v_id
+                ).uid
+            except AssetVersion.DoesNotExist:
+                deployed_version = asset_versions_uids_only.filter(
+                    deployed=True
+                ).first()
+                if deployed_version:
+                    return deployed_version.uid
+                else:
+                    return None
         else:
             return obj.deployment.version_id
 

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -813,17 +813,10 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 
     ### CURRENT ENDPOINT
     """
+
     # Filtering handled by KpiObjectPermissionsFilter.filter_queryset()
-    queryset = Asset.objects.select_related(
-        'owner', 'parent'
-    ).prefetch_related(
-        'permissions',
-        'permissions__permission',
-        'permissions__user',
-        'permissions__content_object',
-        # Getting the tag_string is making one query per object, but
-        # prefetch_related doesn't seem to help
-    ).all()
+    queryset = Asset.objects.all()
+
     serializer_class = AssetSerializer
     lookup_field = 'uid'
     permission_classes = (IsOwnerOrReadOnly,)
@@ -843,15 +836,13 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
             return AssetSerializer
 
     def get_queryset(self, *args, **kwargs):
-        ''' Really temporary way to exclude a taxing field from the database
-        query when the request instructs us to do so. '''
         queryset = super(AssetViewSet, self).get_queryset(*args, **kwargs)
-        # See also AssetSerializer.get_fields()
-        excludes = self.request.GET.get('exclude', '')
-        excludes = excludes.split(',')
-        if 'content' in excludes:
-            queryset = queryset.defer('content')
-        return queryset
+        if self.action == 'list':
+            return queryset.model.optimize_queryset_for_list(queryset)
+        else:
+            # This is called to retrieve an individual record. How much do we
+            # have to care about optimizations for that?
+            return queryset
 
     def _get_clone_serializer(self, current_asset=None):
         """


### PR DESCRIPTION
Response time for a user with 137 surveys (comprising about 184M of data) decreases from ~20 seconds to ~2 seconds.
```
In [10]: aa = Asset.objects.filter(asset_type='survey', owner=u)

In [11]: aa.count()
Out[11]: 137

In [12]: len(pickle.dumps(aa)) / 1024 / 1024
Out[12]: 184
```
![image](https://user-images.githubusercontent.com/2085013/42915413-c7929758-8acd-11e8-9209-761d2e062555.png)