### PR TITLE
Make authentication required more obvious in permissions UI

### DIFF
--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -10,6 +10,7 @@ import {bem} from 'js/bem';
 import {LoadingSpinner} from 'js/ui';
 import {buildUserUrl} from 'utils';
 import {
+  ROUTES,
   ASSET_TYPES,
   ANON_USERNAME,
 } from 'js/constants';
@@ -113,6 +114,21 @@ class SharingForm extends React.Component {
         <bem.Modal__subheader>
           {this.state.asset.name}
         </bem.Modal__subheader>
+
+        {stores.session.currentAccount.extra_details?.require_auth !== true &&
+          <bem.FormModal__item>
+            <bem.FormView__cell m='warning'>
+              <i className='k-icon k-icon-alert' />
+              <p>
+                {t('Anyone can see this blank form and add submissions to it because you have not set ')}
+                <a href={`/#${ROUTES.ACCOUNT_SETTINGS}`}>
+                  {t('your account')}
+                </a>
+                {t(' to require authentication.')}
+              </p>
+            </bem.FormView__cell>
+          </bem.FormModal__item>
+        }
 
         {/* list of users and their permissions */}
         <bem.FormModal__item>

--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -98,6 +98,8 @@ class UserAssetPermsEditor extends React.Component {
     if (this.props.username) {
       this.state.username = this.props.username;
     }
+
+    this.applySubmissionsAddRules(this.state);
   }
 
   componentDidMount() {
@@ -141,6 +143,7 @@ class UserAssetPermsEditor extends React.Component {
     Object.keys(CHECKBOX_PERM_PAIRS).forEach((checkboxName) => {
       stateObj[checkboxName + SUFFIX_DISABLED] = false;
     });
+    this.applySubmissionsAddRules(stateObj);
     // apply permissions configuration rules to checkboxes
     Object.keys(CHECKBOX_PERM_PAIRS).forEach((checkboxName) => {
       this.applyValidityRulesForCheckbox(checkboxName, stateObj);
@@ -155,6 +158,23 @@ class UserAssetPermsEditor extends React.Component {
       }
     });
     return stateObj;
+  }
+
+  /**
+   * For users with disabled `auth_required` we need to force check add
+   * submissions and don't allow unchecking it.
+   *
+   * @param {object} stateObj
+   */
+  applySubmissionsAddRules(stateObj) {
+    if (
+      this.isAssignable(PERMISSIONS_CODENAMES.add_submissions) &&
+      stores.session.currentAccount.extra_details?.require_auth !== true
+    ) {
+      stateObj[CHECKBOX_NAMES.submissionsAdd] = true;
+      stateObj[CHECKBOX_NAMES.submissionsAdd + SUFFIX_DISABLED] = true;
+      this.applyValidityRulesForCheckbox(CHECKBOX_NAMES.submissionsAdd, stateObj);
+    }
   }
 
   /**

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -205,6 +205,7 @@ stores.session = Reflux.createStore({
   },
   isAuthStateKnown: false,
   init() {
+    actions.misc.updateProfile.completed.listen(this.onUpdateProfileCompleted);
     this.listenTo(actions.auth.getEnvironment.completed, this.triggerEnv);
     this.listenTo(actions.auth.verifyLogin.loggedin, this.triggerLoggedIn);
     this.listenTo(actions.auth.verifyLogin.anonymous, (data) => {
@@ -216,6 +217,10 @@ stores.session = Reflux.createStore({
     });
     actions.auth.verifyLogin();
     actions.auth.getEnvironment();
+  },
+  onUpdateProfileCompleted(response) {
+    this.currentAccount = response;
+    this.trigger({currentAccount: this.currentAccount});
   },
   triggerEnv(environment) {
     const nestedArrToChoiceObjs = (i) => {

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -463,14 +463,24 @@
 
     i {
       color: $kobo-orange;
-      font-size: 32px;
-      margin-right: 5px;
+      font-size: 28px;
+      margin-right: 8px;
       vertical-align: -11px;
       display: inline-block;
     }
 
     p {
       margin: 0;
+    }
+
+    a {
+      color: inherit;
+      font-weight: bold;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 
@@ -483,8 +493,8 @@
     align-items: center;
     i {
       color: $kobo-red;
-      font-size: 32px;
-      margin-right: 5px;
+      font-size: 28px;
+      margin-right: 8px;
       // If used in a dropzone, need to overwrite left margin
       margin-left: 0px;
     }

--- a/jsapp/scss/components/_kobo.sharing-modal.scss
+++ b/jsapp/scss/components/_kobo.sharing-modal.scss
@@ -3,6 +3,9 @@ $s-flexed-row-select-width: 200px;
 $s-gray-row-spacing: 10px;
 
 .form-modal--sharing-form {
+  width: 600px;
+  max-width: 100%;
+
   h2 {
     margin: 0;
     font-size: 14px;

--- a/jsapp/scss/components/_kobo.sharing-modal.scss
+++ b/jsapp/scss/components/_kobo.sharing-modal.scss
@@ -3,9 +3,6 @@ $s-flexed-row-select-width: 200px;
 $s-gray-row-spacing: 10px;
 
 .form-modal--sharing-form {
-  width: 600px;
-  max-width: 100%;
-
   h2 {
     margin: 0;
     font-size: 14px;


### PR DESCRIPTION
## Description

When "Authentication required" is not enabled, we display a warning message in "Share project" modal. We also make "Add submissions" always checked (and by the permissions rules "View form" too).

## Additional details

Changes:

<img width="646" alt="Screenshot 2021-08-12 at 08 11 44" src="https://user-images.githubusercontent.com/2521888/129154239-1d37fef4-1d02-43eb-a11f-f10dead3afc0.png">

## Related issues

Fixes #2620