### PR TITLE
Removing unneeded links, fixes #2390

### DIFF
--- a/kpi/templates/registration/registration_form.html
+++ b/kpi/templates/registration/registration_form.html
@@ -55,7 +55,6 @@
       {% if welcome_message %} {{ welcome_message|safe }} {% else %}
       <p>KoBoToolbox is an integrated set of tools for building forms and collecting interview responses. It is built by the Harvard Humanitarian Initiative for easy and reliable use in difficult field settings, such as humanitarian emergencies or
           post-conflict environments. <a href="http://www.kobotoolbox.org">Read more</a></p>
-      <p>You can download and install KoBoToolbox on <a href="http://support.kobotoolbox.org/customer/portal/articles/1691108-install-kobotoolbox-on-your-own-server">your own server</a> or <a href="http://support.kobotoolbox.org/customer/portal/articles/1691105-using-kobotoolbox-offline">on your own computer</a>.</p>
       {% endif %}
   </div>
   <div style="clear:both;"></div>


### PR DESCRIPTION
Both support articles linked to in the default welcome message are broken and should be removed. Whoever sees this default message already managed to install the software anyway.

Closes #2390 