### PR TITLE
Allow non-owners to remove themselves from a shared asset

### DIFF
--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -120,7 +120,7 @@ class AssetNestedObjectPermission(BaseAssetNestedObjectPermission):
     perms_map['HEAD'] = perms_map['GET']
     perms_map['PUT'] = perms_map['POST']
     perms_map['PATCH'] = perms_map['POST']
-    perms_map['DELETE'] = perms_map['POST']
+    perms_map['DELETE'] = perms_map['GET']
 
     def has_permission(self, request, view):
         if not request.user:

--- a/kpi/tests/api/v2/test_api_permissions.py
+++ b/kpi/tests/api/v2/test_api_permissions.py
@@ -239,6 +239,118 @@ class ApiPermissionsTestCase(KpiTestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_shared_asset_remove_own_permissions_allowed(self):
+        """
+        Ensuring that a non-owner who has been shared an asset is able to remove
+        themselves from that asset if they want.
+        """
+        self.client.login(
+            username=self.someuser.username,
+            password=self.someuser_password,
+        )
+        new_asset = self.create_asset(
+            name='a new asset',
+            owner=self.someuser,
+            owner_password=self.someuser_password,
+        )
+        perm = new_asset.assign_perm(self.anotheruser, 'view_asset')
+        kwargs = {
+            'parent_lookup_asset': new_asset.uid,
+            'uid': perm.uid,
+        }
+        url = reverse(
+            'api_v2:asset-permission-assignment-detail', kwargs=kwargs
+        )
+        self.client.logout()
+        self.client.login(
+            username=self.anotheruser.username,
+            password=self.anotheruser_password,
+        )
+        assert self.anotheruser.has_perm(PERM_VIEW_ASSET, new_asset)
+
+        # `anotheruser` attempting to remove themselves from the asset
+        res = self.client.delete(url)
+        assert res.status_code == status.HTTP_204_NO_CONTENT
+        assert not self.anotheruser.has_perm(PERM_VIEW_ASSET, new_asset)
+        assert len(new_asset.get_perms(self.anotheruser)) == 0
+
+    def test_shared_asset_non_owner_remove_owners_permissions_not_allowed(self):
+        """
+        Ensuring that a non-owner who has been shared an asset is not able to
+        remove permissions from the owner of that asset
+        """
+        self.client.login(
+            username=self.someuser.username,
+            password=self.someuser_password,
+        )
+        new_asset = self.create_asset(
+            name='a new asset',
+            owner=self.someuser,
+            owner_password=self.someuser_password,
+        )
+        # someuser obviously has `PERM_VIEW_ASSET` set, but this seems to be
+        # the only way to access the uid of that permission to pass into `kwargs`
+        perm = new_asset.assign_perm(self.someuser, PERM_VIEW_ASSET)
+        new_asset.assign_perm(self.anotheruser, PERM_VIEW_ASSET)
+        kwargs = {
+            'parent_lookup_asset': new_asset.uid,
+            'uid': perm.uid,
+        }
+        url = reverse(
+            'api_v2:asset-permission-assignment-detail', kwargs=kwargs
+        )
+        self.client.logout()
+        self.client.login(
+            username=self.anotheruser.username,
+            password=self.anotheruser_password,
+        )
+        assert self.someuser.has_perm(PERM_VIEW_ASSET, new_asset)
+
+        # `anotheruser` attempting to remove `someuser` from the asset
+        res = self.client.delete(url)
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+        assert self.someuser.has_perm(PERM_VIEW_ASSET, new_asset)
+
+    def test_shared_asset_non_owner_remove_another_non_owners_permissions_not_allowed(self):
+        """
+        Ensuring that a non-owner who has been shared an asset is not able to
+        remove permissions from another non-owner that has also been share the
+        asset
+        """
+        yetanotheruser = User.objects.create(
+            username='yetanotheruser',
+            password='yetanotheruser',
+        )
+        self.client.login(
+            username=self.someuser.username,
+            password=self.someuser_password,
+        )
+        new_asset = self.create_asset(
+            name='a new asset',
+            owner=self.someuser,
+            owner_password=self.someuser_password,
+        )
+        new_asset.assign_perm(self.anotheruser, PERM_VIEW_ASSET)
+        perm = new_asset.assign_perm(yetanotheruser, PERM_VIEW_ASSET)
+        kwargs = {
+            'parent_lookup_asset': new_asset.uid,
+            'uid': perm.uid,
+        }
+        url = reverse(
+            'api_v2:asset-permission-assignment-detail', kwargs=kwargs
+        )
+        self.client.logout()
+        self.client.login(
+            username=self.anotheruser.username,
+            password=self.anotheruser_password,
+        )
+        assert yetanotheruser.has_perm(PERM_VIEW_ASSET, new_asset)
+
+        # `anotheruser` attempting to remove `yetanotheruser` from the asset
+        res = self.client.delete(url)
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+        assert yetanotheruser.has_perm(PERM_VIEW_ASSET, new_asset)
+
     def test_copy_permissions_between_assets(self):
         # Give "someuser" edit permissions on an asset owned by "admin"
         self.add_perm(self.admin_asset, self.someuser, 'change_')

--- a/kpi/tests/api/v2/test_api_permissions.py
+++ b/kpi/tests/api/v2/test_api_permissions.py
@@ -251,7 +251,6 @@ class ApiPermissionsTestCase(KpiTestCase):
         new_asset = self.create_asset(
             name='a new asset',
             owner=self.someuser,
-            owner_password=self.someuser_password,
         )
         perm = new_asset.assign_perm(self.anotheruser, 'view_asset')
         kwargs = {
@@ -286,7 +285,6 @@ class ApiPermissionsTestCase(KpiTestCase):
         new_asset = self.create_asset(
             name='a new asset',
             owner=self.someuser,
-            owner_password=self.someuser_password,
         )
         # someuser obviously has `PERM_VIEW_ASSET` set, but this seems to be
         # the only way to access the uid of that permission to pass into `kwargs`
@@ -313,13 +311,12 @@ class ApiPermissionsTestCase(KpiTestCase):
 
     def test_shared_asset_non_owner_remove_another_non_owners_permissions_not_allowed(self):
         """
-        Ensuring that a non-owner who has been shared an asset is not able to
-        remove permissions from another non-owner that has also been share the
-        asset
+        Ensuring that a non-owner who has an asset shared with them cannot
+        remove permissions from another non-owner with that same asset shared
+        with them.
         """
         yetanotheruser = User.objects.create(
             username='yetanotheruser',
-            password='yetanotheruser',
         )
         self.client.login(
             username=self.someuser.username,

--- a/kpi/tests/api/v2/test_api_permissions.py
+++ b/kpi/tests/api/v2/test_api_permissions.py
@@ -5,7 +5,7 @@ from rest_framework import status
 
 from kpi.constants import PERM_VIEW_ASSET, PERM_CHANGE_ASSET, \
     PERM_SHARE_ASSET
-from kpi.models.object_permission import get_anonymous_user
+from kpi.models.object_permission import get_anonymous_user, ObjectPermission
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
@@ -286,9 +286,10 @@ class ApiPermissionsTestCase(KpiTestCase):
             name='a new asset',
             owner=self.someuser,
         )
-        # someuser obviously has `PERM_VIEW_ASSET` set, but this seems to be
-        # the only way to access the uid of that permission to pass into `kwargs`
-        perm = new_asset.assign_perm(self.someuser, PERM_VIEW_ASSET)
+        # Getting existing permission for the owner of the asset
+        perm = ObjectPermission.objects.filter(asset=new_asset).get(
+            user=self.someuser, permission__codename=PERM_VIEW_ASSET
+        )
         new_asset.assign_perm(self.anotheruser, PERM_VIEW_ASSET)
         kwargs = {
             'parent_lookup_asset': new_asset.uid,

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -233,9 +233,9 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
         object_permission = self.get_object()
         user = object_permission.user
         # If the user is not the owner of the asset, but trying to delete the
-        # owner's permissions, raise permission denied error. However, if it is
-        # the owner of the asset, they should also be prevented from deleting
-        # their own permissions, but given a more appropriate response
+        # owner's permissions, raise permission denied error. However, if they
+        # are the owner of the asset, they should also be prevented from
+        # deleting their own permissions, but given a more appropriate response
         if (self.request.user.pk != self.asset.owner_id) and (
             self.request.user.pk != user.pk
         ):


### PR DESCRIPTION
Permissions on the `DELETE` method of the existing `permission-assignments` endpoint have been modified to allow for non-owners of a shared asset to always be able to remove themselves from the asset:

`DELETE /api/v2/assets/{uid}/permission-assignments/{permission_uid}/`

Non-owners can remove their own permissions, but are not able to delete the permissions of the asset's owner or any other non-owners who may have the asset shared with them.

## Description

This change allows users with `view_asset` to permissions to remove themselves from an asset that has been shared with them as requested in the [community forum](https://community.kobotoolbox.org/t/refuse-and-remove-previsously-shared-form/4380).

## Related issues

closes #2940 
