### PR TITLE
display more than single letter for matrix in reports

### DIFF
--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -530,7 +530,12 @@ class ReportContents extends React.Component {
       <div>
         {
           reportData.map((rowContent, i)=>{
-            var label = (rowContent.row.label && rowContent.row.label[tnslIndex]) ? rowContent.row.label[tnslIndex] : t('Unlabeled');
+            let label = t('Unlabeled');
+            if (_.isArray(rowContent.row.label)) {
+              label = rowContent.row.label[tnslIndex];
+            } else if (_.isString(rowContent.row.label)) {
+              label = rowContent.row.label;
+            }
 
             if (!rowContent.data.provided)
               return false;


### PR DESCRIPTION
## Description

A small but useful change: for Question Matrixes in reports, user will see `group_UID_FIRST_QUESTION_SECOND_QUESTION` instead of `g`. More changes in the related issue will require BE + FE changes.

## Related issues

Part of #1928

