### PR TITLE
Fix parseBackendData for partial permissions

### DIFF
--- a/jsapp/js/components/permissions/permParser.tests.es6
+++ b/jsapp/js/components/permissions/permParser.tests.es6
@@ -105,7 +105,6 @@ describe('permParser', () => {
 
       chai.expect(built).to.deep.equal({
         formView: true,
-        submissionsView: true,
         submissionsViewPartial: true,
         submissionsViewPartialUsers: ['john', 'olivier']
       });


### PR DESCRIPTION
## Description

Fix front-end tests related to UI changes for row-level write permissions

## Additional details

Somewhere down the lines we changed the logic in the sharing form, so checking partial permission no longer checks also the "parent permission" - e.g. when "View submissions only from specific users" is checked previously we were also checking "View submissions", we no longer do it :)

I tried finding the exact moment we broke the tests, but didn't want to spend too much time on it. The fact is that the test is no longer valid, because the context changed.
