### PR TITLE
Enhancement: use searchStore as much as possible when displaying asset list

### DIFF
--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -163,21 +163,6 @@ var dataInterface;
         method: 'GET'
       });
     },
-    assetSearch ({tags, q}) {
-      var params = [];
-      if (tags) {
-        tags.forEach(function(tag){
-          params.push(`tag:${tag}`);
-        });
-      }
-      if (q) {
-        params.push(`(${q})`);
-      }
-      return $ajax({
-        url: `${rootUrl}/assets/?${params.join(' AND ')}`,
-        method: 'GET'
-      });
-    },
     deleteCollection ({uid}) {
       return $ajax({
         url: `${rootUrl}/collections/${uid}/`,
@@ -253,6 +238,12 @@ var dataInterface;
         url: `${rootUrl}/assets/`,
         dataType: 'json',
         data: searchData,
+        method: 'GET'
+      });
+    },
+    assetsHash () {
+      return $ajax({
+        url: `${rootUrl}/assets/hash/`,
         method: 'GET'
       });
     },

--- a/jsapp/js/lists/forms.es6
+++ b/jsapp/js/lists/forms.es6
@@ -30,18 +30,8 @@ class FormsSearchableList extends React.Component {
     };
   }
   componentDidMount () {
-    this.searchDefault();
+    this.searchSemaphore();
   }
-  /*
-  dropAction ({file, event}) {
-    actions.resources.createImport({
-      base64Encoded: event.target.result,
-      name: file.name,
-      lastModified: file.lastModified,
-      contentType: file.type
-    });
-  },
-  */
   render () {
     return (
       <SearchCollectionList

--- a/jsapp/js/lists/sidebarForms.es6
+++ b/jsapp/js/lists/sidebarForms.es6
@@ -35,7 +35,7 @@ class SidebarFormsList extends Reflux.Component {
   componentDidMount () {
     this.listenTo(this.searchStore, this.searchChanged);
     if (!this.isFormList())
-      this.searchDefault();
+      this.searchSemaphore();
   }
   componentWillReceiveProps () {
     this.listenTo(this.searchStore, this.searchChanged);

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -717,8 +717,6 @@ mixins.cloneAssetAsNewType = {
           onComplete: (asset) => {
             dialog.destroy();
 
-            this.refreshSearch && this.refreshSearch();
-
             switch (asset.asset_type) {
               case ASSET_TYPES.survey.id:
                 hashHistory.push(`/forms/${asset.uid}/landing`);

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -6,9 +6,11 @@
 import _ from 'underscore';
 import Reflux from 'reflux';
 import $ from 'jquery';
+import SparkMD5 from 'spark-md5';
 
 import stores from './stores';
 import actions from './actions';
+import {dataInterface} from './dataInterface';
 import {assign} from './utils';
 import assetParserUtils from './assetParserUtils';
 
@@ -239,6 +241,18 @@ function SearchContext(opts={}) {
     }
   };
 
+  const assetsHash = function (assets) {
+    if (assets.length < 1) return false;
+
+    let assetVersionIds = assets.map((asset) => {
+      return asset.version_id;
+    });
+    // Sort alphabetically, same as backend sort
+    assetVersionIds.sort();
+
+    return SparkMD5.hash(assetVersionIds.join(''));
+  }
+
   search.listen(function(_opts={}){
     /*
     search will query whatever values are in the store
@@ -377,6 +391,28 @@ function SearchContext(opts={}) {
       searchStore.quietUpdate(vals);
     },
     searchStore: searchStore,
+    searchSemaphore: function () {
+      // when searchStore exists, display current result set and compare hashes in background,
+      // if hashes don't match, relaunch search (otherwise, current result set is same as BE)
+
+      if (searchStore.state.defaultQueryResultsList === undefined) {
+        this.searchDefault();
+      } else {
+        searchStore.update({defaultQueryState: 'done'});
+
+        dataInterface.assetsHash()
+          .done((data) => {
+            if (data.hash && data.hash === assetsHash(searchStore.state.defaultQueryResultsList)) {
+              // if hashes match, do nothing (current searchStore contents is accurate)
+            } else {
+              this.searchDefault();
+            }
+          })
+          .fail(() => {
+            this.searchDefault();
+          });
+      }
+    },
     searchDefault: function () {
       searchStore.quietUpdate(assign({
         cleared: true,
@@ -433,9 +469,6 @@ var commonMethods = {
       });
       this.debouncedSearch();
     }
-  },
-  refreshSearch () {
-    this.debouncedSearch();
   },
   searchClear () {
     this.searchStore.removeItem('searchString');

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -402,9 +402,8 @@ function SearchContext(opts={}) {
 
         dataInterface.assetsHash()
           .done((data) => {
-            if (data.hash && data.hash === assetsHash(searchStore.state.defaultQueryResultsList)) {
-              // if hashes match, do nothing (current searchStore contents is accurate)
-            } else {
+            if (data.hash && data.hash !== assetsHash(searchStore.state.defaultQueryResultsList)) {
+              // if hashes don't match launch new search request
               this.searchDefault();
             }
           })

--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -106,22 +106,6 @@
         }
     },
     {
-        "model": "kpi.asset",
-        "pk": 2,
-        "collection": 1,
-        "fields": {
-            "name": "fixture asset 2",
-            "content": {"survey": [
-                {"type": "text", "label": "fixture q3", "name": "q3", "kuid": "ghi"},
-                {"type": "text", "label": "fixture q4", "name": "q4", "kuid": "jkl"}
-            ]},
-            "date_created": "2018-08-29T19:12:14.406Z",
-            "date_modified": "2018-08-29T19:12:14.406Z",
-            "owner": 3,
-            "uid": "aFsoVpqanDVqrC7B43Kzh6"
-        }
-    },
-    {
         "model": "authtoken.token",
         "pk": 1,
         "fields": {

--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -106,6 +106,22 @@
         }
     },
     {
+        "model": "kpi.asset",
+        "pk": 2,
+        "collection": 1,
+        "fields": {
+            "name": "fixture asset 2",
+            "content": {"survey": [
+                {"type": "text", "label": "fixture q3", "name": "q3", "kuid": "ghi"},
+                {"type": "text", "label": "fixture q4", "name": "q4", "kuid": "jkl"}
+            ]},
+            "date_created": "2018-08-29T19:12:14.406Z",
+            "date_modified": "2018-08-29T19:12:14.406Z",
+            "owner": 3,
+            "uid": "aFsoVpqanDVqrC7B43Kzh6"
+        }
+    },
+    {
         "model": "authtoken.token",
         "pk": 1,
         "fields": {

--- a/kpi/tests/test_api_assets.py
+++ b/kpi/tests/test_api_assets.py
@@ -84,16 +84,17 @@ class AssetsListApiTests(APITestCase):
 
     def test_assets_hash(self):
         another_user = User.objects.get(username="anotheruser")
-
-        user_asset = Asset.objects.get(pk=1)
+        user_asset = Asset.objects.first()
         user_asset.save()
-
-        another_user_asset = Asset.objects.get(pk=2)
-        another_user_asset.save()
-
         user_asset.assign_perm(another_user, "view_asset")
+
         self.client.logout()
         self.client.login(username="anotheruser", password="anotheruser")
+        creation_response = self.test_create_asset()
+
+        another_user_asset = another_user.assets.last()
+        another_user_asset.save()
+
         versions_ids = [
             user_asset.version_id,
             another_user_asset.version_id

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -756,6 +756,17 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     >
     >       curl -X GET https://[kpi-url]/assets/
 
+    Get an hash of all `version_id`s of assets.
+    Useful to detect any changes in assets with only one call to `API`
+
+    <pre class="prettyprint">
+    <b>GET</b> /assets/hash/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi-url]/assets/hash/
+
     ## CRUD
 
     * `uid` - is the unique identifier of a specific asset

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -1016,7 +1016,7 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     def hash(self, request):
         """
         Creates an hash of `version_id` of all accessible assets by the user.
-        Useful to detect changes between each requests.
+        Useful to detect changes between each request.
 
         :param request:
         :return: JSON

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "roboto-fontface": "^0.4.5",
     "sass-loader": "^7.0.1",
     "select2": "3.5.2-browserify",
+    "spark-md5": "^3.0.0",
     "style-loader": "^0.21.0",
     "underscore": "^1.8.3",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
## Description

Following #1885 and #1973 (please review this after 1973), this PR does the following: 

- when user returns to the Projects list, it displays the list of assets from the searchStore
- in the background, it checks whether BE asset list hash matches FE asset list hash, and only relaunches a network request (i.e. a new search) if there is a mismatch

This should result in improved performance for users, because now the full projects list will only be requested should there be a hash mismatch.  

Fixes #1960 

## Testing notes

When testing this in the UI, please note the following: 

- after this PR, returning to the Projects list should be faster for users, even when they make changes to a project (you should not see a "loading" placeholder when returning to the Projects screen)
- if a second user shares a project with the first user, you should see this new project in the user's Projects list after returning to it from another screen (say, library, form builder, another project, etc.)

## Dev notes

A few small code cleanups are also includes, PR removes some unused methods in searches.es6 and dataInterface.es6.