### PR TITLE
Fix print view for submission

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -108,6 +108,16 @@ class App extends React.Component {
       );
     }
 
+    const pageWrapperModifiers = {
+      'fixed-drawer': this.state.pageState.showFixedDrawer,
+      'in-formbuilder': this.isFormBuilder(),
+      'is-modal-visible': Boolean(this.state.pageState.modal)
+    };
+
+    if (typeof this.state.pageState.modal === 'object') {
+      pageWrapperModifiers[`is-modal-${this.state.pageState.modal.type}`] = true;
+    }
+
     return (
       <DocumentTitle title='KoBoToolbox'>
         <Shortcuts
@@ -123,10 +133,7 @@ class App extends React.Component {
           { !this.isFormBuilder() &&
             <div className='k-header__bar' />
           }
-          <bem.PageWrapper m={{
-              'fixed-drawer': this.state.pageState.showFixedDrawer,
-              'in-formbuilder': this.isFormBuilder()
-                }} className='mdl-layout mdl-layout--fixed-header'>
+          <bem.PageWrapper m={pageWrapperModifiers} className='mdl-layout mdl-layout--fixed-header'>
               { this.state.pageState.modal &&
                 <Modal params={this.state.pageState.modal} />
               }

--- a/jsapp/scss/libs/_print.scss
+++ b/jsapp/scss/libs/_print.scss
@@ -92,6 +92,14 @@
       max-height: none;
     }
   }
+
+  .page-wrapper {
+    &.page-wrapper--is-modal-visible.page-wrapper--is-modal-submission {
+      .form-view.form-view--table {
+        display: none;
+      }
+    }
+  }
 }
 
 @media only screen {


### PR DESCRIPTION
I introduced a helpful class names `is-modal-visible` + `is-modal-submission` that we can use in the future for other print views. Plus this solution allows for printing the table too :)

Fixes #2759 