### PR TITLE
Navigate back to the library list when searching

### DIFF
--- a/jsapp/js/components/header.es6
+++ b/jsapp/js/components/header.es6
@@ -255,7 +255,7 @@ class MainHeader extends Reflux.Component {
             { this.isLibrary() &&
               <div className='mdl-layout__header-searchers'>
                 <SearchBox
-                  placeholder={t('Search Library')}
+                  placeholder={this.isPublicCollections() ? t('Search Public Collections') : t('Search My Library')}
                   disabled={this.isSearchBoxDisabled()}
                 />
               </div>

--- a/jsapp/js/components/header/searchBox.es6
+++ b/jsapp/js/components/header/searchBox.es6
@@ -2,11 +2,13 @@ import _ from 'underscore';
 import React from 'react';
 import Reflux from 'reflux';
 import reactMixin from 'react-mixin';
+import {hashHistory} from 'react-router';
 import autoBind from 'react-autobind';
 import ui from 'js/ui';
 import {bem} from 'js/bem';
 import {searchBoxStore} from './searchBoxStore';
-import {KEY_CODES} from 'js/constants';
+import {KEY_CODES, ROUTES} from 'js/constants';
+import {isOnLibraryAssetRoute} from '../library/libraryUtils';
 
 /**
  * @prop {string} placeholder - A text to be displayed in empty input.
@@ -40,7 +42,14 @@ export default class SearchBox extends React.Component {
 
   onInputKeyUp(evt) {
     if (evt.keyCode === KEY_CODES.ENTER) {
+      this.switchRouteIfNeeded();
       this.setSearchPhrase(evt.target.value.trim());
+    }
+  }
+
+  switchRouteIfNeeded() {
+    if (isOnLibraryAssetRoute()) {
+      hashHistory.push(ROUTES.LIBRARY);
     }
   }
 


### PR DESCRIPTION
## Context
> > Leszek: I've found one more thing - there is a search box on the single collection/asset page being displayed and it does nothing
>
> aha! I'd say to have it search the whole list of "My Library" / "Public Collections" (depending on the breadcrumb). Gmail does this (well, it searches all mail; obvs. there's no "My Mail" vs. "Public Mail")

This doesn't get all the way there—it always searches "My Library"—and it may be evil.

## Description

Change the search placeholder from "Search Library" to "Search My Library" or "Search Public Library" depending on the context. If viewing an individual library item, navigate back to the library list when pushing enter inside the search box.