### PR TITLE
Fix missing help box in formbuilder

### DIFF
--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -467,9 +467,13 @@ $t-form-builder-aside-open: 200ms;
   }
 
   // Semi-hack: lib-list__item already have margins, non-library placeholder
-  // doesn't--for formbuilder revamp all placeholders should be the same
+  // doesn't. lib-list__item should also be transparent--for formbuilder revamp
+  // all placeholders should be the same
   .placeholder {
     margin: 5px 0;
+  }
+  .lib-list__item {
+    background: transparent;
   }
 }
 

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -459,11 +459,17 @@ $t-form-builder-aside-open: 200ms;
 }
 
 .survey-editor {
-  .ui-sortable-placeholder.lib-list__item {
-    border: 1px dashed $kobo-midgray;
+  .ui-sortable-placeholder {
+    border: 2px dashed $kobo-blue;
     visibility: visible !important;
     min-height: 80px;
     padding: 0;
+  }
+
+  // Semi-hack: lib-list__item already have margins, non-library placeholder
+  // doesn't--for formbuilder revamp all placeholders should be the same
+  .placeholder {
+    margin: 5px 0;
   }
 }
 


### PR DESCRIPTION
Small hack fix in comments. We have two different `placeholders` - one for moving questions within the form around and one for dragging questions from the library. It's a bit [hard to notice](https://github.com/kobotoolbox/kpi/blob/7edbc13e5da9982deff701491ee335f89b84f449/jsapp/xlform/src/view.surveyApp.coffee#L466-L527) that the former exists, so the CSS for it was removed in [2774](https://github.com/kobotoolbox/kpi/commit/33cb5c3f75d5c3f3229f89586ba6942bf4dda69b#diff-fd1cc506eb0ff4295748f37cb38f3c37f5f6e473dc67594ddf7a92dda1fd9e69L355-L374).

Since they use different CSS classnames, to avoid giving library specific class names to non-library components I just add the missing CSS to the non-library classname. For the formbuilder revamp we should generalise the placeholders

## Description
The formbuilder used to have a help box displaying where a dragged question will land. Regressed by colour rework PR, fixed here. Also changed colour and thickness

## Related Issues
Fixes #3138 
