### PR TITLE
pull the 64 character csrftoken from document.cookie

### DIFF
--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -25,10 +25,18 @@ function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
+
+let csrfToken = '';
+try {
+  csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
+} catch (err) {
+  console.error('Cookie not matched');
+}
+
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
         if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-            xhr.setRequestHeader('X-CSRFToken', cookies.get('csrftoken'));
+            xhr.setRequestHeader('X-CSRFToken', csrfToken || cookies.get('csrftoken'));
         }
     }
 });


### PR DESCRIPTION
if it exists. otherwise use existing call to `cookies.get(...)`

see https://www.flowdock.com/app/kobotoolbox/support/threads/rn3savXyxGsNszid-PCvOhVqF2D