### PR TITLE
Fix translation not being used in table header

### DIFF
--- a/jsapp/js/components/table.es6
+++ b/jsapp/js/components/table.es6
@@ -545,7 +545,7 @@ export class DataTable extends React.Component {
             {choices.filter(c => c.list_name === col.question.select_from_list_name).map((item, n) => {
               let displayLabel = t('Unlabelled');
               if (item.label) {
-                displayLabel = item.label[0];
+                displayLabel = item.label[translationIndex];
               } else if (item.name) {
                 displayLabel = item.name;
               } else if (item.$autoname) {


### PR DESCRIPTION
## Description

Fix translation not being used for `select_one` question types in table header filter dropdown.
