### PR TITLE
display registration form second half on smaller screens

### DIFF
--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -334,6 +334,9 @@
 @media screen and (max-width: 767px) {
   .registration__bg {
     form.registration--register {
+      display: flex;
+      flex-direction: column;
+
       h1 {
         text-align: center;
         margin-top: 0.5em;
@@ -342,11 +345,16 @@
       .registration--logo {
         display: block;
         text-align: center;
+        order: 1;
       }
-    }
 
-    .registration__second-half {
-      display: none;
+      .registration__first-half {
+        order: 3;
+      }
+
+      .registration__second-half {
+        order: 2;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

The right side of registration screen is being displayed above the form on smaller screens, as per @tinok request.

Before:
![kf kobotoolbox org_accounts_register_ 1](https://user-images.githubusercontent.com/2521888/48331565-c283f480-e650-11e8-93a5-720b08ab3e61.png)

After:
![kf kobotoolbox org_accounts_register_](https://user-images.githubusercontent.com/2521888/48331566-c283f480-e650-11e8-9407-8cdb5d0a93db.png)

## Related issues

Fixes #2065