### PR TITLE
Serve attachments with NGINX

### DIFF
--- a/kpi/deployment_backends/kc_access/storage.py
+++ b/kpi/deployment_backends/kc_access/storage.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from django.conf import settings
+from django.conf import settings as django_settings
 from django.core.files.storage import FileSystemStorage
 from storages.backends.s3boto3 import S3Boto3Storage
 
@@ -10,7 +10,8 @@ def get_kobocat_storage():
     `KOBOCAT_DEFAULT_FILE_STORAGE` value
     """
     if (
-        settings.KOBOCAT_DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage'
+        django_settings.KOBOCAT_DEFAULT_FILE_STORAGE
+        == 'storages.backends.s3boto3.S3Boto3Storage'
     ):
         return KobocatS3Boto3Storage()
     else:
@@ -26,7 +27,7 @@ class KobocatFileSystemStorage(FileSystemStorage):
         file_permissions_mode=None,
         directory_permissions_mode=None,
     ):
-        location = settings.KOBOCAT_MEDIA_PATH if not location else location
+        location = django_settings.KOBOCAT_MEDIA_PATH if not location else location
         super().__init__(
             location=location,
             base_url=base_url,
@@ -38,5 +39,5 @@ class KobocatFileSystemStorage(FileSystemStorage):
 class KobocatS3Boto3Storage(S3Boto3Storage):
 
     def __init__(self, acl=None, bucket=None, **settings):
-        bucket = settings.KOBOCAT_AWS_STORAGE_BUCKET_NAME
+        bucket = django_settings.KOBOCAT_AWS_STORAGE_BUCKET_NAME
         super().__init__(acl=None, bucket=bucket, **settings)

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -56,6 +56,10 @@ class DeploymentNotFound(Exception):
         super().__init__(self.message)
 
 
+class FFMpegException(Exception):
+    pass
+
+
 class ImportAssetException(Exception):
     pass
 
@@ -108,6 +112,10 @@ class KobocatDuplicateSubmissionException(exceptions.APIException):
 
 
 class KobocatProfileException(Exception):
+    pass
+
+
+class NotSupportedFormatException(Exception):
     pass
 
 

--- a/kpi/mixins/audio_converter.py
+++ b/kpi/mixins/audio_converter.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+import subprocess
+
+from kpi.exceptions import FFMpegException, NotSupportedFormatException
+from kpi.utils.log import logging
+
+
+class AudioConverterMixin:
+
+    CONVERSION_AUDIO_FORMAT = 'mp3'
+    SUPPORTED_CONVERTED_FORMAT = (
+        'audio',
+        'video',
+    )
+
+    def get_converted_audio(self, input_file: str) -> bytes:
+
+        supported_formats = (
+            'audio',
+            'video',
+        )
+
+        if not self.mimetype.startswith(supported_formats):
+            raise NotSupportedFormatException
+
+        ffmpeg_command = [
+            '/usr/bin/ffmpeg',
+            '-i',
+            self.path,
+            '-f',
+            self.CONVERSION_AUDIO_FORMAT,
+            'pipe:1',
+        ]
+
+        pipe = subprocess.run(
+            ffmpeg_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        if pipe.returncode:
+            logging.error(f'ffmpeg error: {pipe.stderr}')
+            raise FFMpegException
+
+        return pipe.stdout

--- a/kpi/mixins/mp3_converter.py
+++ b/kpi/mixins/mp3_converter.py
@@ -5,7 +5,7 @@ from kpi.exceptions import FFMpegException, NotSupportedFormatException
 from kpi.utils.log import logging
 
 
-class AudioConverterMixin:
+class MP3ConverterMixin:
 
     CONVERSION_AUDIO_FORMAT = 'mp3'
     SUPPORTED_CONVERTED_FORMAT = (
@@ -13,7 +13,16 @@ class AudioConverterMixin:
         'video',
     )
 
-    def get_converted_audio(self, input_file: str) -> bytes:
+    def get_mp3_content(self) -> bytes:
+        """
+        Convert and return MP3 content of File object located at
+        `self.absolute_path`.
+        """
+
+        if not hasattr(self, 'mimetype') or not hasattr(self, 'absolute_path'):
+            raise NotImplementedError(
+                'Parent class does not implement `mimetype` or `absolute_path'
+            )
 
         supported_formats = (
             'audio',
@@ -26,7 +35,7 @@ class AudioConverterMixin:
         ffmpeg_command = [
             '/usr/bin/ffmpeg',
             '-i',
-            self.path,
+            self.absolute_path,
             '-f',
             self.CONVERSION_AUDIO_FORMAT,
             'pipe:1',

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -2,7 +2,6 @@
 import json
 import re
 from io import StringIO, BytesIO
-from tempfile import NamedTemporaryFile
 from typing import Dict, Optional
 
 from dicttoxml import dicttoxml

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -1,14 +1,15 @@
 # coding: utf-8
 import os
-from tempfile import NamedTemporaryFile
 from mimetypes import guess_type
+from tempfile import NamedTemporaryFile
+from typing import Optional
 
 from django.core.files import File
 
-from kpi.mixins.audio_converter import AudioConverterMixin
+from kpi.mixins.mp3_converter import MP3ConverterMixin
 
 
-class MockAttachment(AudioConverterMixin):
+class MockAttachment(MP3ConverterMixin):
     """
     Mock object to simulate ReadOnlyKobocatAttachment.
     Relationship with ReadOnlyKobocatInstance is ignored but could be implemented
@@ -22,14 +23,14 @@ class MockAttachment(AudioConverterMixin):
         self.media_file.close()
 
     @property
-    def path(self):
+    def absolute_path(self):
         return self.media_file.path
 
-    def protected_path(self, format_):
+    def protected_path(self, format_: Optional[str] = None):
         if format_ == self.CONVERSION_AUDIO_FORMAT:
             suffix = f'.{self.CONVERSION_AUDIO_FORMAT}'
             with NamedTemporaryFile(suffix=suffix) as f:
-                self.content = self.get_converted_audio(self.path)
+                self.content = self.get_mp3_content()
             return f.name
         else:
-            return self.path
+            return self.absolute_path

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -1,11 +1,14 @@
 # coding: utf-8
 import os
+from tempfile import NamedTemporaryFile
 from mimetypes import guess_type
 
 from django.core.files import File
 
+from kpi.mixins.audio_converter import AudioConverterMixin
 
-class MockAttachment:
+
+class MockAttachment(AudioConverterMixin):
     """
     Mock object to simulate ReadOnlyKobocatAttachment.
     Relationship with ReadOnlyKobocatInstance is ignored but could be implemented
@@ -15,6 +18,18 @@ class MockAttachment:
         self.media_file.path = file_
         self.media_file_basename = os.path.basename(file_)
         self.mimetype, _ = guess_type(file_)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.content = self.media_file.read()
         self.media_file.close()
+
+    @property
+    def path(self):
+        return self.media_file.path
+
+    def protected_path(self, format_):
+        if format_ == self.CONVERSION_AUDIO_FORMAT:
+            suffix = f'.{self.CONVERSION_AUDIO_FORMAT}'
+            with NamedTemporaryFile(suffix=suffix) as f:
+                self.content = self.get_converted_audio(self.path)
+            return f.name
+        else:
+            return self.path

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -110,8 +110,8 @@ class AttachmentViewSet(
             }, 'not_supported_format')
 
         # If unit tests are running, pytest webserver does not support
-        # `X-Accel-Redirect` header (or ignores it). We need to pass
-        # the content of the Response object
+        # `X-Accel-Redirect` header (or ignores it?). We need to pass
+        # the content to the Response object
         if settings.TESTING:
             # setting the content type to `None` here allows the renderer to
             # specify the content type for the response

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -1,8 +1,7 @@
 # coding: utf-8
-from typing import Optional, Union
+from typing import Optional
 
 from django.conf import settings
-from django.http import FileResponse
 from django.shortcuts import Http404
 from django.utils.translation import gettext as t
 from rest_framework import viewsets, serializers


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Use `X-Accel-Redirect` header to let NGINX serve the attachments instead of Django.


# Related issues

Blocked by kobotoolbox/kobo-docker#330