### PR TITLE
2778 in app messages

### DIFF
--- a/kobo/apps/help/admin.py
+++ b/kobo/apps/help/admin.py
@@ -20,7 +20,7 @@ class InAppMessageAdmin(MarkdownxModelAdmin):
 
     def get_form(self, *args, **kwargs):
         """
-        Allows us to add warning_messages to the top of the form without
+        Allows us to add warning messages to the top of the form without
         manually maintaining a list of model fields in this class. An
         approximation of a model-level `help_text`
         """
@@ -29,7 +29,7 @@ class InAppMessageAdmin(MarkdownxModelAdmin):
         # of fields, from the superclass
         form = super().get_form(*args, **kwargs)
 
-        # Next, build `fieldsets` using our warning_messages and that list of
+        # Next, build `fieldsets` using our warning messages and that list of
         # fields. From the Django documentation:
         #     fieldsets is a list of two-tuples…in the format (name,
         #     field_options), where name is a string representing the title of

--- a/kobo/apps/help/admin.py
+++ b/kobo/apps/help/admin.py
@@ -6,16 +6,21 @@ from .models import InAppMessage, InAppMessageFile
 
 
 class InAppMessageAdmin(MarkdownxModelAdmin):
-    warning_message = (
+    new_message_warning = (
         '⚠ Warning: always create a new message, from scratch, to display new '
         'information. If someone has already dismissed a message, editing it '
         'here will not cause it to reappear.'
+    )
+    drag_drop_warning = (
+        '⚠ Warning: Please drag and drop photos directly into the Snippet or '
+        'Body boxes. Copying the URL from the in app message files will '
+        'likely cause errors.'
     )
     readonly_fields = ['uid', 'last_editor']
 
     def get_form(self, *args, **kwargs):
         """
-        Allows us to add `warning_message` to the top of the form without
+        Allows us to add warning_messages to the top of the form without
         manually maintaining a list of model fields in this class. An
         approximation of a model-level `help_text`
         """
@@ -24,16 +29,20 @@ class InAppMessageAdmin(MarkdownxModelAdmin):
         # of fields, from the superclass
         form = super().get_form(*args, **kwargs)
 
-        # Next, build `fieldsets` using our `warning_message` and that list of
+        # Next, build `fieldsets` using our warning_messages and that list of
         # fields. From the Django documentation:
         #     fieldsets is a list of two-tuples…in the format (name,
         #     field_options), where name is a string representing the title of
         #     the fieldset and field_options is a dictionary of information
         #     about the fieldset, including a list of fields to be displayed in
         #     it.
+        #     The name is effectively a heading. To use multiple headings as
+        #     for warings, a second field set must be set with with the list
+        #     of fields set to an empty string.
         # https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets
         self.fieldsets = [
-            (self.warning_message, {'fields': form._meta.fields}),
+            (self.new_message_warning, {'fields': ''}),
+            (self.drag_drop_warning, {'fields': form._meta.fields}),
         ]
         return form
 

--- a/kobo/apps/help/admin.py
+++ b/kobo/apps/help/admin.py
@@ -37,7 +37,7 @@ class InAppMessageAdmin(MarkdownxModelAdmin):
         #     about the fieldset, including a list of fields to be displayed in
         #     it.
         #     The name is effectively a heading. To use multiple headings as
-        #     for warings, a second field set must be set with with the list
+        #     for warnings, a second field set must be set with with the list
         #     of fields set to an empty string.
         # https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets
         self.fieldsets = [


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Created a warning for superusers when creating in-app messages.
-This warning is to alert the user that they should drag and drop photos into the snippet and/or body
-The URL from in-app message files takes the user to the right image, but through a path that only superusers can access

## Related issues

Part of #2778
