### PR TITLE
Fix report styles tabs

### DIFF
--- a/jsapp/js/components/reports/reportStyleSettings.es6
+++ b/jsapp/js/components/reports/reportStyleSettings.es6
@@ -132,7 +132,7 @@ export default class ReportStyleSettings extends React.Component {
       }
       return (
         <button
-          className={tabClassNames}
+          className={tabClassNames.join(' ')}
           onClick={this.toggleTab}
           data-index={i}
           key={i}


### PR DESCRIPTION
## Description

Fixes a small bug (probably leftover merge):

<img width="624" alt="Screenshot 2021-06-08 at 14 03 48" src="https://user-images.githubusercontent.com/2521888/121184379-f05b6500-c85c-11eb-8f54-759d55ace586.png">
