### PR TITLE
Removing exported file on delete

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -650,6 +650,11 @@ class ExportTask(ImportExportTask):
             export.result.delete()
             export.delete()
 
+    def delete(self, *args, **kwargs):
+        # removing exported file from storage
+        self.result.delete(save=False)
+        super().delete(*args, **kwargs)
+
 
 def _b64_xls_to_dict(base64_encoded_upload):
     decoded_str = base64.b64decode(base64_encoded_upload)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -646,8 +646,6 @@ class ExportTask(ImportExportTask):
             settings.MAXIMUM_EXPORTS_PER_USER_PER_FORM:
         ]
         for export in excess_exports:
-            # The `result` file must be deleted manually
-            export.result.delete()
             export.delete()
 
     def delete(self, *args, **kwargs):

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -330,6 +330,31 @@ class AssetExportTaskTest(BaseTestCase):
         result_response = self.client.get(detail_response.data['result'])
         self.assertEqual(result_response.status_code, status.HTTP_200_OK)
 
+    def test_owner_can_create_and_delete_export(self):
+        detail_response = self.test_owner_can_create_export()
+        result_response = self.client.get(detail_response.data['result'])
+        file_name = str(result_response._closable_objects[0].name)
+
+        detail_url = reverse("exporttask-detail", kwargs={
+            "uid": detail_response.data['uid']
+            })
+
+        # checking if file exists before attempting to delete
+        file_exists_before_delete = ExportTask.result.field.storage.exists(
+            name=file_name
+        )
+        assert file_exists_before_delete
+
+        # deleting the export
+        delete_response = self.client.delete(detail_url)
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+        # checking if file still exists after attempting to delete it
+        file_exists_after_delete = ExportTask.result.field.storage.exists(
+            name=file_name
+        )
+        assert not file_exists_after_delete
+
 
 class AssetFileTest(test_api_assets.AssetFileTest):
     URL_NAMESPACE = None

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -335,8 +335,8 @@ class AssetExportTaskTest(BaseTestCase):
         result_response = self.client.get(detail_response.data['result'])
         file_name = str(result_response._closable_objects[0].name)
 
-        detail_url = reverse("exporttask-detail", kwargs={
-            "uid": detail_response.data['uid']
+        detail_url = reverse('exporttask-detail', kwargs={
+            'uid': detail_response.data['uid']
             })
 
         # checking if file exists before attempting to delete

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -90,12 +90,18 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
         }, status.HTTP_201_CREATED)
 
     def perform_destroy(self, instance):
-        if 'KPI_DEFAULT_FILE_STORAGE' not in os.environ:
-            print('do something here to delete in S3')
+        if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
+            try:
+                ExportTask.result.field.storage.delete(
+                    name=str(instance.result)
+                )
+            except:
+                pass
         else:
             ROOT = os.environ.get('KPI_SRC_DIR')
             MEDIA = 'media'
-            file_to_delete = instance.result
-            os.remove(f'{ROOT}/{MEDIA}/{file_to_delete}')
+            full_file_path = f'{ROOT}/{MEDIA}/{instance.result}'
+            if os.path.isfile(full_file_path):
+                os.remove(full_file_path)
 
         return super().perform_destroy(instance)

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -86,7 +86,3 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
                 request=request),
             'status': ExportTask.PROCESSING
         }, status.HTTP_201_CREATED)
-
-    def perform_destroy(self, instance):
-        ExportTask.result.field.storage.delete(name=str(instance.result))
-        return super().perform_destroy(instance)

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -1,6 +1,4 @@
 # coding: utf-8
-import os
-
 from rest_framework import status, serializers
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -35,7 +33,7 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
             return queryset
         if q.startswith('source:'):
             q = remove_string_prefix(q, 'source:')
-            queryset = queryset.filter(data__source__icontains=q)
+            queryset = queryset.filter(data__source=q)
         elif q.startswith('uid__in:'):
             q = remove_string_prefix(q, 'uid__in:')
             uids = [uid.strip() for uid in q.split(',')]

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -90,18 +90,5 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
         }, status.HTTP_201_CREATED)
 
     def perform_destroy(self, instance):
-        if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
-            try:
-                ExportTask.result.field.storage.delete(
-                    name=str(instance.result)
-                )
-            except:
-                pass
-        else:
-            ROOT = os.environ.get('KPI_SRC_DIR')
-            MEDIA = 'media'
-            full_file_path = f'{ROOT}/{MEDIA}/{instance.result}'
-            if os.path.isfile(full_file_path):
-                os.remove(full_file_path)
-
+        ExportTask.result.field.storage.delete(name=str(instance.result))
         return super().perform_destroy(instance)


### PR DESCRIPTION
closes #2253 

Previously, as described in the linked issue, when the trash icon in the UI was pressed to delete the export, the file remained in S3. This was also the case for locally stored exports. When the endpoint `exports/<uid>/` was called with the `DELETE` method, only the postgres record was removed but the artifact remained untouched. In the end a simple method was added to achieve this result: `ExportTaskViewSet.perform_destroy` as well as corresponding tests.