### PR TITLE
Configurable metadata fixes

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -164,9 +164,9 @@ actions.misc.updateProfile.failed.listen(function(data) {
   }
 
   if (hadFieldsErrors) {
-    notify(t('Some fields contain errors'), 'error');
+    notify(t('Some fields contain errors!'), 'error');
   } else {
-    notify(t('failed to update profile'), 'error');
+    notify(t('Failed to update profile!'), 'error');
   }
 });
 

--- a/jsapp/js/bemComponents.ts
+++ b/jsapp/js/bemComponents.ts
@@ -15,7 +15,8 @@ bem.KoboLightBadge = makeBem(null, 'kobo-light-badge', 'span');
 
 bem.KoboSelect = makeBem(null, 'kobo-select');
 bem.KoboSelect__wrapper = makeBem(bem.KoboSelect, 'wrapper');
-bem.KoboSelect__errors = makeBem(bem.KoboSelect, 'errors');
+bem.KoboSelect__label = makeBem(bem.KoboSelect, 'label', 'span');
+bem.KoboSelect__error = makeBem(bem.KoboSelect, 'error');
 bem.KoboSelect__optionWrapper = makeBem(bem.KoboSelect, 'option-wrapper');
 bem.KoboSelect__optionBadge = makeBem(bem.KoboSelect, 'option-badge');
 

--- a/jsapp/js/bemComponents.ts
+++ b/jsapp/js/bemComponents.ts
@@ -244,7 +244,6 @@ bem.AccountSettings = makeBem(null, 'account-settings');
 bem.AccountSettings__left = makeBem(bem.AccountSettings, 'left');
 bem.AccountSettings__right = makeBem(bem.AccountSettings, 'right');
 bem.AccountSettings__item = makeBem(bem.FormModal, 'item');
-bem.AccountSettings__desc = makeBem(bem.AccountSettings, 'desc');
 bem.AccountSettings__actions = makeBem(bem.AccountSettings, 'actions');
 
 bem.UserRow = makeBem(null, 'user-row');

--- a/jsapp/js/components/RESTServices/RESTServicesForm.es6
+++ b/jsapp/js/components/RESTServices/RESTServicesForm.es6
@@ -7,7 +7,7 @@ import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {dataInterface} from '../../dataInterface';
 import {actions} from '../../actions';
 import {stores} from '../../stores';
-import Select from 'react-select';
+import WrappedSelect from 'js/components/common/wrappedSelect';
 import Checkbox from 'js/components/common/checkbox';
 import Radio from 'js/components/common/radio';
 import TextBox from 'js/components/common/textBox';
@@ -422,6 +422,7 @@ export default class RESTServicesForm extends React.Component {
           <bem.FormModal__item m='wrapper'>
             <bem.FormModal__item>
               <TextBox
+                customModifiers='on-white'
                 label={t('Name')}
                 type='text'
                 placeholder={t('Service Name')}
@@ -433,6 +434,7 @@ export default class RESTServicesForm extends React.Component {
 
             <bem.FormModal__item>
               <TextBox
+                customModifiers='on-white'
                 label={t('Endpoint URL')}
                 type='text'
                 placeholder={t('https://')}
@@ -471,26 +473,22 @@ export default class RESTServicesForm extends React.Component {
             </bem.FormModal__item>
 
             <bem.FormModal__item>
-              <label htmlFor='rest-service-form--security'>
-                {t('Security')}
-              </label>
-
-              <Select
+              <WrappedSelect
+                label={t('Security')}
                 value={this.state.authLevel}
                 options={this.state.authOptions}
                 onChange={this.handleAuthTypeChange.bind(this)}
-                className='kobo-select'
-                classNamePrefix='kobo-select'
                 id='rest-service-form--security'
                 name='authLevel'
-                menuPlacement='auto'
                 isSearchable={false}
+                isLimitedHeight
               />
             </bem.FormModal__item>
 
             {this.state.authLevel && this.state.authLevel.value === AUTH_OPTIONS.basic_auth.value &&
               <bem.FormModal__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Username')}
                   type='text'
                   value={this.state.authUsername}
@@ -498,6 +496,7 @@ export default class RESTServicesForm extends React.Component {
                 />
 
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Password')}
                   type='text'
                   value={this.state.authPassword}
@@ -513,6 +512,7 @@ export default class RESTServicesForm extends React.Component {
             {this.state.type === EXPORT_TYPES.json.value &&
               <bem.FormModal__item m='rest-custom-wrapper'>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Add custom wrapper around JSON submission (%SUBMISSION% will be replaced by JSON)').replace('%SUBMISSION%', submissionPlaceholder)}
                   type='text-multiline'
                   placeholder={t('Add Custom Wrapper')}

--- a/jsapp/js/components/account/accountSettings.scss
+++ b/jsapp/js/components/account/accountSettings.scss
@@ -94,54 +94,52 @@
     color: colors.$kobo-gray-40;
   }
 
-  .form-modal__item--primary-sector {
-    width: 46%;
-    margin-right: 2%;
-    float: left;
-  }
-
-  .form-modal__item--gender {
-    width: 50%;
-  }
-
-  .form-modal__item--bio {
-    clear: both;
-  }
-
-  .form-modal__item--city {
-    width: 48%;
-    margin-right: 4%;
-    float: left;
-
-    .text-box__input {
-      margin-top: 8px;
+  .form-modal__item {
+    &.form-modal__item--primary-sector {
+      width: 46%;
+      margin-right: 2%;
+      float: left;
     }
-  }
 
-  .form-modal__item--country {
-    width: 48%;
-    float: left;
-  }
+    &.form-modal__item--gender {
+      width: 50%;
+    }
 
-  .form-modal__item--social {
-    clear: both;
+    &.form-modal__item--bio {
+      clear: both;
+    }
 
-    > label {
-      position: relative;
+    &.form-modal__item--country {
+      width: 50%;
+      margin-right: 4%;
+      float: left;
+    }
 
-      &:not(:first-child) {
-        margin-top: sizes.$x5;
-      }
+    &.form-modal__item--city {
+      width: 46%;
+      float: left;
+    }
 
-      > i {
-        position: absolute;
-        font-size: 24px;
-        top: 4px;
-        left: 4px;
-      }
+    &.form-modal__item--social {
+      clear: both;
 
-      .text-box .text-box__input {
-        padding-left: 40px;
+      > label {
+        position: relative;
+
+        &:not(:first-child) {
+          margin-top: sizes.$x5;
+        }
+
+        > i {
+          position: absolute;
+          font-size: 24px;
+          top: 4px;
+          left: 4px;
+        }
+
+        .text-box .text-box__input {
+          padding-left: 40px;
+        }
       }
     }
   }

--- a/jsapp/js/components/account/accountSettings.scss
+++ b/jsapp/js/components/account/accountSettings.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/sizes";
 @use "scss/libs/_mdl";
 
 .account-settings {
@@ -40,6 +41,7 @@
         display: inline-block;
         vertical-align: top;
         width: 50%;
+        margin-right: sizes.$x5;
 
         .text-box__input {
           font-family: mdl.$font_mono;
@@ -69,6 +71,10 @@
     top: 26px;
     right: 0;
 
+    .account-settings-save:last-child {
+      margin-right: 48px;
+    }
+
     .account-settings-close {
       padding: 0 12px;
     }
@@ -95,8 +101,7 @@
   }
 
   .form-modal__item--gender {
-    width: 52%;
-    float: left;
+    width: 50%;
   }
 
   .form-modal__item--bio {
@@ -104,8 +109,8 @@
   }
 
   .form-modal__item--city {
-    width: 46%;
-    margin-right: 2%;
+    width: 48%;
+    margin-right: 4%;
     float: left;
 
     .text-box__input {
@@ -114,27 +119,29 @@
   }
 
   .form-modal__item--country {
-    width: 52%;
+    width: 48%;
     float: left;
   }
 
   .form-modal__item--social {
     clear: both;
 
-    label {
+    > label {
       position: relative;
 
-      i {
+      &:not(:first-child) {
+        margin-top: sizes.$x5;
+      }
+
+      > i {
         position: absolute;
         font-size: 24px;
-        top: 10px;
+        top: 4px;
         left: 4px;
       }
 
-      input {
-        margin-top: 8px;
+      .text-box .text-box__input {
         padding-left: 40px;
-        max-width: 400px;
       }
     }
   }

--- a/jsapp/js/components/account/accountSettings.scss
+++ b/jsapp/js/components/account/accountSettings.scss
@@ -27,9 +27,23 @@
     }
 
     .form-modal__item--api-token {
-      input {
-        font-family: mdl.$font_mono;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      flex-wrap: wrap;
+
+      > label {
+        width: 100%;
+      }
+
+      .text-box {
+        display: inline-block;
+        vertical-align: top;
         width: 50%;
+
+        .text-box__input {
+          font-family: mdl.$font_mono;
+        }
       }
     }
 

--- a/jsapp/js/components/account/accountSettings.scss
+++ b/jsapp/js/components/account/accountSettings.scss
@@ -90,10 +90,6 @@
     color: colors.$kobo-gray-24;
   }
 
-  .account-settings__desc {
-    color: colors.$kobo-gray-40;
-  }
-
   .form-modal__item {
     &.form-modal__item--primary-sector {
       width: 46%;

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -69,8 +69,6 @@ export default class AccountSettings extends React.Component {
       primarySector: currentAccount.extra_details.sector,
       gender: currentAccount.extra_details.gender,
       bio: currentAccount.extra_details.bio,
-      phoneNumber: currentAccount.extra_details.phone_number,
-      address: currentAccount.extra_details.address,
       city: currentAccount.extra_details.city,
       country: currentAccount.extra_details.country,
       requireAuth: currentAccount.extra_details.require_auth,
@@ -119,8 +117,6 @@ export default class AccountSettings extends React.Component {
           sector: this.state.primarySector,
           gender: this.state.gender,
           bio: this.state.bio,
-          phone_number: this.state.phoneNumber,
-          address: this.state.address,
           city: this.state.city,
           country: this.state.country,
           require_auth: this.state.requireAuth,
@@ -326,30 +322,6 @@ export default class AccountSettings extends React.Component {
                     errors={this.state.fieldsWithErrors.extra_details?.bio}
                     value={this.state.bio}
                     id='bio'
-                  />
-                </bem.AccountSettings__item>
-              }
-
-              {envStore.data.getUserMetadataField('phone_number') &&
-                <bem.AccountSettings__item>
-                  <TextBox
-                    customModifiers='on-white'
-                    label={t('Phone Number')}
-                    errors={this.state.fieldsWithErrors.extra_details?.phone_number}
-                    value={this.state.phoneNumber}
-                    onChange={this.phoneNumberChange}
-                  />
-                </bem.AccountSettings__item>
-              }
-
-              {envStore.data.getUserMetadataField('address') &&
-                <bem.AccountSettings__item>
-                  <TextBox
-                    customModifiers='on-white'
-                    label={t('Address')}
-                    errors={this.state.fieldsWithErrors.extra_details?.address}
-                    value={this.state.address}
-                    onChange={this.addressChange}
                   />
                 </bem.AccountSettings__item>
               }

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -219,9 +219,7 @@ export default class AccountSettings extends React.Component {
 
             <bem.AccountSettings__item m='fields'>
               <bem.AccountSettings__item>
-                <bem.AccountSettings__item>
-                  <label htmlFor='requireAuth'>{t('Privacy')}</label>
-                </bem.AccountSettings__item>
+                <label>{t('Privacy')}</label>
 
                 <Checkbox
                   checked={this.state.requireAuth}
@@ -237,7 +235,7 @@ export default class AccountSettings extends React.Component {
                   errors={this.state.fieldsWithErrors.name}
                   value={this.state.name}
                   onChange={this.nameChange}
-                  description={t('Use this to display your real name to other users')}
+                  placeholder={t('Use this to display your real name to other users')}
                 />
               </bem.AccountSettings__item>
 

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -3,7 +3,6 @@ import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
 import DocumentTitle from 'react-document-title';
-import alertify from 'alertifyjs';
 import {actions} from 'js/actions';
 import bem from 'js/bem';
 import {stores} from 'js/stores';
@@ -11,7 +10,6 @@ import TextBox from 'js/components/common/textBox';
 import Checkbox from 'js/components/common/checkbox';
 import WrappedSelect from 'js/components/common/wrappedSelect';
 import ApiTokenDisplay from 'js/components/apiTokenDisplay';
-import {hashHistory} from 'react-router';
 import {stringToColor} from 'utils';
 import {ROUTES} from 'js/router/routerConstants';
 import envStore from 'js/envStore';
@@ -100,29 +98,6 @@ export default class AccountSettings extends React.Component {
       ],
       fieldsWithErrors: {},
     });
-  }
-
-  /**
-   * returns to where you came from
-   */
-  safeClose() {
-    if (this.state.isPristine) {
-      hashHistory.goBack();
-    } else {
-      let dialog = alertify.dialog('confirm');
-      let opts = {
-        title: UNSAVED_CHANGES_WARNING,
-        message: '',
-        labels: {ok: t('Yes, leave settings'), cancel: t('Cancel')},
-        onok: () => {
-          this.setState({isPristine: true});
-          this.unpreventClosingTab();
-          hashHistory.goBack();
-        },
-        oncancel: dialog.destroy,
-      };
-      dialog.set(opts).show();
-    }
   }
 
   preventClosingTab() {
@@ -224,20 +199,13 @@ export default class AccountSettings extends React.Component {
         <bem.AccountSettings>
           <bem.AccountSettings__actions>
             <bem.KoboButton
+              className='account-settings-save'
               onClick={this.updateProfile}
               m={['blue']}
             >
               {t('Save Changes')}
               {!this.state.isPristine && ' *'}
             </bem.KoboButton>
-
-            <bem.Button
-              onClick={this.safeClose}
-              m='icon'
-              className='account-settings-close'
-            >
-              <i className='k-icon k-icon-close'/>
-            </bem.Button>
           </bem.AccountSettings__actions>
 
           <bem.AccountSettings__item m={'column'}>

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -328,9 +328,6 @@ export default class AccountSettings extends React.Component {
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.primarySectorChange}
-                    className='kobo-select'
-                    classNamePrefix='kobo-select'
-                    menuPlacement='auto'
                   />
 
                   <bem.AccountSettings__desc>
@@ -348,9 +345,6 @@ export default class AccountSettings extends React.Component {
                     options={this.state.genderChoices}
                     onChange={this.genderChange}
                     isSearchable={false}
-                    className='kobo-select'
-                    classNamePrefix='kobo-select'
-                    menuPlacement='auto'
                   />
                 </bem.AccountSettings__item>
               }
@@ -410,9 +404,6 @@ export default class AccountSettings extends React.Component {
                     value={this.state.country}
                     options={this.state.countryChoices}
                     onChange={this.countryChange}
-                    className='kobo-select'
-                    classNamePrefix='kobo-select'
-                    menuPlacement='auto'
                   />
                 </bem.AccountSettings__item>
               }

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -264,6 +264,7 @@ export default class AccountSettings extends React.Component {
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.onAnyDataChange.bind(this, 'primarySector')}
+                    isClearable
                   />
 
                   <bem.AccountSettings__desc>
@@ -309,6 +310,7 @@ export default class AccountSettings extends React.Component {
                     value={this.state.country}
                     options={this.state.countryChoices}
                     onChange={this.onAnyDataChange.bind(this, 'country')}
+                    isClearable
                   />
                 </bem.AccountSettings__item>
               }

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -3,6 +3,7 @@ import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
 import DocumentTitle from 'react-document-title';
+import clonedeep from 'lodash.clonedeep';
 import {actions} from 'js/actions';
 import bem from 'js/bem';
 import {stores} from 'js/stores';
@@ -17,6 +18,12 @@ import './accountSettings.scss';
 
 const UNSAVED_CHANGES_WARNING = t('You have unsaved changes. Leave settings without saving?');
 
+/**
+ * NOTE: We have multiple components with similar form:
+ * - ProjectSettings
+ * - AccountSettingsRoute
+ * - LibraryAssetForm
+ */
 export default class AccountSettings extends React.Component {
   constructor(props){
     super(props);
@@ -62,21 +69,23 @@ export default class AccountSettings extends React.Component {
     }
 
     this.setState({
-      name: currentAccount.extra_details.name,
-      email: currentAccount.email,
-      organization: currentAccount.extra_details.organization,
-      organizationWebsite: currentAccount.extra_details.organization_website,
-      primarySector: currentAccount.extra_details.sector,
-      gender: currentAccount.extra_details.gender,
-      bio: currentAccount.extra_details.bio,
-      city: currentAccount.extra_details.city,
-      country: currentAccount.extra_details.country,
-      requireAuth: currentAccount.extra_details.require_auth,
-      twitter: currentAccount.extra_details.twitter,
-      linkedin: currentAccount.extra_details.linkedin,
-      instagram: currentAccount.extra_details.instagram,
-      metadata: currentAccount.extra_details.metadata,
-
+      fields: {
+        name: currentAccount.extra_details.name,
+        email: currentAccount.email,
+        organization: currentAccount.extra_details.organization,
+        organizationWebsite: currentAccount.extra_details.organization_website,
+        primarySector: currentAccount.extra_details.sector,
+        gender: currentAccount.extra_details.gender,
+        bio: currentAccount.extra_details.bio,
+        city: currentAccount.extra_details.city,
+        country: currentAccount.extra_details.country,
+        requireAuth: currentAccount.extra_details.require_auth,
+        twitter: currentAccount.extra_details.twitter,
+        linkedin: currentAccount.extra_details.linkedin,
+        instagram: currentAccount.extra_details.instagram,
+        metadata: currentAccount.extra_details.metadata,
+      },
+      fieldsWithErrors: {},
       languageChoices: environment.all_languages,
       countryChoices: environment.country_choices,
       sectorChoices: environment.sector_choices,
@@ -94,7 +103,6 @@ export default class AccountSettings extends React.Component {
           label: t('Other'),
         },
       ],
-      fieldsWithErrors: {},
     });
   }
 
@@ -109,21 +117,21 @@ export default class AccountSettings extends React.Component {
   updateProfile() {
     actions.misc.updateProfile(
       {
-        email: this.state.email,
+        email: this.state.fields.email,
         extra_details: JSON.stringify({
-          name: this.state.name,
-          organization: this.state.organization,
-          organization_website: this.state.organizationWebsite,
-          sector: this.state.primarySector,
-          gender: this.state.gender,
-          bio: this.state.bio,
-          city: this.state.city,
-          country: this.state.country,
-          require_auth: this.state.requireAuth,
-          twitter: this.state.twitter,
-          linkedin: this.state.linkedin,
-          instagram: this.state.instagram,
-          metadata: this.state.metadata,
+          name: this.state.fields.name,
+          organization: this.state.fields.organization,
+          organization_website: this.state.fields.organizationWebsite,
+          sector: this.state.fields.primarySector,
+          gender: this.state.fields.gender,
+          bio: this.state.fields.bio,
+          city: this.state.fields.city,
+          country: this.state.fields.country,
+          require_auth: this.state.fields.requireAuth,
+          twitter: this.state.fields.twitter,
+          linkedin: this.state.fields.linkedin,
+          instagram: this.state.fields.instagram,
+          metadata: this.state.fields.metadata,
         }),
       },
       {
@@ -145,13 +153,14 @@ export default class AccountSettings extends React.Component {
     this.setState({fieldsWithErrors: data.responseJSON});
   }
 
-  onAnyDataChange(fieldName, newValue) {
+  onAnyFieldChange(fieldName, newFieldValue) {
     this.preventClosingTab();
+    const fields = clonedeep(this.state.fields);
+    fields[fieldName] = newFieldValue;
     this.setState({
       isPristine: false,
-      [fieldName]: newValue,
+      fields: fields,
     });
-
   }
 
   render() {
@@ -193,7 +202,7 @@ export default class AccountSettings extends React.Component {
 
                 <Checkbox
                   checked={this.state.requireAuth}
-                  onChange={this.onAnyDataChange.bind(this, 'requireAuth')}
+                  onChange={this.onAnyFieldChange.bind(this, 'requireAuth')}
                   label={t('Require authentication to see forms and submit data')}
                 />
               </bem.AccountSettings__item>
@@ -204,7 +213,7 @@ export default class AccountSettings extends React.Component {
                   label={t('Name')}
                   errors={this.state.fieldsWithErrors.name}
                   value={this.state.name}
-                  onChange={this.onAnyDataChange.bind(this, 'name')}
+                  onChange={this.onAnyFieldChange.bind(this, 'name')}
                   placeholder={t('Use this to display your real name to other users')}
                 />
               </bem.AccountSettings__item>
@@ -216,7 +225,7 @@ export default class AccountSettings extends React.Component {
                   type='email'
                   errors={this.state.fieldsWithErrors.email}
                   value={this.state.email}
-                  onChange={this.onAnyDataChange.bind(this, 'email')}
+                  onChange={this.onAnyFieldChange.bind(this, 'email')}
                 />
               </bem.AccountSettings__item>
 
@@ -238,7 +247,7 @@ export default class AccountSettings extends React.Component {
                     label={t('Organization')}
                     errors={this.state.fieldsWithErrors.extra_details?.organization}
                     value={this.state.organization}
-                    onChange={this.onAnyDataChange.bind(this, 'organization')}
+                    onChange={this.onAnyFieldChange.bind(this, 'organization')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -251,7 +260,7 @@ export default class AccountSettings extends React.Component {
                     type='url'
                     errors={this.state.fieldsWithErrors.extra_details?.organization_website}
                     value={this.state.organizationWebsite}
-                    onChange={this.onAnyDataChange.bind(this, 'organizationWebsite')}
+                    onChange={this.onAnyFieldChange.bind(this, 'organizationWebsite')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -263,7 +272,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.sector}
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
-                    onChange={this.onAnyDataChange.bind(this, 'primarySector')}
+                    onChange={this.onAnyFieldChange.bind(this, 'primarySector')}
                     placeholder={t('Select the primary sector in which you work. ')}
                     isClearable
                   />
@@ -277,7 +286,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.gender}
                     value={this.state.gender}
                     options={this.state.genderChoices}
-                    onChange={this.onAnyDataChange.bind(this, 'gender')}
+                    onChange={this.onAnyFieldChange.bind(this, 'gender')}
                     isClearable
                     isSearchable={false}
                   />
@@ -290,7 +299,7 @@ export default class AccountSettings extends React.Component {
                     customModifiers='on-white'
                     type='text-multiline'
                     label={t('Bio')}
-                    onChange={this.onAnyDataChange.bind(this, 'bio')}
+                    onChange={this.onAnyFieldChange.bind(this, 'bio')}
                     errors={this.state.fieldsWithErrors.extra_details?.bio}
                     value={this.state.bio}
                     id='bio'
@@ -306,7 +315,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.country}
                     value={this.state.country}
                     options={this.state.countryChoices}
-                    onChange={this.onAnyDataChange.bind(this, 'country')}
+                    onChange={this.onAnyFieldChange.bind(this, 'country')}
                     isClearable
                   />
                 </bem.AccountSettings__item>
@@ -319,7 +328,7 @@ export default class AccountSettings extends React.Component {
                     label={t('City')}
                     errors={this.state.fieldsWithErrors.extra_details?.city}
                     value={this.state.city}
-                    onChange={this.onAnyDataChange.bind(this, 'city')}
+                    onChange={this.onAnyFieldChange.bind(this, 'city')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -339,7 +348,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.twitter}
                         value={this.state.twitter}
-                        onChange={this.onAnyDataChange.bind(this, 'twitter')}
+                        onChange={this.onAnyFieldChange.bind(this, 'twitter')}
                       />
                     </label>
                   }
@@ -352,7 +361,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.linkedin}
                         value={this.state.linkedin}
-                        onChange={this.onAnyDataChange.bind(this, 'linkedin')}
+                        onChange={this.onAnyFieldChange.bind(this, 'linkedin')}
                       />
                     </label>
                   }
@@ -365,7 +374,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.instagram}
                         value={this.state.instagram}
-                        onChange={this.onAnyDataChange.bind(this, 'instagram')}
+                        onChange={this.onAnyFieldChange.bind(this, 'instagram')}
                       />
                     </label>
                   }
@@ -378,7 +387,7 @@ export default class AccountSettings extends React.Component {
                   label={t('Metadata')}
                   errors={this.state.fieldsWithErrors.metadata}
                   value={this.state.metadata}
-                  onChange={this.onAnyDataChange.bind(this, 'metadata')}
+                  onChange={this.onAnyFieldChange.bind(this, 'metadata')}
                 />
               </bem.AccountSettings__item>
             </bem.AccountSettings__item>

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -145,40 +145,14 @@ export default class AccountSettings extends React.Component {
     this.setState({fieldsWithErrors: data.responseJSON});
   }
 
-  handleChange(evt, attr) {
-    let val;
-    if (evt && evt.target) {
-      if (evt.target.type === 'checkbox') {
-        val = evt.target.checked;
-      } else {
-        val = evt.target.value;
-      }
-    } else {
-      // react-select, TextBox and Checkbox just passes a value
-      val = evt;
-    }
+  onAnyDataChange(fieldName, newValue) {
     this.preventClosingTab();
     this.setState({
       isPristine: false,
-      [attr]: val,
+      [fieldName]: newValue,
     });
+
   }
-  nameChange(e) {this.handleChange(e, 'name');}
-  emailChange(e) {this.handleChange(e, 'email');}
-  organizationChange(e) {this.handleChange(e, 'organization');}
-  organizationWebsiteChange(e) {this.handleChange(e, 'organizationWebsite');}
-  primarySectorChange(e) {this.handleChange(e, 'primarySector');}
-  genderChange(e) {this.handleChange(e, 'gender');}
-  bioChange(e) {this.handleChange(e, 'bio');}
-  phoneNumberChange(e) {this.handleChange(e, 'phoneNumber');}
-  addressChange(e) {this.handleChange(e, 'address');}
-  cityChange(e) {this.handleChange(e, 'city');}
-  countryChange(e) {this.handleChange(e, 'country');}
-  requireAuthChange(isChecked) {this.handleChange(isChecked, 'requireAuth');}
-  twitterChange(e) {this.handleChange(e, 'twitter');}
-  linkedinChange(e) {this.handleChange(e, 'linkedin');}
-  instagramChange(e) {this.handleChange(e, 'instagram');}
-  metadataChange(e) {this.handleChange(e, 'metadata');}
 
   render() {
     if(!stores.session.isLoggedIn || !envStore.isReady) {
@@ -219,7 +193,7 @@ export default class AccountSettings extends React.Component {
 
                 <Checkbox
                   checked={this.state.requireAuth}
-                  onChange={this.requireAuthChange}
+                  onChange={this.onAnyDataChange.bind(this, 'requireAuth')}
                   label={t('Require authentication to see forms and submit data')}
                 />
               </bem.AccountSettings__item>
@@ -230,7 +204,7 @@ export default class AccountSettings extends React.Component {
                   label={t('Name')}
                   errors={this.state.fieldsWithErrors.name}
                   value={this.state.name}
-                  onChange={this.nameChange}
+                  onChange={this.onAnyDataChange.bind(this, 'name')}
                   placeholder={t('Use this to display your real name to other users')}
                 />
               </bem.AccountSettings__item>
@@ -242,7 +216,7 @@ export default class AccountSettings extends React.Component {
                   type='email'
                   errors={this.state.fieldsWithErrors.email}
                   value={this.state.email}
-                  onChange={this.emailChange}
+                  onChange={this.onAnyDataChange.bind(this, 'email')}
                 />
               </bem.AccountSettings__item>
 
@@ -264,7 +238,7 @@ export default class AccountSettings extends React.Component {
                     label={t('Organization')}
                     errors={this.state.fieldsWithErrors.extra_details?.organization}
                     value={this.state.organization}
-                    onChange={this.organizationChange}
+                    onChange={this.onAnyDataChange.bind(this, 'organization')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -277,7 +251,7 @@ export default class AccountSettings extends React.Component {
                     type='url'
                     errors={this.state.fieldsWithErrors.extra_details?.organization_website}
                     value={this.state.organizationWebsite}
-                    onChange={this.organizationWebsiteChange}
+                    onChange={this.onAnyDataChange.bind(this, 'organizationWebsite')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -289,7 +263,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.sector}
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
-                    onChange={this.primarySectorChange}
+                    onChange={this.onAnyDataChange.bind(this, 'primarySector')}
                   />
 
                   <bem.AccountSettings__desc>
@@ -305,7 +279,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.gender}
                     value={this.state.gender}
                     options={this.state.genderChoices}
-                    onChange={this.genderChange}
+                    onChange={this.onAnyDataChange.bind(this, 'gender')}
                     isClearable
                     isSearchable={false}
                   />
@@ -318,7 +292,7 @@ export default class AccountSettings extends React.Component {
                     customModifiers='on-white'
                     type='text-multiline'
                     label={t('Bio')}
-                    onChange={this.bioChange}
+                    onChange={this.onAnyDataChange.bind(this, 'bio')}
                     errors={this.state.fieldsWithErrors.extra_details?.bio}
                     value={this.state.bio}
                     id='bio'
@@ -334,7 +308,7 @@ export default class AccountSettings extends React.Component {
                     error={this.state.fieldsWithErrors.extra_details?.country}
                     value={this.state.country}
                     options={this.state.countryChoices}
-                    onChange={this.countryChange}
+                    onChange={this.onAnyDataChange.bind(this, 'country')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -346,7 +320,7 @@ export default class AccountSettings extends React.Component {
                     label={t('City')}
                     errors={this.state.fieldsWithErrors.extra_details?.city}
                     value={this.state.city}
-                    onChange={this.cityChange}
+                    onChange={this.onAnyDataChange.bind(this, 'city')}
                   />
                 </bem.AccountSettings__item>
               }
@@ -366,7 +340,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.twitter}
                         value={this.state.twitter}
-                        onChange={this.twitterChange}
+                        onChange={this.onAnyDataChange.bind(this, 'twitter')}
                       />
                     </label>
                   }
@@ -379,7 +353,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.linkedin}
                         value={this.state.linkedin}
-                        onChange={this.linkedinChange}
+                        onChange={this.onAnyDataChange.bind(this, 'linkedin')}
                       />
                     </label>
                   }
@@ -392,7 +366,7 @@ export default class AccountSettings extends React.Component {
                         customModifiers='on-white'
                         errors={this.state.fieldsWithErrors.extra_details?.instagram}
                         value={this.state.instagram}
-                        onChange={this.instagramChange}
+                        onChange={this.onAnyDataChange.bind(this, 'instagram')}
                       />
                     </label>
                   }
@@ -405,7 +379,7 @@ export default class AccountSettings extends React.Component {
                   label={t('Metadata')}
                   errors={this.state.fieldsWithErrors.metadata}
                   value={this.state.metadata}
-                  onChange={this.metadataChange}
+                  onChange={this.onAnyDataChange.bind(this, 'metadata')}
                 />
               </bem.AccountSettings__item>
             </bem.AccountSettings__item>

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -264,12 +264,9 @@ export default class AccountSettings extends React.Component {
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.onAnyDataChange.bind(this, 'primarySector')}
+                    placeholder={t('Select the primary sector in which you work. ')}
                     isClearable
                   />
-
-                  <bem.AccountSettings__desc>
-                    {t('Select the primary sector in which you work. ')}
-                  </bem.AccountSettings__desc>
                 </bem.AccountSettings__item>
               }
 

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -7,7 +7,6 @@ import alertify from 'alertifyjs';
 import {actions} from 'js/actions';
 import bem from 'js/bem';
 import {stores} from 'js/stores';
-import Select from 'react-select';
 import TextBox from 'js/components/common/textBox';
 import Checkbox from 'js/components/common/checkbox';
 import WrappedSelect from 'js/components/common/wrappedSelect';
@@ -23,12 +22,11 @@ const UNSAVED_CHANGES_WARNING = t('You have unsaved changes. Leave settings with
 export default class AccountSettings extends React.Component {
   constructor(props){
     super(props);
-    let state = {
+    this.state = {
       isPristine: true,
       requireAuth: false,
-      fieldsErrors: {}
+      fieldsWithErrors: {},
     };
-    this.state = state;
     autoBind(this);
   }
 
@@ -50,7 +48,7 @@ export default class AccountSettings extends React.Component {
     this.rebuildState();
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.unpreventClosingTab();
   }
 
@@ -89,18 +87,18 @@ export default class AccountSettings extends React.Component {
       genderChoices: [
         {
           value: 'male',
-          label: t('Male')
+          label: t('Male'),
         },
         {
           value: 'female',
-          label: t('Female')
+          label: t('Female'),
         },
         {
           value: 'other',
-          label: t('Other')
+          label: t('Other'),
         },
       ],
-      fieldsErrors: {}
+      fieldsWithErrors: {},
     });
   }
 
@@ -121,16 +119,14 @@ export default class AccountSettings extends React.Component {
           this.unpreventClosingTab();
           hashHistory.goBack();
         },
-        oncancel: dialog.destroy
+        oncancel: dialog.destroy,
       };
       dialog.set(opts).show();
     }
   }
 
   preventClosingTab() {
-    $(window).on('beforeunload.noclosetab', () => {
-      return UNSAVED_CHANGES_WARNING;
-    });
+    $(window).on('beforeunload.noclosetab', () => (UNSAVED_CHANGES_WARNING));
   }
 
   unpreventClosingTab() {
@@ -157,11 +153,11 @@ export default class AccountSettings extends React.Component {
           linkedin: this.state.linkedin,
           instagram: this.state.instagram,
           metadata: this.state.metadata,
-        })
+        }),
       },
       {
         onComplete: this.onUpdateComplete.bind(this),
-        onFail: this.onUpdateFail.bind(this)
+        onFail: this.onUpdateFail.bind(this),
       }
     );
   }
@@ -170,12 +166,12 @@ export default class AccountSettings extends React.Component {
     this.unpreventClosingTab();
     this.setState({
       isPristine: true,
-      fieldsErrors: {}
+      fieldsWithErrors: {},
     });
   }
 
   onUpdateFail(data) {
-    this.setState({fieldsErrors: data.responseJSON});
+    this.setState({fieldsWithErrors: data.responseJSON});
   }
 
   handleChange(evt, attr) {
@@ -193,25 +189,25 @@ export default class AccountSettings extends React.Component {
     this.preventClosingTab();
     this.setState({
       isPristine: false,
-      [attr]: val
+      [attr]: val,
     });
   }
-  nameChange (e) {this.handleChange(e, 'name');}
-  emailChange (e) {this.handleChange(e, 'email');}
-  organizationChange (e) {this.handleChange(e, 'organization');}
-  organizationWebsiteChange (e) {this.handleChange(e, 'organizationWebsite');}
-  primarySectorChange (e) {this.handleChange(e, 'primarySector');}
-  genderChange (e) {this.handleChange(e, 'gender');}
-  bioChange (e) {this.handleChange(e, 'bio');}
-  phoneNumberChange (e) {this.handleChange(e, 'phoneNumber');}
-  addressChange (e) {this.handleChange(e, 'address');}
-  cityChange (e) {this.handleChange(e, 'city');}
-  countryChange (e) {this.handleChange(e, 'country');}
-  requireAuthChange (isChecked) {this.handleChange(isChecked, 'requireAuth');}
-  twitterChange (e) {this.handleChange(e, 'twitter');}
-  linkedinChange (e) {this.handleChange(e, 'linkedin');}
-  instagramChange (e) {this.handleChange(e, 'instagram');}
-  metadataChange (e) {this.handleChange(e, 'metadata');}
+  nameChange(e) {this.handleChange(e, 'name');}
+  emailChange(e) {this.handleChange(e, 'email');}
+  organizationChange(e) {this.handleChange(e, 'organization');}
+  organizationWebsiteChange(e) {this.handleChange(e, 'organizationWebsite');}
+  primarySectorChange(e) {this.handleChange(e, 'primarySector');}
+  genderChange(e) {this.handleChange(e, 'gender');}
+  bioChange(e) {this.handleChange(e, 'bio');}
+  phoneNumberChange(e) {this.handleChange(e, 'phoneNumber');}
+  addressChange(e) {this.handleChange(e, 'address');}
+  cityChange(e) {this.handleChange(e, 'city');}
+  countryChange(e) {this.handleChange(e, 'country');}
+  requireAuthChange(isChecked) {this.handleChange(isChecked, 'requireAuth');}
+  twitterChange(e) {this.handleChange(e, 'twitter');}
+  linkedinChange(e) {this.handleChange(e, 'linkedin');}
+  instagramChange(e) {this.handleChange(e, 'instagram');}
+  metadataChange(e) {this.handleChange(e, 'metadata');}
 
   render() {
     if(!stores.session.isLoggedIn || !envStore.isReady) {
@@ -220,7 +216,7 @@ export default class AccountSettings extends React.Component {
 
     var accountName = stores.session.currentAccount.username;
     var initialsStyle = {
-      background: `#${stringToColor(accountName)}`
+      background: `#${stringToColor(accountName)}`,
     };
 
     return (
@@ -268,8 +264,9 @@ export default class AccountSettings extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Name')}
-                  errors={this.state.fieldsErrors.name}
+                  errors={this.state.fieldsWithErrors.name}
                   value={this.state.name}
                   onChange={this.nameChange}
                   description={t('Use this to display your real name to other users')}
@@ -278,9 +275,10 @@ export default class AccountSettings extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Email')}
                   type='email'
-                  errors={this.state.fieldsErrors.email}
+                  errors={this.state.fieldsWithErrors.email}
                   value={this.state.email}
                   onChange={this.emailChange}
                 />
@@ -300,8 +298,9 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('organization') &&
                 <bem.AccountSettings__item>
                   <TextBox
+                    customModifiers='on-white'
                     label={t('Organization')}
-                    errors={this.state.fieldsErrors.extra_details?.organization}
+                    errors={this.state.fieldsWithErrors.extra_details?.organization}
                     value={this.state.organization}
                     onChange={this.organizationChange}
                   />
@@ -311,9 +310,10 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('organization_website') &&
                 <bem.AccountSettings__item>
                   <TextBox
+                    customModifiers='on-white'
                     label={t('Organization Website')}
                     type='url'
-                    errors={this.state.fieldsErrors.extra_details?.organization_website}
+                    errors={this.state.fieldsWithErrors.extra_details?.organization_website}
                     value={this.state.organizationWebsite}
                     onChange={this.organizationWebsiteChange}
                   />
@@ -324,7 +324,7 @@ export default class AccountSettings extends React.Component {
                 <bem.AccountSettings__item m='primary-sector'>
                   <WrappedSelect
                     label={t('Primary Sector')}
-                    error={this.state.fieldsErrors.extra_details?.sector}
+                    error={this.state.fieldsWithErrors.extra_details?.sector}
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.primarySectorChange}
@@ -340,7 +340,7 @@ export default class AccountSettings extends React.Component {
                 <bem.AccountSettings__item m='gender'>
                   <WrappedSelect
                     label={t('Gender')}
-                    error={this.state.fieldsErrors.extra_details?.gender}
+                    error={this.state.fieldsWithErrors.extra_details?.gender}
                     value={this.state.gender}
                     options={this.state.genderChoices}
                     onChange={this.genderChange}
@@ -352,10 +352,11 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('bio') &&
                 <bem.AccountSettings__item m='bio'>
                   <TextBox
+                    customModifiers='on-white'
                     type='text-multiline'
                     label={t('Bio')}
                     onChange={this.bioChange}
-                    errors={this.state.fieldsErrors.extra_details?.bio}
+                    errors={this.state.fieldsWithErrors.extra_details?.bio}
                     value={this.state.bio}
                     id='bio'
                   />
@@ -365,8 +366,9 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('phone_number') &&
                 <bem.AccountSettings__item>
                   <TextBox
+                    customModifiers='on-white'
                     label={t('Phone Number')}
-                    errors={this.state.fieldsErrors.extra_details?.phone_number}
+                    errors={this.state.fieldsWithErrors.extra_details?.phone_number}
                     value={this.state.phoneNumber}
                     onChange={this.phoneNumberChange}
                   />
@@ -376,8 +378,9 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('address') &&
                 <bem.AccountSettings__item>
                   <TextBox
+                    customModifiers='on-white'
                     label={t('Address')}
-                    errors={this.state.fieldsErrors.extra_details?.address}
+                    errors={this.state.fieldsWithErrors.extra_details?.address}
                     value={this.state.address}
                     onChange={this.addressChange}
                   />
@@ -387,8 +390,9 @@ export default class AccountSettings extends React.Component {
               {envStore.data.getUserMetadataField('city') &&
                 <bem.AccountSettings__item m='city'>
                   <TextBox
+                    customModifiers='on-white'
                     label={t('City')}
-                    errors={this.state.fieldsErrors.extra_details?.city}
+                    errors={this.state.fieldsWithErrors.extra_details?.city}
                     value={this.state.city}
                     onChange={this.cityChange}
                   />
@@ -400,7 +404,7 @@ export default class AccountSettings extends React.Component {
                   <WrappedSelect
                     isMulti
                     label={t('Country')}
-                    error={this.state.fieldsErrors.extra_details?.country}
+                    error={this.state.fieldsWithErrors.extra_details?.country}
                     value={this.state.country}
                     options={this.state.countryChoices}
                     onChange={this.countryChange}
@@ -420,7 +424,8 @@ export default class AccountSettings extends React.Component {
                       <i className='k-icon k-icon-logo-twitter' />
 
                       <TextBox
-                        errors={this.state.fieldsErrors.extra_details?.twitter}
+                        customModifiers='on-white'
+                        errors={this.state.fieldsWithErrors.extra_details?.twitter}
                         value={this.state.twitter}
                         onChange={this.twitterChange}
                       />
@@ -432,7 +437,8 @@ export default class AccountSettings extends React.Component {
                       <i className='k-icon k-icon-logo-linkedin' />
 
                       <TextBox
-                        errors={this.state.fieldsErrors.extra_details?.linkedin}
+                        customModifiers='on-white'
+                        errors={this.state.fieldsWithErrors.extra_details?.linkedin}
                         value={this.state.linkedin}
                         onChange={this.linkedinChange}
                       />
@@ -444,7 +450,8 @@ export default class AccountSettings extends React.Component {
                       <i className='k-icon k-icon-logo-instagram' />
 
                       <TextBox
-                        errors={this.state.fieldsErrors.extra_details?.instagram}
+                        customModifiers='on-white'
+                        errors={this.state.fieldsWithErrors.extra_details?.instagram}
                         value={this.state.instagram}
                         onChange={this.instagramChange}
                       />
@@ -455,8 +462,9 @@ export default class AccountSettings extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Metadata')}
-                  errors={this.state.fieldsErrors.metadata}
+                  errors={this.state.fieldsWithErrors.metadata}
                   value={this.state.metadata}
                   onChange={this.metadataChange}
                 />

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -326,18 +326,6 @@ export default class AccountSettings extends React.Component {
                 </bem.AccountSettings__item>
               }
 
-              {envStore.data.getUserMetadataField('city') &&
-                <bem.AccountSettings__item m='city'>
-                  <TextBox
-                    customModifiers='on-white'
-                    label={t('City')}
-                    errors={this.state.fieldsWithErrors.extra_details?.city}
-                    value={this.state.city}
-                    onChange={this.cityChange}
-                  />
-                </bem.AccountSettings__item>
-              }
-
               {envStore.data.getUserMetadataField('country') &&
                 <bem.AccountSettings__item m='country'>
                   <WrappedSelect
@@ -347,6 +335,18 @@ export default class AccountSettings extends React.Component {
                     value={this.state.country}
                     options={this.state.countryChoices}
                     onChange={this.countryChange}
+                  />
+                </bem.AccountSettings__item>
+              }
+
+              {envStore.data.getUserMetadataField('city') &&
+                <bem.AccountSettings__item m='city'>
+                  <TextBox
+                    customModifiers='on-white'
+                    label={t('City')}
+                    errors={this.state.fieldsWithErrors.extra_details?.city}
+                    value={this.state.city}
+                    onChange={this.cityChange}
                   />
                 </bem.AccountSettings__item>
               }

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -273,7 +273,6 @@ export default class AccountSettings extends React.Component {
                     value={this.state.primarySector}
                     options={this.state.sectorChoices}
                     onChange={this.onAnyFieldChange.bind(this, 'primarySector')}
-                    placeholder={t('Select the primary sector in which you work. ')}
                     isClearable
                   />
                 </bem.AccountSettings__item>

--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -344,6 +344,7 @@ export default class AccountSettings extends React.Component {
                     value={this.state.gender}
                     options={this.state.genderChoices}
                     onChange={this.genderChange}
+                    isClearable
                     isSearchable={false}
                   />
                 </bem.AccountSettings__item>

--- a/jsapp/js/components/account/accountSidebar.scss
+++ b/jsapp/js/components/account/accountSidebar.scss
@@ -9,6 +9,11 @@
     margin-bottom: 18px;
   }
 
+  .form-sidebar__label[disabled] {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
   .form-sidebar__label--selected {
     border-left: 3px solid $kobo-teal;
   }

--- a/jsapp/js/components/account/accountSidebar.tsx
+++ b/jsapp/js/components/account/accountSidebar.tsx
@@ -71,6 +71,7 @@ export default class AccountSidebar extends React.Component<
           <bem.FormSidebar__label
             m={{selected: this.isDataStorageSelected()}}
             href={'#' + ROUTES.DATA_STORAGE}
+            disabled
           >
             {/*TODO: get the data usage icon*/}
             <Icon name='projects' size='xl'/>
@@ -82,6 +83,7 @@ export default class AccountSidebar extends React.Component<
           <bem.FormSidebar__label
             m={{selected: this.isSecuritySelected()}}
             href={'#' + ROUTES.SECURITY}
+            disabled
           >
             {/*TODO: get the data usage icon*/}
             <Icon name='lock' size='xl'/>

--- a/jsapp/js/components/apiTokenDisplay.es6
+++ b/jsapp/js/components/apiTokenDisplay.es6
@@ -6,6 +6,8 @@ import React from 'react';
 import autoBind from 'react-autobind';
 import bem from 'js/bem';
 import {actions} from 'js/actions';
+import TextBox from 'js/components/common/textBox';
+import Button from 'js/components/common/button';
 
 class ApiTokenDisplay extends React.Component {
   constructor(props) {
@@ -55,22 +57,23 @@ class ApiTokenDisplay extends React.Component {
       <bem.FormModal__item m='api-token'>
         <label>{t('API token')}</label>
 
-        <input
+        <TextBox
+          customModifiers='on-white'
           type={this.state.isTokenVisible && !this.state.isLoadingToken ? 'text' : 'password'}
           value={this.state.token}
           onFocus={this.onInputFocus}
           readOnly
         />
 
-        <bem.Button
-          onClick={this.toggleApiTokenVisibility}
+        <Button
           disabled={this.state.isLoadingToken}
           m='icon'
-        >
-          <i className={this.state.isTokenVisible ? 'k-icon k-icon-hide'
-                                                  : 'k-icon k-icon-view'}
-          />
-        </bem.Button>
+          type='bare'
+          color='storm'
+          size='m'
+          startIcon={this.state.isTokenVisible ? 'hide' : 'view'}
+          onClick={this.toggleApiTokenVisibility}
+        />
       </bem.FormModal__item>
     );
   }

--- a/jsapp/js/components/changePassword.es6
+++ b/jsapp/js/components/changePassword.es6
@@ -124,6 +124,7 @@ export default class ChangePassword extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Current Password')}
                   type='password'
                   errors={this.state.errors.currentPassword}
@@ -141,6 +142,7 @@ export default class ChangePassword extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('New Password')}
                   type='password'
                   errors={this.state.errors.newPassword}
@@ -158,6 +160,7 @@ export default class ChangePassword extends React.Component {
 
               <bem.AccountSettings__item>
                 <TextBox
+                  customModifiers='on-white'
                   label={t('Verify Password')}
                   type='password'
                   errors={this.state.errors.verifyPassword}

--- a/jsapp/js/components/common/checkbox-and-radio.scss
+++ b/jsapp/js/components/common/checkbox-and-radio.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 .radio,
 .checkbox {
@@ -43,7 +44,7 @@
     // it's 28px plus whitespace between inline-blocks
     max-width: calc(100% - 32px);
     color: colors.$kobo-gray-24;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
   }
 
   .radio__input + .radio__label,

--- a/jsapp/js/components/common/loadingSpinner.scss
+++ b/jsapp/js/components/common/loadingSpinner.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 // Loading messages
 .loading {
@@ -37,7 +38,7 @@
     }
 
     .pro-tip {
-      font-size: 14px;
+      font-size: variables.$base-font-size;
       margin-top: 30px;
     }
   }

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -1,5 +1,6 @@
 @use "scss/_colors";
 @use "scss/libs/_mdl";
+@use "scss/_variables";
 
 $z-modal-backdrop: 1101;
 $z-enketo-iframe-icon: 1100;
@@ -355,7 +356,7 @@ $z-modal-x: 10;
       width: 100%;
       display: flex;
       justify-content: space-between;
-      font-size: 14px;
+      font-size: variables.$base-font-size;
       font-weight: 600;
       margin-right: 12px;
 

--- a/jsapp/js/components/common/textBox.scss
+++ b/jsapp/js/components/common/textBox.scss
@@ -9,6 +9,7 @@ label.text-box {
   &.text-box--error {
     color: colors.$kobo-red;
 
+    textarea.text-box__input,
     input.text-box__input {
       // Don't type red if there is an error
       color: colors.$kobo-gray-40;
@@ -19,15 +20,17 @@ label.text-box {
   &.text-box--on-white input.text-box__input,
   &.text-box--on-white textarea.text-box__input {
     border-color: colors.$kobo-gray-92;
-    padding-left: 5px;
-    padding-right: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+    border-radius: 6px;
 
     &:focus {
       border-color: colors.$kobo-blue;
     }
   }
 
-  &.text-box--on-white.text-box--error input.text-box__input {
+  &.text-box--on-white.text-box--error input.text-box__input,
+  &.text-box--on-white.text-box--error textarea.text-box__input {
     border-color: colors.$kobo-red;
   }
 
@@ -42,6 +45,7 @@ label.text-box {
     }
   }
 
+  textarea.text-box__input,
   input.text-box__input {
     width: 100%;
     padding: 5px 0px;
@@ -69,5 +73,11 @@ label.text-box {
     &::placeholder {
       color: colors.$kobo-gray-40;
     }
+  }
+
+  .text-box__error {
+    font-size: 12px;
+    font-weight: 400;
+    font-style: normal;
   }
 }

--- a/jsapp/js/components/common/textBox.scss
+++ b/jsapp/js/components/common/textBox.scss
@@ -48,6 +48,7 @@ label.text-box {
   }
 
   .text-box__label {
+    font-size: sizes.$x13;
     line-height: sizes.$x16;
   }
 
@@ -89,7 +90,7 @@ label.text-box {
   }
 
   .text-box__error {
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 400;
     font-style: normal;
   }

--- a/jsapp/js/components/common/textBox.scss
+++ b/jsapp/js/components/common/textBox.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 // TODO: cleanup the other places
 // this copies a lot of global styles defined in _kobo.bem.ui.scss
@@ -12,7 +13,7 @@ label.text-box {
     textarea.text-box__input,
     input.text-box__input {
       // Don't type red if there is an error
-      color: colors.$kobo-gray-40;
+      color: colors.$kobo-gray-24;
       border-bottom-color: colors.$kobo-red;
     }
   }
@@ -49,8 +50,8 @@ label.text-box {
   input.text-box__input {
     width: 100%;
     padding: 5px 0px;
-    font-size: 14px;
-    color: inherit;
+    font-size: variables.$base-font-size;
+    color: colors.$kobo-gray-24;
     background-color: transparent;
     border: 1px solid transparent;
     border-bottom-color: colors.$kobo-gray-85;
@@ -71,7 +72,8 @@ label.text-box {
     }
 
     &::placeholder {
-      color: colors.$kobo-gray-40;
+      color: colors.$kobo-gray-65;
+      opacity: 1;
     }
   }
 

--- a/jsapp/js/components/common/textBox.scss
+++ b/jsapp/js/components/common/textBox.scss
@@ -46,10 +46,16 @@ label.text-box {
     }
   }
 
+  .text-box__label + textarea.text-box__input,
+  .text-box__label + input.text-box__input {
+    margin-top: 5px;
+  }
+
   textarea.text-box__input,
   input.text-box__input {
     width: 100%;
     padding: 5px 0px;
+    margin: 0;
     font-size: variables.$base-font-size;
     color: colors.$kobo-gray-24;
     background-color: transparent;

--- a/jsapp/js/components/common/textBox.scss
+++ b/jsapp/js/components/common/textBox.scss
@@ -1,3 +1,4 @@
+@use "scss/sizes";
 @use "scss/_colors";
 @use "scss/_variables";
 
@@ -44,6 +45,10 @@ label.text-box {
       display: block;
       margin: 1px;
     }
+  }
+
+  .text-box__label {
+    line-height: sizes.$x16;
   }
 
   .text-box__label + textarea.text-box__input,

--- a/jsapp/js/components/common/textBox.tsx
+++ b/jsapp/js/components/common/textBox.tsx
@@ -124,7 +124,9 @@ class TextBox extends React.Component<TextBoxProps, {}> {
 
         {errors.length > 0 &&
           <bem.TextBox__error>
-            {errors.map((message: string) => (<div>{message}</div>))}
+            {errors.map((message: string, index: number) => (
+              <div key={`textbox-error-${index}`}>{message}</div>
+            ))}
           </bem.TextBox__error>
         }
       </bem.TextBox>

--- a/jsapp/js/components/common/toggleSwitch.scss
+++ b/jsapp/js/components/common/toggleSwitch.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 .toggle-switch {
   position: relative;
@@ -59,6 +60,6 @@
 
   .toggle-switch__label {
     color: colors.$kobo-gray-24;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
   }
 }

--- a/jsapp/js/components/common/wrappedSelect.tsx
+++ b/jsapp/js/components/common/wrappedSelect.tsx
@@ -6,8 +6,9 @@ import bem from 'js/bem';
 // https://github.com/JedWatson/react-select/issues/4327
 
 type WrappedSelectProps = {
-  label: string
-  error: string
+  label?: string
+  error?: string
+  isLimitedHeight?: boolean
 } & Props
 
 /**
@@ -16,18 +17,30 @@ type WrappedSelectProps = {
  */
 class WrappedSelect extends React.Component<WrappedSelectProps> {
   render() {
+    const classNames = ['kobo-select'];
+    if (this.props.isLimitedHeight) {
+      classNames.push('kobo-select--limited-height');
+    }
+
     return(
       <bem.KoboSelect__wrapper m={{
         'error': Boolean(this.props.error)
       }}>
         <label>
-          {this.props.label}
-          <Select {...this.props}/>
+          <bem.KoboSelect__label>
+            {this.props.label}
+          </bem.KoboSelect__label>
+          <Select
+            className={classNames.join(' ')}
+            classNamePrefix='kobo-select'
+            menuPlacement='auto'
+            {...this.props}
+          />
         </label>
         {this.props.error &&
-          <bem.KoboSelect__errors>
+          <bem.KoboSelect__error>
           {this.props.error}
-          </bem.KoboSelect__errors>
+          </bem.KoboSelect__error>
         }
       </bem.KoboSelect__wrapper>
     );

--- a/jsapp/js/components/common/wrappedSelect.tsx
+++ b/jsapp/js/components/common/wrappedSelect.tsx
@@ -34,6 +34,7 @@ class WrappedSelect extends React.Component<WrappedSelectProps> {
             className={classNames.join(' ')}
             classNamePrefix='kobo-select'
             menuPlacement='auto'
+            placeholder={this.props.placeholder || t('Select…')}
             {...this.props}
           />
         </label>

--- a/jsapp/js/components/dataAttachments/connect-projects.scss
+++ b/jsapp/js/components/dataAttachments/connect-projects.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 .connect-projects {
   i.k-icon {
@@ -7,7 +8,7 @@
   }
 
   .form-view__cell--page-title {
-    font-size: 14px !important;
+    font-size: variables.$base-font-size !important;
     display: flex;
     margin-top: 20px !important;
     i {
@@ -87,7 +88,7 @@
 
     label {
       margin-top: 20px;
-      font-size: 14px;
+      font-size: variables.$base-font-size;
       font-weight: bold;
       color: colors.$kobo-gray-40;
     }

--- a/jsapp/js/components/dataAttachments/connect-projects.scss
+++ b/jsapp/js/components/dataAttachments/connect-projects.scss
@@ -61,6 +61,9 @@
     .connect-projects__import-form {
       position: relative;
       display: flex;
+      flex-direction: row;
+      align-items: center;
+      align-content: center;
       margin-top: 10px;
 
       .kobo-select__wrapper {

--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -10,6 +10,7 @@ import mixins from '../mixins';
 import bem from 'js/bem';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import DocumentTitle from 'react-document-title';
+import Icon from 'js/components/common/icon';
 import moment from 'moment';
 import Chart from 'chart.js';
 import {getFormDataTabs} from './formViewTabs';
@@ -24,7 +25,6 @@ import {
   MODAL_TYPES,
   ANON_USERNAME,
 } from 'js/constants';
-import {getCountryDisplayString} from 'js/assetUtils';
 import './formSummary.scss';
 
 class FormSummary extends React.Component {
@@ -217,17 +217,18 @@ class FormSummary extends React.Component {
           to={`/forms/${this.state.uid}/landing`}
           key='landing'
           data-path={`/forms/${this.state.uid}/landing`}
-          onClick={this.triggerRefresh}>
+          onClick={this.triggerRefresh}
+        >
             <i className='k-icon k-icon-projects' />
             {t('Collect data')}
-            <i className='k-icon k-icon-angle-right' />
+            <Icon name='angle-right' size='s'/>
         </Link>
 
         {this.userCan('change_asset', this.state) &&
           <button onClick={this.sharingModal}>
             <i className='k-icon k-icon-user-share'/>
             {t('Share project')}
-            <i className='k-icon k-icon-angle-right' />
+            <Icon name='angle-right' size='s'/>
           </button>
         }
 
@@ -240,14 +241,14 @@ class FormSummary extends React.Component {
           >
             <i className='k-icon k-icon-edit' />
             {t('Edit form')}
-            <i className='k-icon k-icon-angle-right' />
+            <Icon name='angle-right' size='s'/>
           </Link>
         }
 
         <button onClick={this.enketoPreviewModal}>
           <i className='k-icon k-icon-view' />
           {t('Preview form')}
-          <i className='k-icon k-icon-angle-right' />
+          <Icon name='angle-right' size='s'/>
         </button>
       </bem.FormView__cell>
     );
@@ -268,7 +269,7 @@ class FormSummary extends React.Component {
           >
             <i className={`k-icon ${item.icon}`} />
             {item.label}
-            <i className='k-icon k-icon-angle-right' />
+            <Icon name='angle-right' size='s'/>
           </Link>
         )}
       </bem.FormView__cell>

--- a/jsapp/js/components/formSummary.scss
+++ b/jsapp/js/components/formSummary.scss
@@ -129,18 +129,19 @@
       color: colors.$kobo-gray-24;
     }
 
-    .k-icon {
+    .k-icon:not(.k-icon-angle-right) {
       font-size: 24px;
       width: 24px;
       margin: 4px 10px 4px 4px;
       display: inline-block;
       vertical-align: middle;
+    }
 
-      &.k-icon-angle-right {
-        position: absolute;
-        right: 4px;
-        top: 6px;
-      }
+    .k-icon.k-icon-angle-right {
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 }

--- a/jsapp/js/components/library/assetsTable.scss
+++ b/jsapp/js/components/library/assetsTable.scss
@@ -136,7 +136,7 @@ $assets-table-hover-bg: colors.$kobo-gray-98;
   }
 
   .k-icon {
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     margin: 0 3px;
     display: inline-block;
     vertical-align: middle;
@@ -233,7 +233,7 @@ $z-assets-table-row-header: 30;
     }
 
     .k-icon {
-      font-size: 14px;
+      font-size: variables.$base-font-size;
       // to take up space when empty
       min-width: 14px;
       width: 14px;

--- a/jsapp/js/components/map.scss
+++ b/jsapp/js/components/map.scss
@@ -1,5 +1,6 @@
 @use "scss/_colors";
 @use "scss/libs/_mdl";
+@use "scss/_variables";
 
 $z-map-overlay: 1001; // leaflet interface elements
 $z-map-list: 689;
@@ -320,7 +321,7 @@ body .leaflet-control-layers,
     display: block;
     padding: 10px 0 20px;
     position: relative;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
   }
 
   .form-modal__item--list-files {

--- a/jsapp/js/components/modalForms/formMedia.scss
+++ b/jsapp/js/components/modalForms/formMedia.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 .form-view--form-media {
   background-color: colors.$kobo-white;
@@ -48,7 +49,7 @@
       .form-media-upload-url__form {
         .text-box__error {
           padding-top: 6px;
-          font-size: 14px;
+          font-size: variables.$base-font-size;
         }
 
         // Semi-hack: re-used formbuilder button but make it look like

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -250,7 +250,6 @@ export class LibraryAssetForm extends React.Component {
               options={SECTORS}
               isLimitedHeight
               isClearable
-              placeholder={t('Select a sector for your ##type##').replace('##type##', this.getFormAssetType())}
             />
           </bem.FormModal__item>
 
@@ -263,7 +262,6 @@ export class LibraryAssetForm extends React.Component {
               options={COUNTRIES}
               isLimitedHeight
               isClearable
-              placeholder={t('Select countries')}
             />
           </bem.FormModal__item>
 

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -170,11 +170,6 @@ export class LibraryAssetForm extends React.Component {
     this.onAnyDataChange('description', assetUtils.removeInvalidChars(newValue));
   }
 
-  onOrganizationChange(newValue) {this.onAnyDataChange('organization', newValue);}
-  onCountryChange(newValue) {this.onAnyDataChange('country', newValue);}
-  onSectorChange(newValue) {this.onAnyDataChange('sector', newValue);}
-  onTagsChange(newValue) {this.onAnyDataChange('tags', newValue);}
-
   /**
    * @returns existing asset type or desired asset type
    */
@@ -236,7 +231,7 @@ export class LibraryAssetForm extends React.Component {
             <TextBox
               customModifiers='on-white'
               value={this.state.data.organization}
-              onChange={this.onOrganizationChange}
+              onChange={this.onAnyDataChange.bind(this, 'organization')}
               label={t('Organization')}
             />
           </bem.FormModal__item>
@@ -269,7 +264,7 @@ export class LibraryAssetForm extends React.Component {
           <bem.FormModal__item>
             <KoboTagsInput
               tags={this.state.data.tags}
-              onChange={this.onTagsChange}
+              onChange={this.onAnyDataChange.bind(this, 'tags')}
               label={t('Tags')}
             />
           </bem.FormModal__item>

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -2,6 +2,7 @@ import React from 'react';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
+import clonedeep from 'lodash.clonedeep';
 import KoboTagsInput from 'js/components/common/koboTagsInput';
 import WrappedSelect from 'js/components/common/wrappedSelect';
 import PropTypes from 'prop-types';
@@ -22,6 +23,11 @@ import envStore from 'js/envStore';
 /**
  * Modal for creating or updating library asset (collection or template)
  *
+ * NOTE: We have multiple components with similar form:
+ * - ProjectSettings
+ * - AccountSettingsRoute
+ * - LibraryAssetForm
+ *
  * @prop {Object} asset - Modal asset.
  */
 export class LibraryAssetForm extends React.Component {
@@ -30,7 +36,7 @@ export class LibraryAssetForm extends React.Component {
     this.unlisteners = [];
     this.state = {
       isSessionLoaded: !!stores.session.isLoggedIn,
-      data: {
+      fields: {
         name: '',
         organization: '',
         country: null,
@@ -64,22 +70,22 @@ export class LibraryAssetForm extends React.Component {
 
   applyPropsData() {
     if (this.props.asset.name) {
-      this.state.data.name = this.props.asset.name;
+      this.state.fields.name = this.props.asset.name;
     }
     if (this.props.asset.settings.organization) {
-      this.state.data.organization = this.props.asset.settings.organization;
+      this.state.fields.organization = this.props.asset.settings.organization;
     }
     if (this.props.asset.settings.country) {
-      this.state.data.country = this.props.asset.settings.country;
+      this.state.fields.country = this.props.asset.settings.country;
     }
     if (this.props.asset.settings.sector) {
-      this.state.data.sector = this.props.asset.settings.sector;
+      this.state.fields.sector = this.props.asset.settings.sector;
     }
     if (this.props.asset.tag_string) {
-      this.state.data.tags = this.props.asset.tag_string;
+      this.state.fields.tags = this.props.asset.tag_string;
     }
     if (this.props.asset.settings.description) {
-      this.state.data.description = this.props.asset.settings.description;
+      this.state.fields.description = this.props.asset.settings.description;
     }
   }
 
@@ -117,27 +123,27 @@ export class LibraryAssetForm extends React.Component {
       actions.resources.updateAsset(
         this.props.asset.uid,
         {
-          name: this.state.data.name,
+          name: this.state.fields.name,
           settings: JSON.stringify({
-            organization: this.state.data.organization,
-            country: this.state.data.country,
-            sector: this.state.data.sector,
-            description: this.state.data.description,
+            organization: this.state.fields.organization,
+            country: this.state.fields.country,
+            sector: this.state.fields.sector,
+            description: this.state.fields.description,
           }),
-          tag_string: this.state.data.tags,
+          tag_string: this.state.fields.tags,
         }
       );
     } else {
       const params = {
-        name: this.state.data.name,
+        name: this.state.fields.name,
         asset_type: this.getFormAssetType(),
         settings: JSON.stringify({
-          organization: this.state.data.organization,
-          country: this.state.data.country,
-          sector: this.state.data.sector,
-          description: this.state.data.description,
+          organization: this.state.fields.organization,
+          country: this.state.fields.country,
+          sector: this.state.fields.sector,
+          description: this.state.fields.description,
         }),
-        tag_string: this.state.data.tags,
+        tag_string: this.state.fields.tags,
       };
 
       if (
@@ -156,18 +162,18 @@ export class LibraryAssetForm extends React.Component {
     }
   }
 
-  onAnyDataChange(property, newValue) {
-    const data = this.state.data;
-    data[property] = newValue;
-    this.setState({data: data});
+  onAnyFieldChange(fieldName, newFieldValue) {
+    const fields = clonedeep(this.state.fields);
+    fields[fieldName] = newFieldValue;
+    this.setState({fields: fields});
   }
 
   onNameChange(newValue) {
-    this.onAnyDataChange('name', assetUtils.removeInvalidChars(newValue));
+    this.onAnyFieldChange('name', assetUtils.removeInvalidChars(newValue));
   }
 
   onDescriptionChange(newValue) {
-    this.onAnyDataChange('description', assetUtils.removeInvalidChars(newValue));
+    this.onAnyFieldChange('description', assetUtils.removeInvalidChars(newValue));
   }
 
   /**
@@ -209,7 +215,7 @@ export class LibraryAssetForm extends React.Component {
           <bem.FormModal__item>
             <TextBox
               customModifiers='on-white'
-              value={this.state.data.name}
+              value={this.state.fields.name}
               onChange={this.onNameChange.bind(this)}
               label={t('Name')}
               placeholder={t('Enter title of ##type## here').replace('##type##', this.getFormAssetType())}
@@ -220,7 +226,7 @@ export class LibraryAssetForm extends React.Component {
             <TextBox
               customModifiers='on-white'
               type='text-multiline'
-              value={this.state.data.description}
+              value={this.state.fields.description}
               onChange={this.onDescriptionChange.bind(this)}
               label={t('Description')}
               placeholder={t('Enter short description here')}
@@ -230,8 +236,8 @@ export class LibraryAssetForm extends React.Component {
           <bem.FormModal__item>
             <TextBox
               customModifiers='on-white'
-              value={this.state.data.organization}
-              onChange={this.onAnyDataChange.bind(this, 'organization')}
+              value={this.state.fields.organization}
+              onChange={this.onAnyFieldChange.bind(this, 'organization')}
               label={t('Organization')}
             />
           </bem.FormModal__item>
@@ -239,8 +245,8 @@ export class LibraryAssetForm extends React.Component {
           <bem.FormModal__item>
             <WrappedSelect
               label={t('Primary Sector')}
-              value={this.state.data.sector}
-              onChange={this.onAnyDataChange.bind(this, 'sector')}
+              value={this.state.fields.sector}
+              onChange={this.onAnyFieldChange.bind(this, 'sector')}
               options={SECTORS}
               isLimitedHeight
               isClearable
@@ -252,8 +258,8 @@ export class LibraryAssetForm extends React.Component {
             <WrappedSelect
               label={t('Country')}
               isMulti
-              value={this.state.data.country}
-              onChange={this.onAnyDataChange.bind(this, 'country')}
+              value={this.state.fields.country}
+              onChange={this.onAnyFieldChange.bind(this, 'country')}
               options={COUNTRIES}
               isLimitedHeight
               isClearable
@@ -263,8 +269,8 @@ export class LibraryAssetForm extends React.Component {
 
           <bem.FormModal__item>
             <KoboTagsInput
-              tags={this.state.data.tags}
-              onChange={this.onAnyDataChange.bind(this, 'tags')}
+              tags={this.state.fields.tags}
+              onChange={this.onAnyFieldChange.bind(this, 'tags')}
               label={t('Tags')}
             />
           </bem.FormModal__item>

--- a/jsapp/js/components/modalForms/libraryUploadForm.es6
+++ b/jsapp/js/components/modalForms/libraryUploadForm.es6
@@ -4,7 +4,7 @@ import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
 import Dropzone from 'react-dropzone';
-import Select from 'react-select';
+import WrappedSelect from 'js/components/common/wrappedSelect';
 import bem from 'js/bem';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {stores} from 'js/stores';
@@ -109,18 +109,12 @@ class LibraryUploadForm extends React.Component {
             </bem.FormModal__item>
 
             <bem.FormModal__item>
-              <label htmlFor='desired-type'>
-                {t('Choose desired type')}
-              </label>
-
-              <Select
-                id='desired-type'
+              <WrappedSelect
+                label={t('Choose desired type')}
                 value={this.state.desiredType}
                 onChange={this.onDesiredTypeChange}
                 options={DESIRED_TYPES}
-                className='kobo-select'
-                classNamePrefix='kobo-select'
-                menuPlacement='auto'
+                isLimitedHeight
               />
             </bem.FormModal__item>
           </React.Fragment>

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -690,7 +690,7 @@ class ProjectSettings extends React.Component {
     this.setState({fieldsWithErrors: fieldsWithErrors});
 
     if (fieldsWithErrors.length >= 1) {
-      alertify.error(t('Some fields have errors!'));
+      alertify.error(t('Some fields contain errors!'));
       return;
     }
 

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -24,7 +24,6 @@ import {
   escapeHtml,
 } from 'utils';
 import {
-  createEnum,
   NAME_MAX_LENGTH,
   PROJECT_SETTINGS_CONTEXTS,
 } from 'js/constants';
@@ -34,16 +33,6 @@ import {hasAssetRestriction} from 'js/components/locking/lockingUtils';
 import envStore from 'js/envStore';
 
 const VIA_URL_SUPPORT_URL = 'xls_url.html';
-
-const FIELD_NAMES = createEnum([
-  'name',
-  'description',
-  'sector',
-  'country',
-  'share-metadata',
-  'operational_purpose',
-  'collects_pii',
-]);
 
 /*
 This is used for multiple different purposes:
@@ -130,13 +119,13 @@ class ProjectSettings extends React.Component {
   getInitialFieldsFromAsset(asset) {
     const fields = {};
 
-    fields[FIELD_NAMES.name] = asset ? asset[FIELD_NAMES.name] : '';
-    fields[FIELD_NAMES.description] = asset?.settings ? asset?.settings[FIELD_NAMES.description] : '';
-    fields[FIELD_NAMES.sector] = asset?.settings ? asset?.settings[FIELD_NAMES.sector] : null;
-    fields[FIELD_NAMES.country] = asset?.settings ? asset?.settings[FIELD_NAMES.country] : null;
-    fields[FIELD_NAMES['share-metadata']] = asset?.settings ? asset?.settings[FIELD_NAMES['share-metadata']] : false;
-    fields[FIELD_NAMES.operational_purpose] = asset?.settings ? asset?.settings[FIELD_NAMES.operational_purpose] : null;
-    fields[FIELD_NAMES.collects_pii] = asset?.settings ? asset?.settings[FIELD_NAMES.collects_pii] : null;
+    fields.name = asset ? asset.name : '';
+    fields.description = asset?.settings ? asset?.settings.description : '';
+    fields.sector = asset?.settings ? asset?.settings.sector : null;
+    fields.country = asset?.settings ? asset?.settings.country : null;
+    fields['share-metadata'] = asset?.settings ? asset?.settings['share-metadata'] : false;
+    fields.operational_purpose = asset?.settings ? asset?.settings.operational_purpose : null;
+    fields.collects_pii = asset?.settings ? asset?.settings.collects_pii : null;
 
     return fields;
   }
@@ -229,11 +218,11 @@ class ProjectSettings extends React.Component {
   }
 
   onNameChange(newValue) {
-    this.onAnyFieldChange(FIELD_NAMES['name'], assetUtils.removeInvalidChars(newValue).slice(0, NAME_MAX_LENGTH));
+    this.onAnyFieldChange('name', assetUtils.removeInvalidChars(newValue).slice(0, NAME_MAX_LENGTH));
   }
 
   onDescriptionChange(newValue) {
-    this.onAnyFieldChange(FIELD_NAMES['description'], assetUtils.removeInvalidChars(newValue));
+    this.onAnyFieldChange('description', assetUtils.removeInvalidChars(newValue));
   }
 
   onImportUrlChange(value) {
@@ -472,18 +461,18 @@ class ProjectSettings extends React.Component {
 
   getSettingsForEndpoint() {
     return JSON.stringify({
-      description: this.state.fields[FIELD_NAMES.description],
-      sector: this.state.fields[FIELD_NAMES.sector],
-      country: this.state.fields[FIELD_NAMES.country],
-      'share-metadata': this.state.fields[FIELD_NAMES['share-metadata']],
-      operational_purpose: this.state.fields[FIELD_NAMES.operational_purpose],
-      collects_pii: this.state.fields[FIELD_NAMES.collects_pii],
+      description: this.state.fields.description,
+      sector: this.state.fields.sector,
+      country: this.state.fields.country,
+      'share-metadata': this.state.fields['share-metadata'],
+      operational_purpose: this.state.fields.operational_purpose,
+      collects_pii: this.state.fields.collects_pii,
     });
   }
 
   createAssetAndOpenInBuilder() {
     dataInterface.createResource({
-      name: this.state.fields[FIELD_NAMES.name],
+      name: this.state.fields.name,
       settings: this.getSettingsForEndpoint(),
       asset_type: 'survey',
     }).done((asset) => {
@@ -497,7 +486,7 @@ class ProjectSettings extends React.Component {
     actions.resources.updateAsset(
       this.state.formAsset.uid,
       {
-        name: this.state.fields[FIELD_NAMES.name],
+        name: this.state.fields.name,
         settings: this.getSettingsForEndpoint(),
       }
     );
@@ -656,32 +645,32 @@ class ProjectSettings extends React.Component {
     const fieldsWithErrors = [];
 
     // simple non-empty name validation
-    if (!this.state.fields[FIELD_NAMES.name].trim()) {
+    if (!this.state.fields.name.trim()) {
       fieldsWithErrors.push('name');
     }
 
     // superuser-configured metadata
     if (
       envStore.data.getProjectMetadataField('sector').required &&
-      !this.state.fields[FIELD_NAMES.sector]
+      !this.state.fields.sector
     ) {
       fieldsWithErrors.push('sector');
     }
     if (
       envStore.data.getProjectMetadataField('country').required &&
-      !this.state.fields[FIELD_NAMES.country]?.length
+      !this.state.fields.country?.length
     ) {
       fieldsWithErrors.push('country');
     }
     if (
       envStore.data.getProjectMetadataField('operational_purpose').required &&
-      !this.state.fields[FIELD_NAMES.operational_purpose]
+      !this.state.fields.operational_purpose
     ) {
       fieldsWithErrors.push('operational_purpose');
     }
     if (
       envStore.data.getProjectMetadataField('collects_pii').required &&
-      !this.state.fields[FIELD_NAMES.collects_pii]
+      !this.state.fields.collects_pii
     ) {
       fieldsWithErrors.push('collects_pii');
     }
@@ -897,10 +886,10 @@ class ProjectSettings extends React.Component {
             <bem.FormModal__item>
               <TextBox
                 customModifiers='on-white'
-                value={this.state.fields[FIELD_NAMES.name]}
+                value={this.state.fields.name}
                 onChange={this.onNameChange.bind(this)}
                 errors={this.hasFieldError('name') ? t('Please enter a title for your project!') : false}
-                label={this.getNameInputLabel(this.state.fields[FIELD_NAMES.name])}
+                label={this.getNameInputLabel(this.state.fields.name)}
                 placeholder={t('Enter title of project here')}
               />
             </bem.FormModal__item>
@@ -910,7 +899,7 @@ class ProjectSettings extends React.Component {
             <TextBox
               customModifiers='on-white'
               type='text-multiline'
-              value={this.state.fields[FIELD_NAMES.description]}
+              value={this.state.fields.description}
               onChange={this.onDescriptionChange.bind(this)}
               label={t('Description')}
               placeholder={t('Enter short description here')}
@@ -921,8 +910,8 @@ class ProjectSettings extends React.Component {
             <bem.FormModal__item m={bothCountryAndSector ? 'sector' : null}>
               <WrappedSelect
                 label={t('Sector')}
-                value={this.state.fields[FIELD_NAMES.sector]}
-                onChange={this.onAnyFieldChange.bind(this, FIELD_NAMES['sector'])}
+                value={this.state.fields.sector}
+                onChange={this.onAnyFieldChange.bind(this, 'sector')}
                 options={sectors}
                 isLimitedHeight
                 isClearable
@@ -937,12 +926,12 @@ class ProjectSettings extends React.Component {
               <WrappedSelect
                 label={t('Country')}
                 isMulti
-                value={this.state.fields[FIELD_NAMES.country]}
-                onChange={this.onAnyFieldChange.bind(this, FIELD_NAMES['country'])}
+                value={this.state.fields.country}
+                onChange={this.onAnyFieldChange.bind(this, 'country')}
                 options={countries}
                 isLimitedHeight
                 isClearable
-                placeholder={t('Select at least one country')}
+                placeholder={t('Select countries')}
                 error={this.hasFieldError('country') ? t('Please select at least one contry') : false}
               />
             </bem.FormModal__item>
@@ -952,8 +941,8 @@ class ProjectSettings extends React.Component {
             <bem.FormModal__item>
               <WrappedSelect
                 label={t('Operational Purpose of Data')}
-                value={this.state.fields[FIELD_NAMES.operational_purpose]}
-                onChange={this.onAnyFieldChange.bind(this, FIELD_NAMES['operational_purpose'])}
+                value={this.state.fields.operational_purpose}
+                onChange={this.onAnyFieldChange.bind(this, 'operational_purpose')}
                 options={operationalPurposes}
                 isLimitedHeight
                 isClearable
@@ -966,8 +955,8 @@ class ProjectSettings extends React.Component {
             <bem.FormModal__item>
               <WrappedSelect
                 label={t('Does this project collect personally identifiable information?')}
-                value={this.state.fields[FIELD_NAMES.collects_pii]}
-                onChange={this.onAnyFieldChange.bind(this, FIELD_NAMES['collects_pii'])}
+                value={this.state.fields.collects_pii}
+                onChange={this.onAnyFieldChange.bind(this, 'collects_pii')}
                 options={[
                   {value: 'Yes', label: t('Yes')},
                   {value: 'No', label: t('No')},
@@ -981,7 +970,7 @@ class ProjectSettings extends React.Component {
           <bem.FormModal__item m='metadata-share'>
             <Checkbox
               checked={this.state.fields['share-metadata']}
-              onChange={this.onAnyFieldChange.bind(this, FIELD_NAMES['share-metadata'])}
+              onChange={this.onAnyFieldChange.bind(this, 'share-metadata')}
               label={t('Help KoboToolbox improve this product by sharing the sector and country where this project will be deployed.') + ' ' + t('All the information is submitted anonymously, and will not include the project name or description listed above.')}
             />
           </bem.FormModal__item>

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -920,7 +920,6 @@ class ProjectSettings extends React.Component {
                 options={sectors}
                 isLimitedHeight
                 isClearable
-                placeholder={t('Select a sector for your project')}
                 error={this.hasFieldError('sector') ? t('Please choose a sector') : false}
               />
             </bem.FormModal__item>
@@ -936,7 +935,6 @@ class ProjectSettings extends React.Component {
                 options={countries}
                 isLimitedHeight
                 isClearable
-                placeholder={t('Select countries')}
                 error={this.hasFieldError('country') ? t('Please select at least one contry') : false}
               />
             </bem.FormModal__item>

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -917,16 +917,6 @@ class ProjectSettings extends React.Component {
             />
           </bem.FormModal__item>
 
-          {bothCountryAndSector &&
-            <bem.FormModal__item>
-              <label className='long'>
-                {countryField && sectorField && t('Please specify the country and the sector where this project will be deployed.')}
-                {countryField && !sectorField && t('Please specify the country where this project will be deployed.')}
-                {sectorField && !countryField && t('Please specify the sector where this project will be deployed.')}
-              </label>
-            </bem.FormModal__item>
-          }
-
           {sectorField &&
             <bem.FormModal__item m={bothCountryAndSector ? 'sector' : null}>
               <WrappedSelect
@@ -937,7 +927,7 @@ class ProjectSettings extends React.Component {
                 isLimitedHeight
                 isClearable
                 placeholder={t('Select a sector for your project')}
-                error={this.hasFieldError('sector') ? t("Sector can't be empty") : false}
+                error={this.hasFieldError('sector') ? t('Please choose a sector') : false}
               />
             </bem.FormModal__item>
           }
@@ -953,7 +943,7 @@ class ProjectSettings extends React.Component {
                 isLimitedHeight
                 isClearable
                 placeholder={t('Select at least one country')}
-                error={this.hasFieldError('country') ? t('Minimum one contry is required') : false}
+                error={this.hasFieldError('country') ? t('Please select at least one contry') : false}
               />
             </bem.FormModal__item>
           }

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -34,18 +34,23 @@ import envStore from 'js/envStore';
 
 const VIA_URL_SUPPORT_URL = 'xls_url.html';
 
-/*
-This is used for multiple different purposes:
-
-1. When creating new project
-2. When replacing project with new one
-3. When editing project in /settings
-4. When editing or creating asset in Form Builder
-
-Identifying the purpose is done by checking `context` and `formAsset`.
-
-You can listen to field changes by `onProjectDetailsChange` prop function.
-*/
+/**
+ * This is used for multiple different purposes:
+ *
+ * 1. When creating new project
+ * 2. When replacing project with new one
+ * 3. When editing project in /settings
+ * 4. When editing or creating asset in Form Builder
+ *
+ * Identifying the purpose is done by checking `context` and `formAsset`.
+ *
+ * You can listen to field changes by `onProjectDetailsChange` prop function.
+ *
+ * NOTE: We have multiple components with similar form:
+ * - ProjectSettings
+ * - AccountSettingsRoute
+ * - LibraryAssetForm
+ */
 class ProjectSettings extends React.Component {
   constructor(props) {
     super(props);
@@ -120,12 +125,12 @@ class ProjectSettings extends React.Component {
     const fields = {};
 
     fields.name = asset ? asset.name : '';
-    fields.description = asset?.settings ? asset?.settings.description : '';
-    fields.sector = asset?.settings ? asset?.settings.sector : null;
-    fields.country = asset?.settings ? asset?.settings.country : null;
-    fields['share-metadata'] = asset?.settings ? asset?.settings['share-metadata'] : false;
-    fields.operational_purpose = asset?.settings ? asset?.settings.operational_purpose : null;
-    fields.collects_pii = asset?.settings ? asset?.settings.collects_pii : null;
+    fields.description = asset?.settings ? asset.settings.description : '';
+    fields.sector = asset?.settings ? asset.settings.sector : null;
+    fields.country = asset?.settings ? asset.settings.country : null;
+    fields['share-metadata'] = asset?.settings ? asset.settings['share-metadata'] : false;
+    fields.operational_purpose = asset?.settings ? asset.settings.operational_purpose : null;
+    fields.collects_pii = asset?.settings ? asset.settings.collects_pii : null;
 
     return fields;
   }

--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -121,7 +121,7 @@ class SharingForm extends React.Component {
             <bem.FormView__cell m='warning'>
               <i className='k-icon k-icon-alert' />
               <p>
-                {t('Anyone can see this blank form and add submissions to it because you have not set ')}
+                {t('Anyone with the link can see this blank form and add submissions to it because you have not set ')}
                 <a href={`/#${ROUTES.ACCOUNT_SETTINGS}`}>
                   {t('your account')}
                 </a>

--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -121,7 +121,7 @@ class SharingForm extends React.Component {
             <bem.FormView__cell m='warning'>
               <i className='k-icon k-icon-alert' />
               <p>
-                {t('Anyone with the link can see this blank form and add submissions to it because you have not set ')}
+                {t('Anyone can see this blank form and add submissions to it because you have not set ')}
                 <a href={`/#${ROUTES.ACCOUNT_SETTINGS}`}>
                   {t('your account')}
                 </a>

--- a/jsapp/js/components/permissions/sharingForm.scss
+++ b/jsapp/js/components/permissions/sharingForm.scss
@@ -9,7 +9,7 @@ $s-gray-row-spacing: 10px;
 .form-modal--sharing-form {
   h2 {
     margin: 0;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     color: colors.$kobo-gray-24;
     font-weight: 500;
   }
@@ -58,7 +58,7 @@ $s-gray-row-spacing: 10px;
     }
 
     .k-icon {
-      font-size: 14px;
+      font-size: variables.$base-font-size;
       margin: 0 3px;
       vertical-align: middle;
 

--- a/jsapp/js/components/reports/reports.scss
+++ b/jsapp/js/components/reports/reports.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 @media screen and (min-width: 961px) {
   .report-view {
@@ -66,7 +67,7 @@
       color: colors.$kobo-white;
       text-align: right;
       font-weight: normal;
-      font-size: 14px;
+      font-size: variables.$base-font-size;
 
       &:first-child {
         text-align: left;

--- a/jsapp/js/components/submissions/columnsHideDropdown.scss
+++ b/jsapp/js/components/submissions/columnsHideDropdown.scss
@@ -1,4 +1,5 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 // nested selector needed for specificity
 .kobo-dropdown[data-name='columns-hide-dropdown']  {
@@ -13,7 +14,7 @@
   margin: 0;
   padding: 0;
   color: colors.$kobo-gray-55;
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   font-weight: 500;
   line-height: 24px;
 

--- a/jsapp/js/components/submissions/validationStatusDropdown.scss
+++ b/jsapp/js/components/submissions/validationStatusDropdown.scss
@@ -29,6 +29,7 @@
     height: 28px;
     min-height: 28px;
     cursor: pointer;
+    border: 0;
 
     .kobo-select__value-container {
       padding: 0;
@@ -84,6 +85,9 @@
 
   // custom option badge, mostly for validation status select
   .kobo-select__option-badge {
+    // Needed for react-select v5.
+    grid-area: 1 / 1 / 2 / 3;
+    text-align: left;
     font-weight: 500;
     line-height: 1;
     font-size: 12px;

--- a/jsapp/js/components/templatesList.scss
+++ b/jsapp/js/components/templatesList.scss
@@ -1,7 +1,8 @@
 @use "scss/_colors";
+@use "scss/_variables";
 
 .templates-list {
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   width: 100%;
 
   .templates-list__header {

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -797,7 +797,7 @@ export default assign({
               </bem.FormBuilderAside__header>
 
               <label
-                className='kobo-select-label'
+                className='kobo-select__label'
                 htmlFor='webform-style'
               >
                 { hasSettings ?

--- a/jsapp/scss/_variables.scss
+++ b/jsapp/scss/_variables.scss
@@ -13,6 +13,8 @@ $s-drawer-width: 270px;
 
 $mdl-layout-width: 1440px;
 
+$base-font-size: 14px;
+
 // Form Builder variables
 
 $cardBorderColor: colors.$kobo-gray-65;

--- a/jsapp/scss/components/_kobo.asset-row.scss
+++ b/jsapp/scss/components/_kobo.asset-row.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 $hover-asset-row: $kobo-gray-96;
 $hover-transition: 0.3s opacity;
 $asset-row-spacing: 6px;
@@ -68,7 +70,7 @@ $asset-row-spacing: 6px;
   }
 
   .asset-row__cell--name {
-    font-size: 14px;
+    font-size: variables.$base-font-size;
   }
 
   .asset-row__description,

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -128,16 +128,16 @@
   transition: opacity 0.35s;
   opacity: 1;
 
-  &--hiding {
+  &.popover-menu__content--hiding {
     opacity: 0;
     transition: opacity 0.35s;
   }
 
-  &--hidden {
+  &.popover-menu__content--hidden {
     display: none;
   }
 
-  &--visible {
+  &.popover-menu__content--visible {
     display: block;
   }
 }
@@ -425,16 +425,16 @@ iframe {
     }
   }
 
-  &--sector, &--country {
-    width: 50%;
+  &.form-modal__item--sector, &.form-modal__item--country {
+    width: 48%;
     float: left;
   }
 
-  &--sector .kobo-select {
-    margin-right: 30px;
+  &.form-modal__item--sector {
+    margin-right: 4%;
   }
 
-  &--metadata-share {
+  &.form-modal__item--metadata-share {
     padding-top: 15px;
     clear: both;
   }

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -425,13 +425,15 @@ iframe {
     }
   }
 
-  &.form-modal__item--sector, &.form-modal__item--country {
-    width: 48%;
+  &.form-modal__item--sector {
+    width: 50%;
+    margin-right: 4%;
     float: left;
   }
 
-  &.form-modal__item--sector {
-    margin-right: 4%;
+  &.form-modal__item--country {
+    width: 46%;
+    float: left;
   }
 
   &.form-modal__item--metadata-share {

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 .kpiapp,
 .mdl-wrapper,
 .mdl-layout {
@@ -445,7 +447,7 @@ iframe {
     &.long {
       padding-top: 5px;
       margin-bottom: 10px;
-      font-size: 14px;
+      font-size: variables.$base-font-size;
     }
   }
 

--- a/jsapp/scss/components/_kobo.dropzone.scss
+++ b/jsapp/scss/components/_kobo.dropzone.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // Kobo specific dropzone changes
 
 // Extension of `dropzone` used in settings modals
@@ -12,7 +14,7 @@
   // Optional description
   .dropzone-description {
     padding-top: 6px;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
 
     a {
       text-decoration: underline;

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // TODO: This file is too big and it lost it's original purpose.
 // It was supposed to be a general form view layout (AKA "the content"), but
 // over time it accumulated many small unique modifiers.
@@ -98,7 +100,7 @@ $side-tabs-width-mobile: 70px;
     border: none;
     padding: 6px;
     border-left: 2px solid transparent;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     cursor: pointer;
     position: relative;
     color: $kobo-gray-40;
@@ -337,7 +339,7 @@ $side-tabs-width-mobile: 70px;
 
   // preferably with or inside .form-view__cell--first
   &.form-view__cell--label {
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     color: $kobo-gray-24;
     font-weight: 500;
 
@@ -831,7 +833,7 @@ $side-tabs-width-mobile: 70px;
     height: 39px;
 
     a.form-view__tab {
-      font-size: 14px;
+      font-size: variables.$base-font-size;
     }
   }
 

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // header and navigation styling
 
 // This element handles stretched background of app header
@@ -304,7 +306,7 @@
     font-size: 18px;
 
     &.main-header__title--long input {
-      font-size: 14px;
+      font-size: variables.$base-font-size;
     }
 
     input {
@@ -342,7 +344,7 @@
   }
 
   .main-header__counter {
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     margin-right: 20px;
     color: $kobo-gray-65;
   }

--- a/jsapp/scss/components/_kobo.text-button.scss
+++ b/jsapp/scss/components/_kobo.text-button.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // DEPRECATED: please don't use this component. From now on, we will only use
 // the `Button` component (from `js/components/common/button`) as it covers
 // all possible cases.
@@ -10,7 +12,7 @@
   display: inline-block;
   vertical-align: middle;
   position: relative; // needed for tooltips etc.
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   font-weight: 400;
   text-decoration: none;
   border: 0;

--- a/jsapp/scss/libs/_mdl.buttons.scss
+++ b/jsapp/scss/libs/_mdl.buttons.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // TODO: cleanup these buttons
 // 1. stop @extend-ing them, as ut makes for much harder debugging in Dev Tools
 //    instead create few mixins and use those
@@ -10,7 +12,7 @@
   text-decoration: none;
   text-align: center;
   font-weight: normal;
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   letter-spacing: 0;
   height: 40px;
   min-height: 40px;

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -101,7 +101,7 @@
     height: button.$button-height-m - 8px;
   }
 
-  .kobo-select__multi-value-label {
+  .kobo-select__multi-value__label {
     line-height: button.$button-height-m - 8px;
     padding: 0 3px 0 6px;
   }
@@ -113,11 +113,11 @@
 
   .kobo-select__indicator {
     height: 100%;
-    padding: 0 6px
+    padding: 0 6px;
     display: flex;
     flex-direction: row;
     align-content: center;
-    align-items: center;;
+    align-items: center;
   }
 
   .kobo-select__control > * {

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -58,12 +58,14 @@
     border-radius: 6px;
     color: colors.$kobo-gray-40;
     background-color: colors.$kobo-white;
-    height: button.$button-height-m;
-    min-height: auto;
+    min-height: button.$button-height-m;
+    height: auto;
     font-size: inherit;
     padding: 0 8px;
     box-sizing: border-box;
     cursor: pointer;
+    // it's a flexbox wrapper
+    align-content: center;
 
     &:hover {
       border-color: colors.$kobo-gray-92;
@@ -119,10 +121,6 @@
     flex-direction: row;
     align-content: center;
     align-items: center;
-  }
-
-  .kobo-select__control > * {
-    height: calc(100% - 2px);
   }
 
   .kobo-select__menu {

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -2,35 +2,33 @@
 
 .kobo-select__wrapper {
   &.kobo-select__wrapper--error {
-    .kobo-select__errors,
-    > label,
-    .kobo-select-label,
-    .kobo-select-error,
-    .kobo-select .kobo-select__placeholder {
+    .kobo-select__error,
+    .kobo-select__label, {
       color: $kobo-red;
     }
 
     .kobo-select .kobo-select__control {
-      border-bottom-color: $kobo-red;
+      border-color: $kobo-red;
     }
   }
 }
 
-.kobo-select-label {
+.kobo-select__error {
+  font-size: 12px;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.kobo-select__label {
   display: block;
   color: inherit;
   font-size: 12px;
   line-height: 16px;
   font-weight: 400;
-  opacity: 0.38;
 
   & + .kobo-select {
-    margin-top: 10px;
+    margin-top: 5px;
   }
-}
-
-.kobo-select-error {
-  font-size: 12px;
 }
 
 .kobo-select--limited-height {
@@ -50,8 +48,8 @@
 
   .kobo-select__control {
     box-shadow: none;
-    border: none;
-    border-radius: 3px;
+    border: 1px solid $kobo-gray-92;
+    border-radius: 6px;
     color: $kobo-gray-40;
     background-color: $kobo-white;
     min-height: 24px;

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -1,4 +1,5 @@
 @use "js/components/common/button";
+@use "scss/sizes";
 @use "scss/_colors";
 @use "scss/_variables";
 
@@ -26,7 +27,7 @@
   display: block;
   color: inherit;
   font-size: inherit;
-  line-height: 16px;
+  line-height: sizes.$x16;
   font-weight: 400;
 
   & + .kobo-select {

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -89,7 +89,6 @@
   }
 
   .kobo-select__value-container {
-    height: button.$button-height-m;
     padding: 0;
   }
 
@@ -100,7 +99,11 @@
 
   .kobo-select__multi-value {
     height: button.$button-height-m - 8px;
-    margin: 0px 2px 2px;
+  }
+
+  .kobo-select__multi-value-label {
+    line-height: button.$button-height-m - 8px;
+    padding: 0 3px 0 6px;
   }
 
   .kobo-select__multi-value__remove:hover {
@@ -109,8 +112,16 @@
   }
 
   .kobo-select__indicator {
-    height: button.$button-height-m;
-    padding: (button.$button-height-m - 20px) * 0.5;
+    height: 100%;
+    padding: 0 6px
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    align-items: center;;
+  }
+
+  .kobo-select__control > * {
+    height: calc(100% - 2px);
   }
 
   .kobo-select__menu {

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -1,14 +1,17 @@
-@import "../colors";
+@use "js/components/common/button";
+@use "scss/_colors";
+@use "scss/_variables";
 
+// Styles for WrappedSelect.
 .kobo-select__wrapper {
   &.kobo-select__wrapper--error {
     .kobo-select__error,
     .kobo-select__label, {
-      color: $kobo-red;
+      color: colors.$kobo-red;
     }
 
     .kobo-select .kobo-select__control {
-      border-color: $kobo-red;
+      border-color: colors.$kobo-red;
     }
   }
 }
@@ -22,7 +25,7 @@
 .kobo-select__label {
   display: block;
   color: inherit;
-  font-size: 12px;
+  font-size: inherit;
   line-height: 16px;
   font-weight: 400;
 
@@ -41,6 +44,8 @@
 }
 
 .kobo-select {
+  font-size: variables.$base-font-size;
+
   &.kobo-select--is-disabled {
     pointer-events: none;
     opacity: 0.5;
@@ -48,22 +53,23 @@
 
   .kobo-select__control {
     box-shadow: none;
-    border: 1px solid $kobo-gray-92;
+    border: 1px solid colors.$kobo-gray-92;
     border-radius: 6px;
-    color: $kobo-gray-40;
-    background-color: $kobo-white;
-    min-height: 24px;
-    font-size: 12px;
+    color: colors.$kobo-gray-40;
+    background-color: colors.$kobo-white;
+    height: button.$button-height-m;
+    min-height: auto;
+    font-size: inherit;
     padding: 0 8px;
     box-sizing: border-box;
     cursor: pointer;
 
     &:hover {
-      border-color: $kobo-gray-92;
+      border-color: colors.$kobo-gray-92;
     }
 
     &.kobo-select__control--is-focused {
-      border-color: $kobo-blue;
+      border-color: colors.$kobo-blue;
     }
   }
 
@@ -75,11 +81,36 @@
   }
 
   .kobo-select__placeholder {
-    color: $kobo-gray-40;
+    color: colors.$kobo-gray-65;
   }
 
   .kobo-select__indicator-separator {
     display: none;
+  }
+
+  .kobo-select__value-container {
+    height: button.$button-height-m;
+    padding: 0;
+  }
+
+  .kobo-select__single-value,
+  .kobo-select__multi-value, {
+    color: colors.$kobo-gray-24;
+  }
+
+  .kobo-select__multi-value {
+    height: button.$button-height-m - 8px;
+    margin: 0px 2px 2px;
+  }
+
+  .kobo-select__multi-value__remove:hover {
+    color: colors.$kobo-dark-red;
+    background-color: colors.$kobo-light-red;
+  }
+
+  .kobo-select__indicator {
+    height: button.$button-height-m;
+    padding: (button.$button-height-m - 20px) * 0.5;
   }
 
   .kobo-select__menu {
@@ -104,14 +135,14 @@
     cursor: pointer;
 
     &.kobo-select__option--is-selected {
-      background-color: $kobo-white;
-      color: $kobo-blue;
+      background-color: colors.$kobo-white;
+      color: colors.$kobo-blue;
       font-weight: 700;
     }
 
     // is-focused needs to go after is-selected
     &.kobo-select__option--is-focused {
-      background-color: $kobo-gray-96;
+      background-color: colors.$kobo-gray-96;
     }
   }
 }

--- a/jsapp/scss/libs/react-select.overrides.scss
+++ b/jsapp/scss/libs/react-select.overrides.scss
@@ -18,7 +18,7 @@
 }
 
 .kobo-select__error {
-  font-size: 12px;
+  font-size: sizes.$x13;
   font-weight: 400;
   font-style: normal;
 }
@@ -26,7 +26,7 @@
 .kobo-select__label {
   display: block;
   color: inherit;
-  font-size: inherit;
+  font-size: sizes.$x13;
   line-height: sizes.$x16;
   font-weight: 400;
 

--- a/jsapp/scss/stylesheets/partials/_base.scss
+++ b/jsapp/scss/stylesheets/partials/_base.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 /* ==========================================================================
  * Base
  * ========================================================================== */
@@ -22,7 +24,7 @@ body {
 
 html, body, input, textarea, select, button {
   font-family: $font;
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   font-weight: 400;
   line-height: 20px;
 }

--- a/jsapp/scss/stylesheets/partials/_buttons.scss
+++ b/jsapp/scss/stylesheets/partials/_buttons.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // ==========================================================================
 // Buttons
 // ==========================================================================
@@ -20,7 +22,7 @@
     line-height: 30px;
     padding: 0 20px;
     font-weight: 400;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;

--- a/jsapp/scss/stylesheets/partials/_misc.scss
+++ b/jsapp/scss/stylesheets/partials/_misc.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // READ THIS ABOUT THIS FILE
 // -------------------------
 //
@@ -18,7 +20,7 @@
     top: 65px;
     display: block;
     font-weight: bold;
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     line-height: 30px;
     text-align: center;
     text-transform: uppercase;

--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -1,3 +1,5 @@
+@use "scss/_variables";
+
 // ==========================================================================
 // Registration Forms
 // ==========================================================================
@@ -95,7 +97,7 @@
   padding: 5px 8px;
   border: none;
   border-radius: 0px;
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   border-bottom: 3px solid transparent;
   padding-bottom: 3px;
   margin-top: 1px;
@@ -233,7 +235,7 @@
 }
 
 .error-message {
-  font-size: 14px;
+  font-size: variables.$base-font-size;
   color: $kobo-red;
   background-color: rgba($kobo-red, 0.075);
 }
@@ -311,7 +313,7 @@
   }
 
   .registration .registration__kc-domain {
-    font-size: 14px;
+    font-size: variables.$base-font-size;
     letter-spacing: 0em;
   }
 }

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -196,8 +196,6 @@ CONSTANCE_CONFIG = {
             {'name': 'sector', 'required': False},
             {'name': 'gender', 'required': False},
             {'name': 'bio', 'required': False},
-            {'name': 'phone_number', 'required': False},
-            {'name': 'address', 'required': False},
             {'name': 'city', 'required': False},
             {'name': 'country', 'required': False},
             {'name': 'twitter', 'required': False},
@@ -207,8 +205,8 @@ CONSTANCE_CONFIG = {
         # The available fields are hard-coded in the front end
         'Display (and optionally require) these metadata fields for users. '
         "Possible fields are 'organization', 'organization_website', "
-        "'sector', 'gender', 'bio', 'phone_number', 'address', 'city', "
-        "'country', 'twitter', 'linkedin', and 'instagram'",
+        "'sector', 'gender', 'bio', 'city', 'country', 'twitter', 'linkedin', "
+        "and 'instagram'",
         # Use custom field for schema validation
         'metadata_fields_jsonschema'
     ),


### PR DESCRIPTION
## Description

Unified the feel and looks of multiple forms throughout the app. Dropped phone and address fields from Account Settings.

## Additional details

Things changed:
- Unified the looks and feel of multiple forms (fields ordering, placeholders, labels, etc.):
  1. REST Services Modal
  2. New Project Modal
  3. Project Settings
  4. New Library Item Modal
  5. Library Item Details Modal
  6. Modify Password
- Disabled unfinished tabs in Account Settings
- Removed the broken "X" close button from Account Settings
- Dropped `phone_number` and `address` fields from Account Settings
- Unified the base font size (introduced a variable)
- Unified the looks of TextBox and WrappedSelect (`react-select`) components, including error handling
- Some code cleanup included *(mea culpa)*

## Related issues

This is a followup to #3611
Part of #3554
Closes #3629