### PR TITLE
Gracefully handle invalid `PerUserSetting` queries

### DIFF
--- a/hub/tests/test_perusersetting.py
+++ b/hub/tests/test_perusersetting.py
@@ -17,8 +17,8 @@ class PerUserSettingTestCase(TestCase):
         self.non_matching_user = User.objects.create(username='leave_me_alone')
         self.setting = PerUserSetting.objects.create(
             name='test',
-            user_queries=[{"username__icontains": "Match"},
-                          {"email__iendswith": "MatchThis.int"}],
+            user_queries=[{'username__icontains': 'Match'},
+                          {'email__iendswith': 'MatchThis.int'}],
             value_when_matched='great!',
             value_when_not_matched='okay...',
         )
@@ -37,6 +37,14 @@ class PerUserSettingTestCase(TestCase):
         u = AnonymousUser()
         self.assertFalse(self.setting.user_matches(u))
         self.assertEqual(self.setting.get_for_user(u), 'okay...')
+
+    def test_invalid_queries(self):
+        setting = PerUserSetting()
+        setting.name = 'bogus'
+        setting.user_queries = ['not a dictionary']
+        self.assertFalse(setting.user_matches(self.non_matching_user))
+        setting.user_queries = [{'not_a_real_field': 'impossible value'}]
+        self.assertFalse(setting.user_matches(self.non_matching_user))
 
 
 class IntercomConfigurationTestCase(TestCase):


### PR DESCRIPTION
Nice to avoid `500`ing the whole site if you make a mistake with your JSON.