### PR TITLE
Invalidate sessions on password change

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -105,9 +105,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    # TODO: Uncomment this when interoperability with dkobo is no longer
-    # needed. See https://code.djangoproject.com/ticket/21649
-    # 'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'hub.middleware.UsernameInResponseHeaderMiddleware',

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -2,6 +2,7 @@
 import datetime
 import pytz
 
+from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.conf import settings
@@ -101,13 +102,16 @@ class CurrentUserSerializer(serializers.ModelSerializer):
                 if instance.check_password(current_password):
                     instance.set_password(new_password)
                     instance.save()
+                    request = self.context.get('request', False)
+                    if request:
+                        update_session_auth_hash(request, instance)
                 else:
                     raise serializers.ValidationError({
                         'current_password': 'Incorrect current password.'
                     })
         elif any((current_password, new_password)):
             raise serializers.ValidationError(
-                'current_password and new_password must both be sent ' \
+                'current_password and new_password must both be sent '
                 'together; one or the other cannot be sent individually.'
             )
         return super().update(


### PR DESCRIPTION
It makes all (other) sessions invalid when users change their password. 

Closes #2258 