### PR TITLE
Removed duplicate failed notify

### DIFF
--- a/jsapp/js/actions/permissions.es6
+++ b/jsapp/js/actions/permissions.es6
@@ -113,7 +113,6 @@ permissionsActions.removeAssetPermission.listen((assetUid, perm) => {
       permissionsActions.removeAssetPermission.completed();
     })
     .fail(() => {
-      notify(t('failed to remove permission'), 'error');
       permissionsActions.getAssetPermissions(assetUid);
       permissionsActions.removeAssetPermission.failed();
     });
@@ -132,7 +131,6 @@ permissionsActions.removeCollectionPermission.listen((uid, perm) => {
       permissionsActions.removeCollectionPermission.completed();
     })
     .fail(() => {
-      notify(t('failed to remove permission'), 'error');
       permissionsActions.getCollectionPermissions(uid);
       permissionsActions.removeCollectionPermission.failed();
     });


### PR DESCRIPTION
## Description

Removed notify being shown from `permissions.es6` that has the same fail state as notify's being thrown from `actions.es6`

## Related issues

Fixes #2527 

