### PR TITLE
Updating django-storages to use jnm fork

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -5,11 +5,13 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
 amqp==2.5.2               # via -r dependencies/pip/requirements.in, kombu
 anyjson==0.3.3            # via -r dependencies/pip/requirements.in
+appnope==0.1.0            # via ipython
 argparse==1.4.0           # via unittest2
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via jsonschema, pytest
@@ -50,7 +52,6 @@ django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
@@ -65,7 +66,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via jsonschema, kombu, path.py
 invoke==1.3.0             # via fabric
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.9.0            # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -46,7 +47,6 @@ django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
@@ -60,7 +60,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -12,6 +12,10 @@
 # ssrf protect
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
 
+# Necessary to use this fork until the resolution of
+# https://github.com/jschneier/django-storages/issues/566
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
+
 # Regular PyPI packages
 Django>=2.2,<2.3
 Markdown
@@ -41,7 +45,6 @@ django-markitup
 django-mptt
 django-reversion<3.0.2 # Migration issue with 3.0.2
 django-taggit
-django-storages
 django-private-storage
 djangorestframework
 djangorestframework-xml

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -46,7 +47,6 @@ django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -5,6 +5,7 @@
 #    make pip_compile
 #
 -e git+https://github.com/dimagi/django-digest@52ba7edeb326efd97d5670273bb6fa8b0539e501#egg=django_digest  # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@d8d7a64acd69f6c6fa56638588dbe38c7a97a1e0#egg=formpack  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest  # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
@@ -48,7 +49,6 @@ django-redis-sessions==0.6.1  # via -r dependencies/pip/requirements.in
 django-registration-redux==2.6  # via -r dependencies/pip/requirements.in
 django-request-cache==1.2  # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1   # via -r dependencies/pip/requirements.in
-django-storages==1.7.2    # via -r dependencies/pip/requirements.in
 django-taggit==1.1.0      # via -r dependencies/pip/requirements.in
 django-timezone-field==3.1  # via django-celery-beat
 django-userforeignkey==0.3.0  # via django-request-cache
@@ -62,7 +62,7 @@ formencode==1.3.1         # via pyxform
 future==0.18.2            # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0     # via -r dependencies/pip/requirements.in, formpack
 idna==2.8                 # via requests
-importlib-metadata==1.7.0  # via -r dependencies/pip/requirements.in, jsonschema, kombu, path.py
+importlib-metadata==1.7.0  # via jsonschema, kombu, path.py
 jmespath==0.9.4           # via boto3, botocore
 jsonfield==2.0.2          # via -r dependencies/pip/requirements.in
 jsonschema==3.1.1         # via formpack


### PR DESCRIPTION
Using jnm's fork of `django-storages`, the following correct output is now seen using using `tell()` method:

```
>>> from django.core.files.storage import get_storage_class
>>> s = get_storage_class()()
>>> of = s.open('__jnm_delete_me', 'w')
>>> of.write('x' * of.buffer_size)
5242880
>>> of.tell()
5242880
>>> of.write('!')
1
>>> of.tell()
5242881
```
