### PR TITLE
Better deleted submission error and title for REST Services

### DIFF
--- a/jsapp/js/components/modal.es6
+++ b/jsapp/js/components/modal.es6
@@ -160,13 +160,18 @@ class Modal extends React.Component {
     let title = t('Submission Record'),
         p = props.params,
         sid = parseInt(p.sid);
+    console.dir(p);
 
     if (p.tableInfo) {
       let index = p.ids.indexOf(sid) + (p.tableInfo.pageSize * p.tableInfo.currentPage) + 1;
       title =  `${t('Submission Record')} (${index} ${t('of')} ${p.tableInfo.resultsTotal})`;
     } else {
       let index = p.ids.indexOf(sid);
-      title =  `${t('Submission Record')} (${index} ${t('of')} ${p.ids.length})`;
+      if (p.ids.length === 1) {
+          title = `${t('Submission Record')}`;
+      } else {
+          title = `${t('Submission Record')} (${index} ${t('of')} ${p.ids.length})`;
+      }
     }
 
     return title;

--- a/jsapp/js/components/modalForms/submission.es6
+++ b/jsapp/js/components/modalForms/submission.es6
@@ -15,7 +15,8 @@ import ui from 'js/ui';
 import icons from '../../../xlform/src/view.icons';
 import {
   VALIDATION_STATUSES_LIST,
-  MODAL_TYPES
+  MODAL_TYPES,
+  DETAIL_NOT_FOUND
 } from 'js/constants';
 
 class Submission extends React.Component {
@@ -105,12 +106,16 @@ class Submission extends React.Component {
         hasBetaQuestion: hasBetaQuestion
       });
     }).fail((error)=>{
-      if (error.responseText)
-        this.setState({error: error.responseText, loading: false});
-      else if (error.statusText)
-        this.setState({error: error.statusText, loading: false});
-      else
+      if (error.responseText) {
+        let error_message = error.responseText;
+        if (error_message === DETAIL_NOT_FOUND)
+          error_message = 'The submission could not be found. It may have been deleted. Submission ID: ' + sid;
+        this.setState({error: error_message, loading: false});
+      } else if (error.statusText) {
+          this.setState({error: error.statusText, loading: false});
+      } else {
         this.setState({error: t('Error: could not load data.'), loading: false});
+      }
     });
   }
 

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -347,6 +347,8 @@ new Set([
 
 export const NAME_MAX_LENGTH = 255;
 
+export const DETAIL_NOT_FOUND = '{\"detail\":\"Not found.\"}';
+
 const constants = {
   ROOT_URL,
   ANON_USERNAME,


### PR DESCRIPTION
# Description
Two changes:
* Made a better displayed error message if submission is deleted in REST service view
* Removed the `0 of 1` from submission title if there is no sequence of submissions to view. It seems like this happens regardless if the submission is viewed from the REST services table

## Related issues
Fixes #2470 
