### PR TITLE
Travis pytest failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,4 @@ install:
   - pip install pip-tools
   - pip-sync dependencies/pip/requirements.txt
   - pip install coverage codacy-coverage python-coveralls pytest-cov
+  - pip install pytest==3.10  # Force install this version, has to be at the end

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -10,6 +10,8 @@ amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
 backports.os==0.1.1       # via path.py
 bcrypt==3.1.6             # via paramiko
 begins==0.9
@@ -59,7 +61,7 @@ drf-extensions==0.3.1
 enum34==1.1.6             # via cryptography
 fabric==2.4.0
 formencode==1.3.1         # via pyxform
-funcsigs==1.0.2           # via begins, mock
+funcsigs==1.0.2           # via begins, mock, pytest
 functools32==3.2.3.post2  # via jsonschema
 future==0.17.1            # via backports.os, django-ses
 futures==3.2.0            # via s3transfer
@@ -76,14 +78,16 @@ linecache2==1.0.0         # via traceback2
 lxml==4.3.0
 markdown==3.0.1
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 ndg-httpsclient==0.4.2
 oauthlib==1.0.3
 paramiko==2.4.2           # via fabric
 path.py==11.5.0
-pathlib2==2.3.3           # via importlib-metadata
+pathlib2==2.3.3           # via importlib-metadata, pytest
 pbr==4.0.2                # via mock
+pluggy==0.9.0             # via pytest
 psycopg2==2.7.7           # via django-jsonbfield, django-toolbelt
-py==1.4.31                # via pytest
+py==1.8.0                 # via pytest
 pyasn1==0.1.9
 pycparser==2.14           # via cffi
 pygments==2.1.3
@@ -92,7 +96,7 @@ pynacl==1.3.0             # via paramiko
 pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
-pytest==3.0.3             # via pytest-django
+pytest==3.10.0
 python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -10,6 +10,8 @@ amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
 backports.os==0.1.1       # via path.py
 begins==0.9
 billiard==3.5.0.5
@@ -57,7 +59,7 @@ docutils==0.14            # via botocore, statistics
 drf-extensions==0.3.1
 enum34==1.1.6             # via cryptography
 formencode==1.3.1         # via pyxform
-funcsigs==1.0.2           # via begins, mock
+funcsigs==1.0.2           # via begins, mock, pytest
 functools32==3.2.3.post2  # via jsonschema
 future==0.17.1            # via backports.os, django-ses
 futures==3.2.0            # via s3transfer
@@ -73,14 +75,16 @@ linecache2==1.0.0         # via traceback2
 lxml==4.3.0
 markdown==3.0.1
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 ndg-httpsclient==0.4.2
 newrelic==2.84.0.64
 oauthlib==1.0.3
 path.py==11.5.0
-pathlib2==2.3.3           # via importlib-metadata
+pathlib2==2.3.3           # via importlib-metadata, pytest
 pbr==4.0.2                # via mock
+pluggy==0.9.0             # via pytest
 psycopg2==2.7.7           # via django-jsonbfield, django-toolbelt
-py==1.4.31                # via pytest
+py==1.8.0                 # via pytest
 pyasn1==0.1.9
 pycparser==2.14           # via cffi
 pygments==2.1.3
@@ -88,7 +92,7 @@ pymongo==3.7.2
 pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
-pytest==3.0.3             # via pytest-django
+pytest==3.10.0
 python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -53,6 +53,7 @@ mock
 oauthlib
 pymongo
 pytest-django
+pytest==3.10.0
 python-dateutil
 pytz
 pyxform

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -10,6 +10,8 @@ amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
 backports.os==0.1.1       # via path.py
 begins==0.9
 billiard==3.5.0.5
@@ -57,7 +59,7 @@ docutils==0.14            # via botocore, statistics
 drf-extensions==0.3.1
 enum34==1.1.6             # via cryptography
 formencode==1.3.1         # via pyxform
-funcsigs==1.0.2           # via begins, mock
+funcsigs==1.0.2           # via begins, mock, pytest
 functools32==3.2.3.post2  # via jsonschema
 future==0.17.1            # via backports.os, django-ses
 futures==3.2.0            # via s3transfer
@@ -73,13 +75,15 @@ linecache2==1.0.0         # via traceback2
 lxml==4.3.0
 markdown==3.0.1
 mock==2.0.0
+more-itertools==5.0.0     # via pytest
 ndg-httpsclient==0.4.2
 oauthlib==1.0.3
 path.py==11.5.0
-pathlib2==2.3.3           # via importlib-metadata
+pathlib2==2.3.3           # via importlib-metadata, pytest
 pbr==4.0.2                # via mock
+pluggy==0.9.0             # via pytest
 psycopg2==2.7.7           # via django-jsonbfield, django-toolbelt
-py==1.4.31                # via pytest
+py==1.8.0                 # via pytest
 pyasn1==0.1.9
 pycparser==2.14           # via cffi
 pygments==2.1.3
@@ -87,7 +91,7 @@ pymongo==3.7.2
 pyopenssl==18.0.0
 pyquery==1.4.0
 pytest-django==3.1.2
-pytest==3.0.3             # via pytest-django
+pytest==3.10.0
 python-dateutil==2.7.5
 python-digest==1.7
 pytz==2018.9


### PR DESCRIPTION
When `travis` tries to run unit tests, it fails. 
Because `coverage` installed `pytest 4` on top requirements but tests don't pass with `pytest 4`. #2232 
`pytest 3.10` is now force installed at the end of `travis` installation. 
