### PR TITLE
Copy data collection (Enketo) URLs to clipboard as plain text

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -333,7 +333,7 @@ actions.resources.createImport.completed.listen(function(contents){
       notify(t('successfully uploaded file; processing may take a few minutes'));
       log('processing import ' + contents.uid, contents);
     } else {
-      notify(`unexpected import status ${contents.status}`, 'error');
+      notify(t('unexpected import status ##STATUS##').replace('##STATUS##', contents.status), 'error');
     }
   } else {
     notify(t('Error: import.status not available'));

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -264,9 +264,15 @@ export class FormLanding extends React.Component {
               </ui.PopoverMenu>
             </bem.FormView__cell>
             <bem.FormView__cell>
-              {chosenMethod != 'iframe_url' && chosenMethod != 'android' && this.state.deployment__links[chosenMethod] &&
-                <CopyToClipboard text={this.state.deployment__links[chosenMethod]} onCopy={() => notify('copied to clipboard')}>
-                  <button className='copy mdl-button mdl-button--colored'>{t('Copy')}</button>
+              {chosenMethod != 'iframe_url' && chosenMethod != 'android' &&
+               this.state.deployment__links[chosenMethod] &&
+                <CopyToClipboard text={this.state.deployment__links[chosenMethod]}
+                  onCopy={() => notify('copied to clipboard')}
+                  options={{format: 'text/plain'}}
+                >
+                  <button className='copy mdl-button mdl-button--colored'>
+                    {t('Copy')}
+                  </button>
                 </CopyToClipboard>
               }
               {chosenMethod != 'iframe_url' && chosenMethod != 'android' &&
@@ -286,8 +292,12 @@ export class FormLanding extends React.Component {
               {chosenMethod == 'iframe_url' &&
                 <CopyToClipboard
                   text={`<iframe src=${this.state.deployment__links[chosenMethod]} width="800" height="600"></iframe>`}
-                  onCopy={() => notify('copied to clipboard')}>
-                  <button className='copy mdl-button mdl-button--colored'>{t('Copy')}</button>
+                  onCopy={() => notify('copied to clipboard')}
+                  options={{format: 'text/plain'}}
+                >
+                  <button className='copy mdl-button mdl-button--colored'>
+                    {t('Copy')}
+                  </button>
                 </CopyToClipboard>
               }
             </bem.FormView__cell>

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -267,7 +267,7 @@ export class FormLanding extends React.Component {
               {chosenMethod != 'iframe_url' && chosenMethod != 'android' &&
                this.state.deployment__links[chosenMethod] &&
                 <CopyToClipboard text={this.state.deployment__links[chosenMethod]}
-                  onCopy={() => notify('copied to clipboard')}
+                  onCopy={() => notify(t('copied to clipboard'))}
                   options={{format: 'text/plain'}}
                 >
                   <button className='copy mdl-button mdl-button--colored'>
@@ -292,7 +292,7 @@ export class FormLanding extends React.Component {
               {chosenMethod == 'iframe_url' &&
                 <CopyToClipboard
                   text={`<iframe src=${this.state.deployment__links[chosenMethod]} width="800" height="600"></iframe>`}
-                  onCopy={() => notify('copied to clipboard')}
+                  onCopy={() => notify(t('copied to clipboard'))}
                   options={{format: 'text/plain'}}
                 >
                   <button className='copy mdl-button mdl-button--colored'>

--- a/jsapp/js/components/modalForms/translationSettings.es6
+++ b/jsapp/js/components/modalForms/translationSettings.es6
@@ -134,7 +134,7 @@ export class TranslationSettings extends React.Component {
       };
       dialog.set(opts).show();
     } else {
-      notify('Error: translation index mismatch. Cannot delete language.');
+      notify(t('Translation index mismatch. Cannot delete language.'), 'error');
     }
   }
   prepareTranslations(content) {

--- a/jsapp/js/mixins.es6
+++ b/jsapp/js/mixins.es6
@@ -538,7 +538,7 @@ mixins.clickAssets = {
         let onok = (evt, val) => {
           actions.resources.deleteAsset({uid: uid}, {
             onComplete: ()=> {
-              notify(`${assetTypeLabel} ${t('deleted permanently')}`);
+              notify(t('##ASSET_TYPE## deleted permanently').replace('##ASSET_TYPE##', assetTypeLabel));
               if (typeof callback === 'function') {
                 callback();
               }


### PR DESCRIPTION
It's a baby feature :baby: that closes #2333.

I saw some examples of this in the existing code:
```jsx
<LongJSXThing times="good" fun="always"
  properties="many" breaks="multiple"
  line="long" indentation="ambiguous">
  I am a thing inside LongJSXThing
```
To differentiate visually between the properties and nested content, I was tempted to use this style, where the closing `>` has its own line and the hanging indent for the properties is only one space:
```jsx
<LongJSXThing times="good" fun="always"
 properties="many" breaks="multiple"
 line="long" indentation="ambiguous"
>
  I am a thing inside LongJSXThing
```
Ultimately, I used this instead, keeping the indentation consistent but still having my closing `>` by itself:
```jsx
<LongJSXThing times="good" fun="always"
  properties="many" breaks="multiple"
  line="long" indentation="ambiguous"
>
  I am a thing inside LongJSXThing
```
All of them appeased the linter, but I'm curious to know which one you all prefer.