### PR TITLE
Add support to multi architecture docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.8-nodejs10
+FROM python:3.8
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
@@ -50,10 +50,11 @@ RUN apt-get -qq update && \
         libproj-dev \
         locales \
         postgresql-client \
-        python3-virtualenv \
         rsync \
         runit-init \
         vim \
+        nodejs \
+        npm \
         wait-for-it && \
     apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -80,7 +81,7 @@ COPY . "${KPI_SRC_DIR}"
 # Install `pip` packages. #
 ###########################
 
-RUN virtualenv "$VIRTUAL_ENV"
+RUN python3 -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install  --quiet --upgrade pip && \
     pip install  --quiet pip-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,16 @@ RUN apt-get -qq update && \
         rsync \
         runit-init \
         vim \
-        nodejs \
-        npm \
         wait-for-it && \
     apt-get clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+###########################
+# Install NodeJS          #
+###########################
+
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs
 
 ###########################
 # Install locales         #

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN mkdir -p "${NGINX_STATIC_DIR}" && \
 ##########################################
 # Install `apt` packages.                #
 ##########################################
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 
 RUN apt-get -qq update && \
     apt-get -qq -y install \

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -252,7 +252,7 @@ pygments==2.4.2
     #   ipython
 pymongo==3.9.0
     # via -r dependencies/pip/requirements.in
-pynacl==1.3.0
+pynacl==1.4.0
     # via paramiko
 pyopenssl==19.0.0
     # via


### PR DESCRIPTION
## Description

The current base image of KPI `nikolaik/python-nodejs:python3.8-nodejs10` does not seem to support other plaforms than `x86_64/amd64`. Using Official Python image makes it possible. 

## Additional info 

For example, when we try to build the current image on ARM, docker raises this warning:

```
The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

