### PR TITLE
Fix mutated asset object bug

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import autoBind from 'react-autobind';
+import cloneDeep from 'lodash.clonedeep';
 import Select from 'react-select';
 import _ from 'underscore';
 import DocumentTitle from 'react-document-title';
@@ -57,7 +57,13 @@ export default assign({
 
     if (!this.state.isNewAsset) {
       let uid = this.props.params.assetid || this.props.params.uid;
-      stores.allAssets.whenLoaded(uid, (asset) => {
+      stores.allAssets.whenLoaded(uid, (originalAsset) => {
+        // Store asset object is mutable and there is no way to predict all the
+        // bugs that come from this fact. Form Builder code is already changing
+        // the content of the object, so we want to cut all the bugs at the
+        // very start of the process.
+        const asset = cloneDeep(originalAsset);
+
         this.setState({asset: asset});
 
         // HACK switch to setState callback after updating to React 16+

--- a/jsapp/xlform/src/model.inputParser.coffee
+++ b/jsapp/xlform/src/model.inputParser.coffee
@@ -114,8 +114,8 @@ module.exports = do ->
 
     nullified = utils.nullifyTranslations(o.translations, o.translated, o.survey, baseSurvey)
 
-    # we edit the received object directly, which seems like BAD CODE™
-    # but in fact is required for the languages to work properly
+    # we edit the received object directly, which is totally a case of BAD CODE™
+    # but in fact is a necessary part of the nullify hack
     o.survey = nullified.survey;
     o.translations = nullified.translations
     o.translations_0 = nullified.translations_0


### PR DESCRIPTION
## Description

Makes the Form Builder code operating on cloned asset object, not on precious original value. Fixes one known issue and possibly some more we haven't noticed yet.

## Related issues

Fixes #3179