### PR TITLE
Delete users in both database at once

### DIFF
--- a/hub/actions.py
+++ b/hub/actions.py
@@ -18,8 +18,8 @@ def delete_related_objects(modeladmin, request, queryset):
     """
     Action that deletes related objects for the selected items.
 
-    This action first displays a confirmation page whichs shows all the
-    deleteable objects, or, if the user has no permission one of the related
+    This action first displays a confirmation page which shows all the
+    deletable objects, or, if the user has no permission one of the related
     childs (foreignkeys), a "permission denied" message.
 
     Next, it deletes all related objects and redirects back to the change list.
@@ -54,8 +54,7 @@ def delete_related_objects(modeladmin, request, queryset):
     # Populate deletable_objects, a data structure of (string representations
     # of) all related objects that will also be deleted.
     deletable_objects, model_count, perms_needed, protected = get_deleted_objects(
-        first_level_related_objects, opts, request.user,
-        modeladmin.admin_site, using
+        first_level_related_objects, request, modeladmin.admin_site
     )
 
     # The user has already confirmed the deletion.
@@ -107,7 +106,7 @@ def delete_related_objects(modeladmin, request, queryset):
     # Display the confirmation page
     return TemplateResponse(
         request, "delete_related_for_selected_confirmation.html",
-        context, current_app=modeladmin.admin_site.name)
+        context)
 
 
 delete_related_objects.short_description = ugettext_lazy(

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -1,42 +1,81 @@
 # coding: utf-8
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.utils.translation import gettext as _
 
-from .actions import delete_related_objects, remove_from_kobocat
+from kpi.deployment_backends.kc_access.utils import delete_kc_users
 from .models import SitewideMessage, ConfigurationFile, PerUserSetting
 
 
-class UserDeleteKludgeAdmin(UserAdmin):
+class UserDeleteAdmin(UserAdmin):
     """
-    Deleting users is, sadly, a two-step process since KPI and KoBoCAT share
-    the same database but do not know about each other's models.
-
-    First, all KPI objects related to the user should be removed:
-    `delete_related_objects` accomplishes this. With only the user object
-    itself and related KoBoCAT objects remaining, the standard Django deletion
-    machinery in KoBoCAT should succeed. `remove_from_kobocat` helps the
-    superuser invoke that.
-
+    Deleting users used to a two-step process since KPI and KoBoCAT
+    shared the same database, but it's not the case anymore.
     See https://github.com/kobotoolbox/kobocat/issues/92#issuecomment-158219885
+
+    It still implies to delete records in both databases. If users are
+    deleted in KPI database but not in KoboCAT database, they will receive a
+    500 error if they try to recreate an account with a previously deleted
+    username.
+
+    First, all KPI objects related to the user should be removed.
+    Then, KoBoCAT objects related to the user (in KoBoCAT database) except
+    `XForm` and `Instance`. We do not want to delete data without owner's
+    permission
+
     """
 
-    actions = [delete_related_objects, remove_from_kobocat]
-
-    def get_actions(self, request):
+    def delete_queryset(self, request, queryset):
         """
-        Remove the standard "Delete selected users" action, since it will
-        almost always fail
+        Override `ModelAdmin.delete_queryset` to bulk delete users in KPI and KC
         """
+        deleted_pks = list(queryset.values_list('pk', flat=True))
+        # Delete users in KPI database first
+        super().delete_queryset(request, queryset)
 
-        actions = super().get_actions(request)
-        if 'delete_selected' in actions:
-            del actions['delete_selected']
-        return actions
+        if not delete_kc_users(deleted_pks):
+            # Unfortunately, this message does not supersede Django message
+            # when users are successfully deleted.
+            # See https://github.com/django/django/blob/b9cf764be62e77b4777b3a75ec256f6209a57671/django/contrib/admin/actions.py#L41-L43
+            # Maybe it still makes sense because KPI users are deleted.
+            self.message_user(
+                request,
+                _('Could not delete users in KoBoCAT database. They may own '
+                  'projects and/or submissions. Log into KoBoCAT admin '
+                  'interface and delete them from there.'),
+                messages.ERROR
+            )
+
+    def delete_model(self, request, obj):
+        """
+        Override `ModelAdmin.delete_model()` to delete user in KPI and KC
+        """
+        deleted_pk = obj.pk
+        # Delete users in KPI database first.
+        super().delete_model(request, obj)
+
+        # This part could be in a post-delete signal but we would not catch
+        # errors if any.
+        # Moreover, users can be only deleted from the admin interface or from
+        # the shell. We assume that power users who use shell can also call
+        # `delete_kc_users()` manually.
+        if not delete_kc_users([deleted_pk]):
+            # Unfortunately, this message does not supersede Django message
+            # when a user is successfully deleted.
+            # See https://github.com/django/django/blob/b9cf764be62e77b4777b3a75ec256f6209a57671/django/contrib/admin/options.py#L1444-L1451
+            # Maybe it still makes sense because KPI user is deleted.
+            self.message_user(
+                request,
+                _('Could not delete user in KoBoCAT database. They may own '
+                  'projects and/or submissions. Log into KoBoCAT admin '
+                  'interface and delete them from there.'),
+                messages.ERROR
+            )
 
 
 admin.site.register(SitewideMessage)
 admin.site.register(ConfigurationFile)
 admin.site.register(PerUserSetting)
 admin.site.unregister(User)
-admin.site.register(User, UserDeleteKludgeAdmin)
+admin.site.register(User, UserDeleteAdmin)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -659,9 +659,6 @@ KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES = [
     # Each tuple must be (app_label, model_name)
     ('main', 'userprofile'),
     ('logger', 'xform'),
-    ('api', 'project'),
-    ('api', 'team'),
-    ('api', 'organizationprofile'),
     ('logger', 'note'),
 ]
 

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
-from django_digest.models import PartialDigest
 from rest_framework.authtoken.models import Token
 from taggit.models import Tag
 
@@ -11,10 +10,9 @@ from kobo.apps.hook.models.hook import Hook
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatToken,
     KobocatUser,
-    KobocatDigestPartial
 )
 from kpi.deployment_backends.kc_access.utils import grant_kc_model_level_perms
-from kpi.models import Asset, ObjectPermission, TagUid
+from kpi.models import Asset, TagUid
 from kpi.utils.permissions import grant_default_model_level_perms
 
 


### PR DESCRIPTION
Closes (and fixes) #2509
The purpose was to remove the class `UserDeleteKludgeAdmin` but instead, this PR still uses it (but renames it). It deletes users from KC if they have no data related to their account. It displays an error message when deletion is not possible

[This commit](https://github.com/kobotoolbox/kpi/pull/2871/commits/9450888643700fe75eddc15b3dd002dc8d34c0dc) fixes #2865 