### PR TITLE
Preserve Paired Data XPath consistency

### DIFF
--- a/kpi/views/v2/paired_data.py
+++ b/kpi/views/v2/paired_data.py
@@ -254,9 +254,11 @@ class PairedDataViewset(AssetNestedObjectViewsetMixin,
         parsed_submissions = []
 
         for submission in submissions:
-            # Use `rename_root_node_to='data'` to rename the root node of each
-            # submission to `data` so that form authors do not have to rewrite
+            # Use `rename_root_node_to='item'` to rename the root node of each
+            # submission to `item` so that form authors do not have to rewrite
             # their `xml-external` formulas any time the asset UID changes,
+            # and most importantly to integrate well with all pyxform xpath
+            # evaluations that are always prefixed by root/item
             # e.g. when cloning a form or creating a project from a template.
             # Set `use_xpath=True` because `paired_data.fields` uses full group
             # hierarchies, not just question names.
@@ -265,7 +267,7 @@ class PairedDataViewset(AssetNestedObjectViewsetMixin,
                     submission,
                     paired_data.allowed_fields,
                     use_xpath=True,
-                    rename_root_node_to='data',
+                    rename_root_node_to='item',
                 )
             )
 


### PR DESCRIPTION
update(paired-data): replace 'data' node by 'item' node to preserve pattern and integrate better with pyxform.

## Description

We’re used to the following syntax for the calculated fields , checkout the query nodes
```
count(instance('survey')/root/item[P_Enumerator])	
```

While just inside Dynamic Data Attachments the rule is changed to use the below
```
count(instance('survey')/root/data[P_Enumerator])	
```

One of the use cases is when you try to integrate data pulled from another form into any widget.


## Related issues

Checkout the discussion thread on the community forum,

https://community.kobotoolbox.org/t/dynamic-data-attachments-calculation-syntax-enhancement/22580

## Note

The following [docs](https://support.kobotoolbox.org/dynamic_data_attachment.html) must be updated if we elevated the PR.
All the `root/data` expressions must be replaced by `root/item`

