### PR TITLE
Prevent surveys from appearing in form-builder library sidebar (fix for #1 outlined in #2800)

### DIFF
--- a/jsapp/js/editorMixins/assetNavigator.es6
+++ b/jsapp/js/editorMixins/assetNavigator.es6
@@ -10,6 +10,8 @@ import {searches} from '../searches';
 import ui from '../ui';
 import mixins from '../mixins';
 
+import { ASSET_TYPES } from '../constants';
+
 import { t } from '../utils';
 
 import {
@@ -100,9 +102,11 @@ class AssetNavigatorListView extends React.Component {
           {list.map((item)=> {
             var modifiers = [item.asset_type];
             var summ = item.summary;
+            // HACK FIX: (ideally `survey`s would not be searched)
             // Library questions can only be of `question` or `block` types
             // Reject `survey` types to not include current survey on save
-            if (summ.row_count == undefined || item.asset_type == 'survey') {
+            if (summ.row_count == undefined
+              || item.asset_type === ASSET_TYPES.survey.id) {
               return false;
             }
             return (

--- a/jsapp/js/editorMixins/assetNavigator.es6
+++ b/jsapp/js/editorMixins/assetNavigator.es6
@@ -95,13 +95,14 @@ class AssetNavigatorListView extends React.Component {
       window.setTimeout(()=>{
         this.activateSortable();
       }, 1);
-
       return (
         <bem.LibList m={['done', isSearch ? 'search' : 'default']} ref='liblist'>
           {list.map((item)=> {
             var modifiers = [item.asset_type];
             var summ = item.summary;
-            if (summ.row_count == undefined) {
+            // Library questions can only be of `question` or `block` types
+            // Reject `survey` types to not include current survey on save
+            if (summ.row_count == undefined || item.asset_type == 'survey') {
               return false;
             }
             return (


### PR DESCRIPTION
## Description

Fixes issue where saving your form in formbuilder makes the current form show up in library assets sidebar, does so by rejecting `survey` asset types.

## Related issues

Fixes 1. of #2800 

