### PR TITLE
Fix invisible submission counter in header

### DIFF
--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -322,6 +322,7 @@
   }
 
   .form-title__submissions {
+    color: $kobo-white;
     font-size: 14px;
   }
 }


### PR DESCRIPTION
## Description

Set the submission counter text to white in the header. The text couldn't be seen previously because it was the same color as the background.

## Related issues

Fixes #2932