### PR TITLE
[Feature] Adds `background-audio` as a meta question type into formbuilder

### DIFF
--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -242,11 +242,11 @@ export default class MetadataEditor extends React.Component {
               <Select
                 className='kobo-select'
                 classNamePrefix='kobo-select'
-                {/*
+                /*
                   defaultValue only displays the default value, it does not
                   append it to the JSON. If there is no quality parameter then
                   it would default to ODK_DEFAULT_AUDIO_QUALITY behind the scenes
-                */}
+                */
                 defaultValue={ODK_DEFAULT_AUDIO_QUALITY}
                 options={AUDIO_QUALITY_OPTIONS}
                 onChange={this.onBackgroundAudioParametersChange}

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -31,7 +31,7 @@ export default class MetadataEditor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      metaProperties: []
+      metaProperties: [],
     };
     autoBind(this);
   }
@@ -42,7 +42,7 @@ export default class MetadataEditor extends React.Component {
 
   rebuildState() {
     const newState = {
-      metaProperties: []
+      metaProperties: [],
     };
     Object.keys(META_QUESTION_TYPES).forEach((metaType) => {
       const detail = this.getSurveyDetail(metaType);
@@ -54,15 +54,15 @@ export default class MetadataEditor extends React.Component {
   }
 
   getMetaProperty(metaType) {
-    return this.state.metaProperties.find((metaProp) => {
-      return metaProp.name === metaType;
-    });
+    return this.state.metaProperties.find(
+      (metaProp) => metaProp.name === metaType
+    );
   }
 
   getSurveyDetail(sdId) {
-    return this.props.survey.surveyDetails.filter((sd) => {
-      return sd.attributes.name === sdId;
-    })[0];
+    return this.props.survey.surveyDetails.filter(
+      (sd) => sd.attributes.name === sdId
+    )[0];
   }
 
   onCheckboxChange(name, isChecked) {
@@ -142,15 +142,17 @@ export default class MetadataEditor extends React.Component {
       <React.Fragment>
         {t('Audit settings')}
 
-        { stores.serverEnvironment &&
-          stores.serverEnvironment.state.support_url &&
-          <bem.TextBox__labelLink
-            href={stores.serverEnvironment.state.support_url + AUDIT_SUPPORT_URL}
-            target='_blank'
-          >
-            <i className='k-icon k-icon-help'/>
-          </bem.TextBox__labelLink>
-        }
+        {stores.serverEnvironment &&
+          stores.serverEnvironment.state.support_url && (
+            <bem.TextBox__labelLink
+              href={
+                stores.serverEnvironment.state.support_url + AUDIT_SUPPORT_URL
+              }
+              target='_blank'
+            >
+              <i className='k-icon k-icon-help' />
+            </bem.TextBox__labelLink>
+          )}
       </React.Fragment>
     );
   }
@@ -160,16 +162,19 @@ export default class MetadataEditor extends React.Component {
       <React.Fragment>
         {t('Background audio')}
 
-        { stores.serverEnvironment &&
-          stores.serverEnvironment.state.support_url &&
-          <bem.TextBox__labelLink
-            // TODO update support article to include background-audio
-            href={stores.serverEnvironment.state.support_url + RECORDING_SUPPORT_URL}
-            target='_blank'
-          >
-            <i className='k-icon k-icon-help'/>
-          </bem.TextBox__labelLink>
-        }
+        {stores.serverEnvironment &&
+          stores.serverEnvironment.state.support_url && (
+            <bem.TextBox__labelLink
+              // TODO update support article to include background-audio
+              href={
+                stores.serverEnvironment.state.support_url +
+                RECORDING_SUPPORT_URL
+              }
+              target='_blank'
+            >
+              <i className='k-icon k-icon-help' />
+            </bem.TextBox__labelLink>
+          )}
       </React.Fragment>
     );
   }
@@ -241,7 +246,10 @@ export default class MetadataEditor extends React.Component {
 
             <ToggleSwitch
               checked={backgroundAudioProp.value}
-              onChange={this.onCheckboxChange.bind(this, backgroundAudioProp.name)}
+              onChange={this.onCheckboxChange.bind(
+                this,
+                backgroundAudioProp.name
+              )}
               label={
                 backgroundAudioProp.value
                   ? t('This survey will be recorded')
@@ -249,10 +257,9 @@ export default class MetadataEditor extends React.Component {
               }
             />
           </bem.FormModal__item>
-
         </bem.FormBuilderMeta__row>
 
-        {this.isAuditEnabled() &&
+        {this.isAuditEnabled() && (
           <bem.FormBuilderMeta__row>
             <TextBox
               label={this.renderAuditInputLabel()}
@@ -260,14 +267,12 @@ export default class MetadataEditor extends React.Component {
               onChange={this.onAuditParametersChange}
             />
           </bem.FormBuilderMeta__row>
-        }
+        )}
 
-        {this.isBackgroundAudioEnabled() &&
+        {this.isBackgroundAudioEnabled() && (
           <bem.FormBuilderMeta__row>
             <bem.FormModal__item>
-              <label>
-                {t('Audio quality')}
-              </label>
+              <label>{t('Audio quality')}</label>
 
               <Select
                 className='kobo-select'
@@ -279,8 +284,7 @@ export default class MetadataEditor extends React.Component {
               />
             </bem.FormModal__item>
           </bem.FormBuilderMeta__row>
-        }
-
+        )}
       </bem.FormBuilderMeta>
     );
   }

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -206,7 +206,7 @@ export default class MetadataEditor extends React.Component {
 
           <bem.FormModal__item>
             <label className='long'>
-              {t('This functionality is only available for KoboCollect')}
+              {t('This functionality is only available for Collect')}
             </label>
 
             <ToggleSwitch

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -2,6 +2,8 @@ import React from 'react';
 import autoBind from 'react-autobind';
 import Checkbox from 'js/components/common/checkbox';
 import TextBox from 'js/components/common/textBox';
+import ToggleSwitch from 'js/components/common/toggleSwitch';
+import Select from 'react-select';
 import {assign} from 'utils';
 import {
   META_QUESTION_TYPES,
@@ -10,6 +12,14 @@ import {bem} from 'js/bem';
 import {stores} from 'js/stores';
 
 const AUDIT_SUPPORT_URL = 'audit_logging.html';
+const RECORDING_SUPPORT_URL = 'recording-interviews.html';
+
+const AUDIO_QUALITY_OPTIONS = [
+  {value: 'quality=low', label: 'Low'},
+  {value: 'quality=normal', label: 'Normal'},
+  {value: 'quality=voice-only', label: 'Voice only'},
+];
+const ODK_DEFAULT_AUDIO_QUALITY = AUDIO_QUALITY_OPTIONS[2];
 
 /**
  * @prop {object} survey
@@ -74,6 +84,24 @@ export default class MetadataEditor extends React.Component {
     return metaProp.value === true;
   }
 
+  onBackgroundAudioParametersChange(newVal) {
+    this.getSurveyDetail(META_QUESTION_TYPES['background-audio']).set(
+      'parameters',
+      newVal.value
+    );
+    this.rebuildState();
+    if (typeof this.props.onChange === 'function') {
+      this.props.onChange();
+    }
+  }
+
+  isBackgroundAudioEnabled() {
+    const metaProp = this.getMetaProperty(
+      META_QUESTION_TYPES['background-audio']
+    );
+    return metaProp.value === true;
+  }
+
   getAuditParameters() {
     const metaProp = this.getMetaProperty(META_QUESTION_TYPES.audit);
     return metaProp.parameters;
@@ -88,6 +116,25 @@ export default class MetadataEditor extends React.Component {
           stores.serverEnvironment.state.support_url &&
           <bem.TextBox__labelLink
             href={stores.serverEnvironment.state.support_url + AUDIT_SUPPORT_URL}
+            target='_blank'
+          >
+            <i className='k-icon k-icon-help'/>
+          </bem.TextBox__labelLink>
+        }
+      </React.Fragment>
+    );
+  }
+
+  renderBackgroundAudioLabel() {
+    return (
+      <React.Fragment>
+        {t('Background audio')}
+
+        { stores.serverEnvironment &&
+          stores.serverEnvironment.state.support_url &&
+          <bem.TextBox__labelLink
+            // TODO update support article to include background-audio
+            href={stores.serverEnvironment.state.support_url + RECORDING_SUPPORT_URL}
             target='_blank'
           >
             <i className='k-icon k-icon-help'/>
@@ -115,6 +162,10 @@ export default class MetadataEditor extends React.Component {
       META_QUESTION_TYPES.subscriberid,
       META_QUESTION_TYPES.phonenumber,
     ];
+
+    let backgroundAudioProp = this.getMetaProperty(
+      META_QUESTION_TYPES['background-audio']
+    );
 
     return (
       <bem.FormBuilderMeta>
@@ -148,6 +199,29 @@ export default class MetadataEditor extends React.Component {
           </bem.FormBuilderMeta__column>
         </bem.FormBuilderMeta__columns>
 
+        <bem.FormBuilderMeta__row m='background-audio'>
+          <bem.FormBuilderAside__header>
+            {this.renderBackgroundAudioLabel()}
+          </bem.FormBuilderAside__header>
+
+          <bem.FormModal__item>
+            <label className='long'>
+              {t('This functionality is only available for KoboCollect')}
+            </label>
+
+            <ToggleSwitch
+              checked={backgroundAudioProp.value}
+              onChange={this.onCheckboxChange.bind(this, backgroundAudioProp.name)}
+              label={
+                backgroundAudioProp.value
+                  ? t('This survey will be recorded')
+                  : t('Enable audio recording in the background')
+              }
+            />
+          </bem.FormModal__item>
+
+        </bem.FormBuilderMeta__row>
+
         {this.isAuditEnabled() &&
           <bem.FormBuilderMeta__row>
             <TextBox
@@ -155,6 +229,24 @@ export default class MetadataEditor extends React.Component {
               value={this.getAuditParameters()}
               onChange={this.onAuditParametersChange}
             />
+          </bem.FormBuilderMeta__row>
+        }
+
+        {this.isBackgroundAudioEnabled() &&
+          <bem.FormBuilderMeta__row>
+            <bem.FormModal__item>
+              <label>
+                {t('Audio quality')}
+              </label>
+
+              <Select
+                className='kobo-select'
+                classNamePrefix='kobo-select'
+                defaultValue={ODK_DEFAULT_AUDIO_QUALITY}
+                options={AUDIO_QUALITY_OPTIONS}
+                onChange={this.onBackgroundAudioParametersChange}
+              />
+            </bem.FormModal__item>
           </bem.FormBuilderMeta__row>
         }
 

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -241,7 +241,12 @@ export default class MetadataEditor extends React.Component {
 
           <bem.FormModal__item>
             <label className='long'>
-              {t('This functionality is only available for Collect')}
+              {t('This functionality is available in ')}
+              <a title="Install KoBoCollect"
+                target="_blank"
+                href='https://play.google.com/store/apps/details?id=org.koboc.collect.android'>
+                {t('Collect version 1.30 and above')}
+              </a>
             </label>
 
             <ToggleSwitch

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -7,6 +7,8 @@ import Select from 'react-select';
 import {assign} from 'utils';
 import {
   META_QUESTION_TYPES,
+  SURVEY_DETAIL_ATTRIBUTES,
+  FUNCTION_TYPE,
 } from 'js/constants';
 import {bem} from 'js/bem';
 import {stores} from 'js/stores';
@@ -64,17 +66,32 @@ export default class MetadataEditor extends React.Component {
   }
 
   onCheckboxChange(name, isChecked) {
-    this.getSurveyDetail(name).set('value', isChecked);
+    this.getSurveyDetail(name).set(
+      SURVEY_DETAIL_ATTRIBUTES.value.id,
+      isChecked
+    );
+    // Append parameters column with ODK_DEFAULT_AUDIO_QUALITY by default for
+    // background-audio type
+    if (isChecked && name === META_QUESTION_TYPES['background-audio']) {
+      this.getSurveyDetail(name).set(
+        SURVEY_DETAIL_ATTRIBUTES.parameters.id,
+        ODK_DEFAULT_AUDIO_QUALITY.value
+      );
+    }
+
     this.rebuildState();
-    if (typeof this.props.onChange === 'function') {
+    if (typeof this.props.onChange === FUNCTION_TYPE.function.id) {
       this.props.onChange();
     }
   }
 
   onAuditParametersChange(newVal) {
-    this.getSurveyDetail(META_QUESTION_TYPES.audit).set('parameters', newVal);
+    this.getSurveyDetail(META_QUESTION_TYPES.audit).set(
+      SURVEY_DETAIL_ATTRIBUTES.parameters.id,
+      newVal
+    );
     this.rebuildState();
-    if (typeof this.props.onChange === 'function') {
+    if (typeof this.props.onChange === FUNCTION_TYPE.function.id) {
       this.props.onChange();
     }
   }
@@ -86,11 +103,11 @@ export default class MetadataEditor extends React.Component {
 
   onBackgroundAudioParametersChange(newVal) {
     this.getSurveyDetail(META_QUESTION_TYPES['background-audio']).set(
-      'parameters',
+      SURVEY_DETAIL_ATTRIBUTES.parameters.id,
       newVal.value
     );
     this.rebuildState();
-    if (typeof this.props.onChange === 'function') {
+    if (typeof this.props.onChange === FUNCTION_TYPE.function.id) {
       this.props.onChange();
     }
   }
@@ -100,6 +117,19 @@ export default class MetadataEditor extends React.Component {
       META_QUESTION_TYPES['background-audio']
     );
     return metaProp.value === true;
+  }
+
+  getBackgroundAudioParameters() {
+    const metaProp = this.getMetaProperty(
+      META_QUESTION_TYPES['background-audio']
+    );
+    let foundParams = ODK_DEFAULT_AUDIO_QUALITY;
+    if (metaProp.parameters) {
+      foundParams = AUDIO_QUALITY_OPTIONS.find(
+        (option) => option.value === metaProp.parameters
+      );
+    }
+    return foundParams;
   }
 
   getAuditParameters() {
@@ -242,11 +272,7 @@ export default class MetadataEditor extends React.Component {
               <Select
                 className='kobo-select'
                 classNamePrefix='kobo-select'
-                /*
-                  defaultValue only displays the default value, it does not
-                  append it to the JSON. If there is no quality parameter then
-                  it would default to ODK_DEFAULT_AUDIO_QUALITY behind the scenes
-                */
+                value={this.getBackgroundAudioParameters()}
                 defaultValue={ODK_DEFAULT_AUDIO_QUALITY}
                 options={AUDIO_QUALITY_OPTIONS}
                 onChange={this.onBackgroundAudioParametersChange}

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -242,6 +242,11 @@ export default class MetadataEditor extends React.Component {
               <Select
                 className='kobo-select'
                 classNamePrefix='kobo-select'
+                {/*
+                  defaultValue only displays the default value, it does not
+                  append it to the JSON. If there is no quality parameter then
+                  it would default to ODK_DEFAULT_AUDIO_QUALITY behind the scenes
+                */}
                 defaultValue={ODK_DEFAULT_AUDIO_QUALITY}
                 options={AUDIO_QUALITY_OPTIONS}
                 onChange={this.onBackgroundAudioParametersChange}

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -199,6 +199,7 @@ new Set([
   'deviceid',
   'phonenumber',
   'audit',
+  'background-audio',
 ]).forEach((codename) => {META_QUESTION_TYPES[codename] = codename;});
 Object.freeze(META_QUESTION_TYPES);
 

--- a/jsapp/js/constants.es6
+++ b/jsapp/js/constants.es6
@@ -367,6 +367,22 @@ export const COLLECTION_METHODS = Object.freeze({
   },
 });
 
+
+export const SURVEY_DETAIL_ATTRIBUTES = Object.freeze({
+  value: {
+    id: 'value',
+  },
+  parameters: {
+    id: 'parameters',
+  },
+});
+
+export const FUNCTION_TYPE = Object.freeze({
+  function: {
+    id: 'function',
+  },
+});
+
 // NOTE: The default export is mainly for tests
 const constants = {
   ROOT_URL,
@@ -396,6 +412,8 @@ const constants = {
   ROUTES,
   QUERY_LIMIT_DEFAULT,
   CHOICE_LISTS,
+  SURVEY_DETAIL_ATTRIBUTES,
+  FUNCTION_TYPE,
 };
 
 export default constants;

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -700,7 +700,7 @@ export default assign({
           <i className='k-icon k-icon-form-overview'/>
         </span>
 
-        <p>{t('This form will automatically record audio in the background. Consider adding an acknowledgement note to inform respondents or data collectors that they will be recorded while completing this survey. This functionality only works in KoboCollect.')}</p>
+        <p>{t('This form will automatically record audio in the background. Consider adding an acknowledgement note to inform respondents or data collectors that they will be recorded while completing this survey. This functionality only works in Collect.')}</p>
 
         { stores.serverEnvironment &&
           stores.serverEnvironment.state.support_url &&

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -24,6 +24,7 @@ import {
   update_states,
   NAME_MAX_LENGTH,
   ROUTES,
+  META_QUESTION_TYPES,
 } from 'js/constants';
 import ui from '../ui';
 import {bem} from '../bem';
@@ -41,6 +42,8 @@ const WEBFORM_STYLES_SUPPORT_URL = 'alternative_enketo.html';
 const UNSAVED_CHANGES_WARNING = t('You have unsaved changes. Leave form without saving?');
 
 const ASIDE_CACHE_NAME = 'kpi.editable-form.aside';
+
+const RECORDING_SUPPORT_URL = 'recording-interviews.html';
 
 /**
  * This is a component that displays Form Builder's header and aside. It is also
@@ -516,6 +519,12 @@ export default assign({
     this.safeNavigateToRoute(targetRoute);
   },
 
+  hasBackgroundAudio() {
+    return this.app?.survey?.surveyDetails.filter(
+      (sd) => sd.attributes.name === META_QUESTION_TYPES['background-audio']
+    )[0].attributes.value;
+  },
+
   // rendering methods
 
   renderFormBuilderHeader () {
@@ -684,6 +693,33 @@ export default assign({
     );
   },
 
+  renderBackgroundAudioWarning() {
+    return (
+      <bem.FormBuilderMessageBox m='warning'>
+        <span data-tip={t('background recording')}>
+          <i className='k-icon k-icon-form-overview'/>
+        </span>
+
+        <p>{t('This form will automatically record audio in the background. Consider adding an acknowledgement note to inform respondents or data collectors that they will be recorded while completing this survey. This functionality only works in KoboCollect.')}</p>
+
+        { stores.serverEnvironment &&
+          stores.serverEnvironment.state.support_url &&
+          <bem.TextBox__labelLink
+            // TODO update support article to include background-audio
+            href={
+              stores.serverEnvironment.state.support_url +
+              RECORDING_SUPPORT_URL
+            }
+            target='_blank'
+            data-tip={t('help')}
+          >
+            <i className='k-icon k-icon-help' />
+          </bem.TextBox__labelLink>
+        }
+      </bem.FormBuilderMessageBox>
+    );
+  },
+
   renderAside() {
     let {
       styleValue,
@@ -770,6 +806,7 @@ export default assign({
             }
           </bem.FormBuilderAside__content>
         }
+
         { this.state.asideLibrarySearchVisible &&
           <bem.FormBuilderAside__content>
             <bem.FormBuilderAside__row>
@@ -832,6 +869,10 @@ export default assign({
             {this.renderFormBuilderHeader()}
 
               <bem.FormBuilder__contents>
+                {this.hasBackgroundAudio() &&
+                  this.renderBackgroundAudioWarning()
+                }
+
                 <div ref='form-wrap' className='form-wrap'>
                   {!this.state.surveyAppRendered &&
                     this.renderNotLoadedMessage()

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -700,7 +700,15 @@ export default assign({
           <i className='k-icon k-icon-form-overview'/>
         </span>
 
-        <p>{t('This form will automatically record audio in the background. Consider adding an acknowledgement note to inform respondents or data collectors that they will be recorded while completing this survey. This functionality only works in Collect.')}</p>
+        <p>
+          {t('This form will automatically record audio in the background. Consider adding an acknowledgement note to inform respondents or data collectors that they will be recorded while completing this survey. This feature is available in ')}
+          <a title="Install KoBoCollect"
+            target="_blank"
+            href='https://play.google.com/store/apps/details?id=org.koboc.collect.android'>
+            {t('Collect version 1.30 and above')}
+          </a>
+          {'.'}
+        </p>
 
         { stores.serverEnvironment &&
           stores.serverEnvironment.state.support_url &&

--- a/jsapp/scss/components/_kobo.form-builder-message-box.scss
+++ b/jsapp/scss/components/_kobo.form-builder-message-box.scss
@@ -1,3 +1,5 @@
+$message-box-icon-size: 28px;
+
 .form-builder-message-box {
   width: 100%;
   margin: 0 auto 20px;
@@ -11,7 +13,7 @@
 
   i {
     color: $kobo-white;
-    font-size: 28px;
+    font-size: $message-box-icon-size;
     margin-right: 5px;
     vertical-align: -11px;
     display: inline-block;
@@ -21,6 +23,10 @@
     margin: 0;
     flex: 1;
     padding: 0 5px;
+  }
+
+  span {
+    cursor: default;
   }
 
   .form-builder-message-box__toggle {
@@ -49,5 +55,25 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-around;
+  }
+}
+
+.form-builder-message-box--warning {
+  background-color: $kobo-orange-light;
+  color: $kobo-orange-dark;
+
+  a {
+    width: $message-box-icon-size;
+    cursor: pointer;
+  }
+
+  i {
+    color: $kobo-orange-dark;
+  }
+
+  p {
+    margin-left: 12px;
+    margin-right: 12px;
+    font-weight: 500;
   }
 }

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -410,6 +410,22 @@ $s-form-builder-content-width: 1024px;
     margin-top: 10px;
   }
 
+  .form-builder-meta__row--background-audio {
+    margin-top: 20px;
+
+    .form-builder-aside__header {
+      margin-bottom: 0;
+    }
+
+    .toggle-switch {
+      margin-top: 10px;
+    }
+
+    label {
+      font-weight: 500;
+    }
+  }
+
   .form-builder-meta__column {
     flex: 1;
     margin-right: 10px;

--- a/jsapp/xlform/src/model.configs.coffee
+++ b/jsapp/xlform/src/model.configs.coffee
@@ -61,6 +61,11 @@ module.exports = do ->
       label: "audit"
       description: "Records the behavior of enumerators as they navigate through a form"
       default: false
+    bg_aud:
+      name: "background-audio"
+      label: "background audio"
+      description: "record bg audio"
+      default: false
 
   do ->
     class SurveyDetailSchemaItem extends Backbone.Model

--- a/test/xlform/model.tests.coffee
+++ b/test/xlform/model.tests.coffee
@@ -187,6 +187,59 @@ xlform_survey_model = ($model)->
       expect(processed_required(`undefined`)).toEqual('false')
       expect(processed_required('')).toEqual('false')
 
+  describe 'test start questions', ->
+    beforeEach ->
+      @srv = $model.Survey.loadDict({
+        survey: [
+          {
+            type: 'start',
+            name: 'start',
+          },
+        ]
+      })
+    it "loads start meta question", ->
+      start_sd = @srv.surveyDetails.get('start')
+      expect(start_sd.get('name')).toEqual('start')
+      expect(start_sd.get('value')).toEqual(true)
+
+  describe 'test background-audio questions', ->
+    beforeEach ->
+      @srv = $model.Survey.loadDict({
+        survey: [
+          {
+            type: 'background-audio',
+            name: 'background-audio',
+          },
+        ]
+      })
+
+    it "loads background-audio with parameters", ->
+      srv = $model.Survey.loadDict({
+        survey: [
+          {
+            type: 'background-audio',
+            name: 'background-audio',
+            parameters: 'quality=99'
+          },
+        ]
+      })
+      exported = srv.toJSON()
+      expect(exported.survey[0].parameters).toEqual('quality=99')
+
+    it "loads bg audio meta question", ->
+      sd1 = @srv.surveyDetails.get('background-audio')
+      expect(sd1.get('name')).toEqual('background-audio')
+      expect(sd1.get('value')).toEqual(true)
+
+    it "when value is false (un-checked in the interace), no row is added", ->
+      @srv.surveyDetails.get('background-audio').set('value', false)
+      exported = @srv.toJSON()
+      expect(exported.survey.length).toEqual(0)
+
+    it "exports to json properly", ->
+      exported = @srv.toJSON()
+      expect(exported.survey[0].type).toEqual('background-audio')
+      expect(exported.survey[0].name).toEqual('background-audio')
 
     it "captures required values", ->
       srv = $model.Survey.loadDict({


### PR DESCRIPTION
## Description

Can now add a [`background-audio` meta question](https://docs.getodk.org/form-question-types/#background-audio-recording) to forms via the formbuilder sidebar:

![image](https://user-images.githubusercontent.com/16762675/121569964-5f68c300-c9ef-11eb-9bd9-f74994db9102.png)


## Related issues
Formbuilder side of things of #3193 
Fixes #3275 