### PR TITLE
[Public collections] Update query parser parameters for front end

### DIFF
--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -384,6 +384,10 @@ export var dataInterface;
         searchData.metadata = 'on';
       }
 
+      if (params.status) {
+        searchData.status = params.status;
+      }
+
       return $ajax({
         url: `${ROOT_URL}/api/v2/assets/`,
         dataType: 'json',
@@ -410,6 +414,10 @@ export var dataInterface;
         searchData.ordering = params.ordering;
       }
 
+      if (params.status) {
+        searchData.status = params.status;
+      }
+
       return $ajax({
         url: `${ROOT_URL}/api/v2/assets/metadata/`,
         dataType: 'json',
@@ -421,26 +429,28 @@ export var dataInterface;
       return this._searchAssetsWithPredefinedQuery(
         params,
         // we only want orphans (assets not inside collection)
-        `${COMMON_QUERIES.get('qbtc')} AND parent__uid:null`,
+        `${COMMON_QUERIES.get('qbtc')} AND parent:null`,
       );
     },
     searchMyLibraryMetadata(params = {}) {
       return this._searchMetadataWithPredefinedQuery(
         params,
         // we only want orphans (assets not inside collection)
-        `${COMMON_QUERIES.get('qbtc')} AND parent__uid:null`,
+        `${COMMON_QUERIES.get('qbtc')} AND parent:null`,
       );
     },
     searchPublicCollections(params = {}) {
+      params['status'] = 'public-discoverable';
       return this._searchAssetsWithPredefinedQuery(
         params,
-        `${COMMON_QUERIES.get('c')} AND status:public-discoverable`,
+        COMMON_QUERIES.get('c'),
       );
     },
     searchPublicCollectionsMetadata(params = {}) {
+      params['status'] = 'public-discoverable';
       return this._searchMetadataWithPredefinedQuery(
         params,
-        `${COMMON_QUERIES.get('c')} AND status:public-discoverable`,
+        COMMON_QUERIES.get('c'),
       );
     },
     assetsHash () {

--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -440,14 +440,14 @@ export var dataInterface;
       );
     },
     searchPublicCollections(params = {}) {
-      params['status'] = 'public-discoverable';
+      params.status = 'public-discoverable';
       return this._searchAssetsWithPredefinedQuery(
         params,
         COMMON_QUERIES.get('c'),
       );
     },
     searchPublicCollectionsMetadata(params = {}) {
-      params['status'] = 'public-discoverable';
+      params.status = 'public-discoverable';
       return this._searchMetadataWithPredefinedQuery(
         params,
         COMMON_QUERIES.get('c'),


### PR DESCRIPTION
Some changes in the back-end code needed the front-end code to be updated as well.
- `status` is not part of `q` parameter anymore. 
- `parent__uid:null` makes an extra query to DB. To speed-up the response of the back end, `parent:null` is preferable.  

_NB: `parent__uid:<uid>` cannot be avoided because FE doesn't have the parent's pk_