### PR TITLE
Don't display past repeat group responses twice (and badly)

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -740,6 +740,13 @@ export class DataTable extends React.Component {
           if (typeof(row.value) === 'object' || row.value === undefined) {
             const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);
 
+            // Partial bug fix for a case when form used to have a repeat group
+            // in older version, but it was changed into regular group in latest
+            // version. It will display an empty cell instead of "[Object, object]".
+            if (typeof repeatGroupAnswers[0] === 'object') {
+              return '';
+            }
+
             if (repeatGroupAnswers) {
               // display a list of answers from a repeat group question
               return (

--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -742,7 +742,7 @@ export class DataTable extends React.Component {
 
             // Partial bug fix for a case when form used to have a repeat group
             // in older version, but it was changed into regular group in latest
-            // version. It will display an empty cell instead of "[Object, object]".
+            // version. It will display an empty cell instead of "[object Object]".
             if (typeof repeatGroupAnswers[0] === 'object') {
               return '';
             }

--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -739,14 +739,6 @@ export class DataTable extends React.Component {
           }
           if (typeof(row.value) === 'object' || row.value === undefined) {
             const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);
-
-            // Partial bug fix for a case when form used to have a repeat group
-            // in older version, but it was changed into regular group in latest
-            // version. It will display an empty cell instead of "[object Object]".
-            if (typeof repeatGroupAnswers[0] === 'object') {
-              return '';
-            }
-
             if (repeatGroupAnswers) {
               // display a list of answers from a repeat group question
               return (

--- a/jsapp/js/components/submissions/tableStore.es6
+++ b/jsapp/js/components/submissions/tableStore.es6
@@ -205,16 +205,23 @@ const tableStore = Reflux.createStore({
     });
     output = output.filter((key) => excludedMatrixKeys.includes(key) === false);
 
-    // exclude repeat groups as we don't handle them in table yet
-    const excludedRepeatGroups = [];
+    // Exclude repeat groups and regular groups as all of their data is handled
+    // by children rows.
+    // This also fixes the issue when a repeat group in older version becomes
+    // a regular group in new form version (with the same name), and the Table
+    // was displaying "[object Object]" as responses.
+    const excludedGroups = [];
     const flatPathsWithGroups = getSurveyFlatPaths(asset.content.survey, true);
     asset.content.survey.forEach((row) => {
-      if (row.type === GROUP_TYPES_BEGIN.begin_repeat) {
+      if (
+        row.type === GROUP_TYPES_BEGIN.begin_repeat ||
+        row.type === GROUP_TYPES_BEGIN.begin_group
+      ) {
         const rowPath = flatPathsWithGroups[row.name] || flatPathsWithGroups[row.$autoname];
-        excludedRepeatGroups.push(rowPath);
+        excludedGroups.push(rowPath);
       }
     });
-    output = output.filter((key) => excludedRepeatGroups.includes(key) === false);
+    output = output.filter((key) => excludedGroups.includes(key) === false);
 
     return output;
   },


### PR DESCRIPTION
## Description

Changing a repeat group into regular group causes an additional column to appear in Table View with "[object Object]" as cell values. This is now fixed.

## Related issues

Fixes #3594