### PR TITLE
Standardize `country` and `sector` user metadata

### DIFF
--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -70,7 +70,7 @@ export default class AccountSettings extends React.Component {
       email: currentAccount.email,
       organization: currentAccount.extra_details.organization,
       organizationWebsite: currentAccount.extra_details.organization_website,
-      primarySector: currentAccount.extra_details.primary_sector,
+      primarySector: currentAccount.extra_details.sector,
       gender: currentAccount.extra_details.gender,
       bio: currentAccount.extra_details.bio,
       phoneNumber: currentAccount.extra_details.phone_number,
@@ -145,7 +145,7 @@ export default class AccountSettings extends React.Component {
           name: this.state.name,
           organization: this.state.organization,
           organization_website: this.state.organizationWebsite,
-          primary_sector: this.state.primarySector,
+          sector: this.state.primarySector,
           gender: this.state.gender,
           bio: this.state.bio,
           phone_number: this.state.phoneNumber,
@@ -320,11 +320,11 @@ export default class AccountSettings extends React.Component {
                 </bem.AccountSettings__item>
               }
 
-              {envStore.data.getUserMetadataField('primary_sector') &&
+              {envStore.data.getUserMetadataField('sector') &&
                 <bem.AccountSettings__item m='primary-sector'>
                   <WrappedSelect
                     label={t('Primary Sector')}
-                    error={this.state.fieldsErrors.extra_details?.primary_sector}
+                    error={this.state.fieldsErrors.extra_details?.sector}
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.primarySectorChange}

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -193,7 +193,7 @@ CONSTANCE_CONFIG = {
         json.dumps([
             {'name': 'organization', 'required': False},
             {'name': 'organization_website', 'required': False},
-            {'name': 'primary_sector', 'required': False},
+            {'name': 'sector', 'required': False},
             {'name': 'gender', 'required': False},
             {'name': 'bio', 'required': False},
             {'name': 'phone_number', 'required': False},
@@ -207,7 +207,7 @@ CONSTANCE_CONFIG = {
         # The available fields are hard-coded in the front end
         'Display (and optionally require) these metadata fields for users. '
         "Possible fields are 'organization', 'organization_website', "
-        "'primary_sector', 'gender', 'bio', 'phone_number', 'address', 'city', "
+        "'sector', 'gender', 'bio', 'phone_number', 'address', 'city', "
         "'country', 'twitter', 'linkedin', and 'instagram'",
         # Use custom field for schema validation
         'metadata_fields_jsonschema'

--- a/kpi/forms.py
+++ b/kpi/forms.py
@@ -81,7 +81,7 @@ class RegistrationForm(registration_forms.RegistrationForm):
         # Intentional t() call on dynamic string because the default choices
         # are translated (see static_lists.py)
         self.fields['sector'].choices = (('', ''),) + tuple(
-            (s, t(s)) for s in constance.config.SECTOR_CHOICES.split('\n')
+            (s, t(s)) for s in constance.config.SECTOR_CHOICES.split('\r\n')
         )
 
         # It's easier to _remove_ unwanted fields here in the constructor

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -77,16 +77,18 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             return {'message': 'user is not logged in'}
 
         rep = super().to_representation(obj)
-        if not rep['extra_details'] or not isinstance(
-            rep['extra_details'], dict
+        if (
+            not rep['extra_details']
+            or not isinstance(rep['extra_details'], dict)
         ):
             rep['extra_details'] = {}
         extra_details = rep['extra_details']
 
         # the front end used to set `primarySector` but has since been changed
         # to `sector`, which matches the registration form
-        if extra_details.get('primarySector') and not extra_details.get(
-            'sector'
+        if (
+            extra_details.get('primarySector')
+            and not extra_details.get('sector')
         ):
             extra_details['sector'] = extra_details['primarySector']
 

--- a/kpi/tests/api/v1/test_api_users.py
+++ b/kpi/tests/api/v1/test_api_users.py
@@ -1,7 +1,46 @@
 # coding: utf-8
+from django.contrib.auth.models import User
+from rest_framework.reverse import reverse
+
 from kpi.tests.api.v2 import test_api_users
 
 
 class UserListTests(test_api_users.UserListTests):
 
     URL_NAMESPACE = None
+
+    def test_current_user_extra_details_kludges(self):
+        self.client.login(username='someuser', password='someuser')
+        user = User.objects.get(username='someuser')
+        xtradata = user.extra_details.data
+        assert xtradata == {}
+
+        # `primarySector` should be renamed to `sector`
+        xtradata['primarySector'] = 'camelCase Administration'
+        user.extra_details.save()
+        response = self.client.get(reverse('currentuser-detail'))
+        # lone string should be transformed to object with label and value
+        assert response.data['extra_details']['sector'] == {
+            'label': 'camelCase Administration',
+            'value': 'camelCase Administration',
+        }
+        assert not 'primarySector' in response.data['extra_details']
+
+        # …but only if `sector` doesn't already exist
+        xtradata['sector'] = 'Head Honchoing'
+        user.extra_details.save()
+        response = self.client.get(reverse('currentuser-detail'))
+        assert response.data['extra_details']['sector'] == {
+            'label': 'Head Honchoing',
+            'value': 'Head Honchoing',
+        }
+        assert not 'primarySector' in response.data['extra_details']
+
+        # lone `country` string should also be transformed
+        xtradata['country'] = 'KoBoLand'
+        user.extra_details.save()
+        response = self.client.get(reverse('currentuser-detail'))
+        assert response.data['extra_details']['country'] == {
+            'label': 'KoBoLand',
+            'value': 'KoBoLand',
+        }

--- a/kpi/tests/api/v1/test_api_users.py
+++ b/kpi/tests/api/v1/test_api_users.py
@@ -10,6 +10,8 @@ class UserListTests(test_api_users.UserListTests):
     URL_NAMESPACE = None
 
     def test_current_user_extra_details_kludges(self):
+        endpoint = reverse(self._get_endpoint('currentuser-detail'))
+
         self.client.login(username='someuser', password='someuser')
         user = User.objects.get(username='someuser')
         xtradata = user.extra_details.data
@@ -18,28 +20,28 @@ class UserListTests(test_api_users.UserListTests):
         # `primarySector` should be renamed to `sector`
         xtradata['primarySector'] = 'camelCase Administration'
         user.extra_details.save()
-        response = self.client.get(reverse('currentuser-detail'))
+        response = self.client.get(endpoint)
         # lone string should be transformed to object with label and value
         assert response.data['extra_details']['sector'] == {
             'label': 'camelCase Administration',
             'value': 'camelCase Administration',
         }
-        assert not 'primarySector' in response.data['extra_details']
+        assert 'primarySector' not in response.data['extra_details']
 
         # …but only if `sector` doesn't already exist
         xtradata['sector'] = 'Head Honchoing'
         user.extra_details.save()
-        response = self.client.get(reverse('currentuser-detail'))
+        response = self.client.get(endpoint)
         assert response.data['extra_details']['sector'] == {
             'label': 'Head Honchoing',
             'value': 'Head Honchoing',
         }
-        assert not 'primarySector' in response.data['extra_details']
+        assert 'primarySector' not in response.data['extra_details']
 
         # lone `country` string should also be transformed
         xtradata['country'] = 'KoBoLand'
         user.extra_details.save()
-        response = self.client.get(reverse('currentuser-detail'))
+        response = self.client.get(endpoint)
         assert response.data['extra_details']['country'] == {
             'label': 'KoBoLand',
             'value': 'KoBoLand',


### PR DESCRIPTION
Previously, the user registration form saved `sector` in the extra user details, while the account settings screen used `primarySector`. In #3611, `primarySector` was changed to `primary_sector`, but the registration form still used `sector`. This changes the account settings screen to use `sector` to be consistent with the registration form and also the project metadata. It also converts lone-string `sector` and `country` values to the label-value object expected by the front end.

## Description

Fixes an issue where sector and country details entered during account registration did not appear in the account settings page.