### PR TITLE
Less linter spam

### DIFF
--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -28,7 +28,8 @@ module.exports = WebpackCommon({
     hot: true,
     headers: {'Access-Control-Allow-Origin': '*'},
     port: 3000,
-    host: '0.0.0.0'
+    host: '0.0.0.0',
+    clientLogLevel: 'none' // disables linter warnings appearing in DevTools
   },
   plugins: [
     new StyleLintPlugin({

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -11,7 +11,7 @@ var publicDomain = isPublicDomainDefined ? process.env.KOBOFORM_PUBLIC_SUBDOMAIN
 var publicPath = 'http://' + publicDomain + ':3000/static/compiled/';
 
 module.exports = WebpackCommon({
-  mode: "development",
+  mode: 'development',
   entry: {
     app: ['react-hot-loader/patch', './jsapp/js/main.es6'],
     tests: path.resolve(__dirname, '../test/index.js')
@@ -20,7 +20,7 @@ module.exports = WebpackCommon({
     library: 'KPI',
     path: path.resolve(__dirname, '../jsapp/compiled/'),
     publicPath: publicPath,
-    filename: "[name]-[hash].js"
+    filename: '[name]-[hash].js'
   },
   devServer: {
     publicPath: publicPath,

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -24,7 +24,7 @@ var defaultOptions = {
   module: {
     rules: [
       {
-        enforce: "pre",
+        enforce: 'pre',
         test: /\.(js|jsx|es6)$/,
         exclude: /node_modules/,
         loader: 'eslint-loader',
@@ -35,8 +35,8 @@ var defaultOptions = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ["env","react"],
-            plugins: ["add-module-exports", "react-hot-loader/babel"]
+            presets: ['env', 'react'],
+            plugins: ['add-module-exports', 'react-hot-loader/babel']
           }
         }
       },
@@ -56,7 +56,7 @@ var defaultOptions = {
       },
       {
         test: /\.(png|jpg|gif|ttf|eot|svg|woff(2)?)$/,
-        use : {
+        use: {
           loader: 'file-loader',
           options: {
             name: '[name].[ext]'
@@ -83,7 +83,7 @@ var defaultOptions = {
     }),
     new BundleTracker({path: __dirname, filename: '../webpack-stats.json'})
   ]
-}
+};
 
 module.exports = function (options) {
   options = merge(defaultOptions, options || {});

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -28,6 +28,9 @@ var defaultOptions = {
         test: /\.(js|jsx|es6)$/,
         exclude: /node_modules/,
         loader: 'eslint-loader',
+        options: {
+          quiet: true
+        }
       },
       {
         test: /\.(js|jsx|es6)$/,


### PR DESCRIPTION
## Description

Disables linter warnings appearing in Dev Tools console :) Currently all of the warnings appear with every livereload change, and there are a lot of them - makes the console not very usable. Plus there is linting in the editor, which is the only place I use linter.
