### PR TITLE
Hide question asset name editing functionality

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -276,6 +276,8 @@ export var routes = (
 
     <Route path='library' >
       <Route path='new' component={AddToLibrary} />
+      <Route path='new/question' component={AddToLibrary} />
+      <Route path='new/block' component={AddToLibrary} />
       <Route path='new/template' component={AddToLibrary} />
       <Route path='/library/:assetid'>
         {/*<Route name="library-form-download" path="download" handler={FormDownload} />,*/}

--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -408,6 +408,14 @@ export class AddToLibrary extends React.Component {
       backRoute: '/library'
     };
 
+    if (this.props.location.pathname === '/library/new/question') {
+      this.state.desiredAssetType = ASSET_TYPES.question.id;
+    }
+
+    if (this.props.location.pathname === '/library/new/block') {
+      this.state.desiredAssetType = ASSET_TYPES.block.id;
+    }
+
     if (this.props.location.pathname === '/library/new/template') {
       this.state.desiredAssetType = ASSET_TYPES.template.id;
     }

--- a/jsapp/js/components/librarySidebar.es6
+++ b/jsapp/js/components/librarySidebar.es6
@@ -261,9 +261,14 @@ class LibrarySidebar extends Reflux.Component {
           type='new-menu'
           triggerLabel={t('new')}
         >
-          <Link to={'/library/new'} className='popover-menu__link'>
+          <Link to={'/library/new/question'} className='popover-menu__link'>
             <i className='k-icon-question' />
             {t('Question')}
+          </Link>
+
+          <Link to={'/library/new/block'} className='popover-menu__link'>
+            <i className='k-icon-block' />
+            {t('Block')}
           </Link>
 
           <Link to={'/library/new/template'} className='popover-menu__link'>

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -375,7 +375,7 @@ export default assign({
       if (this.state.desiredAssetType) {
         params.asset_type = this.state.desiredAssetType;
       } else {
-        params.asset_type = 'block';
+        params.asset_type = ASSET_TYPES.block.id;
       }
       actions.resources.createResource.triggerAsync(params)
         .then((asset) => {
@@ -610,30 +610,13 @@ export default assign({
       saveButtonText,
     } = this.buttonStates();
 
-    let nameFieldLabel;
-    switch (this.state.asset_type) {
-      case ASSET_TYPES.template.id:
-        nameFieldLabel = ASSET_TYPES.template.label;
-        break;
-      case ASSET_TYPES.survey.id:
-        nameFieldLabel = ASSET_TYPES.survey.label;
-        break;
-      case ASSET_TYPES.block.id:
-        nameFieldLabel = ASSET_TYPES.block.label;
-        break;
-      case ASSET_TYPES.question.id:
-        nameFieldLabel = ASSET_TYPES.question.label;
-        break;
-      default:
-        nameFieldLabel = null;
+    const targetType = this.state.asset_type || this.state.desiredAssetType;
+    let nameFieldLabel
+    if (targetType) {
+      nameFieldLabel = ASSET_TYPES[targetType].label;
     }
 
-    if (
-      nameFieldLabel === null &&
-      this.state.desiredAssetType === ASSET_TYPES.template.id
-    ) {
-      nameFieldLabel = ASSET_TYPES.template.label;
-    }
+    console.log(targetType, nameFieldLabel);
 
     return (
       <bem.FormBuilderHeader>
@@ -648,17 +631,24 @@ export default assign({
           </bem.FormBuilderHeader__cell>
 
           <bem.FormBuilderHeader__cell m={'name'} >
-            <bem.FormModal__item>
-              {nameFieldLabel &&
-                <label>{nameFieldLabel}</label>
-              }
-              <input
-                type='text'
-                onChange={this.nameChange}
-                value={this.state.name}
-                id='nameField'
-              />
-            </bem.FormModal__item>
+            {targetType === ASSET_TYPES.question.id &&
+              <bem.FormModal__item>
+                <label className='left-tooltip left-aligned-tooltip' data-tip={t('Question name is automatically generated')}>{nameFieldLabel}</label>
+              </bem.FormModal__item>
+            }
+            {targetType !== ASSET_TYPES.question.id &&
+              <bem.FormModal__item>
+                {nameFieldLabel &&
+                  <label>{nameFieldLabel}</label>
+                }
+                <input
+                  type='text'
+                  onChange={this.nameChange}
+                  value={this.state.name}
+                  id='nameField'
+                />
+              </bem.FormModal__item>
+            }
           </bem.FormBuilderHeader__cell>
 
           <bem.FormBuilderHeader__cell m={'buttonsTopRight'} >

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -735,6 +735,12 @@ mixins.contextRouter = {
     if (this.context.router.isActive('/library/new'))
       return true;
 
+    if (this.context.router.isActive('/library/new/question'))
+      return true;
+
+    if (this.context.router.isActive('/library/new/block'))
+      return true;
+
     if (this.context.router.isActive('/library/new/template'))
       return true;
 

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -173,6 +173,10 @@ $t-form-builder-aside-open: 200ms;
         text-transform: uppercase;
       }
 
+      label:only-child {
+        padding: 7px 0;
+      }
+
       input {
         border-radius: 0px;
         padding-left: 0;

--- a/jsapp/scss/components/_kobo.tooltips.scss
+++ b/jsapp/scss/components/_kobo.tooltips.scss
@@ -81,10 +81,24 @@
     transform: translate(0);
   }
 
-  // left aligned tooltips
+  // left aligned tooltip triangle
   .left-tooltip [data-tip]::after,
   .left-tooltip[data-tip]::after {
     left: calc(50% - 10px);
+    right: auto;
+    transform: translate(0);
+  }
+
+  // left aligned tooltip and triangle
+  .left-aligned-tooltip [data-tip]::before,
+  .left-aligned-tooltip[data-tip]::before {
+    left: 10px;
+    right: auto;
+    transform: translate(0);
+  }
+  .left-aligned-tooltip [data-tip]::after,
+  .left-aligned-tooltip[data-tip]::after {
+    left: 0;
     right: auto;
     transform: translate(0);
   }


### PR DESCRIPTION
## Description

Changes:

- for `question` asset type, don't display `name` input (as we automatically use question name)
- display helpful tooltip so users will know why no name field is displayed
- be more explicit when creating new Library item, i.e. the `NEW` menu has now "Block" option (this is not bulletproof, as when creating `question`, you can end up with `block` and vice versa - we can address this in future)
- thanks to being explicit we now always display the asset type in FB header

<img width="211" alt="screenshot 2018-12-27 at 23 26 29" src="https://user-images.githubusercontent.com/2521888/50496263-db910b00-0a2e-11e9-8a99-a42d903937b3.png">

<img width="401" alt="screenshot 2018-12-27 at 23 18 38" src="https://user-images.githubusercontent.com/2521888/50496252-c87e3b00-0a2e-11e9-9c1f-b950ac3e9d95.png">

## Related issues

Fixes #663