### PR TITLE
Password strength in registration form

### DIFF
--- a/jsapp/js/bem.es6
+++ b/jsapp/js/bem.es6
@@ -259,6 +259,13 @@ bem.Radio__wrapper = bem.Radio.__('wrapper', '<label>');
 bem.Radio__input = bem.Radio.__('input', '<input>');
 bem.Radio__label = bem.Radio.__('label', '<span>');
 
+bem.PasswordStrength = bem('password-strength');
+bem.PasswordStrength__title = bem.PasswordStrength.__('title');
+bem.PasswordStrength__bar = bem.PasswordStrength.__('bar');
+bem.PasswordStrength__indicator = bem.PasswordStrength.__('indicator');
+bem.PasswordStrength__messages = bem.PasswordStrength.__('messages', '<ul>');
+bem.PasswordStrength__message = bem.PasswordStrength.__('message', '<li>');
+
 bem.PrintOnly = BEM('print-only');
 
 bem.GitRev = BEM('git-rev');

--- a/jsapp/js/components/passwordStrength.es6
+++ b/jsapp/js/components/passwordStrength.es6
@@ -16,11 +16,7 @@ class PasswordStrength extends React.Component {
 
   render() {
     const report = zxcvbn(this.props.password);
-
     const barModifier = `score-${report.score}`;
-
-    console.log(report);
-
     return (
       <bem.PasswordStrength>
         <bem.PasswordStrength__title>
@@ -31,7 +27,7 @@ class PasswordStrength extends React.Component {
           <bem.PasswordStrength__indicator/>
         </bem.PasswordStrength__bar>
 
-        {(report.feedback.warning || report.feedback.suggestions) &&
+        {(report.feedback.warning || report.feedback.suggestions.length > 0) &&
           <bem.PasswordStrength__messages>
             {report.feedback.warning &&
               <bem.PasswordStrength__message m='warning'>
@@ -39,7 +35,7 @@ class PasswordStrength extends React.Component {
               </bem.PasswordStrength__message>
             }
 
-            {report.feedback.suggestions && report.feedback.suggestions.length !== 0 &&
+            {report.feedback.suggestions.length > 0 &&
               report.feedback.suggestions.map((suggestion, index) => {
                 return (
                   <bem.PasswordStrength__message key={index}>

--- a/jsapp/js/components/passwordStrength.es6
+++ b/jsapp/js/components/passwordStrength.es6
@@ -1,0 +1,58 @@
+import React from 'react';
+import autoBind from 'react-autobind';
+import zxcvbn from 'zxcvbn';
+import bem from '../bem';
+import {t} from '../utils';
+
+/*
+Properties:
+- password <string>: required
+*/
+class PasswordStrength extends React.Component {
+  constructor(props){
+    super(props);
+    autoBind(this);
+  }
+
+  render() {
+    const report = zxcvbn(this.props.password);
+
+    const barModifier = `score-${report.score}`;
+
+    console.log(report);
+
+    return (
+      <bem.PasswordStrength>
+        <bem.PasswordStrength__title>
+          {t('Password strength')}
+        </bem.PasswordStrength__title>
+
+        <bem.PasswordStrength__bar m={barModifier}>
+          <bem.PasswordStrength__indicator/>
+        </bem.PasswordStrength__bar>
+
+        {(report.feedback.warning || report.feedback.suggestions) &&
+          <bem.PasswordStrength__messages>
+            {report.feedback.warning &&
+              <bem.PasswordStrength__message m='warning'>
+                {report.feedback.warning}
+              </bem.PasswordStrength__message>
+            }
+
+            {report.feedback.suggestions && report.feedback.suggestions.length !== 0 &&
+              report.feedback.suggestions.map((suggestion, index) => {
+                return (
+                  <bem.PasswordStrength__message key={index}>
+                    {suggestion}
+                  </bem.PasswordStrength__message>
+                )
+              })
+            }
+          </bem.PasswordStrength__messages>
+        }
+      </bem.PasswordStrength>
+    )
+  }
+}
+
+export default PasswordStrength;

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -1,4 +1,5 @@
 import RunRoutes, {routes} from './app';
+import RegistrationPasswordApp from './registrationPasswordApp';
 import {AppContainer} from 'react-hot-loader'
 import $ from 'jquery';
 import 'babel-polyfill'; // required to support Array.prototypes.includes in IE11
@@ -41,3 +42,10 @@ if (document.head.querySelector('meta[name=kpi-root-url]')) {
 } else {
   console.error('no kpi-root-url meta tag set. skipping react-router init');
 }
+
+document.addEventListener('DOMContentLoaded', (evt) => {
+  const registrationPasswordAppEl = document.getElementById('registration-password-app');
+  if (registrationPasswordAppEl) {
+    render(<AppContainer><RegistrationPasswordApp /></AppContainer>, registrationPasswordAppEl);
+  }
+});

--- a/jsapp/js/registrationPasswordApp.es6
+++ b/jsapp/js/registrationPasswordApp.es6
@@ -1,0 +1,34 @@
+import React from 'react';
+import PasswordStrength from './components/passwordStrength';
+
+const PASS_INPUT_ID = 'id_password1';
+
+class RegistrationPasswordApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {currentPass: ''}
+  }
+
+  componentDidMount() {
+    this.watchInput(PASS_INPUT_ID);
+  }
+
+  watchInput(inputId) {
+    const inputEl = document.getElementById(inputId);
+    if (inputEl) {
+      inputEl.addEventListener('input', (evt) => {
+        this.setState({currentPass: evt.currentTarget.value})
+      });
+    } else {
+      throw new Error(`Input "${inputId}" not found!`);
+    }
+  }
+
+  render() {
+    return (
+      <PasswordStrength password={this.state.currentPass} />
+    );
+  }
+};
+
+export default RegistrationPasswordApp;

--- a/jsapp/scss/components/_kobo.password-strength.scss
+++ b/jsapp/scss/components/_kobo.password-strength.scss
@@ -1,0 +1,69 @@
+$s-password-strength-spacing: 10px;
+
+.password-strength {
+  width: 100%;
+  font-size: 0.9em;
+  padding: $s-password-strength-spacing;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.password-strength__title,
+.password-strength__bar {
+  margin-bottom: $s-password-strength-spacing;
+}
+
+.password-strength__bar {
+  width: 100%;
+  height: 5px;
+  position: relative;
+  box-shadow: inset 0 0 0 1px $cool-silver;
+
+  .password-strength__indicator {
+    background: blue;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transition: 0.25s;
+  }
+
+  &.password-strength__bar--score-0 {
+    .password-strength__indicator {
+      width: 1%;
+      background-color: $cool-red;
+    }
+  }
+
+  &.password-strength__bar--score-1 {
+    .password-strength__indicator {
+      width: 25%;
+      background-color: $cool-red;
+    }
+  }
+  &.password-strength__bar--score-2 {
+    .password-strength__indicator {
+      width: 50%;
+      background-color: $cool-orange;
+    }
+  }
+  &.password-strength__bar--score-3 {
+    .password-strength__indicator {
+      width: 75%;
+      background-color: $warm-green;
+    }
+  }
+  &.password-strength__bar--score-4 {
+    .password-strength__indicator {
+      width: 100%;
+      background-color: $cool-blue;
+    }
+  }
+}
+
+
+
+.password-strength__message {
+  &.password-strength__message--warning {
+    color: $cool-red;
+  }
+}

--- a/jsapp/scss/components/_kobo.password-strength.scss
+++ b/jsapp/scss/components/_kobo.password-strength.scss
@@ -1,15 +1,11 @@
-$s-password-strength-spacing: 10px;
-
 .password-strength {
   width: 100%;
   font-size: 0.9em;
-  padding: $s-password-strength-spacing;
-  background: rgba(0, 0, 0, 0.5);
 }
 
 .password-strength__title,
 .password-strength__bar {
-  margin-bottom: $s-password-strength-spacing;
+  margin-bottom: 10px;
 }
 
 .password-strength__bar {
@@ -59,8 +55,6 @@ $s-password-strength-spacing: 10px;
     }
   }
 }
-
-
 
 .password-strength__message {
   &.password-strength__message--warning {

--- a/jsapp/scss/main.scss
+++ b/jsapp/scss/main.scss
@@ -28,6 +28,7 @@
 @import "./components/kobo.lib-list";
 @import "./components/kobo.form-view";
 @import "./components/kobo.form-summary";
+@import "./components/kobo.password-strength";
 @import "./components/kobo.report-view";
 @import "./components/kobo.table";
 @import "./components/kobo.account-settings";

--- a/kpi/templates/registration/registration_form.html
+++ b/kpi/templates/registration/registration_form.html
@@ -40,6 +40,10 @@
             {% endif %}
             {{ field.errors }}
           </div>
+
+          {% if field.name == 'password1' %}
+            <div class="field" id="registration-password-app"></div>
+          {% endif %}
       {% endfor %}
       <input type="submit" value="{% trans 'Create Account' %}" class="registration__action" />
       <div class="registration__orlogin">

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "webpack": "^4.20.2",
     "webpack-bundle-tracker": "0.4.0-beta",
     "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.8"
+    "webpack-dev-server": "^3.1.8",
+    "zxcvbn": "^4.4.2"
   },
   "scripts": {
     "build": "webpack --config webpack/prod.config.js --progress --colors",


### PR DESCRIPTION
## Description

Adds visual password strength helper:

<img width="480" alt="screenshot 2018-10-29 at 13 24 31" src="https://user-images.githubusercontent.com/2521888/47649848-cc045b80-db7e-11e8-907a-c2404e1234c5.png">

It uses the awesome https://github.com/dropbox/zxcvbn library. Mind you, it only gives a clue to the user, it doesn't block bad passwords from being used

## Related issues

Part of #916 
