### PR TITLE
Fix `http://kpi/browser_tests/` URL to run mocha tests

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -300,6 +300,7 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'jsapp'),
     os.path.join(BASE_DIR, 'static'),
     ('mocha', os.path.join(BASE_DIR, 'node_modules', 'mocha'),),
+    ('chai', os.path.join(BASE_DIR, 'node_modules', 'chai'),),
 )
 
 if os.path.exists(os.path.join(BASE_DIR, 'dkobo', 'jsapp')):

--- a/kpi/templates/browser_tests.html
+++ b/kpi/templates/browser_tests.html
@@ -7,11 +7,13 @@
   <title>KPI tests</title>
   <link rel="stylesheet" href="{% static 'mocha/mocha.css' %}"/>
   <script src="{% static 'mocha/mocha.js' %}"></script>
+  <script src="{% static 'chai/chai.js' %}"></script>
 </head>
 <body>
     <script>
       // need "t" defined for tests to pass
       function t (str) { return str; }
+      var expect = chai.expect;
     </script>
     <script>mocha.setup('bdd')</script>
     <div id="mocha"></div>

--- a/kpi/templates/browser_tests.html
+++ b/kpi/templates/browser_tests.html
@@ -9,9 +9,14 @@
   <script src="{% static 'mocha/mocha.js' %}"></script>
 </head>
 <body>
+    <script>
+      // need "t" defined for tests to pass
+      function t (str) { return str; }
+    </script>
     <script>mocha.setup('bdd')</script>
     <div id="mocha"></div>
-    {% render_bundle 'tests' 'js' %}
+    {% render_bundle 'browsertests' 'js' %}
+    {% render_bundle 'vendors' 'js' %}
     <script>mocha.run();</script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -76,10 +76,9 @@
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
-    "build": "webpack --config webpack/prod.config.js --colors",
-    "build-production": "npm run build && echo 'WARNING: npm run build-production DEPRECATED! PLEASE USE npm run build INSTEAD'",
+    "build": "webpack --config webpack/prod.config.js",
     "watch": "webpack-dev-server --config webpack/dev.server.js",
-    "test": "webpack --config webpack/test.config.js --colors && mocha-chrome test/tests.html",
+    "test": "webpack --config webpack/test.config.js && mocha-chrome test/tests.html",
     "lint": "eslint --ext .es6 \"jsapp/js/**/*\"",
     "show-icons": "opn jsapp/fonts/k-icons.html",
     "generate-icons": "node ./scripts/generate_icons.js",

--- a/test/tests.html
+++ b/test/tests.html
@@ -10,9 +10,11 @@
 <body>
     <div id="mocha"></div>
     <script>
-      expect = chai.expect;
+      var expect = chai.expect;
+      // need "t" defined for tests to pass
+      function t (str) { return str; }
     </script>
-    <script src="./compiled/app.js"></script>
+    <script src="./compiled/webpack-built-tests.js"></script>
     <script>
       mocha.run();
     </script>

--- a/webpack/dev.server.js
+++ b/webpack/dev.server.js
@@ -24,7 +24,7 @@ module.exports = WebpackCommon({
   },
   entry: {
     app: ['react-hot-loader/patch', './jsapp/js/main.es6'],
-    tests: path.resolve(__dirname, '../test/index.js')
+    browsertests: path.resolve(__dirname, '../test/index.js')
   },
   output: {
     library: 'KPI',

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -19,7 +19,7 @@ module.exports = WebpackCommon({
   },
   entry: {
     app: './jsapp/js/main.es6',
-    tests: path.resolve(__dirname, '../test/index.js')
+    browsertests: path.resolve(__dirname, '../test/index.js')
   },
   output: {
     path: path.resolve(__dirname, '../jsapp/compiled/'),

--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -8,7 +8,7 @@ module.exports = WebpackCommon({
   output: {
     library: 'tests',
     path: path.resolve(__dirname, '../test/compiled/'),
-    filename: 'app.js'
+    filename: 'webpack-built-tests.js'
   },
   // mainly for hiding stylelint output
   stats: {


### PR DESCRIPTION
* js files for browser_tests
* Added "vendors" to browser_tests.html so that webpack actually executes
* Hard-coded "t()" into template files so tests don't fail

Can verify this works by running `npm run test` or navigating to `http://kf.kobo.local/browser_tests/`

Note:

* The tests should not access any API endpoints or files
* The tests could also be used to help identify if a user experiences a bug specific to their browser

## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

Fixes #2890
Precedes #2829
