### PR TITLE
Store ConfigurationFile content in a public place

### DIFF
--- a/hub/models.py
+++ b/hub/models.py
@@ -34,7 +34,13 @@ class ConfigurationFile(models.Model):
     )
 
     slug = models.CharField(max_length=32, choices=SLUG_CHOICES, unique=True)
-    content = models.FileField()
+    content = models.FileField(
+        upload_to=settings.PUBLIC_MEDIA_PATH,
+        help_text=(
+            'Stored in a PUBLIC location where authentication is '
+            'NOT required for access'
+        ),
+    )
 
     def __str__(self):
         return self.slug

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -280,6 +280,13 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/' + os.environ.get('KPI_MEDIA_URL', 'media').strip('/') + '/'
 
+# `PUBLIC_MEDIA_PATH` sets the `upload_to` attribute of explicitly-public
+# `FileField`s, e.g. in `ConfigurationFile`. The corresponding location on the
+# file system (usually `MEDIA_ROOT + PUBLIC_MEDIA_PATH`) should be exposed to
+# everyone via NGINX. For more information, see
+# https://docs.djangoproject.com/en/2.2/ref/models/fields/#django.db.models.FileField.upload_to
+PUBLIC_MEDIA_PATH = '__public/'
+
 # Following the uWSGI mountpoint convention, this should have a leading slash
 # but no trailing slash
 KPI_PREFIX = os.environ.get('KPI_PREFIX', 'False')


### PR DESCRIPTION
…so that installations using local storage can customize logos and the login page background.

Requires kobotoolbox/kobo-docker#313.

## Description

Allow installations using local storage (not S3, which already worked) to customize logos and the login page background, by placing these image uploads in a publicly-accessible location

## Related issues

Closes #1738 
Related to kobotoolbox/kobo-docker#175