### PR TITLE
Adding gradual pagination to version history

### DIFF
--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -10,7 +10,10 @@ import ui from '../ui';
 import mixins from '../mixins';
 import DocumentTitle from 'react-document-title';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import {MODAL_TYPES} from '../constants';
+import {
+    MODAL_TYPES,
+    DVCOUNT_LIMIT_MINIMUM
+} from '../constants';
 import {
   formatTime,
   t,
@@ -21,7 +24,8 @@ export class FormLanding extends React.Component {
   constructor(props){
     super(props);
     this.state = {
-      selectedCollectMethod: 'offline_url'
+      selectedCollectMethod: 'offline_url',
+      DVCOUNT_LIMIT: 2
     };
     autoBind(this);
   }
@@ -129,6 +133,16 @@ export class FormLanding extends React.Component {
       asset: this.state
     });
   }
+  increaseDVCOUNT_LIMIT() {
+    if (this.state.DVCOUNT_LIMIT + DVCOUNT_LIMIT_MINIMUM <= this.state.deployed_versions.count + DVCOUNT_LIMIT_MINIMUM) {
+      this.setState({ DVCOUNT_LIMIT : this.state.DVCOUNT_LIMIT + DVCOUNT_LIMIT_MINIMUM });
+    }
+  }
+  decreaseDVCOUNT_LIMIT() {
+    if (this.state.DVCOUNT_LIMIT - DVCOUNT_LIMIT_MINIMUM > 0) {
+      this.setState({ DVCOUNT_LIMIT : this.state.DVCOUNT_LIMIT -  DVCOUNT_LIMIT_MINIMUM });
+    }
+  }
   renderHistory () {
     var dvcount = this.state.deployed_versions.count;
     return (
@@ -147,7 +161,7 @@ export class FormLanding extends React.Component {
             </bem.FormView__group>
             {this.state.deployed_versions.results.map((item, n) => {
               return (
-                <bem.FormView__group m='items' key={n} >
+                <bem.FormView__group m='items' key={n} className={n >= this.state.DVCOUNT_LIMIT ? 'hidden' : ''} >
                   <bem.FormView__label m='version'>
                     {`v${dvcount - n}`}
                     {item.uid === this.state.deployed_version_id && this.state.deployment__active &&
@@ -177,6 +191,16 @@ export class FormLanding extends React.Component {
             <button className='mdl-button mdl-button--colored' onClick={this.toggleDeploymentHistory}>
               {this.state.historyExpanded ? t('Hide full history') : t('Show full history')}
             </button>
+            {this.state.historyExpanded &&
+              <button className='mdl-button mdl-button--colored' onClick={this.increaseDVCOUNT_LIMIT}>
+                {this.state.DVCOUNT_LIMIT < dvcount && t('Load more')}
+              </button>
+            }
+            {this.state.historyExpanded &&
+               <button className='mdl-button mdl-button--colored' onClick={this.decreaseDVCOUNT_LIMIT}>
+                  {this.state.DVCOUNT_LIMIT - DVCOUNT_LIMIT_MINIMUM >= DVCOUNT_LIMIT_MINIMUM && t('Load less')}
+              </button>
+            }
           </bem.FormView__cell>
         }
       </bem.FormView__row>

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -11,15 +11,14 @@ import ui from '../ui';
 import mixins from '../mixins';
 import DocumentTitle from 'react-document-title';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import {
-    MODAL_TYPES,
-    DVCOUNT_LIMIT_MINIMUM
-} from '../constants';
+import {MODAL_TYPES} from '../constants';
 import {
   formatTime,
   t,
   notify
 } from '../utils';
+
+const DVCOUNT_LIMIT_MINIMUM = 20;
 
 export class FormLanding extends React.Component {
   constructor(props){

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -5,6 +5,7 @@ import autoBind from 'react-autobind';
 import Reflux from 'reflux';
 import { Link } from 'react-router';
 import {bem} from '../bem';
+import {dataInterface} from '../dataInterface';
 import {stores} from '../stores';
 import ui from '../ui';
 import mixins from '../mixins';
@@ -25,7 +26,9 @@ export class FormLanding extends React.Component {
     super(props);
     this.state = {
       selectedCollectMethod: 'offline_url',
-      DVCOUNT_LIMIT: 2
+      DVCOUNT_LIMIT: 20,
+      currentVersions: {},
+      nextPageUrl: 'inital'
     };
     autoBind(this);
   }
@@ -42,7 +45,6 @@ export class FormLanding extends React.Component {
   renderFormInfo (userCanEdit) {
     var dvcount = this.state.deployed_versions.count;
     var undeployedVersion;
-
     if (!this.isCurrentVersionDeployed()) {
       undeployedVersion = `(${t('undeployed')})`;
       dvcount = dvcount + 1;
@@ -137,14 +139,27 @@ export class FormLanding extends React.Component {
     if (this.state.DVCOUNT_LIMIT + DVCOUNT_LIMIT_MINIMUM <= this.state.deployed_versions.count + DVCOUNT_LIMIT_MINIMUM) {
       this.setState({ DVCOUNT_LIMIT : this.state.DVCOUNT_LIMIT + DVCOUNT_LIMIT_MINIMUM });
     }
-  }
-  decreaseDVCOUNT_LIMIT() {
-    if (this.state.DVCOUNT_LIMIT - DVCOUNT_LIMIT_MINIMUM > 0) {
-      this.setState({ DVCOUNT_LIMIT : this.state.DVCOUNT_LIMIT -  DVCOUNT_LIMIT_MINIMUM });
+    if (this.state.DVCOUNT_LIMIT >= 80) {
+      var curr = this.state.currentVersions;
+      if (this.state.nextPageUrl) {
+        dataInterface.loadNextPageUrl(this.state.nextPageUrl).done((data) => {
+          this.setState({nextPageUrl: data.deployed_versions.next});
+          Object.values(data.deployed_versions.results).forEach(function(ele){
+              curr.push(ele);
+          });
+        });
+      }
+      this.setState({currentVersions: curr});
     }
   }
   renderHistory () {
     var dvcount = this.state.deployed_versions.count;
+    if (this.state.nextPageUrl === 'inital') {
+      this.setState({
+          nextPageUrl: this.state.deployed_versions.next,
+      });
+      this.state.currentVersions = this.state.deployed_versions.results;
+    }
     return (
       <bem.FormView__row className={this.state.historyExpanded ? 'historyExpanded' : 'historyHidden'}>
         <bem.FormView__cell m={['columns', 'history-label']}>
@@ -159,30 +174,32 @@ export class FormLanding extends React.Component {
               <bem.FormView__label m='date'>{t('Last Modified')}</bem.FormView__label>
               <bem.FormView__label m='clone'>{t('Clone')}</bem.FormView__label>
             </bem.FormView__group>
-            {this.state.deployed_versions.results.map((item, n) => {
-              return (
-                <bem.FormView__group m='items' key={n} className={n >= this.state.DVCOUNT_LIMIT ? 'hidden' : ''} >
-                  <bem.FormView__label m='version'>
-                    {`v${dvcount - n}`}
-                    {item.uid === this.state.deployed_version_id && this.state.deployment__active &&
-                      <bem.FormView__cell m='deployed'>
-                        {t('Deployed')}
-                      </bem.FormView__cell>
-                    }
-                  </bem.FormView__label>
-                  <bem.FormView__label m='date'>
-                    {formatTime(item.date_deployed)}
-                  </bem.FormView__label>
-                  <bem.FormView__label m='clone' className='right-tooltip'>
-                      <bem.FormView__link m='clone'
-                          data-version-id={item.uid}
-                          data-tip={t('Clone this version as a new project')}
-                          onClick={this.saveCloneAs}>
-                        <i className='k-icon-clone' />
-                      </bem.FormView__link>
-                  </bem.FormView__label>
-                </bem.FormView__group>
-              );
+            {this.state.currentVersions.map((item, n) => {
+              if (dvcount - n > 0) {
+                return (
+                  <bem.FormView__group m='items' key={n} className={n >= this.state.DVCOUNT_LIMIT ? 'hidden' : ''} >
+                    <bem.FormView__label m='version'>
+                      {`v${dvcount - n}`}
+                      {item.uid === this.state.deployed_version_id && this.state.deployment__active &&
+                        <bem.FormView__cell m='deployed'>
+                          {t('Deployed')}
+                        </bem.FormView__cell>
+                      }
+                    </bem.FormView__label>
+                    <bem.FormView__label m='date'>
+                      {formatTime(item.date_deployed)}
+                    </bem.FormView__label>
+                    <bem.FormView__label m='clone' className='right-tooltip'>
+                        <bem.FormView__link m='clone'
+                            data-version-id={item.uid}
+                            data-tip={t('Clone this version as a new project')}
+                            onClick={this.saveCloneAs}>
+                          <i className='k-icon-clone' />
+                        </bem.FormView__link>
+                    </bem.FormView__label>
+                  </bem.FormView__group>
+                );
+              }
             })}
           </bem.FormView__group>
         </bem.FormView__cell>
@@ -194,11 +211,6 @@ export class FormLanding extends React.Component {
             {this.state.historyExpanded &&
               <button className='mdl-button mdl-button--colored' onClick={this.increaseDVCOUNT_LIMIT}>
                 {this.state.DVCOUNT_LIMIT < dvcount && t('Load more')}
-              </button>
-            }
-            {this.state.historyExpanded &&
-               <button className='mdl-button mdl-button--colored' onClick={this.decreaseDVCOUNT_LIMIT}>
-                  {this.state.DVCOUNT_LIMIT - DVCOUNT_LIMIT_MINIMUM >= DVCOUNT_LIMIT_MINIMUM && t('Load less')}
               </button>
             }
           </bem.FormView__cell>

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -347,8 +347,6 @@ new Set([
 
 export const NAME_MAX_LENGTH = 255;
 
-export const DVCOUNT_LIMIT_MINIMUM = 20;
-
 const constants = {
   ROOT_URL,
   ANON_USERNAME,

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -347,6 +347,8 @@ new Set([
 
 export const NAME_MAX_LENGTH = 255;
 
+export const DVCOUNT_LIMIT_MINIMUM = 20;
+
 const constants = {
   ROOT_URL,
   ANON_USERNAME,


### PR DESCRIPTION
## Description

Added the following changes to how version history is displayed. I've made the changes limited to 2 items each to help paint the picture:

![1306-pagination-1](https://user-images.githubusercontent.com/16762675/80268127-f4392180-8672-11ea-8aa8-ce368fbc2f9a.gif)

As mentioned in #1306 , the `LOAD MORE` and `LOAD LESS` options would increase/decrease the amount of version displayed by 20 (unlike the 2 shown above). `HIDE FULL HISTORY` and `SHOW FULL HISTORY` still function the same and the amount of version displayed remains the same until refreshed

#### Further Improvements
We could also add a field to manually set how many versions to be displayed if an arbitrary number like 20 is too general

Should probably change the name of the button to something like `SHOW VERSION HISTORY`, this is left alone for now due to potential translation issues

## Related issues

Fixes #1306 
