### PR TITLE
Add management command to sync permissions between KPI and KoBoCAT

### DIFF
--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 import json
 import logging
+from typing import Union
 
 import requests
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError, ProgrammingError, transaction
+from django.db.models import Model
 from rest_framework.authtoken.models import Token
 
 from kpi.exceptions import KobocatProfileException
@@ -296,15 +298,16 @@ def set_kc_anonymous_permissions_xform_flags(obj, kpi_codenames, xform_id,
 
 
 @transaction.atomic()
-def assign_applicable_kc_permissions(obj, user, kpi_codenames):
-    r"""
-        Assign the `user` the applicable KC permissions to `obj`, if any
-        exists, given one KPI permission codename as a single string or many
-        codenames as an iterable. If `obj` is not a :py:class:`Asset` or does
-        not have a deployment, take no action.
-        :param obj: Any Django model instance
-        :type user: :py:class:`User` or :py:class:`AnonymousUser`
-        :type kpi_codenames: str or list(str)
+def assign_applicable_kc_permissions(
+    obj: Model,
+    user: Union[AnonymousUser, User, int],
+    kpi_codenames: Union[str, list]
+):
+    """
+    Assign the `user` the applicable KC permissions to `obj`, if any
+    exists, given one KPI permission codename as a single string or many
+    codenames as an iterable. If `obj` is not a :py:class:`Asset` or does
+    not have a deployment, take no action.
     """
     if not obj._meta.model_name == 'asset':
         return
@@ -314,20 +317,33 @@ def assign_applicable_kc_permissions(obj, user, kpi_codenames):
     xform_id = _get_xform_id_for_asset(obj)
     if not xform_id:
         return
-    if is_user_anonymous(user):
+
+    # Retrieve primary key from user object and use it on subsequent queryset.
+    # It avoids loading the object when `user` is passed as an integer.
+    if not isinstance(user, int):
+        if is_user_anonymous(user):
+            user_id = settings.ANONYMOUS_USER_ID
+        else:
+            user_id = user.pk
+    else:
+        user_id = user
+
+    if user_id == settings.ANONYMOUS_USER_ID:
         return set_kc_anonymous_permissions_xform_flags(
             obj, kpi_codenames, xform_id)
+
     xform_content_type = KobocatContentType.objects.get(
         **obj.KC_CONTENT_TYPE_KWARGS)
+
     kc_permissions_already_assigned = KobocatUserObjectPermission.objects.filter(
-        user=user, permission__in=permissions, object_pk=xform_id,
+        user=user_id, permission__in=permissions, object_pk=xform_id,
     ).values_list('permission__codename', flat=True)
     permissions_to_create = []
     for permission in permissions:
         if permission.codename in kc_permissions_already_assigned:
             continue
         permissions_to_create.append(KobocatUserObjectPermission(
-            user=user, permission=permission, object_pk=xform_id,
+            user=user_id, permission=permission, object_pk=xform_id,
             content_type=xform_content_type
         ))
     KobocatUserObjectPermission.objects.bulk_create(permissions_to_create)

--- a/kpi/management/commands/sync_kobocat_perms.py
+++ b/kpi/management/commands/sync_kobocat_perms.py
@@ -1,0 +1,177 @@
+# coding: utf-8
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
+from kpi.constants import PERM_FROM_KC_ONLY
+from kpi.models import Asset, ObjectPermission
+from kpi.deployment_backends.kc_access.utils import (
+    assign_applicable_kc_permissions
+)
+from kpi.deployment_backends.kc_access.shadow_models import (
+    KobocatUserObjectPermission
+)
+from kpi.management.commands.sync_kobocat_xforms import _sync_permissions
+
+
+class Command(BaseCommand):
+
+    help = (
+        "Synchronize permissions of deployed forms with KoBoCAT.\n"
+        "They are synced bidirectionally unless `--mirror-kpi` option is used."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--asset-uid',
+            action='store',
+            dest='asset_uid',
+            default=None,
+            help="Sync only a specific asset's form-media",
+        )
+        parser.add_argument(
+            '--username',
+            action='store',
+            dest='username',
+            default=None,
+            help="Sync only a specific user's form-media for assets that they own",
+        )
+        parser.add_argument(
+            "--chunks",
+            default=1000,
+            type=int,
+            help="Update records by batch of `chunks`.",
+        )
+        parser.add_argument(
+            '--quiet',
+            action='store_true',
+            dest='quiet',
+            default=False,
+            help='Do not output status messages',
+        )
+        parser.add_argument(
+            '--mirror-kpi',
+            action='store_true',
+            dest='mirror_kpi',
+            default=False,
+            help='Mirror KPI permissions only',
+        )
+
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):
+        self._verbosity = options['verbosity']
+        self._username = options['username']
+        self._quiet = options['quiet']
+        self._asset_uid = options['asset_uid']
+        self._chunks = options['chunks']
+
+        if not settings.KOBOCAT_URL or not settings.KOBOCAT_INTERNAL_URL:
+            raise ImproperlyConfigured(
+                'Both KOBOCAT_URL and KOBOCAT_INTERNAL_URL must be '
+                'configured before using this command'
+            )
+        self._sync_perms(**options)
+
+    def _sync_perms(self, **options):
+        assets = Asset.objects.only('id', 'uid', 'owner').filter(
+            _deployment_data__active=True
+        )
+        if self._username:
+            assets = assets.filter(owner__username=self._username)
+        if self._asset_uid:
+            assets = assets.filter(uid=self._asset_uid)
+
+        assets = assets.order_by('owner__username')
+
+        for asset in assets.iterator(chunk_size=self._chunks):
+            if not self._quiet:
+                self.stdout.write('')
+                self.stdout.write(
+                    f'Processing asset {asset.uid} (owner: {asset.owner.username})'
+                )
+                self.stdout.write('')
+
+            if options['mirror_kpi']:
+
+                kc_user_obj_perm_qs = (
+                    KobocatUserObjectPermission.objects.filter(
+                        object_pk=asset.deployment.xform_id
+                    ).exclude(user_id=asset.owner_id)
+                )
+                if kc_user_obj_perm_qs.exists():
+                    if not self._quiet and self._verbosity >= 1:
+                        self.stdout.write(
+                            f'\tDeleting all KoBoCAT permissions...'
+                        )
+                    kc_user_obj_perm_qs.delete()
+
+                self._copy_perms_from_kpi_kc(asset)
+            else:
+
+                if not self._quiet and self._verbosity >= 1:
+                    self.stdout.write(
+                        f'\tPulling permissions from KoBoCAT...'
+                    )
+                affected_users = _sync_permissions(asset, asset.deployment.xform)
+                if self._verbosity >= 2 and affected_users:
+                    self.stdout.write(
+                        f'\t\tAffected users: {affected_users}'
+                    )
+
+                self._copy_perms_from_kpi_kc(asset)
+
+        if not self._quiet and self._verbosity >= 1:
+            self.stdout.write('')
+            self.stdout.write(
+                f'Deleting `{PERM_FROM_KC_ONLY}` permission from KPI...'
+            )
+        deleted = ObjectPermission.objects.filter(
+            permission__codename=PERM_FROM_KC_ONLY
+        ).delete()
+
+        if not self._quiet and self._verbosity >= 2:
+            self.stdout.write(f'\t {deleted[0]} objects')
+
+        if not self._quiet:
+            self.stdout.write('Done!')
+
+    def _copy_perms_from_kpi_kc(self, asset: Asset):
+        codenames = []
+        current_user = None
+        kpi_perms = asset.permissions.exclude(
+            permission__codename=PERM_FROM_KC_ONLY
+        ).order_by('user_id')
+        for perm in kpi_perms:
+            # Skip the copy if user is the owner
+            if perm.user == asset.owner:
+                continue
+
+            if current_user != perm.user:
+                if current_user is not None:
+                    self._copy_user_perms_from_kpi_kc(
+                        asset, current_user, codenames
+                    )
+                codenames = [perm.permission.codename]
+            else:
+                codenames.append(perm.permission.codename)
+            current_user = perm.user
+
+        if codenames:
+            self._copy_user_perms_from_kpi_kc(asset, current_user, codenames)
+
+    def _copy_user_perms_from_kpi_kc(
+        self, asset: Asset, user: 'auth.User', codenames: list
+    ):
+        if not self._quiet:
+            if self._verbosity >= 1:
+                self.stdout.write(
+                    f'\tPushing permissions for user `{user}` to KoBoCAT...'
+                )
+            if self._verbosity >= 2:
+                self.stdout.write(
+                    f'\t\tPermissions: {codenames}'
+                )
+        assign_applicable_kc_permissions(
+            asset, user, codenames
+        )

--- a/kpi/management/commands/sync_kobocat_perms.py
+++ b/kpi/management/commands/sync_kobocat_perms.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
             PERM_FROM_KC_ONLY
         )
         assets = Asset.objects.only('id', 'uid', 'owner').filter(
-            _deployment_data__active=True
+            _deployment_data__backend='kobocat',
         )
         if self._username:
             assets = assets.filter(owner__username=self._username)

--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -539,7 +539,7 @@ class Command(BaseCommand):
                                 'WARN',
                                 user.username,
                                 xform.id_string,
-                                e.message
+                                str(e)
                             ]
                             self._print_tabular(*error_information)
                             continue


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Permissions cannot be set in KoBoCAT anymore. This management command is useful to synchronize permissions one last time to ensure all permissions are in sync between both applications.

## Additional info

It is bidirectionnal by default but it is also possible to copy permissions in only one direction (i.e.: KPI -> KoBoCAT) with `--mirror-kpi` option. 

## Related issues

Closes kobotoolbox/tasks#335

