### PR TITLE
Asset cannot be deleted if it has active REST Services

### DIFF
--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from .base import *
 
-# For tests, don't use KoBoCat's DB
+# For tests, don't use KoBoCAT's DB
 DATABASES = {
     'default': dj_database_url.config(default='sqlite:///%s/db.sqlite3' % BASE_DIR),
 }

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -308,7 +308,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'downloadable': bool(active)
         }
         json_response = self._kobocat_request('PATCH', url, data=payload)
-        assert(json_response['downloadable'] == bool(active))
+        assert json_response['downloadable'] == bool(active)
         self.store_data({
             'active': json_response['downloadable'],
             'backend_response': json_response,
@@ -362,10 +362,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
         try:
             json_response = self._kobocat_request('PATCH', url, data=payload)
-            assert (json_response['has_kpi_hooks'] == has_active_hooks)
-            self.store_data({
-                'backend_response': json_response,
-            })
         except KobocatDeploymentException as e:
             if (
                 has_active_hooks is False
@@ -377,6 +373,11 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 pass
             else:
                 raise
+        else:
+            assert json_response['has_kpi_hooks'] == has_active_hooks
+            self.store_data({
+                'backend_response': json_response,
+            })
 
     def delete(self):
         """

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -317,7 +317,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     def set_asset_uid(self, force=False):
         """
         Link KoBoCAT `XForm` back to its corresponding KPI `Asset` by
-        populating the `kpi_asset_uid` field (use KoBoCat proxy to PATCH XForm).
+        populating the `kpi_asset_uid` field (use KoBoCAT proxy to PATCH XForm).
         Useful when a form is created from the legacy upload form.
         Store results in self.asset._deployment_data
 
@@ -347,7 +347,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     def set_has_kpi_hooks(self):
         """
         PATCH `has_kpi_hooks` boolean of survey.
-        It lets KoBoCat know whether it needs to ping KPI
+        It lets KoBoCAT know whether it needs to ping KPI
         each time a submission comes in.
 
         Store results in self.asset._deployment_data
@@ -388,7 +388,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
     def delete_submission(self, pk, user):
         """
-        Deletes submission through `KoBoCat` proxy
+        Deletes submission through KoBoCAT proxy
         :param pk: int
         :param user: User
         :return: dict
@@ -401,7 +401,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
     def delete_submissions(self, data, user):
         """
-        Deletes submissions through `KoBoCat` proxy
+        Deletes submissions through KoBoCAT proxy
         :param user: User
         :return: dict
         """
@@ -735,7 +735,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         except ValueError as e:
             if not requests_response.status_code == status.HTTP_204_NO_CONTENT:
                 prepared_drf_response['data'] = {
-                    'detail': _('KoBoCat returned an unexpected response: {}'.format(str(e)))
+                    'detail': _('KoBoCAT returned an unexpected response: {}'.format(str(e)))
                 }
 
         return prepared_drf_response

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -347,7 +347,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     def set_has_kpi_hooks(self):
         """
         PATCH `has_kpi_hooks` boolean of survey.
-        It lets `kc` know whether it needs to ping `kpi`
+        It lets KoBoCat know whether it needs to ping KPI
         each time a submission comes in.
 
         Store results in self.asset._deployment_data
@@ -359,11 +359,17 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'has_kpi_hooks': has_active_hooks,
             'kpi_asset_uid': self.asset.uid
         }
-        json_response = self._kobocat_request('PATCH', url, data=payload)
-        assert(json_response['has_kpi_hooks'] == has_active_hooks)
-        self.store_data({
-            'backend_response': json_response,
-        })
+
+        try:
+            json_response = self._kobocat_request('PATCH', url, data=payload)
+            assert (json_response['has_kpi_hooks'] == has_active_hooks)
+            self.store_data({
+                'backend_response': json_response,
+            })
+        except KobocatDeploymentException as e:
+            if not (has_active_hooks is False and hasattr(e, 'response') and
+                    e.response.status_code != status.HTTP_404_NOT_FOUND):
+                raise e
 
     def delete(self):
         """

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -115,7 +115,7 @@ def tag_uid_post_save(sender, instance, created, raw, **kwargs):
     TagUid.objects.get_or_create(tag=instance)
 
 
-@receiver([post_save, post_delete], sender=Hook)
+@receiver(post_save, sender=Hook)
 def update_kc_xform_has_kpi_hooks(sender, instance, **kwargs):
     """
     Updates `kc.XForm` instance as soon as Asset.Hook list is updated.

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -31,7 +31,7 @@ class MongoHelper:
         (re.compile(base64_encodestring('.').strip()), '.'),
     ]
 
-    # Match KoBoCat's variables of ParsedInstance class
+    # Match KoBoCAT's variables of ParsedInstance class
     USERFORM_ID = '_userform_id'
     DEFAULT_BATCHSIZE = 1000
 


### PR DESCRIPTION
Applied change suggested in #2497 but also removed `post_delete` signal which was IMHO useless.

Closes #2497 
