### PR TITLE
Allow change_asset to see Sharing, only owner can see Media

### DIFF
--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -46,12 +46,12 @@ export class FormSubScreens extends React.Component {
     if (!this.state.permissions)
       return false;
 
-    if (this.props.location.pathname != `/forms/${this.state.uid}/settings` && !permAccess) {
+    if (this.props.location.pathname == `/forms/${this.state.uid}/settings` &&
+        !this.userCan('change_asset', this.state)) {
       return (<ui.AccessDeniedMessage/>);
     }
 
-    if (this.props.location.pathname == `/forms/${this.state.uid}/settings` &&
-        !this.userCan('change_asset', this.state)) {
+    if (this.props.location.pathname == `/forms/${this.state.uid}/settings/rest` && !permAccess) {
       return (<ui.AccessDeniedMessage/>);
     }
 

--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -55,6 +55,10 @@ export class FormSubScreens extends React.Component {
       return (<ui.AccessDeniedMessage/>);
     }
 
+    if (this.props.location.pathname == `/forms/${this.state.uid}/settings/media`) {
+      return (<ui.AccessDeniedMessage/>);
+    }
+
     var iframeUrl = '';
     var report__base = '';
     var deployment__identifier = '';

--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -55,7 +55,7 @@ export class FormSubScreens extends React.Component {
       return (<ui.AccessDeniedMessage/>);
     }
 
-    if (this.props.location.pathname == `/forms/${this.state.uid}/settings/media`) {
+    if (this.props.location.pathname == `/forms/${this.state.uid}/settings/media` && !this.userIsOwner(this.state)) {
       return (<ui.AccessDeniedMessage/>);
     }
 

--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -55,6 +55,7 @@ export class FormSubScreens extends React.Component {
       return (<ui.AccessDeniedMessage/>);
     }
 
+    //TODO:Remove owner only access to settings/media after we remove KC iframe: https://github.com/kobotoolbox/kpi/issues/2647#issuecomment-624301693
     if (this.props.location.pathname == `/forms/${this.state.uid}/settings/media` && !this.userIsOwner(this.state)) {
       return (<ui.AccessDeniedMessage/>);
     }

--- a/jsapp/js/components/formViewTabs.es6
+++ b/jsapp/js/components/formViewTabs.es6
@@ -113,7 +113,8 @@ class FormViewTabs extends Reflux.Component {
 
       sideTabs.push({label: t('General'), icon: 'k-icon-settings', path: `/forms/${this.state.assetid}/settings`});
 
-      if (this.state.asset.deployment__active) {
+      //TODO:Remove owner only access to settings/media after we remove KC iframe: https://github.com/kobotoolbox/kpi/issues/2647#issuecomment-624301693
+      if (this.state.asset.deployment__active && mixins.permissions.userIsOwner(this.state.asset)) {
         sideTabs.push({label: t('Media'), icon: 'k-icon-photo-gallery', path: `/forms/${this.state.assetid}/settings/media`});
       }
 


### PR DESCRIPTION
## Description

Implemented changes described here: https://github.com/kobotoolbox/kpi/issues/2647#issuecomment-624301693
Temporary band-aid solution due only owner being able to can manipulate `settings/media`
## Related issues
Replaces PR https://github.com/kobotoolbox/kpi/pull/2656
Fixes #2647 

