### PR TITLE
Improve autonaming

### DIFF
--- a/jsapp/js/formbuild/containers/KoboMatrix.es6
+++ b/jsapp/js/formbuild/containers/KoboMatrix.es6
@@ -116,7 +116,7 @@ class KoboMatrix extends React.Component {
       lowerCase: true,
       lrstrip: true,
       preventDuplicateUnderscores: true,
-      characterLimit: 99,
+      characterLimit: 40,
       incrementorPadding: false,
       validXmlTag: false,
       replaceNonWordCharacters: true

--- a/jsapp/js/formbuild/containers/KoboMatrix.es6
+++ b/jsapp/js/formbuild/containers/KoboMatrix.es6
@@ -116,7 +116,7 @@ class KoboMatrix extends React.Component {
       lowerCase: true,
       lrstrip: true,
       preventDuplicateUnderscores: true,
-      characterLimit: 14,
+      characterLimit: 99,
       incrementorPadding: false,
       validXmlTag: false,
       replaceNonWordCharacters: true

--- a/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_card_multichoice.scss
@@ -100,18 +100,21 @@
     overflow: hidden;
 
     label {
-      width: 32%;
+      display: inline-block;
+      width: 40%;
       padding-left: 4px;
       color: #7E858C;
     }
 
-    span, .editable-container {
+    span,
+    .editable-container {
+      text-align: right;
       display: inline-block;
       float: right;
-      width: 64%;
+      width: 60%;
       padding-right: 4px;
       color: #7E858C;
-      text-align: right;
+      overflow-wrap: break-word;
       cursor: text;
     }
 
@@ -123,8 +126,9 @@
       text-align: right;
       display: inline-block;
       float: right;
+      width: 60% !important;
       color: $linkColor;
-      line-height: 1em;
+      line-height: inherit;
       font-size: 11px;
     }
   }

--- a/jsapp/xlform/src/model.choices.coffee
+++ b/jsapp/xlform/src/model.choices.coffee
@@ -129,7 +129,7 @@ module.exports = do ->
             preventDuplicates: names
             lowerCase: true
             lrstrip: true
-            characterLimit: 14
+            characterLimit: 99
             incrementorPadding: false
             validXmlTag: false
           })

--- a/jsapp/xlform/src/model.choices.coffee
+++ b/jsapp/xlform/src/model.choices.coffee
@@ -129,7 +129,7 @@ module.exports = do ->
             preventDuplicates: names
             lowerCase: true
             lrstrip: true
-            characterLimit: 99
+            characterLimit: 40
             incrementorPadding: false
             validXmlTag: false
           })

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -116,7 +116,7 @@ module.exports = do ->
                     lowerCase: false
                     lrstrip: true
                     incrementorPadding: false
-                    characterLimit: 99
+                    characterLimit: 40
                     validXmlTag: false
                     nonWordCharsExceptions: '+-.'
                   })

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -87,7 +87,7 @@ module.exports = do ->
       @t = $("<i class=\"fa fa-trash-o js-remove-option\">")
       @pw = $("<div class=\"editable-wrapper js-cancel-select-row\">")
       @p = $("<span class=\"js-cancel-select-row\">")
-      @c = $("<code><label>#{_t("Value:")}</label> <span class=\"js-cancel-select-row\">#{_t("AUTOMATIC")}</span></code>")
+      @c = $("<code><label>#{_t("XML value:")}</label> <span class=\"js-cancel-select-row\">#{_t("AUTOMATIC")}</span></code>")
       @d = $('<div>')
       if @model
         @p.html @model.get("label") || 'Empty'
@@ -116,7 +116,7 @@ module.exports = do ->
                     lowerCase: false
                     lrstrip: true
                     incrementorPadding: false
-                    characterLimit: 14
+                    characterLimit: 99
                     validXmlTag: false
                     nonWordCharsExceptions: '+-.'
                   })

--- a/jsapp/xlform/src/view.choices.templates.coffee
+++ b/jsapp/xlform/src/view.choices.templates.coffee
@@ -5,7 +5,7 @@ module.exports = do ->
       """<div class="card__addoptions">
           <div class="card__addoptions__layer"></div>
             <ul><li class="multioptions__option  xlf-option-view xlf-option-view--depr">
-              <div><div class="editable-wrapper"><span class="editable editable-click">+ #{_t("Click to add another response...")}</span></div><code><label>#{_t("Value:")}</label> <span>#{_t("AUTOMATIC")}</span></code></div>
+              <div><div class="editable-wrapper"><span class="editable editable-click">+ #{_t("Click to add another response...")}</span></div><code><label>#{_t("XML value:")}</label> <span>#{_t("AUTOMATIC")}</span></code></div>
             </li></ul>
         </div>"""
 


### PR DESCRIPTION
## Description

Things changed:
- character limit for names is now `40` (same as on BE)
- label is "XML Value"
- long names are now displayed by wrapping the text

Using unicode characters in names works when manually typing in. Doesn't work when leaving on `AUTOMATIC`.

## Related issues

Part of #623 

