### PR TITLE
Enhancement: Keep modal close button always visible

### DIFF
--- a/jsapp/scss/components/_kobo.modal.scss
+++ b/jsapp/scss/components/_kobo.modal.scss
@@ -82,6 +82,7 @@ $z-modal-x: 10;
 .modal__content {
   overflow: auto;
   background-color: #FFF;
+  width: 100%;
 }
 
 .modal__tabs {

--- a/jsapp/scss/components/_kobo.modal.scss
+++ b/jsapp/scss/components/_kobo.modal.scss
@@ -1,3 +1,7 @@
+$z-modal-backdrop: 1001;
+$z-enketo-iframe-icon: 1000;
+$z-modal-x: 10;
+
 // -----------------------------------------------------------------------------
 // common modal parts
 // -----------------------------------------------------------------------------
@@ -6,33 +10,35 @@
   position: fixed;
   height: 100%;
   width: 100%;
-  z-index: 1001;
+  z-index: $z-modal-backdrop;
   top: 0px;
   left: 0px;
   background-color: rgba(0, 0, 0, 0.4) !important;
 }
 
 .modal {
+  align-items: stretch;
+  display: flex;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  min-width: 40%;
+  max-width: 90%;
+  max-height: 95%;
+  overflow-x: auto;
+  box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.06), 0 12px 12px 0 rgba(0, 0, 0, 0.12);
+  border-radius: 2px;
+  visibility: hidden;
+
   &.modal--open {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    min-width: 40%;
-    max-width: 90%;
-    max-height: 95%;
-    overflow-x: auto;
-    box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.06), 0 12px 12px 0 rgba(0, 0, 0, 0.12);
+    visibility: visible;
   }
 
   &.modal--large {
-    &.modal--open {
-      height: 80%;
-      width: 80%;
-      max-width: 1240px;
-      align-items: stretch;
-      display: flex;
-    }
+    height: 80%;
+    width: 80%;
+    max-width: 1240px;
 
     .modal__content {
       height: 100%;
@@ -84,7 +90,6 @@
 }
 
 .modal__header {
-  position: relative;
   min-height: 70px;
   background: $cool-blue;
   color: #FFF;
@@ -99,15 +104,21 @@
 
 .modal__x {
   position: absolute;
-  background-color: transparent;
+  z-index: $z-modal-x;
   top: 0;
   right: 0;
-  padding: 19px;
+  color: inherit;
+  background-color: inherit;
+  padding: 8px;
+  margin: 11px;
+  border-radius: 50%;
   font-size: 20px;
-  color: #FFF;
   cursor: pointer;
 
-  i {font-size: 32px;}
+  i {
+    display: block;
+    font-size: 32px;
+  }
 
   &:hover {opacity: 0.7;}
 }
@@ -177,17 +188,9 @@
 // custom parts and overrides
 // -----------------------------------------------------------------------------
 
-.modal-submission {
-  .modal--open {
-    background-color: #FFF;
-  }
-
+.modal.modal-submission {
   .modal__header {
     background-color: #F8F8F8;
-    color: $layout-text-color;
-  }
-
-  .modal__x {
     color: $layout-text-color;
   }
 
@@ -387,7 +390,7 @@
   right: 6px;
   top: 6px;
   border-radius: 3px;
-  z-index: 1000;
+  z-index: $z-enketo-iframe-icon;
   width: 15px;
   height: 15px;
   cursor: pointer;


### PR DESCRIPTION
## Description

Close button of modal stays in place as you scroll the content - I made the change universal for all modals to make it consistent. Also fixed `z-index` bug of close button (sometimes was underneath modal content inputs).

<img width="1095" alt="screen shot 2018-08-15 at 09 31 25" src="https://user-images.githubusercontent.com/2521888/44136835-929c343a-a06e-11e8-809a-4d0f5dae8e27.png">
<img width="1071" alt="screen shot 2018-08-15 at 09 31 16" src="https://user-images.githubusercontent.com/2521888/44136838-950caf92-a06e-11e8-9088-db9aca6a4448.png">
<img width="700" alt="screen shot 2018-08-15 at 09 31 34" src="https://user-images.githubusercontent.com/2521888/44136842-9aa6c33e-a06e-11e8-80ab-f8c803014dcb.png">
<img width="699" alt="screen shot 2018-08-15 at 09 31 02" src="https://user-images.githubusercontent.com/2521888/44136845-9ca6de8a-a06e-11e8-952d-e083a567c812.png">

## Related issues

Fixes #1919 