### PR TITLE
Display HXL tags in table header

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -49,6 +49,7 @@ export class DataTable extends React.Component {
       showLabels: true,
       translationIndex: 0,
       showGroupName: true,
+      showHXLTags: false,
       resultsTotal: 0,
       selectedRows: {},
       selectAll: false,
@@ -150,6 +151,7 @@ export class DataTable extends React.Component {
 
     let showLabels = this.state.showLabels,
         showGroupName = this.state.showGroupName,
+        showHXLTags = this.state.showHXLTags,
         settings = this.props.asset.settings,
         translationIndex = this.state.translationIndex,
         maxPageRes = Math.min(this.state.pageSize, this.state.tableData.length),
@@ -162,6 +164,10 @@ export class DataTable extends React.Component {
 
     if (settings['data-table'] && settings['data-table']['show-group-name'] != null) {
       showGroupName = settings['data-table']['show-group-name'];
+    }
+
+    if (settings['data-table'] && settings['data-table']['show-hxl-tags'] != null) {
+      showHXLTags = settings['data-table']['show-hxl-tags'];
     }
 
     // check for overrides by users with view permissions only
@@ -233,7 +239,13 @@ export class DataTable extends React.Component {
     });
 
     columns.push({
-      Header: t('Validation status'),
+      Header: () => {
+        return (
+          <span className='column-header-title'>
+            {t('Validation status')}
+          </span>
+        );
+      },
       accessor: '_validation_status.uid',
       index: '__2',
       id: '__ValidationStatus',
@@ -330,8 +342,14 @@ export class DataTable extends React.Component {
       columns.push({
         Header: h => {
           const columnName = _this.getColumnLabel(key, q, qParentG);
+          const columnHXLTags = _this.getColumnHXLTags(key);
           return (
-            <span title={columnName}>{columnName}</span>
+            <React.Fragment>
+              <span className='column-header-title' title={columnName}>{columnName}</span>
+              {columnHXLTags &&
+                <span className='column-header-hxl-tags' title={columnHXLTags}>{columnHXLTags}</span>
+              }
+            </React.Fragment>
           );
         },
         id: key,
@@ -438,15 +456,47 @@ export class DataTable extends React.Component {
       frozenColumn: frozenColumn,
       translationIndex: translationIndex,
       showLabels: showLabels,
-      showGroupName: showGroupName
+      showGroupName: showGroupName,
+      showHXLTags: showHXLTags
     });
+  }
+  getColumnHXLTags(key) {
+    if (this.state.showHXLTags) {
+      const colQuestion = _.find(this.props.asset.content.survey, (question) => {
+        return question.$autoname === key;
+      });
+      if (!colQuestion || !colQuestion.tags) {
+        return null;
+      }
+      const HXLTags = [];
+      colQuestion.tags.map((tag) => {
+        if (tag.startsWith('hxl:')) {
+          HXLTags.push(tag.replace('hxl:', ''));
+        }
+      });
+      if (HXLTags.length === 0) {
+        return null;
+      } else {
+        return HXLTags.join(',');
+      }
+    } else {
+      return null;
+    }
   }
   getColumnLabel(key, q, qParentG, stateOverrides = false) {
     switch(key) {
       case '__SubmissionCheckbox':
-        return t('Multi-select checkboxes column');
+        return (
+          <span className='column-header-title'>
+            {t('Multi-select checkboxes column')}
+          </span>
+        );
       case '__ValidationStatus':
-        return t('Validation status');
+        return (
+          <span className='column-header-title'>
+            {t('Validation status')}
+          </span>
+        );
     }
 
     var label = key;

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -477,7 +477,7 @@ export class DataTable extends React.Component {
       if (HXLTags.length === 0) {
         return null;
       } else {
-        return HXLTags.join(',');
+        return HXLTags.join('');
       }
     } else {
       return null;

--- a/jsapp/js/components/tableColumnFilter.es6
+++ b/jsapp/js/components/tableColumnFilter.es6
@@ -22,6 +22,7 @@ export class TableColumnFilter extends React.Component {
       selectedColumns: [],
       frozenColumn: false,
       showGroupName: true,
+      showHXLTags: false,
       translationIndex: 0
     };
 
@@ -35,6 +36,8 @@ export class TableColumnFilter extends React.Component {
         this.state.showGroupName = _sett['data-table']['show-group-name'];
       if (_sett['data-table']['translation-index'])
         this.state.translationIndex = _sett['data-table']['translation-index'];
+      if (_sett['data-table']['show-hxl-tags'])
+        this.state.showHXLTags = _sett['data-table']['show-hxl-tags'];
     }
 
     autoBind(this);
@@ -54,6 +57,7 @@ export class TableColumnFilter extends React.Component {
       settings['data-table']['frozen-column'] = s.frozenColumn;
       settings['data-table']['show-group-name'] = s.showGroupName;
       settings['data-table']['translation-index'] = s.translationIndex;
+      settings['data-table']['show-hxl-tags'] = s.showHXLTags;
 
       actions.table.updateSettings(this.props.asset.uid, settings);
     } else {
@@ -89,6 +93,11 @@ export class TableColumnFilter extends React.Component {
   updateGroupHeaderDisplay(e) {
     this.setState({
       showGroupName: e.target.checked
+    })
+  }
+  onHXLTagsChange(evt) {
+    this.setState({
+      showHXLTags: evt.currentTarget.checked
     })
   }
   onLabelChange(e) {
@@ -170,6 +179,19 @@ export class TableColumnFilter extends React.Component {
             {t('Show group names in table headers')}
           </label>
         </bem.FormModal__item>
+
+        <bem.FormModal__item>
+          <input
+            type='checkbox'
+            checked={this.state.showHXLTags}
+            onChange={this.onHXLTagsChange}
+            id='hxl-tags'
+          />
+          <label htmlFor='hxl-tags'>
+            {t('Show HXL tags in table headers')}
+          </label>
+        </bem.FormModal__item>
+
         {this.userCan('change_asset', this.props.asset) &&
           <bem.FormModal__item m='advanced-table-options'>
             <bem.FormView__cell m='note'>

--- a/jsapp/js/components/tableColumnFilter.es6
+++ b/jsapp/js/components/tableColumnFilter.es6
@@ -188,7 +188,7 @@ export class TableColumnFilter extends React.Component {
             id='hxl-tags'
           />
           <label htmlFor='hxl-tags'>
-            {t('Show HXL tags in table headers')}
+            {t('Show HXL tags')}
           </label>
         </bem.FormModal__item>
 

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -58,6 +58,31 @@
     }
 
     .rt-thead {
+      .rt-tr {
+        align-items: center;
+      }
+
+      .rt-resizable-header-content {
+        overflow: visible;
+        text-overflow: inherit;
+        line-height: 1.2;
+        padding: 5px 0;
+
+        .column-header-title,
+        .column-header-hxl-tags {
+          display: block;
+          width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .column-header-hxl-tags {
+          color: $cool-silver;
+        }
+      }
+    }
+
+    .rt-thead {
       &.-filters input {
         padding: 2px 4px;
       }


### PR DESCRIPTION
## Description

New option in settings modal that shows XHL tags:

<img width="418" alt="screen shot 2018-08-30 at 14 06 11" src="https://user-images.githubusercontent.com/2521888/44850579-f361a980-ac5d-11e8-9bb1-1b6e5836dc2c.png">
<img width="798" alt="screen shot 2018-08-30 at 14 06 16" src="https://user-images.githubusercontent.com/2521888/44850580-f492d680-ac5d-11e8-9d05-7c242c9da457.png">

## Related issues

Fixes #1954

