### PR TITLE
Describe submissions API unit tests

### DIFF
--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -306,7 +306,6 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
 
         Test that another cannot delete someuser's data
         """
-        # FIXME when merging kpi#3358
         self._log_in_as_another_user()
         partial_perms = {
             PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}],
@@ -330,12 +329,6 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_ids = [int(sub['_id']) for sub in response.data['results']]
         self.assertEqual(sorted(response_ids), sorted(viewable_submission_ids))
-
-        data = {
-            'payload': {
-                'submission_ids': viewable_submission_ids
-            }
-        }
 
         # Try to delete all viewable submissions
         data = {
@@ -976,6 +969,7 @@ class SubmissionViewApiTests(BaseSubmissionTestCase):
         response = self.client.get(self.submission_view_link_url, {'format': 'json'})
         assert response.status_code == status.HTTP_200_OK
 
+    # FIXME when merging kpi#3358
     def test_get_view_link_with_partial_perms_as_anotheruser(self):
         """
         someuser is the owner of the project.

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -306,7 +306,7 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
 
         Test that another cannot delete someuser's data
         """
-
+        # FIXME when merging kpi#3358
         self._log_in_as_another_user()
         partial_perms = {
             PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}],

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -140,6 +140,10 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         )
 
     def test_delete_submissions_as_owner(self):
+        """
+        someuser is the project owner
+        someuser can delete their own data
+        """
         data = {'payload': {'confirm': True}}
         response = self.client.delete(self.submission_bulk_url,
                                       data=data,
@@ -150,6 +154,12 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['count'], 0)
 
     def test_delete_submissions_as_anonymous(self):
+        """
+        someuser is the project owner.
+        The project is not shared publicly.
+        anonymous cannot view someuser's data, therefore cannot delete it.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         data = {'payload': {'confirm': True}}
         response = self.client.delete(self.submission_bulk_url,
@@ -158,6 +168,12 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_not_shared_submissions_as_anotheruser(self):
+        """
+        someuser is the project owner.
+        The project is not shared with anyone.
+        anotheruser cannot view someuser's data, therefore cannot delete it.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         data = {'payload': {'confirm': True}}
         response = self.client.delete(self.submission_bulk_url,
@@ -166,6 +182,12 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_shared_submissions_as_anotheruser(self):
+        """
+        someuser is the project owner.
+        The project is shared with anotheruser.
+        anotheruser can delete someuser's data.
+        """
+
         self.asset.assign_perm(self.anotheruser, PERM_DELETE_SUBMISSIONS)
         self._log_in_as_another_user()
         data = {'payload': {'confirm': True}}
@@ -178,6 +200,14 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['count'], 0)
 
     def test_delete_all_allowed_submissions_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the project owner.
+        anotheruser has partial permissions and can view and delete their own
+        submitted data
+
+        Test that anotheruser can delete all their data at once and if they do,
+        only delete their data.
+        """
         self._log_in_as_another_user()
         partial_perms = {
             PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
@@ -223,6 +253,13 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         )
 
     def test_delete_some_allowed_submissions_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the project owner.
+        anotheruser has partial permissions and can view and delete their own
+        submitted data
+
+        Test that anotheruser can delete part of their data
+        """
         self._log_in_as_another_user()
         partial_perms = {
             PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
@@ -262,10 +299,79 @@ class BulkDeleteSubmissionsApiTests(BaseSubmissionTestCase):
         response = self.client.get(self.submission_list_url, {'format': 'json'})
         self.assertEqual(response.data['count'], count - len(random_submissions))
 
+    def test_cannot_delete_view_only_submissions_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project
+        anotheruser is allowed to view someuser's data and delete their own data
+
+        Test that another cannot delete someuser's data
+        """
+
+        self._log_in_as_another_user()
+        partial_perms = {
+            PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}],
+            PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]  # view_submission is implied
+        }
+
+        # Allow anotheruser to delete their own data
+        self.asset.assign_perm(
+            self.anotheruser,
+            PERM_PARTIAL_SUBMISSIONS,
+            partial_perms=partial_perms,
+        )
+
+        # Try to view all submissions
+        viewable_submissions = (
+            self.submissions_submitted_by_anotheruser
+            + self.submissions_submitted_by_someuser
+        )
+        viewable_submission_ids = [int(sub['_id']) for sub in viewable_submissions]
+        response = self.client.get(self.submission_list_url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_ids = [int(sub['_id']) for sub in response.data['results']]
+        self.assertEqual(sorted(response_ids), sorted(viewable_submission_ids))
+
+        data = {
+            'payload': {
+                'submission_ids': viewable_submission_ids
+            }
+        }
+
+        # Try to delete all viewable submissions
+        data = {
+            'payload': {
+                'submission_ids': viewable_submission_ids
+            }
+        }
+        response = self.client.delete(self.submission_bulk_url,
+                                      data=data,
+                                      format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Try to delete someuser's data
+        data = {
+            'payload': {
+                'submission_ids': [
+                    sub['_id'] for sub in self.submissions_submitted_by_someuser
+                ]
+            }
+        }
+        response = self.client.delete(self.submission_bulk_url,
+                                      data=data,
+                                      format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class SubmissionApiTests(BaseSubmissionTestCase):
 
     def test_cannot_create_submission(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared publicly.
+        anotheruser has view access on someuser's data
+
+        Test that no one can create submissions (with KPI endpoint)
+        """
         submission = {
             "q1": "a5",
             "q2": "a6",
@@ -286,12 +392,21 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_list_submissions_as_owner(self):
+        """
+        someuser is the owner of the project.
+        They can list their own data
+        """
         response = self.client.get(self.submission_list_url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('results'), self.submissions)
         self.assertEqual(response.data.get('count'), len(self.submissions))
 
     def test_list_submissions_as_owner_with_params(self):
+        """
+        someuser is the owner of the project.
+        They can list their own data and they can narrow down the results with
+        params
+        """
         response = self.client.get(
             self.submission_list_url, {
                 'format': 'json',
@@ -307,6 +422,10 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_submissions_limit(self):
+        """
+        someuser is the owner of the project.
+        Test that hard-coded maximum limit cannot be exceeded by user's requests.
+        """
         limit = settings.SUBMISSION_LIST_LIMIT
         excess = 10
         asset = Asset.objects.create(
@@ -342,11 +461,21 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(len(response.data['results']), limit)
 
     def test_list_submissions_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser cannot view someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.get(self.submission_list_url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_list_submissions_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has view access on someuser's data. They can view all
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.get(self.submission_list_url, {"format": "json"})
@@ -355,6 +484,11 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data.get('count'), len(self.submissions))
 
     def test_list_submissions_with_partial_permissions_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial view access on someuser's project.
+        They can view only the data they submitted to someuser's project.
+        """
         self._log_in_as_another_user()
         partial_perms = {
             PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
@@ -375,11 +509,22 @@ class SubmissionApiTests(BaseSubmissionTestCase):
             self.assertTrue(submission['_submitted_by'] == 'anotheruser')
 
     def test_list_submissions_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared publicly.
+        anonymous cannot view someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.get(self.submission_list_url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_list_submissions_asset_publicly_shared_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is shared publicly.
+        anonymous can view someuser's data
+        """
         self.client.logout()
         anonymous_user = get_anonymous_user()
         self.asset.assign_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
@@ -387,7 +532,14 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_list_submissions_asset_publicly_shared_as_authenticated_user(self):
-        """ https://github.com/kobotoolbox/kpi/issues/2698 """
+        """
+        someuser is the owner of the project.
+        The project is shared publicly.
+        anotheruser has view access on someuser's project.
+        Test if anotheruser can see someuser's data
+
+        See https://github.com/kobotoolbox/kpi/issues/2698
+        """
 
         anonymous_user = get_anonymous_user()
         self._log_in_as_another_user()
@@ -408,7 +560,7 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         """
         Running through behaviour described in issue kpi/#2870 where an asset
         that has been publicly shared and then explicity shared with a user, the
-        user has lower permissions than an anonymous user and is therefore
+        user has lower permissions than an anonymous and is therefore
         unable to view submission data.
         """
 
@@ -447,6 +599,10 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.asset.remove_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
 
     def test_retrieve_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can view one of their submission.
+        """
         submission = self.get_random_submission(self.asset.owner)
         url = self.asset.deployment.get_submission_detail_url(submission['_id'])
 
@@ -455,6 +611,11 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, submission)
 
     def test_retrieve_submission_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has no access to someuser's data
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         submission = self.get_random_submission(self.asset.owner)
         url = self.asset.deployment.get_submission_detail_url(submission['_id'])
@@ -462,6 +623,10 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_retrieve_submission_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has view access to someuser's data.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         submission = self.get_random_submission(self.asset.owner)
@@ -471,9 +636,14 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, submission)
 
     def test_retrieve_submission_with_partial_permissions_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial view access to someuser's data.
+        They can only see their own data.
+        """
         self._log_in_as_another_user()
         partial_perms = {
-            PERM_VIEW_SUBMISSIONS: [{'_submitted_by': self.someuser.username}]
+            PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
         }
         self.asset.assign_perm(self.anotheruser, PERM_PARTIAL_SUBMISSIONS,
                                partial_perms=partial_perms)
@@ -484,13 +654,17 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         response = self.client.get(url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        # Try second submission submitted by someuser
-        submission = self.get_random_submission(self.anotheruser)
+        # Try second submission submitted by another
+        submission = self.submissions_submitted_by_anotheruser[0]
         url = self._deployment.get_submission_detail_url(submission['_id'])
         response = self.client.get(url, {"format": "json"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_delete_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can delete their own data.
+        """
         submission = self.get_random_submission(self.asset.owner)
         url = self.asset.deployment.get_submission_detail_url(submission['_id'])
 
@@ -501,11 +675,22 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['count'], len(self.submissions) - 1)
 
     def test_delete_not_existing_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser should receive a 404 if they try to delete a non-existing
+        submission.
+        """
         url = self.asset.deployment.get_submission_detail_url(9999)
         response = self.client.delete(url, HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared publicly.
+        anonymous cannot view someuser's data, therefore they cannot delete it
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         submission = self.get_random_submission(self.asset.owner)
         url = self.asset.deployment.get_submission_detail_url(submission['_id'])
@@ -514,6 +699,12 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_submission_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anynone.
+        anotheruser cannot view someuser's data, therefore they cannot delete it.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         submission = self.get_random_submission(self.asset.owner)
         url = self.asset.deployment.get_submission_detail_url(submission['_id'])
@@ -522,6 +713,11 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_submission_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has view access to someuser's data.
+        anotheruser can view someuser's data but they cannot delete it.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         submission = self.get_random_submission(self.asset.owner)
@@ -543,12 +739,17 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['count'], len(self.submissions) - 1)
 
     def test_delete_submission_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial access to someuser's data.
+        anotheruser can only view/delete their data.
+        """
         self._log_in_as_another_user()
         partial_perms = {
-            PERM_DELETE_SUBMISSIONS: [{'_submitted_by': self.someuser.username}]
+            PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
         }
 
-        # Allow anotheruser to delete someuser's data
+        # Allow anotheruser to view/delete their own data
         self.asset.assign_perm(
             self.anotheruser,
             PERM_PARTIAL_SUBMISSIONS,
@@ -556,17 +757,15 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         )
 
         # Try first submission submitted by unknown
-        submission = self.get_random_submission(self.asset.owner)
+        submission = self.submissions_submitted_by_unknown[0]
         url = self._deployment.get_submission_detail_url(submission['_id'])
         response = self.client.delete(url,
                                       content_type='application/json',
                                       HTTP_ACCEPT='application/json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # Try second submission submitted by someuser
-        anotheruser_submission_count = (
-            self._deployment.calculated_submission_count(self.anotheruser)
-        )
+        # Try second submission submitted by anotheruser
+        anotheruser_submission_count = len(self.submissions_submitted_by_anotheruser)
         submission = self.get_random_submission(self.anotheruser)
         url = self._deployment.get_submission_detail_url(submission['_id'])
         response = self.client.delete(url,
@@ -601,6 +800,10 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         )
 
     def test_get_legacy_edit_link_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can retrieve enketo edit link
+        """
         response = self.client.get(self.submission_url_legacy, {'format': 'json'})
         assert response.status_code == status.HTTP_200_OK
 
@@ -610,6 +813,10 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         assert response.data == expected_response
 
     def test_get_edit_link_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can retrieve enketo edit link
+        """
         response = self.client.get(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_200_OK
 
@@ -618,74 +825,63 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, expected_response)
 
     def test_get_edit_link_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared publicly.
+        anonymous cannot view the project, therefore cannot edit data.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.get(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_edit_link_submission_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser cannot view the project, therefore cannot edit data.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.get(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_cannot_get_edit_link_submission_shared_with_view_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser can only view the project, therefore they cannot edit data.
+        someuser's data existence should not be revealed.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.get(self.submission_url, {'format': 'json'})
+
+        # FIXME if anotheruser has view permissions, they should receive a 403
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_edit_link_submission_shared_with_edit_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has 'change_submissions' permissions.
+        anotheruser can retrieve enketo edit link
+        """
         self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.get(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_200_OK
 
-
-class SubmissionViewApiTests(BaseSubmissionTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.submission = self.get_random_submission(self.asset.owner)
-        self.submission_url = reverse(
-            'submission-enketo-view',
-            kwargs={
-                'parent_lookup_asset': self.asset.uid,
-                'pk': self.submission['_id'],
-                'action': 'view'
-            },
-        )
-
-    def test_get_view_link_submission_as_owner(self):
-        response = self.client.get(self.submission_url, {'format': 'json'})
-        assert response.status_code == status.HTTP_200_OK
-
-        expected_response = {
-            'url': 'http://server.mock/enketo/{}'.format(self.submission['_id'])
-        }
-        assert response.data == expected_response
-
-    def test_get_view_link_submission_as_anonymous(self):
-        self.client.logout()
-        response = self.client.get(self.submission_url, {'format': 'json'})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_cannot_get_view_link_submission_not_shared_as_anotheruser(self):
-        self._log_in_as_another_user()
-        response = self.client.get(self.submission_url, {'format': 'json'})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_get_view_link_submission_shared_with_view_only_as_anotheruser(self):
-        self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
-        self._log_in_as_another_user()
-        response = self.client.get(self.submission_url, {'format': 'json'})
-        assert response.status_code == status.HTTP_200_OK
-
     def test_get_edit_link_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial permissions on someuser's data
+        anotheruser can only view/edit their own data
+        """
         self._log_in_as_another_user()
         partial_perms = {
-            PERM_CHANGE_SUBMISSIONS: [{'_submitted_by': self.someuser.username}]
+            PERM_CHANGE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
         }
 
-        # Allow anotheruser to edit someuser's data
+        # Allow anotheruser to edit their own data
         self.asset.assign_perm(
             self.anotheruser,
             PERM_PARTIAL_SUBMISSIONS,
@@ -704,13 +900,122 @@ class SubmissionViewApiTests(BaseSubmissionTestCase):
         response = self.client.get(url, {'format': 'json'})
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # Try second submission submitted by someuser
+        # Try second submission submitted by anotheruser
         submission = self.get_random_submission(self.anotheruser)
         url = reverse(
             self._get_endpoint('submission-edit'),
             kwargs={
                 'parent_lookup_asset': self.asset.uid,
                 'pk': submission['_id'],
+            },
+        )
+        response = self.client.get(url, {'format': 'json'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        url = f"http://server.mock/enketo/{submission['_id']}"
+        expected_response = {'url': url}
+        self.assertEqual(response.data, expected_response)
+
+
+class SubmissionViewApiTests(BaseSubmissionTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.submission = self.get_random_submission(self.asset.owner)
+        self.submission_view_link_url = reverse(
+            'submission-enketo-view',
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': self.submission['_id'],
+                'action': 'view'
+            },
+        )
+
+    def test_get_view_link_submission_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can get enketo view link
+        """
+        response = self.client.get(self.submission_view_link_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+
+        expected_response = {
+            'url': 'http://server.mock/enketo/{}'.format(self.submission['_id'])
+        }
+        assert response.data == expected_response
+
+    def test_get_view_link_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared publicly.
+        anonymous cannot view the project, therefore cannot retrieve enketo link.
+        someuser's data existence should not be revealed.
+        """
+        self.client.logout()
+        response = self.client.get(self.submission_view_link_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_cannot_get_view_link_submission_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared.
+        anotheruser cannot view the project, therefore cannot retrieve enketo link.
+        someuser's data existence should not be revealed.
+        """
+        self._log_in_as_another_user()
+        response = self.client.get(self.submission_view_link_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_get_view_link_submission_shared_with_view_only_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has 'view_submissions' permissions.
+        anotheruser can retrieve enketo view link.
+        """
+        self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
+        self._log_in_as_another_user()
+        response = self.client.get(self.submission_view_link_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_get_view_link_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial view permissions on someuser's data
+        anotheruser can only view their own data
+        """
+        self._log_in_as_another_user()
+        partial_perms = {
+            PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
+        }
+
+        # Allow anotheruser to view their own data
+        self.asset.assign_perm(
+            self.anotheruser,
+            PERM_PARTIAL_SUBMISSIONS,
+            partial_perms=partial_perms,
+        )
+
+        # Try first submission submitted by unknown
+        submission = self.get_random_submission(self.asset.owner)
+        url = reverse(
+            self._get_endpoint('submission-enketo-view'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': submission['_id'],
+                'action': 'view'
+            },
+        )
+
+        response = self.client.get(url, {'format': 'json'})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Try second submission submitted by anotheruser
+        submission = self.get_random_submission(self.anotheruser)
+        url = reverse(
+            self._get_endpoint('submission-enketo-view'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': self.submission['_id'],
+                'action': 'view'
             },
         )
         response = self.client.get(url, {'format': 'json'})
@@ -761,27 +1066,55 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         assert submission['end'] != duplicate_submission['end']
 
     def test_duplicate_submission_as_owner_allowed(self):
+        """
+        someuser is the owner of the project.
+        someuser is allowed to duplicate their own data
+        """
         response = self.client.post(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_201_CREATED
         self._check_duplicate(response)
 
     def test_duplicate_submission_as_anotheruser_not_allowed(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's data and someuser's data existence
+        should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.post(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_duplicate_submission_as_anonymous_not_allowed(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous has no access to someuser's data and someuser's data existence
+        should not be revealed.
+        """
         self.client.logout()
         response = self.client.post(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_cannot_duplicate_submission_as_anotheruser_with_view_perm(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has only view submissions permission, therefore cannot
+        edit/duplicate someuser's data.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.post(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_duplicate_submission_as_anotheruser_with_change_perm_allowed(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has edit submissions permission. They can edit/duplicate
+        someuser's data.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.post(self.submission_url, {'format': 'json'})
@@ -789,6 +1122,13 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         self._check_duplicate(response)
 
     def test_cannot_duplicate_submission_as_anotheruser_with_view_add_perms(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has view and add submissions permissions.
+        Change and Add submission permissions are needed to duplicate.
+        They cannot duplicate someuser's data.
+        """
         for perm in [PERM_VIEW_SUBMISSIONS, PERM_ADD_SUBMISSIONS]:
             self.asset.assign_perm(self.anotheruser, perm)
         self._log_in_as_another_user()
@@ -796,6 +1136,12 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_duplicate_submission_as_anotheruser_with_partial_perms(self):
+        """
+        someuser is the owner of the project.
+        The project is partially shared with anotheruser.
+        anotheruser has partial change submissions permissions.
+        They can edit/duplicate their own data only.
+        """
         self._log_in_as_another_user()
 
         partial_perms = {
@@ -864,6 +1210,10 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert len(submission_ids) == response.data['successes']
 
     def test_bulk_update_submissions_allowed_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can bulk update their own data.
+        """
         response = self.client.patch(
             self.submission_url, data=self.submitted_payload, format='json'
         )
@@ -871,6 +1221,12 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         self._check_bulk_update(response)
 
     def test_cannot_bulk_update_submissions_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser cannot access someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.patch(
             self.submission_url, data=self.submitted_payload, format='json'
@@ -878,6 +1234,12 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_cannot_bulk_update_submissions_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous cannot access someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.patch(
             self.submission_url, data=self.submitted_payload, format='json'
@@ -885,6 +1247,12 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_cannot_bulk_update_submissions_as_anotheruser_with_view_perm(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser
+        anotheruser can only view someuser's data, therefore they cannot bulk
+        update someuser's data
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.patch(
@@ -893,6 +1261,11 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_bulk_update_submissions_as_anotheruser_with_change_perm(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser
+        anotheruser can edit view someuser's data
+        """
         self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.patch(
@@ -902,10 +1275,16 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         self._check_bulk_update(response)
 
     def test_bulk_update_submissions_as_anotheruser_with_partial_perms(self):
+        """
+        someuser is the owner of the project.
+        The project is partially shared with anotheruser
+        anotheruser can only edit their own data.
+        """
         self._log_in_as_another_user()
-        # Allow anotheruser to update someuser's submissions
+
+        # Allow anotheruser to update their own data
         partial_perms = {
-            PERM_CHANGE_SUBMISSIONS: [{'_submitted_by': self.someuser.username}]
+            PERM_CHANGE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
         }
 
         self.asset.assign_perm(
@@ -913,14 +1292,15 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
             PERM_PARTIAL_SUBMISSIONS,
             partial_perms=partial_perms,
         )
+
         # Try to update all submissions, but anotheruser is allowed to update
-        # someuser's submissions only.
+        # their own submissions only.
         response = self.client.patch(
             self.submission_url, data=self.submitted_payload, format='json'
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-        # Update someuser's submissions
+        # Update some of another's submissions
         random_submissions = self.get_random_submissions(self.anotheruser, 3)
         self.updated_submission_data['submission_ids'] = [
             rs['_id'] for rs in random_submissions
@@ -944,16 +1324,32 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         )
 
     def test_retrieve_status_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can retrieve status of their own submissions
+        """
         response = self.client.get(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, self.submission.get("_validation_status"))
 
     def test_cannot_retrieve_status_of_not_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.get(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_retrieve_status_of_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has view submissions permissions on someuser's data.
+        anotheruser can view validation status of submissions.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.get(self.validation_status_url)
@@ -961,11 +1357,21 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, self.submission.get("_validation_status"))
 
     def test_cannot_retrieve_status_of_shared_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous has no access to someuser's data.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.get(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_status_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can delete the validation status of submissions
+        """
         response = self.client.delete(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -975,11 +1381,24 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, {})
 
     def test_cannot_delete_status_of_not_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's data, therefore cannot delete
+        validation status.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.delete(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_status_of_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser
+        anotheruser has validate submission permission.
+        anotheruser can delete validation status of the project.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
         self._log_in_as_another_user()
         response = self.client.delete(self.validation_status_url)
@@ -991,11 +1410,21 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data, {})
 
     def test_cannot_delete_status_of_not_shared_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous cannot change validation statuses.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.delete(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_status_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can update validation status.
+        """
         data = {
             'validation_status.uid': 'validation_status_not_approved'
         }
@@ -1009,11 +1438,24 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['uid'], data['validation_status.uid'])
 
     def test_cannot_edit_status_of_not_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's submissions and therefore, cannot
+        validate them.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         response = self.client.patch(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_status_of_shared_submission_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has validate submission permission.
+        anotheruser can edit validation status of the project.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
         self._log_in_as_another_user()
         data = {
@@ -1029,14 +1471,26 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.data['uid'], data['validation_status.uid'])
 
     def test_cannot_edit_status_of_not_shared_submission_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous has no access to someuser's submissions and therefore, cannot
+        validate them.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         response = self.client.patch(self.validation_status_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_status_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        anotheruser has partial access to someuser's data.
+        anotheruser can only view and validate their data.
+        """
         self._log_in_as_another_user()
         partial_perms = {
-            PERM_VALIDATE_SUBMISSIONS: [{'_submitted_by': self.someuser.username}]
+            PERM_VALIDATE_SUBMISSIONS: [{'_submitted_by': 'anotheruser'}]
         }
         # Allow anotheruser to validate someuser's data
         self.asset.assign_perm(self.anotheruser, PERM_PARTIAL_SUBMISSIONS,
@@ -1046,7 +1500,7 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         }
 
         # Try first submission submitted by unknown
-        submission = self.get_random_submission(self.asset.owner)
+        submission = self.submissions_submitted_by_unknown[0]
         url = (
             self._deployment.get_submission_validation_status_url(
                 submission['_id']
@@ -1055,8 +1509,8 @@ class SubmissionValidationStatusApiTests(BaseSubmissionTestCase):
         response = self.client.patch(url, data=data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # Try second submission submitted by someuser
-        submission = self.get_random_submission(self.anotheruser)
+        # Try second submission submitted by anotheruser
+        submission = self.submissions_submitted_by_anotheruser[0]
         url = (
             self._deployment.get_submission_validation_status_url(
                 submission['_id']
@@ -1089,6 +1543,10 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         )
 
     def test_delete_all_status_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can bulk delete the status of all their submissions.
+        """
         data = {
             'payload': {
                 'validation_status.uid': None,
@@ -1116,6 +1574,10 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
             self.assertEqual(submission['_validation_status'], {})
 
     def test_delete_some_statuses_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can bulk delete the status of some of their submissions.
+        """
         submission_id = 1
         data = {
             'payload': {
@@ -1144,6 +1606,13 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         # TODO Test with `query` when Mockbackend support Mongo queries
 
     def test_delete_status_of_not_shared_submissions_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's submissions and therefore, cannot
+        bulk delete the validation status of them.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         data = {
             'payload': {
@@ -1158,6 +1627,13 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_status_of_shared_submissions_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser can bulk delete all someuser's submission validation statues
+        at once
+        """
+
         self.asset.assign_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
         self._log_in_as_another_user()
         data = {
@@ -1181,6 +1657,13 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
             self.assertEqual(submission['_validation_status'], {})
 
     def test_delete_all_statuses_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anonymous has no access to someuser's submissions and therefore, cannot
+        bulk delete the validation status of them.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         data = {
             'payload': {
@@ -1195,6 +1678,12 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_all_submission_validation_statuses_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can edit all validation statuses at once.
+        `confirm=true` must be sent when the request alters all the submissions
+        at once.
+        """
         data = {
             'payload': {
                 'validation_status.uid': 'validation_status_approved',
@@ -1226,6 +1715,10 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
             )
 
     def test_edit_some_submission_validation_statuses_as_owner(self):
+        """
+        someuser is the owner of the project.
+        someuser can edit some validation statuses at once.
+        """
         submission_id = 1
         data = {
             'payload': {
@@ -1260,6 +1753,13 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
                 )
 
     def test_cannot_edit_submission_validation_statuses_not_shared_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's submissions and therefore, cannot
+        bulk edit the validation status of them.
+        someuser's data existence should not be revealed.
+        """
         self._log_in_as_another_user()
         data = {
             'payload': {
@@ -1273,6 +1773,14 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_submission_validation_statuses_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is shared with anotheruser.
+        anotheruser has validate submissions permissions and therefore, can
+        bulk edit all the validation status of them at once.
+        `confirm=true` must be sent when the request alters all the submissions
+        at once.
+        """
         self.asset.assign_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
         self._log_in_as_another_user()
         data = {
@@ -1302,6 +1810,13 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
             )
 
     def test_cannot_edit_submission_validation_statuses_as_anonymous(self):
+        """
+        someuser is the owner of the project.
+        The project is not shared with anyone.
+        anotheruser has no access to someuser's submissions and therefore, cannot
+        bulk edit the validation status of them.
+        someuser's data existence should not be revealed.
+        """
         self.client.logout()
         data = {
             'payload': {
@@ -1315,12 +1830,19 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_edit_all_submission_validation_statuses_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is partially shared with anotheruser.
+        anotheruser can only validate their own data.
+        `confirm=true` must be sent when the request alters all their submissions
+        at once.
+        """
         self._log_in_as_another_user()
         partial_perms = {
             PERM_VALIDATE_SUBMISSIONS: [
-                {'_submitted_by': self.someuser.username}]
+                {'_submitted_by': 'anotheruser'}]
         }
-        # Allow anotheruser to validate someuser's data
+        # Allow anotheruser to validate their own data
         self.asset.assign_perm(self.anotheruser, PERM_PARTIAL_SUBMISSIONS,
                                partial_perms=partial_perms)
         data = {
@@ -1348,7 +1870,7 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
         response = self.client.get(self.submission_list_url)
         for submission in response.data['results']:
             validation_status = submission['_validation_status']
-            if submission['_submitted_by'] == 'someuser':
+            if submission['_submitted_by'] == 'anotheruser':
                 self.assertEqual(validation_status['by_whom'], 'anotheruser')
                 self.assertEqual(
                     validation_status['uid'],
@@ -1362,12 +1884,17 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
                 )
 
     def test_edit_some_submission_validation_statuses_with_partial_perms_as_anotheruser(self):
+        """
+        someuser is the owner of the project.
+        The project is partially shared with anotheruser.
+        anotheruser can only validate their own data.
+        """
         self._log_in_as_another_user()
         partial_perms = {
             PERM_VALIDATE_SUBMISSIONS: [
-                {'_submitted_by': self.someuser.username}]
+                {'_submitted_by': 'anotheruser'}]
         }
-        # Allow anotheruser to validate someuser's data
+        # Allow anotheruser to validate their own data
         self.asset.assign_perm(self.anotheruser, PERM_PARTIAL_SUBMISSIONS,
                                partial_perms=partial_perms)
 
@@ -1387,7 +1914,7 @@ class SubmissionValidationStatusesApiTests(BaseSubmissionTestCase):
                                      format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-        # Try 2nd submission submitted by someuser
+        # Try 2nd submission submitted by anotheruser
         random_submissions = self.get_random_submissions(self.anotheruser, 3)
         data['payload']['submission_ids'] = [
             rs['_id'] for rs in random_submissions


### PR DESCRIPTION
## Description
Submission API tests are many and this helps (a little bit more) to understand what they are doing (until #3360 and 3359 are ready to go)

## Additional infos
For tests with partial permissions, `anotheruser` has access to their data instead of the owner of the project `someuser`.
- `test_get_edit_link_with_partial_perms_as_anotheruser()` has been moved to `SubmissionEditApiTests` instead of `SubmissionViewApiTests`
- `test_cannot_delete_view_only_submissions_with_partial_perms_as_anotheruser` has been added to [cover the request change of PR #3123 ](https://github.com/kobotoolbox/kpi/pull/3123#discussion_r671589942)


## Related issues

Part of #2900
Part of #3123 
Related to #3360
Related to #3359 