### PR TITLE
Simplify partial usernames input

### DIFF
--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -214,10 +214,10 @@ class UserAssetPermsEditor extends React.Component {
   }
 
   /**
-   * Enables Enter key on username input.
+   * Enables Enter key on input.
    */
-  onUsernameKeyPress(key, evt) {
-    if (key === 'Enter') {
+  onInputKeyPress(key, evt) {
+    if (key === KEY_CODES.get('ENTER')) {
       evt.currentTarget.blur();
       evt.preventDefault(); // prevent submitting form
     }
@@ -427,7 +427,7 @@ class UserAssetPermsEditor extends React.Component {
               value={this.state.username}
               onChange={this.onUsernameChange}
               onBlur={this.onUsernameChangeEnd}
-              onKeyPress={this.onUsernameKeyPress}
+              onKeyPress={this.onInputKeyPress}
               errors={this.state.username.length === 0}
             />
           </div>

--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -21,6 +21,7 @@ import {
   PERMISSIONS_CODENAMES
 } from 'js/constants';
 
+const PARTIAL_PLACEHOLDER = t('Enter usernames separated by spaces');
 /**
  * Form for adding/changing user permissions for surveys.
  *
@@ -357,6 +358,9 @@ class UserAssetPermsEditor extends React.Component {
     const output = {
       username: this.state.username,
     };
+
+    // use CHECKBOX_PERM_PAIRS on a loop for this
+
     if (this.isAssignable('view_asset')) {output.formView = this.state.formView;}
     if (this.isAssignable('change_asset')) {output.formEdit = this.state.formEdit;}
     if (this.isAssignable('add_submissions')) {output.submissionsAdd = this.state.submissionsAdd;}
@@ -378,6 +382,9 @@ class UserAssetPermsEditor extends React.Component {
     }
 
     const formData = this.getFormData();
+
+    // update perm parser
+
     const parsedUser = permParser.parseFormData(formData);
 
     if (parsedUser.length > 0) {
@@ -400,21 +407,6 @@ class UserAssetPermsEditor extends React.Component {
 
   render() {
     const isNew = typeof this.props.username === 'undefined';
-
-    const submissionsViewPartialUsersInputProps = {
-      placeholder: t('Enter usernames separated by spaces'),
-      onFocus: this.onSubmissionsViewPartialUsersInputFocus,
-      onBlur: this.onSubmissionsViewPartialUsersInputBlur
-    };
-
-    let submissionsViewPartialUsersClassName = 'react-tagsinput';
-    if (
-      this.state.submissionsViewPartial &&
-      this.state.submissionsViewPartialUsers.length === 0 &&
-      !this.state.isAddingPartialUsernames
-    ) {
-      submissionsViewPartialUsersClassName += ' react-tagsinput-invalid';
-    }
 
     const formModifiers = [];
     if (this.state.isSubmitPending) {
@@ -478,14 +470,12 @@ class UserAssetPermsEditor extends React.Component {
               />
 
               {this.state.submissionsViewPartial === true &&
-                <TagsInput
-                  className={submissionsViewPartialUsersClassName}
-                  value={this.state.submissionsViewPartialUsers}
-                  onChange={this.onSubmissionsViewPartialUsersChange}
-                  addOnBlur
-                  addKeys={[KEY_CODES.get('ENTER'), KEY_CODES.get('SPACE'), KEY_CODES.get('TAB')]}
-                  inputProps={submissionsViewPartialUsersInputProps}
-                  onlyUnique
+                <TextBox
+                  placeholder={PARTIAL_PLACEHOLDER}
+                  value={this.state.submissionsViewPartialUsers.join(' ')}
+                  onChange={this.onPartialUsersChange.bind(this, 'submissionsViewPartialUsers')}
+                  errors={this.state.submissionsViewPartial && this.state.submissionsViewPartialUsers.length === 0}
+                  onKeyPress={this.onInputKeyPress}
                 />
               }
             </div>

--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -328,8 +328,6 @@ class UserAssetPermsEditor extends React.Component {
       username: this.state.username,
     };
 
-    // use CHECKBOX_PERM_PAIRS on a loop for this
-
     if (this.isAssignable('view_asset')) {output.formView = this.state.formView;}
     if (this.isAssignable('change_asset')) {output.formEdit = this.state.formEdit;}
     if (this.isAssignable('add_submissions')) {output.submissionsAdd = this.state.submissionsAdd;}
@@ -351,8 +349,6 @@ class UserAssetPermsEditor extends React.Component {
     }
 
     const formData = this.getFormData();
-
-    // update perm parser
 
     const parsedUser = permParser.parseFormData(formData);
 

--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -42,7 +42,6 @@ class UserAssetPermsEditor extends React.Component {
       usernamesBeingChecked: new Set(),
       isSubmitPending: false,
       isEditingUsername: false,
-      isAddingPartialUsernames: false,
       // form user inputs
       username: '',
       formView: false,
@@ -223,37 +222,8 @@ class UserAssetPermsEditor extends React.Component {
     }
   }
 
-  /**
-   * Handles TagsInput change event and blocks adding nonexistent usernames.
-   * Also unblocks the submit button.
-   */
-  onSubmissionsViewPartialUsersChange(allUsers) {
-    this.setState({isAddingPartialUsernames: false});
-    const submissionsViewPartialUsers = [];
-
-    allUsers.forEach((username) => {
-      const userCheck = this.checkUsernameSync(username);
-      if (userCheck === true) {
-        submissionsViewPartialUsers.push(username);
-      } else if (userCheck === undefined) {
-        // we add unknown usernames for now and will check and possibly remove
-        // with checkUsernameAsync
-        submissionsViewPartialUsers.push(username);
-        this.checkUsernameAsync(username);
-      } else {
-        this.notifyUnknownUser(username);
-      }
-    });
-
-    this.setState({submissionsViewPartialUsers: submissionsViewPartialUsers});
-  }
-
-  onSubmissionsViewPartialUsersInputFocus() {
-    this.setState({isAddingPartialUsernames: true});
-  }
-
-  onSubmissionsViewPartialUsersInputBlur() {
-    this.setState({isAddingPartialUsernames: false});
+  onSubmissionsViewPartialUsersChange(users) {
+    this.setState({submissionsViewPartialUsers: users.split(' ')});
   }
 
   /**
@@ -343,7 +313,6 @@ class UserAssetPermsEditor extends React.Component {
       isPartialValid &&
       !this.state.isSubmitPending &&
       !this.state.isEditingUsername &&
-      !this.state.isAddingPartialUsernames &&
       this.state.username.length > 0 &&
       this.state.usernamesBeingChecked.size === 0 &&
       // we don't allow manual setting anonymous user permissions through UI
@@ -473,7 +442,7 @@ class UserAssetPermsEditor extends React.Component {
                 <TextBox
                   placeholder={PARTIAL_PLACEHOLDER}
                   value={this.state.submissionsViewPartialUsers.join(' ')}
-                  onChange={this.onPartialUsersChange.bind(this, 'submissionsViewPartialUsers')}
+                  onChange={this.onSubmissionsViewPartialUsersChange}
                   errors={this.state.submissionsViewPartial && this.state.submissionsViewPartialUsers.length === 0}
                   onKeyPress={this.onInputKeyPress}
                 />


### PR DESCRIPTION
## Description

Fix for self-harm calls causing 502s when checking too many `usernames` at once. It simplifies the partial users input. 

Split out from #2900 to be merged quicker.