### PR TITLE
Send translation settings with saved rows to question library

### DIFF
--- a/jsapp/js/models/surveyScope.es6
+++ b/jsapp/js/models/surveyScope.es6
@@ -2,25 +2,28 @@ import {actions} from '../actions';
 import {
   notify,
   t,
+  unnullifyTranslations,
 } from '../utils';
 
 class SurveyScope {
   constructor ({survey}) {
     this.survey = survey;
   }
-  add_row_to_question_library (row) {
+  add_row_to_question_library (row, assetContent) {
     if (row.constructor.kls === 'Row') {
       var rowJSON = row.toJSON2();
       let content;
       if (rowJSON.type === 'select_one' || rowJSON.type === 'select_multiple') {
         var surv = this.survey.toFlatJSON();
         var choices = surv.choices.filter(s => s.list_name === rowJSON.select_from_list_name);
-        content = JSON.stringify({
-          survey: [
-            row.toJSON2()
-          ],
-          choices: choices || undefined
-        });
+        // content = JSON.stringify({
+        //   survey: [
+        //     row.toJSON2()
+        //   ],
+        //   choices: choices || undefined
+        // });
+        content = unnullifyTranslations(JSON.stringify(surv), assetContent);
+        console.log(content);
       } else {
         content = JSON.stringify({
           survey: [

--- a/jsapp/js/models/surveyScope.es6
+++ b/jsapp/js/models/surveyScope.es6
@@ -20,30 +20,30 @@ class SurveyScope {
        * fish out the saved row and its translation settings out of the unnullified return
        */
       var unnullifiedContent = JSON.parse(unnullifyTranslations(JSON.stringify(surv), assetContent));
-      var settings_obj = unnullifiedContent.settings;
-      var survey_obj = unnullifiedContent.survey;
+      var settingsObj = unnullifiedContent.settings;
+      var surveyObj = unnullifiedContent.survey;
       if (rowJSON.type === 'select_one' || rowJSON.type === 'select_multiple') {
         var choices = unnullifiedContent.choices.filter(s => s.list_name === rowJSON.select_from_list_name);
-        for (var i in survey_obj) {
-          if (survey_obj[i].$kuid == row.toJSON2().$kuid) {
+        for (var i in surveyObj) {
+          if (surveyObj[i].$kuid == row.toJSON2().$kuid) {
             content = JSON.stringify({
               survey: [
-                survey_obj[i]
+                surveyObj[i]
               ],
-              choices: choices || undefined,
-              settings: settings_obj || undefined
+              choices: choices,
+              settings: settingsObj
             });
           }
         }
       } else {
-        for (var j in survey_obj) {
-          if (survey_obj[j].$kuid == row.toJSON2().$kuid) {
+        for (var j in surveyObj) {
+          if (surveyObj[j].$kuid == row.toJSON2().$kuid) {
             content = JSON.stringify({
               survey: [
-                survey_obj[j]
+                surveyObj[j]
               ],
-              choices: choices || undefined,
-              settings: settings_obj || undefined
+              choices: choices,
+              settings: settingsObj
             });
           }
         }

--- a/jsapp/js/models/surveyScope.es6
+++ b/jsapp/js/models/surveyScope.es6
@@ -13,23 +13,40 @@ class SurveyScope {
     if (row.constructor.kls === 'Row') {
       var rowJSON = row.toJSON2();
       let content;
+      var surv = this.survey.toFlatJSON();
+      /*
+       * Apply translations "hack" again for saving single questions to library
+       * Since `unnullifyTranslations` requires the whole survey, we need to
+       * fish out the saved row and its translation settings out of the unnullified return
+       */
+      var unnullifiedContent = JSON.parse(unnullifyTranslations(JSON.stringify(surv), assetContent));
+      var settings_obj = unnullifiedContent.settings;
+      var survey_obj = unnullifiedContent.survey;
       if (rowJSON.type === 'select_one' || rowJSON.type === 'select_multiple') {
-        var surv = this.survey.toFlatJSON();
-        var choices = surv.choices.filter(s => s.list_name === rowJSON.select_from_list_name);
-        // content = JSON.stringify({
-        //   survey: [
-        //     row.toJSON2()
-        //   ],
-        //   choices: choices || undefined
-        // });
-        content = unnullifyTranslations(JSON.stringify(surv), assetContent);
-        console.log(content);
+        var choices = unnullifiedContent.choices.filter(s => s.list_name === rowJSON.select_from_list_name);
+        for (var i in survey_obj) {
+          if (survey_obj[i].$kuid == row.toJSON2().$kuid) {
+            content = JSON.stringify({
+              survey: [
+                survey_obj[i]
+              ],
+              choices: choices || undefined,
+              settings: settings_obj || undefined
+            });
+          }
+        }
       } else {
-        content = JSON.stringify({
-          survey: [
-            row.toJSON2()
-          ]
-        });
+        for (var j in survey_obj) {
+          if (survey_obj[j].$kuid == row.toJSON2().$kuid) {
+            content = JSON.stringify({
+              survey: [
+                survey_obj[j]
+              ],
+              choices: choices || undefined,
+              settings: settings_obj || undefined
+            });
+          }
+        }
       }
       actions.resources.createResource.triggerAsync({
         asset_type: 'question',

--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -139,7 +139,7 @@ module.exports = do ->
 
     add_row_to_question_library: (evt) =>
       evt.stopPropagation()
-      @ngScope?.add_row_to_question_library @model
+      @ngScope?.add_row_to_question_library @model, @model.collection._parent._initialParams
 
   class GroupView extends BaseRowView
     className: "survey__row survey__row--group  xlf-row-view xlf-row-view--depr"


### PR DESCRIPTION
## Description

Forms with translations could not transfer their translation settings when saving a row to library. This was due to [`unnullifyTranslations`](https://github.com/kobotoolbox/kpi/blob/fbc6b6b3609a22fc66f44cfe2af65b523cd705cb/jsapp/js/utils.es6#L71) not being called when saving a single row to the question library.

This PR fixes this issue by sending the entire survey to `unnullifyTranslations` then _fishing_ out the row being saved and sending said row and its translation to the question library. This could be potentially heavy if there is a large form - if so adding a single row version of `unnullifyTranslations` may be needed.

## Related issues

<!-- Fixes #ISSUE -->
Fixes #2731
