### PR TITLE
Do not strip HTML from labels in Form Builder

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -197,7 +197,7 @@ module.exports = do ->
         if value == ''
           return newValue: new Array(10).join('&nbsp;')
         else
-        return newValue: value;
+          return newValue: value;
 
   class RowView extends BaseRowView
     _expandedRender: ->

--- a/jsapp/xlform/src/view.utils.coffee
+++ b/jsapp/xlform/src/view.utils.coffee
@@ -62,7 +62,7 @@ module.exports = do ->
         if new_value.newValue?
           edit_box.remove()
           selector.show()
-          selector.html new_value.newValue
+          selector.html(_.escape(new_value.newValue))
         else
           error_box = $('<div class="error-message">' + new_value + '</div>')
           parent_element.append(error_box)


### PR DESCRIPTION
## Description

Displays HTML as source code:

<img width="422" alt="screenshot 2018-12-05 at 10 57 16" src="https://user-images.githubusercontent.com/2521888/49505777-bfa9a780-f87c-11e8-82bb-1ee4ddc72fb8.png">

## Related issues

Fixes #683
