### PR TITLE
Restore `export default` to fix modals

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -39,7 +39,7 @@ Identifying the purpose is done by checking `context` and `formAsset`.
 
 You can listen to field changes by `onProjectDetailsChange` prop function.
 */
-export class ProjectSettings extends React.Component {
+class ProjectSettings extends React.Component {
   constructor(props){
     super(props);
 

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -812,3 +812,5 @@ reactMixin(ProjectSettings.prototype, mixins.droppable);
 ProjectSettings.contextTypes = {
   router: PropTypes.object
 };
+
+export default ProjectSettings;


### PR DESCRIPTION
For me, it restores the ability to create new forms, which was logging this console error:
```
react.development.js:247 Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `Modal`.
    in Modal (created by App)
    in div (created by BEM.page-wrapper)
    in BEM.page-wrapper (created by App)
    in div (created by Shortcuts)
    in Shortcuts (created by App)
    in DocumentTitle (created by SideEffect(DocumentTitle))
    in SideEffect(DocumentTitle) (created by App)
    in App (created by RouterContext)
    in RouterContext (created by Router)
    in Router (created by RunRoutes)
    in RunRoutes
```