### PR TITLE
Fixed: Forms cannot be shared publicly

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -287,7 +287,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         }
         if specific_user is not None:
             try:
-                user_id = user.pk
+                user_id = specific_user.pk
             except AttributeError:
                 user_id = specific_user
             filters['user_id'] = user_id


### PR DESCRIPTION
## Description
Fix the 500 error returned by the back end when users try to share publicly their form and related data