### PR TITLE
Added a network check before username check

### DIFF
--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -273,7 +273,9 @@ class UserAssetPermsEditor extends React.Component {
   }
 
   notifyUnknownUser(username) {
-    notify(`${t('User not found:')} ${username}`, 'warning');
+    if (navigator.onLine) {
+      notify(`${t('User not found:')} ${username}`, 'warning');
+    }
   }
 
   /**

--- a/jsapp/js/components/permissions/userCollectionPermsEditor.es6
+++ b/jsapp/js/components/permissions/userCollectionPermsEditor.es6
@@ -172,7 +172,9 @@ class UserCollectionPermissionsEditor extends React.Component {
   }
 
   notifyUnknownUser(username) {
-    notify(`${t('User not found:')} ${username}`, 'warning');
+    if (navigator.onLine) {
+      notify(`${t('User not found:')} ${username}`, 'warning');
+    }
   }
 
   /**

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -396,10 +396,8 @@ var selectedAssetStore = Reflux.createStore({
 var userExistsStore = Reflux.createStore({
   init () {
     this.checked = {};
-    if (navigator.onLine) {
-        this.listenTo(actions.misc.checkUsername.completed, this.usernameExists);
-        this.listenTo(actions.misc.checkUsername.failed, this.usernameDoesntExist);
-    }
+    this.listenTo(actions.misc.checkUsername.completed, this.usernameExists);
+    this.listenTo(actions.misc.checkUsername.failed, this.usernameDoesntExist);
   },
   checkUsername (username) {
     if (username in this.checked) {

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -396,8 +396,10 @@ var selectedAssetStore = Reflux.createStore({
 var userExistsStore = Reflux.createStore({
   init () {
     this.checked = {};
-    this.listenTo(actions.misc.checkUsername.completed, this.usernameExists);
-    this.listenTo(actions.misc.checkUsername.failed, this.usernameDoesntExist);
+    if (navigator.onLine) {
+        this.listenTo(actions.misc.checkUsername.completed, this.usernameExists);
+        this.listenTo(actions.misc.checkUsername.failed, this.usernameDoesntExist);
+    }
   },
   checkUsername (username) {
     if (username in this.checked) {


### PR DESCRIPTION
## Description
Added check for active internet connection before checking backend for username
When trying to add permissions during a network failure, no `User not found` notifications are shown

May be a better solution for a more general network failure handling, for example notifying that the connection has dropped (?)
## Related issues
Fixes #2341 
