### PR TITLE
Feature: endpoint for hash of all assets

### DIFF
--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -106,22 +106,6 @@
         }
     },
     {
-        "model": "kpi.asset",
-        "pk": 2,
-        "collection": 1,
-        "fields": {
-            "name": "fixture asset 2",
-            "content": {"survey": [
-                {"type": "text", "label": "fixture q3", "name": "q3", "kuid": "ghi"},
-                {"type": "text", "label": "fixture q4", "name": "q4", "kuid": "jkl"}
-            ]},
-            "date_created": "2018-08-29T19:12:14.406Z",
-            "date_modified": "2018-08-29T19:12:14.406Z",
-            "owner": 3,
-            "uid": "aFsoVpqanDVqrC7B43Kzh6"
-        }
-    },
-    {
         "model": "authtoken.token",
         "pk": 1,
         "fields": {

--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -106,6 +106,22 @@
         }
     },
     {
+        "model": "kpi.asset",
+        "pk": 2,
+        "collection": 1,
+        "fields": {
+            "name": "fixture asset 2",
+            "content": {"survey": [
+                {"type": "text", "label": "fixture q3", "name": "q3", "kuid": "ghi"},
+                {"type": "text", "label": "fixture q4", "name": "q4", "kuid": "jkl"}
+            ]},
+            "date_created": "2018-08-29T19:12:14.406Z",
+            "date_modified": "2018-08-29T19:12:14.406Z",
+            "owner": 3,
+            "uid": "aFsoVpqanDVqrC7B43Kzh6"
+        }
+    },
+    {
         "model": "authtoken.token",
         "pk": 1,
         "fields": {

--- a/kpi/tests/test_api_assets.py
+++ b/kpi/tests/test_api_assets.py
@@ -84,16 +84,17 @@ class AssetsListApiTests(APITestCase):
 
     def test_assets_hash(self):
         another_user = User.objects.get(username="anotheruser")
-
-        user_asset = Asset.objects.get(pk=1)
+        user_asset = Asset.objects.first()
         user_asset.save()
-
-        another_user_asset = Asset.objects.get(pk=2)
-        another_user_asset.save()
-
         user_asset.assign_perm(another_user, "view_asset")
+
         self.client.logout()
         self.client.login(username="anotheruser", password="anotheruser")
+        creation_response = self.test_create_asset()
+
+        another_user_asset = another_user.assets.last()
+        another_user_asset.save()
+
         versions_ids = [
             user_asset.version_id,
             another_user_asset.version_id

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -756,6 +756,17 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     >
     >       curl -X GET https://[kpi-url]/assets/
 
+    Get an hash of all `version_id`s of assets.
+    Useful to detect any changes in assets with only one call to `API`
+
+    <pre class="prettyprint">
+    <b>GET</b> /assets/hash/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi-url]/assets/hash/
+
     ## CRUD
 
     * `uid` - is the unique identifier of a specific asset

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -1016,7 +1016,7 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     def hash(self, request):
         """
         Creates an hash of `version_id` of all accessible assets by the user.
-        Useful to detect changes between each requests.
+        Useful to detect changes between each request.
 
         :param request:
         :return: JSON


### PR DESCRIPTION
Adds endpoint at `assets/hash` with hash of all assets, based on `version_id`. Frontend will consume this endpoint and decide whether to request a refresh of the asset list or not. 

Fixes #1894. 
