### PR TITLE
Make the admin user report pull data from KoBoCAT tables instead of KPI

### DIFF
--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from celery import shared_task
+from django.conf import settings
 
 # Make sure this app is listed in `INSTALLED_APPS`; otherwise, Celery will
 # complain that the task is unregistered
@@ -9,8 +10,8 @@ from celery import shared_task
 def generate_user_report(output_filename):
     import unicodecsv
     from django.core.files.storage import get_storage_class
-    from django.contrib.auth.models import User
     from kpi.deployment_backends.kc_access.shadow_models import (
+        KobocatUser,
         KobocatUserProfile,
         ReadOnlyKobocatXForm,
     )
@@ -22,57 +23,60 @@ def generate_user_report(output_filename):
         else:
             return d
 
-    def get_row_for_user(u):
-        row = []
+    def get_row_for_user(u: KobocatUser) -> list:
+        row_ = []
 
         try:
             profile = KobocatUserProfile.objects.get(user=u)
         except KobocatUserProfile.DoesNotExist:
             profile = None
+
         try:
-            extra_details = u.extra_details.data
+            extra_user_detail = ExtraUserDetail.objects.get(user_id=u.pk)
         except ExtraUserDetail.DoesNotExist:
             extra_details = None
+        else:
+            extra_details = extra_user_detail.data
 
-        row.append(u.username)
-        row.append(u.email)
-        row.append(u.pk)
-        row.append(u.first_name)
-        row.append(u.last_name)
+        row_.append(u.username)
+        row_.append(u.email)
+        row_.append(u.pk)
+        row_.append(u.first_name)
+        row_.append(u.last_name)
 
         if extra_details:
             name = extra_details.get('name', '')
         else:
             name = ''
         if name:
-            row.append(name)
+            row_.append(name)
         elif profile:
-            row.append(profile.name)
+            row_.append(profile.name)
         else:
-            row.append('')
+            row_.append('')
 
         if extra_details:
             organization = extra_details.get('organization', '')
         else:
             organization = ''
         if organization:
-            row.append(organization)
+            row_.append(organization)
         elif profile:
-            row.append(profile.organization)
+            row_.append(profile.organization)
         else:
-            row.append('')
+            row_.append('')
 
-        row.append(ReadOnlyKobocatXForm.objects.filter(user=u).count())
+        row_.append(ReadOnlyKobocatXForm.objects.filter(user=u).count())
 
         if profile:
-            row.append(profile.num_of_submissions)
+            row_.append(profile.num_of_submissions)
         else:
-            row.append(0)
+            row_.append(0)
 
-        row.append(format_date(u.date_joined))
-        row.append(format_date(u.last_login))
+        row_.append(format_date(u.date_joined))
+        row_.append(format_date(u.last_login))
 
-        return row
+        return row_
 
     CHUNK_SIZE = 1000
     columns = [
@@ -93,17 +97,12 @@ def generate_user_report(output_filename):
     with default_storage.open(output_filename, 'wb') as output_file:
         writer = unicodecsv.writer(output_file)
         writer.writerow(columns)
-        u = None
-        while True:
-            users = User.objects.all().order_by('pk')
-            if u:
-                users = users.filter(pk__gt=u.pk)
-            users = users[:CHUNK_SIZE]
-            if not users.exists():
-                break
-            for u in users:
-                try:
-                    row = get_row_for_user(u)
-                except Exception as e:
-                    row = ['!FAILED!', 'User PK: {}'.format(u.pk), repr(e)]
-                writer.writerow(row)
+        kc_users = KobocatUser.objects.exclude(
+            pk=settings.ANONYMOUS_USER_ID
+        ).order_by('pk')
+        for kc_user in kc_users.iterator(CHUNK_SIZE):
+            try:
+                row = get_row_for_user(kc_user)
+            except Exception as e:
+                row = ['!FAILED!', 'User PK: {}'.format(kc_user.pk), repr(e)]
+            writer.writerow(row)

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -103,7 +103,7 @@ class ReadOnlyKobocatXForm(ReadOnlyModel):
     XFORM_TITLE_LENGTH = 255
     xls = models.FileField(null=True)
     xml = models.TextField()
-    user = models.ForeignKey(User, related_name='xforms', null=True,
+    user = models.ForeignKey('KobocatUser', related_name='xforms', null=True,
                              on_delete=models.CASCADE)
     shared = models.BooleanField(default=False)
     shared_data = models.BooleanField(default=False)

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -506,7 +506,8 @@ class Command(BaseCommand):
                 xform_uuids_to_asset_pks[backend_response['uuid']] = \
                     existing_survey.pk
 
-            xforms = user.xforms.all()
+            # ReadOnlyKobocatXForm has a foreign key on KobocatUser, not on User
+            xforms = ReadOnlyKobocatXForm.objects.filter(user_id=user.pk).all()
             for xform in xforms:
                 try:
                     with transaction.atomic():


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

The generated CSV returns the correct values instead of `!FAILED! , Cannot query "<username>": Must be "KoBocatUser instance` 

## Related issues

Fixes 3253
