### PR TITLE
Fix failing mock submission tests

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -103,6 +103,10 @@ class BaseDeploymentBackend(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def delete_submissions(self, data: dict, user: 'auth.User', **kwargs) -> dict:
+        pass
+
+    @abc.abstractmethod
     def duplicate_submission(
         self,  submission_id: int, user: 'auth.User'
     ) -> dict:

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -20,6 +20,7 @@ from kpi.constants import (
 )
 from kpi.models import Asset, ExportTask
 from kpi.utils.object_permission import get_anonymous_user
+from kpi.utils.mongo_helper import drop_mock_only
 
 
 class MockDataExportsBase(TestCase):
@@ -298,9 +299,13 @@ class MockDataExportsBase(TestCase):
         },
     }
 
+    @drop_mock_only
     def setUp(self):
         self.user = User.objects.get(username='someuser')
         self.form_names = list(self.forms.keys())
+        # Clean up MongoDB documents
+        settings.MONGO_DB.instances.drop()
+
         self.assets = {
             name: self._create_asset_with_submissions(
                 user=self.user,
@@ -327,7 +332,7 @@ class MockDataExportsBase(TestCase):
             submission.update({
                 '__version__': v_uid
             })
-        asset.deployment.mock_submissions(submissions)
+        asset.deployment.mock_submissions(submissions, flush_db=False)
         return asset
 
 

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -1,13 +1,26 @@
 # coding: utf-8
 import re
 
-from bson import ObjectId
 from django.conf import settings
-from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
 
 from kpi.constants import NESTED_MONGO_RESERVED_ATTRIBUTES
 from kpi.utils.strings import base64_encodestring
+
+
+def drop_mock_only(func):
+    """
+    This decorator should be used on every method that drop data in MongoDB
+    in a testing environment. It ensures that MockMongo is used and no prodction
+    data is deleted
+    """
+    def _inner(*args, **kwargs):
+        # Ensure we are using MockMongo before deleting data
+        mongo_db_driver__repr = repr(settings.MONGO_DB)
+        if 'mongomock' not in mongo_db_driver__repr:
+            raise Exception('Cannot run tests on a production database')
+        return func(*args, **kwargs)
+
+    return _inner
 
 
 class MongoHelper:


### PR DESCRIPTION
## Description

Flush the mock MongoDB in unit tests only when appropriate—not always—so that tests using multiple assets function properly

## Related issues

Related to #3387