### PR TITLE
Enable file and range question types (simple)

### DIFF
--- a/jsapp/scss/stylesheets/partials/_icons.scss
+++ b/jsapp/scss/stylesheets/partials/_icons.scss
@@ -35,6 +35,7 @@
 .fa.fa-lato-text:before,
 .fa.fa-lato-integer:before,
 .fa.fa-lato-decimal:before,
+.fa.fa-lato-range:before,
 .fa.fa-lato-calculate:before {
   font-family: $font;
   font-weight: 600;
@@ -52,6 +53,11 @@
 
 .fa.fa-lato-decimal:before {
   content: "1.0";
+  font-size: 0.9em;
+}
+
+.fa.fa-lato-range:before {
+  content: "1..1";
   font-size: 0.9em;
 }
 

--- a/jsapp/scss/stylesheets/partials/form_builder/_card.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card.scss
@@ -184,8 +184,11 @@ $cardIndicatorIconWidth: 21px;
         font-size: 0.95em;
         background-color: #8595A5;
     }
-    .fa-lato-calculate, .fa-lato-decimal,
-    .fa-lato-integer, .fa-lato-text {
+    .fa-lato-range,
+    .fa-lato-calculate,
+    .fa-lato-decimal,
+    .fa-lato-integer,
+    .fa-lato-text {
         font-size: 15px;
         width: $cardIndicatorIconWidth;
     }

--- a/jsapp/xlform/src/model.configs.coffee
+++ b/jsapp/xlform/src/model.configs.coffee
@@ -155,7 +155,7 @@ module.exports = do ->
         value: "Enter a date"
     range:
       label:
-        value: "Choose a range"
+        value: "Enter a number within a specified range"
     calculate:
       calculation:
         value: ""

--- a/jsapp/xlform/src/model.configs.coffee
+++ b/jsapp/xlform/src/model.configs.coffee
@@ -132,6 +132,9 @@ module.exports = do ->
     audio:
       label:
         value: "Use the camera's microphone to record a sound"
+    file:
+      label:
+        value: "Upload a file"
     note:
       label:
         value: "This note can be read out loud"
@@ -150,6 +153,9 @@ module.exports = do ->
     date:
       label:
         value: "Enter a date"
+    range:
+      label:
+        value: "Choose a range"
     calculate:
       calculation:
         value: ""
@@ -177,6 +183,7 @@ module.exports = do ->
       ["text", "Text"], # expects text
       ["integer", "Integer"], #e.g. 42
       ["decimal", "Decimal"], #e.g. 3.14
+      ["range", "Range"], #e.g. 1-5
       ["geopoint", "Geopoint (GPS)"], # Can use satelite GPS coordinates
       ["geotrace", "Geotrace (GPS)"], # Can use satelite GPS coordinates
       ["geoshape", "Geoshape (GPS)"], # Can use satelite GPS coordinates
@@ -187,6 +194,7 @@ module.exports = do ->
       ["datetime", "Date and Time"], #e.g. (2012-Jan-4 3:04PM)
       ["audio", "Audio", isMedia: true], # Can use phone microphone to record audio
       ["video", "Video", isMedia: true], # Can use phone camera to record video
+      ["file", "File"],
       ["calculate", "Calculate"],
       ["select_one", "Select", orOtherOption: true, specifyChoice: true],
       ["score", "Score"],

--- a/jsapp/xlform/src/view.icons.coffee
+++ b/jsapp/xlform/src/view.icons.coffee
@@ -114,10 +114,22 @@ module.exports = do ->
       grouping: "r5"
       id: "rank"
     ,
+
+    # r6
       label: _t("Calculate")
       faClass: "lato-calculate"
-      grouping: "r4"
+      grouping: "r6"
       id: "calculate"
+    ,
+      label: _t("Range")
+      faClass: "lato-range"
+      grouping: "r6"
+      id: "range"
+    ,
+      label: _t("File")
+      faClass: "file"
+      grouping: "r6"
+      id: "file"
     ,
     ]
 

--- a/jsapp/xlform/src/view.icons.coffee
+++ b/jsapp/xlform/src/view.icons.coffee
@@ -121,15 +121,15 @@ module.exports = do ->
       grouping: "r6"
       id: "calculate"
     ,
-      label: _t("Range")
-      faClass: "lato-range"
-      grouping: "r6"
-      id: "range"
-    ,
       label: _t("File")
       faClass: "file"
       grouping: "r6"
       id: "file"
+    ,
+      label: _t("Range")
+      faClass: "lato-range"
+      grouping: "r6"
+      id: "range"
     ,
     ]
 

--- a/jsapp/xlform/src/view.rowSelector.coffee
+++ b/jsapp/xlform/src/view.rowSelector.coffee
@@ -69,7 +69,10 @@ module.exports = do ->
       for mrow in $icons.grouped()
         menurow = $("<div>", class: "questiontypelist__row").appendTo $menu
         for mitem, i in mrow when mitem
-          menurow.append $viewTemplates.$$render('xlfRowSelector.cell', mitem.attributes)
+          if mitem.id is 'range'
+            console.warn("range question type is not fully supported yet")
+          else
+            menurow.append $viewTemplates.$$render('xlfRowSelector.cell', mitem.attributes)
 
       @scrollFormBuilder('+=220')
       @$('.questiontypelist__item').click _.bind(@selectMenuItem, @)


### PR DESCRIPTION
## Description

Enable `file` and `range` question types in configuration for form builder. `file` is almost there, as you can add and edit this question type, separate PR will add `body::accept` in `settings`. As for `range` - it is possible to edit existing one (`parameters` text field in `settings`), but until full support is added in separate PR, I disabled possibility of adding this type.

## Related issues

Part of #2051
Part of #2050 

