### PR TITLE
Install `wait-for-it` (to later replace Dockerize)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV KPI_LOGS_DIR=/srv/logs \
     INIT_PATH=/srv/init
 
 # Install Dockerize.
+# TODO: Remove this after merging kobotoolbox/kobo-docker#322
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz -P /tmp \
     && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -40,17 +41,20 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
-RUN apt -qq update && \
-    apt -qq -y install \
+RUN apt-get -qq update && \
+    apt-get -qq -y install \
         gdal-bin \
-        libproj-dev \
         gettext \
-        postgresql-client \
+        less \
+        libproj-dev \
         locales \
-        runit-init \
+        postgresql-client \
+        python3-virtualenv \
         rsync \
-        vim && \
-    apt clean && \
+        runit-init \
+        vim \
+        wait-for-it && \
+    apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ###########################


### PR DESCRIPTION
Dockerize recommends installing only by binary, which supports only limited architectures (e.g. not s390x).

This change supports kobotoolbox/kobo-docker#322, which adjusts the container startup scripts to use `wait-for-it`.

Also adds `python3-virtualenv` to the `apt-get install` command, for better compatibility with other base images. This doesn't appear to cause any problems with `nikolaik/python-nodejs:python3.8-nodejs10`.

(and I alphabetized the Debian packages, too :wink:)

## Description

Use a different tool that works with a variety of CPU architectures when waiting for needed services to start