### PR TITLE
Throw an error for forbidden id column in form file

### DIFF
--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -79,6 +79,11 @@ $t-form-builder-aside-open: 200ms;
     margin: 24px auto;
     padding: 12px 20px;
 
+    p {
+      font-family: monospace;
+      white-space: pre;
+    }
+
     &__strong {
       border: 1px solid black;
       padding-right: 12px;

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -36,6 +36,9 @@ module.exports = do ->
         if !$inputParser.hasBeenParsed(options)
           options.survey = $inputParser.parseArr(options.survey)
         for r in options.survey
+          if typeof r.id isnt 'undefined'
+            throw new Error("Forbidden column `id` for row: #{JSON.stringify(r, null, 2)}")
+
           if r.type in $configs.surveyDetailSchema.typeList()
             @surveyDetails.importDetail(r)
           else


### PR DESCRIPTION
## Description

Having an `id` column in `xls` form file causes the JS code (Backbone) to only display one row. Now KPI will display error instead of silently failing.

## Related issues

Closes #1984