### PR TITLE
New management commands to shrink big tables

### DIFF
--- a/kpi/management/commands/delete_assets_snapshots.py
+++ b/kpi/management/commands/delete_assets_snapshots.py
@@ -6,11 +6,11 @@ from datetime import timedelta
 from django.db.models import Max
 from django.utils import timezone
 
-from .delete_base_command import BaseCommand
+from .delete_base_command import DeleteBaseCommand
 from kpi.models import AssetSnapshot
 
 
-class Command(BaseCommand):
+class Command(DeleteBaseCommand):
 
     help = "Deletes assets snapshots"
 
@@ -20,14 +20,15 @@ class Command(BaseCommand):
 
         # Retrieve Snapshots linked to assets' latest versions.
         # Use iterator to by-pass Django QuerySet caching.
-        latest_versions_ids = [version[1] for version in AssetSnapshot.objects.values_list("asset_id").\
-            annotate(latest_version_id=Max("asset_version_id")).iterator()]
-
-        latest_versions_ids = list(set(latest_versions_ids))
-        if None in latest_versions_ids:
-            latest_versions_ids.remove(None)
+        latest_version_ids = list(
+            AssetSnapshot.objects.exclude(asset_version=None)
+                .values("asset_id")
+                .annotate(latest_version_id=Max("asset_version_id"))
+                .values_list("latest_version_id", flat=True)
+                .distinct()
+        )
 
         # Retrieve all records older than days that are not linked to latest versions
         return AssetSnapshot.objects.filter(
             date_created__lt=timezone.now() - timedelta(days=days),
-        ).exclude(asset_version_id__in=latest_versions_ids)
+        ).exclude(asset_version_id__in=latest_version_ids)

--- a/kpi/management/commands/delete_assets_snapshots.py
+++ b/kpi/management/commands/delete_assets_snapshots.py
@@ -1,58 +1,22 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 from datetime import timedelta
-import sys
 
-from django.core.management.base import BaseCommand
-from django.db import transaction, connection
 from django.db.models import Max
 from django.utils import timezone
 
+from .delete_base_command import BaseCommand
 from kpi.models import AssetSnapshot
-import time
+
 
 class Command(BaseCommand):
 
     help = "Deletes assets snapshots"
 
-    def add_arguments(self, parser):
-        super(Command, self).add_arguments(parser)
-        parser.add_argument(
-            "--days",
-            default=90,
-            type=int,
-            help="Delete only import tasks older than the specified number of days. Default: 90",
-        )
-
-        parser.add_argument(
-            "--chunks",
-            default=1000,
-            type=int,
-            help="Delete only import tasks by batch of `chunks` records. Default: 1000",
-        )
-
-        parser.add_argument(
-            "--vacuum",
-            action='store_true',
-            default=False,
-            help="Run `VACUUM` on tables after deletion",
-        )
-
-        parser.add_argument(
-            "--vacuum-full",
-            action='store_true',
-            default=False,
-            help="Run `VACUUM FULL` instead of `VACUUM`.",
-        )
-
-    def handle(self, *args, **options):
+    def _prepare_delete_queryset(self, **options):
         days = options["days"]
-        chunks = options["chunks"]
-        verbosity = options["verbosity"]
-        vacuum_full = options["vacuum_full"]
-        vacuum = options["vacuum"]
-
+        self._model = AssetSnapshot
 
         # Retrieve Snapshots linked to assets' latest versions.
         # Use iterator to by-pass Django QuerySet caching.
@@ -63,46 +27,7 @@ class Command(BaseCommand):
         if None in latest_versions_ids:
             latest_versions_ids.remove(None)
 
-        snapshots_to_delete = AssetSnapshot.objects.filter(
+        # Retrieve all records older than days that are not linked to latest versions
+        return AssetSnapshot.objects.filter(
             date_created__lt=timezone.now() - timedelta(days=days),
         ).exclude(asset_version_id__in=latest_versions_ids)
-
-        chunked_delete_ids = []
-        chunks_cpt = 1
-        total = snapshots_to_delete.count()
-
-        for snapshot_id in snapshots_to_delete.values_list("id", flat=True).iterator():
-
-            chunked_delete_ids.append(snapshot_id)
-
-            if (chunks_cpt % chunks) == 0 or chunks_cpt == total:
-                with transaction.atomic():  # Wrap into a transaction because of CASCADE, post_delete signals
-                    chuncked_objects_to_delete = AssetSnapshot.objects.filter(id__in=chunked_delete_ids)
-                    if verbosity >= 1:
-                        progress = "\rDeleting {chunk}/{total} assets snapshots...".format(
-                            chunk=chunks_cpt,
-                            total=total
-                        )
-                        sys.stdout.write(progress)
-                        sys.stdout.flush()
-                    chuncked_objects_to_delete.delete()
-                chunked_delete_ids = []
-
-            chunks_cpt += 1
-
-        print("")
-
-        if vacuum is True or vacuum_full is True:
-            self.do_vacuum(vacuum_full)
-
-        print("Done!")
-
-    def do_vacuum(self, full=False):
-        cursor = connection.cursor()
-        if full:
-            print("Vacuuming (full) table {}...".format(AssetSnapshot._meta.db_table))
-            cursor.execute("VACUUM FULL {}".format(AssetSnapshot._meta.db_table))
-        else:
-            print("Vacuuming table {}...".format(AssetSnapshot._meta.db_table))
-            cursor.execute("VACUUM {}".format(AssetSnapshot._meta.db_table))
-        connection.commit()

--- a/kpi/management/commands/delete_base_command.py
+++ b/kpi/management/commands/delete_base_command.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import sys
+
+from django.core.management.base import BaseCommand as DjangoBaseCommand
+from django.db import transaction, connection
+
+
+class BaseCommand(DjangoBaseCommand):
+
+
+    def __init__(self, stdout=None, stderr=None, no_color=False):
+        super(BaseCommand, self).__init__(stdout=stdout, stderr=stderr, no_color=no_color)
+        self._model = None
+
+    def add_arguments(self, parser):
+        super(BaseCommand, self).add_arguments(parser)
+        parser.add_argument(
+            "--days",
+            default=90,
+            type=int,
+            help="Delete only records older than the specified number of days.",
+        )
+
+        parser.add_argument(
+            "--chunks",
+            default=1000,
+            type=int,
+            help="Delete only records by batch of `chunks`.",
+        )
+
+        parser.add_argument(
+            "--vacuum",
+            action='store_true',
+            default=False,
+            help="Run `VACUUM` on tables after deletion.",
+        )
+
+        parser.add_argument(
+            "--vacuum-full",
+            action='store_true',
+            default=False,
+            help="Run `VACUUM FULL` instead of `VACUUM`.",
+        )
+
+    def handle(self, *args, **options):
+
+        chunks = options["chunks"]
+        verbosity = options["verbosity"]
+        vacuum_full = options["vacuum_full"]
+        vacuum = options["vacuum"]
+
+        delete_queryset = self._prepare_delete_queryset(**options)
+        if self._model is None:
+            raise Exception("No models declared!")
+
+        chunked_delete_ids = []
+        chunks_cpt = 1
+        total = delete_queryset.count()
+
+        for record_id in delete_queryset.values_list("id", flat=True).iterator():
+
+            chunked_delete_ids.append(record_id)
+
+            if (chunks_cpt % chunks) == 0 or chunks_cpt == total:
+                with transaction.atomic():  # Wrap into a transaction because of CASCADE, post_delete signals
+                    chuncked_objects_to_delete = self._model.objects.filter(id__in=chunked_delete_ids)
+                    if verbosity >= 1:
+                        progress = "\rDeleting {chunk}/{total} records...".format(
+                            chunk=chunks_cpt,
+                            total=total
+                        )
+                        sys.stdout.write(progress)
+                        sys.stdout.flush()
+                    chuncked_objects_to_delete.delete()
+                chunked_delete_ids = []
+
+            chunks_cpt += 1
+
+        print("")
+
+        if vacuum is True or vacuum_full is True:
+            self._do_vacuum(vacuum_full)
+
+        print("Done!")
+
+    def _prepare_delete_queryset(self, **options):
+        raise Exception("Must be implemented in child class")
+
+    def _do_vacuum(self, full=False):
+        cursor = connection.cursor()
+        if full:
+            print("Vacuuming (full) table {}...".format(self._model._meta.db_table))
+            cursor.execute("VACUUM FULL {}".format(self._model._meta.db_table))
+        else:
+            print("Vacuuming table {}...".format(self._model._meta.db_table))
+            cursor.execute("VACUUM {}".format(self._model._meta.db_table))
+        connection.commit()

--- a/kpi/management/commands/delete_import_tasks.py
+++ b/kpi/management/commands/delete_import_tasks.py
@@ -5,11 +5,11 @@ from datetime import timedelta
 
 from django.utils import timezone
 
-from .delete_base_command import BaseCommand
+from .delete_base_command import DeleteBaseCommand
 from kpi.models import ImportTask
 
 
-class Command(BaseCommand):
+class Command(DeleteBaseCommand):
 
     help = "Deletes import tasks"
 

--- a/kpi/management/commands/delete_import_tasks.py
+++ b/kpi/management/commands/delete_import_tasks.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 
 from datetime import timedelta
-import sys
 
-from django.core.management.base import BaseCommand
-from django.db import transaction, connection
 from django.utils import timezone
 
+from .delete_base_command import BaseCommand
 from kpi.models import ImportTask
 
 
@@ -15,82 +13,10 @@ class Command(BaseCommand):
 
     help = "Deletes import tasks"
 
-    def add_arguments(self, parser):
-        super(Command, self).add_arguments(parser)
-        parser.add_argument(
-            "--days",
-            default=90,
-            type=int,
-            help="Delete only import tasks older than the specified number of days.",
-        )
-
-        parser.add_argument(
-            "--chunks",
-            default=1000,
-            type=int,
-            help="Delete only import tasks by batch of `chunks` records.",
-        )
-
-        parser.add_argument(
-            "--vacuum",
-            action='store_true',
-            default=False,
-            help="Run `VACUUM` on tables after deletion.",
-        )
-
-        parser.add_argument(
-            "--vacuum-full",
-            action='store_true',
-            default=False,
-            help="Run `VACUUM FULL` instead of `VACUUM`.",
-        )
-
-    def handle(self, *args, **options):
+    def _prepare_delete_queryset(self, **options):
         days = options["days"]
-        chunks = options["chunks"]
-        verbosity = options["verbosity"]
-        vacuum_full = options["vacuum_full"]
-        vacuum = options["vacuum"]
-
-        tasks_to_delete = ImportTask.objects.filter(
+        self._model = ImportTask
+        return self._model.objects.filter(
             date_created__lt=timezone.now() - timedelta(days=days),
         )
-        chunked_delete_ids = []
-        chunks_cpt = 1
-        total = tasks_to_delete.count()
 
-        for import_task_id in tasks_to_delete.values_list("id", flat=True).iterator():
-
-            chunked_delete_ids.append(import_task_id)
-
-            if (chunks_cpt % chunks) == 0 or chunks_cpt == total:
-                with transaction.atomic():  # Wrap into a transaction because of CASCADE, post_delete signals
-                    chuncked_objects_to_delete = ImportTask.objects.filter(id__in=chunked_delete_ids)
-                    if verbosity >= 1:
-                        progress = "\rDeleting {chunk}/{total} import tasks...".format(
-                            chunk=chunks_cpt,
-                            total=total
-                        )
-                        sys.stdout.write(progress)
-                        sys.stdout.flush()
-                    chuncked_objects_to_delete.delete()
-                chunked_delete_ids = []
-
-            chunks_cpt += 1
-
-        print("")
-
-        if vacuum is True or vacuum_full is True:
-            self.do_vacuum(vacuum_full)
-
-        print("Done!")
-
-    def do_vacuum(self, full=False):
-        cursor = connection.cursor()
-        if full:
-            print("Vacuuming (full) table {}...".format(ImportTask._meta.db_table))
-            cursor.execute("VACUUM FULL {}".format(ImportTask._meta.db_table))
-        else:
-            print("Vacuuming table {}...".format(ImportTask._meta.db_table))
-            cursor.execute("VACUUM {}".format(ImportTask._meta.db_table))
-        connection.commit()

--- a/kpi/management/commands/delete_import_tasks.py
+++ b/kpi/management/commands/delete_import_tasks.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import timedelta
+import sys
+
+from django.core.management.base import BaseCommand
+from django.db import transaction, connection
+from django.utils import timezone
+
+from kpi.models import ImportTask
+
+
+class Command(BaseCommand):
+
+    help = "Deletes import tasks"
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            "--days",
+            default=90,
+            type=int,
+            help="Delete only import tasks older than the specified number of days.",
+        )
+
+        parser.add_argument(
+            "--chunks",
+            default=1000,
+            type=int,
+            help="Delete only import tasks by batch of `chunks` records.",
+        )
+
+        parser.add_argument(
+            "--vacuum",
+            action='store_true',
+            default=False,
+            help="Run `VACUUM` on tables after deletion.",
+        )
+
+        parser.add_argument(
+            "--vacuum-full",
+            action='store_true',
+            default=False,
+            help="Run `VACUUM FULL` instead of `VACUUM`.",
+        )
+
+    def handle(self, *args, **options):
+        print(options)
+        days = options["days"]
+        chunks = options["chunks"]
+        verbosity = options["verbosity"]
+        vacuum_full = options["vacuum_full"]
+        vacuum = options["vacuum"]
+
+        tasks_to_delete = ImportTask.objects.filter(
+            date_created__lt=timezone.now() - timedelta(days=days),
+        )
+        chunked_delete_ids = []
+        chunks_cpt = 1
+        tasks_to_delete_count = tasks_to_delete.count()
+
+        for import_task_id in tasks_to_delete.values_list("id", flat=True).iterator():
+            if (chunks_cpt % chunks) != 0 and chunks_cpt < tasks_to_delete_count:
+                chunked_delete_ids.append(import_task_id)
+            else:
+                print(chunked_delete_ids)
+                if len(chunked_delete_ids) > 0:
+                    with transaction.atomic():  # Wrap into a transaction because of CASCADE, post_delete signals
+                        chuncked_import_tasks_to_delete = ImportTask.objects.filter(id__in=chunked_delete_ids)
+                        if verbosity >= 1:
+                            progress = "\rDeleting {chunk}/{total} import tasks...".format(
+                                chunk=chunks_cpt,
+                                total=tasks_to_delete_count
+                            )
+                            sys.stdout.write(progress)
+                            sys.stdout.flush()
+                        chuncked_import_tasks_to_delete.delete()
+                        chunked_delete_ids = []
+
+            chunks_cpt += 1
+
+        if vacuum is True or vacuum_full is True:
+            self.do_vacuum(vacuum_full)
+
+        print("Done!")
+
+    def do_vacuum(self, full=False):
+        cursor = connection.cursor()
+        if full:
+            print("Vacuuming (full) table {}...".format(ImportTask._meta.db_table))
+            cursor.execute("VACUUM FULL {}".format(ImportTask._meta.db_table))
+        else:
+            print("Vacuuming table {}...".format(ImportTask._meta.db_table))
+            cursor.execute("VACUUM {}".format(ImportTask._meta.db_table))
+        connection.commit()

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -713,7 +713,7 @@ class Asset(ObjectPermissionMixin,
 
     @transaction.atomic
     def _snapshot(self, regenerate=True):
-        asset_version = self.asset_versions.first()
+        asset_version = self.latest_version
 
         try:
             snapshot = AssetSnapshot.objects.get(asset=self,


### PR DESCRIPTION
Based on `reversion`.`deleterevisions` management commands. I've added two commands:

- `delete_asset_snapshots`
- `delete_import_tasks`

4 options can customized: 
- `days`: Records older than `days` will be deleted
- `chunks`: Number of records per deletion.  
- `vacuum`: Vacuum after deletion
- `vacuum-full`: Full Vacuum after deletion