### PR TITLE
Owner's permissions are duplicated with bulk assignment fix.

### DIFF
--- a/kpi/serializers/v2/asset_permission.py
+++ b/kpi/serializers/v2/asset_permission.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 from collections import defaultdict
-from urlparse import urlparse
 
 from django.contrib.auth.models import Permission, User
 from django.core.urlresolvers import resolve, Resolver404
@@ -49,6 +48,9 @@ class AssetPermissionSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = validated_data['user']
         asset = validated_data['asset']
+        if asset.owner_id == user.id:
+            raise serializers.ValidationError({
+                'user': "Owner's permissions cannot be assigned explicitly"})
         permission = validated_data['permission']
         partial_permissions = validated_data.get('partial_permissions', None)
         return asset.assign_perm(user, permission.codename,

--- a/kpi/serializers/v2/collection_permission.py
+++ b/kpi/serializers/v2/collection_permission.py
@@ -40,6 +40,9 @@ class CollectionPermissionSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = validated_data['user']
         collection = validated_data['collection']
+        if collection.owner_id == user.id:
+            raise serializers.ValidationError({
+                'user': "Owner's permissions cannot be assigned explicitly"})
         permission = validated_data['permission']
         return collection.assign_perm(user, permission.codename)
 

--- a/kpi/tests/api/v2/test_api_asset_permission.py
+++ b/kpi/tests/api/v2/test_api_asset_permission.py
@@ -26,6 +26,10 @@ class BaseApiAssetPermissionTestCase(KpiTestCase):
         self.client.login(username='admin', password='pass')
         self.asset = self.create_asset('An asset to be shared')
 
+        self.admin_detail_url = reverse(
+            self._get_endpoint('user-detail'),
+            kwargs={'username': self.admin.username})
+
         self.someuser_detail_url = reverse(
             self._get_endpoint('user-detail'),
             kwargs={'username': self.someuser.username})
@@ -47,9 +51,6 @@ class BaseApiAssetPermissionTestCase(KpiTestCase):
             kwargs={'parent_lookup_asset': self.asset.uid}
         )
 
-
-class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
-
     def _logged_user_gives_permission(self, username, permission):
         """
         Uses the API to grant `permission` to `username`
@@ -61,6 +62,9 @@ class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         response = self.client.post(self.asset_permissions_list_url,
                                     data, format='json')
         return response
+
+
+class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
     def test_owner_can_give_permissions(self):
         # Current user is `self.admin`
@@ -198,3 +202,55 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         obj_perms = sorted(obj_perms, key=lambda element: (element[0],
                                                            element[1]))
         self.assertEqual(expected_perms, obj_perms)
+
+
+class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
+
+    def _logged_user_gives_permissions(self, assignments):
+        """
+        Uses the API to grant `permission` to `username`
+        """
+        url = '{}bulk/'.format(self.asset_permissions_list_url)
+
+        def get_data_template(username_, permission_):
+            return {
+                'user': getattr(self, '{}_detail_url'.format(username_)),
+                'permission': getattr(self, '{}_permission_detail_url'.format(
+                    permission_))
+            }
+
+        data = []
+        for username, permission in assignments:
+            data.append(get_data_template(username, permission))
+        response = self.client.post(url, data, format='json')
+        return response
+
+    def test_cannot_assign_permissions_to_owner(self):
+        self._logged_user_gives_permission('someuser', PERM_CHANGE_ASSET)
+        self.client.login(username='someuser', password='someuser')
+        response = self._logged_user_gives_permissions([
+            ('admin', PERM_VIEW_ASSET),
+            ('admin', PERM_CHANGE_ASSET)
+        ])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_bulk_assign_permissions(self):
+        # TODO Improve this test
+        permission_list_response = self.client.get(self.asset_permissions_list_url,
+                                                   format='json')
+        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
+        total = permission_list_response.data.get('count')
+        # Add number of permissions added with 'view_asset'
+        total += len(Asset.get_implied_perms(PERM_VIEW_ASSET)) + 1
+        # Add number of permissions added with 'change_asset'
+        total += len(Asset.get_implied_perms(PERM_CHANGE_ASSET)) + 1
+
+        response = self._logged_user_gives_permissions([
+            ('someuser', PERM_VIEW_ASSET),
+            ('someuser', PERM_VIEW_ASSET),  # Add a duplicate which should not count
+            ('anotheruser', PERM_CHANGE_ASSET)
+        ])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), total)
+


### PR DESCRIPTION
Frontend: Avoid to sending owner's assignments twice (Pending) 
Backend: Block owner's assignments.

## Related issues

Fixes #2352 
