### PR TITLE
Expand / collapse groups

### DIFF
--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -377,21 +377,28 @@ module.exports = do ->
       @$el.removeClass("survey-editor--loading")
       @
 
+    shrinkAllGroups: ->
+      $('.survey__row--group:not(.group--shrunk)').each (i, el) ->
+        if !$(el).hasClass('group--shrunk')
+          $(el).find('.group__caret').click()
+
+    expandAllGroups: ->
+      depth = 0
+      while $('.survey__row--group.group--shrunk').length > 0
+        $('.survey__row--group.group--shrunk').each (i, el) ->
+          $(el).find('.group__caret').click()
+        if depth++ > 10
+          break
+
     expandMultioptions: ->
       if @expand_all_multioptions()
-        $('.survey__row--group:not(.group--shrunk)').each (i, el) ->
-          if !$(el).hasClass('group--shrunk')
-            $(el).find('.group__caret').click()
+        @shrinkAllGroups()
         @$(".card--expandedchoices").each (i, el)=>
           @_getViewForTarget(currentTarget: el).hideMultioptions()
           ``
         _expanded = false
       else
-        depth = 0
-        while $('.survey__row--group.group--shrunk').length > 0
-          $('.survey__row--group.group--shrunk').each (i, el) => $(el).find('.group__caret').click()
-          if depth++ > 10
-            break
+        @expandAllGroups()
         @$(".card--selectquestion").each (i, el)=>
           @_getViewForTarget(currentTarget: el).showMultioptions()
           ``

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -378,14 +378,14 @@ module.exports = do ->
       @
 
     shrinkAllGroups: ->
-      $('.survey__row--group:not(.group--shrunk)').each (i, el) ->
+      @$('.survey__row--group:not(.group--shrunk)').each (i, el) ->
         if !$(el).hasClass('group--shrunk')
           $(el).find('.group__caret').click()
 
     expandAllGroups: ->
       depth = 0
-      while $('.survey__row--group.group--shrunk').length > 0
-        $('.survey__row--group.group--shrunk').each (i, el) ->
+      while @$('.survey__row--group.group--shrunk').length > 0
+        @$('.survey__row--group.group--shrunk').each (i, el) ->
           $(el).find('.group__caret').click()
         if depth++ > 10
           break

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -244,6 +244,7 @@ module.exports = do ->
       @_getViewForTarget(evt).toggleSettings()
 
     toggleGroupExpansion: (evt)->
+      console.log evt
       view = @_getViewForTarget(evt)
       groupsAreShrunk = view.$el.hasClass('group--shrunk')
       @surveyStateStore.setState({
@@ -379,11 +380,18 @@ module.exports = do ->
 
     expandMultioptions: ->
       if @expand_all_multioptions()
+        $('.survey__row--group:not(.group--shrunk)').each (i, el) ->
+          if !$(el).hasClass('group--shrunk')
+            $(el).find('.group__caret').click()
         @$(".card--expandedchoices").each (i, el)=>
           @_getViewForTarget(currentTarget: el).hideMultioptions()
           ``
         _expanded = false
       else
+        # while loop is potentially bad if there is a future change that no 
+        # longer updates `group--shrunk` when collapsing groups
+        while $('.survey__row--group.group--shrunk').length > 0
+            $('.survey__row--group.group--shrunk').each (i, el) => $(el).find('.group__caret').click()
         @$(".card--selectquestion").each (i, el)=>
           @_getViewForTarget(currentTarget: el).showMultioptions()
           ``
@@ -393,6 +401,7 @@ module.exports = do ->
           multioptionsExpanded: _expanded
         })
       return
+
 
     closeWarningBox: (evt)->
       @$('.survey-warnings').hide()
@@ -451,7 +460,7 @@ module.exports = do ->
       group_rows = @formEditorEl.find('.group__rows')
       group_rows.each (index) =>
         $(group_rows[index]).sortable({
-          cancel: 'button, .btn--addrow, .well, ul.list-view, li.editor-message, .editableform, .row-extras, .js-cancel-sort, .js-cancel-group-sort' + index
+          cancel: 'button, .btn--addrow, .well, ul.list-view, li.editor-message, .editableform, .row-extras, .js-cancel-sort, .js-cancel-group-sort'# + index
           cursor: "move"
           distance: 5
           items: "> li"

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -387,10 +387,11 @@ module.exports = do ->
           ``
         _expanded = false
       else
-        # while loop is potentially bad if there is a future change that no 
-        # longer updates `group--shrunk` when collapsing groups
+        depth = 0
         while $('.survey__row--group.group--shrunk').length > 0
           $('.survey__row--group.group--shrunk').each (i, el) => $(el).find('.group__caret').click()
+          if depth++ > 10
+            break
         @$(".card--selectquestion").each (i, el)=>
           @_getViewForTarget(currentTarget: el).showMultioptions()
           ``

--- a/jsapp/xlform/src/view.surveyApp.coffee
+++ b/jsapp/xlform/src/view.surveyApp.coffee
@@ -244,7 +244,6 @@ module.exports = do ->
       @_getViewForTarget(evt).toggleSettings()
 
     toggleGroupExpansion: (evt)->
-      console.log evt
       view = @_getViewForTarget(evt)
       groupsAreShrunk = view.$el.hasClass('group--shrunk')
       @surveyStateStore.setState({
@@ -391,7 +390,7 @@ module.exports = do ->
         # while loop is potentially bad if there is a future change that no 
         # longer updates `group--shrunk` when collapsing groups
         while $('.survey__row--group.group--shrunk').length > 0
-            $('.survey__row--group.group--shrunk').each (i, el) => $(el).find('.group__caret').click()
+          $('.survey__row--group.group--shrunk').each (i, el) => $(el).find('.group__caret').click()
         @$(".card--selectquestion").each (i, el)=>
           @_getViewForTarget(currentTarget: el).showMultioptions()
           ``
@@ -401,7 +400,6 @@ module.exports = do ->
           multioptionsExpanded: _expanded
         })
       return
-
 
     closeWarningBox: (evt)->
       @$('.survey-warnings').hide()
@@ -460,7 +458,7 @@ module.exports = do ->
       group_rows = @formEditorEl.find('.group__rows')
       group_rows.each (index) =>
         $(group_rows[index]).sortable({
-          cancel: 'button, .btn--addrow, .well, ul.list-view, li.editor-message, .editableform, .row-extras, .js-cancel-sort, .js-cancel-group-sort'# + index
+          cancel: 'button, .btn--addrow, .well, ul.list-view, li.editor-message, .editableform, .row-extras, .js-cancel-sort, .js-cancel-group-sort' + index
           cursor: "move"
           distance: 5
           items: "> li"


### PR DESCRIPTION
## Description

Extended the actions of clicking `Expand / collapse questions` in `formBuilder` to expand or collapse groups

Other things to potentially look out for:
* create two buttons (instead of the one right now) for expanding/collapsing questions vs groups
* change the tool-tip from "Expand / collapse questions" to something like "Expand / collapse the form" for one button, or "Expand / collapse questions/groups"  if we take the two button approach

## Related issues

Fixes #2204 

