### PR TITLE
Add double quotes to language filters and change `filterBy` type

### DIFF
--- a/jsapp/js/components/library/assetsTable.es6
+++ b/jsapp/js/components/library/assetsTable.es6
@@ -433,7 +433,7 @@ export const ASSETS_TABLE_COLUMNS = new Map([
     'languages', {
       label: t('Languages'),
       id: 'languages',
-      filterBy: 'summary__languages',
+      filterBy: 'summary__languages__icontains',
       filterByPath: ['summary', 'languages'],
       filterByMetadataName: 'languages'
     }

--- a/jsapp/js/components/library/myLibraryStore.es6
+++ b/jsapp/js/components/library/myLibraryStore.es6
@@ -114,6 +114,15 @@ const myLibraryStore = Reflux.createStore({
     }
 
     const params = this.getSearchParams();
+    // Declared languages in forms should contain their codes i.e., English (en)
+    // if this query is not surrounded by double quotes, it would split the
+    // query at the space and break the filter
+    if (
+      params.filterProperty !== undefined &&
+      params.filterProperty.includes('languages')
+    ) {
+      params.filterValue = JSON.stringify(params.filterValue); // Adds quotes
+    }
 
     params.metadata = needsMetadata;
 

--- a/jsapp/js/components/library/myLibraryStore.es6
+++ b/jsapp/js/components/library/myLibraryStore.es6
@@ -114,13 +114,9 @@ const myLibraryStore = Reflux.createStore({
     }
 
     const params = this.getSearchParams();
-    // Declared languages in forms should contain their codes i.e., English (en)
-    // if this query is not surrounded by double quotes, it would split the
-    // query at the space and break the filter
-    if (
-      params.filterProperty !== undefined &&
-      params.filterProperty.includes('languages')
-    ) {
+    // Surrounds `filterValue` with double quotes to avoid filters that have
+    // spaces which would split the query in two, thus breaking the filter
+    if (params.filterProperty !== undefined) {
       params.filterValue = JSON.stringify(params.filterValue); // Adds quotes
     }
 


### PR DESCRIPTION
## Description
Surrounds every filter with double quotes to avoid spacing issue for other filter types.

Semi-hacked double quotes around ~~language~~ all `filteredValue` query parameters just before sending the query as to avoid any bad interactions down the road (specifically checks for `filteredValue` in `assetsTable`)

## Related issues

Fixes #2866 but other filters can also trigger the same exception due to actually being less than 3 characters (not just a spacing issue): Organisations, Countries, for example

