### PR TITLE
Use base image compatible with s390x architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV KPI_LOGS_DIR=/srv/logs \
     INIT_PATH=/srv/init
 
 # Install Dockerize.
+# TODO: Remove this after merging kobotoolbox/kobo-docker#322
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz -P /tmp \
     && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -40,17 +41,20 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
-RUN apt -qq update && \
-    apt -qq -y install \
+RUN apt-get -qq update && \
+    apt-get -qq -y install \
         gdal-bin \
-        libproj-dev \
         gettext \
-        postgresql-client \
+        less \
+        libproj-dev \
         locales \
-        runit-init \
+        postgresql-client \
+        python3-virtualenv \
         rsync \
-        vim && \
-    apt clean && \
+        runit-init \
+        vim \
+        wait-for-it && \
+    apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ###########################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs10
+# TODO: use a multi-architecture base image
+# FROM nikolaik/python-nodejs:python3.8-nodejs10
+FROM s390x/node:16-bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -153,6 +153,8 @@ docutils==0.15.2
     #   statistics
 drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
+excelrd==2.0.3
+    # via -r dependencies/pip/requirements.in
 fabric==2.5.0
     # via -r dependencies/pip/dev_requirements.in
 formencode==1.3.1
@@ -365,7 +367,6 @@ werkzeug==0.16.0
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
     # via
-    #   -r dependencies/pip/requirements.in
     #   pyxform
     #   xlutils
 xlsxwriter==1.2.5

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -12,6 +12,10 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform.git@s390x#egg=pyxform
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   formpack
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.5.2
@@ -20,8 +24,6 @@ amqp==2.5.2
     #   kombu
 anyjson==0.3.3
     # via -r dependencies/pip/requirements.in
-argparse==1.4.0
-    # via unittest2
 atomicwrites==1.3.0
     # via pytest
 attrs==19.3.0
@@ -157,8 +159,6 @@ excelrd==2.0.3
     # via -r dependencies/pip/requirements.in
 fabric==2.5.0
     # via -r dependencies/pip/dev_requirements.in
-formencode==1.3.1
-    # via pyxform
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0
@@ -192,8 +192,6 @@ kombu==4.6.6
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
-linecache2==1.0.0
-    # via traceback2
 lxml==4.4.1
     # via
     #   -r dependencies/pip/requirements.in
@@ -287,10 +285,6 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==1.5.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   formpack
 redis==3.3.11
     # via
     #   celery
@@ -325,7 +319,6 @@ six==1.13.0
     #   responses
     #   ssrf-protect
     #   traitlets
-    #   unittest2
 sqlparse==0.3.0
     # via
     #   -r dependencies/pip/requirements.in
@@ -339,16 +332,10 @@ statistics==1.0.3.5
     # via formpack
 tabulate==0.8.5
     # via -r dependencies/pip/requirements.in
-traceback2==1.4.0
-    # via unittest2
 traitlets==4.3.3
     # via ipython
 unicodecsv==0.14.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
-unittest2==1.1.0
-    # via pyxform
+    # via -r dependencies/pip/requirements.in
 urllib3==1.25.7
     # via
     #   botocore
@@ -366,9 +353,7 @@ wcwidth==0.1.7
 werkzeug==0.16.0
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   pyxform
-    #   xlutils
+    # via xlutils
 xlsxwriter==1.2.5
     # via
     #   -r dependencies/pip/requirements.in

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@f3cdf12110022ebf011ea00b6371329ae3e550f5#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -12,6 +12,10 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform.git@s390x#egg=pyxform
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   formpack
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.5.2
@@ -20,8 +24,6 @@ amqp==2.5.2
     #   kombu
 anyjson==0.3.3
     # via -r dependencies/pip/requirements.in
-argparse==1.4.0
-    # via unittest2
 attrs==19.3.0
     # via jsonschema
 backports.csv==1.0.7
@@ -138,8 +140,6 @@ drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
 excelrd==2.0.3
     # via -r dependencies/pip/requirements.in
-formencode==1.3.1
-    # via pyxform
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0
@@ -165,8 +165,6 @@ kombu==4.6.6
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
-linecache2==1.0.0
-    # via traceback2
 lxml==4.4.1
     # via
     #   -r dependencies/pip/requirements.in
@@ -221,10 +219,6 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==1.5.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   formpack
 raven==6.10.0
     # via -r dependencies/pip/external_services.in
 redis==3.3.11
@@ -253,7 +247,6 @@ six==1.13.0
     #   responses
     #   ssrf-protect
     #   transifex-client
-    #   unittest2
 sqlparse==0.3.0
     # via
     #   -r dependencies/pip/requirements.in
@@ -267,16 +260,10 @@ statistics==1.0.3.5
     # via formpack
 tabulate==0.8.5
     # via -r dependencies/pip/requirements.in
-traceback2==1.4.0
-    # via unittest2
 transifex-client==0.12.5
     # via -r dependencies/pip/external_services.in
 unicodecsv==0.14.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
-unittest2==1.1.0
-    # via pyxform
+    # via -r dependencies/pip/requirements.in
 urllib3==1.25.7
     # via
     #   botocore
@@ -291,9 +278,7 @@ vine==1.3.0
 werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   pyxform
-    #   xlutils
+    # via xlutils
 xlsxwriter==1.2.5
     # via
     #   -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@f3cdf12110022ebf011ea00b6371329ae3e550f5#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -136,6 +136,8 @@ docutils==0.15.2
     #   statistics
 drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
+excelrd==2.0.3
+    # via -r dependencies/pip/requirements.in
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -290,7 +292,6 @@ werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
     # via
-    #   -r dependencies/pip/requirements.in
     #   pyxform
     #   xlutils
 xlsxwriter==1.2.5

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@f3cdf12110022ebf011ea00b6371329ae3e550f5#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -76,7 +76,7 @@ tabulate
 unicodecsv
 uWSGI
 Werkzeug
-xlrd
+excelrd
 xlwt
 xlutils
 XlsxWriter

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -1,6 +1,9 @@
 # File for use with `pip-compile`; see https://github.com/nvie/pip-tools
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
+# s390x-specific pyxform
+-e git+https://github.com/jnm/pyxform.git@s390x#egg=pyxform
+
 # formpack
 -e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
 
@@ -66,7 +69,6 @@ psycopg2
 pymongo
 python-dateutil
 pytz
-pyxform
 requests
 responses
 shortuuid

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -12,6 +12,10 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform.git@s390x#egg=pyxform
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   formpack
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.5.2
@@ -20,8 +24,6 @@ amqp==2.5.2
     #   kombu
 anyjson==0.3.3
     # via -r dependencies/pip/requirements.in
-argparse==1.4.0
-    # via unittest2
 attrs==19.3.0
     # via jsonschema
 backports.csv==1.0.7
@@ -138,8 +140,6 @@ drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
 excelrd==2.0.3
     # via -r dependencies/pip/requirements.in
-formencode==1.3.1
-    # via pyxform
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0
@@ -165,8 +165,6 @@ kombu==4.6.6
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
-linecache2==1.0.0
-    # via traceback2
 lxml==4.4.1
     # via
     #   -r dependencies/pip/requirements.in
@@ -221,10 +219,6 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==1.5.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   formpack
 redis==3.3.11
     # via
     #   celery
@@ -250,7 +244,6 @@ six==1.13.0
     #   python-dateutil
     #   responses
     #   ssrf-protect
-    #   unittest2
 sqlparse==0.3.0
     # via
     #   -r dependencies/pip/requirements.in
@@ -264,14 +257,8 @@ statistics==1.0.3.5
     # via formpack
 tabulate==0.8.5
     # via -r dependencies/pip/requirements.in
-traceback2==1.4.0
-    # via unittest2
 unicodecsv==0.14.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
-unittest2==1.1.0
-    # via pyxform
+    # via -r dependencies/pip/requirements.in
 urllib3==1.25.7
     # via
     #   botocore
@@ -285,9 +272,7 @@ vine==1.3.0
 werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   pyxform
-    #   xlutils
+    # via xlutils
 xlsxwriter==1.2.5
     # via
     #   -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -136,6 +136,8 @@ docutils==0.15.2
     #   statistics
 drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
+excelrd==2.0.3
+    # via -r dependencies/pip/requirements.in
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -284,7 +286,6 @@ werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
     # via
-    #   -r dependencies/pip/requirements.in
     #   pyxform
     #   xlutils
 xlsxwriter==1.2.5

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@f3cdf12110022ebf011ea00b6371329ae3e550f5#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -12,6 +12,10 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
+-e git+https://github.com/jnm/pyxform.git@s390x#egg=pyxform
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   formpack
 -e git+https://github.com/kobotoolbox/ssrf-protect@9eec6c4aa37700c6e7ca90540a9407bd20acddb0#egg=ssrf_protect
     # via -r dependencies/pip/requirements.in
 amqp==2.5.2
@@ -20,8 +24,6 @@ amqp==2.5.2
     #   kombu
 anyjson==0.3.3
     # via -r dependencies/pip/requirements.in
-argparse==1.4.0
-    # via unittest2
 attrs==19.3.0
     # via
     #   jsonschema
@@ -147,8 +149,6 @@ drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
 excelrd==2.0.3
     # via -r dependencies/pip/requirements.in
-formencode==1.3.1
-    # via pyxform
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==0.2.0
@@ -174,8 +174,6 @@ kombu==4.6.6
     # via
     #   -r dependencies/pip/requirements.in
     #   celery
-linecache2==1.0.0
-    # via traceback2
 lxml==4.4.1
     # via
     #   -r dependencies/pip/requirements.in
@@ -256,10 +254,6 @@ pytz==2019.3
     #   celery
     #   django
     #   django-timezone-field
-pyxform==1.5.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   formpack
 pyyaml==5.3.1
     # via python-coveralls
 redis==3.3.11
@@ -291,7 +285,6 @@ six==1.13.0
     #   python-dateutil
     #   responses
     #   ssrf-protect
-    #   unittest2
 sqlparse==0.3.0
     # via
     #   -r dependencies/pip/requirements.in
@@ -305,14 +298,8 @@ statistics==1.0.3.5
     # via formpack
 tabulate==0.8.5
     # via -r dependencies/pip/requirements.in
-traceback2==1.4.0
-    # via unittest2
 unicodecsv==0.14.1
-    # via
-    #   -r dependencies/pip/requirements.in
-    #   pyxform
-unittest2==1.1.0
-    # via pyxform
+    # via -r dependencies/pip/requirements.in
 urllib3==1.25.7
     # via
     #   botocore
@@ -328,9 +315,7 @@ wcwidth==0.1.9
 werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
-    # via
-    #   pyxform
-    #   xlutils
+    # via xlutils
 xlsxwriter==1.2.5
     # via
     #   -r dependencies/pip/requirements.in

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -145,6 +145,8 @@ docutils==0.15.2
     #   statistics
 drf-extensions==0.5.0
     # via -r dependencies/pip/requirements.in
+excelrd==2.0.3
+    # via -r dependencies/pip/requirements.in
 formencode==1.3.1
     # via pyxform
 future==0.18.2
@@ -327,7 +329,6 @@ werkzeug==1.0.1
     # via -r dependencies/pip/requirements.in
 xlrd==1.2.0
     # via
-    #   -r dependencies/pip/requirements.in
     #   pyxform
     #   xlutils
 xlsxwriter==1.2.5

--- a/dependencies/pip/travis_ci.txt
+++ b/dependencies/pip/travis_ci.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@f3cdf12110022ebf011ea00b6371329ae3e550f5#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@s390x#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/kpi/management/commands/import_xls_to_collection.py
+++ b/kpi/management/commands/import_xls_to_collection.py
@@ -2,7 +2,7 @@
 import datetime
 import re
 
-import xlrd
+import excelrd as xlrd
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -4,7 +4,7 @@ import json
 from collections import OrderedDict
 from copy import deepcopy
 
-import xlrd
+import excelrd as xlrd
 from django.contrib.auth.models import User, AnonymousUser
 from django.test import TestCase
 from rest_framework import serializers

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import datetime
 import mock
-import xlrd
+import excelrd as xlrd
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 from xlutils.copy import copy
-from xlrd import open_workbook
+from excelrd import open_workbook
 
 
 class NoFromSheetError(Exception):

--- a/kpi/zip_importer.py
+++ b/kpi/zip_importer.py
@@ -4,7 +4,7 @@ import re
 import zipfile
 from io import BytesIO
 
-from xlrd import open_workbook
+from excelrd import open_workbook
 
 from kpi.exceptions import ImportAssetException
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-loader": "^8.2.0",
     "typescript": "^4.3.5",
     "underscore": "^1.10.2",
-    "webfonts-generator": "^0.4.0",
+    "@vusion/webfonts-generator": "^0.7.3",
     "webpack": "^4.43.0",
     "webpack-bundle-tracker": "0.4.3",
     "webpack-cli": "^3.3.11",

--- a/scripts/generate_icons.js
+++ b/scripts/generate_icons.js
@@ -2,7 +2,7 @@
  * This scripts generates icon font from our SVG icons to be used in the app.
  */
 
-const webfontsGenerator = require('webfonts-generator');
+const webfontsGenerator = require('@vusion/webfonts-generator');
 const replaceInFile = require('replace-in-file');
 const fs = require('fs');
 const sourceDir = 'jsapp/svg-icons/';


### PR DESCRIPTION
Sometimes it's easier to show a draft PR than write an issue. This can't be merged because it simply swaps the standard base image out for one that's built for s390x. The work will be to identify a proper multi-architecture solution that can replace both.