### PR TITLE
Synchronize permissions with KoBoCAT when copying team's permissions from another project 

### DIFF
--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 import json
 import logging
+from typing import Union
 
 import requests
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError, ProgrammingError, transaction
+from django.db.models import Model
 from rest_framework.authtoken.models import Token
 
 from kpi.exceptions import KobocatProfileException
@@ -334,16 +336,18 @@ def assign_applicable_kc_permissions(obj, user, kpi_codenames):
 
 
 @transaction.atomic()
-def remove_applicable_kc_permissions(obj, user, kpi_codenames):
-    r"""
-        Remove the `user` the applicable KC permissions from `obj`, if any
-        exists, given one KPI permission codename as a single string or many
-        codenames as an iterable. If `obj` is not a :py:class:`Asset` or does
-        not have a deployment, take no action.
-        :param obj: Any Django model instance
-        :type user: :py:class:`User` or :py:class:`AnonymousUser`
-        :type kpi_codenames: str or list(str)
+def remove_applicable_kc_permissions(
+    obj: Model,
+    user: Union[AnonymousUser, User, int],
+    kpi_codenames: Union[str, list]
+):
     """
+    Remove the `user` the applicable KC permissions from `obj`, if any
+    exists, given one KPI permission codename as a single string or many
+    codenames as an iterable. If `obj` is not a :py:class:`Asset` or does
+    not have a deployment, take no action.
+    """
+
     if not obj._meta.model_name == 'asset':
         return
     permissions = _get_applicable_kc_permissions(obj, kpi_codenames)
@@ -352,12 +356,24 @@ def remove_applicable_kc_permissions(obj, user, kpi_codenames):
     xform_id = _get_xform_id_for_asset(obj)
     if not xform_id:
         return
-    if is_user_anonymous(user):
+
+    # Retrieve primary key from user object and use it on subsequent queryset.
+    # It avoids loading the object when `user` is passed as an integer.
+    if not isinstance(user, int):
+        if is_user_anonymous(user):
+            user_id = settings.ANONYMOUS_USER_ID
+        else:
+            user_id = user.pk
+    else:
+        user_id = user
+
+    if user_id == settings.ANONYMOUS_USER_ID:
         return set_kc_anonymous_permissions_xform_flags(
             obj, kpi_codenames, xform_id, remove=True)
+
     content_type_kwargs = _get_content_type_kwargs_for_related(obj)
     KobocatUserObjectPermission.objects.filter(
-        user=user, permission__in=permissions, object_pk=xform_id,
+        user_id=user_id, permission__in=permissions, object_pk=xform_id,
         # `permission` has a FK to `ContentType`, but I'm paranoid
         **content_type_kwargs
     ).delete()

--- a/kpi/mixins/object_permission.py
+++ b/kpi/mixins/object_permission.py
@@ -6,6 +6,7 @@ from typing import Optional
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models, transaction
 from django_request_cache import cache_for_request
 from rest_framework import serializers
@@ -88,35 +89,35 @@ class ObjectPermissionMixin:
         if type(source_object) is type(self):
             # First delete all permissions of the target asset (except owner's).
             perm_queryset = self.permissions.exclude(user_id=self.owner_id)
-            codenames = []
-            current_user = None
             # The bulk delete below (i.e.: `perm_queryset.delete()`) does not
             # remove permissions in KoBoCAT.
             # We could loop through `self.permissions` and call `remove_perm`
-            # for each permission but it would take longer with lots of
-            # permissions than grouping codenames and pass it directly to
-            # `remove_applicable_kc_permissions()`
+            # for each permission but it would have probably a performance hit
+            # with assets with lots of permissions.
+            # Let's use PostgreSQL specific function `ArrayAgg` to retrieve all
+            # codenames at once.
 
             # It relies on the fact that permissions are synced in KoBoCAT and KPI.
             # If any permissions are present in KoBoCAT but not in KPI, these
             # permissions will not be deleted and will have to be deleted manually
             # with KoBoCAT.
-            for perm in perm_queryset.order_by('user_id'):
-                if current_user != perm.user:
-                    if current_user is not None:
-                        remove_applicable_kc_permissions(
-                            self, current_user, codenames
-                        )
-                    codenames = [perm.permission.codename]
-                else:
-                    codenames.append(perm.permission.codename)
-                current_user = perm.user
 
-            if codenames:
+            user_codenames = (
+                ObjectPermission.objects.filter(asset_id=self.pk, deny=False)
+                .exclude(user_id=self.owner_id)
+                .values('user_id')
+                .annotate(
+                    all_codenames=ArrayAgg(
+                        'permission__codename', distinct=True
+                    )
+                )
+            )
+            for user_codename in user_codenames:
                 remove_applicable_kc_permissions(
-                    self, current_user, codenames
+                    self, user_codename['user_id'], user_codename['all_codenames']
                 )
 
+            # Remove all permissions from the asset (except the owner's)
             perm_queryset.delete()
 
             # Then copy all permissions from source to target asset


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Permissions on source form will be removed in KPI and KoBoCAT before applying copied team's permissions.

## Additional info

It assumes that KoBoCAT and KPI permissions are in sync. If any permissions are present in KoBoCAT but not in KPI, they will not be removed. To get rid of it. permission must be added in KPI first. 

## Related issues

Fixes #3453 
