### PR TITLE
Coffeelint config

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,135 @@
+{
+  "arrow_spacing": {
+    "level": "warn"
+  },
+  "braces_spacing": {
+    "level": "warn",
+    "spaces": 0,
+    "empty_object_spaces": 0
+  },
+  "camel_case_classes": {
+    "level": "warn"
+  },
+  "coffeescript_error": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "level": "warn",
+    "spacing": {
+      "left": 0,
+      "right": 1
+    }
+  },
+  "cyclomatic_complexity": {
+    "level": "warn",
+    "value": 10
+  },
+  "duplicate_key": {
+    "level": "error"
+  },
+  "empty_constructor_needs_parens": {
+    "level": "warn"
+  },
+  "ensure_comprehensions": {
+    "level": "warn"
+  },
+  "eol_last": {
+    "level": "warn"
+  },
+  "indentation": {
+    "value": 2,
+    "level": "warn"
+  },
+  "line_endings": {
+    "level": "warn",
+    "value": "unix"
+  },
+  "max_line_length": {
+    "value": 80,
+    "level": "warn",
+    "limitComments": false
+  },
+  "missing_fat_arrows": {
+    "level": "warn",
+    "is_strict": false
+  },
+  "newlines_after_classes": {
+    "value": 1,
+    "level": "warn"
+  },
+  "no_backticks": {
+    "level": "warn"
+  },
+  "no_debugger": {
+    "level": "warn",
+    "console": false
+  },
+  "no_empty_functions": {
+    "level": "warn"
+  },
+  "no_empty_param_list": {
+    "level": "ignore"
+  },
+  "no_implicit_braces": {
+    "level": "warn",
+    "strict": true
+  },
+  "no_implicit_parens": {
+    "level": "warn",
+    "strict": true
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "warn"
+  },
+  "no_nested_string_interpolation": {
+    "level": "warn"
+  },
+  "no_plusplus": {
+    "level": "ignore"
+  },
+  "no_private_function_fat_arrows": {
+    "level": "warn"
+  },
+  "no_stand_alone_at": {
+    "level": "warn"
+  },
+  "no_tabs": {
+    "level": "warn"
+  },
+  "no_this": {
+    "level": "warn"
+  },
+  "no_throwing_strings": {
+    "level": "warn"
+  },
+  "no_trailing_semicolons": {
+    "level": "warn"
+  },
+  "no_trailing_whitespace": {
+    "level": "warn",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": true
+  },
+  "no_unnecessary_double_quotes": {
+    "level": "ignore"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "warn"
+  },
+  "non_empty_constructor_needs_parens": {
+    "level": "warn"
+  },
+  "prefer_english_operator": {
+    "level": "warn",
+    "doubleNotLevel": "warn"
+  },
+  "space_operators": {
+    "level": "warn"
+  },
+  "spacing_after_comma": {
+    "level": "warn"
+  },
+  "transform_messes_up_line_numbers": {
+    "level": "warn"
+  }
+}

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -91,7 +91,7 @@
     "level": "warn"
   },
   "no_stand_alone_at": {
-    "level": "warn"
+    "level": "ignore"
   },
   "no_tabs": {
     "level": "warn"


### PR DESCRIPTION
## Description

Added coffee code linting configuration file. Almost all the rules added are set to "warn" level. This is going to be helpful for #3018 to clean up the code before running scripts.

## Related issues

Part of #3018
