### PR TITLE
Fix submission duplication error

### DIFF
--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -209,6 +209,8 @@ class MockDeploymentBackend(BaseDeploymentBackend):
     def duplicate_submission(
         self, requesting_user_id: int, instance_id: int, **kwargs: dict
     ) -> dict:
+        # TODO: Make this operate on XML somehow and reuse code from
+        # KobocatDeploymentBackend, to catch issues like #3054
         all_submissions = self.asset._deployment_data['submissions']
         submission = next(
             filter(lambda sub: sub['_id'] == instance_id, all_submissions)

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -449,6 +449,10 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         super().setUp()
         v_uid = self.asset.latest_deployed_version.uid
         current_time = datetime.now(tz=pytz.UTC).isoformat('T', 'milliseconds')
+        # TODO: also test a submission that's missing `start` or `end`; see
+        # #3054. Right now that would be useless, though, because the
+        # MockDeploymentBackend doesn't use XML at all and won't fail if an
+        # expected field is missing
         self.submissions = [
             {
                 '__version__': v_uid,


### PR DESCRIPTION
## Description

Fix 500 error when attempting to duplicate a submission without `start` or `end` fields.

## Related issues
closes #3053 