### PR TITLE
Allow to delete projects simultaneously

### DIFF
--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -95,9 +95,11 @@ class AssetRow extends React.Component {
         ownedCollections = [],
         parent = undefined;
 
-    var isDeployable = this.props.asset_type && this.props.asset_type === 'survey' && this.props.deployed_version_id === null;
+    var isDeployable = this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && this.props.deployed_version_id === null;
 
     const userCanEdit = this.userCan('change_asset', this.props);
+
+    const assetName = this.props.name || this.props.firstQuestionName;
 
     if (this.props.has_deployment && this.props.deployment__submission_count &&
         this.userCan('view_submissions', this.props)) {
@@ -160,7 +162,7 @@ class AssetRow extends React.Component {
               <bem.AssetRow__cell m='name'>
                 <ui.AssetName {...this.props} />
               </bem.AssetRow__cell>
-              { this.props.asset_type && this.props.asset_type === 'survey' && this.props.settings.description &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && this.props.settings.description &&
                 <bem.AssetRow__description>
                   {this.props.settings.description}
                 </bem.AssetRow__description>
@@ -187,19 +189,19 @@ class AssetRow extends React.Component {
               key={'userlink'}
               className={[
                 'mdl-cell',
-                this.props.asset_type == 'survey' ? 'mdl-cell--2-col mdl-cell--1-col-tablet mdl-cell--hide-phone' : 'mdl-cell--2-col mdl-cell--2-col-tablet mdl-cell--1-col-phone'
+                this.props.asset_type == ASSET_TYPES.survey.id ? 'mdl-cell--2-col mdl-cell--1-col-tablet mdl-cell--hide-phone' : 'mdl-cell--2-col mdl-cell--2-col-tablet mdl-cell--1-col-phone'
               ]}
             >
-              { this.props.asset_type == 'survey' &&
+              { this.props.asset_type == ASSET_TYPES.survey.id &&
                 <span>{ selfowned ? ' ' : this.props.owner__username }</span>
               }
-              { this.props.asset_type != 'survey' &&
+              { this.props.asset_type != ASSET_TYPES.survey.id &&
                 <span>{selfowned ? t('me') : this.props.owner__username}</span>
               }
             </bem.AssetRow__cell>
 
             {/* "date created" column for surveys */}
-            { this.props.asset_type == 'survey' &&
+            { this.props.asset_type == ASSET_TYPES.survey.id &&
               <bem.AssetRow__cell m={'date-created'}
                   key={'date-created'}
                   className='mdl-cell mdl-cell--2-col mdl-cell--hide-tablet mdl-cell--hide-phone'
@@ -217,7 +219,7 @@ class AssetRow extends React.Component {
             </bem.AssetRow__cell>
 
             {/* "submission count" column for surveys */}
-            { this.props.asset_type == 'survey' &&
+            { this.props.asset_type == ASSET_TYPES.survey.id &&
               <bem.AssetRow__cell
                 m={'submission-count'}
                 key={'submisson-count'}
@@ -283,7 +285,7 @@ class AssetRow extends React.Component {
                 data-action='clone'
                 data-tip={t('Clone')}
                 data-asset-type={this.props.kind}
-                data-asset-name={this.props.name}
+                data-asset-name={assetName}
                 data-disabled={false}
                 >
               <i className='k-icon-clone' />
@@ -298,7 +300,7 @@ class AssetRow extends React.Component {
                 data-action={'cloneAsSurvey'}
                 data-tip={t('Create project')}
                 data-asset-type={this.props.kind}
-                data-asset-name={this.props.name}
+                data-asset-name={assetName}
                 data-disabled={false}
               >
                 <i className='k-icon-projects' />
@@ -327,7 +329,7 @@ class AssetRow extends React.Component {
               clearPopover={this.state.clearPopover}
               popoverSetVisible={this.popoverSetVisible}
             >
-              { this.props.asset_type && this.props.asset_type === 'survey' && userCanEdit && isDeployable &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && userCanEdit && isDeployable &&
                 <bem.PopoverMenu__link
                     m={'deploy'}
                     data-action={'deploy'}
@@ -336,7 +338,7 @@ class AssetRow extends React.Component {
                   {t('Deploy this project')}
                 </bem.PopoverMenu__link>
               }
-              { this.props.asset_type && this.props.asset_type === 'survey' && this.props.has_deployment && !this.props.deployment__active && userCanEdit &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && this.props.has_deployment && !this.props.deployment__active && userCanEdit &&
                 <bem.PopoverMenu__link
                       m={'unarchive'}
                       data-action={'unarchive'}
@@ -346,7 +348,7 @@ class AssetRow extends React.Component {
                   {t('Unarchive')}
                 </bem.PopoverMenu__link>
               }
-              { this.props.asset_type && this.props.asset_type === 'survey' && userCanEdit &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && userCanEdit &&
                 <bem.PopoverMenu__link
                   m={'refresh'}
                   data-action={'refresh'}
@@ -375,12 +377,12 @@ class AssetRow extends React.Component {
                     </bem.PopoverMenu__link>
                   );
               })}
-              { this.props.asset_type && this.props.asset_type != 'survey' && ownedCollections.length > 0 &&
+              { this.props.asset_type && this.props.asset_type != ASSET_TYPES.survey.id && ownedCollections.length > 0 &&
                 <bem.PopoverMenu__heading>
                   {t('Move to')}
                 </bem.PopoverMenu__heading>
               }
-              { this.props.asset_type && this.props.asset_type != 'survey' && ownedCollections.length > 0 &&
+              { this.props.asset_type && this.props.asset_type != ASSET_TYPES.survey.id && ownedCollections.length > 0 &&
                 <bem.PopoverMenu__moveTo>
                   {ownedCollections.map((col)=>{
                     return (
@@ -401,7 +403,7 @@ class AssetRow extends React.Component {
                   })}
                 </bem.PopoverMenu__moveTo>
               }
-              { this.props.asset_type && this.props.asset_type === 'survey' && this.props.has_deployment && this.props.deployment__active && userCanEdit &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && this.props.has_deployment && this.props.deployment__active && userCanEdit &&
                 <bem.PopoverMenu__link
                       m={'archive'}
                       data-action={'archive'}
@@ -411,12 +413,12 @@ class AssetRow extends React.Component {
                   {t('Archive')}
                 </bem.PopoverMenu__link>
               }
-              { this.props.asset_type && this.props.asset_type === 'survey' && userCanEdit &&
+              { this.props.asset_type && this.props.asset_type === ASSET_TYPES.survey.id && userCanEdit &&
                 <bem.PopoverMenu__link
                   m={'cloneAsTemplate'}
                   data-action={'cloneAsTemplate'}
                   data-asset-type={this.props.kind}
-                  data-asset-name={this.props.name}
+                  data-asset-name={assetName}
                 >
                   <i className='k-icon-template' />
                   {t('Create template')}
@@ -427,7 +429,7 @@ class AssetRow extends React.Component {
                   m={'delete'}
                   data-action={'delete'}
                   data-asset-type={this.props.kind}
-                  data-asset-name={this.props.name}
+                  data-asset-name={assetName}
                 >
                   <i className='k-icon-trash' />
                   {t('Delete')}

--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -99,7 +99,7 @@ class AssetRow extends React.Component {
 
     const userCanEdit = this.userCan('change_asset', this.props);
 
-    const assetName = this.props.name || this.props.firstQuestionName;
+    const assetName = this.props.name || this.props.firstQuestionLabel;
 
     if (this.props.has_deployment && this.props.deployment__submission_count &&
         this.userCan('view_submissions', this.props)) {

--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -424,10 +424,11 @@ class AssetRow extends React.Component {
               }
               {userCanEdit &&
                 <bem.PopoverMenu__link
-                      m={'delete'}
-                      data-action={'delete'}
-                      data-asset-type={this.props.kind}
-                    >
+                  m={'delete'}
+                  data-action={'delete'}
+                  data-asset-type={this.props.kind}
+                  data-asset-name={this.props.name}
+                >
                   <i className='k-icon-trash' />
                   {t('Delete')}
                 </bem.PopoverMenu__link>

--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -270,7 +270,7 @@ class MainHeader extends Reflux.Component {
                     name='title'
                     placeholder={t('Project title')}
                     value={this.state.asset.name ? this.state.asset.name : ''}
-                    onChange={this.assetTitleChange}
+                    onChange={this.assetTitleChange.bind(this)}
                     onKeyDown={this.assetTitleKeyDown}
                     disabled={!userCanEditAsset}
                   />

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -234,6 +234,7 @@ class ProjectSettings extends React.Component {
   deleteProject() {
     this.deleteAsset(
       this.state.formAsset.uid,
+      this.state.formAsset.name,
       this.goToProjectsList.bind(this)
     );
   }

--- a/jsapp/js/components/searchcollectionlist.es6
+++ b/jsapp/js/components/searchcollectionlist.es6
@@ -79,8 +79,8 @@ class SearchCollectionList extends Reflux.Component {
     var isSelected = stores.selectedAsset.uid === resource.uid;
     var ownedCollections = this.state.ownedCollections;
 
-    // for unnamed assets, we try to display first question name
-    let firstQuestionName;
+    // for unnamed assets, we try to display first question label
+    let firstQuestionLabel;
     if (
       resource.asset_type !== ASSET_TYPES.survey.id &&
       resource.name === '' &&
@@ -88,7 +88,7 @@ class SearchCollectionList extends Reflux.Component {
       resource.summary.labels &&
       resource.summary.labels.length > 0
     ) {
-      firstQuestionName = resource.summary.labels[0]
+      firstQuestionLabel = resource.summary.labels[0]
     }
 
     return (
@@ -98,7 +98,7 @@ class SearchCollectionList extends Reflux.Component {
         isSelected={isSelected}
         ownedCollections={ownedCollections}
         deleting={resource.deleting}
-        firstQuestionName={firstQuestionName}
+        firstQuestionLabel={firstQuestionLabel}
         {...resource}
       />
     );

--- a/jsapp/js/components/searchcollectionlist.es6
+++ b/jsapp/js/components/searchcollectionlist.es6
@@ -13,6 +13,7 @@ import DocumentTitle from 'react-document-title';
 import $ from 'jquery';
 import Dropzone from 'react-dropzone';
 import {t, validFileTypes} from '../utils';
+import {ASSET_TYPES} from '../constants';
 
 class SearchCollectionList extends Reflux.Component {
   constructor(props) {
@@ -78,6 +79,18 @@ class SearchCollectionList extends Reflux.Component {
     var isSelected = stores.selectedAsset.uid === resource.uid;
     var ownedCollections = this.state.ownedCollections;
 
+    // for unnamed assets, we try to display first question name
+    let firstQuestionName;
+    if (
+      resource.asset_type !== ASSET_TYPES.survey.id &&
+      resource.name === '' &&
+      resource.summary &&
+      resource.summary.labels &&
+      resource.summary.labels.length > 0
+    ) {
+      firstQuestionName = resource.summary.labels[0]
+    }
+
     return (
       <this.props.assetRowClass key={resource.uid}
         currentUsername={currentUsername}
@@ -85,6 +98,7 @@ class SearchCollectionList extends Reflux.Component {
         isSelected={isSelected}
         ownedCollections={ownedCollections}
         deleting={resource.deleting}
+        firstQuestionName={firstQuestionName}
         {...resource}
       />
     );

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -163,8 +163,8 @@ mixins.dmix = {
       mixins.clickAssets.click.asset.unarchive(uid, callback);
     }
   },
-  deleteAsset (uid, callback) {
-    mixins.clickAssets.click.asset.delete(uid, callback);
+  deleteAsset (uid, name, callback) {
+    mixins.clickAssets.click.asset.delete(uid, name, callback);
   },
   toggleDeploymentHistory () {
     this.setState({
@@ -513,11 +513,11 @@ mixins.clickAssets = {
         else
           hashHistory.push(`/forms/${uid}/edit`);
       },
-      delete: function(uid, callback){
-        let asset = stores.selectedAsset.asset || stores.allAssets.byUid[uid];
-        var assetTypeLabel = t('project');
+      delete: function(uid, name, callback) {
+        const asset = stores.selectedAsset.asset || stores.allAssets.byUid[uid];
+        let assetTypeLabel = ASSET_TYPES.survey.label;
 
-        if (asset.asset_type != 'survey') {
+        if (asset.asset_type != ASSET_TYPES.survey.id) {
           assetTypeLabel = t('library item');
         }
 
@@ -528,7 +528,6 @@ mixins.clickAssets = {
           actions.resources.deleteAsset({uid: uid}, {
             onComplete: ()=> {
               notify(`${assetTypeLabel} ${t('deleted permanently')}`);
-              $('.alertify-toggle input').prop('checked', false);
               if (typeof callback === 'function') {
                 callback();
               }
@@ -537,7 +536,7 @@ mixins.clickAssets = {
         };
 
         if (!deployed) {
-          if (asset.asset_type != 'survey')
+          if (asset.asset_type != ASSET_TYPES.survey.id)
             msg = t('You are about to permanently delete this item from your library.');
           else
             msg = t('You are about to permanently delete this draft.');
@@ -552,10 +551,13 @@ mixins.clickAssets = {
           onshow = (evt) => {
             let ok_button = dialog.elements.buttons.primary.firstChild;
             let $els = $('.alertify-toggle input');
+
             ok_button.disabled = true;
+            $els.each(function () {$(this).prop('checked', false);});
+
             $els.change(function () {
               ok_button.disabled = false;
-              $els.each(function ( index ) {
+              $els.each(function () {
                 if (!$(this).prop('checked')) {
                   ok_button.disabled = true;
                 }
@@ -564,7 +566,7 @@ mixins.clickAssets = {
           };
         }
         let opts = {
-          title: `${t('Delete')} ${assetTypeLabel}`,
+          title: `${t('Delete')} ${assetTypeLabel} "${name}"`,
           message: msg,
           labels: {
             ok: t('Delete'),

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -515,11 +515,7 @@ mixins.clickAssets = {
       },
       delete: function(uid, name, callback) {
         const asset = stores.selectedAsset.asset || stores.allAssets.byUid[uid];
-        let assetTypeLabel = ASSET_TYPES.survey.label;
-
-        if (asset.asset_type != ASSET_TYPES.survey.id) {
-          assetTypeLabel = t('library item');
-        }
+        let assetTypeLabel = ASSET_TYPES[asset.asset_type].label;
 
         let dialog = alertify.dialog('confirm');
         let deployed = asset.has_deployment;

--- a/jsapp/js/ui.es6
+++ b/jsapp/js/ui.es6
@@ -181,6 +181,7 @@ class AssetName extends React.Component {
     var row_count;
     if (!name) {
       row_count = summary.row_count;
+      // for unnamed assets, we try to display first question name
       name = summary.labels ? summary.labels[0] : false;
       if (!name) {
         isEmpty = true;


### PR DESCRIPTION
## Description

Changes:
- project deletion now is possible to start when previous deletion didn't complete yet
- display asset type instead of "library item" in deletion modal
- display asset name in deletion modal
- use first question ~~name~~ label in deletion modal instead of "untitled"

## Related issues

Fixes #2136 