### PR TITLE
Fix submission modal displaying wrong labels for choices

### DIFF
--- a/jsapp/js/components/submissionDataTable.es6
+++ b/jsapp/js/components/submissionDataTable.es6
@@ -128,7 +128,7 @@ class SubmissionDataTable extends React.Component {
         choice = this.findChoice(listName, data);
         if (!choice) {
           console.error(`Choice not found for "${listName}" and "${data}".`);
-          // fallback to data to display anything meaningful
+          // fallback to raw data to display anything meaningful
           return data;
         } else {
           return (
@@ -143,9 +143,9 @@ class SubmissionDataTable extends React.Component {
             {data.split(' ').map((answer, answerIndex) => {
               choice = this.findChoice(listName, answer);
               if (!choice) {
-                console.error(`Choice not found for "${listName}" and "${data}".`);
-                // fallback to data to display anything meaningful
-                return data;
+                console.error(`Choice not found for "${listName}" and "${answer}".`);
+                // fallback to raw data to display anything meaningful
+                return answer;
               } else {
                 return (
                   <li key={answerIndex}>

--- a/jsapp/js/components/submissionDataTable.es6
+++ b/jsapp/js/components/submissionDataTable.es6
@@ -2,19 +2,19 @@ import React from 'react';
 import autoBind from 'react-autobind';
 import {
   formatTimeDate,
-  formatDate
+  formatDate,
 } from 'utils';
 import {bem} from 'js/bem';
 import {renderTypeIcon} from 'js/assetUtils';
 import {
   DISPLAY_GROUP_TYPES,
-  getSubmissionDisplayData
+  getSubmissionDisplayData,
 } from 'js/submissionUtils';
 import {
   META_QUESTION_TYPES,
   QUESTION_TYPES,
   SCORE_ROW_TYPE,
-  RANK_LEVEL_TYPE
+  RANK_LEVEL_TYPE,
 } from 'js/constants';
 
 /**
@@ -128,7 +128,8 @@ class SubmissionDataTable extends React.Component {
         choice = this.findChoice(listName, data);
         if (!choice) {
           console.error(`Choice not found for "${listName}" and "${data}".`);
-          return null;
+          // fallback to data to display anything meaningful
+          return data;
         } else {
           return (
             <bem.SubmissionDataTable__value>
@@ -143,7 +144,8 @@ class SubmissionDataTable extends React.Component {
               choice = this.findChoice(listName, answer);
               if (!choice) {
                 console.error(`Choice not found for "${listName}" and "${data}".`);
-                return null;
+                // fallback to data to display anything meaningful
+                return data;
               } else {
                 return (
                   <li key={answerIndex}>

--- a/jsapp/js/components/submissionDataTable.es6
+++ b/jsapp/js/components/submissionDataTable.es6
@@ -103,7 +103,7 @@ class SubmissionDataTable extends React.Component {
         </bem.SubmissionDataTable__column>
 
         <bem.SubmissionDataTable__column m='data'>
-          {this.renderResponseData(item.type, item.data)}
+          {this.renderResponseData(item.type, item.data, item.listName)}
         </bem.SubmissionDataTable__column>
       </bem.SubmissionDataTable__row>
     );
@@ -112,8 +112,9 @@ class SubmissionDataTable extends React.Component {
   /**
    * @prop {string} type
    * @prop {string|null} data
+   * @prop {string|undefined} listName
    */
-  renderResponseData(type, data) {
+  renderResponseData(type, data, listName) {
     if (data === null) {
       return null;
     }
@@ -124,24 +125,34 @@ class SubmissionDataTable extends React.Component {
       case QUESTION_TYPES.get('select_one').id:
       case SCORE_ROW_TYPE:
       case RANK_LEVEL_TYPE:
-        choice = this.findChoice(data);
-        return (
-          <bem.SubmissionDataTable__value>
-            {choice.label[this.props.translationIndex]}
-          </bem.SubmissionDataTable__value>
-        );
+        choice = this.findChoice(listName, data);
+        if (!choice) {
+          console.error(`Choice not found for "${listName}" and "${data}".`);
+          return null;
+        } else {
+          return (
+            <bem.SubmissionDataTable__value>
+              {choice.label[this.props.translationIndex] || choice.name}
+            </bem.SubmissionDataTable__value>
+          );
+        }
       case QUESTION_TYPES.get('select_multiple').id:
         return (
           <ul>
             {data.split(' ').map((answer, answerIndex) => {
-              choice = this.findChoice(answer);
-              return (
-                <li key={answerIndex}>
-                  <bem.SubmissionDataTable__value>
-                    {choice.label[this.props.translationIndex]}
-                  </bem.SubmissionDataTable__value>
-                </li>
-              );
+              choice = this.findChoice(listName, answer);
+              if (!choice) {
+                console.error(`Choice not found for "${listName}" and "${data}".`);
+                return null;
+              } else {
+                return (
+                  <li key={answerIndex}>
+                    <bem.SubmissionDataTable__value>
+                      {choice.label[this.props.translationIndex] || choice.name}
+                    </bem.SubmissionDataTable__value>
+                  </li>
+                );
+              }
             })}
           </ul>
         );
@@ -179,12 +190,13 @@ class SubmissionDataTable extends React.Component {
   }
 
   /**
-   * @prop {string} name
+   * @prop {string} listName
+   * @prop {string} choiceName
    * @returns {object|undefined}
    */
-  findChoice(name) {
+  findChoice(listName, choiceName) {
     return this.props.asset.content.choices.find((choice) => {
-      return choice.name === name;
+      return choice.name === choiceName && choice.list_name === listName;
     });
   }
 

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -380,9 +380,16 @@ export const SCORE_ROW_TYPE = 'score__row';
 // a custom question type for rank
 export const RANK_LEVEL_TYPE = 'rank__level';
 
+export const CHOICE_LISTS = Object.freeze({
+  SELECT: 'select_from_list_name',
+  MATRIX: 'kobo--matrix_list',
+  SCORE: 'kobo--score-choices',
+  RANK: 'kobo--rank-items',
+});
+
 export const MATRIX_PAIR_PROPS = {
-  inSurvey: 'kobo--matrix_list',
-  inChoices: 'list_name'
+  inSurvey: CHOICE_LISTS.MATRIX,
+  inChoices: 'list_name',
 };
 
 export const NAME_MAX_LENGTH = 255;
@@ -417,6 +424,7 @@ const constants = {
   RANK_LEVEL_TYPE,
   NAME_MAX_LENGTH,
   CATEGORY_LABELS,
+  CHOICE_LISTS,
 };
 
 export default constants;

--- a/jsapp/js/submissionUtils.mocks.es6
+++ b/jsapp/js/submissionUtils.mocks.es6
@@ -2,40 +2,50 @@ export const simpleSurvey = [{
   'name': 'start',
   'type': 'start',
   '$kuid': '9PMXyB7Sv',
-  '$autoname': 'start'
+  '$autoname': 'start',
 }, {
   'name': 'end',
   'type': 'end',
   '$kuid': 'AkKyOYSIP',
-  '$autoname': 'end'
+  '$autoname': 'end',
 }, {
   'type': 'text',
   '$kuid': 'uw4if17',
   'label': ['First name', 'Pierwsze imię'],
   'required': false,
-  '$autoname': 'First_name'
+  '$autoname': 'First_name',
 }, {
   'name': 'group_favourites',
   'type': 'begin_group',
   '$kuid': 'fx8qb06',
   'label': ['Favourites', 'Ulubione'],
-  '$autoname': 'group_favourites'
+  '$autoname': 'group_favourites',
 }, {
   'type': 'select_one',
   '$kuid': 'az1fc41',
   'label': ['Favourite color', 'Ulubiony kolor'],
   'required': false,
   '$autoname': 'Favourite_color',
-  'select_from_list_name': 'in5tz30'
+  'select_from_list_name': 'fav_col_list',
 }, {
   'type': 'integer',
   '$kuid': 'ka9pv41',
   'label': ['Favourite number', 'Ulubiona liczba'],
   'required': false,
-  '$autoname': 'Favourite_number'
+  '$autoname': 'Favourite_number',
 }, {
   'type': 'end_group',
-  '$kuid': '/fx8qb06'
+  '$kuid': '/fx8qb06',
+}];
+
+export const simpleSurveyChoices = [{
+  'name': 'pink',
+  'label': ['Pink'],
+  'list_name': 'fav_col_list',
+}, {
+  'name': 'blue',
+  'label': ['Blue'],
+  'list_name': 'fav_col_list',
 }];
 
 export const simpleSurveySubmission = {
@@ -87,7 +97,7 @@ export const simpleSurveyDisplayData = [
     type: 'text',
     label: 'Pierwsze imię',
     name: 'First_name',
-    data: 'Leszek'
+    data: 'Leszek',
   },
   {
     type: 'group_regular',
@@ -98,16 +108,17 @@ export const simpleSurveyDisplayData = [
         type: 'select_one',
         label: 'Ulubiony kolor',
         name: 'Favourite_color',
-        data: 'pink'
+        listName: 'fav_col_list',
+        data: 'pink',
       },
       {
         type: 'integer',
         label: 'Ulubiona liczba',
         name: 'Favourite_number',
-        data: '24'
-      }
-    ]
-  }
+        data: '24',
+      },
+    ],
+  },
 ];
 
 export const simpleSurveyDisplayDataEmpty = [
@@ -115,7 +126,7 @@ export const simpleSurveyDisplayDataEmpty = [
     type: 'text',
     label: 'First name',
     name: 'First_name',
-    data: null
+    data: null,
   },
   {
     type: 'group_regular',
@@ -126,56 +137,57 @@ export const simpleSurveyDisplayDataEmpty = [
         type: 'select_one',
         label: 'Favourite color',
         name: 'Favourite_color',
-        data: null
+        listName: 'fav_col_list',
+        data: null,
       },
       {
         type: 'integer',
         label: 'Favourite number',
         name: 'Favourite_number',
-        data: '5'
-      }
-    ]
-  }
+        data: '5',
+      },
+    ],
+  },
 ];
 
 export const repeatSurvey = [{
   'name': 'start',
   'type': 'start',
   '$kuid': 'lMV6oqDcf',
-  '$autoname': 'start'
+  '$autoname': 'start',
 }, {
   'name': 'end',
   'type': 'end',
   '$kuid': 'sdwqjbndr',
-  '$autoname': 'end'
+  '$autoname': 'end',
 }, {
   'name': 'group_members',
   'type': 'begin_repeat',
   '$kuid': 'fd8yo77',
   'label': ['Members'],
   'required': false,
-  '$autoname': 'group_members'
+  '$autoname': 'group_members',
 }, {
   'type': 'text',
   '$kuid': 'lm2ww64',
   'label': ['First name'],
   'required': false,
-  '$autoname': 'First_name'
+  '$autoname': 'First_name',
 }, {
   'type': 'text',
   '$kuid': 'nf9gq14',
   'label': ['Middle name'],
   'required': false,
-  '$autoname': 'Middle_name'
+  '$autoname': 'Middle_name',
 }, {
   'type': 'text',
   '$kuid': 'qt6mr31',
   'label': ['Last name'],
   'required': false,
-  '$autoname': 'Last_name'
+  '$autoname': 'Last_name',
 }, {
   'type': 'end_repeat',
-  '$kuid': '/fd8yo77'
+  '$kuid': '/fd8yo77',
 }];
 
 // NOTE: the second repeat submission has no First_name and Middle_name to test stuff better
@@ -198,9 +210,9 @@ export const repeatSurveySubmission = {
   'group_members': [{
     'group_members/First_name': 'Leszek',
     'group_members/Middle_name': 'Jan',
-    'group_members/Last_name': 'Pietrzak'
+    'group_members/Last_name': 'Pietrzak',
   }, {
-    'group_members/Last_name': 'Niepietrzak'
+    'group_members/Last_name': 'Niepietrzak',
   }],
   'meta/instanceID': 'uuid:651137b9-e465-49ed-9924-a67d7b1c6f76',
   'start': '2020-04-07T16:07:24.044+02:00',
@@ -216,21 +228,21 @@ export const repeatSurveyDisplayData = [
         type: 'text',
         label: 'First name',
         name: 'First_name',
-        data: 'Leszek'
+        data: 'Leszek',
       },
       {
         type: 'text',
         label: 'Middle name',
         name: 'Middle_name',
-        data: 'Jan'
+        data: 'Jan',
       },
       {
         type: 'text',
         label: 'Last name',
         name: 'Last_name',
-        data: 'Pietrzak'
-      }
-    ]
+        data: 'Pietrzak',
+      },
+    ],
   },
   {
     type: 'group_repeat',
@@ -241,64 +253,64 @@ export const repeatSurveyDisplayData = [
         type: 'text',
         label: 'First name',
         name: 'First_name',
-        data: null
+        data: null,
       },
       {
         type: 'text',
         label: 'Middle name',
         name: 'Middle_name',
-        data: null
+        data: null,
       },
       {
         type: 'text',
         label: 'Last name',
         name: 'Last_name',
-        data: 'Niepietrzak'
-      }
-    ]
-  }
+        data: 'Niepietrzak',
+      },
+    ],
+  },
 ];
 
 export const nestedRepeatSurvey = [{
   'name': 'start',
   'type': 'start',
   '$kuid': 'Rq36zKyog',
-  '$autoname': 'start'
+  '$autoname': 'start',
 }, {
   'name': 'end',
   'type': 'end',
   '$kuid': 'Redw9OtxY',
-  '$autoname': 'end'
+  '$autoname': 'end',
 }, {
   'type': 'begin_repeat',
   'label': ['People'],
   'name': 'group_people',
   '$kuid': 'aj45t09',
-  '$autoname': 'group_people'
+  '$autoname': 'group_people',
 }, {
   'type': 'text',
   'label': ['Name'],
   'required': false,
   '$kuid': 'bj78z02',
-  '$autoname': 'Name'
+  '$autoname': 'Name',
 }, {
   'type': 'begin_repeat',
   'label': ['Personal items'],
   'name': 'group_items',
   '$kuid': 'te04d01',
-  '$autoname': 'group_items'
+  '$autoname': 'group_items',
 }, {
   'type': 'text',
   'label': ['Item name'],
   'required': false,
   '$kuid': 'fd1ec62',
-  '$autoname': 'Item_name'
+  '$autoname': 'Item_name',
 }, {
   'type': 'end_repeat',
-  '$kuid': '/te04d01'
+  '$kuid': '/te04d01',
 }, {
   'type': 'end_repeat',
-  '$kuid': '/aj45t09'
+  '$kuid': '/aj45t09',
 }];
 
 export const nestedRepeatSurveySubmission = {
@@ -319,19 +331,19 @@ export const nestedRepeatSurveySubmission = {
   'formhub/uuid': 'd6123d44cf8c4fa78e38556b5af6bd68',
   'group_people': [{
     'group_people/group_items': [{
-      'group_people/group_items/Item_name': 'Notebook'
+      'group_people/group_items/Item_name': 'Notebook',
     }, {
-      'group_people/group_items/Item_name': 'Pen'
+      'group_people/group_items/Item_name': 'Pen',
     }, {
-      'group_people/group_items/Item_name': 'Shoe'
+      'group_people/group_items/Item_name': 'Shoe',
     }],
-    'group_people/Name': 'John'
+    'group_people/Name': 'John',
   }, {
-    'group_people/Name': 'Leszek'
+    'group_people/Name': 'Leszek',
   }, {
     'group_people/group_items': [{
-      'group_people/group_items/Item_name': 'Computer'
-    }]
+      'group_people/group_items/Item_name': 'Computer',
+    }],
   }],
   'meta/deprecatedID': 'uuid:85397438-558e-4b24-94d7-901550744352',
   'meta/instanceID': 'uuid:83aa0573-8a44-42f7-885b-aa7a3afffbd1',
@@ -348,7 +360,7 @@ export const nestedRepeatSurveyDisplayData = [
         type: 'text',
         label: 'Name',
         name: 'Name',
-        data: 'John'
+        data: 'John',
       },
       {
         type: 'group_repeat',
@@ -359,9 +371,9 @@ export const nestedRepeatSurveyDisplayData = [
             type: 'text',
             label: 'Item name',
             name: 'Item_name',
-            data: 'Notebook'
-          }
-        ]
+            data: 'Notebook',
+          },
+        ],
       },
       {
         type: 'group_repeat',
@@ -372,9 +384,9 @@ export const nestedRepeatSurveyDisplayData = [
             type: 'text',
             label: 'Item name',
             name: 'Item_name',
-            data: 'Pen'
-          }
-        ]
+            data: 'Pen',
+          },
+        ],
       },
       {
         type: 'group_repeat',
@@ -385,11 +397,11 @@ export const nestedRepeatSurveyDisplayData = [
             type: 'text',
             label: 'Item name',
             name: 'Item_name',
-            data: 'Shoe'
-          }
-        ]
-      }
-    ]
+            data: 'Shoe',
+          },
+        ],
+      },
+    ],
   },
   {
     type: 'group_repeat',
@@ -400,9 +412,9 @@ export const nestedRepeatSurveyDisplayData = [
         type: 'text',
         label: 'Name',
         name: 'Name',
-        data: 'Leszek'
-      }
-    ]
+        data: 'Leszek',
+      },
+    ],
   },
   {
     type: 'group_repeat',
@@ -413,7 +425,7 @@ export const nestedRepeatSurveyDisplayData = [
         type: 'text',
         label: 'Name',
         name: 'Name',
-        data: null
+        data: null,
       },
       {
         type: 'group_repeat',
@@ -424,54 +436,54 @@ export const nestedRepeatSurveyDisplayData = [
             type: 'text',
             label: 'Item name',
             name: 'Item_name',
-            data: 'Computer'
-          }
-        ]
-      }
-    ]
-  }
+            data: 'Computer',
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export const matrixSurvey = [{
   'name': 'start',
   'type': 'start',
   '$kuid': 'HVwODOAEK',
-  '$autoname': 'start'
+  '$autoname': 'start',
 }, {
   'name': 'end',
   'type': 'end',
   '$kuid': '32gE3g5ST',
-  '$autoname': 'end'
+  '$autoname': 'end',
 }, {
   'name': 'today',
   'type': 'today',
   '$kuid': '3h9Nl2bpx',
-  '$autoname': 'today'
+  '$autoname': 'today',
 }, {
   'name': 'username',
   'type': 'username',
   '$kuid': '3RscqJRor',
-  '$autoname': 'username'
+  '$autoname': 'username',
 }, {
   'name': 'simserial',
   'type': 'simserial',
   '$kuid': 'ozNn7JwMd',
-  '$autoname': 'simserial'
+  '$autoname': 'simserial',
 }, {
   'name': 'subscriberid',
   'type': 'subscriberid',
   '$kuid': 'tStWXbDyQ',
-  '$autoname': 'subscriberid'
+  '$autoname': 'subscriberid',
 }, {
   'name': 'deviceid',
   'type': 'deviceid',
   '$kuid': 'll7GCh9oi',
-  '$autoname': 'deviceid'
+  '$autoname': 'deviceid',
 }, {
   'name': 'phonenumber',
   'type': 'phonenumber',
   '$kuid': 'b02UNLdMV',
-  '$autoname': 'phonenumber'
+  '$autoname': 'phonenumber',
 }, {
   'name': 'countries',
   'type': 'begin_kobomatrix',
@@ -481,7 +493,7 @@ export const matrixSurvey = [{
   '$autoname': 'countries',
   '_isRepeat': 'false',
   'appearance': 'field-list',
-  'kobo--matrix_list': 'matrix_fs3ka58'
+  'kobo--matrix_list': 'count_ch_list',
 }, {
   'hint': [''],
   'name': 'ecology_level',
@@ -490,7 +502,7 @@ export const matrixSurvey = [{
   'label': ['Ecology level'],
   'required': false,
   '$autoname': 'ecology_level',
-  'appearance': 'w1'
+  'appearance': 'w1',
 }, {
   'hint': [''],
   'name': 'secularity_level',
@@ -499,18 +511,18 @@ export const matrixSurvey = [{
   'label': ['Secularity level'],
   'required': false,
   '$autoname': 'secularity_level',
-  'appearance': 'w1'
+  'appearance': 'w1',
 }, {
   'type': 'end_kobomatrix',
-  '$kuid': '/en5ri38'
+  '$kuid': '/en5ri38',
 }];
 
 export const matrixSurveyChoices = [{
   'name': 'poland',
   '$kuid': 'wa9kl23',
   'label': ['Poland'],
-  'list_name': 'matrix_fs3ka58',
-  '$autovalue': 'poland'
+  'list_name': 'count_ch_list',
+  '$autovalue': 'poland',
 }];
 
 export const matrixSurveySubmission = {
@@ -538,7 +550,7 @@ export const matrixSurveySubmission = {
   '_status': 'submitted_via_web',
   '__version__': 'vPNH6GBsRjMKLfXrisReYA',
   'subscriberid': 'subscriberid not found',
-  'today': '2020-04-20'
+  'today': '2020-04-20',
 };
 
 export const matrixSurveyDisplayData = [
@@ -556,18 +568,18 @@ export const matrixSurveyDisplayData = [
             type: 'integer',
             label: 'Ecology level',
             name: 'ecology_level',
-            data: '3'
+            data: '3',
           },
           {
             type: 'integer',
             label: 'Secularity level',
             name: 'secularity_level',
-            data: '-5'
-          }
-        ]
-      }
-    ]
-  }
+            data: '-5',
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export const groupsSurvey = [{
@@ -575,83 +587,83 @@ export const groupsSurvey = [{
   'type': 'begin_repeat',
   '$kuid': 'fs1km00',
   'label': ['People'],
-  '$autoname': 'group_people'
+  '$autoname': 'group_people',
 }, {
   'type': 'text',
   '$kuid': 'sr97c95',
   'label': ['First name'],
   'required': false,
-  '$autoname': 'First_name'
+  '$autoname': 'First_name',
 }, {
   'type': 'end_repeat',
-  '$kuid': '/fs1km00'
+  '$kuid': '/fs1km00',
 }, {
   'name': 'group_location',
   'type': 'begin_group',
   '$kuid': 'lq0th66',
   'label': ['Location'],
-  '$autoname': 'group_location'
+  '$autoname': 'group_location',
 }, {
   'type': 'geopoint',
   '$kuid': 'ug36q69',
   'label': ['Original location'],
   'required': false,
-  '$autoname': 'Original_location'
+  '$autoname': 'Original_location',
 }, {
   'type': 'geopoint',
   '$kuid': 'kw6zd49',
   'label': ['Current location'],
   'required': false,
-  '$autoname': 'Current_location'
+  '$autoname': 'Current_location',
 }, {
   'type': 'end_group',
-  '$kuid': '/lq0th66'
+  '$kuid': '/lq0th66',
 }, {
   'type': 'begin_score',
   '$kuid': 'rd0zi80',
   'label': ['Are you vegan?'],
   'required': false,
   '$autoname': 'Are_you_vegan',
-  'kobo--score-choices': 'cv0ok80'
+  'kobo--score-choices': 'vg_ch_list',
 }, {
   'type': 'score__row',
   '$kuid': 'as5gb66',
   'label': ['Killing humans'],
-  '$autoname': 'Killing_humans'
+  '$autoname': 'Killing_humans',
 }, {
   'type': 'score__row',
   '$kuid': 'kv3uq84',
   'label': ['Killing nonhumans'],
-  '$autoname': 'Killing_nonhumans'
+  '$autoname': 'Killing_nonhumans',
 }, {
   'type': 'end_score',
-  '$kuid': '/rd0zi80'
+  '$kuid': '/rd0zi80',
 }, {
   'type': 'begin_rank',
   '$kuid': 'bj3zo95',
   'label': ['Best things in life'],
   'required': false,
   '$autoname': 'Best_things_in_life',
-  'kobo--rank-items': 'oe89v01',
-  'kobo--rank-constraint-message': 'Items cannot be selected more than once'
+  'kobo--rank-items': 'best_ch_list',
+  'kobo--rank-constraint-message': 'Items cannot be selected more than once',
 }, {
   'type': 'rank__level',
   '$kuid': 'yy8lt23',
   'label': ['1st choice'],
-  '$autoname': '_1st_choice'
+  '$autoname': '_1st_choice',
 }, {
   'type': 'rank__level',
   '$kuid': 'll0ky89',
   'label': ['2nd choice'],
-  '$autoname': '_2nd_choice'
+  '$autoname': '_2nd_choice',
 }, {
   'type': 'rank__level',
   '$kuid': 'cz6uz72',
   'label': ['3rd choice'],
-  '$autoname': '_3rd_choice'
+  '$autoname': '_3rd_choice',
 }, {
   'type': 'end_rank',
-  '$kuid': '/bj3zo95'
+  '$kuid': '/bj3zo95',
 }, {
   'name': 'group_crossbreeding',
   'type': 'begin_kobomatrix',
@@ -660,7 +672,7 @@ export const groupsSurvey = [{
   '$autoname': 'group_crossbreeding',
   '_isRepeat': 'false',
   'appearance': 'field-list',
-  'kobo--matrix_list': 'matrix_go11n34'
+  'kobo--matrix_list': 'crossbr_ch_list',
 }, {
   'hint': [''],
   'name': 'human',
@@ -669,7 +681,7 @@ export const groupsSurvey = [{
   'label': ['Human'],
   'required': false,
   '$autoname': 'human',
-  'appearance': 'w1'
+  'appearance': 'w1',
 }, {
   'hint': [''],
   'name': 'nonhuman',
@@ -678,54 +690,54 @@ export const groupsSurvey = [{
   'label': ['Nonhuman'],
   'required': false,
   '$autoname': 'nonhuman',
-  'appearance': 'w1'
+  'appearance': 'w1',
 }, {
   'type': 'end_kobomatrix',
-  '$kuid': '/vs75w20'
+  '$kuid': '/vs75w20',
 }];
 
 export const groupsSurveyChoices = [{
   'name': 'good',
   '$kuid': '4g11EC3jB',
   'label': ['Good'],
-  'list_name': 'cv0ok80',
-  '$autovalue': 'good'
+  'list_name': 'vg_ch_list',
+  '$autovalue': 'good',
 }, {
   'name': 'bad',
   '$kuid': 'iWSKBTsBL',
   'label': ['Bad'],
-  'list_name': 'cv0ok80',
-  '$autovalue': 'bad'
+  'list_name': 'vg_ch_list',
+  '$autovalue': 'bad',
 }, {
   'name': 'food',
   '$kuid': 'gZdFOT2Au',
   'label': ['Food'],
-  'list_name': 'oe89v01',
-  '$autovalue': 'food'
+  'list_name': 'best_ch_list',
+  '$autovalue': 'food',
 }, {
   'name': 'sleep',
   '$kuid': '29qNZUz3S',
   'label': ['Sleep'],
-  'list_name': 'oe89v01',
-  '$autovalue': 'sleep'
+  'list_name': 'best_ch_list',
+  '$autovalue': 'sleep',
 }, {
   'name': 'conquest',
   '$kuid': 'U0A1jTOH9',
   'label': ['Conquest'],
-  'list_name': 'oe89v01',
-  '$autovalue': 'conquest'
+  'list_name': 'best_ch_list',
+  '$autovalue': 'conquest',
 }, {
   'name': 'fire',
   '$kuid': 'dl9lc82',
   'label': ['Fire'],
-  'list_name': 'matrix_go11n34',
-  '$autovalue': 'fire'
+  'list_name': 'crossbr_ch_list',
+  '$autovalue': 'fire',
 }, {
   'name': 'water',
   '$kuid': 'qn03v13',
   'label': ['Water'],
-  'list_name': 'matrix_go11n34',
-  '$autovalue': 'water'
+  'list_name': 'crossbr_ch_list',
+  '$autovalue': 'water',
 }];
 
 export const groupsSurveySubmission = {
@@ -746,9 +758,9 @@ export const groupsSurveySubmission = {
   'group_crossbreeding_water/group_crossbreeding_water_human': 'waterman',
   'group_location/Current_location': '53.748711 -7.880555 0 0',
   'group_people': [{
-    'group_people/First_name': 'Leszek'
+    'group_people/First_name': 'Leszek',
   }, {
-    'group_people/First_name': 'John'
+    'group_people/First_name': 'John',
   }],
   '_submission_time': '2020-04-23T18:16:08',
   '_notes': [],
@@ -759,7 +771,7 @@ export const groupsSurveySubmission = {
   'Best_things_in_life/_3rd_choice': 'food',
   '_status': 'submitted_via_web',
   '__version__': 'vN4myUe5KyYrGN4dGrpBid',
-  'today': '2020-04-23'
+  'today': '2020-04-23',
 };
 
 export const groupsSurveyDisplayData = [
@@ -772,9 +784,9 @@ export const groupsSurveyDisplayData = [
         type: 'text',
         label: 'First name',
         name: 'First_name',
-        data: 'Leszek'
-      }
-    ]
+        data: 'Leszek',
+      },
+    ],
   },
   {
     type: 'group_repeat',
@@ -785,9 +797,9 @@ export const groupsSurveyDisplayData = [
         type: 'text',
         label: 'First name',
         name: 'First_name',
-        data: 'John'
-      }
-    ]
+        data: 'John',
+      },
+    ],
   },
   {
     type: 'group_regular',
@@ -798,15 +810,15 @@ export const groupsSurveyDisplayData = [
         'type': 'geopoint',
         'label': 'Original location',
         'name': 'Original_location',
-        'data': '52.48278 18.813458 0 0'
+        'data': '52.48278 18.813458 0 0',
       },
       {
         'type': 'geopoint',
         'label': 'Current location',
         'name': 'Current_location',
-        'data': '53.748711 -7.880555 0 0'
-      }
-    ]
+        'data': '53.748711 -7.880555 0 0',
+      },
+    ],
   },
   {
     type: 'group_regular',
@@ -817,15 +829,17 @@ export const groupsSurveyDisplayData = [
         'type': 'score__row',
         'label': 'Killing humans',
         'name': 'Killing_humans',
-        'data': 'good'
+        'listName': 'vg_ch_list',
+        'data': 'good',
       },
       {
         'type': 'score__row',
         'label': 'Killing nonhumans',
         'name': 'Killing_nonhumans',
-        'data': 'bad'
-      }
-    ]
+        'listName': 'vg_ch_list',
+        'data': 'bad',
+      },
+    ],
   },
   {
     type: 'group_regular',
@@ -836,21 +850,24 @@ export const groupsSurveyDisplayData = [
         'type': 'rank__level',
         'label': '1st choice',
         'name': '_1st_choice',
-        'data': 'conquest'
+        'listName': 'best_ch_list',
+        'data': 'conquest',
       },
       {
         'type': 'rank__level',
         'label': '2nd choice',
         'name': '_2nd_choice',
-        'data': 'sleep'
+        'listName': 'best_ch_list',
+        'data': 'sleep',
       },
       {
         'type': 'rank__level',
         'label': '3rd choice',
         'name': '_3rd_choice',
-        'data': 'food'
-      }
-    ]
+        'listName': 'best_ch_list',
+        'data': 'food',
+      },
+    ],
   },
   {
     type: 'group_matrix',
@@ -866,15 +883,15 @@ export const groupsSurveyDisplayData = [
             type: 'text',
             label: 'Human',
             name: 'human',
-            data: 'fireman'
+            data: 'fireman',
           },
           {
             type: 'text',
             label: 'Nonhuman',
             name: 'nonhuman',
-            data: 'firething'
-          }
-        ]
+            data: 'firething',
+          },
+        ],
       },
       {
         type: 'group_matrix_row',
@@ -885,159 +902,159 @@ export const groupsSurveyDisplayData = [
             type: 'text',
             label: 'Human',
             name: 'human',
-            data: 'waterman'
+            data: 'waterman',
           },
           {
             type: 'text',
             label: 'Nonhuman',
             name: 'nonhuman',
-            data: 'waterthing'
-          }
-        ]
+            data: 'waterthing',
+          },
+        ],
       },
-    ]
-  }
+    ],
+  },
 ];
 
 export const everythingSurvey = [{
   'name': 'start',
   'type': 'start',
   '$kuid': 'hI2IjAPLy',
-  '$autoname': 'start'
+  '$autoname': 'start',
 }, {
   'name': 'end',
   'type': 'end',
   '$kuid': 'xVomX5yES',
-  '$autoname': 'end'
+  '$autoname': 'end',
 }, {
   'type': 'select_one',
   '$kuid': 'ys1bd14',
   'label': ['Favourite country'],
   'required': false,
   '$autoname': 'Favourite_country',
-  'select_from_list_name': 'za04s38'
+  'select_from_list_name': 'fav_cntr_list',
 }, {
   'type': 'select_multiple',
   '$kuid': 'ca8bv64',
   'label': ['Favourite food'],
   'required': false,
   '$autoname': 'Favourite_food',
-  'select_from_list_name': 'vx6yh19'
+  'select_from_list_name': 'fav_food_ch_list',
 }, {
   'type': 'text',
   '$kuid': 'gr1hn65',
   'label': ['Your name'],
   'required': false,
-  '$autoname': 'Your_name'
+  '$autoname': 'Your_name',
 }, {
   'type': 'integer',
   '$kuid': 'vw1ya03',
   'label': ['Lucky number'],
   'required': false,
-  '$autoname': 'Lucky_number'
+  '$autoname': 'Lucky_number',
 }, {
   'type': 'decimal',
   '$kuid': 'ia1ux31',
   'label': ['Unlucky number'],
   'required': false,
-  '$autoname': 'Unlucky_number'
+  '$autoname': 'Unlucky_number',
 }, {
   'type': 'date',
   '$kuid': 'vl8ck72',
   'label': ['Birth date'],
   'required': false,
-  '$autoname': 'Birth_date'
+  '$autoname': 'Birth_date',
 }, {
   'type': 'time',
   '$kuid': 'qa9pv52',
   'label': ['Birth time'],
   'required': false,
-  '$autoname': 'Birth_time'
+  '$autoname': 'Birth_time',
 }, {
   'type': 'datetime',
   '$kuid': 'cq0yk16',
   'label': ['Some random date and time'],
   'required': false,
-  '$autoname': 'Some_random_date_and_time'
+  '$autoname': 'Some_random_date_and_time',
 }, {
   'type': 'geopoint',
   '$kuid': 'ib3wx74',
   'label': ['Secret spot'],
   'required': false,
-  '$autoname': 'Secret_spot'
+  '$autoname': 'Secret_spot',
 }, {
   'type': 'image',
   '$kuid': 'vu9cb06',
   'label': ['Selfportrait'],
   'required': false,
   '$autoname': 'Selfportrait',
-  'parameters': 'max-pixels=1024'
+  'parameters': 'max-pixels=1024',
 }, {
   'type': 'audio',
   '$kuid': 'aa28j83',
   'label': ['Voice password'],
   'required': false,
-  '$autoname': 'Voice_password'
+  '$autoname': 'Voice_password',
 }, {
   'type': 'video',
   '$kuid': 'tj2xw94',
   'label': ['A video?'],
   'required': false,
-  '$autoname': 'A_video'
+  '$autoname': 'A_video',
 }, {
   'type': 'geotrace',
   '$kuid': 'bh5yb78',
   'label': ['Shortest path'],
   'required': false,
-  '$autoname': 'Shortest_path'
+  '$autoname': 'Shortest_path',
 }, {
   'type': 'note',
   '$kuid': 'pg3yl90',
   'label': ['This is a secret'],
   'required': false,
-  '$autoname': 'This_is_a_secret'
+  '$autoname': 'This_is_a_secret',
 }, {
   'type': 'barcode',
   '$kuid': 'qu5zg17',
   'label': ['Favourite chocolate barcode'],
   'required': false,
-  '$autoname': 'Favourite_chocolate_barcode'
+  '$autoname': 'Favourite_chocolate_barcode',
 }, {
   'type': 'acknowledge',
   '$kuid': 'ym87f54',
   'label': ['Are you sane?'],
   'required': false,
-  '$autoname': 'Are_you_sane'
+  '$autoname': 'Are_you_sane',
 }, {
   'type': 'geoshape',
   '$kuid': 'ua1av57',
   'label': ['Secret area'],
   'required': false,
-  '$autoname': 'Secret_area'
+  '$autoname': 'Secret_area',
 }, {
   'type': 'begin_score',
   '$kuid': 'yp8ep33',
   'label': ['How are you?'],
   'required': false,
   '$autoname': 'How_are_you',
-  'kobo--score-choices': 'ap7yb23'
+  'kobo--score-choices': 'how_r_u_ch_list',
 }, {
   'name': 'outside',
   'type': 'score__row',
   '$kuid': 'ir6tu76',
   'label': ['Outside'],
   'required': false,
-  '$autoname': 'outside'
+  '$autoname': 'outside',
 }, {
   'name': 'inside',
   'type': 'score__row',
   '$kuid': 'je4go60',
   'label': ['Inside'],
   'required': false,
-  '$autoname': 'inside'
+  '$autoname': 'inside',
 }, {
   'type': 'end_score',
-  '$kuid': '/yp8ep33'
+  '$kuid': '/yp8ep33',
 }, {
   'name': 'test_your_math',
   'type': 'begin_kobomatrix',
@@ -1047,7 +1064,7 @@ export const everythingSurvey = [{
   '$autoname': 'test_your_math',
   '_isRepeat': 'false',
   'appearance': 'field-list',
-  'kobo--matrix_list': 'matrix_cb3fk35'
+  'kobo--matrix_list': 'matrix_cb3fk35',
 }, {
   'hint': [''],
   'name': 'plus',
@@ -1056,7 +1073,7 @@ export const everythingSurvey = [{
   'label': ['Plus'],
   'required': false,
   '$autoname': 'plus',
-  'appearance': 'w1'
+  'appearance': 'w1',
 }, {
   'hint': [''],
   'name': 'minus',
@@ -1066,115 +1083,115 @@ export const everythingSurvey = [{
   'required': false,
   '$autoname': 'minus',
   'appearance': 'w1',
-  'select_from_list_name': 'bp2sj21'
+  'select_from_list_name': 'min_ch_list',
 }, {
   'type': 'end_kobomatrix',
-  '$kuid': '/gy07t52'
+  '$kuid': '/gy07t52',
 }, {
   'type': 'begin_rank',
   '$kuid': 'vs3yt07',
   'label': ['Colours by brightness'],
   'required': false,
   '$autoname': 'Colours_by_brightness',
-  'kobo--rank-items': 'xc5nb13',
-  'kobo--rank-constraint-message': 'Items cannot be selected more than once'
+  'kobo--rank-items': 'col_br_ch_list',
+  'kobo--rank-constraint-message': 'Items cannot be selected more than once',
 }, {
   'type': 'rank__level',
   '$kuid': 'yp71p21',
   'label': ['1st choice'],
   'required': false,
-  '$autoname': '_1st_choice'
+  '$autoname': '_1st_choice',
 }, {
   'type': 'rank__level',
   '$kuid': 'ac8ez34',
   'label': ['2nd choice'],
   'required': false,
-  '$autoname': '_2nd_choice'
+  '$autoname': '_2nd_choice',
 }, {
   'type': 'end_rank',
-  '$kuid': '/vs3yt07'
+  '$kuid': '/vs3yt07',
 }, {
   'type': 'file',
   '$kuid': 'dz9cv47',
   'label': ['We need your CV'],
   'required': false,
   '$autoname': 'We_need_your_CV',
-  'body::accept': 'txt'
+  'body::accept': 'txt',
 }, {
   'type': 'range',
   '$kuid': 'jb6ll34',
   'label': ['Expected lifespan'],
   'required': false,
   '$autoname': 'Expected_lifespan',
-  'parameters': 'start=1;end=125;step=1'
+  'parameters': 'start=1;end=125;step=1',
 }];
 
 export const everythingSurveyChoices = [{
   'name': 'poland',
   '$kuid': 'dVHZ9VigU',
   'label': ['Poland'],
-  'list_name': 'za04s38',
-  '$autovalue': 'poland'
+  'list_name': 'fav_cntr_list',
+  '$autovalue': 'poland',
 }, {
   'name': 'ireland',
   '$kuid': 'awQvU6AGY',
   'label': ['Ireland'],
-  'list_name': 'za04s38',
-  '$autovalue': 'ireland'
+  'list_name': 'fav_cntr_list',
+  '$autovalue': 'ireland',
 }, {
   'name': 'pizza',
   '$kuid': 'V5aeF2EbQ',
   'label': ['Pizza'],
-  'list_name': 'vx6yh19',
-  '$autovalue': 'pizza'
+  'list_name': 'fav_food_ch_list',
+  '$autovalue': 'pizza',
 }, {
   'name': 'apple',
   '$kuid': 'XjaJ0GAm0',
   'label': ['Apple'],
-  'list_name': 'vx6yh19',
-  '$autovalue': 'apple'
+  'list_name': 'fav_food_ch_list',
+  '$autovalue': 'apple',
 }, {
   'name': 'good',
   '$kuid': 'YtKFyrtef',
   'label': ['Good'],
-  'list_name': 'ap7yb23',
-  '$autovalue': 'good'
+  'list_name': 'how_r_u_ch_list',
+  '$autovalue': 'good',
 }, {
   'name': 'bad',
   '$kuid': 'eVEUuBWFf',
   'label': ['Bad'],
-  'list_name': 'ap7yb23',
-  '$autovalue': 'bad'
+  'list_name': 'how_r_u_ch_list',
+  '$autovalue': 'bad',
 }, {
   'name': 'yellow',
   '$kuid': 'DzPdmquZQ',
   'label': ['Yellow'],
-  'list_name': 'xc5nb13',
-  '$autovalue': 'yellow'
+  'list_name': 'col_br_ch_list',
+  '$autovalue': 'yellow',
 }, {
   'name': 'blue',
   '$kuid': '6oHmUYz8S',
   'label': ['Blue'],
-  'list_name': 'xc5nb13',
-  '$autovalue': 'blue'
+  'list_name': 'col_br_ch_list',
+  '$autovalue': 'blue',
 }, {
   'name': '2_and_4',
   '$kuid': 'bd6hu92',
   'label': ['2 and 4'],
   'list_name': 'matrix_cb3fk35',
-  '$autovalue': '2_and_4'
+  '$autovalue': '2_and_4',
 }, {
   'name': 'minus_four',
   '$kuid': 'tq31o95',
   'label': ['-4'],
-  'list_name': 'bp2sj21',
-  '$autovalue': 'minus_four'
+  'list_name': 'min_ch_list',
+  '$autovalue': 'minus_four',
 }, {
   'name': 'minus_two',
   '$kuid': 'ue3oz79',
   'label': ['-2'],
-  'list_name': 'bp2sj21',
-  '$autovalue': 'minus_two'
+  'list_name': 'min_ch_list',
+  '$autovalue': 'minus_two',
 }];
 
 export const everythingSurveySubmission = {
@@ -1218,7 +1235,7 @@ export const everythingSurveySubmission = {
     'instance': 25,
     'download_medium_url': 'http://kc.kobo.local/media/medium?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2FIMG_3619-13_33_22.MOV',
     'id': 6,
-    'xform': 18
+    'xform': 18,
   }, {
     'mimetype': 'audio/mpeg',
     'download_small_url': 'http://kc.kobo.local/media/small?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2F07.+Crazy+Love-13_32_31.mp3',
@@ -1228,7 +1245,7 @@ export const everythingSurveySubmission = {
     'instance': 25,
     'download_medium_url': 'http://kc.kobo.local/media/medium?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2F07.+Crazy+Love-13_32_31.mp3',
     'id': 5,
-    'xform': 18
+    'xform': 18,
   }, {
     'mimetype': 'text/plain',
     'download_small_url': 'http://kc.kobo.local/media/small?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2Fzamki-13_35_5.txt',
@@ -1238,7 +1255,7 @@ export const everythingSurveySubmission = {
     'instance': 25,
     'download_medium_url': 'http://kc.kobo.local/media/medium?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2Fzamki-13_35_5.txt',
     'id': 4,
-    'xform': 18
+    'xform': 18,
   }, {
     'mimetype': 'image/jpeg',
     'download_small_url': 'http://kc.kobo.local/media/small?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2F784397e28b5041d59bef15d5d0b2d0bf--cutaway-dio-13_31_48.jpg',
@@ -1248,7 +1265,7 @@ export const everythingSurveySubmission = {
     'instance': 25,
     'download_medium_url': 'http://kc.kobo.local/media/medium?media_file=kobo%2Fattachments%2F712e5fb8d7364482a57c60df876c57fb%2Ffdd252ee-860a-426c-be90-cbbf61787cb9%2F784397e28b5041d59bef15d5d0b2d0bf--cutaway-dio-13_31_48.jpg',
     'id': 3,
-    'xform': 18
+    'xform': 18,
   }],
   'Expected_lifespan': '88',
   'start': '2020-04-28T13:30:42.903+02:00',
@@ -1258,7 +1275,7 @@ export const everythingSurveySubmission = {
   '_status': 'submitted_via_web',
   'Secret_area': '-7.362467 -54.112248 0 0;24.20689 -79.483642 0 0;25.720735 -41.556644 0 0;2.196727 -40.315761 0 0;-7.362467 -54.112248 0 0',
   'Voice_password': '07. Crazy Love-13_32_31.mp3',
-  'test_your_math_2_and_4/test_your_math_2_and_4_plus': '7'
+  'test_your_math_2_and_4/test_your_math_2_and_4_plus': '7',
 };
 
 export const everythingSurveyDisplayData = [
@@ -1266,97 +1283,99 @@ export const everythingSurveyDisplayData = [
     'type': 'select_one',
     'label': 'Favourite country',
     'name': 'Favourite_country',
-    'data': 'ireland'
+    'listName': 'fav_cntr_list',
+    'data': 'ireland',
   },
   {
     'type': 'select_multiple',
     'label': 'Favourite food',
     'name': 'Favourite_food',
-    'data': 'pizza apple'
+    'listName': 'fav_food_ch_list',
+    'data': 'pizza apple',
   },
   {
     'type': 'text',
     'label': 'Your name',
     'name': 'Your_name',
-    'data': 'Leszek'
+    'data': 'Leszek',
   },
   {
     'type': 'integer',
     'label': 'Lucky number',
     'name': 'Lucky_number',
-    'data': '24'
+    'data': '24',
   },
   {
     'type': 'decimal',
     'label': 'Unlucky number',
     'name': 'Unlucky_number',
-    'data': '-7'
+    'data': '-7',
   },
   {
     'type': 'date',
     'label': 'Birth date',
     'name': 'Birth_date',
-    'data': '1900-04-10'
+    'data': '1900-04-10',
   },
   {
     'type': 'time',
     'label': 'Birth time',
     'name': 'Birth_time',
-    'data': '13:45:00.000+02:00'
+    'data': '13:45:00.000+02:00',
   },
   {
     'type': 'datetime',
     'label': 'Some random date and time',
     'name': 'Some_random_date_and_time',
-    'data': '2020-04-02T01:33:00.000+02:00'
+    'data': '2020-04-02T01:33:00.000+02:00',
   },
   {
     'type': 'geopoint',
     'label': 'Secret spot',
     'name': 'Secret_spot',
-    'data': '47.754098 3.426214 0 0'
+    'data': '47.754098 3.426214 0 0',
   },
   {
     'type': 'image',
     'label': 'Selfportrait',
     'name': 'Selfportrait',
-    'data': '784397e28b5041d59bef15d5d0b2d0bf--cutaway-dio-13_31_48.jpg'
+    'data': '784397e28b5041d59bef15d5d0b2d0bf--cutaway-dio-13_31_48.jpg',
   },
   {
     'type': 'audio',
     'label': 'Voice password',
     'name': 'Voice_password',
-    'data': '07. Crazy Love-13_32_31.mp3'
+    'data': '07. Crazy Love-13_32_31.mp3',
   },
   {
     'type': 'video',
     'label': 'A video?',
     'name': 'A_video',
-    'data': 'IMG_3619-13_33_22.MOV'
+    'data': 'IMG_3619-13_33_22.MOV',
   },
   {
     'type': 'geotrace',
     'label': 'Shortest path',
     'name': 'Shortest_path',
-    'data': '26.74561 -1.485606 0 0;18.979026 23.772309 0 0'
+    'data': '26.74561 -1.485606 0 0;18.979026 23.772309 0 0',
   },
   {
     'type': 'barcode',
     'label': 'Favourite chocolate barcode',
     'name': 'Favourite_chocolate_barcode',
-    'data': '123123123123'
+    'data': '123123123123',
   },
   {
     'type': 'acknowledge',
     'label': 'Are you sane?',
     'name': 'Are_you_sane',
-    'data': 'OK'
+    'data': 'OK',
   },
   {
     'type': 'geoshape',
     'label': 'Secret area',
     'name': 'Secret_area',
-    'data': '-7.362467 -54.112248 0 0;24.20689 -79.483642 0 0;25.720735 -41.556644 0 0;2.196727 -40.315761 0 0;-7.362467 -54.112248 0 0'
+    'data': '-7.362467 -54.112248 0 0;24.20689 -79.483642 0 0;25.720735 -41.556644 0 0;2.196727 -40.315761 0 0;-7.362467 -54.112248 0 0',
   },
   {
     'type': 'group_regular',
@@ -1367,15 +1386,17 @@ export const everythingSurveyDisplayData = [
         'type': 'score__row',
         'label': 'Outside',
         'name': 'outside',
-        'data': 'good'
+        'listName': 'how_r_u_ch_list',
+        'data': 'good',
       },
       {
         'type': 'score__row',
         'label': 'Inside',
         'name': 'inside',
-        'data': 'bad'
-      }
-    ]
+        'listName': 'how_r_u_ch_list',
+        'data': 'bad',
+      },
+    ],
   },
   {
     'type': 'group_matrix',
@@ -1391,17 +1412,18 @@ export const everythingSurveyDisplayData = [
             'type': 'integer',
             'label': 'Plus',
             'name': 'plus',
-            'data': '7'
+            'data': '7',
           },
           {
             'type': 'select_one',
             'label': 'Minus',
             'name': 'minus',
-            'data': 'minus_four'
-          }
-        ]
-      }
-    ]
+            'listName': 'min_ch_list',
+            'data': 'minus_four',
+          },
+        ],
+      },
+    ],
   },
   {
     'type': 'group_regular',
@@ -1412,28 +1434,30 @@ export const everythingSurveyDisplayData = [
         'type': 'rank__level',
         'label': '1st choice',
         'name': '_1st_choice',
-        'data': 'blue'
+        'listName': 'col_br_ch_list',
+        'data': 'blue',
       },
       {
         'type': 'rank__level',
         'label': '2nd choice',
         'name': '_2nd_choice',
-        'data': 'yellow'
-      }
-    ]
+        'listName': 'col_br_ch_list',
+        'data': 'yellow',
+      },
+    ],
   },
   {
     'type': 'file',
     'label': 'We need your CV',
     'name': 'We_need_your_CV',
-    'data': 'zamki-13_35_5.txt'
+    'data': 'zamki-13_35_5.txt',
   },
   {
     'type': 'range',
     'label': 'Expected lifespan',
     'name': 'Expected_lifespan',
-    'data': '88'
-  }
+    'data': '88',
+  },
 ];
 
 export const matrixRepeatSurvey = [
@@ -1441,20 +1465,20 @@ export const matrixRepeatSurvey = [
     'name': 'start',
     'type': 'start',
     '$kuid': '5hhy3gTQM',
-    '$autoname': 'start'
+    '$autoname': 'start',
   },
   {
     'name': 'end',
     'type': 'end',
     '$kuid': 'gIKQbAuFK',
-    '$autoname': 'end'
+    '$autoname': 'end',
   },
   {
     'name': 'Simple_repeat',
     'type': 'begin_repeat',
     '$kuid': 'wr4ir59',
     'label': ['Simple repeat'],
-    '$autoname': 'Simple_repeat'
+    '$autoname': 'Simple_repeat',
   },
   {
     'name': 'Best_food',
@@ -1464,7 +1488,7 @@ export const matrixRepeatSurvey = [
     '$autoname': 'Best_food',
     '_isRepeat': 'false',
     'appearance': 'field-list',
-    'kobo--matrix_list': 'matrix_ri0sw49'
+    'kobo--matrix_list': 'matrix_ri0sw49',
   },
   {
     'hint': [''],
@@ -1474,7 +1498,7 @@ export const matrixRepeatSurvey = [
     'label': ['Salty'],
     'required': false,
     '$autoname': 'Salty',
-    'appearance': 'w1'
+    'appearance': 'w1',
   },
   {
     'hint': [''],
@@ -1484,16 +1508,16 @@ export const matrixRepeatSurvey = [
     'label': ['Sweet'],
     'required': true,
     '$autoname': 'Sweet',
-    'appearance': 'w1'
+    'appearance': 'w1',
   },
   {
     'type': 'end_kobomatrix',
-    '$kuid': '/hn03y22'
+    '$kuid': '/hn03y22',
   },
   {
     'type': 'end_repeat',
-    '$kuid': '/wr4ir59'
-  }
+    '$kuid': '/wr4ir59',
+  },
 ];
 
 export const matrixRepeatSurveyChoices = [
@@ -1502,15 +1526,15 @@ export const matrixRepeatSurveyChoices = [
     '$kuid': 'hb7vh55',
     'label': ['Baked'],
     'list_name': 'matrix_ri0sw49',
-    '$autovalue': 'baked'
+    '$autovalue': 'baked',
   },
   {
     'name': 'raw',
     '$kuid': 'us3nd72',
     'label': ['Raw'],
     'list_name': 'matrix_ri0sw49',
-    '$autovalue': 'raw'
-  }
+    '$autovalue': 'raw',
+  },
 ];
 
 export const matrixRepeatSurveySubmission = {
@@ -1530,23 +1554,23 @@ export const matrixRepeatSurveySubmission = {
       'Simple_repeat/Best_food_raw/Best_food_raw_Sweet': 'apple',
       'Simple_repeat/Best_food_baked/Best_food_baked_Salty': 'bread',
       'Simple_repeat/Best_food_baked/Best_food_baked_Sweet': 'pie',
-      'Simple_repeat/Best_food_raw/Best_food_raw_Salty': 'olive'
+      'Simple_repeat/Best_food_raw/Best_food_raw_Salty': 'olive',
     },
     {
       'Simple_repeat/Best_food_raw/Best_food_raw_Sweet': 'tomato',
       'Simple_repeat/Best_food_baked/Best_food_baked_Salty': 'pizza',
       'Simple_repeat/Best_food_baked/Best_food_baked_Sweet': 'croissant',
-      'Simple_repeat/Best_food_raw/Best_food_raw_Salty': 'cucumber'
-    }
+      'Simple_repeat/Best_food_raw/Best_food_raw_Salty': 'cucumber',
+    },
   ],
   '_submission_time': '2020-08-24T12:50:49',
   '_attachments': [],
   'start': '2020-08-24T14:48:52.577+02:00',
   '_geolocation': [
-    null, null
+    null, null,
   ],
   '_status': 'submitted_via_web',
-  '__version__': 'vLao7eC5zPrkyAHKYFt9kY'
+  '__version__': 'vLao7eC5zPrkyAHKYFt9kY',
 };
 
 export const matrixRepeatSurveyDisplayData = [
@@ -1569,15 +1593,15 @@ export const matrixRepeatSurveyDisplayData = [
                 'type': 'text',
                 'label': 'Salty',
                 'name': 'Salty',
-                'data': 'bread'
+                'data': 'bread',
               },
               {
                 'type': 'text',
                 'label': 'Sweet',
                 'name': 'Sweet',
-                'data': 'pie'
-              }
-            ]
+                'data': 'pie',
+              },
+            ],
           },
           {
             'type': 'group_matrix_row',
@@ -1588,19 +1612,19 @@ export const matrixRepeatSurveyDisplayData = [
                 'type': 'text',
                 'label': 'Salty',
                 'name': 'Salty',
-                'data': 'olive'
+                'data': 'olive',
               },
               {
                 'type': 'text',
                 'label': 'Sweet',
                 'name': 'Sweet',
-                'data': 'apple'
-              }
-            ]
-          }
-        ]
-      }
-    ]
+                'data': 'apple',
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     'type': 'group_repeat',
@@ -1621,15 +1645,15 @@ export const matrixRepeatSurveyDisplayData = [
                 'type': 'text',
                 'label': 'Salty',
                 'name': 'Salty',
-                'data': 'pizza'
+                'data': 'pizza',
               },
               {
                 'type': 'text',
                 'label': 'Sweet',
                 'name': 'Sweet',
-                'data': 'croissant'
-              }
-            ]
+                'data': 'croissant',
+              },
+            ],
           },
           {
             'type': 'group_matrix_row',
@@ -1640,18 +1664,18 @@ export const matrixRepeatSurveyDisplayData = [
                 'type': 'text',
                 'label': 'Salty',
                 'name': 'Salty',
-                'data': 'cucumber'
+                'data': 'cucumber',
               },
               {
                 'type': 'text',
                 'label': 'Sweet',
                 'name': 'Sweet',
-                'data': 'tomato'
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+                'data': 'tomato',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 ];

--- a/jsapp/js/submissionUtils.tests.es6
+++ b/jsapp/js/submissionUtils.tests.es6
@@ -1,5 +1,6 @@
 import {
   simpleSurvey,
+  simpleSurveyChoices,
   simpleSurveySubmission,
   simpleSurveyDisplayData,
   simpleSurveySubmissionEmpty,
@@ -25,21 +26,19 @@ import {
   matrixRepeatSurvey,
   matrixRepeatSurveyChoices,
   matrixRepeatSurveySubmission,
-  matrixRepeatSurveyDisplayData
+  matrixRepeatSurveyDisplayData,
 } from 'js/submissionUtils.mocks';
-import {
-  getSubmissionDisplayData
-} from 'js/submissionUtils';
+import {getSubmissionDisplayData} from 'js/submissionUtils';
 
 describe('getSubmissionDisplayData', () => {
   it('should return a valid data for a survey with a group', () => {
-      const test = getSubmissionDisplayData(simpleSurvey, null, 1, simpleSurveySubmission).children;
+      const test = getSubmissionDisplayData(simpleSurvey, simpleSurveyChoices, 1, simpleSurveySubmission).children;
       const target = simpleSurveyDisplayData;
       expect(test).to.deep.equal(target);
   });
 
   it('should return a null data entries for a survey with no answers', () => {
-      const test = getSubmissionDisplayData(simpleSurvey, null, 0, simpleSurveySubmissionEmpty).children;
+      const test = getSubmissionDisplayData(simpleSurvey, simpleSurveyChoices, 0, simpleSurveySubmissionEmpty).children;
       const target = simpleSurveyDisplayDataEmpty;
       expect(test).to.deep.equal(target);
   });


### PR DESCRIPTION
## Description

Submission Modal was displaying wrong labels for choice type questions (e.g. `select_one`, `rank`, `score`). It happened whenever multiple choices had the same `name` property.

## Related issues

Fixes #2971
Fixes #2969