### PR TITLE
Fixed empty group labels showing for translated forms

### DIFF
--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -102,6 +102,9 @@ export function unnullifyTranslations(surveyDataJSON, assetContent) {
       surveyData.survey.forEach((surveyRow) => {
         translatedProps.forEach((translatedProp) => {
           if (typeof surveyRow[translatedProp] !== 'undefined') {
+            if (surveyData.settings[0].style.includes('theme-grid') && surveyRow.type === 'begin_group') {
+              delete surveyRow[translatedProp];
+            }
             surveyRow[`${translatedProp}::${defaultLang}`] = surveyRow[translatedProp];
             delete surveyRow[translatedProp];
           }

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -102,7 +102,10 @@ export function unnullifyTranslations(surveyDataJSON, assetContent) {
       surveyData.survey.forEach((surveyRow) => {
         translatedProps.forEach((translatedProp) => {
           if (typeof surveyRow[translatedProp] !== 'undefined') {
-            if (surveyData.settings[0].style.includes('theme-grid') && surveyRow.type === 'begin_group') {
+            if (typeof surveyData.settings[0] !== 'undefined'
+                && typeof surveyData.settings[0].style === 'string'
+                && surveyData.settings[0].style.includes('theme-grid')
+                && surveyRow.type === 'begin_group') {
               delete surveyRow[translatedProp];
             }
             surveyRow[`${translatedProp}::${defaultLang}`] = surveyRow[translatedProp];


### PR DESCRIPTION
## Description
`unullifytranslations` attempts to "translate" empty strings when a form has multiple languages. For forms with `grid-theme` empty labels (or all labels?) are expected and should be ignored. The following happens now:
-  when there is a translation for the form, saving the form in the formbuilder then previewing it gives it the messed up look (with the carrot and no label)
- in a similar grid theme layout without translations the above is not reproducible (works as expected)
- in a grid theme with translations the following gets added to each begin_group with no label:
```
"label": [
  "",
  null
],
```
Changes add a check for `grid-theme`'s in `unullifytranslations` to ignore empty group labels.
## Related issues
Semi-related to #2676, fixing this probably needs BE work
Fixes #2707 

