### PR TITLE
Fix table view crashes with missing responses or `name`/`$autoname`

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -173,7 +173,9 @@ export class DataTable extends React.Component {
 
     const surveyKeys = [];
     this.props.asset.content.survey.forEach((row) => {
-      surveyKeys.push(row.$autoname);
+      if (row.$autoname) {
+        surveyKeys.push(row.$autoname);
+      }
     });
 
     // make sure the survey columns are displayed, even if current data's

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -417,7 +417,11 @@ export class DataTable extends React.Component {
                 return formatTimeDate(row.value);
               }
             }
-            return typeof(row.value) == 'object' ? '' : row.value;
+            if (typeof(row.value) == 'object' || row.value === undefined) {
+              return '';
+            } else {
+              return row.value;
+            }
           }
       });
 

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -173,7 +173,9 @@ export class DataTable extends React.Component {
 
     const surveyKeys = [];
     this.props.asset.content.survey.forEach((row) => {
-      if (row.$autoname) {
+      if (row.name) {
+        surveyKeys.push(row.name);
+      } else if (row.$autoname) {
         surveyKeys.push(row.$autoname);
       }
     });
@@ -764,6 +766,8 @@ export class DataTable extends React.Component {
     const val = evt.target.getAttribute('data-value'),
           selectAll = this.state.selectAll;
     var d = null;
+
+    // TODO bulk change to no status
 
     if (!selectAll) {
       d = {


### PR DESCRIPTION
I cherry-picked table view fixes from https://github.com/kobotoolbox/kpi/compare/2188-2189-validation-status-fixes and added another fix for a crash when rendering `Cell`s for missing responses, which appeared in the console as `Uncaught Invariant Violation: Cell(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.`

Now running on https://kf.du.kbtdev.org/