### PR TITLE
Do not expand empty `country` or `sector` values in the current user API

### DIFF
--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -102,10 +102,11 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         # expects an object with both the label and the value.
         # TODO: store and load the value *only*
         for field in 'sector', 'country':
-            if isinstance(extra_details.get(field), str):
+            val = extra_details.get(field)
+            if isinstance(val, str) and val:
                 extra_details[field] = {
-                    'label': extra_details[field],
-                    'value': extra_details[field],
+                    'label': val,
+                    'value': val,
                 }
 
         # `require_auth` needs to be read from KC every time

--- a/kpi/tests/api/v1/test_api_users.py
+++ b/kpi/tests/api/v1/test_api_users.py
@@ -21,7 +21,8 @@ class UserListTests(test_api_users.UserListTests):
         xtradata['primarySector'] = 'camelCase Administration'
         user.extra_details.save()
         response = self.client.get(endpoint)
-        # lone string should be transformed to object with label and value
+        # …and non-empty lone string should be transformed to object with label
+        # and value
         assert response.data['extra_details']['sector'] == {
             'label': 'camelCase Administration',
             'value': 'camelCase Administration',
@@ -38,7 +39,7 @@ class UserListTests(test_api_users.UserListTests):
         }
         assert 'primarySector' not in response.data['extra_details']
 
-        # lone `country` string should also be transformed
+        # non-empty lone `country` string should also be transformed
         xtradata['country'] = 'KoBoLand'
         user.extra_details.save()
         response = self.client.get(endpoint)
@@ -46,3 +47,12 @@ class UserListTests(test_api_users.UserListTests):
             'label': 'KoBoLand',
             'value': 'KoBoLand',
         }
+
+        # empty lone strings should not be transformed
+        xtradata.clear()
+        xtradata['country'] = ''
+        xtradata['sector'] = ''
+        user.extra_details.save()
+        response = self.client.get(endpoint)
+        assert 'label' not in response.data['extra_details']['country']
+        assert 'label' not in response.data['extra_details']['sector']


### PR DESCRIPTION
@magicznyleszek, this prevents existing values like `country: ""` from becoming `country: {label: "", value: ""}`, which leads to a useless-but-present choice appearing in our multiple-select drop downs:
![image](https://user-images.githubusercontent.com/2085013/153245135-9681ceb9-fe47-4875-a17a-12268223dfca.png)

It won't do anything if `country: {label: "", value: ""}` has already been saved into the database, though. If that's something that really happens, we can decide whether to prune it on the back end or have the front end recognize it as a non-choice when rendering selects. I don't think it's worth our time right now, though.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/7-UX.2FUI/topic/UNHCR.20metadata.20additions/near/88340
