### PR TITLE
MongoDB query timeout calculation fix

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -700,7 +700,7 @@ MONGO_CONNECTION = MongoClient(
     MONGO_CONNECTION_URL, j=True, tz_aware=True, connect=False)
 MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
 
-MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 60 * 1000
+MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 1000
 
 SESSION_ENGINE = "redis_sessions.session"
 SESSION_REDIS = RedisHelper.config(default="redis://redis_cache:6380/2")


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

MongoDB query timeout, which is in millisecond, is based on Celery timeout, which is in seconds.
The calculation on MongoDB was wrong. It was converted from minutes to milliseconds instead instead of
seconds to milliseconds.

## Related issues

Fixes #3283 
Related to kobotoolbox/kobocat#731