### PR TITLE
Feature: Finalize GeoJSON endpoint in v2 API

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -5,13 +5,15 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@eb7d723eb2b54dbfd56a1c32d72e0008bbb29149#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
+backports.csv==1.0.7
 backports.os==0.1.1       # via path.py
 backports.shutil-get-terminal-size==1.0.0  # via ipython
 bcrypt==3.1.6             # via paramiko

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -5,7 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@7bd244c43c1da64d13fd152974fa6d7b392f279c#egg=formpack
 -e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -5,11 +5,13 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@eb7d723eb2b54dbfd56a1c32d72e0008bbb29149#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
+backports.csv==1.0.7
 backports.os==0.1.1       # via path.py
 begins==0.9
 billiard==3.5.0.5

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -5,7 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@7bd244c43c1da64d13fd152974fa6d7b392f279c#egg=formpack
 -e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,8 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # Formpack
--e git+https://github.com/kobotoolbox/formpack.git@eb7d723eb2b54dbfd56a1c32d72e0008bbb29149#egg=formpack
+-e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
+-e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,8 +2,10 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # Formpack
+# NB: jnm fork of `geojson-rewind` should not be necessary after upgrading to
+# Python 3
 -e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
--e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@7bd244c43c1da64d13fd152974fa6d7b392f279c#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -5,11 +5,13 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@eb7d723eb2b54dbfd56a1c32d72e0008bbb29149#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3
 argparse==1.4.0           # via unittest2
 asn1crypto==0.24.0        # via cryptography
+backports.csv==1.0.7
 backports.os==0.1.1       # via path.py
 begins==0.9
 billiard==3.5.0.5

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -5,7 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@0eb1c921329dd187c343b61acfbec4e98450136e#egg=django_digest
--e git+https://github.com/kobotoolbox/formpack.git@200-geojson-export#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@7bd244c43c1da64d13fd152974fa6d7b392f279c#egg=formpack
 -e git+https://github.com/jnm/geojson-rewind@0.1.1+py2.jnm#egg=geojson-rewind
 amqp==2.4.0
 anyjson==0.3.3

--- a/kpi/constants.py
+++ b/kpi/constants.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 INSTANCE_FORMAT_TYPE_XML = "xml"
 INSTANCE_FORMAT_TYPE_JSON = "json"
 
+GEO_QUESTION_TYPES = ('geopoint', 'geotrace', 'geoshape')
+
 ASSET_TYPE_TEXT = 'text'
 ASSET_TYPE_EMPTY = 'empty'
 ASSET_TYPE_QUESTION = 'question'

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -370,7 +370,7 @@ class ExportTask(ImportExportTask):
     """
     An (asynchronous) submission data export job. The instantiator must set the
     `data` attribute to a dictionary with the following keys:
-    * `type`: required; `xls` or `csv`
+    * `type`: required; `xls`, `csv`, or `spss_labels`
     * `source`: required; URL of a deployed `Asset`
     * `lang`: optional; the name of the translation to be used for headers and
               response values. Specify `_xml` to use question and choice names

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -79,7 +79,7 @@ class SubmissionGeoJsonRenderer(renderers.BaseRenderer):
         if not geo_question_name:
             # No geo question specified; use the first one in the latest
             # version of the form
-            latest_version = pack.versions.values()[-1]
+            latest_version = next(reversed(pack.versions.values()))
             first_section = next(iter(latest_version.sections.values()))
             geo_questions = (field for field in first_section.fields.values()
                              if field.data_type in GEO_QUESTION_TYPES)

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -31,9 +31,11 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data/
     </pre>
 
-    By default, JSON format is used but XML format can be used too.
+    By default, JSON format is used, but XML and GeoJSON are also available:
+
     <pre class="prettyprint">
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data.xml
+    <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data.geojson
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data.json
     </pre>
 
@@ -41,12 +43,28 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
 
     <pre class="prettyprint">
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data/?format=xml
+    <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data/?format=geojson
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/data/?format=json
     </pre>
 
     > Example
     >
     >       curl -X GET https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/data/
+
+    ## About the GeoJSON format
+
+    Requesting the `geojson` format returns a `FeatureCollection` where each
+    submission is a `Feature`. If your form has multiple geographic questions,
+    use the `geo_question_name` query parameter to determine which question's
+    responses populate the `geometry` for each `Feature`; otherwise, the first
+    geographic question is used.  All question/response pairs are included in
+    the `properties` of each `Feature`, but _repeating groups are omitted_.
+
+    Question types are mapped to GeoJSON geometry types as follows:
+
+    * `geopoint` to `Point`;
+    * `geotrace` to `LineString`;
+    * `geoshape` to `Polygon`.
 
     ## CRUD
 
@@ -211,7 +229,10 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
             # `SubmissionGeoJsonRenderer` handle the rest
             return Response(
                 deployment.get_submissions(
-                    format_type=INSTANCE_FORMAT_TYPE_JSON, **filters)
+                    requesting_user_id=request.user,
+                    format_type=INSTANCE_FORMAT_TYPE_JSON,
+                    **filters
+                )
             )
 
         submissions = deployment.get_submissions(request.user.id,


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure your code lints and you followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] If this is a big feature, make sure to prefix the title with `Feature:` and add a thorough description for non-dev folk

## Description

This finalizes the GeoJSON data list API endpoint, using export logic provided by https://github.com/kobotoolbox/formpack/pull/201. It was previously deployed for testing on https://kf.geojson.s.kbtdev.org/. The endpoint is self-documenting at `https://[your-kpi-host]/api/v2/assets/[your-asset-uid]/data/`:
https://github.com/kobotoolbox/kpi/blob/76906015ebda8820fd481ab0830167bf07e73fe5/kpi/views/v2/data.py#L28-L67