### PR TITLE
Always search for root survey when adding to library

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -137,7 +137,7 @@ module.exports = do ->
 
     add_row_to_question_library: (evt) =>
       evt.stopPropagation()
-      @ngScope?.add_row_to_question_library @model, @model.collection._parent._initialParams
+      @ngScope?.add_row_to_question_library @model, @model.getSurvey()._initialParams
 
   class GroupView extends BaseRowView
     className: "survey__row survey__row--group  xlf-row-view xlf-row-view--depr"


### PR DESCRIPTION
## Description
More so verbose notes for those interested: 
As a consequence to https://github.com/kobotoolbox/kpi/pull/2742, we need the entire survey passed to `unnullifyTranslations` when saving a formbuilder row to the library. The coffee code nests the survey in 2 `._parent` hierarchies for each group (i.e., if a question is in one group, its survey is in `@model.collection._parent_.parent._initalParams`, if nested in two groups its survey would be in `@model.collection._parent_.parent._parent_.parent._initalParams` etc.)

Currently we are sending a static set of 1 `_parent` (which assumes no nested groups). There's a already a function that iterates through each `_parent` and returns the last one. I've used that function here instead.

## Related issues

Fixes #2973 
