### PR TITLE
Declare `classnames` module and assume return type

### DIFF
--- a/jsapp/js/bem.ts
+++ b/jsapp/js/bem.ts
@@ -72,7 +72,7 @@ export function makeBem(
       const wholeName = parent ? `${parent.blockName}__${name}` : name
       classNames.push(wholeName)
 
-      const modifiersList = classnames(this.props.m)
+      const modifiersList: string = classnames(this.props.m)
       modifiersList.split(' ').forEach((modifier) => {
         classNames.push(`${wholeName}--${modifier}`)
       })

--- a/jsapp/js/global.d.ts
+++ b/jsapp/js/global.d.ts
@@ -5,3 +5,5 @@ declare module 'alertifyjs' {
   const defaults: any
   const notify: (msg: string, type?: string) => void
 }
+
+declare module 'classnames';


### PR DESCRIPTION
## Description

After #3469 was merged, the new module was not declared and it's return type is not specified by the module. See errors below
```
ERROR in /srv/src/kpi/jsapp/js/bem.ts
./jsapp/js/bem.ts 2:23-35
[tsl] ERROR in /srv/src/kpi/jsapp/js/bem.ts(2,24)
      TS7016: Could not find a declaration file for module 'classnames'. '/srv/src/kpi/node_modules/classnames/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/classnames` if it exists or add a new declaration (.d.ts) file containing `declare module 'classnames';`

ERROR in /srv/src/kpi/jsapp/js/bem.ts
./jsapp/js/bem.ts 76:40-48
[tsl] ERROR in /srv/src/kpi/jsapp/js/bem.ts(76,41)
      TS7006: Parameter 'modifier' implicitly has an 'any' type.
ℹ ｢wdm｣: Failed to compile.
```
from their `npm` page: https://www.npmjs.com/package/classnames it looks like it's safe to assume the return will always be `string`. 