### PR TITLE
Added EXIF orentation fix for viewing photo submissions

### DIFF
--- a/jsapp/scss/components/_kobo.modal.scss
+++ b/jsapp/scss/components/_kobo.modal.scss
@@ -316,6 +316,7 @@ $z-modal-x: 10;
 
       img {
         max-width: 100%;
+        image-orientation: from-image;
       }
     }
 


### PR DESCRIPTION
#### Description
Viewing photo submissions would maintain EXIF orientation of the original image. Fixes this issue by displaying every image with the 'correct' orientation (i.e., removing the EXIF rotation).

#### Related Issues
Fixes #2241 

