### PR TITLE
Do not expand_content() twice

### DIFF
--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -31,7 +31,7 @@ def build_formpack(asset, submission_stream=None, use_all_form_versions=True):
     version_ids_newest_first = []
     for v in _versions:
         try:
-            fp_schema = v.to_formpack_schema()
+            fp_schema = v.to_formpack_unexpanded_schema()
         # FIXME: should FormPack validation errors have their own
         # exception class?
         except TypeError as e:

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -49,9 +49,9 @@ class AssetVersion(models.Model):
             return to_xlsform_structure(self.version_content,
                                         move_autonames=True)
 
-    def to_formpack_schema(self):
+    def to_formpack_unexpanded_schema(self):
         return {
-            'content': expand_content(self._deployed_content()),
+            'content': self._deployed_content(),
             'version': self.uid,
             'version_id_key': '__version__',
         }

--- a/kpi/tests/test_mock_data.py
+++ b/kpi/tests/test_mock_data.py
@@ -144,7 +144,7 @@ class MockDataReports(TestCase):
                 '__version__': v_uid
             })
         self.asset.deployment.mock_submissions(submissions)
-        schemas = [v.to_formpack_schema() for v in self.asset.deployed_versions]
+        schemas = [v.to_formpack_unexpanded_schema() for v in self.asset.deployed_versions]
         self.fp = FormPack(versions=schemas, id_string=self.asset.uid)
         self.vs = self.fp.versions.keys()
         self.submissions = self.asset.deployment.get_submissions(self.user.id)


### PR DESCRIPTION
#2419  Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure your code lints and you followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] If this is a big feature, make sure to prefix the title with `Feature:` and add a thorough description for non-dev folk

## Description

FormPack consturctor already does that:
https://github.com/kobotoolbox/formpack/blob/master/src/formpack/pack.py#L134
## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
https://community.kobotoolbox.org/t/is-assetversion-immutable-solving-performance-issues-with-big-forms/9046
