### PR TITLE
Optimize queries; fixes #2671

### DIFF
--- a/kobo/apps/reports/views.py
+++ b/kobo/apps/reports/views.py
@@ -1,7 +1,12 @@
 # coding: utf-8
+from django.http import Http404
 from rest_framework import viewsets, mixins
 
-from kpi.constants import PERM_VIEW_SUBMISSIONS, PERM_PARTIAL_SUBMISSIONS
+from kpi.constants import (
+    ASSET_TYPE_SURVEY,
+    PERM_PARTIAL_SUBMISSIONS,
+    PERM_VIEW_SUBMISSIONS,
+)
 from kpi.models import Asset
 from kpi.models.object_permission import get_objects_for_user, get_anonymous_user
 from .serializers import ReportsListSerializer, ReportsDetailSerializer
@@ -11,6 +16,11 @@ class ReportsViewSet(mixins.ListModelMixin,
                      mixins.RetrieveModelMixin,
                      viewsets.GenericViewSet):
     lookup_field = 'uid'
+    # Requesting user must have *any* of these permissions
+    required_permissions = [
+        PERM_VIEW_SUBMISSIONS,
+        PERM_PARTIAL_SUBMISSIONS,
+    ]
 
     def get_serializer_class(self):
         if self.action == 'list':
@@ -18,22 +28,53 @@ class ReportsViewSet(mixins.ListModelMixin,
         else:
             return ReportsDetailSerializer
 
-    def get_queryset(self):
-        
-        # Retrieve all deployed assets first.
-        deployed_assets = Asset.objects.filter(asset_versions__deployed=True).distinct()
-        # Then retrieve all assets user is allowed to view
-        # (user must have 'view_submissions' on Asset objects)
-        required_permissions = [
-            PERM_VIEW_SUBMISSIONS,
-            PERM_PARTIAL_SUBMISSIONS,
-        ]
-        user_assets = get_objects_for_user(self.request.user,
-                                           required_permissions,
-                                           deployed_assets,
-                                           all_perms_required=False)
-        publicly_shared_assets = get_objects_for_user(
-            get_anonymous_user(), required_permissions, deployed_assets,
-            all_perms_required=False)
+    def get_object(self):
+        """
+        Raise a 404 if the user is not allowed to access this asset or the
+        asset is not deployed
+        """
+        asset = super().get_object()  # uses result of `get_queryset()`
+        if not asset.has_deployment:
+            raise Http404
+        for codename in self.required_permissions:
+            # `has_perm()` handles anonymous users
+            if asset.has_perm(self.request.user, codename):
+                # Having any of the `required_permissions` suffices
+                return asset
+        raise Http404
 
-        return user_assets | publicly_shared_assets
+
+    def get_queryset(self):
+        queryset = Asset.objects.filter(asset_type=ASSET_TYPE_SURVEY)
+        if self.action == 'retrieve':
+            # `get_object()` will do the checking; no need to manipulate the
+            # queryset further
+            return queryset.defer('content')
+
+        # `ReportsListSerializer` needs only the UID; don't bother retrieving
+        # anything else from the database
+        queryset = queryset.only('uid')
+
+        # Reduce the number of asset versions we have to consider by filtering
+        # for accessible assets first
+        owned_and_explicitly_shared = get_objects_for_user(
+            self.request.user,
+            self.required_permissions,
+            queryset,
+            all_perms_required=False,
+        )
+        subscribed_and_public = get_objects_for_user(
+            get_anonymous_user(),
+            self.required_permissions,
+            queryset.filter(
+                parent__usercollectionsubscription__user=self.request.user
+            ),
+            all_perms_required=False,
+        )
+
+        # Find which of these are deployed, using a custom manager method
+        deployed_assets = (
+            owned_and_explicitly_shared | subscribed_and_public
+        ) & Asset.objects.deployed()
+
+        return deployed_assets

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -58,46 +58,60 @@ class KpiObjectPermissionsFilter:
         else:
             owned_and_explicitly_shared = get_objects_for_user(
                 user, permission, queryset)
-        public = get_objects_for_user(
-            get_anonymous_user(), permission, queryset)
+
         if view.action != 'list':
             # Not a list, so discoverability doesn't matter
+            public = get_objects_for_user(
+                get_anonymous_user(), permission, queryset
+            )
             return (owned_and_explicitly_shared | public).distinct()
 
-        # For a list, do not include public objects unless they are also
-        # discoverable
-        try:
-            discoverable = public.filter(discoverable_when_public=True)
-        except FieldError:
-            try:
-                # The model does not have a discoverability setting, but maybe
-                # its parent does
-                discoverable = public.filter(
-                    parent__discoverable_when_public=True)
-            except FieldError:
-                # Neither the model or its parent has a discoverability setting
-                discoverable = public.none()
-
         if all_public:
-            # We were asked not to consider subscriptions; return all
-            # discoverable objects
-            return (owned_and_explicitly_shared | discoverable).distinct()
+            # We were asked to return all discoverable objects. It's best to
+            # minimize the queryset before passing it to
+            # `get_objects_for_user()`, since that function executes a large
+            # `__in` query. Find potentially discoverable objects before
+            # verifying that the anonymous user can actually access them
+            try:
+                discoverable = queryset.filter(discoverable_when_public=True)
+            except FieldError:
+                try:
+                    # The model does not have a discoverability setting, but
+                    # maybe its parent does
+                    discoverable = queryset.filter(
+                        parent__discoverable_when_public=True
+                    )
+                except FieldError:
+                    # Neither the model or its parent has a discoverability
+                    # setting
+                    discoverable = queryset.none()
+            # Now, make sure these discoverables are actually public!
+            discoverable_and_public = get_objects_for_user(
+                get_anonymous_user(), permission, discoverable
+            )
+            return (
+                owned_and_explicitly_shared | discoverable_and_public
+            ).distinct()
 
-        # Of the discoverable objects, determine to which the user has
-        # subscribed
+        # `all_public` was not requested; return only objects to which the user
+        # has subscribed
         try:
-            subscribed = public.filter(usercollectionsubscription__user=user)
+            subscribed = queryset.filter(usercollectionsubscription__user=user)
         except FieldError:
             try:
                 # The model does not have a subscription relation, but maybe
                 # its parent does
-                subscribed = public.filter(
-                    parent__usercollectionsubscription__user=user)
+                subscribed = queryset.filter(
+                    parent__usercollectionsubscription__user=user
+                )
             except FieldError:
                 # Neither the model or its parent has a subscription relation
-                subscribed = public.none()
-
-        return (owned_and_explicitly_shared | subscribed).distinct()
+                subscribed = queryset.none()
+        # Make sure the subscribed objects are still public
+        subscribed_and_public = get_objects_for_user(
+            get_anonymous_user(), permission, subscribed
+        )
+        return (owned_and_explicitly_shared | subscribed_and_public).distinct()
 
 
 class RelatedAssetPermissionsFilter(KpiObjectPermissionsFilter):

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -13,7 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import JSONField as JSONBField
 from django.db import models
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Exists, OuterRef, Prefetch
 from django.utils.translation import ugettext_lazy as _
 from jsonfield import JSONField
 from taggit.managers import TaggableManager, _TaggableManager
@@ -109,6 +109,19 @@ class KpiTaggableManager(_TaggableManager):
 
 
 class AssetManager(TaggableModelManager):
+    def deployed(self):
+        """
+        Filter for deployed assets (i.e. assets having at least one deployed
+        version) in an efficient way that doesn't involve joining or counting.
+        https://docs.djangoproject.com/en/2.2/ref/models/expressions/#django.db.models.Exists
+        """
+        deployed_versions = AssetVersion.objects.filter(
+            asset=OuterRef('pk'), deployed=True
+        )
+        return self.annotate(deployed=Exists(deployed_versions)).filter(
+            deployed=True
+        )
+
     def filter_by_tag_name(self, tag_name):
         return self.filter(tags__name=tag_name)
 


### PR DESCRIPTION
Fixes the bug portion of #2679, where the `/reports/` list view shows
public-but-unsubscribed assets. Closes #2653, and includes
`defer('content')` on the report detail view in the hopes that this
improves performance for very large surveys.

Marking as "high priority" because it blocks us releasing the Django 2.2 / Python 3 work on HHI and OCHA