### PR TITLE
Clear default asset ordering in health check

### DIFF
--- a/kobo/apps/service_health/views.py
+++ b/kobo/apps/service_health/views.py
@@ -55,7 +55,7 @@ def service_health(request):
 
     t0 = time.time()
     try:
-        Asset.objects.first()
+        Asset.objects.order_by().first()
     except Exception as e:
         postgres_message = repr(e)
         any_failure = True


### PR DESCRIPTION
## Description

Clear default asset ordering in health check to reduce unnecessary load on the database