### PR TITLE
Bugfix: Form Builder preview style not being set when using default

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -842,7 +842,7 @@ export default assign({
                 onChange={this.onStyleChange}
                 placeholder={AVAILABLE_FORM_STYLES[0].label}
                 options={AVAILABLE_FORM_STYLES}
-                menuPlacement='auto'
+                menuPlacement='bottom'
               />
             </bem.FormBuilderAside__row>
 

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -299,7 +299,7 @@ export default assign({
       evt.preventDefault();
     }
 
-    if (this.state.settings__style) {
+    if (this.state.settings__style !== undefined) {
       this.app.survey.settings.set('style', this.state.settings__style);
     }
 


### PR DESCRIPTION
## Description

Also fixed a small UI bug, when style select input was opening under other elements.

## Related issues

Fixes #2368 