### PR TITLE
Site message edit fix 

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -118,7 +118,7 @@ django-js-asset==1.2.2
     # via django-mptt
 django-loginas==0.3.6
     # via -r dependencies/pip/requirements.in
-django-markdownx==2.0.28
+django-markdownx==3.0.1
     # via -r dependencies/pip/requirements.in
 django-markitup==4.0.0
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -94,7 +94,7 @@ django-js-asset==1.2.2
     # via django-mptt
 django-loginas==0.3.6
     # via -r dependencies/pip/requirements.in
-django-markdownx==2.0.28
+django-markdownx==3.0.1
     # via -r dependencies/pip/requirements.in
 django-markitup==4.0.0
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -94,7 +94,7 @@ django-js-asset==1.2.2
     # via django-mptt
 django-loginas==0.3.6
     # via -r dependencies/pip/requirements.in
-django-markdownx==2.0.28
+django-markdownx==3.0.1
     # via -r dependencies/pip/requirements.in
 django-markitup==4.0.0
     # via -r dependencies/pip/requirements.in

--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     re_path(r'^admin/', include('loginas.urls')),
     re_path(r'^', include('kpi.urls')),
     re_path(r'^markdownx/', include('markdownx.urls')),
+    re_path(r'^markitup/', include('markitup.urls')),
     re_path(r'^help/', include('kobo.apps.help.urls')),
     path('service_health/', service_health),
     re_path(r'kobocat/', RedirectView.as_view(url=settings.KOBOCAT_URL, permanent=True)),


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
When editing site messages, Markdown editor is shown without raising a 500 error

## Additional infos
It seems that we are using `django-mardownx` and `django-markitup` that serve quite the same purpose. 

- `django-mardownx` supports drap&drop for images
- `django-markitup` offers a kind of WYSIWYG editor

Should we open an issue to clean this up?

## Related issues

Fixes #3572 