### PR TITLE
Removed support for duplicate names in XLSForms

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -680,6 +680,7 @@ class Asset(ObjectPermissionMixin,
         update_fields=None,
         adjust_content=True,
         create_version=True,
+        fail_duplicate_names=False,
         update_parent_languages=True,
         *args,
         **kwargs
@@ -701,6 +702,10 @@ class Asset(ObjectPermissionMixin,
 
         if self.content is None:
             self.content = {}
+
+        # if fail_duplicate_names is True:
+        # if 'naming_conflicts' in self.summary:
+        #     raise ValueError('There is an error in your question names')
 
         # in certain circumstances, we don't want content to
         # be altered on save. (e.g. on asset.deploy())

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -713,9 +713,8 @@ class Asset(ObjectPermissionMixin,
         # populate summary
         self._populate_summary()
 
-        if fail_duplicate_names:
-            if 'naming_conflicts' in self.summary:
-                raise ValueError('There are duplicates in the name column')
+        if fail_duplicate_names and 'naming_conflicts' in self.summary:
+            raise ValueError('There are duplicates in the name column')
 
         # infer asset_type only between question and block
         if self.asset_type in [ASSET_TYPE_QUESTION, ASSET_TYPE_BLOCK]:

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -269,7 +269,7 @@ class ImportTask(ImportExportTask):
                     # TODO: review and test carefully
                     asset = destination
                     asset.content = kontent
-                    asset.save()
+                    asset.save(fail_duplicate_names=True)
                     messages['updated'].append({
                             'uid': asset.uid,
                             'kind': 'asset',
@@ -351,6 +351,7 @@ class ImportTask(ImportExportTask):
                     content=survey_dict,
                     asset_type=asset_type,
                     summary={'filename': filename},
+                    fail_duplicate_names=True,
                 )
                 msg_key = 'created'
             else:
@@ -364,7 +365,7 @@ class ImportTask(ImportExportTask):
                         base64_encoded_upload, survey_dict
                     )
                 asset.content = survey_dict
-                asset.save()
+                asset.save(fail_duplicate_names=True)
                 msg_key = 'updated'
 
             messages[msg_key].append({

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -138,7 +138,6 @@ class AssetImportTaskTest(BaseTestCase):
         response = self.client.post(post_url, task_data)
         assert response.status_code == status.HTTP_201_CREATED
         detail_response = self.client.get(response.data['url'])
-        print(detail_response.data['messages'])
         assert detail_response.status_code == status.HTTP_200_OK
         assert detail_response.data['status'] == "error"
         assert detail_response.data['messages']['error'] == "There are duplicates in the name column"

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -86,5 +86,4 @@ class AssetContentAnalyzer:
         }
         if len(naming_conflicts) > 0:
             summary['naming_conflicts'] = naming_conflicts
-            # raise ValueError('Asset_Content_Analyzer: Duplicates')
         return summary

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -86,4 +86,5 @@ class AssetContentAnalyzer:
         }
         if len(naming_conflicts) > 0:
             summary['naming_conflicts'] = naming_conflicts
+            # raise ValueError('Asset_Content_Analyzer: Duplicates')
         return summary


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Removed the support for duplicate name in the `names` columns for imported XLS files and URLs so the user will be aware if there is a problem with their XLSForms.

## Related issues

Fixes #1017
