### PR TITLE
Fix not redirecting to form list after deleting project

### DIFF
--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -119,21 +119,24 @@ function SearchContext(opts={}) {
     },
     // remove asset from all search store lists
     removeAsset(assetOrUid, isNonOwner) {
+      let asset;
+      if (typeof assetOrUid === 'object') {
+        asset = assetOrUid;
+      } else {
+        asset = stores.selectedAsset.asset || stores.allAssets.byUid[assetOrUid];
+      }
+      // non-owner self permission removal only gives an assetUid string, not
+      // an object; for consistency we make it an object here
+      if (!asset) {
+       asset = {uid: assetOrUid};
+      }
+
       // only update things if given asset matches the current context types or
       // a non-owner removed their own permissions
-      if (isNonOwner || this.state.defaultQueryFilterParams?.assetType.includes(asset.assetType)) {
-        let asset;
-        if (typeof assetOrUid === 'object') {
-          asset = assetOrUid;
-        } else {
-          asset = stores.selectedAsset.asset || stores.allAssets.byUid[assetOrUid];
-        }
-
-        // non-owner self permission removal only gives an assetUid string, not
-        // an object; for consistency we make it an object here
-        if (!asset) {
-         asset = {uid: assetOrUid};
-        }
+      if (
+        isNonOwner ||
+        this.state.defaultQueryFilterParams?.assetType.includes(asset.assetType)
+      ) {
         this.removeAssetFromList(asset.uid, 'defaultQueryResultsList');
         this.removeAssetFromList(asset.uid, 'searchResultsList');
         this.rebuildCategorizedList(

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -127,6 +127,8 @@ function SearchContext(opts={}) {
       }
       // non-owner self permission removal only gives an assetUid string, not
       // an object; for consistency we make it an object here
+      // only runs if `isNonOwner` is true, so no need to add `assetType` to
+      // fake object
       if (!asset) {
        asset = {uid: assetOrUid};
       }


### PR DESCRIPTION
PR #2984 left an untouched guard that still looked for `asset`, moved
creation of `asset` from `assetOrUid` before this check
## Description
Fixed bug where if user deleted a project they would not be redirected back to the form list