### PR TITLE
2536 remove excel analyser from download options

### DIFF
--- a/jsapp/js/components/formEditors.es6
+++ b/jsapp/js/components/formEditors.es6
@@ -247,7 +247,6 @@ export class ProjectDownloads extends React.Component {
                         <option value='csv_legacy'>{t('CSV (legacy)')}</option>
                         <option value='zip_legacy'>{t('Media Attachments (ZIP)')}</option>
                         <option value='kml_legacy'>{t('GPS coordinates (KML)')}</option>
-                        <option value='analyser_legacy'>{t('Excel Analyser')}</option>
                         <option value='spss_labels'>{t('SPSS Labels')}</option>
                       </select>
                     </bem.FormModal__item>

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -521,7 +521,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'csv_legacy': '/'.join((exports_base_url, 'csv/')),
             'zip_legacy': '/'.join((exports_base_url, 'zip/')),
             'kml_legacy': '/'.join((exports_base_url, 'kml/')),
-            'analyser_legacy': '/'.join((exports_base_url, 'analyser/')),
             # For GET requests that return files directly
             'xls': '/'.join((reports_base_url, 'export.xlsx')),
             'csv': '/'.join((reports_base_url, 'export.csv')),


### PR DESCRIPTION
## Checklist

1. [N/A ] If you've added code that should be tested, add tests
2. [ N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Remove the Excel Analyser from our list of export options, as it is no longer maintained. Please refer to OCHA's documentation if you would like to use the Excel Analyser: https://www.humanitarianresponse.info/en/applications/kobotoolbox/document/kobotoolbox-excel-data-analyser-v123

## Related issues

Closes #2536 