### PR TITLE
Project title fully displayed in list and sidebar, title attr added

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -664,6 +664,7 @@ export default assign({
                 type='text'
                 onChange={this.nameChange}
                 value={this.state.name}
+                title={this.state.name}
                 id='nameField'
               />
             </bem.FormModal__item>

--- a/jsapp/scss/components/_kobo.asset-row.scss
+++ b/jsapp/scss/components/_kobo.asset-row.scss
@@ -74,7 +74,6 @@ $asset-row-spacing: 6px;
   }
 
   .asset-row__description,
-  .asset-row__cell--name .asset-name,
   .asset-row__cell--date-created .date,
   .asset-row__cell--date-modified .date {
     display: block;


### PR DESCRIPTION
## Description

<!-- Description of the changes -->
The title should now be in full in the Projects list and the sidebar.
In the Form editor it now shows the tooltip on hover.

<!-- Fixes #ISSUE -->
Fixes issue #2294 

