### PR TITLE
Updated the SSRF split() to include `\r`

### DIFF
--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -105,11 +105,11 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
                 ssrf_protect_options = {}
                 if constance.config.SSRF_ALLOWED_IP_ADDRESS.strip():
                     ssrf_protect_options['allowed_ip_addresses'] = constance.\
-                        config.SSRF_ALLOWED_IP_ADDRESS.strip().split('\n')
+                        config.SSRF_ALLOWED_IP_ADDRESS.strip().split('\r\n')
 
                 if constance.config.SSRF_DENIED_IP_ADDRESS.strip():
                     ssrf_protect_options['denied_ip_addresses'] = constance.\
-                        config.SSRF_DENIED_IP_ADDRESS.strip().split('\n')
+                        config.SSRF_DENIED_IP_ADDRESS.strip().split('\r\n')
 
                 SSRFProtect.validate(self._hook.endpoint,
                                      options=ssrf_protect_options)


### PR DESCRIPTION
## Checklist

1. [N/A] If you've added code that should be tested, add tests
2. [N/A] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Added `\r` to the `split('\n')` which turned the IPs in constance/config SSRF_ALLOWED_IP_ADDRESS and SSRF_DENIED_IP_ADDRESS fields into a python readable list.

## Related issues

Fixes #3025 
