### PR TITLE
Fix KoBoCAT user and digest sync

### DIFF
--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -13,6 +13,7 @@ from django.db import (
 )
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from django_digest.models import PartialDigest
 from jsonfield import JSONField
 
 from kpi.constants import SHADOW_MODEL_APP_LABEL
@@ -229,6 +230,10 @@ class KobocatUser(ShadowModel):
         # `auth_user_id_seq` now lags behind `max(id)`. Fix it now!
         update_autofield_sequence(cls)
 
+        # Update django-digest `PartialDigest`s in KoBoCAT.  This is only
+        # necessary if the user's password has changed, but we do it always
+        KobocatDigestPartial.sync(kc_auth_user)
+
 
 class KobocatUserObjectPermission(ShadowModel):
     """
@@ -367,42 +372,21 @@ class KobocatDigestPartial(ShadowModel):
         db_table = "django_digest_partialdigest"
 
     @classmethod
-    def sync(cls, digest_partial, validate_user=True):
-        """`
-        Sync `django_digest_partialdigest` table between `kpi` and `kc``
-
-        A race condition occurs when users are created.
-        `DigestPartial` post-signal is (often) triggered before `User`
-        post-signal.  Because of that, user doesn't exist in `kc` database
-        when `KobocatDigestPartial` is saved.
-
-        `validate_user` is useful to verify whether foreign key exists to avoid
-        getting an `IntegrityError` on save.
-
-        Args:
-            digest_partial (DigestPartial)
-            validate_user (bool)
+    def sync(cls, user):
         """
-        try:
-            if validate_user:
-                # Race condition. `User` post signal can be triggered after
-                # `DigestPartial` post signal.
-                KobocatUser.objects.get(pk=digest_partial.user_id)
-
-            try:
-                kc_digest_partial = cls.objects.get(pk=digest_partial.pk)
-                assert kc_digest_partial.user_id == digest_partial.user_id
-            except KobocatDigestPartial.DoesNotExist:
-                kc_digest_partial = cls(pk=digest_partial.pk,
-                                        user_id=digest_partial.user_id)
-
-            kc_digest_partial.login = digest_partial.login
-            kc_digest_partial.partial_digest = digest_partial.partial_digest
-            kc_digest_partial.confirmed = kc_digest_partial.confirmed
-            kc_digest_partial.save()
-
-        except KobocatUser.DoesNotExist:
-            pass
+        Mimics the behavior of `django_digest.models._store_partial_digests()`,
+        but updates `KobocatDigestPartial` in the KoBoCAT database instead of
+        `PartialDigest` in the KPI database
+        """
+        cls.objects.filter(user=user).delete()
+        # Query for `user_id` since user PKs are synchronized
+        for partial_digest in PartialDigest.objects.filter(user_id=user.pk):
+            cls.objects.create(
+                user=user,
+                login=partial_digest.login,
+                confirmed=partial_digest.confirmed,
+                partial_digest=partial_digest.partial_digest,
+            )
 
 
 def safe_kc_read(func):

--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -10,8 +10,6 @@ from django.db import ProgrammingError, transaction
 from rest_framework.authtoken.models import Token
 
 from kpi.exceptions import KobocatProfileException
-
-
 from kpi.utils.log import logging
 from .shadow_models import (
     safe_kc_read,

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -55,13 +55,6 @@ def save_kobocat_user(sender, instance, created, raw, **kwargs):
             # assigning model-level permissions fails
             grant_kc_model_level_perms(instance)
 
-            # Force PartialDigest to be sync'ed on creation
-            partial_digests = PartialDigest.objects.filter(user_id=instance.pk)
-            for partial_digest in partial_digests:
-                # `KobocatUser` should exist at this point.
-                # We don't need to validate `KobocatUser`'s existence.
-                KobocatDigestPartial.sync(partial_digest, validate_user=False)
-
 
 @receiver(post_save, sender=Token)
 def save_kobocat_token(sender, instance, **kwargs):
@@ -81,27 +74,6 @@ def delete_kobocat_token(sender, instance, **kwargs):
         try:
             KobocatToken.objects.get(pk=instance.pk).delete()
         except KobocatToken.DoesNotExist:
-            pass
-
-
-@receiver(post_save, sender=PartialDigest)
-def save_kobocat_partial_digest(sender, instance, **kwargs):
-    """
-    Sync PartialDigest table between KPI and KC
-    """
-    if not settings.TESTING:
-        KobocatDigestPartial.sync(instance)
-
-
-@receiver(post_delete, sender=PartialDigest)
-def delete_kobocat_partial_digest(sender, instance, **kwargs):
-    """
-    Delete corresponding record from KC PartialDigest table
-    """
-    if not settings.TESTING:
-        try:
-            KobocatDigestPartial.objects.get(pk=instance.pk).delete()
-        except KobocatDigestPartial.DoesNotExist:
             pass
 
 


### PR DESCRIPTION
Fixes #2704:
* Update the KoBoCAT `auth_user_id_seq` sequence after syncing user changes
* Simplify the `django_digest_partialdigest` synchronization to avoid manually setting primary keys