### PR TITLE
Reducing service_health timeout

### DIFF
--- a/kobo/apps/service_health/views.py
+++ b/kobo/apps/service_health/views.py
@@ -15,6 +15,8 @@ def get_response(url_):
     content = None
 
     try:
+        # reponse timeout changed to 10 seconds from 45 as requested in 
+        # issue linked here https://github.com/kobotoolbox/kpi/issues/2642
         response_ = requests.get(url_, timeout=10)
         response_.raise_for_status()
         content = response_.text

--- a/kobo/apps/service_health/views.py
+++ b/kobo/apps/service_health/views.py
@@ -15,7 +15,7 @@ def get_response(url_):
     content = None
 
     try:
-        response_ = requests.get(url_, timeout=45)
+        response_ = requests.get(url_, timeout=10)
         response_.raise_for_status()
         content = response_.text
     except Exception as e:


### PR DESCRIPTION
closes #2642 

Minor change to `service_health/views.py` to decrease timeout from 45 seconds to 10.