### PR TITLE
Remove permission assignments pagination.

### DIFF
--- a/jsapp/js/actions/permissions.es6
+++ b/jsapp/js/actions/permissions.es6
@@ -55,8 +55,8 @@ permissionsActions.getCollectionPermissions.listen((uid) => {
  */
 permissionsActions.bulkSetAssetPermissions.listen((assetUid, perm) => {
   dataInterface.bulkSetAssetPermissions(assetUid, perm)
-    .done(() => {
-      permissionsActions.getAssetPermissions(assetUid);
+    .done((permissionAssignments) => {
+      permissionsActions.getAssetPermissions.completed(permissionAssignments);
       permissionsActions.bulkSetAssetPermissions.completed();
     })
     .fail(() => {

--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -43,10 +43,10 @@ class SharingForm extends React.Component {
     }
   }
 
-  onGetAssetPermissionsCompleted(response) {
-    const parsedPerms = permParser.parseBackendData(response.results, this.state.asset.owner);
+  onGetAssetPermissionsCompleted(permissionAssignments) {
+    const parsedPerms = permParser.parseBackendData(permissionAssignments, this.state.asset.owner);
     const anonUserUrl = buildUserUrl(ANON_USERNAME);
-    const publicPerms = response.results.filter((assignment) => {
+    const publicPerms = permissionAssignments.filter((assignment) => {
       return assignment.user === anonUserUrl;
     });
     const nonOwnerPerms = permParser.parseUserWithPermsList(parsedPerms).filter((perm) => {
@@ -60,8 +60,8 @@ class SharingForm extends React.Component {
     });
   }
 
-  onGetCollectionPermissionsCompleted(response) {
-    const parsedPerms = permParser.parseBackendData(response.results, this.state.asset.owner);
+  onGetCollectionPermissionsCompleted(permissionAssignments) {
+    const parsedPerms = permParser.parseBackendData(permissionAssignments, this.state.asset.owner);
     let nonOwnerPerms = permParser.parseUserWithPermsList(parsedPerms).filter((perm) => {
       return perm.user !== buildUserUrl(this.state.asset.owner);
     });

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -114,7 +114,7 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         admin_perms = self.asset.get_perms(self.admin)
         anotheruser_perms = self.asset.get_perms(self.anotheruser)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # `anotheruser` can only see the owner's permissions `self.admin` and
         # `anotheruser`'s permissions. Should not see `someuser`s ones.
@@ -148,7 +148,7 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         admin_perms = self.asset.get_perms(self.admin)
         someuser_perms = self.asset.get_perms(self.someuser)
         anotheruser_perms = self.asset.get_perms(self.anotheruser)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # As an editor of the asset. `someuser` should see all.
         expected_perms = []
@@ -183,7 +183,7 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         admin_perms = self.asset.get_perms(self.admin)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # Get admin permissions.
         expected_perms = []
@@ -239,7 +239,7 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         permission_list_response = self.client.get(self.asset_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
-        total = permission_list_response.data.get('count')
+        total = len(permission_list_response.data)
         # Add number of permissions added with 'view_asset'
         total += len(Asset.get_implied_perms(PERM_VIEW_ASSET)) + 1
         # Add number of permissions added with 'change_asset'
@@ -252,5 +252,5 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         ])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), total)
+        self.assertEqual(len(response.data), total)
 

--- a/kpi/tests/api/v2/test_api_collection_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_collection_permission_assignment.py
@@ -108,7 +108,7 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         admin_perms = self.collection.get_perms(self.admin)
         anotheruser_perms = self.collection.get_perms(self.anotheruser)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # `anotheruser` can only see the owner's permissions `self.admin` and
         # `anotheruser`'s permissions. Should not see `someuser`s ones.
@@ -142,7 +142,7 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
         admin_perms = self.collection.get_perms(self.admin)
         someuser_perms = self.collection.get_perms(self.someuser)
         anotheruser_perms = self.collection.get_perms(self.anotheruser)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # As an editor of the collection. `someuser` should see all.
         expected_perms = []
@@ -177,7 +177,7 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         admin_perms = self.collection.get_perms(self.admin)
-        results = permission_list_response.data.get('results')
+        results = permission_list_response.data
 
         # As an editor of the collection. `someuser` should see all.
         expected_perms = []
@@ -234,7 +234,7 @@ class ApiBulkCollectionPermissionTestCase(BaseApiCollectionPermissionTestCase):
         permission_list_response = self.client.get(self.collection_permissions_list_url,
                                                    format='json')
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
-        total = permission_list_response.data.get('count')
+        total = len(permission_list_response.data)
         # Add number of permissions added with 'view_collection'
         total += len(Collection.get_implied_perms(PERM_VIEW_COLLECTION)) + 1
         # Add number of permissions added with 'change_collection'
@@ -247,4 +247,4 @@ class ApiBulkCollectionPermissionTestCase(BaseApiCollectionPermissionTestCase):
         ])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), total)
+        self.assertEqual(len(response.data), total)

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -154,6 +154,7 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
     lookup_field = "uid"
     serializer_class = AssetPermissionAssignmentSerializer
     permission_classes = (AssetNestedObjectPermission,)
+    pagination_class = None
 
     @list_route(methods=['POST'], renderer_classes=[renderers.JSONRenderer],
                 url_path='bulk')

--- a/kpi/views/v2/collection_permission_assignment.py
+++ b/kpi/views/v2/collection_permission_assignment.py
@@ -142,6 +142,7 @@ class CollectionPermissionAssignmentViewSet(CollectionNestedObjectViewsetMixin,
     lookup_field = "uid"
     serializer_class = CollectionPermissionAssignmentSerializer
     permission_classes = (CollectionNestedObjectPermission,)
+    pagination_class = None
 
     @list_route(methods=['POST'], renderer_classes=[renderers.JSONRenderer],
                 url_path='bulk')


### PR DESCRIPTION
When number of permission assignments is greater than `PAGINATION_DEFAULT_CLASS` max items per page, some assignments are missing in the UI modal. 

This PR removes the pagination for the `AssetPermissionAssignmentViewSet`