### PR TITLE
2029 snapshot xml renderer - fix

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -284,9 +284,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ],
     'DEFAULT_RENDERER_CLASSES': [
-        'rest_framework.renderers.JSONRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
-        'rest_framework_xml.renderers.XMLRenderer',
+       'rest_framework.renderers.JSONRenderer',
+       'rest_framework.renderers.BrowsableAPIRenderer',
+       'kpi.renderers.XMLRenderer',
     ]
 }
 

--- a/kpi/deployment_backends/mixin.py
+++ b/kpi/deployment_backends/mixin.py
@@ -7,10 +7,10 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 import requests
+from requests.utils import quote
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import detail_route, list_route
-from requests.utils import quote
 
 from .backends import DEPLOYMENT_BACKENDS
 from .kobocat_backend import KobocatDeploymentBackend
@@ -145,10 +145,11 @@ class KobocatDataProxyViewSetMixin(MockDataProxyViewSetMixin):
         django_response.write(requests_response.content)
         return django_response
 
-
+    #@renderer_classes((JSONRenderer, XMLRenderer))
     def list(self, kpi_request, *args, **kwargs):
         return self.retrieve(kpi_request, None, *args, **kwargs)
 
+    #@renderer_classes((JSONRenderer, XMLRenderer))
     def retrieve(self, kpi_request, pk, *args, **kwargs):
 
         asset_uid = self.get_parents_query_dict()['asset']

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -1,6 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
 import json
 
 from rest_framework import renderers
+from rest_framework_xml.renderers import XMLRenderer as DRFXMLRenderer
 
 
 class AssetJsonRenderer(renderers.JSONRenderer):
@@ -19,24 +23,30 @@ class SSJsonRenderer(renderers.JSONRenderer):
         return json.dumps(renderer_context['view'].get_object().to_ss_structure())
 
 
-class XFormRenderer(renderers.BaseRenderer):
-    media_type = 'application/xml'
-    format = 'xml'
-    charset = 'utf-8'
+class XMLRenderer(DRFXMLRenderer):
 
-    def render(self, data, media_type=None, renderer_context=None):
-        asset = renderer_context['view'].get_object()
-        return asset.snapshot.xml
+    def render(self, data, accepted_media_type=None, renderer_context=None, relationship=None):
+        if hasattr(renderer_context.get("view"), "get_object"):
+            obj = renderer_context.get("view").get_object()
+            # If `relationship` is passed among arguments, retrieve `xml` from this relationship.
+            # e.g. obj is `Asset`, relationship can be `snapshot`
+            if relationship is not None and hasattr(obj, relationship):
+                return getattr(obj, relationship).xml
+            return obj.xml
+        else:
+            # @TODO Handle submissions
+            return super(XMLRenderer, self).render(data=data,
+                                                   accepted_media_type=accepted_media_type,
+                                                   renderer_context=renderer_context)
 
 
-class AssetSnapshotXFormRenderer(renderers.BaseRenderer):
-    media_type = 'application/xml'
-    format = 'xml'
-    charset = 'utf-8'
+class XFormRenderer(XMLRenderer):
 
-    def render(self, data, media_type=None, renderer_context=None):
-        asset_snapshot = renderer_context['view'].get_object()
-        return asset_snapshot.xml
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        return super(XFormRenderer, self).render(data=data,
+                                                 accepted_media_type=accepted_media_type,
+                                                 renderer_context=renderer_context,
+                                                 relationship="snapshot")
 
 
 class XlsRenderer(renderers.BaseRenderer):

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -76,7 +76,7 @@ from .renderers import (
     AssetJsonRenderer,
     SSJsonRenderer,
     XFormRenderer,
-    AssetSnapshotXFormRenderer,
+    XMLRenderer,
     XlsRenderer,)
 from .serializers import (
     AssetSerializer, AssetListSerializer,
@@ -596,7 +596,7 @@ class AssetSnapshotViewSet(NoUpdateModelViewSet):
     queryset = AssetSnapshot.objects.all()
 
     renderer_classes = NoUpdateModelViewSet.renderer_classes + [
-        AssetSnapshotXFormRenderer,
+        XMLRenderer,
     ]
 
     def filter_queryset(self, queryset):
@@ -707,6 +707,13 @@ class SubmissionViewSet(NestedViewSetMixin, viewsets.ViewSet,
      `KobocatBackend.get_submission()`
     '''
     parent_model = Asset
+
+    def list(self, request, *args, **kwargs):
+        asset_uid = self.get_parents_query_dict().get("asset")
+        asset = get_object_or_404(self.parent_model, uid=asset_uid)
+        format_type = kwargs.get("format", "json")
+        submissions = asset.deployment.get_submissions(format_type=format_type)
+        return Response(list(submissions))
 
     def create(self, request, *args, **kwargs):
         """

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -708,12 +708,12 @@ class SubmissionViewSet(NestedViewSetMixin, viewsets.ViewSet,
     '''
     parent_model = Asset
 
-    def list(self, request, *args, **kwargs):
-        asset_uid = self.get_parents_query_dict().get("asset")
-        asset = get_object_or_404(self.parent_model, uid=asset_uid)
-        format_type = kwargs.get("format", "json")
-        submissions = asset.deployment.get_submissions(format_type=format_type)
-        return Response(list(submissions))
+    # def list(self, request, *args, **kwargs):
+    #     asset_uid = self.get_parents_query_dict().get("asset")
+    #     asset = get_object_or_404(self.parent_model, uid=asset_uid)
+    #     format_type = kwargs.get("format", "json")
+    #     submissions = asset.deployment.get_submissions(format_type=format_type)
+    #     return Response(list(submissions))
 
     def create(self, request, *args, **kwargs):
         """

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -708,6 +708,7 @@ class SubmissionViewSet(NestedViewSetMixin, viewsets.ViewSet,
     '''
     parent_model = Asset
 
+    # @TODO Handle list of ids before using it
     # def list(self, request, *args, **kwargs):
     #     asset_uid = self.get_parents_query_dict().get("asset")
     #     asset = get_object_or_404(self.parent_model, uid=asset_uid)


### PR DESCRIPTION
@jnm, I finally kept `DEFAULT_RENDERER_CLASSES` in settings.

I just removed `rest_framework_xml.renderers.XMLRenderer` and used an extended class of it. 
This class now replaces `AssetSnapShotRenderer` where it was called. Even `XFormRenderer` is based on it. 

Fixes #2029