### PR TITLE
Run `pip-sync` before `manage.py`

### DIFF
--- a/docker/init.bash
+++ b/docker/init.bash
@@ -14,6 +14,7 @@ if [[ -z $DATABASE_URL ]]; then
 fi
 
 # Handle Python dependencies BEFORE attempting any `manage.py` commands
+KPI_WEB_SERVER="${KPI_WEB_SERVER:-uWSGI}"
 if [[ "${KPI_WEB_SERVER,,}" == 'uwsgi' ]]; then
     # `diff` returns exit code 1 if it finds a difference between the files
     DIFF=$(diff "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt" || true)

--- a/docker/init.bash
+++ b/docker/init.bash
@@ -17,15 +17,15 @@ fi
 KPI_WEB_SERVER="${KPI_WEB_SERVER:-uWSGI}"
 if [[ "${KPI_WEB_SERVER,,}" == 'uwsgi' ]]; then
     # `diff` returns exit code 1 if it finds a difference between the files
-    DIFF=$(diff "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt" || true)
-    if [[ -n "$DIFF" ]]; then
+    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt"
+    then
         echo "Syncing production pip dependencies..."
         pip-sync dependencies/pip/external_services.txt 1>/dev/null
         cp "dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt"
     fi
 else
-    DIFF=$(diff "${KPI_SRC_DIR}/dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt" || true)
-    if [[ -n "$DIFF" ]]; then
+    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"
+    then
         echo "Syncing development pip dependencies..."
         pip-sync dependencies/pip/dev_requirements.txt 1>/dev/null
         cp "dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"

--- a/docker/run_uwsgi.bash
+++ b/docker/run_uwsgi.bash
@@ -5,30 +5,11 @@ source /etc/profile
 KPI_WEB_SERVER="${KPI_WEB_SERVER:-uWSGI}"
 UWSGI_COMMAND="$(command -v uwsgi) --ini ${KPI_SRC_DIR}/uwsgi.ini"
 
+cd "${KPI_SRC_DIR}"
 if [[ "${KPI_WEB_SERVER,,}" == 'uwsgi' ]]; then
-    cd "${KPI_SRC_DIR}"
-    DIFF=$(diff "${KPI_SRC_DIR}/dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt")
-    if [[ -n "$DIFF" ]]; then
-        echo "Syncing pip dependencies..."
-        pip-sync dependencies/pip/external_services.txt 1>/dev/null
-        cp "dependencies/pip/external_services.txt" "/srv/tmp/pip_dependencies.txt"
-    fi
     echo "Running \`kpi\` container with uWSGI application server."
     exec ${UWSGI_COMMAND}
 else
-    cd "${KPI_SRC_DIR}"
-    DIFF=$(diff "${KPI_SRC_DIR}/dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt")
-    if [[ -n "$DIFF" ]]; then
-        echo "Syncing pip dependencies..."
-        pip-sync dependencies/pip/dev_requirements.txt 1>/dev/null
-        cp "dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"
-    fi
-
-    if [[ -n "$RAVEN_DSN" ]]; then
-        echo "Sentry detected. Installing \`raven\` pip dependency..."
-        pip install raven
-    fi
-
     echo "Running \`kpi\` container with \`runserver_plus\` debugging application server."
     exec python manage.py runserver_plus 0:8000
 fi


### PR DESCRIPTION
## Description

Install Python dependencies before trying to run any Python scripts, fixing errors like `ModuleNotFoundError: No module named 'django_digest'` that previously required a full rebuild to resolve.