### PR TITLE
Rename "Replace project" to "Replace form"

### DIFF
--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -353,7 +353,7 @@ class AssetRow extends React.Component {
                   data-asset-type={this.props.kind}
                 >
                   <i className='k-icon-replace' />
-                  {t('Replace project')}
+                  {t('Replace form')}
                 </bem.PopoverMenu__link>
               }
               { userCanEdit &&

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -362,7 +362,7 @@ export class FormLanding extends React.Component {
         {userCanEdit &&
           <bem.FormView__link
             m='upload'
-            data-tip={t('Replace project')}
+            data-tip={t('Replace form')}
             onClick={this.showReplaceProjectModal}
           >
             <i className='k-icon-replace' />

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -126,7 +126,7 @@ class ProjectSettings extends React.Component {
       case PROJECT_SETTINGS_CONTEXTS.NEW:
         return t('Create project');
       case PROJECT_SETTINGS_CONTEXTS.REPLACE:
-        return t('Replace project');
+        return t('Replace form');
       case PROJECT_SETTINGS_CONTEXTS.EXISTING:
       case PROJECT_SETTINGS_CONTEXTS.BUILDER:
       default:

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -353,7 +353,7 @@ mixins.droppable = {
             } else {
               if (!assetUid) {
                 // TODO: use a more specific error message here
-                alertify.error(t('XLSForm Import failed. Check that the XLSForm and/or the URL are valid, and try again using the "Replace project" icon.'));
+                alertify.error(t('XLSForm Import failed. Check that the XLSForm and/or the URL are valid, and try again using the "Replace form" icon.'));
                 if (params.assetUid)
                   hashHistory.push(`/forms/${params.assetUid}`);
               } else {


### PR DESCRIPTION
## Description

Simple renaming "Replace project" to "Replace form", as it makes more logical sense.

## Related issues

Closes #2158 