### PR TITLE
Let Django create urls based on proxy hostname and port

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -47,7 +47,7 @@ if 'SECURE_PROXY_SSL_HEADER' in os.environ:
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
-if os.getenv("USE_X_FORWARDED_HOST", "True") == "True":
+if os.getenv("USE_X_FORWARDED_HOST", "False") == "True":
     USE_X_FORWARDED_HOST = True
 
 UPCOMING_DOWNTIME = False

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -46,7 +46,7 @@ if 'SECURE_PROXY_SSL_HEADER' in os.environ:
                                      os.environ['SECURE_PROXY_SSL_HEADER'].split(',')))
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
-# It avoids to add `8000` port the kpi urls.
+# It avoids to add the debugger webserver port (i.e. `:8000`) at the end of urls.
 if os.getenv("USE_X_FORWARDED_HOST", "True") == "True":
     USE_X_FORWARDED_HOST = True
 

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -46,7 +46,7 @@ if 'SECURE_PROXY_SSL_HEADER' in os.environ:
                                      os.environ['SECURE_PROXY_SSL_HEADER'].split(',')))
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
-# It avoids to add the debugger webserver port (i.e. `:8000`) at the end of urls.
+# It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
 if os.getenv("USE_X_FORWARDED_HOST", "True") == "True":
     USE_X_FORWARDED_HOST = True
 

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -45,6 +45,11 @@ if 'SECURE_PROXY_SSL_HEADER' in os.environ:
     SECURE_PROXY_SSL_HEADER = tuple((substring.strip() for substring in
                                      os.environ['SECURE_PROXY_SSL_HEADER'].split(',')))
 
+# Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
+# It avoids to add `8000` port the kpi urls.
+if os.getenv("USE_X_FORWARDED_HOST", "True") == "True":
+    USE_X_FORWARDED_HOST = True
+
 UPCOMING_DOWNTIME = False
 
 # Domain must not exclude KoBoCAT when sharing sessions


### PR DESCRIPTION
To make `NginX` work in front of Django debugger webserver (instead of) uWSGI. 
`USE_X_FORWARDED_HOST` must be set to `True` to create url based on `nginx` $host. 
e.g.
- nginx servername and port: `kpi.kobo.local:80`
- django listener : 0.0.0.0:8000

Django will generate urls like this `kpi.kobo.local:8000` if `USE_X_FORWARDED_HOST` not equals `True`