### PR TITLE
Fix page crash when translating empty form

### DIFF
--- a/jsapp/js/components/modalForms/translationSettings.es6
+++ b/jsapp/js/components/modalForms/translationSettings.es6
@@ -16,8 +16,12 @@ export class TranslationSettings extends React.Component {
   constructor(props){
     super(props);
 
-    let translations = null;
-    if (props.asset && props.asset.content) {
+    let translations = [];
+    if (
+      props.asset &&
+      props.asset.content &&
+      props.asset.content.translations
+    ) {
       translations = props.asset.content.translations;
     }
 


### PR DESCRIPTION
## Description

Fix issue where attempting to translate an empty form crashes the page

## Related issues
Fixes #3232 