### PR TITLE
Fix crash when getRowLockingProfile is called without asset

### DIFF
--- a/jsapp/js/components/locking/lockingUtils.es6
+++ b/jsapp/js/components/locking/lockingUtils.es6
@@ -92,7 +92,9 @@ export function getLockingProfile(assetContent, profileName) {
  * @returns {object|null} null for no found
  */
 export function getRowLockingProfile(assetContent, rowName) {
-  let found = null;
+  if (!assetContent?.survey) {
+    return null;
+  }
 
   const foundRow = assetContent.survey.find((row) => {
     return getRowName(row) === rowName;
@@ -105,7 +107,7 @@ export function getRowLockingProfile(assetContent, rowName) {
     return getLockingProfile(assetContent, foundRow[LOCKING_PROFILE_PROP_NAME]);
   }
 
-  return found;
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixing error that is showing up in Sentry (https://sentry.kbtdev.org/organizations/kobo/issues/431074/), but I wasn't able to reproduce it - some edge case perhaps?
