### PR TITLE
Fix broken disaggregate button for map view 

### DIFF
--- a/jsapp/js/components/map.scss
+++ b/jsapp/js/components/map.scss
@@ -100,7 +100,7 @@ $z-map-settings-3: 701;
   }
 }
 
-.popover-menu--viewby-menu {
+.popover-menu.popover-menu--viewby-menu {
   position: absolute;
   bottom: 15px;
   left: 15px;


### PR DESCRIPTION
## Description

Fixes the "Disaggregate by survey responses" button weirdly/unusable positioned bug.

## Additional details

We must've changed the order of some of our styles, and the poorly written disaggregate button selector stopped working.

## Related issues

Fixes #3550

Back port of #3551 