### PR TITLE
Add `label` to `AssetPermissionSerializer`…

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -521,7 +521,7 @@ class Asset(ObjectPermissionMixin,
         ASSET_TYPE_QUESTION: _('question'),
         ASSET_TYPE_TEXT: _('text'), # unused?
         ASSET_TYPE_EMPTY: _('empty'), # unused?
-        #ASSET_TYPE_COLLECTION: _('Collection'),
+        #ASSET_TYPE_COLLECTION: _('collection'),
     }
 
     # Assignable permissions that are stored in the database.

--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -81,16 +81,6 @@ class Collection(ObjectPermissionMixin, TagStringMixin, MPTTModel):
 
     # Assignable permissions that are stored in the database
     ASSIGNABLE_PERMISSIONS = (PERM_VIEW_COLLECTION, PERM_CHANGE_COLLECTION)
-
-    # Names exposed in API.
-    # Useful for FE to display human readable name for permissions
-    # TODO Merge with `ASSIGNABLE_PERMISSIONS` and use .keys() wherever
-    # `ASSIGNABLE_PERMISSIONS` is used.
-    PERMISSIONS_NAMES = {
-        PERM_VIEW_COLLECTION: _('View collection'),
-        PERM_CHANGE_COLLECTION: _('Change collection')
-    }
-
     # Calculated permissions that are neither directly assignable nor stored
     # in the database, but instead implied by assignable permissions
     CALCULATED_PERMISSIONS = (PERM_SHARE_COLLECTION, PERM_DELETE_COLLECTION)

--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -219,6 +219,10 @@ class ObjectPermission(models.Model):
     def kind(self):
         return 'objectpermission'
 
+    @property
+    def label(self):
+        return self.content_object.get_label_for_permission(self.permission)
+
     class Meta:
         unique_together = ('user', 'permission', 'deny', 'inherited',
             'object_id', 'content_type')

--- a/kpi/serializers/v2/asset_permission.py
+++ b/kpi/serializers/v2/asset_permission.py
@@ -40,10 +40,11 @@ class AssetPermissionSerializer(serializers.ModelSerializer):
             'url',
             'user',
             'permission',
-            'partial_permissions'
+            'partial_permissions',
+            'label',
         )
 
-        read_only_fields = ('uid', )
+        read_only_fields = ('uid', 'label')
 
     def create(self, validated_data):
         user = validated_data['user']

--- a/kpi/serializers/v2/permission.py
+++ b/kpi/serializers/v2/permission.py
@@ -19,7 +19,6 @@ class PermissionSerializer(serializers.ModelSerializer):
     implied = serializers.SerializerMethodField()
     contradictory = serializers.SerializerMethodField()
     name = serializers.SerializerMethodField()
-    description = serializers.SerializerMethodField()
 
     class Meta:
         model = Permission
@@ -29,11 +28,10 @@ class PermissionSerializer(serializers.ModelSerializer):
             'implied',
             'contradictory',
             'name',
-            'description'
         )
 
         read_only_fields = ('url', 'codename', 'implied', 'contradictory',
-                            'name', 'description')
+                            'name')
 
     def __init__(self, instance=None, data=empty, **kwargs):
         # Init dicts for later purpose (see below)
@@ -61,7 +59,7 @@ class PermissionSerializer(serializers.ModelSerializer):
             return contradictory_permissions.get(permission.codename, [])
         return []
 
-    def get_description(self, permission):
+    def get_name(self, permission):
         return _(permission.name)
 
     def get_implied(self, permission):
@@ -73,14 +71,6 @@ class PermissionSerializer(serializers.ModelSerializer):
         if implied_permissions:
             return implied_permissions.get(permission.codename, [])
         return []
-
-    def get_name(self, permission):
-        name = Asset.PERMISSIONS_NAMES.get(permission.codename,
-                                           Collection.PERMISSIONS_NAMES.get(
-                                               permission.codename))
-        if not name:
-            name = permission.codename.replace('_', ' ').capitalize()
-        return name
 
     @staticmethod
     def __get_key(app_label, model_name):

--- a/kpi/views/v2/permission.py
+++ b/kpi/views/v2/permission.py
@@ -45,8 +45,7 @@ class PermissionViewSet(viewsets.ReadOnlyModelViewSet):
     >                   "contradictory": [
     >                       "http://kpi/api/v2/permissions/partial_submissions/"
     >                   ],
-    >                   "name": "Change data",
-    >                   "description": "Can modify submitted data for asset"
+    >                   "name": "Can modify submitted data for asset"
     >                },
     >                ...
     >               {
@@ -54,8 +53,7 @@ class PermissionViewSet(viewsets.ReadOnlyModelViewSet):
     >                   "codename": "add_submissions",
     >                   "implied": [],
     >                   "contradictory": [],
-    >                   "name": "View collection",
-    >                   "description": "Can view collection"
+    >                   "name": "Can view collection"
     >                }
     >           ]
     >        }
@@ -81,8 +79,7 @@ class PermissionViewSet(viewsets.ReadOnlyModelViewSet):
     >                   "contradictory": [
     >                       "http://kpi/api/v2/permissions/partial_submissions/"
     >                   ],
-    >                   "name": "Change data",
-    >                   "description": "Can modify submitted data for asset"
+    >                   "name": "Can modify submitted data for asset"
     >                }
 
 


### PR DESCRIPTION
that respects the `asset_type`. Remove `name` from `PermissionSerializer` and
change `description` to `name` to match Django convention

This is the back-end work for #2316