### PR TITLE
[Public collections] Verify parent write access before moving a child from/to a collection.

### DIFF
--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -813,8 +813,10 @@ class ObjectPermissionMixin:
             user_ids = {x[0] for x in user_perm_ids}
             return User.objects.filter(pk__in=user_ids)
 
-    def has_perm(self, user_obj, perm):
-        """ Does user_obj have perm on this object? (True/False) """
+    def has_perm(self, user_obj: models.Model, perm: str) -> bool:
+        """
+        Does `user_obj` have perm on this object? (True/False)
+        """
         app_label, codename = perm_parse(perm, self)
         is_anonymous = False
         if isinstance(user_obj, AnonymousUser):

--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -770,8 +770,10 @@ class ObjectPermissionMixin:
         return new_permission
 
     def get_perms(self, user_obj):
-        """ Return a list of codenames of all effective grant permissions that
-        user_obj has on this object. """
+        """
+        Return a list of codenames of all effective grant permissions that
+        user_obj has on this object.
+        """
         user_perm_ids = self._get_effective_perms(user=user_obj)
         perm_ids = [x[1] for x in user_perm_ids]
         return Permission.objects.filter(pk__in=perm_ids).values_list(

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -396,11 +396,13 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         # `user` must have write access to target parent before being able to
         # move the asset.
-        if not parent.has_perm(user, PERM_CHANGE_ASSET):
-            # We usually return a 404 if users don't have `view_asset` permission
-            # We send a generic message to avoid exposing the existence of
-            # the object.
-            raise serializers.ValidationError(_('Invalid target collection'))
+        parent_perms = parent.get_perms(user)
+        if PERM_VIEW_ASSET not in parent_perms:
+            raise serializers.ValidationError(_('Target collection not found'))
+
+        if PERM_CHANGE_ASSET not in parent_perms:
+            raise serializers.ValidationError(
+                _('User cannot update target parent collection'))
 
         return parent
 

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -2,6 +2,7 @@
 import json
 
 from django.conf import settings
+from django.utils.translation import ugettext as _
 from rest_framework import serializers
 from rest_framework.relations import HyperlinkedIdentityField
 from rest_framework.reverse import reverse
@@ -14,12 +15,16 @@ from kpi.constants import (
     ASSET_TYPES,
     ASSET_TYPE_COLLECTION,
     PERM_DISCOVER_ASSET,
+    PERM_CHANGE_ASSET,
     PERM_VIEW_ASSET,
     PERM_PARTIAL_SUBMISSIONS,
     PERM_VIEW_SUBMISSIONS,
 )
-from kpi.fields import RelativePrefixHyperlinkedRelatedField, WritableJSONField, \
-    PaginatedApiField
+from kpi.fields import (
+    PaginatedApiField,
+    RelativePrefixHyperlinkedRelatedField,
+    WritableJSONField,
+)
 from kpi.models import Asset, AssetVersion
 from kpi.models.asset import UserAssetSubscription
 from kpi.models.object_permission import get_anonymous_user
@@ -164,16 +169,6 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_fields(self, *args, **kwargs):
         fields = super().get_fields(*args, **kwargs)
-        user = self.context['request'].user
-        # Check if the user is anonymous. The
-        # django.contrib.auth.models.AnonymousUser object doesn't work for
-        # queries.
-        if user.is_anonymous:
-            user = get_anonymous_user()
-        if 'parent' in fields:
-            # TODO: remove this restriction?
-            fields['parent'].queryset = fields['parent'].queryset.filter(
-                owner=user)
         # Honor requests to exclude fields
         # TODO: Actually exclude fields from tha database query! DRF grabs
         # all columns, even ones that are never named in `fields`
@@ -207,8 +202,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         def _reverse_lookup_format(fmt):
             url = reverse('asset-%s' % fmt,
-                                    args=(obj.uid,),
-                                    request=request)
+                          args=(obj.uid,),
+                          request=request)
             return {'format': fmt,
                     'url': url, }
 
@@ -382,6 +377,31 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             return 'superuser'
         raise Exception(
             f'{request.user.username} has unexpected access to {obj.uid}')
+
+    def validate_parent(self, parent: Asset) -> Asset:
+        request = self.context['request']
+        user = request.user
+        if user.is_anonymous:
+            user = get_anonymous_user()
+
+        # Validate first if user can update the current parent
+        if self.instance.parent is not None:
+            if not self.instance.parent.has_perm(user, PERM_CHANGE_ASSET):
+                raise serializers.ValidationError(
+                    _('User cannot update current parent collection'))
+
+        if parent is None:
+            return parent
+
+        # `user` must have write access to target parent before being able to
+        # move the asset.
+        if not parent.has_perm(user, PERM_CHANGE_ASSET):
+            # We usually return a 404 if users don't have `view_asset` permission
+            # We send a generic message to avoid exposing the existence of
+            # the object.
+            raise serializers.ValidationError(_('Invalid target collection'))
+
+        return parent
 
     def _content(self, obj):
         return json.dumps(obj.content)

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -385,11 +385,12 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             user = get_anonymous_user()
 
         # Validate first if user can update the current parent
-        if self.instance.parent is not None:
+        if self.instance and self.instance.parent is not None:
             if not self.instance.parent.has_perm(user, PERM_CHANGE_ASSET):
                 raise serializers.ValidationError(
                     _('User cannot update current parent collection'))
 
+        # Target collection is `None`, no need to check permissions
         if parent is None:
             return parent
 

--- a/kpi/tests/api/v2/test_api_collections.py
+++ b/kpi/tests/api/v2/test_api_collections.py
@@ -4,11 +4,14 @@ import re
 from django.contrib.auth.models import User, AnonymousUser
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.response import Response
 
 from kpi.constants import (
     ASSET_TYPE_BLOCK,
     ASSET_TYPE_COLLECTION,
+    ASSET_TYPE_SURVEY,
     ASSET_TYPE_TEMPLATE,
+    PERM_CHANGE_ASSET,
     PERM_DISCOVER_ASSET,
     PERM_VIEW_ASSET,
 )
@@ -365,3 +368,64 @@ class CollectionsTests(BaseTestCase):
         response = self.client.get(coll_list_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 0)
+
+    def test_move_child_from_not_writable_source_collection(self):
+        anotheruser = User.objects.get(username='anotheruser')
+        response = self._move_child_to_collection(anotheruser,
+                                                  PERM_CHANGE_ASSET,
+                                                  PERM_VIEW_ASSET)
+
+        # It should fail because of a lack of permissions on `self.coll`
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_move_child_to_not_writable_target_collection(self):
+
+        anotheruser = User.objects.get(username='anotheruser')
+        response = self._move_child_to_collection(anotheruser, PERM_VIEW_ASSET)
+
+        # It should fail because of a lack of permissions on `some_collection`
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_move_child_to_writable_target_collection(self):
+
+        anotheruser = User.objects.get(username='anotheruser')
+        response = self._move_child_to_collection(anotheruser, PERM_CHANGE_ASSET)
+
+        # It should be ok. `anotheruser` is allowed to write to target collection
+        assert response.status_code == status.HTTP_200_OK
+
+    def _move_child_to_collection(
+            self, user_: User,
+            target_parent_perm: str,
+            source_parent_perm: str = PERM_CHANGE_ASSET) -> Response:
+
+        some_asset = Asset.objects.create(
+            asset_type=ASSET_TYPE_SURVEY,
+            name='some asset',
+            owner=self.someuser,
+            parent_id=self.coll.pk
+        )
+        some_collection = Asset.objects.create(
+            asset_type=ASSET_TYPE_COLLECTION,
+            name='some collection',
+            owner=self.someuser,
+        )
+
+        self.coll.assign_perm(user_, source_parent_perm)
+        some_asset.assign_perm(user_, PERM_CHANGE_ASSET)
+        some_collection.assign_perm(user_, target_parent_perm)
+        self.login_as_other_user(user_.username, user_.username)
+
+        some_collection_url = self.absolute_reverse(
+            self._get_endpoint('asset-detail'),
+            args=[some_collection.uid]
+        )
+
+        some_asset_url = reverse(
+            self._get_endpoint('asset-detail'),
+            kwargs={'uid': some_asset.uid, 'format': 'json'},
+        )
+
+        data = {'parent': some_collection_url}
+        # Try to move `some_asset` from `self.coll` to `some_collection`.
+        return self.client.patch(some_asset_url, data)

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -487,7 +487,8 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
             queryset = super().get_queryset()
 
             # 1) Retrieve all asset IDs of current list
-            asset_ids = AssetPagination.get_all_asset_ids_from_queryset(self.filter_queryset(queryset))
+            asset_ids = AssetPagination.get_all_asset_ids_from_queryset(
+                self.filter_queryset(queryset))
 
             # 2) Get object permissions per asset
             object_permissions = ObjectPermission.objects.filter(
@@ -520,16 +521,16 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
             context_['user_subscriptions_per_asset'] = user_subscriptions_per_asset
 
             # 4) Get children count per asset
-            records = Asset.objects.filter(parent_id__in=asset_ids). \
-                values('parent_id').annotate(children_count=Count('id'))
             # Ordering must be cleared otherwise group_by is wrong
             # (i.e. default ordered field `date_modified` must be removed)
-            records.order_by()
+            records = Asset.objects.filter(parent_id__in=asset_ids). \
+                values('parent_id').annotate(children_count=Count('id')).order_by()
 
             children_count_per_asset = {
                 r.get('parent_id'): r.get('children_count', 0)
                 for r in records if r.get('parent_id') is not None
             }
+
             context_['children_count_per_asset'] = children_count_per_asset
 
         return context_


### PR DESCRIPTION
Validate whether source and target collections are writable.

Closes #2546 
