### PR TITLE
Add KPI identifier to service_health response

### DIFF
--- a/kobo/apps/service_health/views.py
+++ b/kobo/apps/service_health/views.py
@@ -17,7 +17,7 @@ def get_response(url_):
     try:
         response_ = requests.get(url_, timeout=45)
         response_.raise_for_status()
-        content = response_.content
+        content = response_.text
     except Exception as e:
         response_ = None
         message = repr(e)
@@ -74,7 +74,7 @@ def service_health(request):
     kobocat_time = time.time() - t0
 
     output = (
-        '{}\r\n\r\n'
+        '{} KPI\r\n\r\n'
         'Mongo: {} in {:.3} seconds\r\n'
         'Postgres: {} in {:.3} seconds\r\n'
         'Enketo [{}]: {} in {:.3} seconds\r\n'


### PR DESCRIPTION
and use the KoBoCAT response `text` (a `str`) instead of the `content`, which is `bytes`.

The KPI identifier should help us quickly identify (through an uptime monitoring tool) any problem that causes NGINX to use stale hostname resolutions for `proxy_pass`. Not official documentation, but:
> Nginx resolves the address defined in the proxy_pass directive just once — on startup. (https://medium.com/driven-by-code/dynamic-dns-resolution-in-nginx-22133c22e3ab)

Discussion:
https://www.flowdock.com/app/kobotoolbox/kobo/threads/bH41Cw_DamKEU7swXGwfGgFQNFR
https://www.flowdock.com/app/kobotoolbox/servers/threads/xSo4amQqWTRHd4fZ2_V3vO8ZDmF