### PR TITLE
Stop sharing cookie for CSRF, but continue…

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -46,9 +46,8 @@ if os.getenv("USE_X_FORWARDED_HOST", "False") == "True":
     USE_X_FORWARDED_HOST = True
 
 # Domain must not exclude KoBoCAT when sharing sessions
-if os.environ.get('CSRF_COOKIE_DOMAIN'):
-    CSRF_COOKIE_DOMAIN = os.environ['CSRF_COOKIE_DOMAIN']
-    SESSION_COOKIE_DOMAIN = CSRF_COOKIE_DOMAIN
+if os.environ.get('SESSION_COOKIE_DOMAIN'):
+    SESSION_COOKIE_DOMAIN = os.environ['SESSION_COOKIE_DOMAIN']
     SESSION_COOKIE_NAME = 'kobonaut'
 
 # "Although the setting offers little practical benefit, it's sometimes


### PR DESCRIPTION
sharing the session cookie with KoBoCAT. Requires accompanying changes in
KoBoCAT and kobo-docker.  Fixes kobotoolbox/kpi#2658.

Requires https://github.com/kobotoolbox/kobocat/pull/610.