### PR TITLE
Basic better default translation modal

### DIFF
--- a/jsapp/js/components/modalForms/translationSettings.es6
+++ b/jsapp/js/components/modalForms/translationSettings.es6
@@ -296,6 +296,12 @@ export class TranslationSettings extends React.Component {
           <bem.FormView__cell m='label'>
             {t('Current languages')}
           </bem.FormView__cell>
+          {translations[0] == null &&
+            <bem.FormView__cell m={['warning', 'translation-modal-warning']}>
+              <i className='k-icon-alert' />
+              <p>{t('You have named translations in your form but the default translation is unnamed. Please specifiy a default translation or make an existing one default.')}</p>
+            </bem.FormView__cell>
+          }
           {translations.map((l, i) => {
             return (
               <React.Fragment key={`lang-${i}`}>
@@ -412,7 +418,8 @@ export class TranslationSettings extends React.Component {
     let translations = this.state.translations;
     if (translations.length === 0) {
       return this.renderEmptyMessage();
-    } else if (translations && translations[0] === null) {
+    } else if (translations.length == 1 && translations[0] === null) {
+      // use this modal if there are only unnamed translations
       return this.renderUndefinedDefaultSettings();
     } else {
       return this.renderTranslationsSettings(translations);

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -311,6 +311,10 @@ $z-form-view-fullscreen: 101;
       margin: 0;
     }
   }
+
+  &.form-view__cell--translation-modal-warning {
+    margin-bottom: 20px;
+  }
 }
 
 .form-view__icon-button {


### PR DESCRIPTION
## Description

When adding translated questions from the library to a form with no translations (or null as the default) the "manage languages" modal does not show the newly added translations, which can result in attempting to add an already existing language. 

This fix only shows the default modal if there exists `null` as the only translation for the form, otherwise,  if the first (default) translation is `null`, and there exist other translations, show the following modal instead:
![image](https://user-images.githubusercontent.com/16762675/95266627-91db7400-0801-11eb-8e91-02d9100038fd.png)


## Related issues

Fixes 5. of #2800 

