### PR TITLE
Handle anonymous users properly in `PerUserSetting`

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -10,6 +10,8 @@ from jsonbfield.fields import JSONField as JSONBField
 from jsonfield import JSONField
 from markitup.fields import MarkupField
 
+from kpi.models.object_permission import get_anonymous_user
+
 
 class SitewideMessage(models.Model):
     slug = models.CharField(max_length=50)
@@ -67,6 +69,8 @@ class PerUserSetting(models.Model):
     value_when_not_matched = models.CharField(max_length=2048, blank=True)
 
     def user_matches(self, user):
+        if user.is_anonymous():
+            user = get_anonymous_user()
         manager = user._meta.model.objects
         queryset = manager.none()
         for user_query in self.user_queries:

--- a/hub/tests/test_perusersetting.py
+++ b/hub/tests/test_perusersetting.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, AnonymousUser
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -30,6 +30,11 @@ class PerUserSettingTestCase(TestCase):
 
     def test_non_matching_user(self):
         u = self.non_matching_user
+        self.assertFalse(self.setting.user_matches(u))
+        self.assertEqual(self.setting.get_for_user(u), 'okay...')
+
+    def test_anonymous_user(self):
+        u = AnonymousUser()
         self.assertFalse(self.setting.user_matches(u))
         self.assertEqual(self.setting.get_for_user(u), 'okay...')
 


### PR DESCRIPTION
Resolves 500 error on all pages when not logged in