### PR TITLE
hide stylelint output for test run

### DIFF
--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -9,5 +9,12 @@ module.exports = WebpackCommon({
     library: 'tests',
     path: path.resolve(__dirname, '../test/compiled/'),
     filename: 'app.js'
+  },
+  // mainly for hiding stylelint output
+  stats: {
+    all: false,
+    maxModules: 0,
+    errors: true,
+    errorDetails: true
   }
 });


### PR DESCRIPTION
## Description

I've hidden output for `npm run build` but forgot to hide for `npm run test`. Now it's fixed :heart:

