### PR TITLE
Upgrade pyxform to 1.5.1

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -281,7 +281,7 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==0.15.1
+pyxform==1.5.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -217,7 +217,7 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==0.15.1
+pyxform==1.5.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -217,7 +217,7 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==0.15.1
+pyxform==1.5.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -252,7 +252,7 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==0.15.1
+pyxform==1.5.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack


### PR DESCRIPTION
## Description

Upgrade pyxform from 0.15.1 to 1.5.1. Please see the [change log](https://github.com/jnm/pyxform/blob/d054d389d158bc0b2665f88a94600f040b23c8e6/CHANGES.txt) for a complete list of changes.

## Related issues

Closes #2605
Supersedes #3125