### PR TITLE
Remove orphaned `update_search_index` task

### DIFF
--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -6,11 +6,6 @@ from kpi.models import ImportTask, ExportTask
 
 
 @shared_task
-def update_search_index():
-    call_command('update_index', using=['default',], remove=True)
-
-
-@shared_task
 def import_in_background(import_task_uid):
     import_task = ImportTask.objects.get(uid=import_task_uid)
     import_task.run()


### PR DESCRIPTION
It was for the Whoosh search engine, which has been removed