### PR TITLE
Hide non-data rows from bulk edit form

### DIFF
--- a/jsapp/js/components/modalForms/bulkEditSubmissionsForm.es6
+++ b/jsapp/js/components/modalForms/bulkEditSubmissionsForm.es6
@@ -6,10 +6,7 @@ import {
   getSurveyFlatPaths,
   getFlatQuestionsList,
 } from 'js/assetUtils';
-import {
-  QUESTION_TYPES,
-  FORM_VERSION_NAME,
-} from 'js/constants';
+import {QUESTION_TYPES} from 'js/constants';
 import {bem} from 'js/bem';
 import {actions} from 'js/actions';
 import TextBox from 'js/components/common/textBox';
@@ -180,12 +177,9 @@ class BulkEditSubmissionsForm extends React.Component {
     const flatPaths = getSurveyFlatPaths(this.props.asset.content.survey);
 
     questions = questions.filter((question) => {
-      // we don't want to include special calculate row used to store form version
-      if (question.type === QUESTION_TYPES.calculate.id && question.name === FORM_VERSION_NAME) {
-        return false;
-      }
-      // notes and hidden don't carry submission data, we ignore them
+      // let's hide rows that don't carry any submission data
       if (
+        question.type === QUESTION_TYPES.calculate.id ||
         question.type === QUESTION_TYPES.note.id ||
         question.type === QUESTION_TYPES.hidden.id
       ) {

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -327,8 +327,6 @@ new Set([
 ]).forEach((kind) => {GROUP_TYPES_END[kind] = kind;});
 Object.freeze(GROUP_TYPES_END);
 
-export const FORM_VERSION_NAME = '__version__';
-
 // a custom question type for score
 export const SCORE_ROW_TYPE = 'score__row';
 
@@ -420,7 +418,6 @@ const constants = {
   ACCESS_TYPES,
   GROUP_TYPES_BEGIN,
   GROUP_TYPES_END,
-  FORM_VERSION_NAME,
   SCORE_ROW_TYPE,
   RANK_LEVEL_TYPE,
   DEPLOYMENT_CATEGORIES,

--- a/jsapp/js/submissionUtils.es6
+++ b/jsapp/js/submissionUtils.es6
@@ -5,7 +5,6 @@ import {
   isRowSpecialLabelHolder,
 } from 'js/assetUtils';
 import {
-  FORM_VERSION_NAME,
   SCORE_ROW_TYPE,
   RANK_LEVEL_TYPE,
   MATRIX_PAIR_PROPS,
@@ -110,12 +109,9 @@ export function getSubmissionDisplayData(survey, choices, translationIndex, subm
       if (!isRowCurrentLevel) {
         continue;
       }
-      // we don't want to include special calculate row used to store form version
-      if (row.type === QUESTION_TYPES.calculate.id && rowName === FORM_VERSION_NAME) {
-        continue;
-      }
-      // notes and hidden don't carry submission data, we ignore them
+      // let's hide rows that don't carry any submission data
       if (
+        row.type === QUESTION_TYPES.calculate.id ||
         row.type === QUESTION_TYPES.note.id ||
         row.type === QUESTION_TYPES.hidden.id
       ) {

--- a/jsapp/js/submissionUtils.es6
+++ b/jsapp/js/submissionUtils.es6
@@ -114,8 +114,11 @@ export function getSubmissionDisplayData(survey, choices, translationIndex, subm
       if (row.type === QUESTION_TYPES.calculate.id && rowName === FORM_VERSION_NAME) {
         continue;
       }
-      // notes don't carry submission data, we ignore them
-      if (row.type === QUESTION_TYPES.note.id) {
+      // notes and hidden don't carry submission data, we ignore them
+      if (
+        row.type === QUESTION_TYPES.note.id ||
+        row.type === QUESTION_TYPES.hidden.id
+      ) {
         continue;
       }
       /*


### PR DESCRIPTION
## Description

The `hidden`, `note` and `calculate` questions don't carry submission data, so we hide them from the Bulk Edit Submissions form (and Single Submission Modal).
