### PR TITLE
Reduce session timeout to 1 week

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -56,6 +56,9 @@ if os.environ.get('SESSION_COOKIE_DOMAIN'):
 CSRF_COOKIE_HTTPONLY = True
 # SESSION_COOKIE_HTTPONLY is more useful, but it defaults to True.
 
+# Limit sessions to 1 week (the default is 2 weeks)
+SESSION_COOKIE_AGE = 604800
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = (os.environ.get('DJANGO_DEBUG', 'True') == 'True')
 


### PR DESCRIPTION
The documented Django default was 2 weeks. Closes kobotoolbox/tasks#336.

Timeout setting tested locally using a value of 30 seconds.

Related: https://github.com/kobotoolbox/kobocat/pull/620