### PR TITLE
Use year-month-day format for version string and add a unit test

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -1102,16 +1102,16 @@ class Asset(ObjectPermissionMixin,
             return latest_version.uid
 
     @property
-    def version_number_and_date(self):
-        # Returns the count of all deployed version + a version
-        # if the most recent version is undeployed and the date
-        # the asset was last modified
+    def version_number_and_date(self) -> str:
+        # Returns the count of all deployed versions (plus one for the current
+        # version if it is not deployed) and the date the asset was last
+        # modified
         count = self.deployed_versions.count()
 
         if not self.latest_version.deployed:
             count = count + 1
 
-        return f'{count} {self.date_modified:(%m-%d-%Y %H:%M:%S)}'
+        return f'{count} {self.date_modified:(%Y-%m-%d %H:%M:%S)}'
 
     def _populate_report_styles(self):
         default = self.report_styles.get(DEFAULT_REPORTS_KEY, {})

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import datetime
 import json
 from collections import OrderedDict
 from copy import deepcopy
@@ -349,6 +350,18 @@ class AssetContentTests(AssetsTestCase):
             cell.value for cell in settings_sheet.col(settings_sheet.ncols - 1)
         ]
         self.assertEqual(xls_version_col[0], 'version')
+
+    def test_to_xls_io_includes_version_number_and_date(self):
+        date_string = '2021-03-17 11:12:13'
+        self.asset.date_modified = datetime.datetime.fromisoformat(date_string)
+        xls_io = self.asset.to_xls_io(versioned=True)
+        workbook = xlrd.open_workbook(file_contents=xls_io.read())
+        settings_sheet = workbook.sheet_by_name('settings')
+        version_col = [cell.value for cell in settings_sheet.row(0)].index(
+            'version'
+        )
+        version_string = settings_sheet.col(version_col)[1].value
+        assert version_string == f'1 ({date_string})'
 
 
 class AssetSettingsTests(AssetsTestCase):


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] ~~If you've changed APIs, update (or create!) the documentation~~
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Use year-month-day format for the version string included in the `settings` sheet of XLSForm exports, which appears in ODK Collect after the form is deployed, and add a unit test

## Related issues

Part of #3006