### PR TITLE
Update webpack packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
     "underscore": "^1.8.3",
     "vinyl-source-stream": "^1.1.0",
     "webfonts-generator": "^0.4.0",
-    "webpack": "^4.10.1",
+    "webpack": "^4.20.2",
     "webpack-bundle-tracker": "0.4.0-beta",
-    "webpack-cli": "^2.1.4",
-    "webpack-dev-middleware": "3.0.0",
+    "webpack-cli": "^3.1.1",
+    "webpack-dev-middleware": "3.4.0",
     "webpack-dev-server": "^3.1.8",
-    "webpack-hot-middleware": "2.21.2"
+    "webpack-hot-middleware": "2.24.2"
   },
   "scripts": {
     "build": "webpack --config webpack/prod.config.js --progress --colors",


### PR DESCRIPTION
See https://github.com/webpack/webpack/issues/8082#issuecomment-424307938.

Fixes this error during the build process:
```
> webpack --config webpack/prod.config.js --progress --colors

/srv/node_modules/webpack-cli/bin/config-yargs.js:89
                describe: optionsSchema.definitions.output.properties.path.description,
                                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/srv/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at /srv/node_modules/webpack-cli/bin/webpack.js:60:27
    at Object.<anonymous> (/srv/node_modules/webpack-cli/bin/webpack.js:515:3)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
```