### PR TITLE
Fix dropdown memory leak causing console errors

### DIFF
--- a/jsapp/js/components/common/koboDropdown.tsx
+++ b/jsapp/js/components/common/koboDropdown.tsx
@@ -69,6 +69,8 @@ export default class KoboDropdown extends React.Component<
     this.state = {isMenuVisible: false};
   }
 
+  private checkOutsideClickBound = this.checkOutsideClick.bind(this)
+
   private unlisteners: Function[] = []
 
   componentDidMount() {
@@ -138,17 +140,17 @@ export default class KoboDropdown extends React.Component<
   }
 
   registerOutsideClickListener() {
-    window.addEventListener('click', this.checkOutsideClick.bind(this));
-    window.addEventListener('touch', this.checkOutsideClick.bind(this));
-    window.addEventListener('touchstart', this.checkOutsideClick.bind(this));
-    window.addEventListener('contextmenu', this.checkOutsideClick.bind(this));
+    window.addEventListener('click', this.checkOutsideClickBound);
+    window.addEventListener('touch', this.checkOutsideClickBound);
+    window.addEventListener('touchstart', this.checkOutsideClickBound);
+    window.addEventListener('contextmenu', this.checkOutsideClickBound);
   }
 
   cancelOutsideClickListener() {
-    window.removeEventListener('click', this.checkOutsideClick.bind(this));
-    window.removeEventListener('touch', this.checkOutsideClick.bind(this));
-    window.removeEventListener('touchstart', this.checkOutsideClick.bind(this));
-    window.removeEventListener('contextmenu', this.checkOutsideClick.bind(this));
+    window.removeEventListener('click', this.checkOutsideClickBound);
+    window.removeEventListener('touch', this.checkOutsideClickBound);
+    window.removeEventListener('touchstart', this.checkOutsideClickBound);
+    window.removeEventListener('contextmenu', this.checkOutsideClickBound);
   }
 
   checkOutsideClick(evt: React.ChangeEvent<HTMLInputElement> | any) {


### PR DESCRIPTION
## Description

Leaving Data route with dropdown opened was causing a console error.

## Additional details

The bug was happening because the function passed to `addEventListener` was not being recognized by `removeEventListener` so the listener was not removed, and the Node stops existing after changing route.

## Related issues

Fixes #3497