### PR TITLE
Nested repeat submission detail crash - quickfix

### DIFF
--- a/jsapp/js/components/modalForms/submission.es6
+++ b/jsapp/js/components/modalForms/submission.es6
@@ -263,6 +263,13 @@ class Submission extends React.Component {
       case 'video':
         return this.renderAttachment(submissionValue, q.type);
         break;
+      case 'begin_repeat':
+        const list = submissionValue.map((r) => {
+          const stringified = JSON.stringify(r);
+          return <li key={stringified}>{stringified}</li>
+        });
+        return <ul>{list}</ul>
+        break;
       default:
         return submissionValue;
         break;

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -12,6 +12,7 @@ $viewParams = require './view.params'
 $viewRowDetail = require './view.rowDetail'
 renderKobomatrix = require('js/formbuild/renderInBackbone').renderKobomatrix
 _t = require('utils').t
+alertify = require 'alertifyjs'
 
 module.exports = do ->
   class BaseRowView extends Backbone.View
@@ -179,7 +180,7 @@ module.exports = do ->
           $appearanceField.find('input:checkbox').prop('checked', false)
           appearanceModel = @model.get('appearance')
           if appearanceModel.getValue()
-            @surveyView.ngScope.miscUtils.alert(_t("You can't display nested groups on the same screen - the setting has been removed from the parent group"))
+            alertify.warning(_t("You can't display nested groups on the same screen - the setting has been removed from the parent group"))
           appearanceModel.set('value', '')
 
       @model.on 'remove', (row) =>

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -11,6 +11,7 @@ $rowView = require './view.row'
 $baseView = require './view.pluggedIn.backboneView'
 $viewUtils = require './view.utils'
 _t = require('utils').t
+alertify = require 'alertifyjs'
 
 module.exports = do ->
   surveyApp = {}
@@ -681,16 +682,8 @@ module.exports = do ->
           enketoServer: window.koboConfigs?.enketoServer or false
           enketoPreviewUri: window.koboConfigs?.enketoPreviewUri or false
           onSuccess: => @onEscapeKeydown = $viewUtils.enketoIframe.close
-          onError: (message, opts)=> @alert message, opts
+          onError: (message)=> alertify.error(message)
       return
-
-    alert: (message, opts={}) ->
-      title = opts.title or 'Error'
-      $('.alert-modal').html(message).dialog('option', {
-        title: title,
-        width: 500,
-        dialogClass: 'surveyapp__alert'
-      }).dialog 'open'
     downloadButtonClick: (evt)->
       # Download = save a CSV file to the disk
       surveyCsv = @survey.toCSV()


### PR DESCRIPTION
## Description

This PR only avoids crashing by displaying a stringified nested repeat submission value:

<img width="980" alt="screenshot 2018-12-29 at 21 04 13" src="https://user-images.githubusercontent.com/2521888/50541790-626bf200-0bad-11e9-82fc-7d95b63dcc11.png">

From what I've discovered, it seems we would need to refactor this piece of code, as the code doesn't seem to be recursive enough.

**Bonus**: while debugging, I've found some old broken alert method; changed it to alertify :)

## Related issues

Part of #2137 

