### PR TITLE
Remove duplicated rank preview

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -456,7 +456,6 @@ module.exports = do ->
       template_args.rank_rows = rank_rows
       extra_score_contents = $viewTemplates.$$render('row.rankView', @, template_args)
       @$('.card--selectquestion__expansion').eq(0).append(extra_score_contents).addClass('js-cancel-select-row')
-      @$('.card--selectquestion__expansion').eq(0).append(extra_score_contents).addClass('js-cancel-select-row')
       @editRanks()
     editRanks: ->
       @$([


### PR DESCRIPTION
## Description

This bug was introduced while I was removing "beta" info from rank question (see https://github.com/kobotoolbox/kpi/commit/1197e6ced). I have not idea why I added this line there - seems like a bad case of merge conflict :-? 

## Related issues

Fixes #2421 