### PR TITLE
quickfix checkbox displacement

### DIFF
--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -742,10 +742,6 @@ span.svg-icon {
     padding-left: 35px;
     cursor: pointer;
     font-size: 1rem;
-    user-select: none;
-    // match checkbox rectangle size
-    line-height: 22px;
-    display: inline-block;
   }
 
   + label:after {

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -355,6 +355,13 @@ $t-form-builder-aside-open: 200ms;
   box-shadow: 0 0 3px 0 rgba($black, 0.2), 0 0 10px 0 rgba($black, 0.1);
   z-index: $z-form-builder-aside;
 
+  [type="checkbox"] + label {
+    user-select: none;
+    // match checkbox rectangle size
+    line-height: 22px;
+    display: inline-block;
+  }
+
   .Select-menu-outer {
     // getting select menus to appear over checkboxes
     z-index: 2;


### PR DESCRIPTION
Those styles were added for Form Builder aside panel ("Metadata" section), but they caused a misplacement of checkboxes elsewhere (i.e. `/data/table` view)