### PR TITLE
Rename nested permissions endpoint

### DIFF
--- a/jsapp/js/components/permissions/permissionsMocks.es6
+++ b/jsapp/js/components/permissions/permissionsMocks.es6
@@ -111,147 +111,147 @@ const permissions = {
   ]
 };
 
-// /api/v2/assets/<uid>/permissions/
+// /api/v2/assets/<uid>/permission-assignments/
 const assetWithAnonymousUser = {
   'count': 7,
   'next': null,
   'previous': null,
   'results': [
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pTi9qyEax49ZA5RP9KnNHB/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pTi9qyEax49ZA5RP9KnNHB/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/add_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pATUgtDW6v44QG4dDDpnEV/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pATUgtDW6v44QG4dDDpnEV/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pUUcqTtQ6FgEDfHUiQbS24/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pUUcqTtQ6FgEDfHUiQbS24/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/p5BjfEz9JDQtQTzkT7fHA5/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/p5BjfEz9JDQtQTzkT7fHA5/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/validate_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pBjfyz5Zxj95866GtEtsR2/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pBjfyz5Zxj95866GtEtsR2/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pQGiudmuLvN6iHEdH8dJAs/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pQGiudmuLvN6iHEdH8dJAs/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pV9kCoWAQT9QUeV2EsTLqj/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pV9kCoWAQT9QUeV2EsTLqj/',
       'user': '/api/v2/users/AnonymousUser/',
       'permission': '/api/v2/permissions/view_asset/'
     }
   ]
 };
 
-// /api/v2/assets/<uid>/permissions/
+// /api/v2/assets/<uid>/permission-assignments/
 const assetWithMultipleUsers = {
   'count': 9,
   'next': null,
   'previous': null,
   'results': [
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pTi9qyEax49ZA5RP9KnNHB/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pTi9qyEax49ZA5RP9KnNHB/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/add_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pATUgtDW6v44QG4dDDpnEV/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pATUgtDW6v44QG4dDDpnEV/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pUUcqTtQ6FgEDfHUiQbS24/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pUUcqTtQ6FgEDfHUiQbS24/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/p5BjfEz9JDQtQTzkT7fHA5/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/p5BjfEz9JDQtQTzkT7fHA5/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/validate_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pBjfyz5Zxj95866GtEtsR2/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pBjfyz5Zxj95866GtEtsR2/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pQGiudmuLvN6iHEdH8dJAs/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pQGiudmuLvN6iHEdH8dJAs/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pETvxGayAJwvPaCnt5biVD/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pETvxGayAJwvPaCnt5biVD/',
       'user': '/api/v2/users/olivier/',
       'permission': '/api/v2/permissions/view_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/p6KekjhZabd7ao9MBQwN7X/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/p6KekjhZabd7ao9MBQwN7X/',
       'user': '/api/v2/users/john/',
       'permission': '/api/v2/permissions/view_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pxp7BPnP9fohF5ZoH5Uwfa/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pxp7BPnP9fohF5ZoH5Uwfa/',
       'user': '/api/v2/users/john/',
       'permission': '/api/v2/permissions/view_asset/'
     }
   ]
 };
 
-// /api/v2/assets/<uid>/permissions/
+// /api/v2/assets/<uid>/permission-assignments/
 const assetWithPartial = {
   'count': 8,
   'next': null,
   'previous': null,
   'results': [
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pTi9qyEax49ZA5RP9KnNHB/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pTi9qyEax49ZA5RP9KnNHB/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/add_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pATUgtDW6v44QG4dDDpnEV/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pATUgtDW6v44QG4dDDpnEV/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pUUcqTtQ6FgEDfHUiQbS24/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pUUcqTtQ6FgEDfHUiQbS24/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/change_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/p5BjfEz9JDQtQTzkT7fHA5/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/p5BjfEz9JDQtQTzkT7fHA5/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/validate_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pBjfyz5Zxj95866GtEtsR2/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pBjfyz5Zxj95866GtEtsR2/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pQGiudmuLvN6iHEdH8dJAs/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pQGiudmuLvN6iHEdH8dJAs/',
       'user': '/api/v2/users/kobo/',
       'permission': '/api/v2/permissions/view_submissions/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/p6KekjhZabd7ao9MBQwN7X/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/p6KekjhZabd7ao9MBQwN7X/',
       'user': '/api/v2/users/leszek/',
       'permission': '/api/v2/permissions/view_asset/'
     },
     {
-      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permissions/pxp7BPnP9fohF5ZoH5Uwfa/',
+      'url': '/api/v2/assets/arMB2dNgwewktv954wmo9e/permission-assignments/pxp7BPnP9fohF5ZoH5Uwfa/',
       'user': '/api/v2/users/leszek/',
       'permission': '/api/v2/permissions/partial_submissions/',
       'partial_permissions': [

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -213,21 +213,21 @@ var dataInterface;
 
     getAssetPermissions(assetUid) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permissions/`,
+        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permission-assignments/`,
         method: 'GET'
       });
     },
 
     getCollectionPermissions(uid) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/collections/${uid}/permissions/`,
+        url: `${ROOT_URL}/api/v2/collections/${uid}/permission-assignments/`,
         method: 'GET'
       });
     },
 
     bulkSetAssetPermissions(assetUid, perms) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permissions/bulk/`,
+        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permission-assignments/bulk/`,
         method: 'POST',
         data: JSON.stringify(perms),
         dataType: 'json',
@@ -237,7 +237,7 @@ var dataInterface;
 
     assignAssetPermission(assetUid, perm) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permissions/`,
+        url: `${ROOT_URL}/api/v2/assets/${assetUid}/permission-assignments/`,
         method: 'POST',
         data: JSON.stringify(perm),
         dataType: 'json',
@@ -247,7 +247,7 @@ var dataInterface;
 
     assignCollectionPermission(uid, perm) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/collections/${uid}/permissions/`,
+        url: `${ROOT_URL}/api/v2/collections/${uid}/permission-assignments/`,
         method: 'POST',
         data: JSON.stringify(perm),
         dataType: 'json',
@@ -264,7 +264,7 @@ var dataInterface;
 
     copyPermissionsFrom(sourceUid, targetUid) {
       return $ajax({
-        url: `${ROOT_URL}/api/v2/assets/${targetUid}/permissions/`,
+        url: `${ROOT_URL}/api/v2/assets/${targetUid}/permission-assignments/`,
         method: 'PATCH',
         data: {
           clone_from: sourceUid

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -519,8 +519,8 @@ class Asset(ObjectPermissionMixin,
         ASSET_TYPE_TEMPLATE: _('template'),
         ASSET_TYPE_BLOCK: _('block'),
         ASSET_TYPE_QUESTION: _('question'),
-        ASSET_TYPE_TEXT: _('text'), # unused?
-        ASSET_TYPE_EMPTY: _('empty'), # unused?
+        ASSET_TYPE_TEXT: _('text'),  # unused?
+        ASSET_TYPE_EMPTY: _('empty'),  # unused?
         #ASSET_TYPE_COLLECTION: _('collection'),
     }
 
@@ -543,8 +543,8 @@ class Asset(ObjectPermissionMixin,
         ASSET_TYPE_TEMPLATE: (PERM_VIEW_ASSET, PERM_CHANGE_ASSET),
         ASSET_TYPE_BLOCK: (PERM_VIEW_ASSET, PERM_CHANGE_ASSET),
         ASSET_TYPE_QUESTION: (PERM_VIEW_ASSET, PERM_CHANGE_ASSET),
-        ASSET_TYPE_TEXT: (), # unused?
-        ASSET_TYPE_EMPTY: (), # unused?
+        ASSET_TYPE_TEXT: (),  # unused?
+        ASSET_TYPE_EMPTY: (),  # unused?
         #ASSET_TYPE_COLLECTION: # tbd
     }
 
@@ -663,7 +663,6 @@ class Asset(ObjectPermissionMixin,
             return perms.get(perm)
         return None
 
-
     def get_label_for_permission(self, permission_or_codename):
         try:
             codename = permission_or_codename.codename
@@ -687,7 +686,6 @@ class Asset(ObjectPermissionMixin,
             six.text_type(self.ASSET_TYPE_LABELS[self.asset_type])
         )
         return label
-
 
     def get_partial_perms(self, user_id, with_filters=False):
         """

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -16,7 +16,7 @@ from kpi.utils.object_permission_helper import ObjectPermissionHelper
 
 from .ancestor_collections import AncestorCollectionsSerializer
 from .asset_version import AssetVersionListSerializer
-from .asset_permission import AssetPermissionSerializer
+from .asset_permission_assignment import AssetPermissionAssignmentSerializer
 
 
 class AssetSerializer(serializers.HyperlinkedModelSerializer):
@@ -276,14 +276,14 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         queryset = ObjectPermissionHelper.get_assignments_queryset(obj,
                                                                    request.user)
         # Need to pass `asset` and `asset_uid` to context of
-        # AssetPermissionSerializer serializer to avoid extra queries to DB
+        # AssetPermissionAssignmentSerializer serializer to avoid extra queries to DB
         # within the serializer to retrieve the asset object.
         context.update({'asset': obj})
         context.update({'asset_uid': obj.uid})
 
-        return AssetPermissionSerializer(queryset.all(),
-                                         many=True, read_only=True,
-                                         context=context).data
+        return AssetPermissionAssignmentSerializer(queryset.all(),
+                                                   many=True, read_only=True,
+                                                   context=context).data
 
     def _content(self, obj):
         return json.dumps(obj.content)

--- a/kpi/serializers/v2/asset_permission_assignment.py
+++ b/kpi/serializers/v2/asset_permission_assignment.py
@@ -17,7 +17,7 @@ from kpi.models.object_permission import ObjectPermission
 from kpi.utils.urls import absolute_resolve
 
 
-class AssetPermissionSerializer(serializers.ModelSerializer):
+class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
 
     url = serializers.SerializerMethodField()
     user = RelativePrefixHyperlinkedRelatedField(
@@ -79,7 +79,7 @@ class AssetPermissionSerializer(serializers.ModelSerializer):
 
     def get_url(self, object_permission):
         asset_uid = self.context.get('asset_uid')
-        return reverse('asset-permission-detail',
+        return reverse('asset-permission-assignment-detail',
                        args=(asset_uid, object_permission.uid),
                        request=self.context.get('request', None))
 
@@ -175,7 +175,8 @@ class AssetPermissionSerializer(serializers.ModelSerializer):
         """
         Doesn't display 'partial_permissions' attribute if it's `None`.
         """
-        repr_ = super(AssetPermissionSerializer, self).to_representation(instance)
+        repr_ = super(AssetPermissionAssignmentSerializer, self).\
+            to_representation(instance)
         for k, v in repr_.items():
             if k == 'partial_permissions' and v is None:
                 del repr_[k]
@@ -218,7 +219,7 @@ class AssetPermissionSerializer(serializers.ModelSerializer):
                        request=self.context.get('request', None))
 
 
-class AssetBulkInsertPermissionSerializer(AssetPermissionSerializer):
+class AssetBulkInsertPermissionSerializer(AssetPermissionAssignmentSerializer):
 
     class Meta:
         model = ObjectPermission

--- a/kpi/serializers/v2/collection.py
+++ b/kpi/serializers/v2/collection.py
@@ -13,7 +13,7 @@ from kpi.utils.object_permission_helper import ObjectPermissionHelper
 
 from .asset import AssetListSerializer
 from .ancestor_collections import AncestorCollectionsSerializer
-from .collection_permission import CollectionPermissionSerializer
+from .collection_permission_assignment import CollectionPermissionAssignmentSerializer
 
 
 class CollectionChildrenSerializer(serializers.Serializer):
@@ -130,12 +130,12 @@ class CollectionSerializer(serializers.HyperlinkedModelSerializer):
         queryset = ObjectPermissionHelper.get_assignments_queryset(obj,
                                                                    request.user)
         # Need to pass `collection` and `collection_uid` to context of
-        # `CollectionPermissionSerializer` serializer to avoid extra queries to DB
+        # `CollectionPermissionAssignmentSerializer` serializer to avoid extra queries to DB
         # within the serializer to retrieve the asset object.
         context.update({'collection': obj})
         context.update({'collection_uid': obj.uid})
 
-        return CollectionPermissionSerializer(queryset.all(),
+        return CollectionPermissionAssignmentSerializer(queryset.all(),
                                               many=True, read_only=True,
                                               context=context).data
 

--- a/kpi/serializers/v2/collection_permission_assignment.py
+++ b/kpi/serializers/v2/collection_permission_assignment.py
@@ -11,7 +11,7 @@ from kpi.models.collection import Collection
 from kpi.models.object_permission import ObjectPermission
 
 
-class CollectionPermissionSerializer(serializers.ModelSerializer):
+class CollectionPermissionAssignmentSerializer(serializers.ModelSerializer):
 
     url = serializers.SerializerMethodField()
     user = RelativePrefixHyperlinkedRelatedField(
@@ -48,7 +48,7 @@ class CollectionPermissionSerializer(serializers.ModelSerializer):
 
     def get_url(self, object_permission):
         collection_uid = self.context.get('collection_uid')
-        return reverse('collection-permission-detail',
+        return reverse('collection-permission-assignment-detail',
                        args=(collection_uid, object_permission.uid),
                        request=self.context.get('request', None))
 
@@ -85,7 +85,7 @@ class CollectionPermissionSerializer(serializers.ModelSerializer):
                        request=self.context.get('request', None))
 
 
-class CollectionBulkInsertPermissionSerializer(CollectionPermissionSerializer):
+class CollectionBulkInsertPermissionSerializer(CollectionPermissionAssignmentSerializer):
 
     class Meta:
         model = ObjectPermission

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -5,14 +5,14 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from rest_framework import status
 
-from kpi.constants import PERM_VIEW_COLLECTION, PERM_CHANGE_COLLECTION
-from kpi.models import Collection
+from kpi.constants import PERM_VIEW_ASSET, PERM_CHANGE_ASSET
+from kpi.models import Asset
 from kpi.models.object_permission import get_anonymous_user
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
 
-class BaseApiCollectionPermissionTestCase(KpiTestCase):
+class BaseApiAssetPermissionTestCase(KpiTestCase):
 
     fixtures = ["test_data"]
 
@@ -24,7 +24,7 @@ class BaseApiCollectionPermissionTestCase(KpiTestCase):
         self.anotheruser = User.objects.get(username='anotheruser')
 
         self.client.login(username='admin', password='pass')
-        self.collection = self.create_collection('A collection to be shared')
+        self.asset = self.create_asset('An asset to be shared')
 
         self.admin_detail_url = reverse(
             self._get_endpoint('user-detail'),
@@ -38,86 +38,92 @@ class BaseApiCollectionPermissionTestCase(KpiTestCase):
             self._get_endpoint('user-detail'),
             kwargs={'username': self.anotheruser.username})
 
-        self.view_collection_permission_detail_url = reverse(
+        self.view_asset_permission_detail_url = reverse(
             self._get_endpoint('permission-detail'),
-            kwargs={'codename': PERM_VIEW_COLLECTION})
+            kwargs={'codename': PERM_VIEW_ASSET})
 
-        self.change_collection_permission_detail_url = reverse(
+        self.change_asset_permission_detail_url = reverse(
             self._get_endpoint('permission-detail'),
-            kwargs={'codename': PERM_CHANGE_COLLECTION})
+            kwargs={'codename': PERM_CHANGE_ASSET})
 
-        self.collection_permissions_list_url = reverse(
-            self._get_endpoint('collection-permission-list'),
-            kwargs={'parent_lookup_collection': self.collection.uid}
+        self.asset_permissions_list_url = reverse(
+            self._get_endpoint('asset-permission-assignment-list'),
+            kwargs={'parent_lookup_asset': self.asset.uid}
         )
 
     def _logged_user_gives_permission(self, username, permission):
+        """
+        Uses the API to grant `permission` to `username`
+        """
         data = {
             'user': getattr(self, '{}_detail_url'.format(username)),
             'permission': getattr(self, '{}_permission_detail_url'.format(permission))
         }
-        response = self.client.post(self.collection_permissions_list_url,
+        response = self.client.post(self.asset_permissions_list_url,
                                     data, format='json')
         return response
 
 
-class ApiCollectionPermissionTestCase(BaseApiCollectionPermissionTestCase):
+class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
     def test_owner_can_give_permissions(self):
         # Current user is `self.admin`
-        response = self._logged_user_gives_permission('someuser', PERM_VIEW_COLLECTION)
+        response = self._logged_user_gives_permission('someuser', PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_viewers_can_not_give_permissions(self):
-        self._logged_user_gives_permission('someuser', PERM_VIEW_COLLECTION)
+        self._logged_user_gives_permission('someuser', PERM_VIEW_ASSET)
         self.client.login(username='someuser', password='someuser')
         # Current user is now: `self.someuser`
-        response = self._logged_user_gives_permission('anotheruser', PERM_VIEW_COLLECTION)
+        response = self._logged_user_gives_permission('anotheruser', PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_editors_can_give_permissions(self):
-        self._logged_user_gives_permission('someuser', PERM_CHANGE_COLLECTION)
+        self._logged_user_gives_permission('someuser', PERM_CHANGE_ASSET)
         self.client.login(username='someuser', password='someuser')
         # Current user is now: `self.someuser`
-        response = self._logged_user_gives_permission('anotheruser', PERM_VIEW_COLLECTION)
+        response = self._logged_user_gives_permission('anotheruser', PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_anonymous_can_not_give_permissions(self):
         self.client.logout()
-        response = self._logged_user_gives_permission('someuser', PERM_VIEW_COLLECTION)
+        response = self._logged_user_gives_permission('someuser', PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
-class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
+class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
+    """
+    TODO Refactor tests - Redundant codes
+    """
     fixtures = ["test_data"]
 
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     def setUp(self):
-        super(ApiCollectionPermissionListTestCase, self).setUp()
+        super(ApiAssetPermissionListTestCase, self).setUp()
 
-        self.collection.assign_perm(self.someuser, PERM_CHANGE_COLLECTION)
-        self.collection.assign_perm(self.anotheruser, PERM_VIEW_COLLECTION)
+        self.asset.assign_perm(self.someuser, PERM_CHANGE_ASSET)
+        self.asset.assign_perm(self.anotheruser, PERM_VIEW_ASSET)
 
     def test_viewers_see_only_their_own_assignments_and_owner_s(self):
 
         # Checks if can see all permissions
         self.client.login(username='anotheruser', password='anotheruser')
-        permission_list_response = self.client.get(self.collection_permissions_list_url,
+        permission_list_response = self.client.get(self.asset_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
-        admin_perms = self.collection.get_perms(self.admin)
-        anotheruser_perms = self.collection.get_perms(self.anotheruser)
+        admin_perms = self.asset.get_perms(self.admin)
+        anotheruser_perms = self.asset.get_perms(self.anotheruser)
         results = permission_list_response.data.get('results')
 
         # `anotheruser` can only see the owner's permissions `self.admin` and
         # `anotheruser`'s permissions. Should not see `someuser`s ones.
         expected_perms = []
         for admin_perm in admin_perms:
-            if admin_perm in Collection.get_assignable_permissions():
+            if admin_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.admin.username, admin_perm))
         for anotheruser_perm in anotheruser_perms:
-            if anotheruser_perm in Collection.get_assignable_permissions():
+            if anotheruser_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.anotheruser.username, anotheruser_perm))
 
         expected_perms = sorted(expected_perms, key=lambda element: (element[0],
@@ -136,24 +142,24 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
     def test_editors_see_all_assignments(self):
 
         self.client.login(username='someuser', password='someuser')
-        permission_list_response = self.client.get(self.collection_permissions_list_url,
+        permission_list_response = self.client.get(self.asset_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
-        admin_perms = self.collection.get_perms(self.admin)
-        someuser_perms = self.collection.get_perms(self.someuser)
-        anotheruser_perms = self.collection.get_perms(self.anotheruser)
+        admin_perms = self.asset.get_perms(self.admin)
+        someuser_perms = self.asset.get_perms(self.someuser)
+        anotheruser_perms = self.asset.get_perms(self.anotheruser)
         results = permission_list_response.data.get('results')
 
-        # As an editor of the collection. `someuser` should see all.
+        # As an editor of the asset. `someuser` should see all.
         expected_perms = []
         for admin_perm in admin_perms:
-            if admin_perm in Collection.get_assignable_permissions():
+            if admin_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.admin.username, admin_perm))
         for someuser_perm in someuser_perms:
-            if someuser_perm in Collection.get_assignable_permissions():
+            if someuser_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.someuser.username, someuser_perm))
         for anotheruser_perm in anotheruser_perms:
-            if anotheruser_perm in Collection.get_assignable_permissions():
+            if anotheruser_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.anotheruser.username, anotheruser_perm))
 
         expected_perms = sorted(expected_perms, key=lambda element: (element[0],
@@ -172,17 +178,17 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
     def test_anonymous_get_only_owner_s_assignments(self):
 
         self.client.logout()
-        self.collection.assign_perm(get_anonymous_user(), PERM_VIEW_COLLECTION)
-        permission_list_response = self.client.get(self.collection_permissions_list_url,
+        self.asset.assign_perm(get_anonymous_user(), PERM_VIEW_ASSET)
+        permission_list_response = self.client.get(self.asset_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
-        admin_perms = self.collection.get_perms(self.admin)
+        admin_perms = self.asset.get_perms(self.admin)
         results = permission_list_response.data.get('results')
 
-        # As an editor of the collection. `someuser` should see all.
+        # Get admin permissions.
         expected_perms = []
         for admin_perm in admin_perms:
-            if admin_perm in Collection.get_assignable_permissions():
+            if admin_perm in Asset.get_assignable_permissions():
                 expected_perms.append((self.admin.username, admin_perm))
 
         expected_perms = sorted(expected_perms, key=lambda element: (element[0],
@@ -198,13 +204,13 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
         self.assertEqual(expected_perms, obj_perms)
 
 
-class ApiBulkCollectionPermissionTestCase(BaseApiCollectionPermissionTestCase):
+class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
     def _logged_user_gives_permissions(self, assignments):
         """
         Uses the API to grant `permission` to `username`
         """
-        url = '{}bulk/'.format(self.collection_permissions_list_url)
+        url = '{}bulk/'.format(self.asset_permissions_list_url)
 
         def get_data_template(username_, permission_):
             return {
@@ -216,35 +222,35 @@ class ApiBulkCollectionPermissionTestCase(BaseApiCollectionPermissionTestCase):
         data = []
         for username, permission in assignments:
             data.append(get_data_template(username, permission))
-
         response = self.client.post(url, data, format='json')
         return response
 
     def test_cannot_assign_permissions_to_owner(self):
-        self._logged_user_gives_permission('someuser', PERM_CHANGE_COLLECTION)
+        self._logged_user_gives_permission('someuser', PERM_CHANGE_ASSET)
         self.client.login(username='someuser', password='someuser')
         response = self._logged_user_gives_permissions([
-            ('admin', PERM_VIEW_COLLECTION),
-            ('admin', PERM_CHANGE_COLLECTION)
+            ('admin', PERM_VIEW_ASSET),
+            ('admin', PERM_CHANGE_ASSET)
         ])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_bulk_assign_permissions(self):
         # TODO Improve this test
-        permission_list_response = self.client.get(self.collection_permissions_list_url,
+        permission_list_response = self.client.get(self.asset_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         total = permission_list_response.data.get('count')
-        # Add number of permissions added with 'view_collection'
-        total += len(Collection.get_implied_perms(PERM_VIEW_COLLECTION)) + 1
-        # Add number of permissions added with 'change_collection'
-        total += len(Collection.get_implied_perms(PERM_CHANGE_COLLECTION)) + 1
+        # Add number of permissions added with 'view_asset'
+        total += len(Asset.get_implied_perms(PERM_VIEW_ASSET)) + 1
+        # Add number of permissions added with 'change_asset'
+        total += len(Asset.get_implied_perms(PERM_CHANGE_ASSET)) + 1
 
         response = self._logged_user_gives_permissions([
-            ('someuser', PERM_VIEW_COLLECTION),
-            ('someuser', PERM_VIEW_COLLECTION),  # Add a duplicate which should not count
-            ('anotheruser', PERM_CHANGE_COLLECTION)
+            ('someuser', PERM_VIEW_ASSET),
+            ('someuser', PERM_VIEW_ASSET),  # Add a duplicate which should not count
+            ('anotheruser', PERM_CHANGE_ASSET)
         ])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('count'), total)
+

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -9,11 +9,11 @@ from kobo.apps.hook.views.v2.hook_signal import HookSignalViewSet
 
 from kpi.views.v2.asset import AssetViewSet
 from kpi.views.v2.asset_file import AssetFileViewSet
-from kpi.views.v2.asset_permission import AssetPermissionViewSet
+from kpi.views.v2.asset_permission_assignment import AssetPermissionAssignmentViewSet
 from kpi.views.v2.asset_snapshot import AssetSnapshotViewSet
 from kpi.views.v2.asset_version import AssetVersionViewSet
 from kpi.views.v2.collection import CollectionViewSet
-from kpi.views.v2.collection_permission import CollectionPermissionViewSet
+from kpi.views.v2.collection_permission_assignment import CollectionPermissionAssignmentViewSet
 from kpi.views.v2.data import DataViewSet
 
 from kpi.views.v2.permission import PermissionViewSet
@@ -31,9 +31,9 @@ asset_routes.register(r'files',
                       parents_query_lookups=['asset'],
                       )
 
-asset_routes.register(r'permissions',
-                      AssetPermissionViewSet,
-                      base_name='asset-permission',
+asset_routes.register(r'permission-assignments',
+                      AssetPermissionAssignmentViewSet,
+                      base_name='asset-permission-assignment',
                       parents_query_lookups=['asset'],
                       )
 
@@ -71,9 +71,9 @@ router_api_v2.register(r'asset_snapshots', AssetSnapshotViewSet)
 
 collection_routes = router_api_v2.register(r'collections', CollectionViewSet,
                                            base_name='collection')
-collection_routes.register(r'permissions',
-                           CollectionPermissionViewSet,
-                           base_name='collection-permission',
+collection_routes.register(r'permission-assignments',
+                           CollectionPermissionAssignmentViewSet,
+                           base_name='collection-permission-assignment',
                            parents_query_lookups=['collection'],
                            )
 

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -47,7 +47,7 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     <span class='label label-danger'>WARNING</span>
     Do not use the `permissions` array returned by this endpoint, as it will be
     changed or removed in an upcoming release. Instead, use
-    <b>/api/v2/assets/<code>{uid}</code>/permissions/</b> to retrieve the list
+    <b>/api/v2/assets/<code>{uid}</code>/permission-assignments/</b> to retrieve the list
     of permission assignments for a particular asset.
 
     ## List of asset endpoints

--- a/kpi/views/v2/collection_permission_assignment.py
+++ b/kpi/views/v2/collection_permission_assignment.py
@@ -11,24 +11,30 @@ from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, \
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from kpi.constants import CLONE_ARG_NAME, PERM_VIEW_ASSET, PERM_SHARE_ASSET
-from kpi.models.asset import Asset
+from kpi.constants import CLONE_ARG_NAME, PERM_SHARE_COLLECTION, \
+    PERM_VIEW_COLLECTION
+from kpi.models.collection import Collection
 from kpi.models.object_permission import ObjectPermission
-from kpi.permissions import AssetNestedObjectPermission
-from kpi.serializers.v2.asset_permission import AssetPermissionSerializer, \
-    AssetBulkInsertPermissionSerializer
+from kpi.permissions import CollectionNestedObjectPermission
+from kpi.serializers.v2.collection_permission_assignment import CollectionPermissionAssignmentSerializer, \
+    CollectionBulkInsertPermissionSerializer
 from kpi.utils.object_permission_helper import ObjectPermissionHelper
-from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
+from kpi.utils.viewset_mixins import CollectionNestedObjectViewsetMixin
 
 
-class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
-                             CreateModelMixin, RetrieveModelMixin,
-                             DestroyModelMixin, ListModelMixin,
-                             viewsets.GenericViewSet):
+class CollectionPermissionAssignmentViewSet(CollectionNestedObjectViewsetMixin,
+                                           NestedViewSetMixin,
+                                           CreateModelMixin, RetrieveModelMixin,
+                                           DestroyModelMixin, ListModelMixin,
+                                           viewsets.GenericViewSet):
+    
+    # TODO Refactor AssetPermissionAssignmentViewSet & CollectionPermissionAssignmentViewSet tox
+    # use same core.
+
     """
-    ## Permissions of an asset
+    ## Permission assignments of an collection
 
-    This endpoint shows assignments on an asset. An assignment implies:
+    This endpoint shows assignments on an collection. An assignment implies:
 
     - a `Permission` object
     - a `User` object
@@ -41,26 +47,26 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
     - Anonymous users see only owner's permissions
 
 
-    `uid` - is the unique identifier of a specific asset
+    `uid` - is the unique identifier of a specific collection
 
     **Retrieve assignments**
     <pre class="prettyprint">
-    <b>GET</b> /api/v2/assets/<code>{uid}</code>/permissions/
+    <b>GET</b> /api/v2/collections/<code>{uid}</code>/permissions/
     </pre>
 
     > Example
     >
-    >       curl -X GET https://[kpi]/assets/aSAvYreNzVEkrWg5Gdcvg/permissions/
+    >       curl -X GET https://[kpi]/collections/cSAvYreNzVEkrWg5Gdcvg/permissions/
 
 
     **Assign a permission**
     <pre class="prettyprint">
-    <b>POST</b> /api/v2/assets/<code>{uid}</code>/permissions/
+    <b>POST</b> /api/v2/collections/<code>{uid}</code>/permissions/
     </pre>
 
     > Example
     >
-    >       curl -X POST https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permissions/ \\
+    >       curl -X POST https://[kpi]/api/v2/collections/cSAvYreNzVEkrWg5Gdcvg/permissions/ \\
     >            -H 'Content-Type: application/json' \\
     >            -d '<payload>'  # Payload is sent as the string
 
@@ -72,50 +78,33 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
     >           "permission": "https://[kpi]/api/v2/permissions/{codename}/",
     >        }
 
-    > _Payload to assign partial permissions_
-    >
-    >        {
-    >           "user": "https://[kpi]/api/v2/users/{username}/",
-    >           "permission": "https://[kpi]/api/v2/permissions/{partial_permission_codename}/",
-    >           "partial_permissions": [
-    >               {
-    >                   "url": "https://[kpi]/api/v2/permissions/{codename}/",
-    >                   "filters": [
-    >                       {"_submitted_by": {"$in": ["{username}", "{username}"]}}
-    >                   ]
-    >              },
-    >           ]
-    >        }
-
     N.B.:
 
-    - Only submissions support partial (`view`) permissions so far.
-    - Filters use Mongo Query Engine to narrow down results.
-    - Implied permissions will be also assigned. (e.g. `change_asset` will add `view_asset` too)
+    - Implied permissions will be also assigned. (e.g. `change_collection` will add `view_collection` too)
 
 
 
     **Remove a permission**
 
     <pre class="prettyprint">
-    <b>DELETE</b> /api/v2/assets/<code>{uid}</code>/permissions/{permission_uid}/
+    <b>DELETE</b> /api/v2/collections/<code>{uid}</code>/permissions/{permission_uid}/
     </pre>
 
     > Example
     >
-    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permissions/pG6AeSjCwNtpWazQAX76Ap/
+    >       curl -X DELETE https://[kpi]/api/v2/collections/cSAvYreNzVEkrWg5Gdcvg/permissions/pG6AeSjCwNtpWazQAX76Ap/
 
 
     **Assign all permissions at once**
 
     <span class='label label-danger'>All permissions will erased (except the owner's) before new assignments</span>
     <pre class="prettyprint">
-    <b>POST</b> /api/v2/assets/<code>{uid}</code>/permissions/bulk/
+    <b>POST</b> /api/v2/collections/<code>{uid}</code>/permissions/bulk/
     </pre>
 
     > Example
     >
-    >       curl -X POST https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permissions/bulk/
+    >       curl -X POST https://[kpi]/api/v2/collections/cSAvYreNzVEkrWg5Gdcvg/permissions/bulk/
 
     > _Payload to assign all permissions at once_
     >
@@ -129,21 +118,21 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
     >        },...]
 
 
-    **Clone permissions from another asset**
+    **Clone permissions from another collection**
 
     <span class='label label-danger'>All permissions will erased (except the owner's) before new assignments</span>
     <pre class="prettyprint">
-    <b>PATCH</b> /api/v2/assets/<code>{uid}</code>/permissions/clone/
+    <b>PATCH</b> /api/v2/collections/<code>{uid}</code>/permissions/clone/
     </pre>
 
     > Example
     >
-    >       curl -X PATCH https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permissions/clone/
+    >       curl -X PATCH https://[kpi]/api/v2/collections/cSAvYreNzVEkrWg5Gdcvg/permissions/clone/
 
-    > _Payload to clone permissions from another asset_
+    > _Payload to clone permissions from another collection_
     >
     >        {
-    >           "clone_from": "{source_asset_uid}"
+    >           "clone_from": "{source_collection_uid}"
     >        }
 
     ### CURRENT ENDPOINT
@@ -151,14 +140,14 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
 
     model = ObjectPermission
     lookup_field = "uid"
-    serializer_class = AssetPermissionSerializer
-    permission_classes = (AssetNestedObjectPermission,)
+    serializer_class = CollectionPermissionAssignmentSerializer
+    permission_classes = (CollectionNestedObjectPermission,)
 
     @list_route(methods=['POST'], renderer_classes=[renderers.JSONRenderer],
                 url_path='bulk')
     def bulk_assignments(self, request, *args, **kwargs):
         """
-        Assigns all permissions at once for the same asset.
+        Assigns all permissions at once for the same collection.
 
         :param request:
         :return: JSON
@@ -172,33 +161,32 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
 
             # First delete all assignments before assigning new ones.
             # If something fails later, this query should rollback
-            self.asset.permissions.exclude(user__username=self.asset.owner.username).delete()
+            self.collection.permissions.exclude(
+                user__username=self.collection.owner.username).delete()
 
             for assignment in assignments:
                 context_ = dict(self.get_serializer_context())
-                if 'partial_permissions' in assignment:
-                    context_.update({'partial_permissions': assignment['partial_permissions']})
-                serializer = AssetBulkInsertPermissionSerializer(
+                serializer = CollectionBulkInsertPermissionSerializer(
                     data=assignment,
                     context=context_
                 )
                 serializer.is_valid(raise_exception=True)
-                serializer.save(asset=self.asset)
+                serializer.save(collection=self.collection)
 
-            # returns asset permissions. Users who can change permissions can
+            # returns collection permissions. Users who can change permissions can
             # see all permissions.
             return self.list(request, *args, **kwargs)
 
     @list_route(methods=['PATCH'], renderer_classes=[renderers.JSONRenderer])
     def clone(self, request, *args, **kwargs):
 
-        source_asset_uid = self.request.data[CLONE_ARG_NAME]
-        source_asset = get_object_or_404(Asset, uid=source_asset_uid)
+        source_collection_uid = self.request.data[CLONE_ARG_NAME]
+        source_collection = get_object_or_404(Collection, uid=source_collection_uid)
         user = request.user
 
-        if user.has_perm(PERM_SHARE_ASSET, self.asset) and \
-                user.has_perm(PERM_VIEW_ASSET, source_asset):
-            if not self.asset.copy_permissions_from(source_asset):
+        if user.has_perm(PERM_SHARE_COLLECTION, self.collection) and \
+                user.has_perm(PERM_VIEW_COLLECTION, source_collection):
+            if not self.collection.copy_permissions_from(source_collection):
                 http_status = status.HTTP_400_BAD_REQUEST
                 response = {'detail': _("Source and destination objects don't "
                                         "seem to have the same type")}
@@ -206,37 +194,36 @@ class AssetPermissionViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         else:
             raise exceptions.PermissionDenied()
 
-        # returns asset permissions. Users who can change permissions can
+        # returns collection permissions. Users who can change permissions can
         # see all permissions.
         return self.list(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
         object_permission = self.get_object()
         user = object_permission.user
-        if user.pk == self.asset.owner_id:
+        if user.pk == self.collection.owner_id:
             return Response({
                 'detail': _("Owner's permissions cannot be deleted")
             }, status=status.HTTP_409_CONFLICT)
 
         codename = object_permission.permission.codename
-        self.asset.remove_perm(user, codename)
+        self.collection.remove_perm(user, codename)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get_serializer_context(self):
         """
         Extra context provided to the serializer class.
-        Inject asset_uid to avoid extra queries to DB inside the serializer.
+        Inject collection_uid to avoid extra queries to DB inside the serializer.
         """
-
-        context_ = super(AssetPermissionViewSet, self).get_serializer_context()
+        context_ = super(CollectionPermissionAssignmentViewSet, self).get_serializer_context()
         context_.update({
-            'asset_uid': self.asset.uid
+            'collection_uid': self.collection.uid
         })
         return context_
 
     def get_queryset(self):
-        return ObjectPermissionHelper.get_assignments_queryset(self.asset,
+        return ObjectPermissionHelper.get_assignments_queryset(self.collection,
                                                                self.request.user)
 
     def perform_create(self, serializer):
-        serializer.save(asset=self.asset)
+        serializer.save(collection=self.collection)


### PR DESCRIPTION
## Description

To avoid misleading and confusion, nested `permissions` endpoints of `Asset` and `Collection` have been renamed from `/api/v2/assets/[asset uid]/permissions/` to `/api/v2/assets/[asset uid]/permission-assignments/`

## Related issues

Part of #2316

