### PR TITLE
Temporarily disable encryption settings modal

### DIFF
--- a/jsapp/js/components/assetrow.es6
+++ b/jsapp/js/components/assetrow.es6
@@ -348,6 +348,7 @@ class AssetRow extends React.Component {
                   {t('Manage Translations')}
                 </bem.PopoverMenu__link>
               }
+              { /* temporarily disabled
               <bem.PopoverMenu__link
                 data-action={'encryption'}
                 data-asset-uid={this.props.uid}
@@ -355,6 +356,7 @@ class AssetRow extends React.Component {
                 <i className='k-icon-lock'/>
                 {t('Manage Encryption')}
               </bem.PopoverMenu__link>
+              */ }
               {this.props.downloads.map((dl)=>{
                 return (
                     <bem.PopoverMenu__link m={`dl-${dl.format}`} href={dl.url}

--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -470,10 +470,12 @@ export class FormLanding extends React.Component {
               {t('Manage Translations')}
             </bem.PopoverMenu__link>
           }
+          { /* temporarily disabled
           <bem.PopoverMenu__link onClick={this.showEncryptionModal}>
             <i className='k-icon-lock'/>
             {t('Manage Encryption')}
           </bem.PopoverMenu__link>
+          */ }
         </ui.PopoverMenu>
       </bem.FormView__group>
     );


### PR DESCRIPTION
I think we can get this back quickly with some warning verbiage, but
that verbiage needs to be chosen carefully

## Description

Temporarily disable unreleased encryption settings modal pending addition of important warning and instructions

## Related issues

Part of #2692