### PR TITLE
Build Docker images with GitLab CI and deploy to beta instance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ build:
   services:
     - docker:dind
   before_script:
-    - echo "$DOCKER_REGISTRY_PASS" | docker login $DOCKER_REGISTRY --username $DOCKER_REGISTRY_USER --password-stdin
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME || true
     - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,15 @@ stages:
   - test
   - deploy
 
+# Workaround to prevent duplicate CI runs
+# https://gitlab.com/gitlab-org/gitlab/-/issues/201845
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
+      when: never
+    - if: '$CI_COMMIT_BRANCH'
+
 build:
   image: docker
   services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,16 @@
+# Workaround to prevent duplicate CI runs
+# https://gitlab.com/gitlab-org/gitlab/-/issues/299409
+workflow:
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+    - if: $CI_OPEN_MERGE_REQUESTS
+      when: never
+    - if: $CI_COMMIT_BRANCH
+
 stages:
   - build
   - test
   - deploy
-
-# Workaround to prevent duplicate CI runs
-# https://gitlab.com/gitlab-org/gitlab/-/issues/201845
-workflow:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS'
-      when: never
-    - if: '$CI_COMMIT_BRANCH'
 
 build:
   image: docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,3 +14,21 @@ build:
     - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+
+deploy-beta:
+  stage: deploy
+  image:
+    name: alpine/helm:3.7.2
+    entrypoint: [""]
+  script:
+    - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
+    - helm -n beta upgrade kobo-beta kobo/kobo --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+  environment:
+    name: beta
+    url: https://kf.beta.kobotoolbox.org
+  only:
+    refs:
+      - master
+      - gitlab-ci-build
+    variables:
+      - $CI_COMMIT_REF_PROTECTED

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+stages:
+  - build
+  - test
+  - deploy
+
+build:
+  image: docker
+  services:
+    - docker:dind
+  script:
+    - docker pull $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME || true
+    - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,8 @@ build:
   image: docker
   services:
     - docker:dind
+  before_script:
+    - echo "$DOCKER_REGISTRY_PASS" | docker login $DOCKER_REGISTRY --username $DOCKER_REGISTRY_USER --password-stdin
   script:
     - docker pull $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME || true
     - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,6 @@ build:
     - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME || true
-    - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .
+    - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,3 @@
-# Workaround to prevent duplicate CI runs
-# https://gitlab.com/gitlab-org/gitlab/-/issues/299409
-workflow:
-  rules:
-    - if: $CI_MERGE_REQUEST_IID
-    - if: $CI_OPEN_MERGE_REQUESTS
-      when: never
-    - if: $CI_COMMIT_BRANCH
-
 stages:
   - build
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ deploy-beta:
     entrypoint: [""]
   script:
     - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
-    - helm -n beta upgrade kobo-beta kobo/kobo --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+    - helm -n beta upgrade kobo-beta kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
   environment:
     name: beta
     url: https://kf.beta.kobotoolbox.org

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,6 @@ build:
     - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME || true
-    - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .
-    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    - docker build --cache-from $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:CI_COMMIT_REF_NAME .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME


### PR DESCRIPTION
## Description

- Build docker images on commit, tag as both short sha hash and ref (branch/tag). Push to gitlab docker registry.
- On beta (and this branch to test) push to a beta instance via helm chart

CI configuration and builds are public. They depend on a protected gitlab ci variable for pushing in [gitlab settings](https://gitlab.com/kobo_toolbox/kpi/-/settings/repository) for those with access. Information on how permissions work for this aren't related to this specific PR but are important for how it works.

## Related issues

kobotoolbox/kobocat#785