### PR TITLE
Always show group separator

### DIFF
--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -284,15 +284,14 @@ export class ProjectDownloads extends React.Component {
                             {t('Include groups in headers')}
                           </label>
                         </bem.FormModal__item>,
-                        this.state.hierInLabels ?
-                          <bem.FormModal__item key={'g'}>
-                            <label htmlFor='group_sep'>{t('Group separator')}</label>
-                            <input type='text' name='group_sep'
-                              value={this.state.groupSep}
-                              onChange={this.groupSepChange}
-                            />
-                          </bem.FormModal__item>
-                        : null,
+
+                        <bem.FormModal__item key={'g'}>
+                          <label htmlFor='group_sep'>{t('Group separator')}</label>
+                          <input type='text' name='group_sep'
+                            value={this.state.groupSep}
+                            onChange={this.groupSepChange}
+                          />
+                        </bem.FormModal__item>
                       ] : null,
                       dvcount > 1 ?
                         <bem.FormModal__item key={'v'} m='export-fields-from-all-versions'>


### PR DESCRIPTION
## Description

Displays the group separator input regardless of `Include groups in headers` checkbox

## Related issues

Fixes #2044