### PR TITLE
Add ottoyiu/django-cors-headers

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -33,6 +33,7 @@ dj-static==0.0.6
 django-braces==1.13.0
 django-celery-beat==1.1.1
 django-constance[database]==2.2.0
+django-cors-headers==2.4.0
 django-debug-toolbar==1.4
 django-extensions==1.6.7
 django-haystack==2.6.0

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -32,6 +32,7 @@ dj-static==0.0.6
 django-braces==1.13.0
 django-celery-beat==1.1.1
 django-constance[database]==2.2.0
+django-cors-headers==2.4.0
 django-debug-toolbar==1.4
 django-extensions==1.6.7
 django-haystack==2.6.0

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -25,6 +25,7 @@ dj-database-url
 django-braces
 django-celery-beat
 django-constance[database]
+django-cors-headers
 django-debug-toolbar
 django-extensions
 django-jsonbfield

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -32,6 +32,7 @@ dj-static==0.0.6
 django-braces==1.13.0
 django-celery-beat==1.1.1
 django-constance[database]==2.2.0
+django-cors-headers==2.4.0
 django-debug-toolbar==1.4
 django-extensions==1.6.7
 django-haystack==2.6.0

--- a/kobo/settings.py
+++ b/kobo/settings.py
@@ -100,9 +100,11 @@ INSTALLED_APPS = (
     'constance.backends.database',
     'kobo.apps.hook',
     'django_celery_beat',
+    'corsheaders',
 )
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
Not very useful without #2210, but it doesn't seem to break anything :wink:

Closes #2209