### PR TITLE
Simplify KoBoCAT user deletion kludge; fixes #2193

### DIFF
--- a/hub/actions.py
+++ b/hub/actions.py
@@ -1,7 +1,7 @@
 import requests
 from collections import OrderedDict
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.contrib.admin import helpers
@@ -116,33 +116,25 @@ delete_related_objects.short_description = ugettext_lazy(
 
 def remove_from_kobocat(modeladmin, kpi_request, queryset):
     '''
-    This is a hack to try and make administrators' lives less miserable when
-    they need to delete users. It proxies the initial delete request to KoBoCAT
-    and returns the confirmation response, mangling the HTML form action so
-    that clicking "Yes, I'm sure" POSTs to KoBoCAT instead of KPI.
+    This is a shortcut to try and make administrators' lives less miserable
+    when they need to delete users. It simply takes the list of selected users
+    (from `queryset`) and redirects to a filtered list view in the KoBoCAT
+    Django admin interface. From there, an administrator can easily select all
+    matching users and delete them.
     '''
     if not kpi_request.user.is_superuser:
         raise PermissionDenied
     if kpi_request.method != 'POST':
         raise NotImplementedError
-    post_data = dict(kpi_request.POST)
-    post_data['action'] = 'delete_selected'
     kc_url = settings.KOBOCAT_URL + kpi_request.path
-    kc_response = requests.post(kc_url, data=post_data,
-                                cookies=kpi_request.COOKIES)
-    our_response = HttpResponse()
-    our_response.status_code = kc_response.status_code
-    # I'm sorry. If something is going to break, it's probably this.
-    find_text = '<form action="" '
-    replace_text = '<form action="{kc_url}" ' \
-                   'onsubmit="return confirm(\'{hint}\');" '
-    hint = 'Confusion ahead! You will now be taken to the KoBoCAT admin ' \
-           'interface. If you want to come back here, to the KPI admin ' \
-           'interface, you must do so manually.'
-    replace_text = replace_text.format(kc_url=kc_url, hint=hint)
-    awful_content = kc_response.content.replace(find_text, replace_text)
-    our_response.write(awful_content)
-    return our_response
+    response = HttpResponseRedirect(
+        kc_url + '?pk__in=' + ','.join(
+            map(str, queryset.values_list('pk', flat=True))
+        )
+    )
+    return response
 
 remove_from_kobocat.short_description = ugettext_lazy(
-    "Remove these %(verbose_name_plural)s from KoBoCAT (deletion step 2)")
+    "View these %(verbose_name_plural)s in the KoBoCAT admin interface "
+    "(deletion step 2)"
+)


### PR DESCRIPTION
The old hack wouldn't work on a real server because of Django's CSRF protection.

This is deployed for testing at https://kf.du.kbtdev.org/admin/auth/user/.