### PR TITLE
Fix default checkbox styling

### DIFF
--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -686,15 +686,14 @@ span.svg-icon {
 // Checkboxes
 
 // Remove default checkbox
-[type="checkbox"]:not(.checkbox .checkbox__input):not(:checked),
-[type="checkbox"]:not(.checkbox .checkbox__input):checked {
+[type="checkbox"]:not(.checkbox__input) {
   position: absolute;
   left: -9999px;
   opacity: 0;
 }
 
 // Checkbox Styles
-[type="checkbox"]:not(.checkbox .checkbox__input) {
+[type="checkbox"]:not(.checkbox__input) {
   + label {
     position: relative;
     padding-left: 35px;


### PR DESCRIPTION
## Description

We lost default stylings somewhere while merging `REST-UI` branch, which adds a nice `<Checkbox>` component.

Before:
<img width="389" alt="screen shot 2018-10-04 at 08 46 17" src="https://user-images.githubusercontent.com/2521888/46457291-124de100-c7b2-11e8-9bd5-1d44408759b4.png">

After:
<img width="391" alt="screen shot 2018-10-04 at 08 45 55" src="https://user-images.githubusercontent.com/2521888/46457287-0feb8700-c7b2-11e8-9046-feb04f0557b9.png">
