### PR TITLE
Add Guidance Hints to Form Builder

### DIFF
--- a/jsapp/xlform/src/model.base.coffee
+++ b/jsapp/xlform/src/model.base.coffee
@@ -161,7 +161,7 @@ module.exports = do ->
       #     @_parent.trigger "change", @key, val, ctxt
 
       # when attributes change, register changes with parent survey
-      if @key in ["name", "label", "hint", "required",
+      if @key in ["name", "label", "hint", "guidance_hint", "required",
                   "calculation", "default", "appearance",
                   "constraint_message", "tags"] or @key.match(/^.+::.+/)
         @on "change", (changes)=>

--- a/jsapp/xlform/src/model.configs.coffee
+++ b/jsapp/xlform/src/model.configs.coffee
@@ -168,7 +168,17 @@ module.exports = do ->
       label:
         value: "Acknowledge"
 
-  configs.columns = ["type", "name", "label", "hint", "required", "relevant", "default", "constraint"]
+  configs.columns = [
+    "type",
+    "name",
+    "label",
+    "hint",
+    "guidance_hint",
+    "required",
+    "relevant",
+    "default",
+    "constraint"
+  ]
 
   configs.lookupRowType = do->
     typeLabels = [
@@ -232,6 +242,8 @@ module.exports = do ->
     hint:
       value: ""
       _hideUnlessChanged: true
+    guidance_hint:
+      value: ""
     required:
       value: false
       _hideUnlessChanged: true

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -167,6 +167,13 @@ module.exports = do ->
     afterRender: ->
       @listenForInputChange()
 
+  viewRowDetail.DetailViewMixins.guidance_hint =
+    html: ->
+      @$el.addClass("card__settings__fields--active")
+      viewRowDetail.Templates.textbox @cid, @model.key, _t("Guidance hint"), 'text'
+    afterRender: ->
+      @listenForInputChange()
+
   viewRowDetail.DetailViewMixins.constraint_message =
     html: ->
       @$el.addClass("card__settings__fields--active")


### PR DESCRIPTION
## Description

You can find text input for guidance hints just below question hints.

## Related issues

Fixes #2054