### PR TITLE
Make BEM modifiers more flexible

### DIFF
--- a/jsapp/js/bem.ts
+++ b/jsapp/js/bem.ts
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from 'react'
+import classnames from 'classnames'
 
 /**
  * USAGE:
@@ -17,7 +18,7 @@ interface bemInstances {
  */
 const bem: bemInstances = {}
 
-export default bem;
+export default bem
 
 type BemModifiersObject = {
   [modifierName: string]: boolean
@@ -43,15 +44,15 @@ export function compileModifierObject(
   bmo: BemModifiersObject,
   wholeName: string
 ): string {
-  let newModifier: string = '';
+  let newModifier: string = ''
 
   Object.entries(bmo).forEach((entry) => {
     if (entry[1] === true) {
-      newModifier = `${wholeName}--${entry[0]}`;
+      newModifier = `${wholeName}--${entry[0]}`
     }
-  });
+  })
 
-  return newModifier;
+  return newModifier
 }
 
 /**
@@ -69,40 +70,27 @@ export function makeBem(
     static blockName: string = parent ? parent.blockName : name
 
     constructor(props: BemComponentProps) {
-      super(props);
+      super(props)
     }
 
     render() {
-      let classNames: string[] = [];
+      let classNames: string[] = []
 
       // Keep existing className attribute if given (either string or array)
       if (typeof this.props.className === 'string') {
-        classNames.push(this.props.className);
+        classNames.push(this.props.className)
       } else if (Array.isArray(this.props.className)) {
-        classNames.push(this.props.className.join(' '));
+        classNames.push(this.props.className.join(' '))
       }
 
       // wholeName includes parent, e.g. `parent-block__child-element`
       const wholeName = parent ? `${parent.blockName}__${name}` : name
-      classNames.push(wholeName);
+      classNames.push(wholeName)
 
-      // modifiers could be a single string or array of strings or object with booleans
-      if (typeof this.props.m === 'string' && this.props.m.length >= 1) {
-        // Case 1: string
-        classNames.push(`${wholeName}--${this.props.m}`);
-      } else if (Array.isArray(this.props.m)) {
-        // Case 2: array
-        this.props.m.forEach((modifier) => {
-          if (typeof modifier === 'string' && modifier.length >= 1) {
-            classNames.push(`${wholeName}--${modifier}`);
-          } else if (modifier !== null && typeof modifier === 'object') {
-            classNames.push(compileModifierObject(modifier, wholeName))
-          }
-        });
-      } else if (typeof this.props.m === 'object' && this.props.m !== null) {
-        // Case 3: object
-        classNames.push(compileModifierObject(this.props.m, wholeName))
-      }
+      const modifiersList = classnames(this.props.m)
+      modifiersList.split(' ').forEach((modifier) => {
+        classNames.push(`${wholeName}--${modifier}`)
+      })
 
       const newProps: {[propName: string]: any} = {
         className: classNames.join(' ')
@@ -112,11 +100,11 @@ export function makeBem(
       // className (we use our own).
       Object.entries(this.props).forEach((propEntry) => {
         if (propEntry[0] !== 'm' && propEntry[0] !== 'className') {
-          newProps[propEntry[0]] = propEntry[1];
+          newProps[propEntry[0]] = propEntry[1]
         }
-      });
+      })
 
-      return React.createElement(htmlTagName, newProps);
+      return React.createElement(htmlTagName, newProps)
     }
   }
 

--- a/jsapp/js/bem.ts
+++ b/jsapp/js/bem.ts
@@ -40,21 +40,6 @@ interface BemInstance extends React.ComponentClass<BemComponentProps, {}> {
   blockName: string
 }
 
-export function compileModifierObject(
-  bmo: BemModifiersObject,
-  wholeName: string
-): string {
-  let newModifier: string = ''
-
-  Object.entries(bmo).forEach((entry) => {
-    if (entry[1] === true) {
-      newModifier = `${wholeName}--${entry[0]}`
-    }
-  })
-
-  return newModifier
-}
-
 /**
  * Creates a BEM class for block or element.
  * For first parameter pass `null` to create a Block component,

--- a/jsapp/js/bem.ts
+++ b/jsapp/js/bem.ts
@@ -32,11 +32,26 @@ interface BemComponentProps extends React.ComponentProps<any> {
    *   'another-modifier': <boolean>,
    * }
    */
-  m?: null | string | string[] | BemModifiersObject
+  m?: null | string | string[] | BemModifiersObject | (string | BemModifiersObject)[]
 }
 
 interface BemInstance extends React.ComponentClass<BemComponentProps, {}> {
   blockName: string
+}
+
+export function compileModifierObject(
+  bmo: BemModifiersObject,
+  wholeName: string
+): string {
+  let newModifier: string = '';
+
+  Object.entries(bmo).forEach((entry) => {
+    if (entry[1] === true) {
+      newModifier = `${wholeName}--${entry[0]}`;
+    }
+  });
+
+  return newModifier;
 }
 
 /**
@@ -80,15 +95,13 @@ export function makeBem(
         this.props.m.forEach((modifier) => {
           if (typeof modifier === 'string' && modifier.length >= 1) {
             classNames.push(`${wholeName}--${modifier}`);
+          } else if (modifier !== null && typeof modifier === 'object') {
+            classNames.push(compileModifierObject(modifier, wholeName))
           }
         });
       } else if (typeof this.props.m === 'object' && this.props.m !== null) {
         // Case 3: object
-        Object.entries(this.props.m).forEach((entry) => {
-          if (entry[1] === true) {
-            classNames.push(`${wholeName}--${entry[0]}`);
-          }
-        });
+        classNames.push(compileModifierObject(this.props.m, wholeName))
       }
 
       const newProps: {[propName: string]: any} = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "chai": "^4.2.0",
         "chart.js": "^2.9.3",
         "circular-dependency-plugin": "^5.2.0",
-        "classnames": "^2.2.6",
+        "classnames": "^2.3.1",
         "coffee-loader": "^0.9.0",
         "coffeelint": "^1.16.2",
         "coffeescript": "^1.12.0",
@@ -3556,9 +3556,9 @@
       }
     },
     "node_modules/classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
       "dev": true
     },
     "node_modules/cli-cursor": {
@@ -20523,9 +20523,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
       "dev": true
     },
     "cli-cursor": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chai": "^4.2.0",
     "chart.js": "^2.9.3",
     "circular-dependency-plugin": "^5.2.0",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "coffee-loader": "^0.9.0",
     "coffeelint": "^1.16.2",
     "coffeescript": "^1.12.0",


### PR DESCRIPTION
## Description

With the merging of #3452 we have a revamped way to use BEM in KPI. There was a missed spot for passing bem modifiers as a array that is a combination of strings and objects, namely here:
https://github.com/kobotoolbox/kpi/blob/ae5fe4518a6eba11957f5ede09ab7e4704009205/jsapp/js/editorMixins/editableForm.es6#L624-L628

PR allows this type though. For future we should maybe figure out all allowed cases/bad cases in the `es6` code

Fixes #3467 