### PR TITLE
Fix #2058: `IntegrityError` when previewing

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -313,7 +313,7 @@ export default assign({
     if (this.state.asset) {
       surveyJSON = unnullifyTranslations(surveyJSON, this.state.asset.content);
     }
-    let params = {content: surveyJSON};
+    let params = {source: surveyJSON};
 
     params = koboMatrixParser(params);
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -818,9 +818,9 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
 
     def save(self, *args, **kwargs):
         if self.asset is not None:
-            if self.asset_version is None:
-                self.asset_version = self.asset.latest_version
             if self.source is None:
+                if self.asset_version is None:
+                    self.asset_version = self.asset.latest_version
                 self.source = self.asset_version.version_content
             if self.owner is None:
                 self.owner = self.asset.owner


### PR DESCRIPTION
...unsaved changes to a form multiple times. Related to https://github.com/kobotoolbox/kpi/issues/2055.

This change prevents `asset_version` from being set on an `AssetSnapshot` that is created with _both_ a `source` and an `asset`.