### PR TITLE
Wrong version deploying bug

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -542,6 +542,13 @@ class ProjectSettings extends React.Component {
           this.applyFileToAsset(files[0], asset).then(
             (data) => {
               dataInterface.getAsset({id: data.uid}).done((finalAsset) => {
+                // TODO: Getting asset outside of actions.resources.loadAsset
+                // is not going to notify all the listeners, causing some hard
+                // to identify bugs.
+                // Until we switch this code to use actions we HACK it so other
+                // places are notified.
+                actions.resources.loadAsset.completed(finalAsset);
+
                 if (this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE) {
                   // when replacing, we omit PROJECT_DETAILS step
                   this.goToFormLanding();

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -32,7 +32,7 @@ import {
 
 import icons from '../xlform/src/view.icons';
 
-const IMPORT_CHECK_INTERVAL = 500;
+const IMPORT_CHECK_INTERVAL = 1000;
 
 var mixins = {};
 


### PR DESCRIPTION
## Description

After file upload FE is getting the fresh asset data in a very direct way, omitting all neat listeners that update all the places in the app. This fix is a oneliner hack, so in future it would be nice to rewrite file dropping code to use `actions.resources.loadAsset` :+1:

Plus I noticed we're calling BE very often during file upload (to check if upload completed), I doubled it to `1 s`.

## Related issues

Fixes #2205