### PR TITLE
Fix unnecessary double reports API call

### DIFF
--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -736,7 +736,7 @@ class Reports extends React.Component {
       showCustomReportModal: false,
       currentCustomReport: false,
       currentQuestionGraph: false,
-      groupBy: []
+      groupBy: ''
     };
     autoBind(this);
   }
@@ -760,7 +760,7 @@ class Reports extends React.Component {
       let rowsByKuid = {};
       let rowsByIdentifier = {};
       let names = [],
-          groupBy = [],
+          groupBy = '',
           reportStyles = asset.report_styles,
           reportCustom = asset.report_custom;
 
@@ -818,7 +818,7 @@ class Reports extends React.Component {
         }).fail((err)=> {
           if (groupBy.length > 0 && !this.state.currentCustomReport && reportStyles.default.groupDataBy !== undefined) {
             // reset default report groupBy if it fails and notify user
-            reportStyles.default.groupDataBy = [];
+            reportStyles.default.groupDataBy = '';
             this.setState({
               reportStyles: reportStyles
             });
@@ -842,7 +842,7 @@ class Reports extends React.Component {
         rowsByIdentifier = this.state.rowsByIdentifier,
         customReport = this.state.currentCustomReport;
 
-    var groupBy = [];
+    var groupBy = '';
 
     if (!customReport && this.state.reportStyles.default.groupDataBy !== undefined)
       groupBy = this.state.reportStyles.default.groupDataBy;


### PR DESCRIPTION
## Description

The `refreshReportData` method was making unneeded calls, because for some reason the default/empty value for `groupBy` was set to be empty array (and comparing empty array to empty array failed), which doesn't make sense, as `groupBy` is just a string