### PR TITLE
Fix bulk delete chevron icon

### DIFF
--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -362,7 +362,7 @@ $mdl-layout-width: 1440px;
     &::after {
       content: "\F107";
       font-family: "FontAwesome";
-      margin-left: 5px;
+      margin-left: 3px;
     }
   }
 

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -360,11 +360,9 @@ $mdl-layout-width: 1440px;
     }
 
     &::after {
-      content: "\2304";
-      font-size: 33px;
-      line-height: 34px;
-      display: inline-block;
-      vertical-align: top;
+      content: "\F107";
+      font-family: "FontAwesome";
+      margin-left: 5px;
     }
   }
 

--- a/jsapp/scss/components/_kobo.table.scss
+++ b/jsapp/scss/components/_kobo.table.scss
@@ -15,7 +15,8 @@
 
     .form-view__item--table-meta {
       flex-grow: 1;
-      line-height: 40px;
+      line-height: 20px;
+      padding: 10px 0;
 
       > *:not(:first-child)::before {
         content: "·";


### PR DESCRIPTION
## Description

Now it will look like this:
<img width="460" alt="Screenshot 2019-10-30 at 21 51 16" src="https://user-images.githubusercontent.com/2521888/67897947-acbc5780-fb5f-11e9-84d0-4d7fd74a8933.png">

## Related issues

Fixes https://www.flowdock.com/app/kobotoolbox/ux-ui/threads/1fyGHf2XcxFz1t3-BBn2kP-8V-2
