### PR TITLE
Improve tags input UX

### DIFF
--- a/jsapp/js/components/RESTServices/RESTServicesForm.es6
+++ b/jsapp/js/components/RESTServices/RESTServicesForm.es6
@@ -1,6 +1,6 @@
 import React from 'react';
 import autoBind from 'react-autobind';
-import TagsInput from 'react-tagsinput';
+import KoboTagsInput from 'js/components/common/koboTagsInput';
 import alertify from 'alertifyjs';
 import {bem} from '../../bem';
 import {dataInterface} from '../../dataInterface';
@@ -383,26 +383,18 @@ export default class RESTServicesForm extends React.Component {
    * handle fields
    */
 
-  onSubsetFieldsChange(evt) {
-    this.setState({subsetFields: evt});
+  onSubsetFieldsChange(newValue) {
+    this.setState({subsetFields: newValue.split(',')});
   }
 
   renderFieldsSelector() {
-    const inputProps = {
-      placeholder: t('Add field(s)'),
-      id: 'subset-fields-input'
-    };
-
     return (
       <bem.FormModal__item>
-        <label htmlFor='subset-fields-input'>
-          {t('Select fields subset')}
-        </label>
-
-        <TagsInput
-          value={this.state.subsetFields}
-          onChange={this.onSubsetFieldsChange.bind(this)}
-          inputProps={inputProps}
+        <KoboTagsInput
+          tags={this.state.subsetFields.join(',')}
+          onChange={this.onSubsetFieldsChange}
+          placeholder={t('Add field(s)')}
+          label={t('Select fields subset')}
         />
       </bem.FormModal__item>
     );

--- a/jsapp/js/components/common/koboTagsInput.es6
+++ b/jsapp/js/components/common/koboTagsInput.es6
@@ -1,0 +1,71 @@
+import React from 'react';
+import autoBind from 'react-autobind';
+import TagsInput from 'react-tagsinput';
+import {cleanupTags} from 'js/assetUtils';
+
+const DEFAULT_PLACEHOLDER = t('Type and confirm with ENTER');
+const TAGS_SEPARATOR = ',';
+
+/**
+ * This component is a wrapper around 3rd party react-tagsinput to allow for
+ * common settings to be reused in a better way.
+ *
+ * @prop {string} tags a comma-separated list of tags (the asset keeps it that way)
+ * @prop {callback} onChange - returns stringified comma-separated new tags string
+ * @prop {string} [label] optional title
+ * @prop {string} [placeholder] optional as default is provided
+ */
+class KoboTagsInput extends React.Component {
+  constructor(props) {
+    super(props);
+    autoBind(this);
+  }
+
+  onChange(tags) {
+    const cleanTags = cleanupTags(tags);
+    this.props.onChange(cleanTags.join(TAGS_SEPARATOR));
+  }
+
+  // splits pasted text by TAGS_SEPARATOR and trims all white space
+  pasteSplit(data) {
+    return data.split(TAGS_SEPARATOR).map((tag) => {return tag.trim();});
+  }
+
+  render() {
+    const inputProps = {
+      placeholder: this.props.placeholder || DEFAULT_PLACEHOLDER,
+    };
+
+    if (this.props.label) {
+      // generate a unique id for the input
+      inputProps.id = String(encodeURI(this.props.label) + '_' + Date.now()).toLowerCase();
+    }
+
+    let tagsArray = [];
+    if (typeof this.props.tags === 'string' && this.props.tags.length >= 1) {
+      tagsArray = this.props.tags.split(TAGS_SEPARATOR);
+    }
+
+    return (
+      <div>
+        {this.props.label &&
+          <label htmlFor={inputProps.id}>
+            {this.props.label}
+          </label>
+        }
+
+        <TagsInput
+          value={tagsArray}
+          onChange={this.onChange}
+          inputProps={inputProps}
+          onlyUnique
+          addOnBlur
+          addOnPaste
+          pasteSplit={this.pasteSplit}
+        />
+      </div>
+    );
+  }
+}
+
+export default KoboTagsInput;

--- a/jsapp/js/components/common/koboTagsInput.es6
+++ b/jsapp/js/components/common/koboTagsInput.es6
@@ -22,7 +22,11 @@ class KoboTagsInput extends React.Component {
   }
 
   onChange(tags) {
-    const cleanTags = cleanupTags(tags);
+    // make sure to split all multiple tags added (i.e. when users types in few
+    // tags at once separated by TAGS_SEPARATOR)
+    let cleanTags = tags.join(TAGS_SEPARATOR).split(TAGS_SEPARATOR);
+    // we then make sure the list contains only unique values and cleaned up
+    cleanTags = Array.from(new Set(cleanupTags(cleanTags)));
     this.props.onChange(cleanTags.join(TAGS_SEPARATOR));
   }
 

--- a/jsapp/js/components/modalForms/assetTagsForm.es6
+++ b/jsapp/js/components/modalForms/assetTagsForm.es6
@@ -2,12 +2,11 @@ import React from 'react';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
-import TagsInput from 'react-tagsinput';
+import KoboTagsInput from 'js/components/common/koboTagsInput';
 import {bem} from 'js/bem';
 import {stores} from 'js/stores';
 import {actions} from 'js/actions';
 import {notify} from 'utils';
-import {cleanupTags} from 'js/assetUtils';
 import {renderLoading} from './modalHelpers';
 
 /**
@@ -16,16 +15,16 @@ import {renderLoading} from './modalHelpers';
 export class AssetTagsForm extends React.Component {
   constructor(props) {
     super(props);
-    this.unlisteners = [];
+
     this.state = {
       isSessionLoaded: !!stores.session.currentAccount,
-      tags: [],
-      isPending: false
+      tags: this.props.asset?.tag_string || '',
+      isPending: false,
     };
+
+    this.unlisteners = [];
+
     autoBind(this);
-    if (this.props.asset) {
-      this.applyPropsData();
-    }
   }
 
   componentDidMount() {
@@ -40,12 +39,6 @@ export class AssetTagsForm extends React.Component {
 
   componentWillUnmount() {
     this.unlisteners.forEach((clb) => {clb();});
-  }
-
-  applyPropsData() {
-    if (this.props.asset.tag_string) {
-      this.state.tags = this.props.asset.tag_string.split(',');
-    }
   }
 
   onUpdateAssetCompleted() {
@@ -63,12 +56,12 @@ export class AssetTagsForm extends React.Component {
     this.setState({isPending: true});
     actions.resources.updateAsset(
       this.props.asset.uid,
-      {tag_string: this.state.tags.join(',')}
+      {tag_string: this.state.tags}
     );
   }
 
   onTagsChange(newValue) {
-    this.setState({tags: cleanupTags(newValue)});
+    this.setState({tags: newValue});
   }
 
   getSubmitButtonLabel() {
@@ -88,10 +81,9 @@ export class AssetTagsForm extends React.Component {
       <bem.FormModal__form className='project-settings'>
         <bem.FormModal__item m='wrapper' disabled={this.state.isPending}>
           <bem.FormModal__item>
-            <TagsInput
-              value={this.state.tags}
+            <KoboTagsInput
+              tags={this.state.tags}
               onChange={this.onTagsChange}
-              inputProps={{placeholder: t('Tags')}}
             />
           </bem.FormModal__item>
         </bem.FormModal__item>

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -2,7 +2,7 @@ import React from 'react';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
-import TagsInput from 'react-tagsinput';
+import KoboTagsInput from 'js/components/common/koboTagsInput';
 import Select from 'react-select';
 import PropTypes from 'prop-types';
 import TextBox from 'js/components/common/textBox';
@@ -37,7 +37,7 @@ export class LibraryAssetForm extends React.Component {
         organization: '',
         country: null,
         sector: null,
-        tags: [],
+        tags: '',
         description: ''
       },
       isPending: false
@@ -78,7 +78,7 @@ export class LibraryAssetForm extends React.Component {
       this.state.data.sector = this.props.asset.settings.sector;
     }
     if (this.props.asset.tag_string) {
-      this.state.data.tags = this.props.asset.tag_string.split(',');
+      this.state.data.tags = this.props.asset.tag_string;
     }
     if (this.props.asset.settings.description) {
       this.state.data.description = this.props.asset.settings.description;
@@ -126,7 +126,7 @@ export class LibraryAssetForm extends React.Component {
             sector: this.state.data.sector,
             description: this.state.data.description
           }),
-          tag_string: this.state.data.tags.join(',')
+          tag_string: this.state.data.tags,
         }
       );
     } else {
@@ -139,7 +139,7 @@ export class LibraryAssetForm extends React.Component {
           sector: this.state.data.sector,
           description: this.state.data.description
         }),
-        tag_string: this.state.data.tags.join(',')
+        tag_string: this.state.data.tags,
       };
 
       if (
@@ -168,7 +168,7 @@ export class LibraryAssetForm extends React.Component {
   onOrganizationChange(newValue) {this.onPropertyChange('organization', newValue);}
   onCountryChange(newValue) {this.onPropertyChange('country', newValue);}
   onSectorChange(newValue) {this.onPropertyChange('sector', newValue);}
-  onTagsChange(newValue) {this.onPropertyChange('tags', assetUtils.cleanupTags(newValue));}
+  onTagsChange(newValue) {this.onPropertyChange('tags', newValue);}
   onDescriptionChange(evt) {this.onPropertyChange('description', assetUtils.removeInvalidChars(evt.target.value));}
 
   /**
@@ -258,10 +258,10 @@ export class LibraryAssetForm extends React.Component {
           </bem.FormModal__item>
 
           <bem.FormModal__item>
-            <TagsInput
-              value={this.state.data.tags}
+            <KoboTagsInput
+              tags={this.state.data.tags}
               onChange={this.onTagsChange}
-              inputProps={{placeholder: t('Tags')}}
+              label={t('Tags')}
             />
           </bem.FormModal__item>
 

--- a/jsapp/js/components/tagInput.es6
+++ b/jsapp/js/components/tagInput.es6
@@ -44,6 +44,8 @@ class TagInput extends React.Component {
         inputValue={this.state.tag}
         inputProps={inputProps}
         onChangeInput={this.handleChangeInput.bind(this)}
+        onlyUnique
+        addOnBlur
       />
     );
   }

--- a/jsapp/js/components/tagInput.es6
+++ b/jsapp/js/components/tagInput.es6
@@ -33,6 +33,10 @@ class TagInput extends React.Component {
     this.setState({tag});
   }
 
+  pasteSplit(data) {
+    return data.split(',').map((tag) => {return tag.trim();});
+  }
+
   render() {
     var inputProps = {
       placeholder: t('Add tag(s)')
@@ -46,6 +50,8 @@ class TagInput extends React.Component {
         onChangeInput={this.handleChangeInput.bind(this)}
         onlyUnique
         addOnBlur
+        addOnPaste
+        pasteSplit={this.pasteSplit}
       />
     );
   }

--- a/jsapp/js/components/tagInput.es6
+++ b/jsapp/js/components/tagInput.es6
@@ -1,3 +1,10 @@
+// NOTE Plese do not use it!
+//
+// TODO This component is very specific in usage as it is calling actions itself
+// to update the tags. It should be incorporated into assetrow (the only file
+// that uses it) with the use of KoboTagsInput. OR it should be left here to die
+// as assetrow is going away in future.
+
 import React from 'react';
 import autoBind from 'react-autobind';
 import TagsInput from 'react-tagsinput';


### PR DESCRIPTION
## Description

This introduces a few UX improvements in the tags inputs:

1. The input is described in clearer way (that you need to type and ENTER-confirm tags)
2. If user forgets to ENTER-confirm tag, it will still be saved
3. We now allow only unique tags to be added
4. It is possible to paste comma-separated tags into the input

It will be applied to:

- REST Services field selector
- Tag editor modal in Library
- Tag editor in New Library Item modal
- Tag editor in Edit Library Item modal
- Inline Tag editor on Projects List