### PR TITLE
Fix exports (two-databases branch)

### DIFF
--- a/jsapp/js/components/accountSettings.es6
+++ b/jsapp/js/components/accountSettings.es6
@@ -19,6 +19,7 @@ import {
   log,
   stringToColor,
 } from '../utils';
+import {ROOT_URL} from './constants';
 
 export class AccountSettings extends React.Component {
   constructor(props){
@@ -532,7 +533,7 @@ export class ChangePassword extends React.Component {
                 onChange={this.currentPasswordChange}
               />
 
-              <a href={`${dataInterface.rootUrl}/accounts/password/reset/`}>
+              <a href={`${ROOT_URL}/accounts/password/reset/`}>
                 {t('Forgot Password?')}
               </a>
             </bem.ChangePassword__item>

--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -18,9 +18,10 @@ import {
   formatTime,
 } from '../utils';
 import {
+  ROOT_URL,
   update_states,
   ASSET_TYPES
-} from '../constants';
+} from 'js/constants';
 
 const newFormMixins = [
     Reflux.ListenerMixin,
@@ -76,11 +77,7 @@ export class ProjectDownloads extends React.Component {
     }.bind(this), 5000);
 
     if (this.state.type.indexOf('_legacy') < 0) {
-      let url = this.props.asset.deployment__data_download_links[
-        this.state.type
-      ];
       if (['xls', 'csv', 'spss_labels'].includes(this.state.type)) {
-        url = `${dataInterface.rootUrl}/exports/`; // TODO: have the backend pass the URL in the asset
         let postData = {
           source: this.props.asset.url,
           type: this.state.type,
@@ -94,12 +91,10 @@ export class ProjectDownloads extends React.Component {
             group_sep: this.state.groupSep
           });
         }
-        $.ajax({
-          method: 'POST',
-          url: url,
-          data: postData
-        }).done((data) => {
-          $.ajax({url: data.url}).then((taskData) => {
+        dataInterface.createExport(postData).done((data) => {
+          // TODO: have the backend pass this URL in the asset, so there is no
+          // need to requestExports first
+          $.ajax({url: data.url}).then(() => {
             // this.checkForFastExport(data.url);
             this.getExports();
           }).fail((taskFail) => {
@@ -111,6 +106,7 @@ export class ProjectDownloads extends React.Component {
           log('export creation failed', failData);
         });
       } else {
+        const url = this.props.asset.deployment__data_download_links[this.state.type];
         redirectTo(url);
       }
     }

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -336,6 +336,22 @@ var dataInterface;
         return $.getJSON(`${ROOT_URL}/api/v2/assets/${params.id}/`);
       }
     },
+    /**
+     * @param {object} data
+     * @param {string} [data.source]
+     * @param {string} [data.type]
+     * @param {boolean} [data.fields_from_all_versions]
+     * @param {string} [data.lang]
+     * @param {boolean} [data.hierarchy_in_labels]
+     * @param {string} [data.group_sep]
+     */
+    createExport (data) {
+      return $ajax({
+        url: `${ROOT_URL}/exports/`,
+        method: 'POST',
+        data: data
+      });
+    },
     getAssetExports (uid) {
       return $ajax({
         url: `${ROOT_URL}/exports/`,


### PR DESCRIPTION
## Description

Error caused by not updating all `dataInterface.rootUrl` when introducing `ROOT_URL` constant.

(Also fixes password reset link not working)

## Related issues

Fixes #2369