### PR TITLE
Allows webpack to work with `kobo-install` when it doesn't run from the host OS.

### DIFF
--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -534,7 +534,12 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': True
-        }
+        },
+        'django.db.backends': {
+            'level': 'ERROR',
+            'handlers': ['console'],
+            'propagate': True
+        },
     }
 }
 

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -3,7 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 const WebpackCommon = require('./webpack.common');
 const BundleTracker = require('webpack-bundle-tracker');
-var publicPath = 'http://localhost:3000/static/compiled/';
+var publicPath = 'http://kpi.kobo.local:3000/static/compiled/';
 
 module.exports = WebpackCommon({
   mode: "development",
@@ -22,7 +22,8 @@ module.exports = WebpackCommon({
     disableHostCheck: true,
     hot: true,
     headers: {'Access-Control-Allow-Origin': '*'},
-    port: 3000
+    port: 3000,
+    host: '0.0.0.0'
   },
   plugins: [
     new BundleTracker({path: __dirname, filename: '../webpack-stats.json'}),

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -3,7 +3,11 @@ const path = require('path');
 const webpack = require('webpack');
 const WebpackCommon = require('./webpack.common');
 const BundleTracker = require('webpack-bundle-tracker');
-var publicPath = 'http://kpi.kobo.local:3000/static/compiled/';
+var isPublicDomainDefined = process.env.KOBOFORM_PUBLIC_SUBDOMAIN &&
+  process.env.PUBLIC_DOMAIN_NAME;
+var publicDomain = isPublicDomainDefined ? process.env.KOBOFORM_PUBLIC_SUBDOMAIN
+  + '.' + process.env.PUBLIC_DOMAIN_NAME : 'localhost';
+var publicPath = 'http://' + publicDomain + ':3000/static/compiled/';
 
 module.exports = WebpackCommon({
   mode: "development",


### PR DESCRIPTION
With `kobo-install` ip address is not used anymore. It only uses a fake domain name which is added to `/etc/hosts`. 
I'm running docker in `linux` VM and using the browser from `macOS`, so `webpack` sees `localhost` as the `host` OS, not the virtual machine. 
This PR allows `webpack` to bind all ips on port 3000 (not only `localhost`) and points the its web server to good IP thanks to the fake domain name.

@magicznyleszek :
it should work in `kobo-docker` from `master` or `kobo-install` branches. Do you see any potential issues to do this? Can you test it?

@jnm:
I added you too as a reviewer because of a small python change in configuration where RAVEN is not enabled. 
