### PR TITLE
Changed the `version` field in the XLSForm to the version number and date

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -710,21 +710,6 @@ class Asset(ObjectPermissionMixin,
             '-date_modified')
 
     @property
-    def version_number_and_date(self):
-        # Returns the count of all deployed version + a version
-        # if the most recent version is undeployed and the date
-        # the asset was last modified
-        asset_versions = AssetVersion.objects.filter(
-            asset=self.pk).order_by('-date_modified')
-        latest_version = asset_versions.first()
-        count = self.deployed_versions.count()
-
-        if latest_version.deployed is False:
-            count = count + 1
-
-        return f'{count} {self.date_modified:(%m-%d-%Y %H:%M:%S)}'
-
-    @property
     def discoverable_when_public(self):
         # This property is only needed when `self` is a collection.
         # We want to make a distinction between a collection which is not
@@ -1094,6 +1079,18 @@ class Asset(ObjectPermissionMixin,
         latest_version = self.latest_version
         if latest_version:
             return latest_version.uid
+
+    @property
+    def version_number_and_date(self):
+        # Returns the count of all deployed version + a version
+        # if the most recent version is undeployed and the date
+        # the asset was last modified
+        count = self.deployed_versions.count()
+
+        if not self.latest_version.deployed:
+            count = count + 1
+
+        return f'{count} {self.date_modified:(%m-%d-%Y %H:%M:%S)}'
 
     def _populate_report_styles(self):
         default = self.report_styles.get(DEFAULT_REPORTS_KEY, {})


### PR DESCRIPTION
## Checklist

1. [N/A] If you've added code that should be tested, add tests
2. [N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

When downloading the XLSForm for a survey, the `version` in the `settings` sheet will display as the version number with the date next to it to match what is displayed on the front end.

Before: 
vBdzksT2SSU9LZi88pxHxQ

After:
2 (03-03-2021   04:08:52)


## Related issues

Fixes #3006 
Part of kobotoolbox/kobocat#676
