### PR TITLE
Get project name from imported file name instead of using "Untitled"

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -550,10 +550,15 @@ class ProjectSettings extends React.Component {
                   // when replacing, we omit PROJECT_DETAILS step
                   this.goToFormLanding();
                 } else {
-                  // try proposing something more meaningful than "Untitled"
+                  // TODO: allow serializers to take care of file names to
+                  // remove this bandaid fix for "Untitled" filenames
+                  var assetName = finalAsset.name;
+                  if (assetName === 'Untitled') {
+                    assetName = files[0].name.split('.xlsx')[0];
+                  }
                   this.setState({
                     formAsset: finalAsset,
-                    name: finalAsset.name,
+                    name: assetName,
                     description: finalAsset.settings.description,
                     sector: finalAsset.settings.sector,
                     country: finalAsset.settings.country,

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -152,6 +152,10 @@ class ProjectSettings extends React.Component {
     }
   }
 
+  getFilenameFromURI(url) {
+    return decodeURIComponent(new URL(url).pathname.split('/').pop().split('.')[0]);
+  }
+
   /*
    * handling user input
    */
@@ -492,10 +496,15 @@ class ProjectSettings extends React.Component {
                   // when replacing, we omit PROJECT_DETAILS step
                   this.goToFormLanding();
                 } else {
+                  // TODO: allow serializers to take care of file names to
+                  // remove this bandaid fix for "Untitled" filenames
+                  var assetName = finalAsset.name;
+                  if (assetName === 'Untitled') {
+                    assetName = this.getFilenameFromURI(importUrl);
+                  }
                   this.setState({
                     formAsset: finalAsset,
-                    // try proposing something more meaningful than "Untitled"
-                    name: finalAsset.name,
+                    name: assetName,
                     description: finalAsset.settings.description,
                     sector: finalAsset.settings.sector,
                     country: finalAsset.settings.country,


### PR DESCRIPTION
## Description

Temporary fix due to the goal being a backend solution for forms being imported having a default "Untitled" title. 

These changes check if there is a `form_title` field in the xlsx form, if so use it, otherwise use the filename instead. URLs no longer show "Untitled" but if the file is not in the url (ex: google sheets publications), the title would still be ambiguous.

## Related issues
Part of #2700 

