### PR TITLE
Control `EXPOSE_GIT_REV` through django-constance

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -170,6 +170,10 @@ CONSTANCE_CONFIG = {
         '',
         'Blacklisted IP addresses to bypass SSRF protection\nOne per line',
     ),
+    'EXPOSE_GIT_REV': (
+        False,
+        'Display information about the running commit to non-superusers',
+    ),
 }
 # Tell django-constance to use a database model instead of Redis
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
@@ -643,9 +647,6 @@ for git_rev_key, git_command in (
         GIT_REV[git_rev_key] = False
 if GIT_REV['branch'] == 'HEAD':
     GIT_REV['branch'] = False
-# Only superusers will be able to see this information unless
-# EXPOSE_GIT_REV=TRUE is set in the environment
-EXPOSE_GIT_REV = os.environ.get('EXPOSE_GIT_REV', '').upper() == 'TRUE'
 
 
 '''

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -2,6 +2,7 @@
 import datetime
 import pytz
 
+import constance
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -63,7 +64,9 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_git_rev(self, obj):
         request = self.context.get('request', False)
-        if settings.EXPOSE_GIT_REV or (request and request.user.is_superuser):
+        if constance.config.EXPOSE_GIT_REV or (
+            request and request.user.is_superuser
+        ):
             return settings.GIT_REV
         else:
             return False


### PR DESCRIPTION
Previously, an environment variable had to be set to show information about the running commit to non-superusers. This allows that behavior to be controlled within the Django admin interface.