### PR TITLE
Fix missing directory error when npm building

### DIFF
--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -1,8 +1,13 @@
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const BundleTracker = require('webpack-bundle-tracker');
 const publicPath = (process.env.KPI_PREFIX === '/' ? '' : (process.env.KPI_PREFIX || '')) + '/static/compiled/';
 const WebpackCommon = require('./webpack.common');
+
+const outputPath = path.resolve(__dirname, '../jsapp/compiled/');
+// ExtractTranslationKeysPlugin, for one, just fails if this directory doesn't exist
+fs.mkdirSync(outputPath, {recursive: true});
 
 module.exports = WebpackCommon({
   mode: 'production',
@@ -22,7 +27,7 @@ module.exports = WebpackCommon({
     browsertests: path.resolve(__dirname, '../test/index.js')
   },
   output: {
-    path: path.resolve(__dirname, '../jsapp/compiled/'),
+    path: outputPath,
     publicPath: publicPath,
     filename: '[name]-[hash].js'
   },


### PR DESCRIPTION
The full error was:
```
Error: ENOENT: no such file or directory, open '/srv/src/kpi/jsapp/compiled/extracted-strings.json'
```

## Description

The first run of `npm run build` could fail because the translatable strings extractor would attempt to write its output to a file in a directory that didn't exist yet.