### PR TITLE
Revert "Temporarily return to text-based JSON fields"

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -65,7 +65,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
 invoke==1.3.0             # via fabric
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.9.0            # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -60,7 +60,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -60,7 +60,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -62,7 +62,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -4,6 +4,7 @@ from hashlib import md5
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.postgres.fields import JSONField as JSONBField
 from django.core.exceptions import ValidationError
 from django.db import (
     ProgrammingError,
@@ -14,7 +15,6 @@ from django.db import (
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django_digest.models import PartialDigest
-from jsonfield import JSONField
 
 from kpi.constants import SHADOW_MODEL_APP_LABEL
 from kpi.utils.strings import hashable_str
@@ -335,7 +335,7 @@ class KobocatUserProfile(ShadowModel):
     created_by = models.ForeignKey(User, null=True, blank=True,
                                    on_delete=models.CASCADE)
     num_of_submissions = models.IntegerField(default=0)
-    metadata = JSONField(default=dict, blank=True)
+    metadata = JSONBField(default=dict, blank=True)
 
 
 class KobocatToken(ShadowModel):

--- a/kpi/management/commands/copy_kc_profile.py
+++ b/kpi/management/commands/copy_kc_profile.py
@@ -43,10 +43,8 @@ class Command(BaseCommand):
             raise CommandError('No users selected!')
         initial_count = users.count()
         if not options.get('again'):
-            # Poor man's query within JSONField that saves a little time. We'll
-            # check `copied_kc_profile` again after parsing the JSON
             users = users.exclude(
-                extra_details__data__contains='"copied_kc_profile":true')
+                extra_details__data__copied_kc_profile=True)
         copied_count = 0
         for user in users:
             extra_details, created = ExtraUserDetail.objects.get_or_create(

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -785,11 +785,8 @@ class Asset(ObjectPermissionMixin,
     def optimize_queryset_for_list(queryset):
         """ Used by serializers to improve performance when listing assets """
         queryset = queryset.defer(
-            # Avoid pulling these `JSONField`s from the database because:
-            #   * they are stored as plain text, and just deserializing them
-            #     to Python objects is CPU-intensive;
-            #   * they are often huge;
-            #   * we don't need them for list views.
+            # Avoid pulling these from the database because they are often huge
+            # and we don't need them for list views.
             'content', 'report_styles'
         ).select_related(
             # We only need `username`, but `select_related('owner__username')`

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -15,7 +15,6 @@ from django.db import models
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Prefetch
 from django.utils.translation import ugettext_lazy as _
-from jsonfield import JSONField
 from taggit.managers import TaggableManager, _TaggableManager
 from taggit.utils import require_instance_manager
 
@@ -476,8 +475,8 @@ class Asset(ObjectPermissionMixin,
     name = models.CharField(max_length=255, blank=True, default='')
     date_created = models.DateTimeField(auto_now_add=True)
     date_modified = models.DateTimeField(auto_now=True)
-    content = JSONField(default=dict)
-    summary = JSONField(default=dict)
+    content = JSONBField(default=dict)
+    summary = JSONBField(default=dict)
     report_styles = JSONBField(default=dict)
     report_custom = JSONBField(default=dict)
     map_styles = LazyDefaultJSONBField(default=dict)
@@ -495,7 +494,7 @@ class Asset(ObjectPermissionMixin,
 
     # _deployment_data should be accessed through the `deployment` property
     # provided by `DeployableMixin`
-    _deployment_data = JSONField(default=dict)
+    _deployment_data = JSONBField(default=dict)
 
     permissions = GenericRelation(ObjectPermission)
 
@@ -1089,8 +1088,8 @@ class AssetSnapshot(models.Model, XlsExportable, FormpackXLSFormUtils):
     Remove above lines when PR is merged
     """
     xml = models.TextField()
-    source = JSONField(default=dict)
-    details = JSONField(default=dict)
+    source = JSONBField(null=True)
+    details = JSONBField(default=dict)
     owner = models.ForeignKey('auth.User', related_name='asset_snapshots',
                               null=True, on_delete=models.CASCADE)
     asset = models.ForeignKey(Asset, null=True, on_delete=models.CASCADE)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -13,10 +13,10 @@ import dateutil.parser
 import pytz
 import requests
 from django.conf import settings
+from django.contrib.postgres.fields import JSONField as JSONBField
 from django.core.files.base import ContentFile
 from django.urls import Resolver404, resolve
 from django.db import models, transaction
-from jsonfield import JSONField
 from private_storage.fields import PrivateFileField
 from pyxform import xls2json_backends
 from rest_framework import exceptions
@@ -82,8 +82,8 @@ class ImportExportTask(models.Model):
     )
 
     user = models.ForeignKey('auth.User', on_delete=models.CASCADE)
-    data = JSONField()
-    messages = JSONField(default=dict)
+    data = JSONBField()
+    messages = JSONBField(default=dict)
     status = models.CharField(choices=STATUS_CHOICES, max_length=32,
                               default=CREATED)
     date_created = models.DateTimeField(auto_now_add=True)
@@ -596,14 +596,6 @@ class ExportTask(ImportExportTask):
         # exports in excess of the per-user, per-form limit
         self.remove_excess(self.user, source_url)
 
-    @staticmethod
-    def _filter_by_source_kludge(queryset, source):
-        """
-        A disposable way to filter a queryset by source URL.
-        TODO: make `data` a `JSONBField` and use proper filtering
-        """
-        return queryset.filter(data__contains=source)
-
     @classmethod
     @transaction.atomic
     def log_and_mark_stuck_as_errored(cls, user, source):
@@ -624,9 +616,9 @@ class ExportTask(ImportExportTask):
         oldest_allowed_timestamp = this_moment - max_allowed_export_age
         stuck_exports = cls.objects.filter(
             user=user,
-            date_created__lt=oldest_allowed_timestamp
+            date_created__lt=oldest_allowed_timestamp,
+            data__source=source,
         ).exclude(status__in=(cls.COMPLETE, cls.ERROR))
-        stuck_exports = cls._filter_by_source_kludge(stuck_exports, source)
         for stuck_export in stuck_exports:
             logging.warning(
                 'Stuck export {}: type {}, username {}, source {}, '
@@ -651,8 +643,8 @@ class ExportTask(ImportExportTask):
 
         `source` is the source URL as included in the `data` attribute.
         """
-        user_source_exports = cls._filter_by_source_kludge(
-            cls.objects.filter(user=user), source
+        user_source_exports = cls.objects.filter(
+            user=user, data__source=source
         ).order_by('-date_created')
         excess_exports = user_source_exports[
             settings.MAXIMUM_EXPORTS_PER_USER_PER_FORM:

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -162,10 +162,8 @@ class AssetsListApiTests(BaseAssetTestCase):
         )
         self.assertListEqual(results, [template.uid, question.uid])
 
-        # TODO Uncomment the 2 lines below when
-        # https://github.com/kobotoolbox/kpi/issues/2635 is merged
-        # results = uids_from_search_results('🧀')
-        # self.assertListEqual(results, [template.uid])
+        results = uids_from_search_results('🧀')
+        self.assertListEqual(results, [template.uid])
 
         results = uids_from_search_results('pk:alrighty')
         self.assertListEqual(results, [])

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -477,9 +477,8 @@ class MockDataExports(TestCase):
             export_task.user = self.user
             export_task.data = task_data
             export_task.save()
-        created_export_tasks = ExportTask._filter_by_source_kludge(
-            ExportTask.objects.filter(user=self.user),
-            task_data['source']
+        created_export_tasks = ExportTask.objects.filter(
+            user=self.user, data__source=task_data['source']
         )
         self.assertEqual(excess_count + 1, created_export_tasks.count())
         # Identify which exports should be kept
@@ -490,13 +489,13 @@ class MockDataExports(TestCase):
         self.assertEqual(export_task.status, ExportTask.COMPLETE)
         # Verify the cleanup
         self.assertFalse(result.storage.exists(result.name))
-        self.assertListEqual( # assertSequenceEqual isn't working...
+        self.assertListEqual(  # assertSequenceEqual isn't working...
             list(export_tasks_to_keep.values_list('pk', flat=True)),
-            list(ExportTask._filter_by_source_kludge(
+            list(
                 ExportTask.objects.filter(
-                    user=self.user),
-                task_data['source']
-            ).order_by('-date_created').values_list('pk', flat=True))
+                    user=self.user, data__source=task_data['source']
+                ).order_by('-date_created').values_list('pk', flat=True)
+            ),
         )
 
     def test_log_and_mark_stuck_exports_as_errored(self):
@@ -506,11 +505,9 @@ class MockDataExports(TestCase):
         }
         self.assertEqual(
             0,
-            ExportTask._filter_by_source_kludge(
-                ExportTask.objects.filter(
-                    user=self.user),
-                task_data['source']
-            ).count()
+            ExportTask.objects.filter(
+                user=self.user, data__source=task_data['source']
+            ).count(),
         )
         # Simulate a few stuck exports
         for status in (ExportTask.CREATED, ExportTask.PROCESSING):
@@ -523,11 +520,9 @@ class MockDataExports(TestCase):
             export_task.save()
         self.assertSequenceEqual(
             [ExportTask.CREATED, ExportTask.PROCESSING],
-            ExportTask._filter_by_source_kludge(
-                ExportTask.objects.filter(
-                    user=self.user),
-                task_data['source']
-            ).order_by('pk').values_list('status', flat=True)
+            ExportTask.objects.filter(
+                user=self.user, data__source=task_data['source']
+            ).order_by('pk').values_list('status', flat=True),
         )
         # Run another export, which invokes the cleanup logic
         export_task = ExportTask()
@@ -538,11 +533,9 @@ class MockDataExports(TestCase):
         # Verify that the stuck exports have been marked
         self.assertSequenceEqual(
             [ExportTask.ERROR, ExportTask.ERROR, ExportTask.COMPLETE],
-            ExportTask._filter_by_source_kludge(
-                ExportTask.objects.filter(
-                    user=self.user),
-                task_data['source']
-            ).order_by('pk').values_list('status', flat=True)
+            ExportTask.objects.filter(
+                user=self.user, data__source=task_data['source']
+            ).order_by('pk').values_list('status', flat=True),
         )
 
     def test_export_long_form_title(self):

--- a/kpi/utils/query_parser/query_parser.py
+++ b/kpi/utils/query_parser/query_parser.py
@@ -55,10 +55,6 @@ class QueryParseActions(object):
         # is saved in the database as `pr\u00e9mier`. Let's handle this only
         # for `summary` to make people's lives easier. If they try to search
         # another text-based JSONField, tough luck.
-        # TODO: Remove after converting `summary` to a JSONBField
-        if field == 'summary' or field.startswith('summary_'):
-            return json.dumps(value).strip('"')
-
         if value == 'null':
             return None
         else:

--- a/kpi/utils/query_parser/query_parser.py
+++ b/kpi/utils/query_parser/query_parser.py
@@ -51,10 +51,6 @@ class QueryParseActions(object):
         # TODO: Use Django or DRF machinery (or JSON parsing?) to handle types
         # that need special treatment, like dates
 
-        # The `summary` text-based JSONField uses `\u` escaping, e.g. `prémier`
-        # is saved in the database as `pr\u00e9mier`. Let's handle this only
-        # for `summary` to make people's lives easier. If they try to search
-        # another text-based JSONField, tough luck.
         if value == 'null':
             return None
         else:

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -33,9 +33,7 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
             return queryset
         if q.startswith('source:'):
             q = remove_string_prefix(q, 'source:')
-            # This is exceedingly crude... but support for querying inside
-            # JSONField not available until Django 1.9
-            queryset = queryset.filter(data__contains=q)
+            queryset = queryset.filter(data__source=q)
         elif q.startswith('uid__in:'):
             q = remove_string_prefix(q, 'uid__in:')
             uids = [uid.strip() for uid in q.split(',')]


### PR DESCRIPTION
Closes #2635 
```
This reverts commit cc6a31dd6801601d5dfde567c2a226beea4a934d.

 # Conflicts:
 #	kpi/deployment_backends/kc_access/shadow_models.py
 #	kpi/models/asset.py
```