### PR TITLE
Fix JSON parse error when saving in formbuilder

### DIFF
--- a/jsapp/js/components/formBuilder/formBuilderUtils.es6
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.es6
@@ -24,7 +24,7 @@ export function surveyToValidJson(survey) {
   // to "survey.toFlatJSON()"
   survey.toFlatJSON();
   // returning the result of the second call to "toFlatJSON()"
-  return survey.toFlatJSON();
+  return JSON.stringify(survey.toFlatJSON());
 }
 
 /**


### PR DESCRIPTION
## Description

Attempting to save a form in formbuilder was causing a crash at `JSON.parse(...)` in the translations hack. This is due to an unfinished attempt at reverting some changes to the translations hack, see https://github.com/kobotoolbox/kpi/commit/6bb852c277