### PR TITLE
Refactor `get_label_for_permission()`

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -4,12 +4,14 @@ import copy
 import sys
 from collections import OrderedDict
 from functools import reduce
-from operator import add
 from io import BytesIO
+from operator import add
+from typing import Union
 
 import six
 import xlsxwriter
 from django.conf import settings
+from django.contrib.auth.models import Permission
 from django.contrib.postgres.fields import JSONField as JSONBField
 from django.db import models
 from django.db import transaction
@@ -727,18 +729,26 @@ class Asset(ObjectPermissionMixin,
             return perms.get(perm)
         return None
 
-    def get_label_for_permission(self, permission_or_codename):
-
+    def get_label_for_permission(
+        self, permission_or_codename: Union[Permission, str]
+    ) -> str:
+        """
+        Get the correct label for a permission (object or codename) based on
+        the type of this asset
+        """
         try:
             codename = permission_or_codename.codename
             permission = permission_or_codename
         except AttributeError:
             codename = permission_or_codename
             permission = None
+
         try:
             label = self.ASSIGNABLE_PERMISSIONS_WITH_LABELS[codename]
         except KeyError:
-            if not permission:
+            if permission:
+                label = permission.name
+            else:
                 cached_code_names = get_cached_code_names()
                 label = cached_code_names[codename]['name']
 


### PR DESCRIPTION
When a `Permission` object that was not included in `ASSIGNABLE_PERMISSIONS_WITH_LABELS` was passed to `get_label_for_permission()`, an `UnboundLocalError` exception would be raised:
```
>>> Asset(asset_type='survey').get_label_for_permission(Permission.objects.get(codename='from_kc_only'))
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/srv/src/yay/kpi/models/asset.py", line 745, in get_label_for_permission
    label = label.replace(
UnboundLocalError: local variable 'label' referenced before assignment
```

## Description

Fix a problem with fetching the label of a non-assignable permission