### PR TITLE
Fix "Data column name" regression

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -17,9 +17,8 @@ import {
   surveyToValidJson,
   unnullifyTranslations,
   assign,
-  koboMatrixParser,
-  syncCascadeChoiceNames
-} from 'utils';
+  koboMatrixParser
+} from '../utils';
 import {
   ASSET_TYPES,
   AVAILABLE_FORM_STYLES,
@@ -229,11 +228,11 @@ export default assign({
     if (this.state.settings__style !== undefined) {
       this.app.survey.settings.set('style', this.state.settings__style);
     }
+
     let surveyJSON = surveyToValidJson(this.app.survey);
     if (this.state.asset) {
       let surveyJSONWithMatrix = koboMatrixParser({source: surveyJSON}).source;
-      let surveyJSONCascade = syncCascadeChoiceNames({source: surveyJSONWithMatrix}).source;
-      surveyJSON = unnullifyTranslations(surveyJSONCascade, this.state.asset.content);
+      surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, this.state.asset.content);
     }
     let params = {content: surveyJSON};
 

--- a/jsapp/js/utils.es6
+++ b/jsapp/js/utils.es6
@@ -24,16 +24,6 @@ alertify.defaults.notifier.position = 'bottom-left';
 alertify.defaults.notifier.closeButton = true;
 
 const cookies = new Cookies();
-const modelUtils = require('../xlform/src/model.utils');
-
-const SLUGGIFY_LABEL_OPTIONS = {
-  lowerCase: false,
-  preventDuplicateUnderscores: true,
-  stripSpaces: true,
-  lrstrip: true,
-  incrementorPadding: 3,
-  validXmlTag: true
-};
 
 export function notify(msg, atype='success') {
   alertify.notify(msg, atype);
@@ -413,47 +403,6 @@ export function validFileTypes() {
     '' // Keep this to fix issue with IE Edge sending an empty MIME type
   ];
   return VALID_ASSET_UPLOAD_FILE_TYPES.join(',');
-}
-
-/*
- * Syncs the `choice_filter` of each cascading question to any changes made to
- * dependent cascading question labels
- */
-export function syncCascadeChoiceNames(params) {
-  let content = {};
-  if (params.content) {
-    content = JSON.parse(params.content);
-  }
-  if (params.source) {
-    content = JSON.parse(params.source);
-  }
-
-  if (!content.survey) {
-    return params;
-  }
-
-  for(var i = 0; i < content.survey.length; i++) {
-    var sluggifiedLabel;
-    if (content.survey[i].name !== undefined && content.survey[i].label !== undefined) {
-      sluggifiedLabel = modelUtils.sluggify(content.survey[i].label, SLUGGIFY_LABEL_OPTIONS);
-      content.survey[i].name = sluggifiedLabel;
-    }
-    if (content.survey[i].choice_filter !== undefined && content.survey[i - 1].label !== undefined) {
-      var choiceQuestion = '' + content.survey[i].choice_filter.split('=')[0];
-      sluggifiedLabel = modelUtils.sluggify(content.survey[i - 1].label, SLUGGIFY_LABEL_OPTIONS);
-      var choiceLabel = '=${' + sluggifiedLabel + '}';
-      content.survey[i].choice_filter = choiceQuestion + choiceLabel;
-    }
-  }
-
-  if (params.content) {
-    params.content = JSON.stringify(content);
-  }
-  if (params.source) {
-    params.source = JSON.stringify(content);
-  }
-  return params;
-
 }
 
 export function koboMatrixParser(params) {

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -268,7 +268,7 @@ module.exports = do ->
         @model.set 'value', value
         @model.deduplicate @model.getSurvey()
       )
-      update_view = () => @$el.find('input').eq(0).val($modelUtils.sluggifyLabel @model._parent.getValue('label') || @model.get("value"))
+      update_view = () => @$el.find('input').eq(0).val(@model.get("value") || $modelUtils.sluggifyLabel @model._parent.getValue('label'))
       update_view()
 
       @model._parent.get('label').on 'change:value', update_view

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -268,10 +268,7 @@ module.exports = do ->
         @model.set 'value', value
         @model.deduplicate @model.getSurvey()
       )
-      # Update "Data Column Name" with `name` of question first, then use label.
-      # The order was swapped to fix kpi#706 but using the current order does
-      # not break the fix and is necessary to fix kpi#2873.
-      update_view = () => @$el.find('input').eq(0).val(@model.get("value") || $modelUtils.sluggifyLabel @model._parent.getValue('label'))
+      update_view = () => @$el.find('input').eq(0).val($modelUtils.sluggifyLabel @model._parent.getValue('label') || @model.get("value"))
       update_view()
 
       @model._parent.get('label').on 'change:value', update_view


### PR DESCRIPTION
## Description

Revert a change that caused the form builder to discard manual data column names.

## Related issues

Fixes #2873
Reverts #2877 
Reverts #2723 
Un-fixes #706