### PR TITLE
Void dynamic data attachment cache on preview

### DIFF
--- a/kpi/models/paired_data.py
+++ b/kpi/models/paired_data.py
@@ -264,6 +264,12 @@ class PairedData(OpenRosaManifestInterface,
             create_version=False,
         )
 
+    def void_external_xml_cache(self):
+        # We delete the content of `self.asset_file` to force its regeneration
+        # when the 'xml_endpoint' is called
+        if self.asset_file and self.asset_file.content:
+            self.asset_file.content.delete()
+
     def update(self, updated_values):
         for key, value in updated_values.items():
             if not hasattr(self, key):
@@ -272,8 +278,5 @@ class PairedData(OpenRosaManifestInterface,
                 )
             setattr(self, key, value)
 
-        # We delete the content of `self.asset_file` to force its regeneration
-        # when the 'xml_endpoint' is called
-        if self.asset_file and self.asset_file.content:
-            self.asset_file.content.delete()
+        self.void_external_xml_cache()
 

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -85,8 +85,13 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
                 date_deleted__isnull=True,
             )
         )
-        paired_data_files = list(PairedData.objects(asset).values())
-        files = form_media_files + paired_data_files
+        files = form_media_files
+        # paired data files are treated differently from form media files
+        # void any cache when previewing the form
+        for paired_data in PairedData.objects(asset).values():
+            paired_data.void_external_xml_cache()
+            files.append(paired_data)
+
         context = {'request': request}
         serializer = ManifestSerializer(files, many=True, context=context)
 

--- a/kpi/views/v2/paired_data.py
+++ b/kpi/views/v2/paired_data.py
@@ -242,6 +242,7 @@ class PairedDataViewset(AssetNestedObjectViewsetMixin,
                     timedelta.total_seconds() > settings.PAIRED_DATA_EXPIRATION
                 )
 
+        # ToDo evaluate adding headers for caching and a HTTP 304 status code
         if not has_expired:
             return Response(asset_file.content.file.read().decode())
 
@@ -267,6 +268,11 @@ class PairedDataViewset(AssetNestedObjectViewsetMixin,
             f'{parsed_submissions_to_str}'
             f'</{root_tag_name}>'
         )
+
+        if not parsed_submissions:
+            # We do not want to cache an empty file
+            return Response(xml_)
+
         # We need to delete the current file (if it exists) when filename
         # has changed. Otherwise, it would leave an orphan file on storage
         if asset_file.pk and asset_file.content.name != filename:


### PR DESCRIPTION
## Description
Dynamic data attachment is cached 5 minutes by default. Any new submissions that come in the source project are available in the destination project up to 5 minutes later. 
It can be inconvenient when starting a project (e.g. testing formulas), the cache is voided each time the destination project is previewed.

## Related

Part of #3057 
