### PR TITLE
remove old way to get server env

### DIFF
--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -11,6 +11,8 @@ import {
   FormPage,
   LibraryAssetEditor,
 } from 'js/components/formEditors';
+import {actions} from 'js/actions';
+import {envStore} from 'js/envStore'; // initializing it
 import MyLibraryRoute from 'js/components/library/myLibraryRoute';
 import PublicCollectionsRoute from 'js/components/library/publicCollectionsRoute';
 import AssetRoute from 'js/components/library/assetRoute';
@@ -26,7 +28,6 @@ import FormXform from 'js/components/formXform';
 import FormJson from 'js/components/formJson';
 import FormsSearchableList from 'js/lists/forms';
 import {ROUTES} from 'js/router/routerConstants';
-import {actions} from 'js/actions';
 import permConfig from 'js/components/permissions/permConfig';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 
@@ -40,7 +41,6 @@ export default class AllRoutes extends React.Component {
 
   componentDidMount() {
     actions.permissions.getConfig.completed.listen(this.onGetConfigCompleted.bind(this));
-    actions.misc.getServerEnvironment();
     actions.permissions.getConfig();
   }
 


### PR DESCRIPTION
## Description

#3391 refactored the way we use the server environment, that PR did not have the `allRoutes.es6` file so that file was missing this change:
https://github.com/kobotoolbox/kpi/pull/3391/files#diff-f4c3c2939c9dcce19a4d067f421e2a2ac1f0fb575fd935ab0b2303a81970779eR22-R72

PR applies the change to `allRoutes.es6`