### PR TITLE
2523 media links in table view

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -753,7 +753,6 @@ export class DataTable extends React.Component {
   }
   bulkSelectAllRows(isChecked) {
     let s = this.state.selectedRows;
-    let ind = 0;
     this.state.tableData.forEach(function(r) {
       if (isChecked) {
         s[r._id] = true;

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -413,6 +413,9 @@ export class DataTable extends React.Component {
 
               if (q.type == 'audio') {
                 var kc_server = document.createElement('a');
+                //var deployment_id = this.props.asset.deployment__identifier;
+                console.log('asset: ' + this.props.asset);
+                console.log('hello????');
                 //kc_server.href = this.props.asset.deployment__identifier;
                 // // if this has more components than /{username}/forms/{uid}, it's safe to assume kobocat is running under a
                 // // KOBOCAT_ROOT_URI_PREFIX

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -984,8 +984,8 @@ export class DataTable extends React.Component {
   }
   getMediaDownloadLink(fileName) {
     var attachmentUrl = null;
-    this.state.tableData.some(function(a) {
-        a._attachments.some(function(b) {
+    this.state.tableData.forEach(function(a) {
+        a._attachments.forEach(function(b) {
           if (b.filename.includes(fileName)) {
             fileName = b.filename;
           }

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -405,6 +405,25 @@ export class DataTable extends React.Component {
         filterable: false,
         Cell: row => {
             if (showLabels && q && q.type && row.value) {
+              console.log('q: ' + q + ' q.type: ' + q.type + ' row.value: ' + row.value);
+
+              if (q.type == 'image') {
+                return <a href="https://google.com">hello</a>;
+              }
+
+              if (q.type == 'audio') {
+                var kc_server = document.createElement('a');
+                //kc_server.href = this.props.asset.deployment__identifier;
+                // // if this has more components than /{username}/forms/{uid}, it's safe to assume kobocat is running under a
+                // // KOBOCAT_ROOT_URI_PREFIX
+                // const kc_prefix = kc_server.pathname.split('/').length > 4 ? '/' + kc_server.pathname.split('/')[1] : '';
+                // var kc_base = `${kc_server.origin}${kc_prefix}`;
+
+                // // build media attachment URL using the KC endpoint
+                // attachmentUrl = `${kc_base}/attachment/original?media_file=${encodeURI(filename)}`;
+                // return <a href={attachmentUrl} target='_blank'>{originalFilename}</a>
+              }
+
               // show proper labels for choice questions
               if (q.type == 'select_one') {
                 let choice = choices.find(o => o.list_name == q.select_from_list_name && (o.name === row.value || o.$autoname == row.value));
@@ -748,14 +767,19 @@ export class DataTable extends React.Component {
   }
   bulkSelectAllRows(isChecked) {
     let s = this.state.selectedRows;
-
+    let ind = 0;
     this.state.tableData.forEach(function(r) {
+          console.log(r);
       if (isChecked) {
         s[r._id] = true;
       } else {
         delete s[r._id];
       }
-    });
+    },
+
+    //console.log(this.state.tableData.valueOf())
+    console.log(this.state.tableData[ind]),
+    );
 
     // If the entirety of the results has been selected, selectAll should be true
     // Useful when the # of results is smaller than the page size.
@@ -774,6 +798,16 @@ export class DataTable extends React.Component {
     }
 
   }
+
+  addLinksToFileNames() {
+
+    for (var i = 0; i<this.state.tableData.length; i++) {
+      console.log('@: ' + this.state.tableData[i].valueOf());
+    }
+
+    return this.state.tableData
+  }
+
   onBulkUpdateStatus(evt) {
     const val = evt.target.getAttribute('data-value');
     const selectAll = this.state.selectAll;

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -25,8 +25,7 @@ import {
   t,
   notify,
   formatTimeDate,
-  renderCheckbox,
-  getMediaDownloadLink
+  renderCheckbox
 } from '../utils';
 
 const NOT_ASSIGNED = 'validation_status_not_assigned';
@@ -322,7 +321,7 @@ export class DataTable extends React.Component {
 
     let survey = this.props.asset.content.survey;
     let choices = this.props.asset.content.choices;
-    uniqueKeys.forEach(function(key){
+    uniqueKeys.forEach((key) => {
       var q = undefined;
       var qParentG = [];
       if (key.includes('/')) {
@@ -405,18 +404,10 @@ export class DataTable extends React.Component {
         filterable: false,
         Cell: row => {
             if (showLabels && q && q.type && row.value) {
-              if (q.type == 'image') {
-                return <a href="https://google.com">{row.value}</a>;
+              if (q.type == 'image' || q.type == 'audio' || q.type == 'video') {
+                var mediaURL = this.getMediaDownloadLink(row.value);
+                return <a href={mediaURL}>{row.value}</a>;
               }
-
-              if (q.type == 'audio') {
-                return <a href="https://google.com">{row.value}</a>;
-              }
-
-              if (q.type == 'video') {
-                return <a href="https://google.com">{row.value}</a>;
-              }
-
               // show proper labels for choice questions
               if (q.type == 'select_one') {
                 let choice = choices.find(o => o.list_name == q.select_from_list_name && (o.name === row.value || o.$autoname == row.value));
@@ -635,7 +626,7 @@ export class DataTable extends React.Component {
     stores.pageState.hideModal();
     this.setState({
       overrideLabelsAndGroups: overrides
-    }, function() {
+    }, () => {
       this._prepColumns(this.state.tableData);
     });
   }
@@ -990,6 +981,24 @@ export class DataTable extends React.Component {
         }
       </bem.FormView__item>
     );
+  }
+  getMediaDownloadLink(fileName) {
+    var attachmentUrl = null;
+    this.state.tableData.some(function(a) {
+        a._attachments.some(function(b) {
+          if (b.filename.includes(fileName)) {
+            fileName = b.filename;
+          }
+        });
+
+    });
+
+    var kc_server = document.createElement('a');
+    kc_server.href = this.props.asset.deployment__identifier;
+    const kc_prefix = kc_server.pathname.split('/').length > 4 ? '/' + kc_server.pathname.split('/')[1] : '';
+    var kc_base = `${kc_server.origin}${kc_prefix}`;
+    attachmentUrl = `${kc_base}/attachment/original?media_file=${encodeURI(fileName)}`;
+    return attachmentUrl;
   }
   render () {
     if (this.state.error) {

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -19,7 +19,8 @@ import {DebounceInput} from 'react-debounce-input';
 import {
   VALIDATION_STATUSES,
   VALIDATION_STATUSES_LIST,
-  MODAL_TYPES
+  MODAL_TYPES,
+  QUESTION_TYPES
 } from '../constants';
 import {
   t,
@@ -404,7 +405,7 @@ export class DataTable extends React.Component {
         filterable: false,
         Cell: row => {
             if (showLabels && q && q.type && row.value) {
-              if (q.type == 'image' || q.type == 'audio' || q.type == 'video') {
+              if (q.type === QUESTION_TYPES.get('image').id || q.type === QUESTION_TYPES.get('audio').id || q.type === QUESTION_TYPES.get('video').id) {
                 var mediaURL = this.getMediaDownloadLink(row.value);
                 return <a href={mediaURL} target="_blank">{row.value}</a>;
               }
@@ -733,11 +734,6 @@ export class DataTable extends React.Component {
     this.setState({ promptRefresh: false });
   }
 
-  printAssets(){
-    console.log('-----assets:------');
-    console.dir(this.props.asset);
-  }
-
   clearPromptRefresh() {
     this.setState({ promptRefresh: false });
   }
@@ -759,16 +755,12 @@ export class DataTable extends React.Component {
     let s = this.state.selectedRows;
     let ind = 0;
     this.state.tableData.forEach(function(r) {
-          console.log(r);
       if (isChecked) {
         s[r._id] = true;
       } else {
         delete s[r._id];
       }
-    },
-
-    //console.log(this.state.tableData.valueOf())
-    console.log(this.state.tableData[ind]),
+    }
     );
 
     // If the entirety of the results has been selected, selectAll should be true
@@ -787,15 +779,6 @@ export class DataTable extends React.Component {
       });
     }
 
-  }
-
-  addLinksToFileNames() {
-
-    for (var i = 0; i<this.state.tableData.length; i++) {
-      console.log('@: ' + this.state.tableData[i].valueOf());
-    }
-
-    return this.state.tableData
   }
 
   onBulkUpdateStatus(evt) {

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -25,7 +25,8 @@ import {
   t,
   notify,
   formatTimeDate,
-  renderCheckbox
+  renderCheckbox,
+  getMediaDownloadLink
 } from '../utils';
 
 const NOT_ASSIGNED = 'validation_status_not_assigned';
@@ -321,7 +322,6 @@ export class DataTable extends React.Component {
 
     let survey = this.props.asset.content.survey;
     let choices = this.props.asset.content.choices;
-
     uniqueKeys.forEach(function(key){
       var q = undefined;
       var qParentG = [];
@@ -405,26 +405,16 @@ export class DataTable extends React.Component {
         filterable: false,
         Cell: row => {
             if (showLabels && q && q.type && row.value) {
-              console.log('q: ' + q + ' q.type: ' + q.type + ' row.value: ' + row.value);
-
               if (q.type == 'image') {
-                return <a href="https://google.com">hello</a>;
+                return <a href="https://google.com">{row.value}</a>;
               }
 
               if (q.type == 'audio') {
-                var kc_server = document.createElement('a');
-                //var deployment_id = this.props.asset.deployment__identifier;
-                console.log('asset: ' + this.props.asset);
-                console.log('hello????');
-                //kc_server.href = this.props.asset.deployment__identifier;
-                // // if this has more components than /{username}/forms/{uid}, it's safe to assume kobocat is running under a
-                // // KOBOCAT_ROOT_URI_PREFIX
-                // const kc_prefix = kc_server.pathname.split('/').length > 4 ? '/' + kc_server.pathname.split('/')[1] : '';
-                // var kc_base = `${kc_server.origin}${kc_prefix}`;
+                return <a href="https://google.com">{row.value}</a>;
+              }
 
-                // // build media attachment URL using the KC endpoint
-                // attachmentUrl = `${kc_base}/attachment/original?media_file=${encodeURI(filename)}`;
-                // return <a href={attachmentUrl} target='_blank'>{originalFilename}</a>
+              if (q.type == 'video') {
+                return <a href="https://google.com">{row.value}</a>;
               }
 
               // show proper labels for choice questions
@@ -751,6 +741,12 @@ export class DataTable extends React.Component {
     this.fetchData(this.state.fetchState, this.state.fetchInstance);
     this.setState({ promptRefresh: false });
   }
+
+  printAssets(){
+    console.log('-----assets:------');
+    console.dir(this.props.asset);
+  }
+
   clearPromptRefresh() {
     this.setState({ promptRefresh: false });
   }

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -406,7 +406,7 @@ export class DataTable extends React.Component {
             if (showLabels && q && q.type && row.value) {
               if (q.type == 'image' || q.type == 'audio' || q.type == 'video') {
                 var mediaURL = this.getMediaDownloadLink(row.value);
-                return <a href={mediaURL}>{row.value}</a>;
+                return <a href={mediaURL} target="_blank">{row.value}</a>;
               }
               // show proper labels for choice questions
               if (q.type == 'select_one') {

--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -965,7 +965,6 @@ export class DataTable extends React.Component {
     );
   }
   getMediaDownloadLink(fileName) {
-    var attachmentUrl = null;
     this.state.tableData.forEach(function(a) {
         a._attachments.forEach(function(b) {
           if (b.filename.includes(fileName)) {
@@ -979,8 +978,7 @@ export class DataTable extends React.Component {
     kc_server.href = this.props.asset.deployment__identifier;
     const kc_prefix = kc_server.pathname.split('/').length > 4 ? '/' + kc_server.pathname.split('/')[1] : '';
     var kc_base = `${kc_server.origin}${kc_prefix}`;
-    attachmentUrl = `${kc_base}/attachment/original?media_file=${encodeURI(fileName)}`;
-    return attachmentUrl;
+    return `${kc_base}/attachment/original?media_file=${encodeURI(fileName)}`;
   }
   render () {
     if (this.state.error) {

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -524,8 +524,3 @@ export function renderCheckbox(id, label, isImportant) {
   }
   return `<div class="alertify-toggle checkbox ${additionalClass}"><label class="checkbox__wrapper"><input type="checkbox" class="checkbox__input" id="${id}"><span class="checkbox__label">${label}</span></label></div>`;
 };
-
-export function getMediaDownloadLink(asset) {
-  console.log('------assets:-----');
-  console.dir(asset);
-}

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -524,3 +524,8 @@ export function renderCheckbox(id, label, isImportant) {
   }
   return `<div class="alertify-toggle checkbox ${additionalClass}"><label class="checkbox__wrapper"><input type="checkbox" class="checkbox__input" id="${id}"><span class="checkbox__label">${label}</span></label></div>`;
 };
+
+export function getMediaDownloadLink(asset) {
+  console.log('------assets:-----');
+  console.dir(asset);
+}


### PR DESCRIPTION
## Description

Fixed #2523, adds clickable link in table view for all media type files in form (images, audio, video).

Refactoring note: This change uses very similar code to https://github.com/kobotoolbox/kpi/blob/1c2dec92faf4cbbda88092f5b7c97d5388dd0dcd/jsapp/js/components/modalForms/submission.es6#L156-L183 inside of https://github.com/kobotoolbox/kpi/blob/5f97496c8e5a6c37d31ee4274f2002066df3c07e/jsapp/js/components/table.es6#L985-L1002 

The returns and little pieces of logic are different between the two functions, not sure if there's a clean way to refactor both of these out to an external file.

