### PR TITLE
Fix to point the URL in the REST submission email to the correct screen in the UI

### DIFF
--- a/kobo/apps/hook/tasks.py
+++ b/kobo/apps/hook/tasks.py
@@ -110,6 +110,7 @@ def failures_reports():
                 max_length = 0
                 records[record.hook.asset.owner.id]['assets'][record.hook.asset.uid] = {
                     'name': record.hook.asset.name,
+                    'hook_uid': record.hook.uid,
                     'max_length': 0,
                     'logs': []
                 }

--- a/kobo/apps/hook/templates/reports/failures_email_body.html
+++ b/kobo/apps/hook/templates/reports/failures_email_body.html
@@ -12,7 +12,7 @@
 
 {% for asset_uid, asset in assets.items %}
   {% url 'api_v2:asset-detail' uid=asset_uid as asset_url %}
-  <p>{{ i18n_asset }}: <b><a href="{{ kpi_base_url }}{{ asset_url }}">{{ asset.name }}</a></b></p>
+  <p>{{ i18n_asset }}: <b><a href="{{ kpi_base_url }}/#/forms/{{asset_uid}}/settings/rest/{{asset.hook_uid}}">{{ asset.name }}</a></b></p>
     <table>
         <tr>
           <th style="border-bottom:1px solid black;">{{ i18n_hook }}</th>

--- a/kobo/apps/hook/templates/reports/failures_email_body.txt
+++ b/kobo/apps/hook/templates/reports/failures_email_body.txt
@@ -13,7 +13,7 @@
 
 {% for asset_uid, asset in assets.items %}
 {% url 'api_v2:asset-detail' uid=asset_uid as asset_url %}
-{{ i18n_asset }}: {{ asset.name }} - [{{ kpi_base_url }}{{ asset_url }}]
+{{ i18n_asset }}: {{ asset.name }} - [{{ kpi_base_url }}/#/forms/{{asset_uid}}/settings/rest/{{asset.hook_uid}}]
 
     {% with max_length=asset.max_length|add:"2" %}
     {{ i18n_hook|center:max_length }}|{{ i18n_submission|center:25 }}|{{ i18n_status_code|center:15 }}|{{ i18n_message|truncatechars:23|center:25 }}|{{ i18n_date|center:25 }}

--- a/kobo/apps/hook/tests/test_email.py
+++ b/kobo/apps/hook/tests/test_email.py
@@ -36,6 +36,7 @@ class EmailTestCase(HookTestCase):
             "assets": {
                 self.asset.uid: {
                     "name": self.asset.name,
+                    "hook_uid": self.hook.uid,
                     "max_length": len(self.hook.name),
                     "logs": [{
                         "hook_name": self.hook.name,


### PR DESCRIPTION

## Checklist

1. [x] If you've added code that should be tested, add tests
2. [N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

When a user has set up a REST service AND has checked the Receive emails notifications box in the REST settings, the user was receiving an email with a link to the API view for the form.
The link in that email will now take the user directly to the correct screen which lists the REST submissions.

## Related issues

Fixes issue #2750 
