### PR TITLE
Fix broken background audio link in table view

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -940,7 +940,7 @@ export class DataTable extends React.Component {
         backgroundAudioName &&
         Object.keys(row.original).includes(backgroundAudioName)
       ) {
-        let backgroundAudioUrl = this.getMediaDownloadLink(
+        let backgroundAudioUrl = this.getMediaAttachment(
           row,
           row.original[backgroundAudioName]
         );


### PR DESCRIPTION
## Description

Due to a bad merge a non existent function was being used to get background audio, PR fixes this