### PR TITLE
Use `name` first to update data column

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -269,7 +269,10 @@ module.exports = do ->
         @model.set 'value', value
         @model.deduplicate @model.getSurvey()
       )
-      update_view = () => @$el.find('input').eq(0).val($modelUtils.sluggifyLabel @model._parent.getValue('label') || @model.get("value"))
+      # Update "Data Column Name" with `name` of question first, then use label.
+      # The order was swapped was added to fix kpi#706 but using this order does
+      # not break the fix and is necessary to fix kpi#2873.
+      update_view = () => @$el.find('input').eq(0).val(@model.get("value") || $modelUtils.sluggifyLabel @model._parent.getValue('label'))
       update_view()
 
       @model._parent.get('label').on 'change:value', update_view

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -270,7 +270,7 @@ module.exports = do ->
         @model.deduplicate @model.getSurvey()
       )
       # Update "Data Column Name" with `name` of question first, then use label.
-      # The order was swapped was added to fix kpi#706 but using this order does
+      # The order was swapped to fix kpi#706 but using the current order does
       # not break the fix and is necessary to fix kpi#2873.
       update_view = () => @$el.find('input').eq(0).val(@model.get("value") || $modelUtils.sluggifyLabel @model._parent.getValue('label'))
       update_view()


### PR DESCRIPTION
Issue was caused by a conditional assignment switch made in #2723 and this PR switches it back. See https://chat.kobotoolbox.org/#narrow/stream/4-KoBo-Dev/topic/Form.20builder.20question.20name.20regression/near/5615

## Description

Fix a regression where "Data Column Name" is not saved by the form builder

## Related issues

Fixes #2873 
