### PR TITLE
Removing nested children from asset detail endpoint

### DIFF
--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -86,6 +86,9 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     # Only add link instead of hooks list to avoid multiple access to DB.
     hooks_link = serializers.SerializerMethodField()
 
+    # children = PaginatedApiField(
+    #     serializer_class="kpi.serializers.v2.asset.AssetListSerializer"
+    # )
 
     children = serializers.SerializerMethodField()
     subscribers_count = serializers.SerializerMethodField()

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -86,10 +86,6 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     # Only add link instead of hooks list to avoid multiple access to DB.
     hooks_link = serializers.SerializerMethodField()
 
-    # children = PaginatedApiField(
-    #     serializer_class="kpi.serializers.v2.asset.AssetListSerializer"
-    # )
-
     children = serializers.SerializerMethodField()
     subscribers_count = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -86,11 +86,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     # Only add link instead of hooks list to avoid multiple access to DB.
     hooks_link = serializers.SerializerMethodField()
 
-    # Only relevant for collections
-    children = PaginatedApiField(
-        serializer_class="kpi.serializers.v2.asset.AssetListSerializer"
-    )
 
+    children = serializers.SerializerMethodField()
     subscribers_count = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
     access_type = serializers.SerializerMethodField()
@@ -318,6 +315,11 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 'label': asset.get_label_for_permission(codename),
             }
             for codename in asset.ASSIGNABLE_PERMISSIONS_BY_TYPE[asset.asset_type]]
+
+    def get_children(self, asset):
+        children_count = asset.children.count()
+
+        return {'count': children_count}
 
     def get_subscribers_count(self, asset):
         if asset.asset_type != ASSET_TYPE_COLLECTION:

--- a/kpi/tests/kpi_test_case.py
+++ b/kpi/tests/kpi_test_case.py
@@ -116,15 +116,9 @@ class KpiTestCase(BaseTestCase, BasePermissionsTestCase):
         child_data = child_detail_response.data
         self.assertIn(parent_url, child_data['parent'])
 
-        child_field = 'children'
-        child_found = False
-        # TODO: Request next page of children if child was not found on first
-        # page
-        for child in parent_data[child_field]['results']:
-            if child['url'].endswith(child_url):
-                child_found = True
-                break
-        self.assertTrue(child_found)
+        assert parent_collection.children.count() ==\
+            parent_data['children']['count']
+
 
     def add_to_collection(self, child, parent_collection,
                           owner=None, owner_password=None):


### PR DESCRIPTION
closes #2854 

Changing the output of the `asset-detail` endpoint from a nested list of children to a count of children, i.e. from:

```
...
"children": [
    ...
]
...
```
to:
```
...
"children": {
    "count": <int>
}
...
```

The tests were also updated to account for this change and to make them pass again by making a minor change to the `KpiTestCase.assert_child_of` method.

_**Note that this change currently breaks the display of child assets when viewing a collection in the frontend.**_