### PR TITLE
better error message for import failure

### DIFF
--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -455,8 +455,12 @@ export class ProjectSettings extends React.Component {
                 alertify.error(t('Failed to reload project after upload!'));
               });
             },
-            () => {
-              alertify.error(t('Could not initialize XLSForm upload!'));
+            (response) => {
+              if (response && response.messages && response.messages.error) {
+                alertify.error(response.messages.error);
+              } else {
+                alertify.error(t('Could not initialize XLSForm upload!'));
+              }
             }
           );
         },


### PR DESCRIPTION
## Description

Use error message from backend instead of showing general one.

@jnm btw. should I check the FE code and do similar thing for other error handling? I could do it for all BE calls FE makes - the only problem is that the responses differ: sometimes error message is in `responseJSON.detail`, sometimes in `messages.error`, and sometimes error response is html code - created an issue for this idea: #1926 