### PR TITLE
Support anonymous exports

### DIFF
--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -26,6 +26,7 @@ from formpack.constants import (
 
 from kpi.fields import ReadOnlyJSONField
 from kpi.models import ExportTask, Asset
+from kpi.models.object_permission import get_anonymous_user
 from kpi.tasks import export_in_background
 from kpi.utils.export_task import format_exception_values
 
@@ -56,8 +57,11 @@ class ExportTaskSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: dict) -> ExportTask:
         # Create a new export task
+        user = self._get_request.user
+        if user.is_anonymous:
+            user = get_anonymous_user()
         export_task = ExportTask.objects.create(
-            user=self._get_request.user, data=validated_data
+            user=user, data=validated_data
         )
         # Have Celery run the export in the background
         export_in_background.delay(export_task_uid=export_task.uid)

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -21,11 +21,12 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
 
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
-    def _create_export_task(self, asset=None, _type='csv'):
+    def _create_export_task(self, asset=None, user=None, _type='csv'):
         uid = self.asset.uid if asset is None else asset.uid
+        user = self.user if user is None else user
 
         export_task = ExportTask()
-        export_task.user = self.user
+        export_task.user = user
         export_task.data = {
             'source': reverse(
                 self._get_endpoint('asset-detail'),
@@ -81,6 +82,46 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         )
         response = self.client.get(list_url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_export_task_list_anon_public_asset(self):
+        # make submissions public
+        self.asset.assign_perm(get_anonymous_user(), PERM_VIEW_SUBMISSIONS)
+        for _type in ['csv', 'xls', 'spss_labels']:
+            self._create_export_task(_type=_type)
+
+        self.client.logout()
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'parent_lookup_asset': self.asset.uid},
+        )
+        response = self.client.get(list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        # should not list any results as exports were created by another user
+        assert not data['results']
+
+    def test_create_export_anon(self):
+        anon = get_anonymous_user()
+        self.asset.assign_perm(anon, PERM_VIEW_SUBMISSIONS)
+        self._create_export_task(_type='xls', user=self.user)
+
+        self.client.logout()
+        self._create_export_task(_type='xls', user=anon)
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'parent_lookup_asset': self.asset.uid},
+        )
+        response = self.client.get(list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        # two total exports on asset, but only one by anon
+        assert len(data['results']) == 1
+
+        download_url = data['results'][0]['result']
+        download_response = self.client.get(download_url)
+        assert download_response.status_code == status.HTTP_200_OK
 
     def test_export_task_list_anotheruser(self):
         for _type in ['csv', 'xls', 'spss_labels']:

--- a/kpi/utils/private_storage.py
+++ b/kpi/utils/private_storage.py
@@ -2,6 +2,7 @@
 from rest_framework.request import Request as DRFRequest
 from rest_framework.settings import api_settings
 
+from kpi.models.object_permission import get_anonymous_user
 
 def superuser_or_username_matches_prefix(private_file):
     """
@@ -27,11 +28,12 @@ def superuser_or_username_matches_prefix(private_file):
             private_file.request,
             authenticators=[
                 auth() for auth in api_settings.DEFAULT_AUTHENTICATION_CLASSES
-            ]
+            ],
         )
         user = request.user
-        if not user.is_authenticated:
-            return False
+
+    if user.is_anonymous:
+        user = get_anonymous_user()
 
     if user.is_superuser:
         return True

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -13,6 +13,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from kpi.filters import SearchFilter
 from kpi.models import ExportTask
+from kpi.models.object_permission import get_anonymous_user
 from kpi.permissions import ExportTaskPermission
 from kpi.serializers.v2.export_task import ExportTaskSerializer
 from kpi.tasks import export_in_background
@@ -146,8 +147,11 @@ class ExportTaskViewSet(
     ]
 
     def get_queryset(self):
+        user = self.request.user
+        if user.is_anonymous:
+            user = get_anonymous_user()
         return self.model.objects.filter(
-            user=self.request.user,
+            user=user,
             data__source__icontains=self.kwargs['parent_lookup_asset'],
         )
 


### PR DESCRIPTION
## Description

Allow anonymous users on publicly shared assets (`AnonymousUser` has `view_submissions` permission) to create exports, list exports created by `AnonymousUser` and download the resulting file.

## Related issues

closes #3293 
