### PR TITLE
Copy .stylelintrc.json for production builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ COPY ./scripts/copy_fonts.py ${KPI_SRC_DIR}/scripts/copy_fonts.py
 COPY ./scripts/generate_icons.js ${KPI_SRC_DIR}/scripts/generate_icons.js
 COPY ./webpack ${KPI_SRC_DIR}/webpack
 COPY ./.eslintrc ${KPI_SRC_DIR}/.eslintrc
+COPY ./.stylelintrc.json ${KPI_SRC_DIR}/.stylelintrc.json
 COPY ./test ${KPI_SRC_DIR}/test
 
 COPY ./jsapp ${KPI_SRC_DIR}/jsapp


### PR DESCRIPTION
Fixes this error during Docker builds:
```
[ubuntu@kf.unu.kbtdev.org] out: Error: No configuration provided for /srv/src/kpi/jsapp/scss/kobo.scss
[ubuntu@kf.unu.kbtdev.org] out:     at module.exports (/srv/node_modules/stylelint/lib/utils/configurationError.js:8:28)
[ubuntu@kf.unu.kbtdev.org] out:     at searchForConfig.then.then.config (/srv/node_modules/stylelint/lib/getConfigForFile.js:55:15)
[ubuntu@kf.unu.kbtdev.org] out:     at <anonymous>
```