### PR TITLE
Remove warning message from ZIP exports

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -683,10 +683,12 @@ export default class ProjectExportsCreator extends React.Component {
           {this.renderExportTypeSelector()}
         </bem.ProjectDownloads__selectorRow>
 
-        <bem.FormView__cell m='warning'>
-          <i className='k-icon-alert' />
-          <p>{t('This export format will not be supported in the future. Please consider using one of the other export types available.')}</p>
-        </bem.FormView__cell>
+        {this.state.selectedExportType.value !== EXPORT_TYPES.zip_legacy.value && (
+          <bem.FormView__cell m='warning'>
+            <i className='k-icon-alert' />
+            <p>{t('This export format will not be supported in the future. Please consider using one of the other export types available.')}</p>
+          </bem.FormView__cell>
+        )}
 
         <div className='project-downloads__legacy-iframe-wrapper'>
           <iframe src={


### PR DESCRIPTION
Fixes #3186

## Checklist

1. [ ] ~~If you've added code that should be tested, add tests~~
2. [ ] ~~If you've changed APIs, update (or create!) the documentation~~
3. [ ] ~~Ensure the tests pass~~
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

Remove the message "This export format will not be supported in the future. Please consider using one of the other export types available" from ZIP exports. It was misleading because ZIP exports will be supported indefinitely: there's not yet a replacement for them in KPI (non-legacy) exports, and when there is, we'll offer a seamless transition path.

## Related issues

Fixes #3186