### PR TITLE
added verbose response to sentry, changed error displayed

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -131,8 +131,12 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         except ValueError as e:
             # Unparseable KC API output
             # TODO: clarify that the user cannot correct this
+            logging.error('KoBoCAT returned invalid JSON',
+                          extra={'kc_response': response.content})
             raise KobocatDeploymentException(
-                detail=str(e), response=response)
+                detail=_('Could not parse KoBoCAT response'),
+                response=response
+            )
 
         # Check for failure
         if response.status_code != expected_status_code or (


### PR DESCRIPTION
## Description

Added more verbose error message when uploading bad XLSForm. The following now shows for the same form specified in #2590 :
![Screenshot from 2020-03-30 15-27-23](https://user-images.githubusercontent.com/16762675/77953484-5cc2f780-729b-11ea-9a7f-d517d399b214.png)

Fix is coupled with https://github.com/kobotoolbox/kobocat/pull/605 for removing UnicodeDecodeError

Added `logging` to send more verbose errors to Sentry, changed the displayed error message for other errors. 

## Related issues
Fixes #2590 

