### PR TITLE
Remember Form Builder aside panel state in sessionStorage

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -167,9 +167,13 @@ class FormSettingsBox extends React.Component {
   }
 };
 
+const ASIDE_CACHE_NAME = 'kpi.editable-form.aside';
+
 export default assign({
   componentDidMount() {
     document.body.classList.add('hide-edge');
+
+    this.loadAsideSettings();
 
     if (this.state.editorState === 'existing') {
       let uid = this.props.params.assetid;
@@ -205,6 +209,17 @@ export default assign({
       this.app.survey.off('change');
     }
     this.unpreventClosingTab();
+  },
+
+  loadAsideSettings() {
+    const asideSettings = sessionStorage.getItem(ASIDE_CACHE_NAME);
+    if (asideSettings) {
+      this.setState(JSON.parse(asideSettings));
+    }
+  },
+
+  saveAsideSettings(asideSettings) {
+    sessionStorage.setItem(ASIDE_CACHE_NAME, JSON.stringify(asideSettings));
   },
 
   onFormSettingsBoxChange() {
@@ -462,18 +477,22 @@ export default assign({
 
   toggleAsideLibrarySearch(evt) {
     evt.target.blur();
-    this.setState({
+    const asideSettings = {
       asideLayoutSettingsVisible: false,
       asideLibrarySearchVisible: !this.state.asideLibrarySearchVisible,
-    });
+    };
+    this.setState(asideSettings);
+    this.saveAsideSettings(asideSettings);
   },
 
   toggleAsideLayoutSettings(evt) {
     evt.target.blur();
-    this.setState({
+    const asideSettings = {
       asideLayoutSettingsVisible: !this.state.asideLayoutSettingsVisible,
       asideLibrarySearchVisible: false
-    });
+    };
+    this.setState(asideSettings);
+    this.saveAsideSettings(asideSettings);
   },
 
   hidePreview() {


### PR DESCRIPTION
## Description

Save Form Builder aside panel state in browser memory, so it stays open when editing different forms.

## Related issues

Fixes #1908