### PR TITLE
Fixed bug where adding translations to matrix would add another null …

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -233,8 +233,9 @@ export default assign({
     }
 
     let surveyJSON = surveyToValidJson(this.app.survey);
+    let surveyJSONWithMatrix = koboMatrixParser({source: surveyJSON}).source;
     if (this.state.asset) {
-      surveyJSON = unnullifyTranslations(surveyJSON, this.state.asset.content);
+      surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, this.state.asset.content);
     }
     let params = {content: surveyJSON};
 
@@ -263,8 +264,6 @@ export default assign({
       }
       params.settings = JSON.stringify(settings);
     }
-
-    params = koboMatrixParser(params);
 
     if (this.state.editorState === 'new') {
       // we're intentionally leaving after creating new asset,

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -233,8 +233,8 @@ export default assign({
     }
 
     let surveyJSON = surveyToValidJson(this.app.survey);
-    let surveyJSONWithMatrix = koboMatrixParser({source: surveyJSON}).source;
     if (this.state.asset) {
+      let surveyJSONWithMatrix = koboMatrixParser({source: surveyJSON}).source;
       surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, this.state.asset.content);
     }
     let params = {content: surveyJSON};


### PR DESCRIPTION
## Description

There was an error with the way `label`s were being set by `unnullifyTranslation`. The function was being fed no choices so it didn't bother setting all `label`s to something like `label::(Translation (tr))`

Changed the way `editableForm` saves forms with Matrices

## Related issues

Fixed #2604 
