### PR TITLE
Switched KOBOCAT_URL to KOBOCAT_INTERNAL_URL

### DIFF
--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -30,7 +30,7 @@ def _trigger_kc_profile_creation(user):
     Get the user's profile via the KC API, causing KC to create a KC
     UserProfile if none exists already
     """
-    url = settings.KOBOCAT_URL + '/api/v1/user'
+    url = settings.KOBOCAT_INTERNAL_URL + '/api/v1/user'
     token, _ = Token.objects.get_or_create(user=user)
     response = requests.get(
         url, headers={'Authorization': 'Token ' + token.key})


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Points the URL used to create user profiles in KoBoCat from the external URL to the internal URL

## Related issues

closes #3001 