### PR TITLE
update support url

### DIFF
--- a/jsapp/js/editorMixins/cascadeMixin.es6
+++ b/jsapp/js/editorMixins/cascadeMixin.es6
@@ -10,7 +10,7 @@ var CascadePopup = bem.create('cascade-popup'),
     CascadePopup__buttonWrapper = bem.create('cascade-popup__buttonWrapper'),
     CascadePopup__button = bem.create('cascade-popup__button', '<button>');
 
-var choiceListHelpUrl = 'http://support.kobotoolbox.org/customer/en/portal/articles/1682856';
+var choiceListHelpUrl = 'http://support.kobotoolbox.org/creating-forms/general/adding-cascading-select-questions';
 
 import {t} from '../utils';
 


### PR DESCRIPTION
## Description

> The link to the adding cascading menu tutorial is broken
> if you go to the form editor and click on the cascading btn, there is "?" in the dialog that takes you to the old link

This is fixed :)