### PR TITLE
Make `access_type` an array

### DIFF
--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -388,8 +388,10 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         if request.user.is_superuser:
             access_types.append('superuser')
-        raise Exception(
-            f'{request.user.username} has unexpected access to {obj.uid}')
+
+        if not access_types:
+            raise Exception(
+                f'{request.user.username} has unexpected access to {obj.uid}')
 
         return access_types
 
@@ -554,8 +556,10 @@ class AssetListSerializer(AssetSerializer):
         # User is big brother.
         if request.user.is_superuser:
             access_types.append('superuser')
-        raise Exception(
-            f'{request.user.username} has unexpected access to {obj.uid}')
+
+        if not access_types:
+            raise Exception(
+                f'{request.user.username} has unexpected access to {obj.uid}')
 
         return access_types
 

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -375,9 +375,14 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                     permission.user_id == settings.ANONYMOUS_USER_ID and
                     permission.permission.codename == PERM_DISCOVER_ASSET):
                 access_types.append('public')
+                if request.user == obj.owner:
+                    # Do not go further, `access_type` cannot be `shared`
+                    # and `owned`
+                    break
 
-            if not permission.deny and permission.user == request.user:
-                # No need to go further, we assume `settings.ANONYMOUS_USER_ID`
+            if request.user != obj.owner and not permission.deny \
+                    and permission.user == request.user:
+                # Do not go further, we assume `settings.ANONYMOUS_USER_ID`
                 # equals -1. Thus, `public` access_type should be discovered at
                 # first
                 access_types.append('shared')
@@ -536,9 +541,15 @@ class AssetListSerializer(AssetSerializer):
                     obj_permission.permission.codename == PERM_DISCOVER_ASSET):
                 access_types.append('public')
 
-            if not obj_permission.deny and obj_permission.user == request.user:
+                if request.user == obj.owner:
+                    # Do not go further, `access_type` cannot be `shared`
+                    # and `owned`
+                    break
+
+            if (request.user != obj.owner and not obj_permission.deny
+                    and obj_permission.user == request.user):
                 access_types.append('shared')
-                # No need to go further, we assume `settings.ANONYMOUS_USER_ID`
+                # Do not go further, we assume `settings.ANONYMOUS_USER_ID`
                 # equals -1. Thus, `public` access_type should be discovered at
                 # first
                 break

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -383,7 +383,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             if request.user != obj.owner and not permission.deny \
                     and permission.user == request.user:
                 # Do not go further, we assume `settings.ANONYMOUS_USER_ID`
-                # equals -1. Thus, `public` access_type should be discovered at
+                # equals -1. Thus, `public` access type should be discovered at
                 # first
                 access_types.append('shared')
                 break
@@ -550,7 +550,7 @@ class AssetListSerializer(AssetSerializer):
                     and obj_permission.user == request.user):
                 access_types.append('shared')
                 # Do not go further, we assume `settings.ANONYMOUS_USER_ID`
-                # equals -1. Thus, `public` access_type should be discovered at
+                # equals -1. Thus, `public` access type should be discovered at
                 # first
                 break
 

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -93,7 +93,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     subscribers_count = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
-    access_type = serializers.SerializerMethodField()
+    access_types = serializers.SerializerMethodField()
 
     class Meta:
         model = Asset
@@ -140,7 +140,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                   'children',
                   'subscribers_count',
                   'status',
-                  'access_type',
+                  'access_types',
                   )
         extra_kwargs = {
             'parent': {
@@ -353,7 +353,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                                                    many=True, read_only=True,
                                                    context=context).data
 
-    def get_access_type(self, obj):
+    def get_access_types(self, obj):
         # Avoid extra queries if obj is not a collection
         if obj.asset_type != ASSET_TYPE_COLLECTION:
             return None
@@ -496,11 +496,11 @@ class AssetListSerializer(AssetSerializer):
                   'data',
                   'subscribers_count',
                   'status',
-                  'access_type',
+                  'access_types',
                   'children'
                   )
 
-    def get_access_type(self, obj):
+    def get_access_types(self, obj):
         """
         Overrides parent's method to benefit of
         `AssetViewSet.get_serializer_context()` "cache" for the list endpoint.
@@ -524,7 +524,7 @@ class AssetListSerializer(AssetSerializer):
             asset_permission_assignments = self.context[
                 'object_permissions_per_asset'].get(obj.pk)
         except KeyError:
-            return super().get_access_type(obj)
+            return super().get_access_types(obj)
 
         # We test at the same time whether the collection is public or not
         for obj_permission in asset_permission_assignments:

--- a/kpi/tests/api/v2/test_api_collections.py
+++ b/kpi/tests/api/v2/test_api_collections.py
@@ -227,19 +227,36 @@ class CollectionsTests(BaseTestCase):
             owner=another_user
         )
 
+        shared_subscribed_collection = Asset.objects.create(
+            asset_type=ASSET_TYPE_COLLECTION,
+            name='shared & subscribed collection',
+            owner=another_user
+        )
+
         # Make `public_collection` and `subscribed_collection` public-discoverable
         public_collection.assign_perm(AnonymousUser(), PERM_DISCOVER_ASSET)
         subscribed_collection.assign_perm(AnonymousUser(), PERM_DISCOVER_ASSET)
+        shared_subscribed_collection.assign_perm(AnonymousUser(),
+                                                 PERM_DISCOVER_ASSET)
 
-        # Make `shared_collection` shared
+        # Make `shared_collection` and `shared_subscribed_collection` shared
         shared_collection.assign_perm(self.someuser, PERM_VIEW_ASSET)
+        shared_subscribed_collection.assign_perm(self.someuser, PERM_VIEW_ASSET)
 
-        # Subscribe `someuser` to  `subscribed_collection`.
+        # Subscribe `someuser` to `subscribed_collection`.
         subscription_url = reverse(
             self._get_endpoint('userassetsubscription-list'))
         asset_detail_url = self.absolute_reverse(
             self._get_endpoint('asset-detail'),
             kwargs={'uid': subscribed_collection.uid})
+        response = self.client.post(subscription_url, data={
+            'asset': asset_detail_url})
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # Subscribe `someuser` to `shared_subscribed_collection`.
+        asset_detail_url = self.absolute_reverse(
+            self._get_endpoint('asset-detail'),
+            kwargs={'uid': shared_subscribed_collection.uid})
         response = self.client.post(subscription_url, data={
             'asset': asset_detail_url})
         assert response.status_code == status.HTTP_201_CREATED
@@ -253,26 +270,31 @@ class CollectionsTests(BaseTestCase):
         expected = {
             'public collection': {
                 'status': 'public-discoverable',
-                'access_type': 'public'
+                'access_types': ['public']
             },
             'shared collection': {
                 'status': 'shared',
-                'access_type': 'shared'
+                'access_types': ['shared']
             },
             'subscribed collection': {
                 'status': 'public-discoverable',
-                'access_type': 'subscribed'
+                'access_types': ['public', 'subscribed']
             },
             'test collection': {
                 'status': 'private',
-                'access_type': 'owned'
+                'access_types': ['owned']
+            },
+            'shared & subscribed collection': {
+                'status': 'public-discoverable',
+                'access_types': ['public', 'shared', 'subscribed']
             }
         }
 
         for collection in response.data['results']:
             expected_collection = expected[collection.get('name')]
             assert expected_collection['status'] == collection['status']
-            assert expected_collection['access_type'] == collection['access_type']
+            assert expected_collection['access_types'] \
+                   == collection['access_types']
 
     def test_collection_subscribe(self):
         public_collection = Asset.objects.create(


### PR DESCRIPTION
`access_type` has been renamed `access_types` to match its type. 
If object is not a collection, `access_types` equals `None`, not `[None]` 