### PR TITLE
[Public Collections] Fix app crashing when language is not English

### DIFF
--- a/jsapp/js/components/reportViewItem.es6
+++ b/jsapp/js/components/reportViewItem.es6
@@ -185,6 +185,11 @@ class ReportViewItem extends React.Component {
     Chart.defaults.global.elements.arc.backgroundColor = baseColor;
     Chart.defaults.global.maintainAspectRatio = false;
 
+    // if report styles are invalid we default to vertical
+    if (Array.from(REPORT_STYLES.keys()).includes(chartType) !== true) {
+      chartType = REPORT_STYLES.get('vertical').value;
+    }
+
     if (chartType === REPORT_STYLES.get('donut').value) {
       chartType = 'pie';
     }

--- a/jsapp/js/components/reportViewItem.es6
+++ b/jsapp/js/components/reportViewItem.es6
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import _ from 'underscore';
 import Chart from 'chart.js';
 import {bem} from '../bem';
+import {REPORT_STYLES} from 'js/constants';
 
 class ReportTable extends React.Component {
   constructor(props) {
@@ -184,19 +185,19 @@ class ReportViewItem extends React.Component {
     Chart.defaults.global.elements.arc.backgroundColor = baseColor;
     Chart.defaults.global.maintainAspectRatio = false;
 
-    if (chartType === 'donut') {
+    if (chartType === REPORT_STYLES.get('donut').value) {
       chartType = 'pie';
     }
 
-    if (chartType === 'area') {
+    if (chartType === REPORT_STYLES.get('area').value) {
       chartType = 'line';
     }
 
-    if (chartType === 'horizontal') {
+    if (chartType === REPORT_STYLES.get('horizontal').value) {
       chartType = 'horizontalBar';
     }
 
-    if (chartType === 'vertical' || chartType === 'bar_chart') {
+    if (chartType === REPORT_STYLES.get('vertical').value || chartType === 'bar_chart') {
       chartType = 'bar';
     }
 
@@ -296,12 +297,12 @@ class ReportViewItem extends React.Component {
       opts.options.scales.xAxes = [];
       opts.options.scales.yAxes = [];
 
-      if (this.props.style.report_type === 'donut') {
+      if (this.props.style.report_type === REPORT_STYLES.get('donut').value) {
         opts.options.cutoutPercentage = 50;
       }
     }
 
-    if (this.props.style.report_type === 'area') {
+    if (this.props.style.report_type === REPORT_STYLES.get('area').value) {
       opts.data.datasets[0].backgroundColor = colors[0];
     }
 

--- a/jsapp/js/components/reports.es6
+++ b/jsapp/js/components/reports.es6
@@ -21,18 +21,15 @@ import {
   assign,
   launchPrinting
 } from 'utils';
-
-function labelVal(label, value) {
-  return {label: label, value: (value || label.toLowerCase().replace(/\W+/g, '_'))};
-}
+import {REPORT_STYLES} from 'js/constants';
 
 let reportStyles = [
-  labelVal(t('Vertical')),
-  labelVal(t('Donut')),
-  labelVal(t('Area')),
-  labelVal(t('Horizontal')),
-  labelVal(t('Pie')),
-  labelVal(t('Line')),
+  REPORT_STYLES.get('vertical'),
+  REPORT_STYLES.get('donut'),
+  REPORT_STYLES.get('area'),
+  REPORT_STYLES.get('horizontal'),
+  REPORT_STYLES.get('pie'),
+  REPORT_STYLES.get('line'),
 ];
 
 class ChartTypePicker extends React.Component {
@@ -732,7 +729,7 @@ class Reports extends React.Component {
 
       // TODO: improve the defaults below
       if (reportStyles.default.report_type === undefined) {
-        reportStyles.default.report_type = 'vertical';
+        reportStyles.default.report_type = REPORT_STYLES.get('vertical').value;
       }
       if (reportStyles.default.translationIndex === undefined) {
         reportStyles.default.translationIndex = 0;

--- a/jsapp/js/components/searchcollectionlist.es6
+++ b/jsapp/js/components/searchcollectionlist.es6
@@ -16,7 +16,7 @@ import {
   ASSET_TYPES,
   COMMON_QUERIES,
   ACCESS_TYPES,
-  CATEGORY_LABELS
+  DEPLOYMENT_CATEGORIES
 } from '../constants';
 
 class SearchCollectionList extends Reflux.Component {
@@ -161,14 +161,14 @@ class SearchCollectionList extends Reflux.Component {
       searchResultsBucket = 'searchResultsCategorizedResultsLists';
     }
 
-    var results = ['Deployed', 'Draft', 'Archived'].map(
+    var results = Array.from(DEPLOYMENT_CATEGORIES.keys()).map(
       (category, i) => {
         if (this.state[searchResultsBucket][category].length < 1) {
           return [];
         }
         return [
           <bem.List__subheading key={i}>
-            {CATEGORY_LABELS[category]}
+            {DEPLOYMENT_CATEGORIES.get(category).label}
           </bem.List__subheading>,
 
           <bem.AssetItems m={i + 1} key={i + 2}>

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -405,11 +405,11 @@ export const MATRIX_PAIR_PROPS = {
   inChoices: 'list_name'
 };
 
-export const CATEGORY_LABELS = {
-  Deployed: t('Deployed'),
-  Draft: t('Draft'),
-  Archived: t('Archived')
-};
+export const DEPLOYMENT_CATEGORIES = new Map([
+  ['Deployed', {id: 'Deployed', label: t('Deployed')}],
+  ['Draft', {id: 'Draft', label: t('Draft')}],
+  ['Archived', {id: 'Archived', label: t('Archived')}],
+]);
 
 const constants = {
   ROOT_URL,
@@ -434,7 +434,7 @@ const constants = {
   FORM_VERSION_NAME,
   SCORE_ROW_TYPE,
   RANK_LEVEL_TYPE,
-  CATEGORY_LABELS,
+  DEPLOYMENT_CATEGORIES,
 };
 
 export default constants;

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -411,6 +411,15 @@ export const DEPLOYMENT_CATEGORIES = new Map([
   ['Archived', {id: 'Archived', label: t('Archived')}],
 ]);
 
+export const REPORT_STYLES = new Map([
+  ['vertical', {value: 'vertical', label: t('Vertical')}],
+  ['donut', {value: 'donut', label: t('Donut')}],
+  ['area', {value: 'area', label: t('Area')}],
+  ['horizontal', {value: 'horizontal', label: t('Horizontal')}],
+  ['pie', {value: 'pie', label: t('Pie')}],
+  ['line', {value: 'line', label: t('Line')}],
+]);
+
 const constants = {
   ROOT_URL,
   ANON_USERNAME,
@@ -435,6 +444,7 @@ const constants = {
   SCORE_ROW_TYPE,
   RANK_LEVEL_TYPE,
   DEPLOYMENT_CATEGORIES,
+  REPORT_STYLES,
 };
 
 export default constants;

--- a/jsapp/js/lists/sidebarForms.es6
+++ b/jsapp/js/lists/sidebarForms.es6
@@ -11,7 +11,7 @@ import {searches} from '../searches';
 import {stores} from '../stores';
 import {
   COMMON_QUERIES,
-  CATEGORY_LABELS
+  DEPLOYMENT_CATEGORIES
 } from 'js/constants';
 
 class SidebarFormsList extends Reflux.Component {
@@ -119,40 +119,42 @@ class SidebarFormsList extends Reflux.Component {
                 </bem.Loading>
               );
             } else if (s.defaultQueryState === 'done') {
-              return [CATEGORY_LABELS.Deployed, CATEGORY_LABELS.Draft, CATEGORY_LABELS.Archived].map(
-                (category) => {
-                  var categoryVisible = this.state.selectedCategories[category];
-                  if (s[activeItems][category].length < 1) {
+              return Array.from(DEPLOYMENT_CATEGORIES.keys()).map(
+                (categoryId) => {
+                  var categoryVisible = this.state.selectedCategories[categoryId];
+                  if (s[activeItems][categoryId].length < 1) {
                     categoryVisible = false;
                   }
 
                   const icon = ['k-icon'];
-                  if (category === CATEGORY_LABELS.Deployed) {
+                  if (categoryId === DEPLOYMENT_CATEGORIES.get('Deployed').id) {
                     icon.push('k-icon-deploy');
                   }
-                  if (category === CATEGORY_LABELS.Draft) {
+                  if (categoryId === DEPLOYMENT_CATEGORIES.get('Draft').id) {
                     icon.push('k-icon-drafts');
                   }
-                  if (category === CATEGORY_LABELS.Archived) {
+                  if (categoryId === DEPLOYMENT_CATEGORIES.get('Archived').id) {
                     icon.push('k-icon-archived');
                   }
 
                   return [
                     <bem.FormSidebar__label
-                      m={[category, categoryVisible ? 'visible' : 'collapsed']}
-                      onClick={this.toggleCategory(category)}
-                      key={`${category}-label`}
+                      m={[categoryId, categoryVisible ? 'visible' : 'collapsed']}
+                      onClick={this.toggleCategory(categoryId)}
+                      key={`${categoryId}-label`}
                     >
                       <i className={icon.join(' ')}/>
-                      <bem.FormSidebar__labelText>{category}</bem.FormSidebar__labelText>
-                      <bem.FormSidebar__labelCount>{s[activeItems][category].length}</bem.FormSidebar__labelCount>
+                      <bem.FormSidebar__labelText>
+                        {DEPLOYMENT_CATEGORIES.get(categoryId).label}
+                      </bem.FormSidebar__labelText>
+                      <bem.FormSidebar__labelCount>{s[activeItems][categoryId].length}</bem.FormSidebar__labelCount>
                     </bem.FormSidebar__label>,
 
                     <bem.FormSidebar__grouping
-                      m={[category, categoryVisible ? 'visible' : 'collapsed']}
-                      key={`${category}-group`}
+                      m={[categoryId, categoryVisible ? 'visible' : 'collapsed']}
+                      key={`${categoryId}-group`}
                     >
-                      {s[activeItems][category].map(this.renderMiniAssetRow.bind(this))}
+                      {s[activeItems][categoryId].map(this.renderMiniAssetRow.bind(this))}
                     </bem.FormSidebar__grouping>
                   ];
                 }


### PR DESCRIPTION
## Description

Frontend code was wrongly using translated labels as id's to display deployment groups ("Drafts", "Deployed" and "Archived") which was causing the crash when the language was other than English (e.g. endpoint expected `Drafts` but was getting `Brouillons` when set to French).

It also includes a fix for when a graph style override was saved with the UI language other than English. There is no way to set invalid value through UI now and we will ignore existing invalid values and use default style instead.

## Additional details

Also includes a fix for #2950