### PR TITLE
Moved reading CSRF cookie to ajax

### DIFF
--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -27,14 +27,14 @@ function csrfSafeMethod(method) {
 }
 
 let csrfToken = '';
-try {
-  csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
-} catch (err) {
-  console.error('Cookie not matched');
-}
 
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
+	try {
+	  csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
+	} catch (err) {
+	  console.error('Cookie not matched');
+	}
         if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
             xhr.setRequestHeader('X-CSRFToken', csrfToken || cookies.get('csrftoken'));
         }

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -30,11 +30,11 @@ let csrfToken = '';
 
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
-	try {
-	  csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
-	} catch (err) {
-	  console.error('Cookie not matched');
-	}
+        try {
+            csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
+        } catch (err) {
+            console.error('Cookie not matched');
+        }
         if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
             xhr.setRequestHeader('X-CSRFToken', csrfToken || cookies.get('csrftoken'));
         }

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -26,10 +26,9 @@ function csrfSafeMethod(method) {
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 
-let csrfToken = '';
-
 $.ajaxSetup({
     beforeSend: function(xhr, settings) {
+        let csrfToken = '';
         try {
             csrfToken = document.cookie.match(/csrftoken=(\w{64})/)[1];
         } catch (err) {


### PR DESCRIPTION
## Description

Moved #2728 fix to the ajax request, `x-csrftoken` header now matches `csrftoken` cookie when updated:

![image](https://user-images.githubusercontent.com/16762675/88326252-d9b72880-ccf3-11ea-9080-204fe4b1dd3f.png)


![image](https://user-images.githubusercontent.com/16762675/88326308-e76cae00-ccf3-11ea-97e5-8a3ed2f69165.png)



## Related issues

Fixes #2717

