### PR TITLE
Display translations box for no languages

### DIFF
--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -127,6 +127,9 @@ export class FormLanding extends React.Component {
   isFormRedeploymentNeeded() {
     return !this.isCurrentVersionDeployed() && this.userCan('change_asset', this.state);
   }
+  hasLanguagesDefined(translations) {
+    return translations && (translations.length > 1 || translations[0] !== null);
+  }
   showLanguagesModal (evt) {
     evt.preventDefault();
     stores.pageState.showModal({
@@ -429,10 +432,10 @@ export class FormLanding extends React.Component {
         <bem.FormView__cell m='translation-list'>
           <strong>{t('Languages:')}</strong>
           &nbsp;
-          {!translations || translations.length < 2 &&
+          {!this.hasLanguagesDefined(translations) &&
             t('This project has no languages defined yet')
           }
-          {translations && translations.length >= 2 &&
+          {this.hasLanguagesDefined(translations) &&
             <ul>
               {translations.map((langString, n)=>{
                 return (

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -423,23 +423,26 @@ export class FormLanding extends React.Component {
   }
   renderLanguages (canEdit) {
     let translations = this.state.content.translations;
-    if (!translations || translations.length < 2)
-      return false;
 
     return (
       <bem.FormView__cell m={['columns', 'padding', 'bordertop']}>
         <bem.FormView__cell m='translation-list'>
           <strong>{t('Languages:')}</strong>
           &nbsp;
-          <ul>
-            {translations.map((langString, n)=>{
-              return (
-                <li key={n}>
-                  {langString || t('Unnamed language')}
-                </li>
-              );
-            })}
-          </ul>
+          {!translations || translations.length < 2 &&
+            t('This project has no languages defined yet')
+          }
+          {translations && translations.length >= 2 &&
+            <ul>
+              {translations.map((langString, n)=>{
+                return (
+                  <li key={n}>
+                    {langString || t('Unnamed language')}
+                  </li>
+                );
+              })}
+            </ul>
+          }
         </bem.FormView__cell>
 
         {canEdit &&


### PR DESCRIPTION
## Description

When a project doesn't have any languages defined, we will display this:

<img width="921" alt="screenshot 2019-01-17 at 09 51 59" src="https://user-images.githubusercontent.com/2521888/51306436-9b291980-1a3d-11e9-9a4a-bb023ccf63f5.png">

And otherwise same as before:

<img width="922" alt="screenshot 2019-01-17 at 09 52 11" src="https://user-images.githubusercontent.com/2521888/51306443-a2e8be00-1a3d-11e9-9b09-8ff7246ffcac.png">

## Related issues

Fixes #2156 