### PR TITLE
Adding `__filtered_queryset` variable to prevent double calls of `filter_queryset()`

### DIFF
--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -484,11 +484,16 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
             # for each asset in the list.
             # The serializer will be able to pick what it needs from that dict
             # and narrow down data according to users' permissions.
-            queryset = super().get_queryset()
+
+            # self.__filtered_queryset is set in the `list()` method that
+            # DRF automatically calls and is overridden below. This is
+            # to prevent double calls to `filter_queryset()` as described in
+            # the issue here: https://github.com/kobotoolbox/kpi/issues/2576
+            queryset = self.__filtered_queryset
 
             # 1) Retrieve all asset IDs of current list
-            asset_ids = AssetPagination.get_all_asset_ids_from_queryset(
-                self.filter_queryset(queryset))
+            asset_ids = AssetPagination.\
+                get_all_asset_ids_from_queryset(queryset)
 
             # 2) Get object permissions per asset
             object_permissions = ObjectPermission.objects.filter(
@@ -541,17 +546,19 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         return Response({'asset': asset, }, template_name='koboform.html')
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
+        # assigning global filtered query set to prevent additional,
+        # unnecessary calls to `filter_queryset`
+        self.__filtered_queryset = self.filter_queryset(self.get_queryset())
 
-        page = self.paginate_queryset(queryset)
+        page = self.paginate_queryset(self.__filtered_queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)
             metadata = None
             if request.GET.get('metadata') == 'on':
-                metadata = self.get_metadata(queryset)
+                metadata = self.get_metadata(self.__filtered_queryset)
             return self.get_paginated_response(serializer.data, metadata)
 
-        serializer = self.get_serializer(queryset, many=True)
+        serializer = self.get_serializer(self.__filtered_queryset, many=True)
         return Response(serializer.data)
 
     @action(detail=False, methods=['GET'],


### PR DESCRIPTION
Closes #2576 

As described in #2576, double calls to `filter_queryset()` where being made, one internally by DRF and one within the viewset in `AssetViewSet.get_serializer_context()`. This was prevented by using assigning the filtered queryset to a global a class scoped variable (`__filtered_queryset`) from the first call made in the `AssetViewSet.list()` method. 