### PR TITLE
Upgrade formpack to fix #2057

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file dependencies/pip/dev_requirements.txt dependencies/pip/dev_requirements.in
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@b9f00374d65391dd456fc117d5321461b7acdc42#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@fb462015ece8ec48d62ceed3b1015df1901d5557#egg=formpack
 amqp==2.1.4
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file dependencies/pip/external_services.txt dependencies/pip/external_services.in
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@b9f00374d65391dd456fc117d5321461b7acdc42#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@fb462015ece8ec48d62ceed3b1015df1901d5557#egg=formpack
 amqp==2.3.2
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # Formpack
--e git+https://github.com/kobotoolbox/formpack.git@b9f00374d65391dd456fc117d5321461b7acdc42#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@fb462015ece8ec48d62ceed3b1015df1901d5557#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file dependencies/pip/requirements.txt dependencies/pip/requirements.in
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@b9f00374d65391dd456fc117d5321461b7acdc42#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@fb462015ece8ec48d62ceed3b1015df1901d5557#egg=formpack
 amqp==2.3.2
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2


### PR DESCRIPTION
Fixes #2057. :warning: references a commit from an unmerged PR on formpack: https://github.com/kobotoolbox/formpack/pull/180

This is now running on https://kf.master.kbtdev.org/. To test:
1. Create a blank form;
1. Add a "Select One" question;
1. Drag "Option 2" to the top;
1. Click the preview icon.

The fix only works for **new** `AssetSnapshot`s. That means that trying to preview _outside_ the form builder, on a form that has not been saved since deploying this fix, will still fail with `argument of type 'int' is not iterable`. To clean up the mess, we will need to run this:
```python
AssetSnapshot.objects.filter(xml='', details__contains='''"argument of type 'int' is not iterable"''').delete()
```