### PR TITLE
2549 Updated PR

### DIFF
--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -238,13 +238,18 @@ export class FormMap extends React.Component {
     // TODO: support area / line geodata questions
     let selectedQuestion = this.props.asset.map_styles.selectedQuestion || null;
     var fq = ['_id', '_geolocation'];
+    var queryLimit = 5000;
     if (selectedQuestion) fq.push(selectedQuestion);
     if (nextViewBy) fq.push(this.nameOfFieldInGroup(nextViewBy));
 
     const sort = [{id: '_id', desc: true}];
 
+    if (fq.length > 3) {
+      queryLimit = 20000;
+    } 
+
     // TODO: handle forms with over 5000 results
-    dataInterface.getSubmissions(this.props.asset.uid, 5000, 0, sort, fq).done((data) => {
+    dataInterface.getSubmissions(this.props.asset.uid, queryLimit, 0, sort, fq).done((data) => {
       let results = data.results;
       if (selectedQuestion) {
         results.forEach(function(row, i) {

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -491,18 +491,10 @@ export var dataInterface;
       if (fields.length)
         f = `&fields=${JSON.stringify(fields)}`;
 
-      if (fields.length > 3) {
-        const query_no_limit = `&start=${page}`;
-        return $ajax({
-          url: `${ROOT_URL}/api/v2/assets/${uid}/data/?${query_no_limit}${s}${f}${filter}`,
-          method: 'GET'
-        });
-      } else {
-        return $ajax({
+      return $ajax({
           url: `${ROOT_URL}/api/v2/assets/${uid}/data/?${query}${s}${f}${filter}`,
           method: 'GET'
         });
-      }
     },
     getSubmission(uid, sid) {
       return $ajax({

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -492,9 +492,9 @@ export var dataInterface;
         f = `&fields=${JSON.stringify(fields)}`;
 
       return $ajax({
-          url: `${ROOT_URL}/api/v2/assets/${uid}/data/?${query}${s}${f}${filter}`,
-          method: 'GET'
-        });
+        url: `${ROOT_URL}/api/v2/assets/${uid}/data/?${query}${s}${f}${filter}`,
+        method: 'GET'
+      });
     },
     getSubmission(uid, sid) {
       return $ajax({


### PR DESCRIPTION
## Description

Fixes #2549 same PR as https://github.com/kobotoolbox/kpi/pull/2554 except moved changes from `dataInterface.es6` to `map.es6`. Also merged branch into new one due to new changes on `two-databases`.

Since `map.es6` cannot directly change the `getSubmissions` query in `dataInterface.es6`, the limit is just increased to 20,000 (from 5000) after a specific question is selected.
