### PR TITLE
Fix how integer validation handles parentheses

### DIFF
--- a/jsapp/xlform/src/model.validationLogicParser.coffee
+++ b/jsapp/xlform/src/model.validationLogicParser.coffee
@@ -8,7 +8,7 @@ module.exports = do ->
         (?:                              #   start of a non-matching group
           date\(\'\d{4}-\d{2}-\d{2}\'\)) #     something resembling a date: date('xxxx-xx-xx')
         |                                #   or
-          (?:-?(?:\d+\.\d+|\.\d+|\d+.?)) #     a signed integer or decimal
+          (?:-?(?:\d+\.\d+|\.\d+|\d+))   #     a signed integer or decimal
         |                                #   or
           (?:\'[^']+\')                  #     a string surrounded by single quotes (careful: the quotes are included in the match!)
       )                                  # end of the value group

--- a/test/xlform/validationLogicParser.tests.coffee
+++ b/test/xlform/validationLogicParser.tests.coffee
@@ -1,0 +1,126 @@
+{expect} = require('../helper/fauxChai')
+
+$validationParser = require("../../jsapp/xlform/src/model.validationLogicParser")
+$choices = require("../../jsapp/xlform/src/model.choices")
+$surveys = require("../fixtures/xlformSurveys")
+
+do ->
+  describe '" $validationLogicParser', ->
+    describe 'equalityCriterionPattern', ->
+      it 'matches resp_equals operators', ->
+        results = $validationParser('. = 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '123'}]
+          })
+
+      it 'matches resp_notequals operators', ->
+        results = $validationParser('. != 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_notequals', response_value: '123'}]
+          })
+
+      it 'matches resp_greater operators', ->
+        results = $validationParser('. > 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_greater', response_value: '123'}]
+          })
+
+      it 'matches resp_less operators', ->
+        results = $validationParser('. < 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_less', response_value: '123'}]
+          })
+
+      it 'matches resp_greaterequals operators', ->
+        results = $validationParser('. >= 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_greaterequals', response_value: '123'}]
+          })
+
+      it 'matches resp_lessequals operators', ->
+        results = $validationParser('. <= 123')
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_lessequals', response_value: '123'}]
+          })
+
+      it 'matches date response values ', ->
+        results = $validationParser(". = 'date(1991-09-02)'")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: 'date(1991-09-02)'}]
+          })
+
+      # Same test as the first, but duplicated anyway because it's for a different purpose
+      it 'matches integer response values ', ->
+        results = $validationParser(". = 123")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '123'}]
+          })
+
+      it 'matches decimal response values ', ->
+        results = $validationParser(". = 123.456")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '123.456'}]
+          })
+
+      it 'matches decimal (nothing in front of the radix point) with response values', ->
+        results = $validationParser(". = .654")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '.654'}]
+          })
+
+      it 'matches string response values ', ->
+        results = $validationParser(". = 'pineapple is great on pizza'")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: 'pineapple is great on pizza'}]
+          })
+
+      it 'does not include closing parentheses in date response values', ->
+        results = $validationParser("(. = 'date(1991-09-02)')")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: 'date(1991-09-02)'}]
+          })
+
+      it 'does not include closing parentheses in integer response values', ->
+        results = $validationParser("(. = 123)")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '123'}]
+          })
+
+      it 'does not include closing parentheses in decimal response values', ->
+        results = $validationParser("(. = 123.456)")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '123.456'}]
+          })
+
+      it 'does not include closing parentheses in decimal (nothing in front of the radix point) response values', ->
+        results = $validationParser("(. = .456)")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: '.456'}]
+          })
+
+      it 'does not include closing parentheses in string response values', ->
+        results = $validationParser("(. = 'coriander is delicious')")
+        expect(results).toEqual(
+          {
+            criteria: [{name:'.', operator:'resp_equals', response_value: 'coriander is delicious'}]
+          })
+
+
+
+
+


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
3. [X] Ensure the tests pass

## Description

Got caught out by this one during the week, so figured it was worth fixing.

Currently the validation criteria
`(. = 123.456)` will be parsed as `{name:'.', operator:'resp_equals', response_value: '123.456'}`
but
`(. = 123)` will be parsed as `{name:'.', operator:'resp_equals', response_value: '123)'}`.

That is, the closing parentheses sneaks its way into `response_value`. Only behaves this way for integers, not for dates, strings or decimal numbers.

This PR fixes this, and adds a bunch of tests onto the `validationLogicParser` (currently just on `equalityCriterionPattern`).

Thought about refactoring out the criterion so they could have their own unit tests, but it seemed overkill...


