### PR TITLE
Bugfix: Simplify and fix fullscreen handling

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -121,23 +121,21 @@ class App extends React.Component {
           global
           isolate>
 
-          { !this.isFormBuilder() && !this.state.pageState.headerHidden &&
+          { !this.isFormBuilder() &&
             <div className='k-header__bar' />
           }
           <bem.PageWrapper m={{
               'fixed-drawer': this.state.pageState.showFixedDrawer,
-              'header-hidden': this.state.pageState.headerHidden,
-              'drawer-hidden': this.state.pageState.drawerHidden,
               'in-formbuilder': this.isFormBuilder()
                 }} className='mdl-layout mdl-layout--fixed-header'>
               { this.state.pageState.modal &&
                 <Modal params={this.state.pageState.modal} />
               }
 
-              { !this.isFormBuilder() && !this.state.pageState.headerHidden &&
+              { !this.isFormBuilder() &&
                 <MainHeader assetid={assetid}/>
               }
-              { !this.isFormBuilder() && !this.state.pageState.drawerHidden &&
+              { !this.isFormBuilder() &&
                 <Drawer/>
               }
               <bem.PageWrapper__content className='mdl-layout__content' m={this.isFormSingle() ? 'form-landing' : ''}>

--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -78,7 +78,7 @@ export class FormMap extends React.Component {
       hasGeoPoint: hasGeoPoint,
       submissions: [],
       error: false,
-      showExpandedMap: false,
+      isFullscreen: false,
       showExpandedLegend: true,
       langIndex: 0,
       filteredByMarker: false,
@@ -565,11 +565,8 @@ export class FormMap extends React.Component {
     let map = this.refreshMap();
     this.requestData(map, this.props.viewby);
   }
-  toggleExpandedMap () {
-    stores.pageState.hideDrawerAndHeader(!this.state.showExpandedMap);
-    this.setState({
-      showExpandedMap: !this.state.showExpandedMap,
-    });
+  toggleFullscreen () {
+    this.setState({isFullscreen: !this.state.isFullscreen});
 
     var map = this.state.map;
     setTimeout(function(){ map.invalidateSize()}, 300);
@@ -680,12 +677,17 @@ export class FormMap extends React.Component {
       });
     }
 
+    const formViewModifiers = ['map'];
+    if (this.state.isFullscreen) {
+      formViewModifiers.push('fullscreen');
+    }
+
     return (
-      <bem.FormView m='map' className='right-tooltip'>
+      <bem.FormView m={formViewModifiers} className='right-tooltip'>
         <bem.FormView__mapButton m={'expand'}
-          onClick={this.toggleExpandedMap}
+          onClick={this.toggleFullscreen}
           data-tip={t('Toggle Fullscreen')}
-          className={this.state.toggleExpandedMap ? 'active': ''}>
+          className={this.state.toggleFullscreen ? 'active': ''}>
           <i className='k-icon-expand' />
         </bem.FormView__mapButton>
         <bem.FormView__mapButton m={'markers'}

--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -1015,9 +1015,11 @@ class Reports extends React.Component {
           </button>
         }
 
-        <button className='mdl-button mdl-button--icon report-button__expand'
-                onClick={this.toggleFullscreen}
-                data-tip={t('Toggle fullscreen')}>
+        <button
+          className='mdl-button mdl-button--icon report-button__expand right-tooltip'
+          onClick={this.toggleFullscreen}
+          data-tip={t('Toggle fullscreen')}
+        >
           <i className='k-icon-expand' />
         </button>
 

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -491,24 +491,12 @@ export class DataTable extends React.Component {
     });
   }
   toggleExpandedTable () {
-    if (this.state.showExpandedTable) {
-      // load asset again to restore header title and submission count after exiting expanded report
-      actions.resources.loadAsset({id: this.props.asset.uid});
-    }
-
-    stores.pageState.hideDrawerAndHeader(!this.state.showExpandedTable);
-    this.setState({
-      showExpandedTable: !this.state.showExpandedTable,
-    });
+    this.setState({showExpandedTable: !this.state.showExpandedTable});
   }
   componentDidMount() {
     this.listenTo(actions.resources.updateSubmissionValidationStatus.completed, this.refreshSubmission);
-    this.listenTo(actions.table.updateSettings.completed, this.tableSettingsUpdated);
-    this.listenTo(stores.pageState, this.onPageStateUpdate);
-  }
-  componentWillUnmount() {
-    if (this.state.showExpandedTable)
-      stores.pageState.hideDrawerAndHeader(!this.state.showExpandedTable);
+    this.listenTo(actions.table.updateSettings.completed, this.onTableUpdateSettingsCompleted);
+    this.listenTo(stores.pageState, this.onPageStateUpdated);
   }
   refreshSubmission(result, sid) {
     if (sid) {
@@ -521,7 +509,7 @@ export class DataTable extends React.Component {
       }
     }
   }
-  tableSettingsUpdated() {
+  onTableUpdateSettingsCompleted() {
     stores.pageState.hideModal();
     this._prepColumns(this.state.tableData);
   }
@@ -563,7 +551,7 @@ export class DataTable extends React.Component {
       }
     });
   }
-  launchTableColumnsModal () {
+  showTableColumsOptionsModal () {
     stores.pageState.showModal({
       type: MODAL_TYPES.TABLE_COLUMNS,
       asset: this.props.asset,
@@ -588,7 +576,7 @@ export class DataTable extends React.Component {
       }
     });
   }
-  onPageStateUpdate(pageState) {
+  onPageStateUpdated(pageState) {
     if (!pageState.modal)
       return false;
 
@@ -764,8 +752,12 @@ export class DataTable extends React.Component {
     let asset = this.props.asset,
         tableClasses = this.state.frozenColumn ? '-striped -highlight has-frozen-column' : '-striped -highlight';
 
+    const formViewModifiers = ['table'];
+    if (this.state.showExpandedTable) {
+      formViewModifiers.push('fullscreen');
+    }
     return (
-      <bem.FormView m='table'>
+      <bem.FormView m={formViewModifiers}>
         {this.state.promptRefresh &&
           <bem.FormView__cell m='table-warning'>
             <i className='k-icon-alert' />
@@ -801,15 +793,18 @@ export class DataTable extends React.Component {
               </ui.PopoverMenu>
             }
 
-            <button className='mdl-button mdl-button--icon report-button__expand'
-                    onClick={this.toggleExpandedTable}
-                    data-tip={this.state.showExpandedTable ? t('Contract') : t('Expand')}>
+            <button
+              className='mdl-button mdl-button--icon report-button__expand'
+              onClick={this.toggleExpandedTable}
+              data-tip={this.state.showExpandedTable ? t('Contract') : t('Expand')}>
               <i className='k-icon-expand' />
             </button>
 
-            <button className='mdl-button mdl-button--icon report-button__expand'
-                    onClick={this.launchTableColumnsModal}
-                    data-tip={t('Display options')}>
+            <button
+              className='mdl-button mdl-button--icon report-button__expand right-tooltip'
+              onClick={this.showTableColumsOptionsModal}
+              data-tip={t('Display options')}
+            >
               <i className='k-icon-settings' />
             </button>
           </bem.FormView__item>

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -41,7 +41,7 @@ export class DataTable extends React.Component {
       selectedColumns: false,
       frozenColumn: false,
       sids: [],
-      showExpandedTable: false,
+      isFullscreen: false,
       defaultPageSize: 30,
       pageSize: 30,
       currentPage: 0,
@@ -490,8 +490,8 @@ export class DataTable extends React.Component {
       this._prepColumns(this.state.tableData);
     });
   }
-  toggleExpandedTable () {
-    this.setState({showExpandedTable: !this.state.showExpandedTable});
+  toggleFullscreen () {
+    this.setState({isFullscreen: !this.state.isFullscreen});
   }
   componentDidMount() {
     this.listenTo(actions.resources.updateSubmissionValidationStatus.completed, this.refreshSubmission);
@@ -753,7 +753,7 @@ export class DataTable extends React.Component {
         tableClasses = this.state.frozenColumn ? '-striped -highlight has-frozen-column' : '-striped -highlight';
 
     const formViewModifiers = ['table'];
-    if (this.state.showExpandedTable) {
+    if (this.state.isFullscreen) {
       formViewModifiers.push('fullscreen');
     }
     return (
@@ -795,8 +795,9 @@ export class DataTable extends React.Component {
 
             <button
               className='mdl-button mdl-button--icon report-button__expand'
-              onClick={this.toggleExpandedTable}
-              data-tip={this.state.showExpandedTable ? t('Contract') : t('Expand')}>
+              onClick={this.toggleFullscreen}
+              data-tip={t('Toggle fullscreen')}
+            >
               <i className='k-icon-expand' />
             </button>
 

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -794,7 +794,7 @@ export class DataTable extends React.Component {
             }
 
             <button
-              className='mdl-button mdl-button--icon report-button__expand'
+              className='mdl-button mdl-button--icon report-button__expand right-tooltip'
               onClick={this.toggleFullscreen}
               data-tip={t('Toggle fullscreen')}
             >

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -92,9 +92,7 @@ var pageStateStore = Reflux.createStore({
   init () {
     this.state = {
       assetNavExpanded: false,
-      showFixedDrawer: false,
-      headerHidden: false,
-      drawerHidden: false
+      showFixedDrawer: false
     };
   },
   setState (chz) {
@@ -123,17 +121,6 @@ var pageStateStore = Reflux.createStore({
     this.setState({
       modal: false
     });
-  },
-  hideDrawerAndHeader (tf) {
-    var val = !!tf;
-    if (val !== this.state.drawerHidden) {
-      var _changes = {
-        drawerHidden: val,
-        headerHidden: val
-      };
-      assign(this.state, _changes);
-      this.trigger(this.state);
-    }
   }
 });
 

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -44,16 +44,6 @@
   }
 }
 
-// full screen overrides (for expanded reports, table, maps, etc.)
-.mdl-layout.page-wrapper--header-hidden.page-wrapper--drawer-hidden {
-  max-width: 100%;
-
-  .mdl-layout__content.page-wrapper__content--form-landing {
-    box-shadow: none;
-    height: calc(100% - 40px);
-  }
-}
-
 .ui-panel {
   height: 100%;
   margin: 0px 8px;
@@ -108,16 +98,6 @@
 
   .ui-panel {
     margin: 0px;
-  }
-}
-
-// Expanded report layout, disable drawer
-.mdl-layout.page-wrapper--drawer-hidden .mdl-layout__content {
-  margin-left: 16px;
-
-  .report-view {
-    height: 100%;
-    overflow: auto;
   }
 }
 

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -32,10 +32,15 @@ $z-form-view-fullscreen: 101;
     right: 0;
     width: 100%;
     height: 100%;
+    // min/max sizes to override any custom @media or other .form-view styles
+    min-width: 100%;
+    max-width: 100%;
+    min-height: 100%;
+    max-height: 100%;
   }
 }
 
-.form-view__sidetabs + .form-view:not(.form-view--fullscreen),
+.form-view__sidetabs + .form-view,
 .form-view__sidetabs + .report-view,
 .form-view__sidetabs + .loading {
   width: calc(100% - 170px);

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -1,3 +1,5 @@
+$z-form-view-fullscreen: 101;
+
 .form-view__toptabs {
   background: white;
   text-align: center;
@@ -20,9 +22,20 @@
   height: calc(100% - 48px);
   overflow-y: auto;
   background: #F8F8F8;
+
+  &.form-view--fullscreen {
+    position: fixed;
+    z-index: $z-form-view-fullscreen;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 
-.form-view__sidetabs + .form-view,
+.form-view__sidetabs + .form-view:not(.form-view--fullscreen),
 .form-view__sidetabs + .report-view,
 .form-view__sidetabs + .loading {
   width: calc(100% - 170px);

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -55,7 +55,7 @@ $z-form-view-fullscreen: 101;
   }
 }
 
-.form-view__sidetabs + .form-view--table {
+.form-view__sidetabs + .form-view.form-view--table {
   overflow: hidden;
 }
 
@@ -125,24 +125,6 @@ $z-form-view-fullscreen: 101;
     span {
       vertical-align: middle;
     }
-  }
-}
-
-.page-wrapper--header-hidden.page-wrapper--drawer-hidden {
-  .form-view__sidetabs {
-    width: 0px;
-    border-right: none;
-  }
-
-  .form-view__sidetabs + .form-view,
-  .form-view__sidetabs + .report-view {
-    width: calc(100% - 1px);
-    height: 100%;
-    background: #F8F8F8;
-  }
-
-  .form-view__toptabs {
-    display: none;
   }
 }
 

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -11,7 +11,9 @@ $z-form-view-fullscreen: 101;
   border-right: 1px solid $divider-color;
   width: 170px;
   height: 100%;
-  overflow: hidden;
+  max-height: calc(100% - 48px);
+  overflow-x: hidden;
+  overflow-y: auto;
   float: left;
   background: white;
   padding-top: 20px;
@@ -648,6 +650,17 @@ $z-form-view-fullscreen: 101;
 
   .form-view__cell {
     margin-top: 25px;
+  }
+}
+
+@media screen and (max-height: 420px) {
+  .form-view__sidetabs {
+    padding-top: 0;
+
+    a.form-view__tab {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
   }
 }
 

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -252,18 +252,6 @@
   }
 }
 
-.page-wrapper--header-hidden.page-wrapper--drawer-hidden {
-  .form-view--table {
-    padding: 0px;
-    overflow: hidden;
-    background: transparent !important;
-
-    .form-view__group--table-header {
-      padding-top: 0px;
-    }
-  }
-}
-
 .tableColumn-modal {
   .form-view__cell--label {
     padding-bottom: 10px;


### PR DESCRIPTION
## Description

Simplify fullscreen handling for Map, Reports and Table views, by using CSS `position: fixed` instead of hiding layout elements with JS.

Also added some better accessibility related styles for sidetabs.

Hint: Use " Hide whitespace changes" when reviewing the changes.

## Related issues

Fixes #1920

