### PR TITLE
Removed old check for non-geopoint question

### DIFF
--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -666,7 +666,7 @@ export class FormMap extends React.Component {
         }
       });
     } else if (this.state.noData && this.state.hasGeoPoint) {
-      label = `${t('No GeoPoint Data to show')}`;
+      label = `${t('No "geopoint" responses have been received')}`;
     } else if (!this.state.hasGeoPoint) {
       label = `${t('The map does not show data because this form does not have a "geopoint" field.')}`
     }
@@ -764,7 +764,7 @@ export class FormMap extends React.Component {
          <div className="map-transparent-background">
            <div className="map-no-geopoint-wrapper">
             <p className="map-no-geopoint">
-              {t('No GeoPoint Data to show.')}
+              {t('No "geopoint" responses have been received')}
             </p>
           </div>
          </div>

--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -246,12 +246,6 @@ export class FormMap extends React.Component {
     // TODO: support area / line geodata questions
     let selectedQuestion = this.props.asset.map_styles.selectedQuestion || null;
 
-    this.props.asset.content.survey.forEach(function(row) {
-      if (row.label !== null && selectedQuestion === row.label[0] && row.type !== QUESTION_TYPES.get('geopoint').id) {
-        selectedQuestion = null; //Ignore if not a geopoint question type
-      }
-    });
-
     let queryLimit = QUERY_LIMIT_DEFAULT;
     if (this.state.overridenStyles && this.state.overridenStyles.querylimit) {
       queryLimit = this.state.overridenStyles.querylimit;


### PR DESCRIPTION
## Description
Removed the following check for `selectedQuestion` being a `geopoint` (in `map.es6`):
```
        this.props.asset.content.survey.forEach(function(row) {
          if (row.label !== null && selectedQuestion === row.label[0] && row.type !== QUESTION_TYPES.get('geopoint').id) {
            selectedQuestion = null; //Ignore if not a geopoint question type
          }
        });
```
The error was being caused by `row.label` returning `undefined` in the first condition (`row.label !== null`), which causes the other conditions to crash the application.

#### Outputs of `row` and `row.label` for reference:
`row`:
```
Object { name: "start", type: "start", "$kuid": "65PI7Btdy", "$autoname": "start" }
Object { name: "end", type: "end", "$kuid": "ZeV7uCElD", "$autoname": "end" }
Object { type: "select_one", "$kuid": "ng02y22", label: (1) […], required: false, "$autoname": "New_Question", select_from_list_name: "zo74p35" }
```
`row.label`:
```
undefined
Array [ "New Question" ]
```

Removing check to avoid further complications since the expected behaviour works without it.

## Related issues
Scenarios mentioned in https://github.com/kobotoolbox/kpi/issues/2670#issuecomment-631857461 now working.
Fixes #2670, #2682 

