### PR TITLE
Fix to allow non-owners with `manage_asset` permission to remove other non-owners' permissions

### DIFF
--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -237,9 +237,13 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
         # If the user is not the owner of the asset, but trying to delete the
         # owner's permissions, raise permission denied error. However, if they
         # are the owner of the asset, they should also be prevented from
-        # deleting their own permissions, but given a more appropriate response
-        if (self.request.user.pk != self.asset.owner_id) and (
-            self.request.user.pk != user.pk
+        # deleting their own permissions, but given a more appropriate
+        # response. Only those with `manage_asset` permissions can delete all
+        # permissions from other non-owners with whom the form is shared.
+        if (
+            not request.user.has_perm(PERM_MANAGE_ASSET, self.asset)
+            and (request.user.pk != self.asset.owner_id)
+            and (request.user.pk != user.pk)
         ):
             raise exceptions.PermissionDenied()
         elif user.pk == self.asset.owner_id:


### PR DESCRIPTION
## Description

A fix to allow non-owners with `manage_asset` permissions to manage all permissions of a form including removing all permissions of other non-owners.

## Related issues

closes #3154 
