### PR TITLE
Fix previews of unsaved surveys in the form builder

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -313,7 +313,7 @@ export default assign({
     if (this.state.asset) {
       surveyJSON = unnullifyTranslations(surveyJSON, this.state.asset.content);
     }
-    let params = {content: surveyJSON};
+    let params = {source: surveyJSON};
 
     params = koboMatrixParser(params);
 


### PR DESCRIPTION
Resolves the error `The survey sheet is either empty or missing important column headers`. Fixes #2055.