### PR TITLE
Custom export format options fix

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -589,13 +589,19 @@ export default class ProjectExportsCreator extends React.Component {
               label={t('Select which questions to be exported')}
             />
 
-            <bem.ProjectDownloads__textButton onClick={this.selectAllRows}>
+            <bem.ProjectDownloads__textButton
+              disabled={!this.state.isCustomSelectionEnabled}
+              onClick={this.selectAllRows}
+            >
               {t('Select all')}
             </bem.ProjectDownloads__textButton>
 
             <span className='project-downloads__vr'/>
 
-            <bem.ProjectDownloads__textButton onClick={this.clearSelectedRows}>
+            <bem.ProjectDownloads__textButton
+              disabled={!this.state.isCustomSelectionEnabled}
+              onClick={this.clearSelectedRows}
+            >
               {t('Deselect all')}
             </bem.ProjectDownloads__textButton>
           </bem.ProjectDownloads__columnRow>

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -755,6 +755,7 @@ export default class ProjectExportsCreator extends React.Component {
             m='blue'
             type='submit'
             onClick={this.onSubmit}
+            disabled={this.state.selectedRows.size === 0}
           >
             {t('Export')}
           </bem.KoboButton>

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -148,26 +148,33 @@ export default class ProjectExportsCreator extends React.Component {
   }
 
   getExportFormatOptions() {
-    if (this.props.asset.summary?.languages.length >= 2) {
-      const options = [];
-      // all defined languages should go first
-      // and they replace `_default` option
+    const options = [];
+
+    // Step 1: add all defined languages as options (both named and unnamed)
+    if (this.props.asset.summary?.languages.length >= 1) {
       this.props.asset.summary.languages.forEach((language, index) => {
-        options.push({
-          value: language,
-          label: language,
-          langIndex: index, // needed for later
-        });
+        // unnamed language gives the `_default` option
+        if (language === null) {
+          options.push(EXPORT_FORMATS._default);
+        } else {
+          options.push({
+            value: language,
+            label: language,
+            langIndex: index, // needed for later
+          });
+        }
       });
-      options.push(EXPORT_FORMATS._xml);
-      return options;
-    } else {
-      return [
-        // `_default` should be first
-        EXPORT_FORMATS._default,
-        EXPORT_FORMATS._xml,
-      ];
     }
+
+    // Step 2: if for some reason nothing was added yet, add `_default`
+    if (options.length === 0) {
+      options.push(EXPORT_FORMATS._default);
+    }
+
+    // Step 3: `_xml` is always available and always last
+    options.push(EXPORT_FORMATS._xml);
+
+    return options;
   }
 
   /**

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -586,7 +586,7 @@ export default class ProjectExportsCreator extends React.Component {
                 this,
                 'isCustomSelectionEnabled'
               )}
-              label={t('Select which questions to be exported')}
+              label={t('Select questions to be exported')}
             />
 
             <bem.ProjectDownloads__textButton

--- a/jsapp/scss/components/_kobo.project-downloads.scss
+++ b/jsapp/scss/components/_kobo.project-downloads.scss
@@ -102,6 +102,11 @@
       transform: translateY(1px);
     }
 
+    &[disabled] {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
     .k-icon {
       vertical-align: middle;
       margin-left: 3px;


### PR DESCRIPTION
## Description

Rewrite format options list to work with single named language and unnamed language aside named ones. Also some small tweaks: fixed label, disable EXPORT button when zero rows selected, and disale (un)select all buttons when toggle switch is not on.

## Related issues

Fixes #3107