### PR TITLE
Bring back webpack console logging, drop stylelint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "spark-md5": "^3.0.0",
     "style-loader": "^0.23.0",
     "stylelint": "^9.9.0",
-    "stylelint-webpack-plugin": "^0.10.5",
     "underscore": "^1.8.3",
     "webfonts-generator": "^0.4.0",
     "webpack": "^4.20.2",

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -3,7 +3,6 @@ const path = require('path');
 const webpack = require('webpack');
 const WebpackCommon = require('./webpack.common');
 const BundleTracker = require('webpack-bundle-tracker');
-const StyleLintPlugin = require('stylelint-webpack-plugin');
 var isPublicDomainDefined = process.env.KOBOFORM_PUBLIC_SUBDOMAIN &&
   process.env.PUBLIC_DOMAIN_NAME;
 var publicDomain = isPublicDomainDefined ? process.env.KOBOFORM_PUBLIC_SUBDOMAIN
@@ -28,16 +27,9 @@ module.exports = WebpackCommon({
     hot: true,
     headers: {'Access-Control-Allow-Origin': '*'},
     port: 3000,
-    host: '0.0.0.0',
-    clientLogLevel: 'none' // disables linter warnings appearing in DevTools
+    host: '0.0.0.0'
   },
   plugins: [
-    new StyleLintPlugin({
-      failOnError: false,
-      emitErrors: true,
-      syntax: 'scss',
-      files: './jsapp/**/*.scss'
-    }),
     new BundleTracker({path: __dirname, filename: '../webpack-stats.json'}),
     new webpack.NamedModulesPlugin(),
     new webpack.HotModuleReplacementPlugin()

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const BundleTracker = require('webpack-bundle-tracker');
-const StyleLintPlugin = require('stylelint-webpack-plugin');
 var merge = require('lodash.merge');
 
 // HACK: we needed to define this postcss-loader because of a problem with
@@ -78,12 +77,6 @@ var defaultOptions = {
     }
   },
   plugins: [
-    new StyleLintPlugin({
-      failOnError: false,
-      emitErrors: true,
-      syntax: 'scss',
-      files: './jsapp/**/*.scss'
-    }),
     new BundleTracker({path: __dirname, filename: '../webpack-stats.json'})
   ]
 };


### PR DESCRIPTION
Undo silencing console output. Drop `stylelint-webpack-plugin`, as it can't do what I would like it to do. We will not have stylelint output while building, will stick to editor stylelint :+1:
