### PR TITLE
Make it possible to drag from Library into group in Form Builder

### DIFF
--- a/jsapp/js/editorMixins/assetNavigator.es6
+++ b/jsapp/js/editorMixins/assetNavigator.es6
@@ -46,7 +46,10 @@ class AssetNavigatorListView extends React.Component {
       cursor: 'move',
       distance: 5,
       items: '> li',
-      connectWith: '.survey-editor__list',
+      connectWith: [
+        '.survey-editor__list',
+        '.group__rows'
+      ],
       opacity: 0.9,
       scroll: false,
       deactivate: ()=> {

--- a/jsapp/js/models/surveyScope.es6
+++ b/jsapp/js/models/surveyScope.es6
@@ -38,8 +38,13 @@ class SurveyScope {
       console.error('cannot add group to question library');
     }
   }
-  handleItem({position, itemData}) {
-    actions.survey.addItemAtPosition({position: position, uid: itemData.uid, survey: this.survey});
+  handleItem({position, itemData, groupId}) {
+    actions.survey.addItemAtPosition({
+      position: position,
+      uid: itemData.uid,
+      survey: this.survey,
+      groupId: groupId
+    });
   }
 }
 

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -299,10 +299,10 @@ var surveyCompanionStore = Reflux.createStore({
   init () {
     this.listenTo(actions.survey.addItemAtPosition, this.addItemAtPosition);
   },
-  addItemAtPosition ({position, survey, uid}) {
+  addItemAtPosition ({position, survey, uid, groupId}) {
     stores.allAssets.whenLoaded(uid, function(asset){
       var _s = dkobo_xlform.model.Survey.loadDict(asset.content, survey)
-      survey.insertSurvey(_s, position);
+      survey.insertSurvey(_s, position, groupId);
     });
   }
 })

--- a/jsapp/xlform/src/model.inputParser.coffee
+++ b/jsapp/xlform/src/model.inputParser.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+cloneDeep = require('lodash.clonedeep')
 $aliases = require './model.aliases'
 utils = require '../../js/utils'
 
@@ -97,7 +98,11 @@ module.exports = do ->
   inputParser.parseArr = parseArr
 
   # pass baseSurvey whenever you import other asset into existing form
-  inputParser.parse = (o, baseSurvey)->
+  inputParser.parse = (originalObj, baseSurvey)->
+    # cloning received object to avoid errors happening because
+    # of messing around with original data
+    o = cloneDeep(originalObj)
+
     translations = o.translations
 
     nullified = utils.nullifyTranslations(o.translations, o.translated, o.survey, baseSurvey)

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -223,9 +223,10 @@ module.exports = do ->
       if !parent
         parent = @
       parent.rows.add(row, {at: index})
-      # WTF: commented this line out because it looks like BAD CODE™
-      # it would be nice to know the reason for it
-      # row._parent = parent.rows
+
+      # line below looks like BAD CODE™ but in fact it enables row reordering
+      row._parent = parent.rows
+
       if opts.event
         parent.rows.trigger(opts.event)
       return

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -107,11 +107,6 @@ module.exports = do ->
               {includeGroups: true}
             )
 
-          # TODO: adding same block multiple times places it in wrong place
-          # after first time
-
-          console.log('_insertRowInPlace index_incr', index_incr)
-
           @_insertRowInPlace(
             row,
             {

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -107,6 +107,9 @@ module.exports = do ->
               {includeGroups: true}
             )
 
+          # TODO: adding same block multiple times places it in wrong place
+          # after first time
+
           @_insertRowInPlace(
             row,
             {

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -88,6 +88,7 @@ module.exports = do ->
     insertSurvey: (survey, index=-1, targetGroupId)->
       index = @rows.length if index is -1
       for row, row_i in survey.rows.models
+        # TODO: insert group into group
         index_incr = index + row_i
         if row.rows
           # item is a group

--- a/jsapp/xlform/src/model.survey.coffee
+++ b/jsapp/xlform/src/model.survey.coffee
@@ -110,6 +110,8 @@ module.exports = do ->
           # TODO: adding same block multiple times places it in wrong place
           # after first time
 
+          console.log('_insertRowInPlace index_incr', index_incr)
+
           @_insertRowInPlace(
             row,
             {

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -436,14 +436,15 @@ module.exports = do ->
           receive: (evt, ui) =>
             if ui.sender.hasClass('group__rows')
               return
-            item = ui.item.prev()
+            prevItem = ui.item.prev()
+            prevItemPosition = @getItemPosition(prevItem)
             if @ngScope.handleItem
               @ngScope.handleItem({
-                  position: @getItemPosition(item) - 1,
+                  position: prevItemPosition - 1
                   itemData: ui.item.data()
                 })
             else
-              @ngScope.add_item @getItemPosition(item) - 1
+              @ngScope.add_item @getItemPosition(prevItem) - 1
             ui.sender.sortable('cancel')
         })
       group_rows = @formEditorEl.find('.group__rows')

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -447,8 +447,8 @@ module.exports = do ->
             ui.sender.sortable('cancel')
         })
       group_rows = @formEditorEl.find('.group__rows')
-      group_rows.each (index) ->
-        $(@).sortable({
+      group_rows.each (index) =>
+        $(group_rows[index]).sortable({
           cancel: 'button, .btn--addrow, .well, ul.list-view, li.editor-message, .editableform, .row-extras, .js-cancel-sort, .js-cancel-group-sort' + index
           cursor: "move"
           distance: 5
@@ -460,6 +460,22 @@ module.exports = do ->
           stop: sortable_stop
           activate: sortable_activate_deactivate
           deactivate: sortable_activate_deactivate
+          receive: (evt, ui) =>
+            if ui.sender.hasClass('group__rows')
+              return
+            prevItem = ui.item.prev()
+            if @ngScope.handleItem
+              uiItemParentWithId = $(ui.item).parents('[data-row-id]')[0]
+              if uiItemParentWithId
+                groupId = uiItemParentWithId.dataset.rowId
+              @ngScope.handleItem({
+                  position: @getItemPosition(prevItem),
+                  itemData: ui.item.data(),
+                  groupId: groupId
+                })
+            else
+              @ngScope.add_item(@getItemPosition(prevItem))
+            ui.sender.sortable('cancel')
         })
         $(@).attr('data-sortable-index', index)
 


### PR DESCRIPTION
## Description

Changes:

- some whitespace stuff for readability
- enabling dragging from Library list into groups
- fixed `inputParse.parse` bugs caused by messing with original object data
- I had a problem with dragging the same item multiple times (consecutive items were placed at bottom of form regardless where I dropped them) - after lots of uneventful debugging, my macOS needed restarting for updates and the bug was gone 🤷‍♂️❓ Tried to reproduce it with no success - my guess is that webpack hotreload did something funky or it stopped working and I didn't notice

## Related issues

#1592

## Fun fact

1592 AD had "The Ultimate Pi Day" on 3-14-1592, it was the largest correspondence between calendar dates and significant digits of pi (`3.141592…`) ever