### PR TITLE
Hide hint for calculate questions

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -87,6 +87,9 @@ module.exports = do ->
           questionType: questionType
         }).render().insertInDOMAfter(@$header)
 
+      if questionType is 'calculate'
+        @$hint.hide()
+
       if 'getList' of @model and (cl = @model.getList())
         @$card.addClass('card--selectquestion card--expandedchoices')
         @is_expanded = true


### PR DESCRIPTION
## Description

Hides `hint` for `calculate` questions, as they will never be used.

## Related issues

Fixes #2208