### PR TITLE
Define shadow UserObjectPermission; fixes #2148

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -29,7 +29,6 @@ django-celery-beat==1.1.1
 django-constance[database]==2.2.0
 django-debug-toolbar==1.6
 django-extensions==1.7.6
-django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -30,7 +30,6 @@ django-celery-beat==1.1.1
 django-constance[database]==2.2.0
 django-debug-toolbar==1.4
 django-extensions==1.6.7
-django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3
@@ -85,7 +84,7 @@ pytest==3.0.3             # via pytest-django
 python-dateutil==2.6.0
 python-digest==1.7
 pytz==2016.4
-pyxform==0.11.5
+pyxform==0.12.0
 raven==5.32.0
 requests==2.10.0
 responses==0.9.0

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -9,9 +9,6 @@
 python-digest==1.7
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
 
-# django-guardian must match KoBoCAT's version
-django-guardian==1.4.1
-
 # Regular PyPI packages
 Django<1.9
 Markdown

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -29,7 +29,6 @@ django-celery-beat==1.1.1
 django-constance[database]==2.2.0
 django-debug-toolbar==1.4
 django-extensions==1.6.7
-django-guardian==1.4.1
 django-haystack==2.6.0
 django-jsonbfield==0.1.0
 django-loginas==0.2.3

--- a/hub/actions.py
+++ b/hub/actions.py
@@ -13,7 +13,7 @@ from django.template.response import TemplateResponse
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy, ugettext as _
 
-from kpi.deployment_backends.kc_access.shadow_models import _ReadOnlyModel
+from kpi.deployment_backends.kc_access.shadow_models import _ShadowModel
 
 def delete_related_objects(modeladmin, request, queryset):
     """
@@ -47,7 +47,7 @@ def delete_related_objects(modeladmin, request, queryset):
                 # element. We can skip it since delete() on the first
                 # level of related objects will cascade.
                 continue
-            elif not isinstance(obj, _ReadOnlyModel):
+            elif not isinstance(obj, _ShadowModel):
                 first_level_related_objects.append(obj)
 
     # Populate deletable_objects, a data structure of (string representations

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -98,7 +98,6 @@ INSTALLED_APPS = (
     'kobo.apps.service_health',
     'constance',
     'constance.backends.database',
-    'guardian', # For access to KC permissions ONLY
     'kobo.apps.hook',
     'django_celery_beat',
 )

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -1,9 +1,16 @@
-from django.contrib.auth.models import User
-from django.contrib.contenttypes.models import ContentType
-from django.db import models
-from django.db import ProgrammingError
-from django.utils.translation import ugettext_lazy
 from hashlib import md5
+
+from django.db import models
+from django.conf import settings
+from django.db import ProgrammingError
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.auth.models import User, Permission
+from django.contrib.contenttypes.models import ContentType
+
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 
 from jsonfield import JSONField
 
@@ -42,12 +49,19 @@ class LazyModelGroup:
             self._define()
         return self._UserProfile
 
+    @property
+    def UserObjectPermission(self):
+        if not hasattr(self, '_UserObjectPermission'):
+            self._define()
+        return self._UserObjectPermission
+
     @staticmethod
     def get_content_type_for_model(model):
         MODEL_NAME_MAPPING = {
             '_readonlyxform': ('logger', 'xform'),
             '_readonlyinstance': ('logger', 'instance'),
-            '_userprofile': ('main', 'userprofile')
+            '_userprofile': ('main', 'userprofile'),
+            '_userobjectpermission': ('guardian', 'userobjectpermission'),
         }
         try:
             app_label, model_name = MODEL_NAME_MAPPING[model._meta.model_name]
@@ -88,6 +102,7 @@ class LazyModelGroup:
                 ''' Matches what's returned by the KC API '''
                 return u"md5:%s" % self.hash
 
+
         class _ReadOnlyInstance(_ReadOnlyModel):
             class Meta:
                 managed = False
@@ -104,6 +119,7 @@ class LazyModelGroup:
             status = models.CharField(max_length=20,
                                       default=u'submitted_via_web')
             uuid = models.CharField(max_length=249, default=u'')
+
 
         class _UserProfile(models.Model):
             '''
@@ -129,7 +145,7 @@ class LazyModelGroup:
             description = models.CharField(max_length=255, blank=True)
             require_auth = models.BooleanField(
                 default=False,
-                verbose_name=ugettext_lazy(
+                verbose_name=_(
                     "Require authentication to see forms and submit data"
                 )
             )
@@ -139,9 +155,55 @@ class LazyModelGroup:
             num_of_submissions = models.IntegerField(default=0)
             metadata = JSONField(default={}, blank=True)
 
+
+        class _UserObjectPermission(models.Model):
+            '''
+            For the _sole purpose_ of letting us manipulate KoBoCAT
+            permissions, this comprises the following django-guardian classes
+            all condensed into one:
+
+              * UserObjectPermission
+              * UserObjectPermissionBase
+              * BaseGenericObjectPermission
+              * BaseObjectPermission
+
+            CAVEAT LECTOR: The django-guardian custom manager,
+            UserObjectPermissionManager, is NOT included!
+            '''
+            permission = models.ForeignKey(Permission)
+            content_type = models.ForeignKey(ContentType)
+            object_pk = models.CharField(_('object ID'), max_length=255)
+            content_object = GenericForeignKey(fk_field='object_pk')
+            user = models.ForeignKey(
+                getattr(settings, 'AUTH_USER_MODEL', 'auth.User'))
+
+            class Meta:
+                db_table = 'guardian_userobjectpermission'
+                unique_together = ['user', 'permission', 'object_pk']
+
+            def __unicode__(self):
+                return '%s | %s | %s' % (
+                    unicode(self.content_object),
+                    unicode(getattr(self, 'user', False) or self.group),
+                    unicode(self.permission.codename))
+
+            def save(self, *args, **kwargs):
+                content_type = ContentType.objects.get_for_model(
+                    self.content_object)
+                if content_type != self.permission.content_type:
+                    raise ValidationError(
+                        "Cannot persist permission not designed for this "
+                        "class (permission's type is %r and object's type is "
+                        "%r)"
+                        % (self.permission.content_type, content_type)
+                    )
+                return super(UserObjectPermission, self).save(*args, **kwargs)
+
+
         self._XForm = _ReadOnlyXform
         self._Instance = _ReadOnlyInstance
         self._UserProfile = _UserProfile
+        self._UserObjectPermission = _UserObjectPermission
 
 _models = LazyModelGroup()
 

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -16,7 +16,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import get_storage_class
 from django.core.management.base import BaseCommand
 from django.db import models, transaction
-from guardian.models import UserObjectPermission
 from rest_framework.authtoken.models import Token
 
 from formpack.utils.xls_to_ss_structure import xls_to_dicts
@@ -303,7 +302,7 @@ def _sync_permissions(asset, xform):
         return []
 
     # Get all applicable KC permissions set for this xform
-    xform_user_perms = UserObjectPermission.objects.filter(
+    xform_user_perms = _models.UserObjectPermission.objects.filter(
         permission_id__in=PERMISSIONS_MAP.keys(),
         content_type=XFORM_CT,
         object_pk=xform.pk


### PR DESCRIPTION
Also removes django-guardian dependency (and its pesky warning!)

~~Edit: this doesn't work. Or, more accurately, it works only in threads where the shadow models have not been [defined](https://github.com/kobotoolbox/kpi/blob/1000a9e0f4b5e68c4894585361788969bd3b9e9c/kpi/deployment_backends/kc_access/shadow_models.py#L73) yet.~~ (Fixed!)