### PR TITLE
fix tooltips covering stuff

### DIFF
--- a/jsapp/scss/components/_kobo.tooltips.scss
+++ b/jsapp/scss/components/_kobo.tooltips.scss
@@ -3,7 +3,13 @@
   [data-tip] {
     position: relative;
 
-    &:after {
+    // avoid tooltips getting in front of other interactive layout elements
+    &::before,
+    &::after {
+      pointer-events: none;
+    }
+
+    &::after {
       content: attr(data-tip);
       font-size: 13px;
       line-height: 1.35em;
@@ -23,7 +29,7 @@
       @include box-shadow;
     }
 
-    &:before {
+    &::before {
       border-bottom: 5px solid darken($cool-gray, 10%);
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
@@ -50,13 +56,13 @@
   // Modify positioning for sidebar elements
 
   .k-drawer {
-    [data-tip]:after {
+    [data-tip]::after {
       left: 95%;
       top: 50%;
       transform: translate(0, -50%);
     }
 
-    [data-tip]:before {
+    [data-tip]::before {
       left: calc(95% - 5px);
       top: 50%;
       transform: translate(0, -50%);
@@ -68,33 +74,33 @@
   }
 
   // right aligned tooltips
-  .right-tooltip [data-tip]:after,
-  .right-tooltip[data-tip]:after {
+  .right-tooltip [data-tip]::after,
+  .right-tooltip[data-tip]::after {
     left: auto;
     right: calc(50% - 10px);
     transform: translate(0);
   }
 
   // left aligned tooltips
-  .left-tooltip [data-tip]:after,
-  .left-tooltip[data-tip]:after {
+  .left-tooltip [data-tip]::after,
+  .left-tooltip[data-tip]::after {
     left: calc(50% - 10px);
     right: auto;
     transform: translate(0);
   }
 
   // more actions in asset-row adjustment
-  .asset-row .popover-menu [data-tip]:after {
+  .asset-row .popover-menu [data-tip]::after {
     left: -60%;
   }
 
   // Modify positioning to header tooltips
 
-  .mdl-layout__header [data-tip]:after {
+  .mdl-layout__header [data-tip]::after {
     left: 50px;
   }
 
-  .mdl-layout__header [data-tip]:before {
+  .mdl-layout__header [data-tip]::before {
     left: 50px;
   }
 }


### PR DESCRIPTION
## Description

Makes tooltips non-interactive, i.e. if the tooltip covers other interactive element (e.g. button), it will no longer block it from being clicked.

## Related issues

Fixes #1915