### PR TITLE
Allow users to delete submissions when they have 'change_submissions' permission

### DIFF
--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -120,7 +120,7 @@ class SubmissionsPermissions(AssetNestedObjectsPermissions):
     Permissions for submissions
     """
 
-    MODEL_NAME = "submissions"  # Hardcode model_name to match permissions
+    MODEL_NAME = "submissions"  # Hard-code `model_name` to match permissions
     
     perms_map = {
         'GET': ['%(app_label)s.view_%(model_name)s'],
@@ -128,7 +128,7 @@ class SubmissionsPermissions(AssetNestedObjectsPermissions):
         'HEAD': ['%(app_label)s.view_%(model_name)s'],
         'POST': ['%(app_label)s.add_%(model_name)s'],
         'PATCH': ['%(app_label)s.change_%(model_name)s'],
-        'DELETE': ['%(app_label)s.delete_%(model_name)s'],
+        'DELETE': ['%(app_label)s.change_%(model_name)s'],
     }
 
     action_map = {

--- a/kpi/tests/test_api_submissions.py
+++ b/kpi/tests/test_api_submissions.py
@@ -211,7 +211,7 @@ class SubmissionApiTests(BaseTestCase):
         response = self.client.delete(url,
                                       content_type="application/json",
                                       HTTP_ACCEPT="application/json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class SubmissionEditApiTests(BaseTestCase):


### PR DESCRIPTION
## Description
There is no `delete_submissions` permission yet. When users get `change_submissions`, this implies they can edit & delete submissions 

## Related issues
Fixes #2366 
Related to #2282 