### PR TITLE
Less verbose prod build

### DIFF
--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -15,5 +15,10 @@ module.exports = WebpackCommon({
     filename: '[name]-[hash].js'
   },
   // mainly for hiding stylelint output
-  stats: 'none'
+  stats: {
+    all: false,
+    maxModules: 0,
+    errors: true,
+    errorDetails: true
+  }
 });

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -4,7 +4,7 @@ const publicPath = (process.env.KPI_PREFIX === '/' ? '' : (process.env.KPI_PREFI
 const WebpackCommon = require('./webpack.common');
 
 module.exports = WebpackCommon({
-  mode: "production",
+  mode: 'production',
   entry: {
     app: './jsapp/js/main.es6',
     tests: path.resolve(__dirname, '../test/index.js')
@@ -12,6 +12,8 @@ module.exports = WebpackCommon({
   output: {
     path: path.resolve(__dirname, '../jsapp/compiled/'),
     publicPath: publicPath,
-    filename: "[name]-[hash].js"
+    filename: '[name]-[hash].js'
   },
+  // mainly for hiding stylelint output
+  stats: 'none'
 });


### PR DESCRIPTION
## Description

For production build (`npm run build`) we now only output errors.
