### PR TITLE
Make `tell()` accurate when using s3boto3, by…

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -45,12 +46,11 @@ django-markitup==4.0.0    # via -r dependencies/pip/requirements.in
 django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
 django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-private-storage==2.2.2  # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -41,12 +42,11 @@ django-markitup==4.0.0    # via -r dependencies/pip/requirements.in
 django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
 django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-private-storage==2.2.2  # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -12,6 +12,10 @@
 # ssrf protect
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
 
+# Necessary to use this fork until the resolution of
+# https://github.com/jschneier/django-storages/issues/566
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
+
 # Regular PyPI packages
 Django>=2.2,<2.3
 Markdown
@@ -41,7 +45,6 @@ django-markitup
 django-mptt
 django-reversion<3.0.2 # Migration issue with 3.0.2
 django-taggit
-django-storages
 django-private-storage
 djangorestframework
 djangorestframework-xml

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -41,12 +42,11 @@ django-markitup==4.0.0    # via -r dependencies/pip/requirements.in
 django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
 django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-private-storage==2.2.2  # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -43,12 +44,11 @@ django-markitup==4.0.0    # via -r dependencies/pip/requirements.in
 django-mptt==0.10.0       # via -r dependencies/pip/requirements.in
 django-oauth-toolkit==1.2.0  # via -r dependencies/pip/requirements.in
 django-picklefield==2.0   # via django-constance
-django-private-storage==2.2.1  # via -r dependencies/pip/requirements.in
+django-private-storage==2.2.2  # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache


### PR DESCRIPTION
using my fork of django-storages. See kobotoolbox/kobocat#475.

before:
```
>>> from django.core.files.storage import get_storage_class
>>> s = get_storage_class()()
>>> of = s.open('__jnm_delete_me', 'w')
>>> of.write('x' * of.buffer_size)
5242880
>>> of.tell()
5242880
>>> of.write('!')
1
>>> of.tell()
1
>>> 
```

after:
```
>>> from django.core.files.storage import get_storage_class
>>> s = get_storage_class()()
>>> of = s.open('__jnm_delete_me', 'w')
>>> of.write('x' * of.buffer_size)
5242880
>>> of.tell()
5242880
>>> of.write('!')
1
>>> of.tell()
5242881
>>> 
```

test code, for easy copy&paste:
```
from django.core.files.storage import get_storage_class
s = get_storage_class()()
of = s.open('__jnm_delete_me', 'w')
of.write('x' * of.buffer_size)
of.tell()
of.write('!')
of.tell()
```