### PR TITLE
Move surveyCompanion store to separate file

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -21,6 +21,8 @@ import {
 import moment from 'moment';
 import {actions} from './actions';
 import {stores} from './stores';
+// importing it so it exists
+import {surveyCompanionStore} from './surveyCompanionStore';
 import {dataInterface} from './dataInterface';
 import {bem} from './bem';
 import ui from './ui';

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -16,8 +16,6 @@
 
 import Reflux from 'reflux';
 import {Cookies} from 'react-cookie';
-import clonedeep from 'lodash.clonedeep';
-import dkobo_xlform from '../xlform/src/_xlform.init';
 import {parsed, parseTags} from './assetParserUtils';
 import {actions} from './actions';
 import {
@@ -266,25 +264,6 @@ stores.assetContent = Reflux.createStore({
     this.trigger(this.data, resp.uid);
   },
 });
-
-stores.surveyCompanion = Reflux.createStore({
-  init () {
-    this.listenTo(actions.survey.addExternalItemAtPosition, this.addExternalItemAtPosition);
-  },
-  addExternalItemAtPosition ({position, survey, uid, groupId}) {
-    // `survey` is what's currently open in the form builder
-    // `uid` identifies the library item being added to `survey`
-    stores.allAssets.whenLoaded(uid, function(asset){
-      // `asset` is the library item being added to `survey`
-      // be careful not to mutate it, becuase it's kept in a store and not
-      // re-fetched from the server each time it's loaded
-      let assetCopy = clonedeep(asset);
-      // `loadDict()` will mutate its first argument; see `inputParser.parse()`
-      let _s = dkobo_xlform.model.Survey.loadDict(assetCopy.content, survey)
-      survey.insertSurvey(_s, position, groupId);
-    });
-  }
-})
 
 stores.allAssets = Reflux.createStore({
   init() {

--- a/jsapp/js/surveyCompanionStore.es6
+++ b/jsapp/js/surveyCompanionStore.es6
@@ -1,0 +1,26 @@
+import Reflux from 'reflux';
+import clonedeep from 'lodash.clonedeep';
+import dkobo_xlform from '../xlform/src/_xlform.init';
+import {actions} from 'js/actions';
+import {stores} from 'js/stores';
+
+const surveyCompanionStore = Reflux.createStore({
+  init() {
+    this.listenTo(actions.survey.addExternalItemAtPosition, this.addExternalItemAtPosition);
+  },
+  addExternalItemAtPosition({position, survey, uid, groupId}) {
+    // `survey` is what's currently open in the form builder
+    // `uid` identifies the library item being added to `survey`
+    stores.allAssets.whenLoaded(uid, function(asset){
+      // `asset` is the library item being added to `survey`
+      // be careful not to mutate it, becuase it's kept in a store and not
+      // re-fetched from the server each time it's loaded
+      let assetCopy = clonedeep(asset);
+      // `loadDict()` will mutate its first argument; see `inputParser.parse()`
+      let _s = dkobo_xlform.model.Survey.loadDict(assetCopy.content, survey);
+      survey.insertSurvey(_s, position, groupId);
+    });
+  },
+});
+
+export default surveyCompanionStore;


### PR DESCRIPTION
## Description

This is small code refactor change, nothing user oriented. I moved one of the stores to a separate file to avoid potential circular import warning.

## Additional details

This is needed for upcoming Library Locking feature #3032. The code I'm writing for will make the potential circular import warning a reality.

## Related issues

Part of #3032