### PR TITLE
Add checks for two-database upgrade problems

### DIFF
--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -1,6 +1,13 @@
 # coding: utf-8
 from django.apps import AppConfig
+from django.core.checks import register, Tags
+
+from kpi.utils.two_database_configuration_checker import \
+    TwoDatabaseConfigurationChecker
 
 
 class KpiConfig(AppConfig):
     name = 'kpi'
+
+
+register(TwoDatabaseConfigurationChecker().as_check(), Tags.database)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -196,12 +196,12 @@ SKIP_HEAVY_MIGRATIONS = os.environ.get('SKIP_HEAVY_MIGRATIONS', 'False') == 'Tru
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 
-kobocat_database_url = os.getenv("KC_DATABASE_URL", "sqlite:///%s/db.sqlite3" % BASE_DIR)
-
 DATABASES = {
     'default': dj_database_url.config(default="sqlite:///%s/db.sqlite3" % BASE_DIR),
-    'kobocat': dj_database_url.parse(kobocat_database_url)
 }
+kobocat_database_url = os.getenv('KC_DATABASE_URL')
+if kobocat_database_url:
+    DATABASES['kobocat'] = dj_database_url.parse(kobocat_database_url)
 
 DATABASE_ROUTERS = ['kpi.db_routers.DefaultDatabaseRouter']
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -203,12 +203,7 @@ DATABASES = {
     'kobocat': dj_database_url.parse(kobocat_database_url)
 }
 
-USE_SAME_DATABASE = DATABASES['default'] == DATABASES['kobocat']
-
 DATABASE_ROUTERS = ['kpi.db_routers.DefaultDatabaseRouter']
-if USE_SAME_DATABASE is True:
-    DATABASE_ROUTERS = ['kpi.db_routers.SingleDatabaseRouter']
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/kpi/management/commands/is_database_empty.py
+++ b/kpi/management/commands/is_database_empty.py
@@ -72,5 +72,7 @@ class Command(BaseCommand):
             except OperationalError as e:
                 if str(e).strip().endswith('does not exist'):
                     results.append(True)
+                else:
+                    raise
 
         self.stdout.write('\t'.join([str(x) for x in results]))

--- a/kpi/management/commands/is_database_empty.py
+++ b/kpi/management/commands/is_database_empty.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connections
+from django.db.utils import ConnectionDoesNotExist, OperationalError
+
+
+class Command(BaseCommand):
+    help = (
+        'Determine if one or more databases are empty, returning a '
+        'tab-separated list of True or False. Non-existent databases are '
+        'considered empty.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'database',
+            type=str,
+            nargs='+',
+            help='a database configured in django.conf.settings.DATABASES'
+        )
+
+    @staticmethod
+    def test_table_exists_and_has_any_row(cursor, table):
+        cursor.execute(
+            'SELECT (1) AS "exists" FROM "pg_tables" '
+            'WHERE "tablename" = %s '
+            'LIMIT 1;', [table]
+        )
+        if not cursor.fetchone():
+            return False
+
+        cursor.execute(
+            f'SELECT (1) AS "exists" FROM "{table}" LIMIT 1;'
+        )
+        return cursor.fetchone() is not None
+
+    def handle(self, *args, **options):
+        connection_keys = options.get('database')
+        connection_keys = [
+            # For convenience, allow 'kpi' to be an alias for 'default'
+            'default' if x == 'kpi' else x for x in connection_keys
+        ]
+
+        table_to_test_for_connection_key = {
+            'default': 'kpi_asset',
+            'kobocat': 'logger_xform',
+        }
+
+        results = []
+        for connection_key in connection_keys:
+            try:
+                connection = connections[connection_key]
+            except ConnectionDoesNotExist:
+                raise CommandError(
+                    f'{connection_key} is not a configured database'
+                )
+            try:
+                table_to_test = table_to_test_for_connection_key[
+                    connection_key
+                ]
+            except KeyError:
+                raise CommandError(
+                    f"I don't know how to handle {connection_key}. Sorry!"
+                )
+            try:
+                with connection.cursor() as cursor:
+                    results.append(
+                        not self.test_table_exists_and_has_any_row(
+                            cursor, table_to_test
+                        )
+                    )
+            except OperationalError as e:
+                if str(e).strip().endswith('does not exist'):
+                    results.append(True)
+
+        self.stdout.write('\t'.join([str(x) for x in results]))

--- a/kpi/management/commands/wait_for_database.py
+++ b/kpi/management/commands/wait_for_database.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+from django.db.utils import OperationalError
+
+
+class Command(BaseCommand):
+    help = (
+        'Repeatedly attempt to connect to the default database, exiting '
+        'silently once the connection succeeds, or with an error if a '
+        'connection cannot be established'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--retries',
+            default=5,
+            type=int,
+            help=(
+                'Try this many times before giving up, waiting 2 seconds '
+                'between each attempt'
+            ),
+        )
+
+    def handle(self, *args, **options):
+        for _ in range(options.get('retries')):
+            try:
+                with connection.cursor() as cursor:
+                    return
+            except OperationalError as e:
+                if str(e).strip().endswith('does not exist'):
+                    # OK for our purposes if the database doesn't exist;
+                    # knowing that proves we were able to connect
+                    return
+            time.sleep(2)
+
+        raise CommandError('Retries exceeded; failed to connect')

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -44,8 +44,7 @@ def save_kobocat_user(sender, instance, created, raw, **kwargs):
     `settings.KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES`
     """
     if not settings.TESTING:
-        if not settings.USE_SAME_DATABASE:
-            KobocatUser.sync(instance)
+        KobocatUser.sync(instance)
 
         if created:
             # FIXME: If this fails, the next attempt results in
@@ -56,13 +55,12 @@ def save_kobocat_user(sender, instance, created, raw, **kwargs):
             # assigning model-level permissions fails
             grant_kc_model_level_perms(instance)
 
-            if not settings.USE_SAME_DATABASE:
-                # Force PartialDigest to be sync'ed on creation
-                partial_digests = PartialDigest.objects.filter(user_id=instance.pk)
-                for partial_digest in partial_digests:
-                    # `KobocatUser` should exist at this point.
-                    # We don't need to validate `KobocatUser`'s existence.
-                    KobocatDigestPartial.sync(partial_digest, validate_user=False)
+            # Force PartialDigest to be sync'ed on creation
+            partial_digests = PartialDigest.objects.filter(user_id=instance.pk)
+            for partial_digest in partial_digests:
+                # `KobocatUser` should exist at this point.
+                # We don't need to validate `KobocatUser`'s existence.
+                KobocatDigestPartial.sync(partial_digest, validate_user=False)
 
 
 @receiver(post_save, sender=Token)
@@ -70,7 +68,7 @@ def save_kobocat_token(sender, instance, **kwargs):
     """
     Sync AuthToken table between KPI and KC
     """
-    if not settings.TESTING and not settings.USE_SAME_DATABASE:
+    if not settings.TESTING:
         KobocatToken.sync(instance)
 
 
@@ -79,7 +77,7 @@ def delete_kobocat_token(sender, instance, **kwargs):
     """
     Delete corresponding record from KC AuthToken table
     """
-    if not settings.TESTING and not settings.USE_SAME_DATABASE:
+    if not settings.TESTING:
         try:
             KobocatToken.objects.get(pk=instance.pk).delete()
         except KobocatToken.DoesNotExist:
@@ -91,7 +89,7 @@ def save_kobocat_partial_digest(sender, instance, **kwargs):
     """
     Sync PartialDigest table between KPI and KC
     """
-    if not settings.TESTING and not settings.USE_SAME_DATABASE:
+    if not settings.TESTING:
         KobocatDigestPartial.sync(instance)
 
 
@@ -100,7 +98,7 @@ def delete_kobocat_partial_digest(sender, instance, **kwargs):
     """
     Delete corresponding record from KC PartialDigest table
     """
-    if not settings.TESTING and not settings.USE_SAME_DATABASE:
+    if not settings.TESTING:
         try:
             KobocatDigestPartial.objects.get(pk=instance.pk).delete()
         except KobocatDigestPartial.DoesNotExist:

--- a/kpi/utils/two_database_configuration_checker.py
+++ b/kpi/utils/two_database_configuration_checker.py
@@ -1,0 +1,142 @@
+# coding: utf-8
+from django.conf import settings
+from django.core.checks import Error
+from django.db import connections
+from django.utils.translation import ugettext as _
+
+
+class TwoDatabaseConfigurationChecker:
+    """
+    This class detects certain problems that might arise when upgrading an
+    installation that used a single, shared database for both KPI and KoBoCAT
+    to a new configuration with separate databases for each Django project.
+
+    If any issue is found, the application should be stopped to avoid a messy
+    situation where KPI data from two databases would have to be merged
+    together, as opposed to simply copied from the old database to the new one.
+    """
+
+    HELP_PAGE = 'https://community.kobotoolbox.org/t/upgrading-to-separate-databases-for-kpi-and-kobocat/7202'
+    GUIDANCE_TEMPLATE = 'For assistance, please visit {HELP_PAGE}.'
+
+    def __init__(self):
+        self.errors = []
+
+    @classmethod
+    def __str__(cls):
+        return cls.__name__
+
+    @property
+    def guidance_message(self):
+        return ' ' + _(self.GUIDANCE_TEMPLATE).format(HELP_PAGE=self.HELP_PAGE)
+
+    def check_for_two_databases(self):
+        if sorted(list(settings.DATABASES.keys())) != ['default', 'kobocat']:
+            self.errors.append(Error(
+                _('Exactly two databases must be configured'),
+                hint=_('KPI and KoBoCAT must each have their own databases. '
+                       "Configure the KPI database as 'default' and the "
+                       "KoBoCAT database as 'kobocat'.")
+                      + self.guidance_message,
+                obj=self,
+                id='KPI.E021',
+            ))
+            return False
+        return True
+
+    def check_for_distinct_databases(self):
+        DATABASE_IDENTIFYING_KEYS = ['HOST', 'PORT', 'NAME']
+        kpi_db = settings.DATABASES['default']
+        kc_db = settings.DATABASES['kobocat']
+        databases_distinct = False
+        for key_to_check in DATABASE_IDENTIFYING_KEYS:
+            if kpi_db[key_to_check] != kc_db[key_to_check]:
+                databases_distinct = True
+                break
+        if not databases_distinct:
+            self.errors.append(Error(
+                _('KPI may not share a database with KoBoCAT'),
+                hint=_('KPI and KoBoCAT must each have their own databases.')
+                       + self.guidance_message,
+                obj=self,
+                id='KPI.E022',
+            ))
+            return False
+        return True
+
+    def check_for_migration_from_shared_database(self):
+        def db_contains_app_migrations(db_connection, app):
+            # Does the migrations table exist?
+            with db_connection.cursor() as cursor:
+                cursor.execute(
+                    '''SELECT (1) AS "exists" FROM "pg_tables" '''
+                    '''WHERE "tablename" = 'django_migrations' '''
+                    '''LIMIT 1;'''
+                )
+                if not cursor.fetchone():
+                    return False
+            # Does the migrations table contain any KPI migration?
+            with db_connection.cursor() as cursor:
+                cursor.execute(
+                    '''SELECT (1) AS "exists" FROM "django_migrations" '''
+                    '''WHERE "app" = %s '''
+                    '''LIMIT 1;''', [app]
+                )
+                if not cursor.fetchone():
+                    return False
+            return True
+
+        kpi_connection = connections['default']
+        kc_connection = connections['kobocat']
+        kpi_app = 'kpi'
+        kc_app = 'logger'
+
+        if db_contains_app_migrations(kc_connection, kpi_app):
+            # This was formerly a single-database setup, since the KC database
+            # contains KPI migrations
+            if not db_contains_app_migrations(kpi_connection, kc_app):
+                # When migrating from the single, shared database setup:
+                #   1. A new database for KPI should have been created;
+                #   2. Certain tables, including `django_migrations`, should
+                #      have been copied from the original, shared database to
+                #      the new one;
+                #   3. KoBoCAT should have been configured to continue using
+                #      the original database;
+                #   4. KPI should have been configured to use the newly-created
+                #      database;
+                #   5. Because `django_migrations` should have been copied from
+                #      the original database to the new one, we should see
+                #      KoBoCAT migrations in the KPI database.
+                # Since we _do not_ see any KoBoCAT migrations, stop now and
+                # get the human to fix their installation.
+                self.errors.append(Error(
+                    _('Incomplete migration from shared-database installation'),
+                    hint=_('The KoBoCAT database was originally shared by '
+                           'KPI, but the KPI tables were not copied from that '
+                           'shared database to the new, KPI-only database.')
+                         + self.guidance_message,
+                    obj=self,
+                    id='KPI.E023',
+                ))
+                return False
+        return True
+
+    def do_checks(self, app_configs, **kwargs):
+        checks = [
+            self.check_for_two_databases,
+            self.check_for_distinct_databases,
+            self.check_for_migration_from_shared_database,
+        ]
+        for check in checks:
+            if not check():
+                # Each check depends on the one before; it makes no sense to
+                # continue any further
+                break
+        return self.errors
+
+    def as_check(self):
+        """ For use with django.core.checks.register() """
+
+        def wrapper(*args, **kwargs):
+            return self.do_checks(*args, **kwargs)
+        return wrapper


### PR DESCRIPTION
Since they are tagged with `Tags.database`, these checks won't run when the application starts up to serve requests, but they _will_ stop migrations from happening.

Closes #2543. Work continues at kobotoolbox/kobo-install#65.

P.S.: I've added a new `is_database_empty` management command to this PR that I'll use for kobotoolbox/kobo-install#65.

P.P.S.: I've added another management command, `wait_for_database`, so that we know when it's safe to run `is_database_empty`.