### PR TITLE
Remove unnecessary filter from database queries

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -929,7 +929,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
         queryset = ReadOnlyKobocatInstance.objects.filter(
             xform_id=self.xform_id,
-            deleted_at=None
         )
 
         if len(instance_ids) > 0 or use_mongo:

--- a/kpi/tests/test_mongo_decoding.py
+++ b/kpi/tests/test_mongo_decoding.py
@@ -6,6 +6,7 @@ from kpi.utils.mongo_helper import MongoHelper
 
 
 def get_instances_from_mongo():
+    # TODO: remove this as we no longer use `_deleted_at`
     query = {'_deleted_at': {'$exists': False}}
     instances = settings.MONGO_DB.instances.find(query)
     return (

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -63,12 +63,11 @@ class MongoHelper:
 
     @classmethod
     def get_count(
-            cls, mongo_userform_id, hide_deleted=True, query=None, instance_ids=None,
+            cls, mongo_userform_id, query=None, instance_ids=None,
             permission_filters=None):
 
         _, total_count = cls._get_cursor_and_count(
             mongo_userform_id,
-            hide_deleted=hide_deleted,
             fields={'_id': 1},
             query=query,
             instance_ids=instance_ids,
@@ -78,13 +77,12 @@ class MongoHelper:
 
     @classmethod
     def get_instances(
-            cls, mongo_userform_id, hide_deleted=True, start=None, limit=None,
+            cls, mongo_userform_id, start=None, limit=None,
             sort=None, fields=None, query=None, instance_ids=None,
             permission_filters=None
     ):
         cursor, total_count = cls._get_cursor_and_count(
             mongo_userform_id,
-            hide_deleted=hide_deleted,
             fields=fields,
             query=query,
             instance_ids=instance_ids,
@@ -252,7 +250,7 @@ class MongoHelper:
                cls.KEY_WHITELIST and (key.startswith('$') or key.count('.') > 0)
 
     @classmethod
-    def _get_cursor_and_count(cls, mongo_userform_id, hide_deleted=True,
+    def _get_cursor_and_count(cls, mongo_userform_id,
                               fields=None, query=None, instance_ids=None,
                               permission_filters=None):
 
@@ -270,14 +268,6 @@ class MongoHelper:
                 permission_filters_query['$or'].append(permission_filter)
 
             query = {'$and': [query, permission_filters_query]}
-
-        if hide_deleted:
-            # display only active elements
-            deleted_at_query = {
-                '$or': [{'_deleted_at': {'$exists': False}},
-                        {'_deleted_at': None}]}
-            # join existing query with deleted_at_query on an $and
-            query = {'$and': [query, deleted_at_query]}
 
         query = cls.to_safe_dict(query, reading=True)
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)

## Description

When deleting submissions through the legacy KoBoCAT UI, a special marker was applied to the "deleted" submissions instead of removing them outright. This meant that every query to retrieve submitted data needed to filter out submissions having this marker. We now always remove submissions outright when deleting and therefore no longer need this extra filter, which caused high database overhead.

## Related issues

Part of kobotoolbox/kobocat#696