### PR TITLE
Submissions chart now based on computer timezone, changed stats display

### DIFF
--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -78,8 +78,8 @@ class FormSummary extends React.Component {
     }
   }
   prepSubmissions(assetid) {
-    var wkStart = this.state.chartPeriod == 'week' ? moment().subtract(6, 'days') : moment().subtract(30, 'days');
-    var lastWeekStart = this.state.chartPeriod == 'week' ? moment().subtract(13, 'days') : moment().subtract(60, 'days');
+    var wkStart = this.state.chartPeriod == 'week' ? moment().startOf('days').subtract(6, 'days') : moment().startOf('days').subtract(30, 'days');
+    var lastWeekStart = this.state.chartPeriod == 'week' ? moment().startOf('days').subtract(13, 'days') : moment().startOf('days').subtract(60, 'days');
 
     const query = `query={"_submission_time": {"$gte":"${wkStart.toISOString()}"}}&fields=["_id","_submission_time"]`;
     dataInterface.getSubmissionsQuery(assetid, query).done((thisWeekSubs) => {
@@ -95,8 +95,13 @@ class FormSummary extends React.Component {
             subsPerDay = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
           thisWeekSubs.forEach(function(s, i){
-            var d = moment(s._submission_time);
-            var diff = d.diff(wkStart, 'days');
+            console.log(s);
+            // As submission times are in UTC,
+            // this will get the computer timezone difference with UTC
+            // and adapt the submission date to reflect that in the chart.
+            var d = new Date(s._submission_time);
+            var timezoneToday = moment(d.valueOf() - (d.getTimezoneOffset() * 60 * 1000));
+            var diff = timezoneToday.diff(wkStart, 'days');
             subsPerDay[diff] += 1;
           });
 
@@ -163,10 +168,10 @@ class FormSummary extends React.Component {
               <span className='subs-graph-number'>{this.state.subsCurrentPeriod}</span>
               <bem.FormView__label>
                 {this.state.chartPeriod=='week' &&
-                  `${t('Today')} - ${formatDate(moment().subtract(6, 'days'))}`
+                  `${formatDate(moment().subtract(6, 'days'))} - ${formatDate(moment())}`
                 }
                 {this.state.chartPeriod!='week' &&
-                  `${t('Today')} - ${formatDate(moment().subtract(30, 'days'))}`
+                  `${formatDate(moment().subtract(30, 'days'))} - ${formatDate(moment())}`
                 }
               </bem.FormView__label>
             </bem.FormView__cell>
@@ -174,10 +179,10 @@ class FormSummary extends React.Component {
               <span className='subs-graph-number'>{this.state.subsPreviousPeriod}</span>
               <bem.FormView__label>
                 {this.state.chartPeriod=='week' &&
-                  `${formatDate(moment().subtract(7, 'days'))} - ${formatDate(moment().subtract(13, 'days'))}`
+                  `${formatDate(moment().subtract(13, 'days'))} - ${formatDate(moment().subtract(7, 'days'))}`
                 }
                 {this.state.chartPeriod!='week' &&
-                  `${formatDate(moment().subtract(31, 'days'))} - ${formatDate(moment().subtract(60, 'days'))}`
+                  `${formatDate(moment().subtract(60, 'days'))} - ${formatDate(moment().subtract(31, 'days'))}`
                 }
               </bem.FormView__label>
             </bem.FormView__cell>

--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -95,7 +95,6 @@ class FormSummary extends React.Component {
             subsPerDay = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
           thisWeekSubs.forEach(function(s, i){
-            console.log(s);
             // As submission times are in UTC,
             // this will get the computer timezone difference with UTC
             // and adapt the submission date to reflect that in the chart.


### PR DESCRIPTION
## Description

Submissions chart showed submission dates based on their UTC time. 
They now will show depending on the computer's timezone instead.

I also changed the stats under the chart so they displayed weekly/monthly numbers (used to be "Today") and the previous period numbers have been put in the correct order.

Before
<img width="441" alt="Screen Shot 2019-08-19 at 1 58 24 PM" src="https://user-images.githubusercontent.com/1126329/63287957-8a69ac00-c289-11e9-81c2-9938a796d640.png">

After
<img width="445" alt="Screen Shot 2019-08-19 at 2 01 35 PM" src="https://user-images.githubusercontent.com/1126329/63288091-e3d1db00-c289-11e9-87c8-efc106650fd1.png">

## Related issues

<!-- Fixes #ISSUE -->
Fixes #2327 
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->

