### PR TITLE
Fix misaligned icon

### DIFF
--- a/jsapp/scss/components/_kobo.help-bubble.scss
+++ b/jsapp/scss/components/_kobo.help-bubble.scss
@@ -58,7 +58,7 @@ $s-help-bubble-row-spacing: 20px;
   display: block;
   font-weight: normal;
   color: $cool-silver;
-  // mimick .k-drawer__link
+  // mimic .k-drawer__link
   border-left: 3px solid transparent;
 
   .help-bubble--open & {

--- a/jsapp/scss/components/_kobo.help-bubble.scss
+++ b/jsapp/scss/components/_kobo.help-bubble.scss
@@ -58,6 +58,8 @@ $s-help-bubble-row-spacing: 20px;
   display: block;
   font-weight: normal;
   color: $cool-silver;
+  // mimick .k-drawer__link
+  border-left: 3px solid transparent;
 
   .help-bubble--open & {
     color: $cool-green;


### PR DESCRIPTION
## Description

Icon was misaligned because it missed a transparent left border 🤷‍♂ 

## Related issues

Fixes #2277