### PR TITLE
Remove deprecated KC content types

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -662,9 +662,6 @@ KOBOCAT_DEFAULT_PERMISSION_CONTENT_TYPES = [
     # Each tuple must be (app_label, model_name)
     ('main', 'userprofile'),
     ('logger', 'xform'),
-    ('api', 'project'),
-    ('api', 'team'),
-    ('api', 'organizationprofile'),
     ('logger', 'note'),
 ]
 


### PR DESCRIPTION
## Description

Some parts of KoBoCAT have been removed in [version 2.020.40](https://community.kobotoolbox.org/t/release-notes-kobocat-version-2-020-40a-2-020-40b-2-020-40c/12715)
When a user account is created, several tasks are triggered to synchronize KPI and KoBoCAT databases. One of them is to synchronize permissions of KC objects. This part is failing because KPI references KC objects that do not exist anymore.

## Related issues

Closes #2865