### PR TITLE
Account menu is scrollable and language menu toggles on click

### DIFF
--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -64,6 +64,9 @@ class MainHeader extends Reflux.Component {
   logout () {
     actions.auth.logout();
   }
+  toggleLanguageSelector() {
+    this.setState({isLanguageSelectorVisible: !this.state.isLanguageSelectorVisible})
+  }
   accountSettings () {
     // verifyLogin also refreshes stored profile data
     actions.auth.verifyLogin.triggerAsync().then(() => {
@@ -139,13 +142,16 @@ class MainHeader extends Reflux.Component {
                   </bem.AccountBox__menuLI>
                 }
                 <bem.AccountBox__menuLI m={'lang'} key='3'>
-                  <bem.AccountBox__menuLink>
+                  <bem.AccountBox__menuLink onClick={this.toggleLanguageSelector} data-popover-menu-stop-blur tabIndex='0'>
                     <i className='k-icon-language' />
                     {t('Language')}
                   </bem.AccountBox__menuLink>
-                  <ul>
-                    {langs.map(this.renderLangItem)}
-                  </ul>
+
+                  {this.state.isLanguageSelectorVisible &&
+                    <ul>
+                      {langs.map(this.renderLangItem)}
+                    </ul>
+                  }
                 </bem.AccountBox__menuLI>
                 <bem.AccountBox__menuLI m={'logout'} key='4'>
                   <bem.AccountBox__menuLink onClick={this.logout}>

--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -29,6 +29,7 @@ class MainHeader extends Reflux.Component {
     this.state = assign({
       asset: false,
       currentLang: currentLang(),
+      isLanguageSelectorVisible: false,
       libraryFiltersContext: searches.getSearchContext('library', {
         filterParams: {
           assetType: 'asset_type:question OR asset_type:block OR asset_type:template',

--- a/jsapp/js/ui.es6
+++ b/jsapp/js/ui.es6
@@ -230,6 +230,18 @@ class PopoverMenu extends React.Component {
     if (isBlur && this.props.blurEventDisabled)
       return false;
 
+    if (
+      isBlur &&
+      evt.relatedTarget &&
+      evt.relatedTarget.dataset &&
+      evt.relatedTarget.dataset.popoverMenuStopBlur
+    ) {
+      // bring back focus to trigger to still enable this toggle callback
+      // but don't close the menu
+      evt.target.focus();
+      return false;
+    }
+
     if (this.state.popoverVisible || isBlur) {
         $popoverMenu = $(evt.target).parents('.popover-menu').find('.popover-menu__content');
         this.setState({

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -142,6 +142,8 @@ $headerAccountTextColor: #dbedf7;
 
 .account-box__menu {
   min-width: 270px;
+  max-height: 80vh;
+  overflow-y: auto;
 
   .account-box__menu-item--avatar {
     display: inline-block;
@@ -215,17 +217,10 @@ $headerAccountTextColor: #dbedf7;
     padding-bottom: 5px;
 
     ul {
-      position: absolute;
-      right: 100%;
-      top: 0px;
       background-color: #FFF;
       color: $cool-gray;
       min-width: 140px;
-      transition: all 0.5s;
-      max-height: 0px;
-      opacity: 0;
-      overflow: hidden;
-      padding: 8px 0px;
+      padding: 0;
 
       @include box-shadow;
 
@@ -238,13 +233,6 @@ $headerAccountTextColor: #dbedf7;
           border-bottom: 0px;
         }
       }
-    }
-
-    &:hover > ul {
-      transition: all 0.5s;
-      max-height: 1000px;
-      opacity: 1;
-      overflow: visible;
     }
   }
 


### PR DESCRIPTION
## Description

So the problem wasn't only on mobile - you can't reach any account menu options on given viewports. On mobile the problem was with reaching logout button, but on desktop you can still have some issues with reaching last languages form the Language submenu.

Changes:
- Languages don't open on hover, but they toggle-click below the button
- Account menu is scrollable if doesn't fit the screen vertically

## Related issues

Fixes #2111