### PR TITLE
Add support for OAuth2 authenticated request to API.

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -335,6 +335,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'kpi.paginators.Paginated',
     'PAGE_SIZE': 100,
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         # SessionAuthentication and BasicAuthentication would be included by
         # default
         'rest_framework.authentication.SessionAuthentication',

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -335,12 +335,12 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'kpi.paginators.Paginated',
     'PAGE_SIZE': 100,
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         # SessionAuthentication and BasicAuthentication would be included by
         # default
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
     ],
     'DEFAULT_RENDERER_CLASSES': [
        'rest_framework.renderers.JSONRenderer',


### PR DESCRIPTION

## Description

Users can use OAuth2 to fetch data from API with OAuth2 `access_token` and `refresh_token`

## Related issues

Fixes #3589 