### PR TITLE
add lang_header parameter for specify language header values in export

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -348,6 +348,12 @@ class ExportTask(ImportExportTask):
               response values. Specify `_xml` to use question and choice names
               instead of labels. Leave unset, or use `_default` for labels in
               the default language
+    * `lang_header`: optional; the name of the translation to be used just for
+              headers values. Specify `_xml` to use question names in headers
+              instead of labels. Use `_default` for headers labels in the
+              default language. Leave unset for override it and use lang arg
+              value.
+              Need this PR : https://github.com/kobotoolbox/formpack/pull/215
     * `hierarchy_in_labels`: optional; when `true`, include the labels for all
                              ancestor groups in each field label, separated by
                              `group_sep`. Defaults to `False`
@@ -462,10 +468,12 @@ class ExportTask(ImportExportTask):
         group_sep = self.data.get('group_sep', '/')
         translations = pack.available_translations
         lang = self.data.get('lang', None) or next(iter(translations), None)
+        lang_header = self.data.get('lang_header', lang) or next(iter(translations), None)
         try:
             # If applicable, substitute the constants that formpack expects for
             # friendlier language strings used by the API
             lang = self.API_LANGUAGE_TO_FORMPACK_LANGUAGE[lang]
+            lang_header = self.API_LANGUAGE_TO_FORMPACK_LANGUAGE[lang_header]
         except KeyError:
             pass
         tag_cols_for_header = self.data.get('tag_cols_for_header', ['hxl'])
@@ -478,6 +486,7 @@ class ExportTask(ImportExportTask):
             'copy_fields': self.COPY_FIELDS,
             'force_index': True,
             'tag_cols_for_header': tag_cols_for_header,
+            'lang_header': lang_header,
         }
 
     def _record_last_submission_time(self, submission_stream):

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -348,7 +348,7 @@ class ExportTask(ImportExportTask):
               response values. Specify `_xml` to use question and choice names
               instead of labels. Leave unset, or use `_default` for labels in
               the default language
-    * `lang_header`: optional; the name of the translation to be used just for
+    * `header_lang`: optional; the name of the translation to be used just for
               headers values. Specify `_xml` to use question names in headers
               instead of labels. Use `_default` for headers labels in the
               default language. Leave unset for override it and use lang arg
@@ -468,12 +468,12 @@ class ExportTask(ImportExportTask):
         group_sep = self.data.get('group_sep', '/')
         translations = pack.available_translations
         lang = self.data.get('lang', None) or next(iter(translations), None)
-        lang_header = self.data.get('lang_header', lang) or next(iter(translations), None)
+        header_lang = self.data.get('header_lang', lang)
         try:
             # If applicable, substitute the constants that formpack expects for
             # friendlier language strings used by the API
             lang = self.API_LANGUAGE_TO_FORMPACK_LANGUAGE[lang]
-            lang_header = self.API_LANGUAGE_TO_FORMPACK_LANGUAGE[lang_header]
+            header_lang = self.API_LANGUAGE_TO_FORMPACK_LANGUAGE[header_lang]
         except KeyError:
             pass
         tag_cols_for_header = self.data.get('tag_cols_for_header', ['hxl'])
@@ -486,7 +486,7 @@ class ExportTask(ImportExportTask):
             'copy_fields': self.COPY_FIELDS,
             'force_index': True,
             'tag_cols_for_header': tag_cols_for_header,
-            'lang_header': lang_header,
+            'header_lang': header_lang,
         }
 
     def _record_last_submission_time(self, submission_stream):

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -56,6 +56,7 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
             'lang',
             'hierarchy_in_labels',
             'fields_from_all_versions',
+            'lang_header',
         )
         task_data = {}
         for opt in valid_options:

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -56,7 +56,7 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
             'lang',
             'hierarchy_in_labels',
             'fields_from_all_versions',
-            'lang_header',
+            'header_lang',
         )
         task_data = {}
         for opt in valid_options:


### PR DESCRIPTION
add lang_header parameter. lang_header can be used for specify the language for header values in excel/csv export (you can have _xml header values and _default values for submits datas). If not set, lang arg override lang_header arg value. Need this PR : https://github.com/kobotoolbox/formpack/pull/215