### PR TITLE
Add file name to import error messages

### DIFF
--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -26,7 +26,8 @@ import {
   t,
   assign,
   notify,
-  stringToColor
+  stringToColor,
+  escapeHtml
 } from './utils';
 
 import icons from '../xlform/src/view.icons';
@@ -303,7 +304,7 @@ mixins.droppable = {
     }
 
     dataInterface.postCreateImport(params).then((data)=> {
-      window.setTimeout((()=>{
+      window.setTimeout((() => {
         dataInterface.getImportDetails({
           uid: data.uid,
         }).done((importData) => {
@@ -330,22 +331,26 @@ mixins.droppable = {
                 notify(t('XLS Import completed'));
               }
             }
-          }
-          // If the import task didn't complete immediately, inform the user accordingly.
-          else if (importData.status === 'processing') {
+          } else if (importData.status === 'processing') {
+            // If the import task didn't complete immediately, inform the user accordingly.
             alertify.warning(t('Your upload is being processed. This may take a few moments.'));
           } else if (importData.status === 'created') {
             alertify.warning(t('Your upload is queued for processing. This may take a few moments.'));
           } else if (importData.status === 'error')  {
-            let error_message = t('Import Failure.');
-            if (importData.messages.error)
-              error_message = `<strong>${t('Import Failure.')}</strong><br><code><strong>${importData.messages.error_type}</strong><br>${importData.messages.error}</code>`;
-            alertify.error(error_message);
+            const errLines = [];
+            errLines.push(t('Import Failed!'));
+            if (params.name) {
+              errLines.push(`<code>Name: ${params.name}</code>`);
+            }
+            if (importData.messages.error) {
+              errLines.push(`<code>${importData.messages.error_type}: ${escapeHtml(importData.messages.error)}</code>`);
+            }
+            alertify.error(errLines.join('<br/>'));
           } else {
-            alertify.error(t('Import Failure.'));
+            alertify.error(t('Import Failed!'));
           }
         }).fail((failData)=>{
-          alertify.error(t('Import Failed.'));
+          alertify.error(t('Import Failed!'));
           log('import failed', failData);
         });
         stores.pageState.hideModal();

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -262,3 +262,9 @@ export function koboMatrixParser(params) {
   }
   return params;
 }
+
+export function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.appendChild(document.createTextNode(str));
+  return div.innerHTML;
+}


### PR DESCRIPTION
## Description

Having name of file will make it easier to identify which form failed when uploading multiple:

Using `Crete New Form > Import an XLSForm via URL` modal:
<img width="349" alt="screen shot 2018-08-25 at 08 48 37" src="https://user-images.githubusercontent.com/2521888/44615869-5c9f8200-a844-11e8-9851-0a6c2bb20d70.png">

Using drag & drop on document:
<img width="346" alt="screen shot 2018-08-25 at 08 49 26" src="https://user-images.githubusercontent.com/2521888/44615870-5d381880-a844-11e8-9cb9-64acc7c15a42.png">

## Related issues

Related to #1962 and #1926

