### PR TITLE
Back button navigates to Library List for Library Item

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -584,8 +584,20 @@ export default assign({
     }
   },
 
-  safeNavigateToFormsList() {
-    this.safeNavigateToRoute('/forms/');
+  safeNavigateToList() {
+    if (this.state.asset_type) {
+      if (this.state.asset_type === 'survey') {
+        this.safeNavigateToRoute('/forms/');
+      } else {
+        this.safeNavigateToRoute('/library/');
+      }
+    } else {
+      if (this.props.location.pathname.startsWith('/library/new')) {
+        this.safeNavigateToRoute('/library/');
+      } else {
+        this.safeNavigateToRoute('/forms/');
+      }
+    }
   },
 
   safeNavigateToForm() {
@@ -641,7 +653,7 @@ export default assign({
             m={'logo'}
             data-tip={t('Return to list')}
             className='left-tooltip'
-            onClick={this.safeNavigateToFormsList}
+            onClick={this.safeNavigateToList}
           >
             <i className='k-icon-kobo' />
           </bem.FormBuilderHeader__cell>


### PR DESCRIPTION
## Description

This button now goes back to Library List if you create/edit questions, blocks or templates:

<img width="124" alt="screenshot 2018-12-03 at 09 58 28" src="https://user-images.githubusercontent.com/2521888/49363489-1a5acc00-f6e2-11e8-8d20-83ba8770bd95.png">

## Related issues

Fixes #2101