### PR TITLE
Fix bulk library imports (by renaming XLS sheet)

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -11,7 +11,6 @@
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect  # via -r dependencies/pip/requirements.in
 amqp==2.5.2               # via -r dependencies/pip/requirements.in, kombu
 anyjson==0.3.3            # via -r dependencies/pip/requirements.in
-appnope==0.1.0            # via ipython
 argparse==1.4.0           # via unittest2
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via jsonschema, pytest
@@ -129,9 +128,10 @@ uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit, pytest
 werkzeug==0.16.0          # via -r dependencies/pip/dev_requirements.in
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform, xlutils
 xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in
+xlutils==2.0.0            # via -r dependencies/pip/requirements.in
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in, xlutils
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -103,9 +103,10 @@ unittest2==1.1.0          # via pyxform
 urllib3==1.25.7           # via botocore, requests, transifex-client
 uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform, xlutils
 xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in
+xlutils==2.0.0            # via -r dependencies/pip/requirements.in
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in, xlutils
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -73,6 +73,7 @@ unicodecsv
 uWSGI
 xlrd
 xlwt
+xlutils
 XlsxWriter
 
 # These packages allow `requests` to support SNI

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -101,9 +101,10 @@ unittest2==1.1.0          # via pyxform
 urllib3==1.25.7           # via botocore, requests
 uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform, xlutils
 xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in
+xlutils==2.0.0            # via -r dependencies/pip/requirements.in
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in, xlutils
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -115,9 +115,10 @@ urllib3==1.25.7           # via botocore, requests
 uwsgi==2.0.18             # via -r dependencies/pip/requirements.in
 vine==1.3.0               # via amqp, celery
 wcwidth==0.1.9            # via pytest
-xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform
+xlrd==1.2.0               # via -r dependencies/pip/requirements.in, pyxform, xlutils
 xlsxwriter==1.2.5         # via -r dependencies/pip/requirements.in, formpack
-xlwt==1.3.0               # via -r dependencies/pip/requirements.in
+xlutils==2.0.0            # via -r dependencies/pip/requirements.in
+xlwt==1.3.0               # via -r dependencies/pip/requirements.in, xlutils
 zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -662,14 +662,15 @@ def _b64_xls_to_dict(base64_encoded_upload):
         renamed_sheet = rename_xls_sheet(BytesIO(decoded_str),
                                          from_sheet='library',
                                          to_sheet='survey')
-        survey_dict = xls2json_backends.xls_to_dict(renamed_sheet)
-        survey_dict['library'] = survey_dict.pop('survey')
     except ConflictSheetError:
         raise ValueError('An import cannot have both "survey" and'
                          ' "library" sheets.')
     except NoFromSheetError:
         # library did not exist in the xls file
         survey_dict = xls2json_backends.xls_to_dict(BytesIO(decoded_str))
+    else:
+        survey_dict = xls2json_backends.xls_to_dict(renamed_sheet)
+        survey_dict['library'] = survey_dict.pop('survey')
     return _strip_header_keys(survey_dict)
 
 

--- a/kpi/tests/api/v1/test_api_imports.py
+++ b/kpi/tests/api/v1/test_api_imports.py
@@ -99,7 +99,7 @@ class AssetImportTaskTest(BaseTestCase):
         self.assertEqual(detail_response.data['status'], 'error')
         self.assertTrue(
             detail_response.data['messages']['error'].startswith(
-                'Error reading .xls file: Unsupported format'
+                'Unsupported format, or corrupt file'
             )
         )
 

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -1,15 +1,7 @@
-'''
-Opens a stream (BytesIO) with XLS contents and renames
-a sheet (e.g. "library") to a new name (e.g. "survey")
-to get around restrictions on sheet names in pyxform
-inputs
-'''
-
 from io import BytesIO
 
 from xlutils.copy import copy
 from xlrd import open_workbook
-
 
 
 class NoFromSheetError(Exception):
@@ -19,7 +11,15 @@ class ConflictSheetError(ValueError):
     pass
 
 
-def rename_xls_sheet(xls_stream, from_sheet, to_sheet):
+def rename_xls_sheet(
+    xls_stream: BytesIO, from_sheet: str, to_sheet: str
+) -> BytesIO:
+    """
+    Opens a stream (BytesIO) with XLS contents and renames a sheet (e.g.
+    "library") to a new name (e.g. "survey") to get around restrictions on
+    sheet names in pyxform inputs;
+    see https://github.com/XLSForm/pyxform/issues/229.
+    """
     readable = open_workbook(file_contents=xls_stream.read())
     writable = copy(readable)
     sheet_names = readable.sheet_names()

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -5,8 +5,11 @@ to get around restrictions on sheet names in pyxform
 inputs
 '''
 
+from io import BytesIO
+
 from xlutils.copy import copy
 from xlrd import open_workbook
+
 
 
 class NoFromSheetError(Exception):

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -9,10 +9,22 @@ from xlutils.copy import copy
 from xlrd import open_workbook
 
 
+class NoFromSheetError(Exception):
+    pass
+
+class ConflictSheetError(ValueError):
+    pass
+
+
 def rename_xls_sheet(xls_stream, from_sheet, to_sheet):
     readable = open_workbook(file_contents=xls_stream.read())
     writable = copy(readable)
-    index = readable.sheet_names().index(from_sheet)
+    sheet_names = readable.sheet_names()
+    if from_sheet in sheet_names and to_sheet in sheet_names:
+        raise ConflictSheetError()
+    if from_sheet not in sheet_names:
+        raise NoFromSheetError(from_sheet)
+    index = sheet_names.index(from_sheet)
     writable.get_sheet(index).name = to_sheet
     stream = BytesIO()
     writable.save(stream)

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -1,0 +1,20 @@
+'''
+Opens a stream (BytesIO) with XLS contents and renames
+a sheet (e.g. "library") to a new name (e.g. "survey")
+to get around restrictions on sheet names in pyxform
+inputs
+'''
+
+from xlutils.copy import copy
+from xlrd import open_workbook
+
+
+def rename_xls_sheet(xls_stream, from_sheet, to_sheet):
+    readable = open_workbook(file_contents=xls_stream.read())
+    writable = copy(readable)
+    index = readable.sheet_names().index(from_sheet)
+    writable.get_sheet(index).name = to_sheet
+    stream = BytesIO()
+    writable.save(stream)
+    stream.seek(0)
+    return stream


### PR DESCRIPTION
Fixes #2784 by renaming the `library` worksheet to `survey`, calling pyxform's `xls2json_backends.xls_to_dict()` on the modified XLS, and then changing the `survey` key in the resulting dictionary key back to `library`. Avoids re-implementing parts of pyxform in our code (as I'd originally suggested to @duvld—thanks to him for implementing that in #2798).