### PR TITLE
On app load, remove "user.history" from localStorage

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -89,6 +89,13 @@ class App extends React.Component {
   }
   componentDidMount () {
     actions.misc.getServerEnvironment();
+
+    // TODO: this operation should be removed after March 1, 2019
+    // To avoid issues with localStorage limits, delete user.history from browser's localStorage
+    // user.history was an unusued store, it was removed in https://github.com/kobotoolbox/kpi/pull/1878
+    if (localStorage && localStorage['user.history']) {
+      localStorage.removeItem('user.history');
+    }
   }
   _handleShortcuts(action) {
     switch (action) {


### PR DESCRIPTION
We previously had a store that saved the user asset details in localStorage and some users with large assets were running into blocking QuotaExceededErrors. Cleaning up "user.history" so it does not come back to haunt us in the future. An additional fix for #1877.