### PR TITLE
Use XlsxWriter instead of xlwt in to_xls_io()

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -4,13 +4,13 @@
 #
 #    make pip_compile
 #
--e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in (line 10)
--e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in (line 13)
--e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in (line 16)
--e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in (line 5)
--e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in (line 9)
-amqp==2.5.2               # via -r dependencies/pip/requirements.in (line 22), kombu
-anyjson==0.3.3            # via -r dependencies/pip/requirements.in (line 23)
+-e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
+amqp==2.5.2               # via -r dependencies/pip/requirements.in, kombu
+anyjson==0.3.3            # via -r dependencies/pip/requirements.in
 argparse==1.4.0           # via unittest2
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via jsonschema, pytest
@@ -18,10 +18,10 @@ backcall==0.1.0           # via ipython
 backports.csv==1.0.7      # via formpack
 bcrypt==3.1.7             # via paramiko
 begins==0.9               # via formpack
-billiard==3.6.1.0         # via -r dependencies/pip/requirements.in (line 24), celery
-boto3==1.10.15            # via -r dependencies/pip/requirements.in (line 25), django-amazon-ses
+billiard==3.6.1.0         # via -r dependencies/pip/requirements.in, celery
+boto3==1.10.15            # via -r dependencies/pip/requirements.in, django-amazon-ses
 botocore==1.13.15         # via boto3, s3transfer
-celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in (line 26), -r dependencies/pip/requirements.in (line 27)
+celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in
 certifi==2019.9.11        # via requests
 cffi==1.13.2              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
@@ -29,57 +29,57 @@ cryptography==2.8         # via paramiko, pyopenssl
 cssselect==1.1.0          # via pyquery
 decorator==4.4.1          # via ipython, traitlets
 defusedxml==0.6.0         # via djangorestframework-xml
-dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in (line 28)
-dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in (line 30)
-dj-static==0.0.6          # via -r dependencies/pip/requirements.in (line 29)
-django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in (line 39)
-django-braces==1.13.0     # via -r dependencies/pip/requirements.in (line 31)
-django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in (line 32)
-django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in (line 33)
-django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in (line 34)
-django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in (line 35)
-django-extensions==2.2.5  # via -r dependencies/pip/requirements.in (line 36)
+dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in
+dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in
+dj-static==0.0.6          # via -r dependencies/pip/requirements.in
+django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in
+django-braces==1.13.0     # via -r dependencies/pip/requirements.in
+django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in
+django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in
+django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in
+django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in
+django-extensions==2.2.5  # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2    # via django-mptt
-django-loginas==0.3.6     # via -r dependencies/pip/requirements.in (line 41)
-django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in (line 42)
-django-mptt==0.10.0       # via -r dependencies/pip/requirements.in (line 44)
-django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in (line 37)
+django-loginas==0.3.6     # via -r dependencies/pip/requirements.in
+django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in
+django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
+django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in (line 48)
-django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in (line 51)
-django-registration-redux==2.6  # via -r dependencies/pip/requirements.in (line 38)
-django-reversion==3.0.1   # via -r dependencies/pip/requirements.in (line 45)
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in (line 47)
-django-taggit==1.1.0      # via -r dependencies/pip/requirements.in (line 46)
+django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
+django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
+django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
+django-storages==1.7.2    # via -r dependencies/pip/requirements.in
+django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
-django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in (line 40)
-django==2.2.7             # via -r dependencies/pip/requirements.in (line 19), django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
-djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in (line 50)
-djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in (line 49), drf-extensions
+django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in
+django==2.2.7             # via -r dependencies/pip/requirements.in, django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
+djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in
+djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in, drf-extensions
 docutils==0.15.2          # via botocore, statistics
-drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in (line 52)
-fabric==2.5.0             # via -r dependencies/pip/dev_requirements.in (line 3)
+drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in
+fabric==2.5.0             # via -r dependencies/pip/dev_requirements.in
 formencode==1.3.1         # via pyxform
-future==0.18.2            # via -r dependencies/pip/requirements.in (line 53)
-geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in (line 54), formpack
+future==0.18.2            # via -r dependencies/pip/requirements.in
+geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via jsonschema, kombu, path.py
 invoke==1.3.0             # via fabric
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.9.0            # via -r dependencies/pip/dev_requirements.in (line 5)
+ipython==7.9.0            # via -r dependencies/pip/dev_requirements.in
 jedi==0.15.1              # via ipython
 jmespath==0.9.4           # via boto3, botocore
-jsonfield==2.0.2          # via -r dependencies/pip/requirements.in (line 55)
+jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack
-kombu==4.6.6              # via -r dependencies/pip/requirements.in (line 56), celery
+kombu==4.6.6              # via -r dependencies/pip/requirements.in, celery
 linecache2==1.0.0         # via traceback2
-lxml==4.4.1               # via -r dependencies/pip/requirements.in (line 57), formpack, pyquery
-markdown==3.1.1           # via -r dependencies/pip/requirements.in (line 20), django-markdownx
-mock==3.0.5               # via -r dependencies/pip/dev_requirements.in (line 9)
+lxml==4.4.1               # via -r dependencies/pip/requirements.in, formpack, pyquery
+markdown==3.1.1           # via -r dependencies/pip/requirements.in, django-markdownx
+mock==3.0.5               # via -r dependencies/pip/dev_requirements.in
 more-itertools==7.2.0     # via pytest, zipp
-ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in (line 78)
-oauthlib==3.1.0           # via -r dependencies/pip/requirements.in (line 58), django-oauth-toolkit
+ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in
+oauthlib==3.1.0           # via -r dependencies/pip/requirements.in, django-oauth-toolkit
 packaging==19.2           # via pytest
 paramiko==2.6.0           # via fabric
 parso==0.5.1              # via jedi
@@ -89,47 +89,47 @@ pickleshare==0.7.5        # via ipython
 pillow==6.2.1             # via django-markdownx
 pluggy==0.13.0            # via pytest
 prompt-toolkit==2.0.10    # via ipython
-psycopg2==2.8.4           # via -r dependencies/pip/requirements.in (line 60)
+psycopg2==2.8.4           # via -r dependencies/pip/requirements.in
 ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest
-pyasn1==0.4.7             # via -r dependencies/pip/requirements.in (line 79), ndg-httpsclient
+pyasn1==0.4.7             # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pycparser==2.19           # via cffi
-pygments==2.4.2           # via -r dependencies/pip/requirements.in (line 21), ipython
-pymongo==3.9.0            # via -r dependencies/pip/requirements.in (line 61)
+pygments==2.4.2           # via -r dependencies/pip/requirements.in, ipython
+pymongo==3.9.0            # via -r dependencies/pip/requirements.in
 pynacl==1.3.0             # via paramiko
-pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in (line 77), ndg-httpsclient
+pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pyparsing==2.4.5          # via packaging
 pyquery==1.4.1            # via formpack
 pyrsistent==0.15.5        # via jsonschema
-pytest-django==3.7.0      # via -r dependencies/pip/dev_requirements.in (line 6)
-pytest-env==0.6.2         # via -r dependencies/pip/dev_requirements.in (line 7)
-pytest==5.2.2             # via -r dependencies/pip/dev_requirements.in (line 8), pytest-django, pytest-env
+pytest-django==3.7.0      # via -r dependencies/pip/dev_requirements.in
+pytest-env==0.6.2         # via -r dependencies/pip/dev_requirements.in
+pytest==5.2.2             # via -r dependencies/pip/dev_requirements.in, pytest-django, pytest-env
 python-crontab==2.4.0     # via django-celery-beat
-python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in (line 62), botocore, python-crontab
-pytz==2019.3              # via -r dependencies/pip/requirements.in (line 63), celery, django, django-timezone-field
-pyxform==0.15.1           # via -r dependencies/pip/requirements.in (line 64), formpack
+python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in, botocore, python-crontab
+pytz==2019.3              # via -r dependencies/pip/requirements.in, celery, django, django-timezone-field
+pyxform==0.15.1           # via -r dependencies/pip/requirements.in, formpack
 redis==3.3.11             # via celery, django-redis-sessions
-requests==2.22.0          # via -r dependencies/pip/requirements.in (line 65), django-oauth-toolkit, responses
-responses==0.10.6         # via -r dependencies/pip/requirements.in (line 66)
+requests==2.22.0          # via -r dependencies/pip/requirements.in, django-oauth-toolkit, responses
+responses==0.10.6         # via -r dependencies/pip/requirements.in
 s3transfer==0.2.1         # via boto3
-shortuuid==0.5.0          # via -r dependencies/pip/requirements.in (line 67)
+shortuuid==0.5.0          # via -r dependencies/pip/requirements.in
 six==1.13.0               # via bcrypt, cryptography, django-extensions, jsonschema, mock, packaging, prompt-toolkit, pynacl, pyopenssl, pyrsistent, python-dateutil, responses, traitlets, unittest2
-sqlparse==0.3.0           # via -r dependencies/pip/requirements.in (line 68), django, django-debug-toolbar
-static3==0.7.0            # via -r dependencies/pip/requirements.in (line 69), dj-static
+sqlparse==0.3.0           # via -r dependencies/pip/requirements.in, django, django-debug-toolbar
+static3==0.7.0            # via -r dependencies/pip/requirements.in, dj-static
 statistics==1.0.3.5       # via formpack
-tabulate==0.8.5           # via -r dependencies/pip/requirements.in (line 70)
+tabulate==0.8.5           # via -r dependencies/pip/requirements.in
 traceback2==1.4.0         # via unittest2
 traitlets==4.3.3          # via ipython
-unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in (line 71), pyxform
+unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in, pyxform
 unittest2==1.1.0          # via pyxform
 urllib3==1.25.7           # via botocore, requests
-uwsgi==2.0.18             # via -r dependencies/pip/requirements.in (line 72)
+uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit, pytest
-werkzeug==0.16.0          # via -r dependencies/pip/dev_requirements.in (line 4)
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in (line 73), pyxform
-xlsxwriter==1.2.5         # via formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in (line 74)
+werkzeug==0.16.0          # via -r dependencies/pip/dev_requirements.in
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -4,107 +4,107 @@
 #
 #    make pip_compile
 #
--e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in (line 10)
--e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in (line 13)
--e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in (line 16)
--e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in (line 5)
--e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in (line 9)
-amqp==2.5.2               # via -r dependencies/pip/requirements.in (line 22), kombu
-anyjson==0.3.3            # via -r dependencies/pip/requirements.in (line 23)
+-e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
+amqp==2.5.2               # via -r dependencies/pip/requirements.in, kombu
+anyjson==0.3.3            # via -r dependencies/pip/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==19.3.0             # via jsonschema
 backports.csv==1.0.7      # via formpack
 begins==0.9               # via formpack
-billiard==3.6.1.0         # via -r dependencies/pip/requirements.in (line 24), celery
-boto3==1.10.15            # via -r dependencies/pip/requirements.in (line 25), django-amazon-ses
+billiard==3.6.1.0         # via -r dependencies/pip/requirements.in, celery
+boto3==1.10.15            # via -r dependencies/pip/requirements.in, django-amazon-ses
 botocore==1.13.15         # via boto3, s3transfer
-celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in (line 26), -r dependencies/pip/requirements.in (line 27)
+celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in
 certifi==2019.9.11        # via requests
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==2.8         # via pyopenssl
 cssselect==1.1.0          # via pyquery
 defusedxml==0.6.0         # via djangorestframework-xml
-dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in (line 28)
-dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in (line 30)
-dj-static==0.0.6          # via -r dependencies/pip/requirements.in (line 29)
-django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in (line 39)
-django-braces==1.13.0     # via -r dependencies/pip/requirements.in (line 31)
-django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in (line 32)
-django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in (line 33)
-django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in (line 34)
-django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in (line 35)
-django-extensions==2.2.5  # via -r dependencies/pip/requirements.in (line 36)
+dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in
+dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in
+dj-static==0.0.6          # via -r dependencies/pip/requirements.in
+django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in
+django-braces==1.13.0     # via -r dependencies/pip/requirements.in
+django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in
+django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in
+django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in
+django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in
+django-extensions==2.2.5  # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2    # via django-mptt
-django-loginas==0.3.6     # via -r dependencies/pip/requirements.in (line 41)
-django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in (line 42)
-django-mptt==0.10.0       # via -r dependencies/pip/requirements.in (line 44)
-django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in (line 37)
+django-loginas==0.3.6     # via -r dependencies/pip/requirements.in
+django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in
+django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
+django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in (line 48)
-django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in (line 51)
-django-registration-redux==2.6  # via -r dependencies/pip/requirements.in (line 38)
-django-reversion==3.0.1   # via -r dependencies/pip/requirements.in (line 45)
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in (line 47)
-django-taggit==1.1.0      # via -r dependencies/pip/requirements.in (line 46)
+django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
+django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
+django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
+django-storages==1.7.2    # via -r dependencies/pip/requirements.in
+django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
-django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in (line 40)
-django==2.2.7             # via -r dependencies/pip/requirements.in (line 19), django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
-djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in (line 50)
-djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in (line 49), drf-extensions
+django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in
+django==2.2.7             # via -r dependencies/pip/requirements.in, django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
+djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in
+djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in, drf-extensions
 docutils==0.15.2          # via botocore, statistics
-drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in (line 52)
+drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in
 formencode==1.3.1         # via pyxform
-future==0.18.2            # via -r dependencies/pip/requirements.in (line 53)
-geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in (line 54), formpack
+future==0.18.2            # via -r dependencies/pip/requirements.in
+geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
-jsonfield==2.0.2          # via -r dependencies/pip/requirements.in (line 55)
+jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack
-kombu==4.6.6              # via -r dependencies/pip/requirements.in (line 56), celery
+kombu==4.6.6              # via -r dependencies/pip/requirements.in, celery
 linecache2==1.0.0         # via traceback2
-lxml==4.4.1               # via -r dependencies/pip/requirements.in (line 57), formpack, pyquery
-markdown==3.1.1           # via -r dependencies/pip/requirements.in (line 20), django-markdownx
+lxml==4.4.1               # via -r dependencies/pip/requirements.in, formpack, pyquery
+markdown==3.1.1           # via -r dependencies/pip/requirements.in, django-markdownx
 more-itertools==7.2.0     # via zipp
-ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in (line 78)
-oauthlib==3.1.0           # via -r dependencies/pip/requirements.in (line 58), django-oauth-toolkit
+ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in
+oauthlib==3.1.0           # via -r dependencies/pip/requirements.in, django-oauth-toolkit
 path.py==12.0.2           # via formpack
 pillow==6.2.1             # via django-markdownx
-psycopg2==2.8.4           # via -r dependencies/pip/requirements.in (line 60)
-pyasn1==0.4.7             # via -r dependencies/pip/requirements.in (line 79), ndg-httpsclient
+psycopg2==2.8.4           # via -r dependencies/pip/requirements.in
+pyasn1==0.4.7             # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pycparser==2.19           # via cffi
-pygments==2.4.2           # via -r dependencies/pip/requirements.in (line 21)
-pymongo==3.9.0            # via -r dependencies/pip/requirements.in (line 61)
-pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in (line 77), ndg-httpsclient
+pygments==2.4.2           # via -r dependencies/pip/requirements.in
+pymongo==3.9.0            # via -r dependencies/pip/requirements.in
+pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pyquery==1.4.1            # via formpack
 pyrsistent==0.15.5        # via jsonschema
 python-crontab==2.4.0     # via django-celery-beat
-python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in (line 62), botocore, python-crontab
-pytz==2019.3              # via -r dependencies/pip/requirements.in (line 63), celery, django, django-timezone-field
-pyxform==0.15.1           # via -r dependencies/pip/requirements.in (line 64), formpack
-raven==6.10.0             # via -r dependencies/pip/external_services.in (line 5)
+python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in, botocore, python-crontab
+pytz==2019.3              # via -r dependencies/pip/requirements.in, celery, django, django-timezone-field
+pyxform==0.15.1           # via -r dependencies/pip/requirements.in, formpack
+raven==6.10.0             # via -r dependencies/pip/external_services.in
 redis==3.3.11             # via celery, django-redis-sessions
-requests==2.22.0          # via -r dependencies/pip/requirements.in (line 65), django-oauth-toolkit, responses
-responses==0.10.6         # via -r dependencies/pip/requirements.in (line 66)
+requests==2.22.0          # via -r dependencies/pip/requirements.in, django-oauth-toolkit, responses
+responses==0.10.6         # via -r dependencies/pip/requirements.in
 s3transfer==0.2.1         # via boto3
-shortuuid==0.5.0          # via -r dependencies/pip/requirements.in (line 67)
+shortuuid==0.5.0          # via -r dependencies/pip/requirements.in
 six==1.13.0               # via cryptography, django-extensions, jsonschema, pyopenssl, pyrsistent, python-dateutil, responses, transifex-client, unittest2
-sqlparse==0.3.0           # via -r dependencies/pip/requirements.in (line 68), django, django-debug-toolbar
-static3==0.7.0            # via -r dependencies/pip/requirements.in (line 69), dj-static
+sqlparse==0.3.0           # via -r dependencies/pip/requirements.in, django, django-debug-toolbar
+static3==0.7.0            # via -r dependencies/pip/requirements.in, dj-static
 statistics==1.0.3.5       # via formpack
-tabulate==0.8.5           # via -r dependencies/pip/requirements.in (line 70)
+tabulate==0.8.5           # via -r dependencies/pip/requirements.in
 traceback2==1.4.0         # via unittest2
-transifex-client==0.12.5  # via -r dependencies/pip/external_services.in (line 6)
-unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in (line 71), pyxform
+transifex-client==0.12.5  # via -r dependencies/pip/external_services.in
+unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in, pyxform
 unittest2==1.1.0          # via pyxform
 urllib3==1.25.7           # via botocore, requests, transifex-client
-uwsgi==2.0.18             # via -r dependencies/pip/requirements.in (line 72)
+uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in (line 73), pyxform
-xlsxwriter==1.2.5         # via formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in (line 74)
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -72,6 +72,7 @@ unicodecsv
 uWSGI
 xlrd
 xlwt
+XlsxWriter
 
 # These packages allow `requests` to support SNI
 pyopenssl

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -4,105 +4,105 @@
 #
 #    make pip_compile
 #
--e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in (line 10)
--e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in (line 13)
--e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in (line 16)
--e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in (line 5)
--e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in (line 9)
-amqp==2.5.2               # via -r dependencies/pip/requirements.in (line 22), kombu
-anyjson==0.3.3            # via -r dependencies/pip/requirements.in (line 23)
+-e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/st8st8/django-markitup@1370b43dc519b1441510a17330b8e980d29a7bf3#egg=django_markitup  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/django-request-cache@c240abdd660cc59f5f5280beee30b3e011332a34#egg=django_request_cache  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/kobotoolbox/formpack.git@a08b7626507c2ceff35b816f1e1e0845c85cce26#egg=formpack  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
+amqp==2.5.2               # via -r dependencies/pip/requirements.in, kombu
+anyjson==0.3.3            # via -r dependencies/pip/requirements.in
 argparse==1.4.0           # via unittest2
 attrs==19.3.0             # via jsonschema
 backports.csv==1.0.7      # via formpack
 begins==0.9               # via formpack
-billiard==3.6.1.0         # via -r dependencies/pip/requirements.in (line 24), celery
-boto3==1.10.15            # via -r dependencies/pip/requirements.in (line 25), django-amazon-ses
+billiard==3.6.1.0         # via -r dependencies/pip/requirements.in, celery
+boto3==1.10.15            # via -r dependencies/pip/requirements.in, django-amazon-ses
 botocore==1.13.15         # via boto3, s3transfer
-celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in (line 26), -r dependencies/pip/requirements.in (line 27)
+celery[redis]==4.3.0      # via -r dependencies/pip/requirements.in
 certifi==2019.9.11        # via requests
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==2.8         # via pyopenssl
 cssselect==1.1.0          # via pyquery
 defusedxml==0.6.0         # via djangorestframework-xml
-dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in (line 28)
-dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in (line 30)
-dj-static==0.0.6          # via -r dependencies/pip/requirements.in (line 29)
-django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in (line 39)
-django-braces==1.13.0     # via -r dependencies/pip/requirements.in (line 31)
-django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in (line 32)
-django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in (line 33)
-django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in (line 34)
-django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in (line 35)
-django-extensions==2.2.5  # via -r dependencies/pip/requirements.in (line 36)
+dicttoxml==1.7.4          # via -r dependencies/pip/requirements.in
+dj-database-url==0.5.0    # via -r dependencies/pip/requirements.in
+dj-static==0.0.6          # via -r dependencies/pip/requirements.in
+django-amazon-ses==2.1.1  # via -r dependencies/pip/requirements.in
+django-braces==1.13.0     # via -r dependencies/pip/requirements.in
+django-celery-beat==1.5.0  # via -r dependencies/pip/requirements.in
+django-constance[database]==2.4.0  # via -r dependencies/pip/requirements.in
+django-cors-headers==3.1.1  # via -r dependencies/pip/requirements.in
+django-debug-toolbar==2.1  # via -r dependencies/pip/requirements.in
+django-extensions==2.2.5  # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2    # via django-mptt
-django-loginas==0.3.6     # via -r dependencies/pip/requirements.in (line 41)
-django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in (line 42)
-django-mptt==0.10.0       # via -r dependencies/pip/requirements.in (line 44)
-django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in (line 37)
+django-loginas==0.3.6     # via -r dependencies/pip/requirements.in
+django-markdownx==2.0.28  # via -r dependencies/pip/requirements.in
+django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
+django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in (line 48)
-django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in (line 51)
-django-registration-redux==2.6  # via -r dependencies/pip/requirements.in (line 38)
-django-reversion==3.0.1   # via -r dependencies/pip/requirements.in (line 45)
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in (line 47)
-django-taggit==1.1.0      # via -r dependencies/pip/requirements.in (line 46)
+django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
+django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
+django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
+django-storages==1.7.2    # via -r dependencies/pip/requirements.in
+django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
-django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in (line 40)
-django==2.2.7             # via -r dependencies/pip/requirements.in (line 19), django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
-djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in (line 50)
-djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in (line 49), drf-extensions
+django-webpack-loader==0.6.0  # via -r dependencies/pip/requirements.in
+django==2.2.7             # via -r dependencies/pip/requirements.in, django-amazon-ses, django-cors-headers, django-debug-toolbar, django-markdownx, django-mptt, django-oauth-toolkit, django-picklefield, django-request-cache, django-reversion, django-storages, django-taggit, django-timezone-field, jsonfield
+djangorestframework-xml==1.4.0  # via -r dependencies/pip/requirements.in
+djangorestframework==3.10.3  # via -r dependencies/pip/requirements.in, drf-extensions
 docutils==0.15.2          # via botocore, statistics
-drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in (line 52)
+drf-extensions==0.5.0     # via -r dependencies/pip/requirements.in
 formencode==1.3.1         # via pyxform
-future==0.18.2            # via -r dependencies/pip/requirements.in (line 53)
-geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in (line 54), formpack
+future==0.18.2            # via -r dependencies/pip/requirements.in
+geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
 importlib-metadata==0.23  # via jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
-jsonfield==2.0.2          # via -r dependencies/pip/requirements.in (line 55)
+jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack
-kombu==4.6.6              # via -r dependencies/pip/requirements.in (line 56), celery
+kombu==4.6.6              # via -r dependencies/pip/requirements.in, celery
 linecache2==1.0.0         # via traceback2
-lxml==4.4.1               # via -r dependencies/pip/requirements.in (line 57), formpack, pyquery
-markdown==3.1.1           # via -r dependencies/pip/requirements.in (line 20), django-markdownx
+lxml==4.4.1               # via -r dependencies/pip/requirements.in, formpack, pyquery
+markdown==3.1.1           # via -r dependencies/pip/requirements.in, django-markdownx
 more-itertools==7.2.0     # via zipp
-ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in (line 78)
-oauthlib==3.1.0           # via -r dependencies/pip/requirements.in (line 58), django-oauth-toolkit
+ndg-httpsclient==0.5.1    # via -r dependencies/pip/requirements.in
+oauthlib==3.1.0           # via -r dependencies/pip/requirements.in, django-oauth-toolkit
 path.py==12.0.2           # via formpack
 pillow==6.2.1             # via django-markdownx
-psycopg2==2.8.4           # via -r dependencies/pip/requirements.in (line 60)
-pyasn1==0.4.7             # via -r dependencies/pip/requirements.in (line 79), ndg-httpsclient
+psycopg2==2.8.4           # via -r dependencies/pip/requirements.in
+pyasn1==0.4.7             # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pycparser==2.19           # via cffi
-pygments==2.4.2           # via -r dependencies/pip/requirements.in (line 21)
-pymongo==3.9.0            # via -r dependencies/pip/requirements.in (line 61)
-pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in (line 77), ndg-httpsclient
+pygments==2.4.2           # via -r dependencies/pip/requirements.in
+pymongo==3.9.0            # via -r dependencies/pip/requirements.in
+pyopenssl==19.0.0         # via -r dependencies/pip/requirements.in, ndg-httpsclient
 pyquery==1.4.1            # via formpack
 pyrsistent==0.15.5        # via jsonschema
 python-crontab==2.4.0     # via django-celery-beat
-python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in (line 62), botocore, python-crontab
-pytz==2019.3              # via -r dependencies/pip/requirements.in (line 63), celery, django, django-timezone-field
-pyxform==0.15.1           # via -r dependencies/pip/requirements.in (line 64), formpack
+python-dateutil==2.8.0    # via -r dependencies/pip/requirements.in, botocore, python-crontab
+pytz==2019.3              # via -r dependencies/pip/requirements.in, celery, django, django-timezone-field
+pyxform==0.15.1           # via -r dependencies/pip/requirements.in, formpack
 redis==3.3.11             # via celery, django-redis-sessions
-requests==2.22.0          # via -r dependencies/pip/requirements.in (line 65), django-oauth-toolkit, responses
-responses==0.10.6         # via -r dependencies/pip/requirements.in (line 66)
+requests==2.22.0          # via -r dependencies/pip/requirements.in, django-oauth-toolkit, responses
+responses==0.10.6         # via -r dependencies/pip/requirements.in
 s3transfer==0.2.1         # via boto3
-shortuuid==0.5.0          # via -r dependencies/pip/requirements.in (line 67)
+shortuuid==0.5.0          # via -r dependencies/pip/requirements.in
 six==1.13.0               # via cryptography, django-extensions, jsonschema, pyopenssl, pyrsistent, python-dateutil, responses, unittest2
-sqlparse==0.3.0           # via -r dependencies/pip/requirements.in (line 68), django, django-debug-toolbar
-static3==0.7.0            # via -r dependencies/pip/requirements.in (line 69), dj-static
+sqlparse==0.3.0           # via -r dependencies/pip/requirements.in, django, django-debug-toolbar
+static3==0.7.0            # via -r dependencies/pip/requirements.in, dj-static
 statistics==1.0.3.5       # via formpack
-tabulate==0.8.5           # via -r dependencies/pip/requirements.in (line 70)
+tabulate==0.8.5           # via -r dependencies/pip/requirements.in
 traceback2==1.4.0         # via unittest2
-unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in (line 71), pyxform
+unicodecsv==0.14.1        # via -r dependencies/pip/requirements.in, pyxform
 unittest2==1.1.0          # via pyxform
 urllib3==1.25.7           # via botocore, requests
-uwsgi==2.0.18             # via -r dependencies/pip/requirements.in (line 72)
+uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in (line 73), pyxform
-xlsxwriter==1.2.5         # via formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in (line 74)
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from io import BytesIO
 
 import six
-import xlwt
+import xlsxwriter
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -434,22 +434,23 @@ class XlsExportable:
             # and its return value *only*. Calling deepcopy() is required to
             # achieve this isolation.
             ss_dict = self.ordered_xlsform_content(**kwargs)
-            workbook = xlwt.Workbook()
-            for sheet_name, contents in ss_dict.items():
-                cur_sheet = workbook.add_sheet(sheet_name)
-                _add_contents_to_sheet(cur_sheet, contents)
+            output = BytesIO()
+            with xlsxwriter.Workbook(output) as workbook:
+                for sheet_name, contents in ss_dict.items():
+                    cur_sheet = workbook.add_worksheet(sheet_name)
+                    _add_contents_to_sheet(cur_sheet, contents)
         except Exception as e:
             six.reraise(
-                Exception,
-                "asset.content improperly formatted for XLS "
-                "export: %s" % repr(e),
-                sys.exc_info()[2]
+                type(e),
+                type(e)(
+                    "asset.content improperly formatted for XLS "
+                    "export: %s" % repr(e)
+                ),
+                sys.exc_info()[2],
             )
 
-        obj = BytesIO()
-        workbook.save(obj)
-        obj.seek(0)
-        return obj
+        output.seek(0)
+        return output
 
 
 class Asset(ObjectPermissionMixin,

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -116,7 +116,10 @@ class SubmissionXMLRenderer(DRFXMLRenderer):
 
 
 class XlsRenderer(renderers.BaseRenderer):
-    media_type = 'application/xls'
+    media_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    # Really, this should be `format = 'xlsx'`, but let's not make a breaking
+    # change to the API just to use a newer Excel format. Instead, we'll rely
+    # on `AssetViewSet.finalize_response()` to set the filename appropriately
     format = 'xls'
 
     versioned = True

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -554,16 +554,22 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         # model-level permissions, accepted_renderer won't be present.
         if hasattr(request, 'accepted_renderer'):
             # Check the class of the renderer instead of just looking at the
-            # format, because we don't want to set Content-Disposition:
-            # attachment on asset snapshot XML
-            if (isinstance(request.accepted_renderer, XlsRenderer) or
-                    isinstance(request.accepted_renderer, XFormRenderer)):
+            # format, because we don't want to set
+            # `Content-Disposition: attachment` on asset snapshot XML
+            if isinstance(request.accepted_renderer, XFormRenderer):
+                filename = '.'.join(
+                    (self.get_object().uid, request.accepted_renderer.format)
+                )
                 response[
                     'Content-Disposition'
-                ] = 'attachment; filename={}.{}'.format(
-                    self.get_object().uid,
-                    request.accepted_renderer.format
-                )
+                ] = 'attachment; filename={}'.format(filename)
+            if isinstance(request.accepted_renderer, XlsRenderer):
+                # `accepted_renderer.format` is 'xls' here for historical
+                # reasons, but what we actually serve now is xlsx (Excel 2007+)
+                filename = '.'.join((self.get_object().uid, 'xlsx'))
+                response[
+                    'Content-Disposition'
+                ] = 'attachment; filename={}'.format(filename)
 
         return super().finalize_response(
             request, response, *args, **kwargs)


### PR DESCRIPTION
XLSX is now used instead of XLS when deploying forms to KoBoCAT and downloading forms as XLSForm. Fixes #2591.