### PR TITLE
Move static lists to `/environment` endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ env:
        DJANGO_DEBUG=False
        DJANGO_SECRET_KEY=ZGtvYm90cmF2aXM
        DJANGO_SETTINGS_MODULE=kobo.settings.testing
+       DJANGO_LANGUAGE_CODES="en ar es fr hi ku pl pt zh-hans"
        DATABASE_URL="postgres://postgres@localhost:5432/travis_ci_test"
        TRAVIS_NODE_VERSION="8"
        PATH=$PATH:$HOME/build/kobotoolbox/kpi/node_modules/.bin/
@@ -58,5 +59,9 @@ install:
   - pip install --upgrade 'pip>=8.0' wheel
   - pip install pip-tools
   - pip-sync dependencies/pip/requirements.txt
+  - >-
+        git submodule init &&
+        git submodule update --remote &&
+        python manage.py compilemessages
   - pip install coverage codacy-coverage python-coveralls pytest-cov pytest-django pytest-env
   - pip install pytest==3.10  # Force install this version, has to be at the end

--- a/jsapp/js/components/accountSettings.es6
+++ b/jsapp/js/components/accountSettings.es6
@@ -67,9 +67,9 @@ export class AccountSettings extends React.Component {
       instagram: currentAccount.extra_details.instagram,
       metadata: currentAccount.extra_details.metadata,
 
-      languageChoices: currentAccount.all_languages,
-      countryChoices: currentAccount.available_countries,
-      sectorChoices: currentAccount.available_sectors,
+      languageChoices: stores.session.environment.all_languages,
+      countryChoices: stores.session.environment.available_countries,
+      sectorChoices: stores.session.environment.available_sectors,
       genderChoices: [
         {
           value: 'male',

--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -98,12 +98,13 @@ class MainHeader extends Reflux.Component {
     );
   }
   renderAccountNavMenu () {
-    var langs = [];
-
+    let langs = [];
+    if (stores.session.environment) {
+      langs = stores.session.environment.interface_languages;
+    }
     if (stores.session.currentAccount) {
       var accountName = stores.session.currentAccount.username;
       var accountEmail = stores.session.currentAccount.email;
-      langs = stores.session.currentAccount.languages;
 
       var initialsStyle = {background: `#${stringToColor(accountName)}`};
       var accountMenuLabel = <bem.AccountBox__initials style={initialsStyle}>{accountName.charAt(0)}</bem.AccountBox__initials>;

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -755,8 +755,8 @@ class ProjectSettings extends React.Component {
   }
 
   renderStepProjectDetails() {
-    const sectors = session.currentAccount.available_sectors;
-    const countries = session.currentAccount.available_countries;
+    const sectors = stores.session.environment.available_sectors;
+    const countries = stores.session.environment.available_countries;
 
     return (
       <bem.FormModal__form

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -219,31 +219,33 @@ var sessionStore = Reflux.createStore({
   },
   triggerAnonymous (/*data*/) {},
   triggerEnv (environment) {
+    const nestedArrToChoiceObjs = (i) => {
+      return {
+        value: i[0],
+        label: i[1],
+      };
+    };
+    if (environment.available_sectors) {
+      environment.available_sectors = environment.available_sectors.map(
+        nestedArrToChoiceObjs);
+    }
+    if (environment.available_countries) {
+      environment.available_countries = environment.available_countries.map(
+        nestedArrToChoiceObjs);
+    }
+    if (environment.interface_languages) {
+      environment.interface_languages = environment.interface_languages.map(
+        nestedArrToChoiceObjs);
+    }
+    if (environment.all_languages) {
+      environment.all_languages = environment.all_languages.map(
+        nestedArrToChoiceObjs);
+    }
     this.environment = environment;
+    this.trigger({environment: environment});
   },
   triggerLoggedIn (acct) {
     this.currentAccount = acct;
-    var nestedArrToChoiceObjs = function (_s) {
-      return {
-        value: _s[0],
-        label: _s[1],
-      };
-    };
-    if (acct.available_sectors) {
-      acct.available_sectors = acct.available_sectors.map(
-        nestedArrToChoiceObjs);
-    }
-    if (acct.available_countries) {
-      acct.available_countries = acct.available_countries.map(
-        nestedArrToChoiceObjs);
-    }
-    if (acct.languages) {
-      acct.languages = acct.languages.map(nestedArrToChoiceObjs);
-    }
-    if (acct.all_languages) {
-      acct.all_languages = acct.all_languages.map(nestedArrToChoiceObjs);
-    }
-
     this.trigger({
       isLoggedIn: true,
       sessionIsLoggedIn: true,

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -223,27 +223,6 @@ var sessionStore = Reflux.createStore({
   },
   triggerLoggedIn (acct) {
     this.currentAccount = acct;
-    if (acct.upcoming_downtime) {
-      var downtimeString = acct.upcoming_downtime[0];
-      acct.downtimeDate = new Date(Date.parse(acct.upcoming_downtime[0]));
-      acct.downtimeMessage = acct.upcoming_downtime[1];
-      stores.pageState._onHideModal = function () {
-        window.localStorage.setItem('downtimeNoticeSeen', downtimeString);
-      }
-      if (window.localStorage['downtimeNoticeSeen'] !== downtimeString) {
-        // user has not seen the notification about upcoming downtime
-        window.setTimeout(function(){
-          stores.pageState.showModal({
-            message: acct.downtimeMessage,
-            icon: 'gears',
-          })
-        }, 1500);
-      }
-    } else {
-      if ('downtimeNoticeSeen' in window.localStorage) {
-        localStorage.removeItem('downtimeNoticeSeen');
-      }
-    }
     var nestedArrToChoiceObjs = function (_s) {
       return {
         value: _s[0],

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -44,8 +44,6 @@ if 'SECURE_PROXY_SSL_HEADER' in os.environ:
 if os.getenv("USE_X_FORWARDED_HOST", "False") == "True":
     USE_X_FORWARDED_HOST = True
 
-UPCOMING_DOWNTIME = False
-
 # Domain must not exclude KoBoCAT when sharing sessions
 if os.environ.get('CSRF_COOKIE_DOMAIN'):
     CSRF_COOKIE_DOMAIN = os.environ['CSRF_COOKIE_DOMAIN']

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -18,7 +18,6 @@ from rest_framework.pagination import LimitOffsetPagination, PageNumberPaginatio
 from rest_framework.reverse import reverse_lazy, reverse
 from taggit.models import Tag
 
-from kobo.static_lists import SECTORS, COUNTRIES, LANGUAGES
 from hub.models import SitewideMessage, ExtraUserDetail
 from .fields import PaginatedApiField, SerializerMethodFileField
 from .models import Asset
@@ -915,7 +914,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     date_joined = serializers.SerializerMethodField()
     projects_url = serializers.SerializerMethodField()
     gravatar = serializers.SerializerMethodField()
-    languages = serializers.SerializerMethodField()
     extra_details = WritableJSONField(source='extra_details.data')
     current_password = serializers.CharField(write_only=True, required=False)
     new_password = serializers.CharField(write_only=True, required=False)
@@ -935,7 +933,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             'gravatar',
             'is_staff',
             'last_login',
-            'languages',
             'extra_details',
             'current_password',
             'new_password',
@@ -957,9 +954,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     def get_gravatar(self, obj):
         return gravatar_url(obj.email)
 
-    def get_languages(self, obj):
-        return settings.LANGUAGES
-
     def get_git_rev(self, obj):
         request = self.context.get('request', False)
         if settings.EXPOSE_GIT_REV or (request and request.user.is_superuser):
@@ -971,11 +965,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         if obj.is_anonymous():
             return {'message': 'user is not logged in'}
         rep = super(CurrentUserSerializer, self).to_representation(obj)
-        # TODO: Find a better location for SECTORS and COUNTRIES
-        # as the functionality develops. (possibly in tags?)
-        rep['available_sectors'] = SECTORS
-        rep['available_countries'] = COUNTRIES
-        rep['all_languages'] = LANGUAGES
         if not rep['extra_details']:
             rep['extra_details'] = {}
         # `require_auth` needs to be read from KC every time

--- a/kpi/serializers.py
+++ b/kpi/serializers.py
@@ -971,10 +971,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         if obj.is_anonymous():
             return {'message': 'user is not logged in'}
         rep = super(CurrentUserSerializer, self).to_representation(obj)
-        if settings.UPCOMING_DOWNTIME:
-            # setting is in the format:
-            # [dateutil.parser.parse('6pm edt').isoformat(), countdown_msg]
-            rep['upcoming_downtime'] = settings.UPCOMING_DOWNTIME
         # TODO: Find a better location for SECTORS and COUNTRIES
         # as the functionality develops. (possibly in tags?)
         rep['available_sectors'] = SECTORS

--- a/kpi/tests/test_api_environment.py
+++ b/kpi/tests/test_api_environment.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# 😇
+
+from __future__ import unicode_literals
 import constance
 from django.http import HttpRequest
 from django.core.urlresolvers import reverse
@@ -11,24 +15,43 @@ class EnvironmentTests(APITestCase):
 
     def setUp(self):
         self.url = reverse('environment')
-        self.expected_dict = {
+        self.dict_checks = {
             'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,
             'privacy_policy_url': constance.config.PRIVACY_POLICY_URL,
             'source_code_url': constance.config.SOURCE_CODE_URL,
             'support_url': constance.config.SUPPORT_URL,
             'support_email': constance.config.SUPPORT_EMAIL,
+            'available_sectors': lambda x: \
+                len(x) > 10 and ("Humanitarian - Sanitation, Water & Hygiene",
+                    "Humanitarian - Sanitation, Water & Hygiene"
+                ) in x,
+            'available_countries': lambda x: \
+                len(x) > 200 and ('KEN', 'Kenya') in x,
+            'all_languages': lambda x: \
+                len(x) > 100 and ('fa', 'Persian') in x,
+            'interface_languages': lambda x: \
+                len(x) > 5 and ('ar', 'العربيّة') in x,
         }
+
+    def _check_response_dict(self, response_dict):
+        self.assertEqual(len(response_dict), len(self.dict_checks))
+        for key, callable_or_value in self.dict_checks.items():
+            try:
+                self.assertTrue(callable_or_value(response_dict[key]))
+            except TypeError:
+                self.assertEqual(response_dict[key], callable_or_value)
 
     def test_anonymous_succeeds(self):
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertDictEqual(response.data, self.expected_dict)
+        self._check_response_dict(response.data)
 
     def test_authenticated_succeeds(self):
         self.client.login(username='admin', password='pass')
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertDictEqual(response.data, self.expected_dict)
+        self._check_response_dict(response.data)
+
 
     def test_template_context_processor(self):
         ''' Not an API test, but hey: nevermind the hobgoblins '''

--- a/kpi/tests/test_api_environment.py
+++ b/kpi/tests/test_api_environment.py
@@ -22,24 +22,33 @@ class EnvironmentTests(APITestCase):
             'support_url': constance.config.SUPPORT_URL,
             'support_email': constance.config.SUPPORT_EMAIL,
             'available_sectors': lambda x: \
-                len(x) > 10 and ("Humanitarian - Sanitation, Water & Hygiene",
-                    "Humanitarian - Sanitation, Water & Hygiene"
-                ) in x,
+                self.assertGreater(len(x), 10) and self.assertIn(
+                    ("Humanitarian - Sanitation, Water & Hygiene",
+                     "Humanitarian - Sanitation, Water & Hygiene"),
+                    x
+                ),
             'available_countries': lambda x: \
-                len(x) > 200 and ('KEN', 'Kenya') in x,
+                self.assertGreater(len(x), 200) and self.assertIn(
+                    ('KEN', 'Kenya'), x
+                ),
             'all_languages': lambda x: \
-                len(x) > 100 and ('fa', 'Persian') in x,
+                self.assertGreater(len(x), 100) and self.assertIn(
+                    ('fa', 'Persian'), x
+                ),
             'interface_languages': lambda x: \
-                len(x) > 5 and ('ar', 'العربيّة') in x,
+                self.assertGreater(len(x), 5) and self.assertIn(
+                    ('ar', 'العربيّة'), x
+                ),
         }
 
     def _check_response_dict(self, response_dict):
         self.assertEqual(len(response_dict), len(self.dict_checks))
         for key, callable_or_value in self.dict_checks.items():
+            response_value = response_dict[key]
             try:
-                self.assertTrue(callable_or_value(response_dict[key]))
+                callable_or_value(response_value)
             except TypeError:
-                self.assertEqual(response_dict[key], callable_or_value)
+                self.assertEqual(response_value, callable_or_value)
 
     def test_anonymous_succeeds(self):
         response = self.client.get(self.url, format='json')

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -1394,11 +1394,18 @@ class EnvironmentView(APIView):
     ]
 
     def get(self, request, *args, **kwargs):
-        '''
+        """
         Return the lowercased key and value of each setting in
-        `CONFIGS_TO_EXPOSE`
-        '''
-        return Response({
+        `CONFIGS_TO_EXPOSE`, along with the static lists of sectors, countries,
+        all known languages, and languages for which the interface has
+        translations.
+        """
+        data = {
             key.lower(): getattr(constance.config, key)
                 for key in self.CONFIGS_TO_EXPOSE
-        })
+        }
+        data['available_sectors'] = SECTORS
+        data['available_countries'] = COUNTRIES
+        data['all_languages'] = LANGUAGES
+        data['interface_languages'] = settings.LANGUAGES
+        return Response(data)

--- a/kpi/views.py
+++ b/kpi/views.py
@@ -1,113 +1,126 @@
-from distutils.util import strtobool
-from itertools import chain
-import copy
-from hashlib import md5
-import json
 import base64
+import copy
 import datetime
+import json
+from distutils.util import strtobool
+from hashlib import md5
+from itertools import chain
 
+import constance
+from django.conf import settings
 from django.contrib.auth import login
-from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.db import transaction
-from django.db.models import Q, Count
+from django.db.models import Count, Q
 from django.forms import model_to_dict
 from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
-from django.utils.http import is_safe_url
 from django.shortcuts import get_object_or_404, resolve_url
 from django.template.response import TemplateResponse
-from django.conf import settings
-from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
+from django.utils.http import is_safe_url
 from django.utils.translation import ugettext_lazy as _
-
-
-from rest_framework import (
-    viewsets,
-    mixins,
-    renderers,
-    status,
-    exceptions,
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from private_storage.views import PrivateStorageDetailView
+from rest_framework import exceptions, mixins, renderers, status, viewsets
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    detail_route,
+    list_route,
+    renderer_classes
 )
-from rest_framework.decorators import api_view
-from rest_framework.decorators import renderer_classes
-from rest_framework.decorators import detail_route, list_route
-from rest_framework.decorators import authentication_classes
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.authtoken.models import Token
 from rest_framework.views import APIView
 from rest_framework_extensions.mixins import NestedViewSetMixin
-
-import constance
 from taggit.models import Tag
-from private_storage.views import PrivateStorageDetailView
 
-from .filters import KpiAssignedObjectPermissionsFilter
-from .filters import AssetOwnerFilterBackend
-from .filters import KpiObjectPermissionsFilter, RelatedAssetPermissionsFilter
-from .filters import SearchFilter
-from .highlighters import highlight_xform
+from deployment_backends.backends import DEPLOYMENT_BACKENDS
+from deployment_backends.mixin import KobocatDataProxyViewSetMixin
 from hub.models import SitewideMessage
+from kobo.apps.hook.utils import HookUtils
+from kobo.static_lists import COUNTRIES, LANGUAGES, SECTORS
+
+from .constants import (
+    ASSET_TYPE_ARG_NAME,
+    ASSET_TYPE_SURVEY,
+    ASSET_TYPE_TEMPLATE,
+    ASSET_TYPES,
+    CLONE_ARG_NAME,
+    CLONE_COMPATIBLE_TYPES,
+    CLONE_FROM_VERSION_ID_ARG_NAME,
+    COLLECTION_CLONE_FIELDS
+)
+from .exceptions import BadAssetTypeException
+from .filters import (
+    AssetOwnerFilterBackend,
+    KpiAssignedObjectPermissionsFilter,
+    KpiObjectPermissionsFilter,
+    RelatedAssetPermissionsFilter,
+    SearchFilter
+)
+from .highlighters import highlight_xform
+from .model_utils import disable_auto_field_update, remove_string_prefix
 from .models import (
-    Collection,
     Asset,
-    AssetVersion,
-    AssetSnapshot,
     AssetFile,
-    ImportTask,
-    ExportTask,
-    ObjectPermission,
+    AssetSnapshot,
+    AssetVersion,
     AuthorizedApplication,
+    Collection,
+    ExportTask,
+    ImportTask,
+    ObjectPermission,
     OneTimeAuthenticationKey,
-    UserCollectionSubscription,
-    )
-from .models.object_permission import get_anonymous_user, get_objects_for_user
+    UserCollectionSubscription
+)
 from .models.authorized_application import ApplicationTokenAuthentication
 from .models.import_export_task import _resolve_url_to_asset_or_collection
-from .model_utils import disable_auto_field_update, remove_string_prefix
+from .models.object_permission import get_anonymous_user, get_objects_for_user
 from .permissions import (
     IsOwnerOrReadOnly,
     PostMappedToChangePermission,
-    get_perm_name,
+    get_perm_name
 )
 from .renderers import (
     AssetJsonRenderer,
     SSJsonRenderer,
     XFormRenderer,
-    XMLRenderer,
-    XlsRenderer,)
+    XlsRenderer,
+    XMLRenderer
+)
 from .serializers import (
-    AssetSerializer, AssetListSerializer,
+    AssetFileSerializer,
+    AssetListSerializer,
+    AssetSerializer,
+    AssetSnapshotSerializer,
     AssetVersionListSerializer,
     AssetVersionSerializer,
-    AssetFileSerializer,
-    AssetSnapshotSerializer,
-    SitewideMessageSerializer,
-    CollectionSerializer, CollectionListSerializer,
-    UserSerializer,
-    CurrentUserSerializer, CreateUserSerializer,
-    TagSerializer, TagListSerializer,
-    ImportTaskSerializer, ImportTaskListSerializer,
-    ExportTaskSerializer,
-    ObjectPermissionSerializer,
     AuthorizedApplicationUserSerializer,
-    OneTimeAuthenticationKeySerializer,
+    CollectionListSerializer,
+    CollectionSerializer,
+    CreateUserSerializer,
+    CurrentUserSerializer,
     DeploymentSerializer,
-    UserCollectionSubscriptionSerializer,)
+    ExportTaskSerializer,
+    ImportTaskListSerializer,
+    ImportTaskSerializer,
+    ObjectPermissionSerializer,
+    OneTimeAuthenticationKeySerializer,
+    SitewideMessageSerializer,
+    TagListSerializer,
+    TagSerializer,
+    UserCollectionSubscriptionSerializer,
+    UserSerializer
+)
+from .tasks import export_in_background, import_in_background
 from .utils.gravatar_url import gravatar_url
 from .utils.kobo_to_xlsform import to_xlsform_structure
+from .utils.log import logging
 from .utils.ss_structure_to_mdtable import ss_structure_to_mdtable
-from .tasks import import_in_background, export_in_background
-from .constants import CLONE_ARG_NAME, CLONE_FROM_VERSION_ID_ARG_NAME, \
-    COLLECTION_CLONE_FIELDS, ASSET_TYPE_ARG_NAME, CLONE_COMPATIBLE_TYPES, \
-    ASSET_TYPE_TEMPLATE, ASSET_TYPE_SURVEY, ASSET_TYPES
-from deployment_backends.backends import DEPLOYMENT_BACKENDS
-from deployment_backends.mixin import KobocatDataProxyViewSetMixin
-from kobo.apps.hook.utils import HookUtils
-from kpi.exceptions import BadAssetTypeException
-from kpi.utils.log import logging
 
 
 @login_required


### PR DESCRIPTION
…including sectors, countries, all known languages, and languages for which the interface has translations. The latter has been renamed from `languages` to `interface_languages`. These were previously included in the `/me` endpoint.

Additional clean-ups:
* Re-sort imports per agreement with @noliveleger
* Remove obsolete downtime-notice code

Fixes #2301 