### PR TITLE
Update activation email

### DIFF
--- a/kpi/templates/registration/activation_email.txt
+++ b/kpi/templates/registration/activation_email.txt
@@ -1,13 +1,13 @@
 {% load i18n %}
 {% trans "Thanks for signing up with KoBoToolbox!" %}
 
-{% trans "Confirming your account will give you full access to KoBoToolbox applications. Please visit the following url to finish activation of your new account." %}
+{% trans "Confirming your account will give you access to KoBoToolbox applications. Please visit the following URL to finish activation of your new account." %}
 
-{{ user }}
+{{ kpi_protocol }}://{{ site.domain }}/accounts/activate/{{activation_key}}
 
-{{ kpi_protocol }}://{{ site.domain }}/accounts/activate/{{activation_key}}/
+{% trans "Your username is: " %} {{ user }} 
 
-{% trans "Please visit http://help.kobotoolbox.org to find information on how to get started. There you can also post questions to the community (recommended) or to us directly." %}
+{% trans "Please visit https://community.kobotoolbox.org/ to find information on how to get started. There you can also post questions to the community (recommended) or to us directly." %}
 
 {% trans "Best," %}
 KoBoToolbox


### PR DESCRIPTION
## Description

Added the items from the #2433 checklist.

Removing the trailing `/` makes the registration link work for hotmail, gmail, and yahoo mail.

## Related issues

Fixes #2433 , #605 
