### PR TITLE
Allow viewing REST services settings for archived forms

### DIFF
--- a/jsapp/js/components/formViewTabs.es6
+++ b/jsapp/js/components/formViewTabs.es6
@@ -167,7 +167,9 @@ class FormViewTabs extends Reflux.Component {
       sideTabs.push({label: t('Sharing'), icon: 'k-icon-user-share', path: `/forms/${this.state.assetid}/settings/sharing`});
 
       if (
-        this.state.asset.deployment__active &&
+        (this.state.asset.deployment__active ||
+          // REST services should be visible for archived forms but not drafts
+          this.state.asset.deployed_versions.count > 0) &&
         mixins.permissions.userCan(PERMISSIONS_CODENAMES.view_submissions, this.state.asset) &&
         mixins.permissions.userCan(PERMISSIONS_CODENAMES.change_asset, this.state.asset)
       ) {


### PR DESCRIPTION
## Description

REST services are now reachable for archived forms. Form media is already reachable after the form media updates (no changes required) 

## Related issues

Fixes #3290 
