### PR TITLE
Prevent default submit action that caused a bug

### DIFF
--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -336,7 +336,9 @@ class UserAssetPermsEditor extends React.Component {
     };
   }
 
-  submit() {
+  submit(evt) {
+    evt.preventDefault();
+
     if (!this.isSubmitEnabled()) {
       return;
     }
@@ -358,6 +360,8 @@ class UserAssetPermsEditor extends React.Component {
       // if nothing changes but user submits, just notify parent we're good
       this.notifyParentAboutSubmitEnd(true);
     }
+
+    return false;
   }
 
   render() {

--- a/jsapp/js/components/permissions/userCollectionPermsEditor.es6
+++ b/jsapp/js/components/permissions/userCollectionPermsEditor.es6
@@ -205,7 +205,9 @@ class UserCollectionPermissionsEditor extends React.Component {
     );
   }
 
-  submit() {
+  submit(evt) {
+    evt.preventDefault();
+
     if (!this.isSubmitEnabled()) {
       return;
     }
@@ -254,6 +256,8 @@ class UserCollectionPermissionsEditor extends React.Component {
     ) {
       this.props.onSubmitEnd(true);
     }
+
+    return false;
   }
 
   render() {


### PR DESCRIPTION
## Description

I don't know why it was seemingly random, but preventing the default event on submitting the Edit Permissions Form makes it go away.

## Related issues

Fixes #2382