### PR TITLE
Fix check for anonymous permissions when…

### DIFF
--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -1126,13 +1126,14 @@ class ObjectPermissionMixin:
             all_object_permissions = self.__get_all_user_permissions(
                 content_type_id=object_content_type_id,
                 user_id=user_id)
-            if not all_object_permissions:
+            perms = build_dict(user_id, all_object_permissions.get(self.pk))
+
+            if not perms:
                 # Try AnonymousUser's permissions in case user does not have any.
                 all_object_permissions = self.__get_all_user_permissions(
                     content_type_id=object_content_type_id,
                     user_id=settings.ANONYMOUS_USER_ID)
-
-            perms = build_dict(user_id, all_object_permissions.get(self.pk))
+                perms = build_dict(user_id, all_object_permissions.get(self.pk))
         else:
             all_object_permissions = self.__get_all_object_permissions(
                 content_type_id=object_content_type_id,

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -215,6 +215,20 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.asset.remove_perm(anonymous_user, 'view_submissions')
 
+    def test_list_submissions_authenticated_asset_publicly_shared(self):
+        # https://github.com/kobotoolbox/kpi/issues/2698
+        self._log_in_as_another_user()
+
+        # give the poor schmuck their own asset; needed to expose flaw in
+        # `ObjectPermissionMixin.__get_object_permissions()`
+        Asset.objects.create(name='i own it', owner=self.anotheruser)
+
+        anonymous_user = get_anonymous_user()
+        self.asset.assign_perm(anonymous_user, 'view_submissions')
+        response = self.client.get(self.submission_url, {"format": "json"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.asset.remove_perm(anonymous_user, 'view_submissions')
+
     def test_retrieve_submission_owner(self):
         submission = self.submissions[0]
         url = self.asset.deployment.get_submission_detail_url(submission.get(

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -210,10 +210,10 @@ class SubmissionApiTests(BaseSubmissionTestCase):
     def test_list_submissions_anonymous_asset_publicly_shared(self):
         self.client.logout()
         anonymous_user = get_anonymous_user()
-        self.asset.assign_perm(anonymous_user, 'view_submissions')
+        self.asset.assign_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
         response = self.client.get(self.submission_url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.asset.remove_perm(anonymous_user, 'view_submissions')
+        self.asset.remove_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
 
     def test_list_submissions_authenticated_asset_publicly_shared(self):
         # https://github.com/kobotoolbox/kpi/issues/2698
@@ -224,10 +224,10 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         Asset.objects.create(name='i own it', owner=self.anotheruser)
 
         anonymous_user = get_anonymous_user()
-        self.asset.assign_perm(anonymous_user, 'view_submissions')
+        self.asset.assign_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
         response = self.client.get(self.submission_url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.asset.remove_perm(anonymous_user, 'view_submissions')
+        self.asset.remove_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
 
     def test_retrieve_submission_owner(self):
         submission = self.submissions[0]
@@ -325,7 +325,7 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         # Only owner can delete submissions on `kpi`. `delete_submissions` is
         # a calculated permission and thus, can not be assigned.
         # TODO Review this test when kpi#2282 is released.
-        self.asset.assign_perm(self.anotheruser, 'change_submissions')
+        self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
         response = self.client.delete(url,
                                       content_type="application/json",
                                       HTTP_ACCEPT="application/json")


### PR DESCRIPTION
an authenticated user has no explicitly-assigned permissions.
Fixes #2698.