### PR TITLE
Update XLS types export

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@b5076d6687f2448c6c95148578f6d4903f23a726#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@55f3aa49a69669130e3368217ba7cfdbf19b911a#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@b5076d6687f2448c6c95148578f6d4903f23a726#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@55f3aa49a69669130e3368217ba7cfdbf19b911a#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@b5076d6687f2448c6c95148578f6d4903f23a726#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@55f3aa49a69669130e3368217ba7cfdbf19b911a#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@b5076d6687f2448c6c95148578f6d4903f23a726#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@55f3aa49a69669130e3368217ba7cfdbf19b911a#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@b5076d6687f2448c6c95148578f6d4903f23a726#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@55f3aa49a69669130e3368217ba7cfdbf19b911a#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/jsapp/js/components/projectDownloads/exportsConstants.es6
+++ b/jsapp/js/components/projectDownloads/exportsConstants.es6
@@ -58,7 +58,7 @@ export const DEFAULT_EXPORT_SETTINGS = Object.freeze({
   // xls is the most popular choice and we respect that
   EXPORT_TYPE: EXPORT_TYPES.xls,
   FLATTEN_GEO_JSON: false,
-  XLS_TYPES: false,
+  XLS_TYPES_AS_TEXT: false,
   GROUP_SEPARATOR: '/',
   INCLUDE_ALL_VERSIONS: true,
   INCLUDE_GROUPS: false,

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -58,7 +58,7 @@ export default class ProjectExportsCreator extends React.Component {
       customExportName: DEFAULT_EXPORT_SETTINGS.CUSTOM_EXPORT_NAME,
       isCustomSelectionEnabled: DEFAULT_EXPORT_SETTINGS.CUSTOM_SELECTION,
       isFlattenGeoJsonEnabled: DEFAULT_EXPORT_SETTINGS.FLATTEN_GEO_JSON,
-      isXlsTypesEnabled: DEFAULT_EXPORT_SETTINGS.XLS_TYPES,
+      isXlsTypesAsTextEnabled: DEFAULT_EXPORT_SETTINGS.XLS_TYPES_AS_TEXT,
       selectedRows: new Set(),
       selectableRowsCount: 0,
       selectedDefinedExport: null,
@@ -105,7 +105,7 @@ export default class ProjectExportsCreator extends React.Component {
       customExportName: DEFAULT_EXPORT_SETTINGS.CUSTOM_EXPORT_NAME,
       isCustomSelectionEnabled: DEFAULT_EXPORT_SETTINGS.CUSTOM_SELECTION,
       isFlattenGeoJsonEnabled: DEFAULT_EXPORT_SETTINGS.FLATTEN_GEO_JSON,
-      isXlsTypesEnabled: DEFAULT_EXPORT_SETTINGS.XLS_TYPES,
+      isXlsTypesAsTextEnabled: DEFAULT_EXPORT_SETTINGS.XLS_TYPES_AS_TEXT,
       selectedRows: new Set(this.getAllSelectableRows()),
     });
   }
@@ -312,7 +312,7 @@ export default class ProjectExportsCreator extends React.Component {
       customExportName: data.name,
       isCustomSelectionEnabled: customSelectionEnabled,
       isFlattenGeoJsonEnabled: data.export_settings.flatten,
-      isXlsTypesEnabled: data.export_settings.xls_types,
+      isXlsTypesAsTextEnabled: data.export_settings.xls_types_as_text,
       selectedRows: new Set(data.export_settings.fields),
     };
 
@@ -352,9 +352,9 @@ export default class ProjectExportsCreator extends React.Component {
       payload.export_settings.flatten = this.state.isFlattenGeoJsonEnabled;
     }
 
-    // xls_types is only for xls
+    // xls_types_as_text is only for xls
     if (this.state.selectedExportType.value === EXPORT_TYPES.xls.value) {
-      payload.export_settings.xls_types = this.state.isXlsTypesEnabled;
+      payload.export_settings.xls_types_as_text = this.state.isXlsTypesAsTextEnabled;
     }
 
     // if custom export is enabled, but there is no name provided
@@ -547,9 +547,9 @@ export default class ProjectExportsCreator extends React.Component {
           {this.state.selectedExportType.value === EXPORT_TYPES.xls.value &&
             <bem.ProjectDownloads__columnRow>
               <Checkbox
-                checked={this.state.isXlsTypesEnabled}
-                onChange={this.onAnyInputChange.bind(this, 'isXlsTypesEnabled')}
-                label={t('Use XLS date and number formats')}
+                checked={this.state.isXlsTypesAsTextEnabled}
+                onChange={this.onAnyInputChange.bind(this, 'isXlsTypesAsTextEnabled')}
+                label={t('Store date and number responses as text')}
               />
             </bem.ProjectDownloads__columnRow>
           }

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -538,7 +538,7 @@ class ExportTask(ImportExportTask):
         translations = pack.available_translations
         lang = self.data.get('lang', None) or next(iter(translations), None)
         fields = self.data.get('fields', [])
-        xls_types = self.data.get('xls_types', False)
+        xls_types_as_text = self.data.get('xls_types_as_text', True)
         force_index = True if not fields or '_index' in fields else False
         try:
             # If applicable, substitute the constants that formpack expects for
@@ -558,7 +558,7 @@ class ExportTask(ImportExportTask):
             'force_index': force_index,
             'tag_cols_for_header': tag_cols_for_header,
             'filter_fields': fields,
-            'xls_types': xls_types,
+            'xls_types_as_text': xls_types_as_text,
         }
 
     def _record_last_submission_time(self, submission_stream):

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -16,7 +16,7 @@ from formpack.constants import (
     EXPORT_SETTING_MULTIPLE_SELECT,
     EXPORT_SETTING_SOURCE,
     EXPORT_SETTING_TYPE,
-    EXPORT_SETTING_XLS_TYPES,
+    EXPORT_SETTING_XLS_TYPES_AS_TEXT,
     REQUIRED_EXPORT_SETTINGS,
     VALID_DEFAULT_LANGUAGES,
     VALID_EXPORT_SETTINGS,
@@ -89,8 +89,10 @@ class ExportTaskSerializer(serializers.ModelSerializer):
         if EXPORT_SETTING_FLATTEN in data_:
             attrs[EXPORT_SETTING_FLATTEN] = data_[EXPORT_SETTING_FLATTEN]
 
-        if EXPORT_SETTING_XLS_TYPES in data_:
-            attrs[EXPORT_SETTING_XLS_TYPES] = data_[EXPORT_SETTING_XLS_TYPES]
+        if EXPORT_SETTING_XLS_TYPES_AS_TEXT in data_:
+            attrs[EXPORT_SETTING_XLS_TYPES_AS_TEXT] = data_[
+                EXPORT_SETTING_XLS_TYPES_AS_TEXT
+            ]
 
         return attrs
 


### PR DESCRIPTION
Update settings in the UI and change export setting from `xls_types` to `xls_types_as_text`.

![](https://user-images.githubusercontent.com/50016008/130878529-2f6ae20d-11bb-49ea-add6-e405a1cf8992.png)

## Description

Update XLS types export setting label in the UI to "Store date and number responses as text" and have it disabled by default (new XLS types enabled by default).

## Related issues

closes #3443
blocked by kobotoolbox/formpack#257
related to #3330 