### PR TITLE
Revert "Removed support for duplicate names in XLSForms"

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -73,7 +73,6 @@ from .asset_version import AssetVersion
 class AssetManager(models.Manager):
     def create(self, *args, children_to_create=None, tag_string=None, **kwargs):
         update_parent_languages = kwargs.pop('update_parent_languages', True)
-        fail_duplicate_names = kwargs.pop('fail_duplicate_names', False)
 
         # 3 lines below are copied from django.db.models.query.QuerySet.create()
         # because we need to pass an argument to save()
@@ -81,7 +80,6 @@ class AssetManager(models.Manager):
         created = self.model(**kwargs)
         self._for_write = True
         created.save(force_insert=True, using=self.db,
-                     fail_duplicate_names=fail_duplicate_names,
                      update_parent_languages=update_parent_languages)
 
         if tag_string:
@@ -682,7 +680,6 @@ class Asset(ObjectPermissionMixin,
         update_fields=None,
         adjust_content=True,
         create_version=True,
-        fail_duplicate_names=False,
         update_parent_languages=True,
         *args,
         **kwargs
@@ -712,9 +709,6 @@ class Asset(ObjectPermissionMixin,
 
         # populate summary
         self._populate_summary()
-
-        if fail_duplicate_names and 'naming_conflicts' in self.summary:
-            raise ValueError('There are duplicates in the name column')
 
         # infer asset_type only between question and block
         if self.asset_type in [ASSET_TYPE_QUESTION, ASSET_TYPE_BLOCK]:

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -275,7 +275,7 @@ class ImportTask(ImportExportTask):
                     # TODO: review and test carefully
                     asset = destination
                     asset.content = kontent
-                    asset.save(fail_duplicate_names=True)
+                    asset.save()
                     messages['updated'].append({
                             'uid': asset.uid,
                             'kind': 'asset',
@@ -357,7 +357,6 @@ class ImportTask(ImportExportTask):
                     content=survey_dict,
                     asset_type=asset_type,
                     summary={'filename': filename},
-                    fail_duplicate_names=True,
                 )
                 msg_key = 'created'
             else:
@@ -371,7 +370,7 @@ class ImportTask(ImportExportTask):
                         base64_encoded_upload, survey_dict
                     )
                 asset.content = survey_dict
-                asset.save(fail_duplicate_names=True)
+                asset.save()
                 msg_key = 'updated'
 
             messages[msg_key].append({

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -116,33 +116,6 @@ class AssetImportTaskTest(BaseTestCase):
         self._post_import_task_and_compare_created_asset_to_source(task_data,
                                                                    self.asset)
 
-    def test_import_duplicate_names(self):
-        survey_questions = [
-            ['type', 'name', 'label'],
-            ['text', 'fruit', 'Favourite Fruit'],
-            ['text', 'fruit', 'Least Favourite Fruit'],
-            ['integer', 'count', 'Count of fruits eaten'],
-            ['integer', 'count', 'Count of apples eaten'],
-        ]
-
-        survey_settings = []
-        content = (
-            ('survey', survey_questions),
-            ('settings', survey_settings),
-        )
-        task_data = self._construct_xls_for_import(
-            content, name='Duplicates Survey Names'
-        )
-
-        post_url = reverse('api_v2:importtask-list')
-        response = self.client.post(post_url, task_data)
-        assert response.status_code == status.HTTP_201_CREATED
-        detail_response = self.client.get(response.data['url'])
-        assert detail_response.status_code == status.HTTP_200_OK
-        assert detail_response.data['status'] == "error"
-        assert detail_response.data['messages']['error'] == "There are duplicates in the name column"
-        assert detail_response.data['messages']['error_type'] == "ValueError"
-
     def test_import_locking_xls_as_survey(self):
         survey_sheet_content = [
             ['type', 'name', 'label::English (en)', 'required', 'relevant', 'kobo--locking-profile'],


### PR DESCRIPTION
Go back to the old behavior of silently renaming duplicate questions (#1017) until we exclude `$given_name` and `__version__` from XLSForm downloads (#3539).