### PR TITLE
Added parenthesis around library default query

### DIFF
--- a/jsapp/js/dataInterface.es6
+++ b/jsapp/js/dataInterface.es6
@@ -429,14 +429,14 @@ export var dataInterface;
       return this._searchAssetsWithPredefinedQuery(
         params,
         // we only want orphans (assets not inside collection)
-        `${COMMON_QUERIES.get('qbtc')} AND parent:null`,
+        `(${COMMON_QUERIES.get('qbtc')}) AND parent:null`,
       );
     },
     searchMyLibraryMetadata(params = {}) {
       return this._searchMetadataWithPredefinedQuery(
         params,
         // we only want orphans (assets not inside collection)
-        `${COMMON_QUERIES.get('qbtc')} AND parent:null`,
+        `(${COMMON_QUERIES.get('qbtc')}) AND parent:null`,
       );
     },
     searchPublicCollections(params = {}) {


### PR DESCRIPTION
## Description

<!-- Description of the changes -->
A tale of two parenthesis:

The default query to get library assets was: 
`asset_type:question OR asset_type:block OR asset_type:template OR asset_type:collection AND parent:null`
which is equivalent to:
`asset_type:question OR asset_type:block OR asset_type:template OR (asset_type:collection AND parent:null)`
which may be a mistake since `(asset_type:collection AND parent:null)` would be redundant as collections do not have parents.

PR adds parenthesis around the query to make it `(asset_type:question OR asset_type:block OR asset_type:template OR asset_type:collection) AND parent:null`, preventing assets in a collection from showing up in the default query. 

## Related issues

Semi-related to #2833 #2824 
