### PR TITLE
custom exports final FE tweaks

### DIFF
--- a/jsapp/js/bem.es6
+++ b/jsapp/js/bem.es6
@@ -338,4 +338,17 @@ bem.PrintOnly = BEM('print-only');
 bem.GitRev = BEM('git-rev');
 bem.GitRev__item = bem.GitRev.__('item', '<div>');
 
+bem.ProjectDownloads = BEM('project-downloads');
+bem.ProjectDownloads__advancedView = bem.ProjectDownloads.__('advanced-view', 'section');
+bem.ProjectDownloads__column = bem.ProjectDownloads.__('column');
+bem.ProjectDownloads__columnRow = bem.ProjectDownloads.__('column-row');
+bem.ProjectDownloads__title = bem.ProjectDownloads.__('title', 'span');
+bem.ProjectDownloads__textButton = bem.ProjectDownloads.__('text-button', 'button');
+bem.ProjectDownloads__selectorRow = bem.ProjectDownloads.__('selector-row');
+bem.ProjectDownloads__legacyIframeWrapper = bem.ProjectDownloads.__('legacy-iframe-wrapper');
+bem.ProjectDownloads__submitRow = bem.ProjectDownloads.__('submit-row', 'footer');
+bem.ProjectDownloads__definedExportsSelector = bem.ProjectDownloads.__('defined-exports-selector');
+bem.ProjectDownloads__deleteSettingsButton = bem.ProjectDownloads.__('delete-settings-button', 'button');
+bem.ProjectDownloads__exportsCreator = bem.ProjectDownloads.__('exports-creator');
+
 bem.create = BEM;

--- a/jsapp/js/components/projectDownloads/exportsConstants.es6
+++ b/jsapp/js/components/projectDownloads/exportsConstants.es6
@@ -52,7 +52,7 @@ export const DEFAULT_EXPORT_SETTINGS = Object.freeze({
   CUSTOM_SELECTION: false,
   // Export format options are contextual - if asset has multiple languages,
   // then there is no `_default` option, but the list of languages. Only `_xml`
-  // option is always here, so we make it a default.
+  // option is always here, so we treat it as a fallback default.
   EXPORT_FORMAT: EXPORT_FORMATS._xml,
   EXPORT_MULTIPLE: EXPORT_MULTIPLE_OPTIONS.both,
   // xls is the most popular choice and we respect that

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -272,7 +272,18 @@ export default class ProjectExportsCreator extends React.Component {
     this.setState({selectedRows: newSelectedRows});
   }
 
-  toggleAdvancedView() {
+  selectAllRows(evt) {
+    evt.preventDefault();
+    this.setState({selectedRows: new Set(this.getAllSelectableRows())});
+  }
+
+  clearSelectedRows(evt) {
+    evt.preventDefault();
+    this.setState({selectedRows: new Set()});
+  }
+
+  toggleAdvancedView(evt) {
+    evt.preventDefault();
     this.setState({isAdvancedViewVisible: !this.state.isAdvancedViewVisible});
   }
 
@@ -466,16 +477,16 @@ export default class ProjectExportsCreator extends React.Component {
     ];
 
     return (
-      <div className='project-downloads__advanced-view'>
-        <div className='project-downloads__column project-downloads__column--left'>
+      <bem.ProjectDownloads__advancedView>
+        <bem.ProjectDownloads__column m='left'>
           <label className='project-downloads__column-row'>
-            <span className='project-downloads__title'>
+            <bem.ProjectDownloads__title>
               {t('Export')}
               &nbsp;
               <em>{t('Select Many')}</em>
               &nbsp;
               {t('questions as…')}
-            </span>
+            </bem.ProjectDownloads__title>
 
             <Select
               value={this.state.selectedExportMultiple}
@@ -491,15 +502,15 @@ export default class ProjectExportsCreator extends React.Component {
             />
           </label>
 
-          <div className='project-downloads__column-row'>
+          <bem.ProjectDownloads__columnRow>
             <Checkbox
               checked={this.state.isIncludeAllVersionsEnabled}
               onChange={this.onAnyInputChange.bind(this, 'isIncludeAllVersionsEnabled')}
               label={includeAllVersionsLabel}
             />
-          </div>
+          </bem.ProjectDownloads__columnRow>
 
-          <div className='project-downloads__column-row'>
+          <bem.ProjectDownloads__columnRow>
             <Checkbox
               checked={this.state.isIncludeGroupsEnabled}
               onChange={this.onAnyInputChange.bind(this, 'isIncludeGroupsEnabled')}
@@ -517,19 +528,19 @@ export default class ProjectExportsCreator extends React.Component {
                 (!this.state.isIncludeGroupsEnabled ? 'group-separator-disabled' : undefined),
               ]}
             />
-          </div>
+          </bem.ProjectDownloads__columnRow>
 
           {this.state.selectedExportType.value === EXPORT_TYPES.geojson.value &&
-            <div className='project-downloads__column-row'>
+            <bem.ProjectDownloads__columnRow>
               <Checkbox
                 checked={this.state.isFlattenGeoJsonEnabled}
                 onChange={this.onAnyInputChange.bind(this, 'isFlattenGeoJsonEnabled')}
                 label={t('Flatten GeoJSON')}
               />
-            </div>
+            </bem.ProjectDownloads__columnRow>
           }
 
-          <div className='project-downloads__column-row'>
+          <bem.ProjectDownloads__columnRow>
             <Checkbox
               checked={this.state.isSaveCustomExportEnabled}
               onChange={this.onAnyInputChange.bind(
@@ -546,32 +557,44 @@ export default class ProjectExportsCreator extends React.Component {
               placeholder={t('Name your export settings')}
               customModifiers={['on-white', 'custom-export']}
             />
-          </div>
-        </div>
+          </bem.ProjectDownloads__columnRow>
+        </bem.ProjectDownloads__column>
 
-        <div className='project-downloads__column project-downloads__column--right'>
-          <ToggleSwitch
-            checked={this.state.isCustomSelectionEnabled}
-            onChange={this.onAnyInputChange.bind(
-              this,
-              'isCustomSelectionEnabled'
-            )}
-            label={t('Select which questions to be exported')}
-          />
+        <bem.ProjectDownloads__column m='right'>
+          <bem.ProjectDownloads__columnRow m='rows-selector-header'>
+            <ToggleSwitch
+              checked={this.state.isCustomSelectionEnabled}
+              onChange={this.onAnyInputChange.bind(
+                this,
+                'isCustomSelectionEnabled'
+              )}
+              label={t('Select which questions to be exported')}
+            />
+
+            <bem.ProjectDownloads__textButton onClick={this.selectAllRows}>
+              {t('Select all')}
+            </bem.ProjectDownloads__textButton>
+
+            <span className='project-downloads__vr'/>
+
+            <bem.ProjectDownloads__textButton onClick={this.clearSelectedRows}>
+              {t('Deselect all')}
+            </bem.ProjectDownloads__textButton>
+          </bem.ProjectDownloads__columnRow>
 
           {this.renderRowsSelector()}
-        </div>
+        </bem.ProjectDownloads__column>
 
         <hr />
-      </div>
+      </bem.ProjectDownloads__advancedView>
     );
   }
 
   getGroupSeparatorLabel() {
     return (
-      <span className='project-downloads__title'>
+      <bem.ProjectDownloads__title>
         {t('Group separator')}
-      </span>
+      </bem.ProjectDownloads__title>
     );
   }
 
@@ -590,9 +613,9 @@ export default class ProjectExportsCreator extends React.Component {
 
     return (
       <label>
-        <span className='project-downloads__title'>
+        <bem.ProjectDownloads__title>
           {t('Select export type')}
-        </span>
+        </bem.ProjectDownloads__title>
 
         <Select
           value={this.state.selectedExportType}
@@ -609,9 +632,9 @@ export default class ProjectExportsCreator extends React.Component {
   renderLegacy() {
     return (
       <React.Fragment>
-        <div className='project-downloads__selector-row'>
+        <bem.ProjectDownloads__selectorRow>
           {this.renderExportTypeSelector()}
-        </div>
+        </bem.ProjectDownloads__selectorRow>
 
         <bem.FormView__cell m='warning'>
           <i className='k-icon-alert' />
@@ -632,13 +655,13 @@ export default class ProjectExportsCreator extends React.Component {
 
     return (
       <React.Fragment>
-        <div className='project-downloads__selector-row'>
+        <bem.ProjectDownloads__selectorRow>
           {this.renderExportTypeSelector()}
 
           <label>
-            <span className='project-downloads__title'>
+            <bem.ProjectDownloads__title>
               {t('Value and header format')}
-            </span>
+            </bem.ProjectDownloads__title>
 
             <Select
               value={this.state.selectedExportFormat}
@@ -652,12 +675,9 @@ export default class ProjectExportsCreator extends React.Component {
               menuPlacement='auto'
             />
           </label>
-        </div>
+        </bem.ProjectDownloads__selectorRow>
 
-        <div
-          className='project-downloads__advanced-toggle'
-          onClick={this.toggleAdvancedView}
-        >
+        <bem.ProjectDownloads__textButton onClick={this.toggleAdvancedView}>
           {t('Advanced options')}
           {this.state.isAdvancedViewVisible && (
             <i className='k-icon k-icon-up' />
@@ -665,20 +685,20 @@ export default class ProjectExportsCreator extends React.Component {
           {!this.state.isAdvancedViewVisible && (
             <i className='k-icon k-icon-down' />
           )}
-        </div>
+        </bem.ProjectDownloads__textButton>
 
         <hr />
 
         {this.state.isAdvancedViewVisible && this.renderAdvancedView()}
 
-        <div className='project-downloads__submit-row'>
-          <div className='project-downloads__defined-exports-selector'>
+        <bem.ProjectDownloads__submitRow>
+          <bem.ProjectDownloads__definedExportsSelector>
             {this.state.definedExports.length >= 1 &&
               <React.Fragment>
                 <label>
-                  <span className='project-downloads__title'>
+                  <bem.ProjectDownloads__title>
                     {t('Apply saved export settings')}
-                  </span>
+                  </bem.ProjectDownloads__title>
 
                   <Select
                     isLoading={this.state.isUpdatingDefinedExportsList}
@@ -694,19 +714,18 @@ export default class ProjectExportsCreator extends React.Component {
 
                 {this.state.selectedDefinedExport &&
                   mixins.permissions.userCan(PERMISSIONS_CODENAMES.manage_asset, this.props.asset) &&
-                  <button
-                    className='project-downloads__delete-settings-button'
+                  <bem.ProjectDownloads__deleteSettingsButton
                     onClick={this.onDeleteExportSetting.bind(
                       this,
                       this.state.selectedDefinedExport.data.uid
                     )}
                   >
                     <i className='k-icon k-icon-trash'/>
-                  </button>
+                  </bem.ProjectDownloads__deleteSettingsButton>
                 }
               </React.Fragment>
             }
-          </div>
+          </bem.ProjectDownloads__definedExportsSelector>
 
           <bem.KoboButton
             m='blue'
@@ -715,15 +734,15 @@ export default class ProjectExportsCreator extends React.Component {
           >
             {t('Export')}
           </bem.KoboButton>
-        </div>
+        </bem.ProjectDownloads__submitRow>
       </React.Fragment>
     );
   }
 
   render() {
-    let formClassNames = ['exports-creator'];
+    let formClassNames = ['project-downloads__exports-creator'];
     if (!this.state.isComponentReady) {
-      formClassNames.push('exports-creator--loading');
+      formClassNames.push('project-downloads__exports-creator--loading');
     }
 
     return (

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -281,8 +281,9 @@ new Set([
 ]).forEach((codename) => {META_QUESTION_TYPES[codename] = codename;});
 Object.freeze(META_QUESTION_TYPES);
 
-// submission data extras being added by backend. see:
-// https://github.com/kobotoolbox/kobocat/blob/78133d519f7b7674636c871e3ba5670cd64a7227/onadata/apps/viewer/models/parsed_instance.py#L242-L260
+// submission data extras being added by backend. see both of these:
+// 1. https://github.com/kobotoolbox/kobocat/blob/78133d519f7b7674636c871e3ba5670cd64a7227/onadata/apps/viewer/models/parsed_instance.py#L242-L260
+// 2. https://github.com/kobotoolbox/kpi/blob/7db39015866c905edc645677d72b9c1ea16067b1/jsapp/js/constants.es6#L284-L294
 export const ADDITIONAL_SUBMISSION_PROPS = {};
 new Set([
   '_id',
@@ -290,6 +291,9 @@ new Set([
   '_submission_time',
   '_submitted_by',
   '_status',
+  '_validation_status',
+  '_notes',
+  '_tags',
 ]).forEach((codename) => {ADDITIONAL_SUBMISSION_PROPS[codename] = codename;});
 Object.freeze(ADDITIONAL_SUBMISSION_PROPS);
 

--- a/jsapp/scss/components/_kobo.project-downloads.scss
+++ b/jsapp/scss/components/_kobo.project-downloads.scss
@@ -84,7 +84,11 @@
     }
   }
 
-  .project-downloads__advanced-toggle {
+  .project-downloads__text-button {
+    border: 0;
+    margin: 0;
+    padding: 0;
+    background: none;
     display: inline-block;
     color: $kobo-blue;
     cursor: pointer;
@@ -134,6 +138,25 @@
 
       &:not(:last-child) {
         margin-bottom: 20px;
+      }
+
+      &.project-downloads__column-row--rows-selector-header {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        .toggle-switch {
+          flex: 1;
+        }
+
+        .project-downloads__vr {
+          width: 1px;
+          height: 1em;
+          display: block;
+          vertical-align: middle;
+          margin: 0 10px;
+          background-color: $kobo-lightgray;
+        }
       }
     }
   }
@@ -200,8 +223,8 @@
     }
   }
 
-  .exports-creator {
-    &.exports-creator--loading {
+  .project-downloads__exports-creator {
+    &.project-downloads__exports-creator--loading {
       opacity: 0.5;
       pointer-events: none;
     }


### PR DESCRIPTION
## Description

Add (de)select all rows button to custom exports view. Cleanup styles. Bring back original default export format handling (`_default` or asset's default language).