### PR TITLE
Replacing `returnURL` with `return_url`

### DIFF
--- a/jsapp/js/components/formLanding.es6
+++ b/jsapp/js/components/formLanding.es6
@@ -248,7 +248,7 @@ export class FormLanding extends React.Component {
         }],
         ['single_url', {
           label: t('Online-Only (single submission)'),
-          desc: t('This allows a single submission, and can be paired with the "returnURL" parameter to redirect the user to a URL of your choice after the form has been submitted.')
+          desc: t('This allows a single submission, and can be paired with the "return_url" parameter to redirect the user to a URL of your choice after the form has been submitted.')
         }],
         ['single_once_url', {
           label: t('Online-only (once per respondent)'),


### PR DESCRIPTION
## Description

Updating redirect query parameter from `returnURL` to the updated `return_url`.

## Related issues

closes #2947 