### PR TITLE
Fix react-select noOptionsMessage crash

### DIFF
--- a/jsapp/js/components/list.es6
+++ b/jsapp/js/components/list.es6
@@ -126,7 +126,7 @@ export class ListTagFilter extends React.Component {
           isLoading={!this.state.tagsLoaded}
           loadingMessage={t('Tags are loading...')}
           placeholder={t('Search Tags')}
-          noOptionsMessage={t('No results found')}
+          noOptionsMessage={() => t('No results found')}
           options={this.state.availableTags}
           onChange={this.onTagsChange}
           className={[this.props.hidden ? 'hidden' : null, 'kobo-select'].join(' ')}


### PR DESCRIPTION
by passing a function instead of a string. See JedWatson/react-select#3331

## Description

Make sure the tags search field in the form builder's library sidebar keeps working by updating configuration for the select control