### PR TITLE
Added id's of subscribed collection assets to permission filter

### DIFF
--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -170,6 +170,9 @@ function SearchContext(opts={}) {
         params.string = this.state.searchString;
       }
       if (this.state.parentUid) {
+        // TODO: currently this parent__uid query param returns nothing. See
+        // https://github.com/kobotoolbox/kpi/issues/2832 for the in place
+        // bypass solution
         params.parentUid = `parent__uid:${this.state.parentUid}`;
       }
       if (this.state.parentName) {

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -170,9 +170,6 @@ function SearchContext(opts={}) {
         params.string = this.state.searchString;
       }
       if (this.state.parentUid) {
-        // TODO: currently this parent__uid query param returns nothing. See
-        // https://github.com/kobotoolbox/kpi/issues/2832 for the in place
-        // bypass solution
         params.parentUid = `parent__uid:${this.state.parentUid}`;
       }
       if (this.state.parentName) {

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -77,14 +77,17 @@ class KpiObjectPermissionsFilter:
         # the query to be processed right now. Otherwise, because queryset is
         # a lazy query, Django creates (left) joins on tables when queryset is
         # interpreted and it is way slower than running this extra query.
-
-        # TODO: Figure out a better way to get subscribed collection's children
-        # As a temporary fix we union a separate query for id's of subscribed
-        # collection parents, bypassing the broken `?q=parent__uid` query
         asset_ids = list(
-            (owned_and_explicit_shared.union(subscribed).union(
-                queryset.filter(parent__in=subscribed).values('pk')
-            )).values_list('id', flat=True)
+            (
+                owned_and_explicit_shared
+                    .union(subscribed)
+                    # Since user would be subscribed to a collcetion and not
+                    # the assets themselves, we append children of subscribed
+                    # collections to the queryset in order for `?q=parent__uid`
+                    # queries to return the collection's children
+                    .union(queryset.filter(parent__in=subscribed).values("pk")
+                )
+            ).values_list("id", flat=True)
         )
         return queryset.filter(pk__in=asset_ids)
 

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -77,6 +77,10 @@ class KpiObjectPermissionsFilter:
         # the query to be processed right now. Otherwise, because queryset is
         # a lazy query, Django creates (left) joins on tables when queryset is
         # interpreted and it is way slower than running this extra query.
+
+        # TODO: Figure out a better way to get subscribed collection's children
+        # As a temporary fix we union a separate query for id's of subscribed
+        # collection parents, bypassing the broken `?q=parent__uid` query
         asset_ids = list(
             (owned_and_explicit_shared.union(subscribed).union(
                 queryset.filter(parent__in=subscribed).values('pk')

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -77,8 +77,11 @@ class KpiObjectPermissionsFilter:
         # the query to be processed right now. Otherwise, because queryset is
         # a lazy query, Django creates (left) joins on tables when queryset is
         # interpreted and it is way slower than running this extra query.
-        asset_ids = list(owned_and_explicit_shared.union(subscribed)
-                         .values_list('id', flat=True))
+        asset_ids = list(
+            (owned_and_explicit_shared.union(subscribed).union(
+                queryset.filter(parent__in=subscribed).values('pk')
+            )).values_list('id', flat=True)
+        )
         return queryset.filter(pk__in=asset_ids)
 
     def _get_discoverable(self, queryset):

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -81,7 +81,7 @@ class KpiObjectPermissionsFilter:
             (
                 owned_and_explicit_shared
                     .union(subscribed)
-                    # Since user would be subscribed to a collcetion and not
+                    # Since user would be subscribed to a collection and not
                     # the assets themselves, we append children of subscribed
                     # collections to the queryset in order for `?q=parent__uid`
                     # queries to return the collection's children


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests (test is on #2840)
~~2. [ ] If you've changed APIs, update (or create!) the documentation~~
3. [x] Ensure the tests pass
4. [ ] Make sure your code lints and you followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md#use-a-consistent-coding-style) (please check my formatting!)

## Description

When querying for subscribed collections, right now `?=parent__uid:<some uid>` returns nothing. As a temporary fix we union a query for all subscribed collection assets with a query for their parents

## Related issues

Part of #2832 