### PR TITLE
Make assets without versions cloneable

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -702,7 +702,27 @@ class Asset(ObjectPermissionMixin,
 
     def clone(self, version_uid=None):
         # not currently used, but this is how "to_clone_dict" should work
-        return Asset.objects.create(**self.to_clone_dict(version_uid))
+        return Asset.objects.create(**self.to_clone_dict(version=version_uid))
+
+    def create_version(self) -> [AssetVersion, None]:
+        """
+        Create a version of current asset.
+        Asset has to belong to `ASSET_TYPE_WITH_CONTENT` otherwise no version
+        is created and `None` is returned.
+        """
+        if self.asset_type not in ASSET_TYPES_WITH_CONTENT:
+            return
+
+        return self.asset_versions.create(
+            name=self.name,
+            version_content=self.content,
+            _deployment_data=self._deployment_data,
+            # Any new version starts out as not-deployed,
+            # even if the asset itself is already deployed.
+            # Note: `asset_version.deployed` is set in the
+            # serializer `DeploymentSerializer`
+            deployed=False,
+        )
 
     @property
     def deployed_versions(self):
@@ -966,13 +986,7 @@ class Asset(ObjectPermissionMixin,
                 self.parent.update_languages()
 
         if _create_version:
-            self.asset_versions.create(name=self.name,
-                                       version_content=self.content,
-                                       _deployment_data=self._deployment_data,
-                                       # asset_version.deployed is set in the
-                                       # DeploymentSerializer
-                                       deployed=False,
-                                       )
+            self.create_version()
 
     @property
     def snapshot(self):
@@ -993,20 +1007,23 @@ class Asset(ObjectPermissionMixin,
         intended_tags = value.split(',')
         self.tags.set(*intended_tags)
 
-    def to_clone_dict(self, version_uid=None, version=None):
+    def to_clone_dict(
+            self,
+            version: Union[str, AssetVersion] = None
+    ) -> dict:
         """
-        Returns a dictionary of the asset based on version_uid or version.
-        If `version` is specified, there are no needs to provide `version_uid` and make another request to DB.
-        :param version_uid: string
-        :param version: AssetVersion
-        :return: dict
-        """
+        Returns a dictionary of the asset based on its version.
 
+        :param version: Optional. It can be an object or its unique id
+        :return dict
+        """
         if not isinstance(version, AssetVersion):
-            if version_uid:
-                version = self.asset_versions.get(uid=version_uid)
+            if version:
+                version = self.asset_versions.get(uid=version)
             else:
                 version = self.asset_versions.first()
+                if not version:
+                    version = self.create_version()
 
         return {
             'name': version.name,

--- a/kpi/tests/test_cloning.py
+++ b/kpi/tests/test_cloning.py
@@ -30,17 +30,32 @@ class TestCloningOrm(AssetsTestCase):
         self.asset.save()
         v3_uid = self.asset.asset_versions.first().uid
 
-        # unused feature. TODO: fix test when time
-        '''
-        v3_clone_data = self.asset.to_clone_dict(version_uid=v3_uid)
-        v2_clone_data = self.asset.to_clone_dict(version_uid=v2_uid)
+        v3_clone_data = self.asset.to_clone_dict(version=v3_uid)
+        v2_clone_data = self.asset.to_clone_dict(version=v2_uid)
 
         self.assertEqual(v2_clone_data['name'], 'Version 2')
         self.assertEqual(v2_clone_data['content']['survey'][0]['type'], 'integer')
 
         self.assertEqual(v3_clone_data['name'], 'Version 3')
         self.assertEqual(v3_clone_data['content']['survey'][0]['type'], 'note')
-        '''
+
+    def test_clone_asset_without_version(self):
+        """
+        This test is pretty basic. It just validates that a version is created
+        when asset is cloned if it does have any
+        """
+        self.asset.asset_versions.all().delete()
+        asset_versions_count = self.asset.asset_versions.count()
+        assert asset_versions_count == 0
+        cloned_dict = self.asset.to_clone_dict()
+        expected = {
+            'name': self.asset.name,
+            'content': self.asset.content,
+            'asset_type': self.asset.asset_type,
+            'tag_string': self.asset.tag_string,
+        }
+        self.assertEqual(cloned_dict, expected)
+        assert asset_versions_count + 1 == self.asset.asset_versions.count()
 
 
 class TestCloning(KpiTestCase):

--- a/kpi/tests/test_cloning.py
+++ b/kpi/tests/test_cloning.py
@@ -1,9 +1,5 @@
 # coding: utf-8
-"""
-Created on Jun 15, 2015
 
-@author: esmail
-"""
 import json
 import unittest
 
@@ -42,7 +38,7 @@ class TestCloningOrm(AssetsTestCase):
     def test_clone_asset_without_version(self):
         """
         This test is pretty basic. It just validates that a version is created
-        when asset is cloned if it does have any
+        when asset is cloned if it does not have any
         """
         self.asset.asset_versions.all().delete()
         asset_versions_count = self.asset.asset_versions.count()


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. N/A If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Cloning is based on a version and uses the latest one by default. 
Some assets do not have any versions, therefore cannot be cloned. A version is force created now on cloning if none exists.

## Related issues

Closes #3020 
