### PR TITLE
Set editors_can_change_permissions to False…

### DIFF
--- a/kpi/migrations/0026_disable_editors_can_change_permissions.py
+++ b/kpi/migrations/0026_disable_editors_can_change_permissions.py
@@ -1,0 +1,39 @@
+import sys
+
+from django.db import migrations
+
+
+def forwards_func(apps, schema_editor):
+    sys.stderr.write(
+        'Disabling `editors_can_change_permissions` on all assets and '
+        'collections...'
+    )
+    sys.stderr.flush()
+
+    Asset = apps.get_model('kpi', 'Asset')  # noqa
+    Collection = apps.get_model('kpi', 'Collection')  # noqa
+    Asset.objects.update(editors_can_change_permissions=False)
+    Collection.objects.update(editors_can_change_permissions=False)
+
+
+def reverse_func(apps, schema_editor):
+    sys.stderr.write(
+        'ENABLING `editors_can_change_permissions` on all assets and '
+        'collections...'
+    )
+    sys.stderr.flush()
+
+    Asset = apps.get_model('kpi', 'Asset')  # noqa
+    Collection = apps.get_model('kpi', 'Collection')  # noqa
+    Asset.objects.update(editors_can_change_permissions=True)
+    Collection.objects.update(editors_can_change_permissions=True)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kpi', '0025_assign_delete_submissions_permissions'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -487,7 +487,9 @@ class Asset(ObjectPermissionMixin,
                                null=True, blank=True, on_delete=models.CASCADE)
     owner = models.ForeignKey('auth.User', related_name='assets', null=True,
                               on_delete=models.CASCADE)
-    editors_can_change_permissions = models.BooleanField(default=True)
+    # TODO: remove this flag; support for it has been removed from
+    # ObjectPermissionMixin
+    editors_can_change_permissions = models.BooleanField(default=False)
     uid = KpiUidField(uid_prefix='a')
     tags = TaggableManager(manager=KpiTaggableManager)
     settings = JSONBField(default=dict)

--- a/kpi/models/collection.py
+++ b/kpi/models/collection.py
@@ -52,7 +52,7 @@ class Collection(ObjectPermissionMixin, TagStringMixin, MPTTModel):
                             related_name='children', on_delete=models.CASCADE)
     owner = models.ForeignKey('auth.User', related_name='owned_collections',
                               on_delete=models.CASCADE)
-    editors_can_change_permissions = models.BooleanField(default=True)
+    editors_can_change_permissions = models.BooleanField(default=False)
     discoverable_when_public = models.BooleanField(default=False)
     uid = KpiUidField(uid_prefix='c')
     date_created = models.DateTimeField(auto_now_add=True)

--- a/kpi/models/object_permission.py
+++ b/kpi/models/object_permission.py
@@ -443,45 +443,23 @@ class ObjectPermissionMixin:
             effective_perms = set()
         else:
             effective_perms_copy = copy.copy(effective_perms)
-        if self.editors_can_change_permissions and (
-                codename is None or codename.startswith('share_')
-        ):
-            # Everyone with change_ should also get share_
-            change_permissions = self.__get_permissions_for_content_type(
-                content_type.pk, codename__startswith='change_')
-
-            for change_perm_pk, change_perm_codename in change_permissions:
-                share_permission_codename = re.sub(
-                    '^change_', 'share_', change_perm_codename, 1)
-                if (codename is not None and
-                        share_permission_codename != codename
-                ):
-                    # If the caller specified `codename`, skip anything that
-                    # doesn't match exactly. Necessary because `Asset` has
-                    # `*_submissions` in addition to `*_asset`
-                    continue
-                share_perm_pk, _ = self.__get_permissions_for_content_type(
-                    content_type.pk,
-                    codename=share_permission_codename)[0]
-                for user_id, permission_id in effective_perms_copy:
-                    if permission_id == change_perm_pk:
-                        effective_perms.add((user_id, share_perm_pk))
-        # The owner has the delete_ permission
-        if self.owner is not None and (
-                user is None or user.pk == self.owner.pk) and (
-                codename is None or codename.startswith('delete_')
-        ):
-            delete_permissions = self.__get_permissions_for_content_type(
-                content_type.pk, codename__startswith='delete_')
-            for delete_perm_pk, delete_perm_codename in delete_permissions:
-                if (codename is not None and
-                        delete_perm_codename != codename
-                ):
-                    # If the caller specified `codename`, skip anything that
-                    # doesn't match exactly. Necessary because `Asset` has
-                    # `delete_submissions` in addition to `delete_asset`
-                    continue
-                effective_perms.add((self.owner.pk, delete_perm_pk))
+        # The owner has the share_ and delete_ permission
+        for codename_prefix in ('share_', 'delete_'):
+            if self.owner is not None and (
+                    user is None or user.pk == self.owner.pk) and (
+                    codename is None or codename.startswith(codename_prefix)
+            ):
+                matching_permissions = self.__get_permissions_for_content_type(
+                    content_type.pk, codename__startswith=codename_prefix)
+                for perm_pk, perm_codename in matching_permissions:
+                    if (codename is not None and
+                            perm_codename != codename
+                    ):
+                        # If the caller specified `codename`, skip anything that
+                        # doesn't match exactly. Necessary because `Asset` has
+                        # `delete_submissions` in addition to `delete_asset`
+                        continue
+                    effective_perms.add((self.owner.pk, perm_pk))
         # We may have calculated more permissions for anonymous users
         # than they are allowed to have. Remove them.
         if user is None or user.pk == settings.ANONYMOUS_USER_ID:

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -146,7 +146,7 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         self.assertEqual(expected_perms, obj_perms)
 
 
-    def test_editors_see_all_assignments(self):
+    def test_editors_see_only_self_anon_and_owner_assignments(self):
 
         self.client.login(username='someuser', password='someuser')
         permission_list_response = self.client.get(
@@ -157,13 +157,12 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         )
         results = permission_list_response.data
 
-        # As an editor of the asset, `someuser` should see all.
         assignable_perms = Asset.get_assignable_permissions()
         expected_perms = []
         for user in [
             self.admin,
             self.someuser,
-            self.anotheruser,
+            # Permissions assigned to self.anotheruser must not appear
             get_anonymous_user(),
         ]:
             user_perms = self.asset.get_perms(user)

--- a/kpi/tests/api/v2/test_api_collection_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_collection_permission_assignment.py
@@ -131,7 +131,7 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
 
         self.assertEqual(expected_perms, obj_perms)
 
-    def test_editors_see_all_assignments(self):
+    def test_editors_see_only_self_anon_and_owner_assignments(self):
 
         self.client.login(username='someuser', password='someuser')
         permission_list_response = self.client.get(self.collection_permissions_list_url,
@@ -142,7 +142,6 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
         anotheruser_perms = self.collection.get_perms(self.anotheruser)
         results = permission_list_response.data
 
-        # As an editor of the collection. `someuser` should see all.
         expected_perms = []
         for admin_perm in admin_perms:
             if admin_perm in Collection.get_assignable_permissions():
@@ -150,9 +149,7 @@ class ApiCollectionPermissionListTestCase(BaseApiCollectionPermissionTestCase):
         for someuser_perm in someuser_perms:
             if someuser_perm in Collection.get_assignable_permissions():
                 expected_perms.append((self.someuser.username, someuser_perm))
-        for anotheruser_perm in anotheruser_perms:
-            if anotheruser_perm in Collection.get_assignable_permissions():
-                expected_perms.append((self.anotheruser.username, anotheruser_perm))
+        # Permissions assigned to self.anotheruser must not appear
 
         expected_perms = sorted(expected_perms, key=lambda element: (element[0],
                                                                      element[1]))

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -667,18 +667,13 @@ class ShareAssetsTest(AssetsTestCase):
             self.asset_in_coll
         ))
 
-    def test_change_permission_provides_share_permission(self):
+    def test_change_permission_does_not_provide_share_permission(self):
         anotheruser = User.objects.get(username='anotheruser')
         self.assertFalse(anotheruser.has_perm(
             PERM_CHANGE_ASSET, self.asset))
         # Grant the change permission and make sure it provides
         # share_asset
         self.asset.assign_perm(anotheruser, PERM_CHANGE_ASSET)
-        self.assertTrue(anotheruser.has_perm(
-            PERM_SHARE_ASSET, self.asset))
-        # Restrict share_asset to the owner and make sure anotheruser loses
-        # the permission
-        self.asset.editors_can_change_permissions = False
         self.assertFalse(anotheruser.has_perm(
             PERM_SHARE_ASSET, self.asset))
 

--- a/kpi/tests/test_collections.py
+++ b/kpi/tests/test_collections.py
@@ -430,17 +430,12 @@ class ShareCollectionTests(TestCase):
             coll
         ))
 
-    def test_change_permission_provides_share_permission(self):
+    def test_change_permission_does_not_provide_share_permission(self):
         self.assertFalse(self.someuser.has_perm(
             PERM_CHANGE_COLLECTION, self.standalone_coll))
-        # Grant the change permission and make sure it provides
+        # Grant the change permission and make sure it does not provide
         # share_collection
         self.standalone_coll.assign_perm(self.someuser, PERM_CHANGE_COLLECTION)
-        self.assertTrue(self.someuser.has_perm(
-            'share_collection', self.standalone_coll))
-        # Restrict share_collection to the owner and make sure someuser loses
-        # share_collection
-        self.standalone_coll.editors_can_change_permissions = False
         self.assertFalse(self.someuser.has_perm(
             'share_collection', self.standalone_coll))
 

--- a/kpi/tests/test_permissions.py
+++ b/kpi/tests/test_permissions.py
@@ -447,12 +447,10 @@ class PermissionsTestCase(BasePermissionsTestCase):
         collection = self.admin_collection
         asset_editor_permissions = [
             PERM_CHANGE_ASSET,
-            PERM_SHARE_ASSET,
             PERM_VIEW_ASSET
         ]
         collection_editor_permissions = [
             PERM_CHANGE_COLLECTION,
-            'share_collection',
             PERM_VIEW_COLLECTION
         ]
         asset.assign_perm(grantee, PERM_CHANGE_ASSET)
@@ -469,7 +467,6 @@ class PermissionsTestCase(BasePermissionsTestCase):
         asset = self.admin_asset
         submission_editor_permissions = [
             PERM_CHANGE_SUBMISSIONS,
-            PERM_SHARE_SUBMISSIONS,
             PERM_VIEW_ASSET,
             PERM_VIEW_SUBMISSIONS,
         ]
@@ -501,7 +498,6 @@ class PermissionsTestCase(BasePermissionsTestCase):
 
         assigned_someuser_perms = [
             PERM_CHANGE_ASSET,
-            PERM_SHARE_ASSET,
             PERM_VIEW_ASSET
         ]
 
@@ -539,7 +535,6 @@ class PermissionsTestCase(BasePermissionsTestCase):
 
         assigned_someuser_perms = [
             PERM_CHANGE_ASSET,
-            PERM_SHARE_ASSET,
             PERM_VIEW_ASSET
         ]
 
@@ -563,8 +558,6 @@ class PermissionsTestCase(BasePermissionsTestCase):
             PERM_CHANGE_ASSET,
             PERM_CHANGE_SUBMISSIONS,
             PERM_DELETE_SUBMISSIONS,
-            PERM_SHARE_ASSET,
-            PERM_SHARE_SUBMISSIONS,
             PERM_VALIDATE_SUBMISSIONS,
             PERM_VIEW_ASSET,
             PERM_VIEW_SUBMISSIONS

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -43,7 +43,6 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
     **Roles' permissions:**
 
     - Owner sees all permissions
-    - Editors see all permissions
     - Viewers see owner's permissions and their permissions
     - Anonymous users see only owner's permissions
 


### PR DESCRIPTION
everywhere, by changing its default to False and setting it to False on
all existing assets and collections

WIP - WILL FIX PR MESSAGE SHORTLY

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
