### PR TITLE
Adding meta descriptions for public-facing page templates

### DIFF
--- a/kpi/templates/base.html
+++ b/kpi/templates/base.html
@@ -14,7 +14,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <title>KoBoToolbox {% block title %}{% endblock %}</title>
-<meta name="description" content="">
+<meta name="description" content="KoBoToolbox is a free toolkit collecting and managing data in challenging environments and is the most widely-used tool in humanitarian emergencies">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}" />
 <!-- iPhone + iPad icons -->

--- a/kpi/templates/index.html
+++ b/kpi/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{{title}}</title>
-    <meta name="description" content="koboform view">
+    <meta name="description" content="KoBoToolbox is a free toolkit collecting and managing data in challenging environments and is the most widely-used tool in humanitarian emergencies">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="kpi-root-url" content="{% url 'kpi-root' %}">
     {% if csrf_token %}<meta name="csrf-token" content="{{csrf_token}}">{% endif %}


### PR DESCRIPTION
Fixes issue #2355 by adding description to base.html and index.html to show meta description on login and registration pages.