### PR TITLE
Allow setting Celery worker count in Django admin

### DIFF
--- a/docker/run_celery.bash
+++ b/docker/run_celery.bash
@@ -3,9 +3,13 @@ set -e
 source /etc/profile
 
 # Run the main Celery worker (will not process `sync_kobocat_xforms` jobs).
+# Start 2 processes by default; this will be overridden later, in Python code,
+# according to the user's preference saved by django-constance
 cd "${KPI_SRC_DIR}"
+
 exec celery worker -A kobo --loglevel=info \
     --hostname=kpi_main_worker@%h \
     --logfile=${KPI_LOGS_DIR}/celery.log \
     --pidfile=/tmp/celery.pid \
-    --exclude-queues=sync_kobocat_xforms_queue
+    --exclude-queues=sync_kobocat_xforms_queue \
+    --autoscale 2,2

--- a/kobo/__init__.py
+++ b/kobo/__init__.py
@@ -1,4 +1,1 @@
 # coding: utf-8
-# This will make sure the app is always imported when
-# Django starts so that shared_task will use this app.
-from .celery import app as celery_app

--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import kombu.exceptions
 from django.apps import AppConfig
 from django.core.checks import register, Tags
 
@@ -8,6 +9,20 @@ from kpi.utils.two_database_configuration_checker import \
 
 class KpiConfig(AppConfig):
     name = 'kpi'
+
+    def ready(self, *args, **kwargs):
+        # Once it's okay to read from the database, apply the user-desired
+        # autoscaling configuration for Celery workers
+        from kobo.celery import update_concurrency_from_constance
+        # oh boy oberto
+        try:
+            update_concurrency_from_constance.delay()
+        except kombu.exceptions.OperationalError as e:
+            # It's normal for Django to start without access to a message
+            # broker, e.g. while running `./manage.py collectstatic`
+            # during a Docker image build
+            pass
+        return super().ready(*args, **kwargs)
 
 
 register(TwoDatabaseConfigurationChecker().as_check(), Tags.database)

--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -15,6 +15,9 @@ class KpiConfig(AppConfig):
         # autoscaling configuration for Celery workers
         from kobo.celery import update_concurrency_from_constance
         try:
+            # Push this onto the task queue with `delay()` instead of calling
+            # it directly because a direct call in the absence of any Celery
+            # workers hangs indefinitely
             update_concurrency_from_constance.delay()
         except kombu.exceptions.OperationalError as e:
             # It's normal for Django to start without access to a message

--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -14,7 +14,6 @@ class KpiConfig(AppConfig):
         # Once it's okay to read from the database, apply the user-desired
         # autoscaling configuration for Celery workers
         from kobo.celery import update_concurrency_from_constance
-        # oh boy oberto
         try:
             update_concurrency_from_constance.delay()
         except kombu.exceptions.OperationalError as e:

--- a/kobo/celery.py
+++ b/kobo/celery.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 import logging
+import multiprocessing
 import os
 
 import celery
+import constance
 from django.apps import apps
 from django.conf import settings
 
@@ -30,22 +32,45 @@ if hasattr(settings, 'RAVEN_CONFIG'):
             register_signal(raven_client)
     Celery = RavenCelery
 
-app = Celery(PROJECT_NAME)
+celery_app = Celery(PROJECT_NAME)
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+celery_app.config_from_object('django.conf:settings', namespace='CELERY')
 
-# The `app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)` technique
-# described in
+# The `celery_app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)`
+# technique described in
 # http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
 # fails when INSTALLED_APPS includes a "dotted path to the appropriate
 # AppConfig subclass" as recommended by
 # https://docs.djangoproject.com/en/1.8/ref/applications/#configuring-applications.
 # Ask Solem recommends the following workaround; see
 # https://github.com/celery/celery/issues/2248#issuecomment-97404667
-app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])
+celery_app.autodiscover_tasks(lambda: [n.name for n in apps.get_app_configs()])
 
 
-@app.task(bind=True)
+@celery_app.task
+def update_concurrency_from_constance():
+    """
+    Reads Celery worker concurrency configuration from django-constance
+    and applies maximum and minimum settings to the Celery worker process
+    autoscaler. Requires `celery worker` to be started with the `--autoscale=`
+    argument; see `docker/run_celery.bash`.
+    """
+    try:
+        max_ = int(constance.config.CELERY_WORKER_MAX_CONCURRENCY)
+    except ValueError:
+        max_ = min(multiprocessing.cpu_count(), 6)
+    try:
+        min_ = int(constance.config.CELERY_WORKER_MIN_CONCURRENCY)
+    except ValueError:
+        min_ = 2
+
+    # If the configured values don't make sense, let the minimum prevail
+    max_ = max(max_, min_)
+
+    celery_app.control.autoscale(max_, min_)
+
+
+@celery_app.task(bind=True)
 def debug_task(self):
     print('Request: {0!r}'.format(self.request))

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import multiprocessing
 import os
 import subprocess
 from mimetypes import add_type
@@ -174,6 +173,20 @@ CONSTANCE_CONFIG = {
     'EXPOSE_GIT_REV': (
         False,
         'Display information about the running commit to non-superusers',
+    ),
+    'CELERY_WORKER_MAX_CONCURRENCY': (
+        '',
+        'Maximum number of asynchronous worker processes to run. When '
+        'unspecified, the default is the number of CPU cores on your server, '
+        'down to a minimum of 2 and up to a maximum of 6. You may override '
+        'here with larger values',
+        # Omit type specification because int doesn't allow an empty default
+    ),
+    'CELERY_WORKER_MIN_CONCURRENCY': (
+        2,
+        'Minimum number of asynchronous worker processes to run. If larger '
+        'than the maximum, the maximum will be ignored',
+        int
     ),
 }
 # Tell django-constance to use a database model instead of Redis
@@ -411,14 +424,6 @@ CELERY_TIMEZONE = "UTC"
 if os.environ.get('SKIP_CELERY', 'False') == 'True':
     # helpful for certain debugging
     CELERY_TASK_ALWAYS_EAGER = True
-
-# Celery defaults to having as many workers as there are cores. To avoid
-# excessive resource consumption, don't spawn more than 6 workers by default
-# even if there more than 6 cores.
-
-CELERYD_MAX_CONCURRENCY = int(os.environ.get('CELERYD_MAX_CONCURRENCY', 6))
-if multiprocessing.cpu_count() > CELERYD_MAX_CONCURRENCY:
-    CELERY_WORKER_CONCURRENCY = CELERYD_MAX_CONCURRENCY
 
 # Replace a worker after it completes 7 tasks by default. This allows the OS to
 # reclaim memory allocated during large tasks

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from constance.signals import config_updated
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save, post_delete
@@ -7,6 +8,7 @@ from rest_framework.authtoken.models import Token
 from taggit.models import Tag
 
 from kobo.apps.hook.models.hook import Hook
+from kobo.celery import update_concurrency_from_constance
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatToken,
     KobocatUser,
@@ -14,6 +16,15 @@ from kpi.deployment_backends.kc_access.shadow_models import (
 from kpi.deployment_backends.kc_access.utils import grant_kc_model_level_perms
 from kpi.models import Asset, TagUid
 from kpi.utils.permissions import grant_default_model_level_perms
+
+
+@receiver(config_updated)
+def constance_updated(sender, key, old_value, new_value, **kwargs):
+    if key in (
+        'CELERY_WORKER_MAX_CONCURRENCY',
+        'CELERY_WORKER_MIN_CONCURRENCY',
+    ):
+        update_concurrency_from_constance()
 
 
 @receiver(post_save, sender=User)

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -1,9 +1,10 @@
 # coding: utf-8
-from celery import shared_task
 from django.core.management import call_command
 
+from kobo.celery import celery_app
 
-@shared_task
+
+@celery_app.task
 def import_in_background(import_task_uid):
     from kpi.models.import_export_task import ImportTask  # avoid circular imports
 
@@ -11,7 +12,7 @@ def import_in_background(import_task_uid):
     import_task.run()
 
 
-@shared_task
+@celery_app.task
 def export_in_background(export_task_uid):
     from kpi.models.import_export_task import ExportTask  # avoid circular imports
 
@@ -19,7 +20,7 @@ def export_in_background(export_task_uid):
     export_task.run()
 
 
-@shared_task
+@celery_app.task
 def sync_kobocat_xforms(
     username=None,
     quiet=True,
@@ -35,7 +36,7 @@ def sync_kobocat_xforms(
     )
 
 
-@shared_task
+@celery_app.task
 def sync_media_files(asset_uid):
     from kpi.models.asset import Asset  # avoid circular imports
 


### PR DESCRIPTION
Warning: the unit tests do **not** currently pass due to an unrelated issue with exports. See the [internal discussion](https://chat.kobotoolbox.org/#narrow/stream/4-KoBo-Dev/topic/formpack.20error).

## Description

When lots of I/O-bound tasks are enqueued, like REST Services pushes to slow external servers, it can be helpful to increase the number of asynchronous worker processes well beyond the number of CPU cores. This allows that without modifying environment variables or having to restart server processes for changes to take effect.