### PR TITLE
Create project button fix

### DIFF
--- a/jsapp/js/components/library/assetActionButtons.es6
+++ b/jsapp/js/components/library/assetActionButtons.es6
@@ -456,7 +456,7 @@ class AssetActionButtons extends React.Component {
           </bem.AssetActionButtons__iconButton>
         }
 
-        {userCanEdit && assetType === ASSET_TYPES.template.id &&
+        {assetType === ASSET_TYPES.template.id &&
           <bem.AssetActionButtons__iconButton
             onClick={this.cloneAsSurvey}
             data-tip={t('Create project')}


### PR DESCRIPTION
## Description

Allow creating projects from any viewable templates (previously user needed edit permissions).

## Related issues

Fixes #3162