### PR TITLE
Bumped redis version to 3.2.0

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -97,7 +97,7 @@ python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
-redis==3.2.0              # via celery
+redis==3.2.0
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -97,7 +97,7 @@ python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
-redis==3.0.1              # via celery
+redis==3.2.0              # via celery
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -94,7 +94,7 @@ python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
 raven==5.32.0
-redis==3.0.1              # via celery
+redis==3.2.0              # via celery
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -94,7 +94,7 @@ python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
 raven==5.32.0
-redis==3.2.0              # via celery
+redis==3.2.0
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -74,3 +74,6 @@ xlwt
 pyopenssl
 ndg-httpsclient
 pyasn1
+
+# Force new version of redis
+redis==3.2.0

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -92,7 +92,7 @@ python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
-redis==3.0.1              # via celery
+redis==3.2.0              # via celery
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -92,7 +92,7 @@ python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9
 pyxform==0.12.0
-redis==3.2.0              # via celery
+redis==3.2.0
 requests==2.21.0
 responses==0.9.0
 s3transfer==0.1.13        # via boto3


### PR DESCRIPTION
`kpi` doesn't have the same issue as `kobocat` (https://github.com/kobotoolbox/kobocat/issues/532), but it's better to keep versions synchronized. 
