### PR TITLE
Enhancement: Make long table column names viewable

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -329,7 +329,10 @@ export class DataTable extends React.Component {
 
       columns.push({
         Header: h => {
-          return _this.getColumnLabel(key, q, qParentG);
+          const columnName = _this.getColumnLabel(key, q, qParentG);
+          return (
+            <span title={columnName}>{columnName}</span>
+          );
         },
         id: key,
         accessor: row => row[key],

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -53,16 +53,6 @@
     }
 
     .rt-thead {
-      // allow wrapping labels for long column names
-      .rt-resizable-header-content {
-        overflow: initial;
-        text-overflow: initial;
-        white-space: initial;
-        word-wrap: break-word;
-        line-height: 16px;
-        padding: 7px 0 4px;
-      }
-
       &.-filters input {
         padding: 2px 4px;
       }

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -53,6 +53,16 @@
     }
 
     .rt-thead {
+      // allow wrapping labels for long column names
+      .rt-resizable-header-content {
+        overflow: initial;
+        text-overflow: initial;
+        white-space: initial;
+        word-wrap: break-word;
+        line-height: 16px;
+        padding: 7px 0 4px;
+      }
+
       &.-filters input {
         padding: 2px 4px;
       }

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -52,6 +52,11 @@
       }
     }
 
+    // minimum body height so at least two rows are visible
+    .rt-tbody {
+      min-height: 72px;
+    }
+
     .rt-thead {
       &.-filters input {
         padding: 2px 4px;


### PR DESCRIPTION
## Description

Override react-table styles and allow column name wrapping. I decided to additional break words by letters (if by whitespace is not possible), because we often have very_long_snake_cased column names.

## Screenshots

Before:
<img width="812" alt="screen shot 2018-08-15 at 18 03 15" src="https://user-images.githubusercontent.com/2521888/44158720-b5895080-a0b5-11e8-8fb6-d00a7ae9324c.png">

After:
<img width="800" alt="screen shot 2018-08-15 at 18 03 35" src="https://user-images.githubusercontent.com/2521888/44158732-bde18b80-a0b5-11e8-95d8-291ed4309b60.png">

## Related issues

Fixes #1935