### PR TITLE
Clean up ROOT_URL; add some temporary workarounds for `/api/v2/`

### DIFF
--- a/jsapp/js/components/permissions/publicShareSettings.es6
+++ b/jsapp/js/components/permissions/publicShareSettings.es6
@@ -36,8 +36,7 @@ class PublicShareSettings extends React.Component {
   }
   render () {
     var uid = this.props.uid;
-    var href = `${ROOT_URL}/#/forms/${uid}`;
-    var url = `${window.location.protocol}//${window.location.host}${href}`;
+    var url = `${ROOT_URL}/#/forms/${uid}`;
 
     var anonCanView = this.props.publicPerms.filter(function(perm){return perm.permission === 'view_asset';})[0];
     var anonCanViewData = this.props.publicPerms.filter(function(perm){return perm.permission === 'view_submissions';})[0];

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -1,12 +1,17 @@
 import {t} from './utils';
 
 const ROOT_URL = (() => {
-  try {
-    return document.head.querySelector('meta[name=kpi-root-url]').content.replace(/\/$/, '');
-  } catch (e) {
-    console.error('no kpi-root-url meta tag set. defaulting to ""');
-    return '';
+  // This is an "absolute path reference (a URL without the domain name)"
+  // according to the Django docs
+  let rootPath = document.head.querySelector('meta[name=kpi-root-path]');
+  if (rootPath === null) {
+    console.error('no kpi-root-path meta tag set. defaulting to ""');
+    rootPath = '';
+  } else {
+    // Strip trailing slashes
+    rootPath = rootPath.content.replace(/\/*$/, '');
   }
+  return `${window.location.protocol}//${window.location.host}${rootPath}`;
 })();
 
 const ANON_USERNAME = 'AnonymousUser';

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -124,25 +124,25 @@ var dataInterface;
     },
     getHookLogs(uid, hookUid) {
       return $ajax({
-        url: `/assets/${uid}/hooks/${hookUid}/logs/`,
+        url: `${ROOT_URL}/assets/${uid}/hooks/${hookUid}/logs/`,
         method: 'GET'
       });
     },
     getHookLog(uid, hookUid, lid) {
       return $ajax({
-        url: `/assets/${uid}/hooks/${hookUid}/logs/${lid}/`,
+        url: `${ROOT_URL}/assets/${uid}/hooks/${hookUid}/logs/${lid}/`,
         method: 'GET'
       });
     },
     retryExternalServiceLogs(uid, hookUid) {
       return $ajax({
-        url: `/assets/${uid}/hooks/${hookUid}/retry/`,
+        url: `${ROOT_URL}/assets/${uid}/hooks/${hookUid}/retry/`,
         method: 'PATCH'
       });
     },
     retryExternalServiceLog(uid, hookUid, lid) {
       return $ajax({
-        url: `/assets/${uid}/hooks/${hookUid}/logs/${lid}/retry/`,
+        url: `${ROOT_URL}/assets/${uid}/hooks/${hookUid}/logs/${lid}/retry/`,
         method: 'PATCH'
       });
     },

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -31,7 +31,7 @@ $.ajaxSetup({
     }
 });
 
-if (document.head.querySelector('meta[name=kpi-root-url]')) {
+if (document.head.querySelector('meta[name=kpi-root-path]')) {
 
   render(<RunRoutes routes={routes} />, el);
 
@@ -42,7 +42,7 @@ if (document.head.querySelector('meta[name=kpi-root-url]')) {
     });
   }
 } else {
-  console.error('no kpi-root-url meta tag set. skipping react-router init');
+  console.error('no kpi-root-path meta tag set. skipping react-router init');
 }
 
 document.addEventListener('DOMContentLoaded', (evt) => {

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -181,6 +181,10 @@ export function getUsernameFromUrl(userUrl) {
 }
 
 export function buildUserUrl(username) {
+  if (username.startsWith(window.location.protocol)) {
+    console.error("buildUserUrl() called with URL instead of username (incomplete v2 migration)");
+    return username;
+  }
   return `${ROOT_URL}/api/v2/users/${username}/`;
 }
 
@@ -192,6 +196,11 @@ export function parsePermissions(owner, permissions) {
   }
   permissions.map((perm) => {
     perm.user__username = perm.user.match(/\/users\/(.*)\//)[1];
+    const codename = perm.permission.match(/\/permissions\/(.+)\//);
+    if (codename !== null) {
+      console.error("parsePermissions(): converting new-style permission URL to codename (incomplete v2 migration)");
+      perm.permission = codename[1];
+    }
     return perm;
   }).filter((perm)=> {
     return ( perm.user__username !== owner && perm.user__username !== ANON_USERNAME);

--- a/kpi/templates/index.html
+++ b/kpi/templates/index.html
@@ -6,7 +6,8 @@
     <title>{{title}}</title>
     <meta name="description" content="koboform view">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="kpi-root-url" content="{% url 'kpi-root' %}">
+    {# From the Django documentation: the `url` tag "Returns an absolute path reference (a URL without the domain name)" #}
+    <meta name="kpi-root-path" content="{% url 'kpi-root' %}">
     {% if csrf_token %}<meta name="csrf-token" content="{{csrf_token}}">{% endif %}
 
     {% if raven_js_dsn %}


### PR DESCRIPTION
The last commit, https://github.com/kobotoolbox/kpi/commit/cf59fccb3e3050c10610acfb538b6c37e5e35b5a, is fairly ugly, but it gets the job done. I imagine it'll be cleaned up by https://github.com/kobotoolbox/kpi/issues/2328.

This stops the frontend from sending the owner's permissions when using the backend's bulk endpoint, and it fixes `Access Denied` when trying to view the summary screen as a user who is not the owner but _has_ been assigned `view_asset` and `view_submissions`.