### PR TITLE
added apis for superusers to add and edit users

### DIFF
--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -383,3 +383,18 @@ class XMLExternalDataPermission(permissions.BasePermission):
             raise Http404
 
         return True
+
+
+class UserActionPermission(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        try:
+            if view.action in ['list', 'retrieve']:
+                return True
+            else:   # ['create', 'update', 'partial_update', 'destroy']
+                if request.user.is_authenticated and request.user.is_superuser:
+                    return True
+                else:
+                    return False
+        except:
+            return False

--- a/kpi/serializers/v2/user.py
+++ b/kpi/serializers/v2/user.py
@@ -2,7 +2,7 @@
 import pytz
 
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django_request_cache import cache_for_request
 from rest_framework import serializers
@@ -15,10 +15,23 @@ from kpi.models.object_permission import ObjectPermission
 from .asset import AssetUrlListSerializer
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
 
+    class Meta:
+        model = Group
+        fields = ('id', 'url', 'name')
+
+
+class PermissionSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Permission
+        fields = ('id', 'url', 'name', 'codename')
+
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
     url = HyperlinkedIdentityField(
         lookup_field='username', view_name='user-detail')
+
     assets = PaginatedApiField(
         serializer_class=AssetUrlListSerializer
     )
@@ -28,13 +41,29 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ('url',
-                  'username',
-                  'assets',
-                  'date_joined',
-                  'public_collection_subscribers_count',
-                  'public_collections_count',
-                  )
+        fields = (
+            'url',
+            'username',
+            'password',
+            'first_name',
+            'last_name',
+            'email',
+            'is_active',
+            'is_superuser',
+            'is_staff',
+            'assets',
+            'date_joined',
+            'public_collection_subscribers_count',
+            'public_collections_count',
+            'groups',
+            'user_permissions'
+        )
+
+        read_only_fields = ('assets', 'date_joined', 'public_collection_subscribers_count', 'public_collections_count')
+
+        extra_kwargs = {
+            'password': {'write_only': True, 'required': False},
+        }
 
     def get_date_joined(self, obj):
         return obj.date_joined.astimezone(pytz.UTC).strftime(

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -17,6 +17,7 @@ from kpi.views.v2.paired_data import PairedDataViewset
 from kpi.views.v2.permission import PermissionViewSet
 from kpi.views.v2.user import UserViewSet
 from kpi.views.v2.user_asset_subscription import UserAssetSubscriptionViewSet
+from kpi.views.v2.user import GroupViewSet, PermissionViewSet as UserPermissionViewSet
 
 
 URL_NAMESPACE = 'api_v2'
@@ -90,6 +91,8 @@ router_api_v2.register(
 router_api_v2.register(r'users', UserViewSet)
 router_api_v2.register(r'permissions', PermissionViewSet)
 router_api_v2.register(r'imports', ImportTaskViewSet)
+router_api_v2.register(r'groups', GroupViewSet)
+router_api_v2.register(r'user_permissions', UserPermissionViewSet)
 
 # TODO migrate ViewSet below
 # router_api_v2.register(r'sitewide_messages', SitewideMessageViewSet)

--- a/kpi/views/v2/user.py
+++ b/kpi/views/v2/user.py
@@ -1,91 +1,233 @@
 # coding: utf-8
-from django.contrib.auth.models import User
-from rest_framework import exceptions, mixins, renderers, status, viewsets
-from rest_framework.decorators import action
+from multiprocessing.sharedctypes import Value
+import re
+from django.contrib.auth.models import User, Group, Permission
+from rest_framework import status, viewsets
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from kpi.tasks import sync_kobocat_xforms
 from kpi.models.authorized_application import ApplicationTokenAuthentication
-from kpi.serializers.v2.user import UserSerializer
+from kpi.serializers.v2.user import UserSerializer, GroupSerializer, PermissionSerializer
+from kpi.permissions import UserActionPermission
 
 
-class UserViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
-    """
-    This viewset provides only the `detail` action; `list` is *not* provided to
-    avoid disclosing every username in the database
-    """
+# Create your views here.
+class UserViewSet(viewsets.ModelViewSet):
 
     queryset = User.objects.all()
     serializer_class = UserSerializer
     lookup_field = 'username'
+    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
+    permission_classes = (UserActionPermission,)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.authentication_classes += [ApplicationTokenAuthentication]
+
+    def get_pk_from_url(self, url, url_type):
+        try:
+            # check if the last char is '/' or not
+            if url[-1] == '/':
+                url = url[:-1]
+
+            last_index = url.rindex(url_type)
+            pk = int(url[last_index + len(url_type):])
+
+            return pk
+
+        except:
+            return -1
 
     def list(self, request, *args, **kwargs):
-        raise exceptions.PermissionDenied()
+        return super().list(request, args, kwargs)
 
-    @action(detail=True, methods=['GET'],
-            renderer_classes=[renderers.JSONRenderer],
-            url_path=r'migrate(?:/(?P<task_id>[\d\w\-]+))?')
-    def migrate(self, request, task_id: str = None, **kwargs):
-        """
-        A temporary endpoint that allows superusers to migrate other users'
-        projects, and users to migrate their own projects, from Kobocat to KPI.
-        This is required while users transition from the legacy interface to
-        the new.
+    def create(self, request, *args, **kwargs):
+        """Create and return a new user."""
+        requested_data = request.data
+        response_data = {}
+        try:
+            if 'username' not in requested_data:
+                return Response({
+                    'error': '"username" should be included.'
+                }, status=status.HTTP_400_BAD_REQUEST)
 
-        1. Call this endpoint with `?username=<username>`
-        2. Fetch url provided to check the state of the Celery task.
-           It can be:
-            - 'PENDING'
-            - 'FAILED'
-            - 'SUCCESS'
+            user = User(
+                username=requested_data['username'],
+            )
+            response_data['username'] = requested_data['username']
 
-        Notes: Be aware that the Celery `res.state` isn't too reliable, it
-        returns 'PENDING' if task does not exist.
+            if 'password' not in requested_data:
+                return Response({
+                    'error': '"password" should be included.'
+                }, status=status.HTTP_400_BAD_REQUEST)
 
-        """
+            if requested_data['password'] == '':
+                return Response({
+                    'error': '"password" should not be blank.'
+                }, status=status.HTTP_400_BAD_REQUEST)
 
-        request_user = request.user
-        migrate_user = kwargs.get('username')
-        if request_user.is_anonymous or (
-            not request_user.is_superuser
-            and request_user.username != migrate_user
-        ):
-            raise exceptions.PermissionDenied()
+            user.set_password(requested_data['password'])  # Hash the raw password
+            response_data['password'] = requested_data['password']
 
-        if task_id:
-            from celery.result import AsyncResult
-            res = AsyncResult(task_id)
-            if res:
-                return Response({'status': res.state})
+            if 'first_name' in requested_data:
+                user.first_name = requested_data['first_name']
+                response_data['first_name'] = requested_data['first_name']
+
+            if 'last_name' in requested_data:
+                user.last_name = requested_data['last_name']
+                response_data['last_name'] = requested_data['last_name']
+
+            if 'email' in requested_data:
+                regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+                if re.fullmatch(regex, requested_data['email']):
+                    user.email = requested_data['email']
+                    response_data['email'] = requested_data['email']
+                else:
+                    return Response({
+                        'error': 'email address is invalid.'
+                    }, status=status.HTTP_400_BAD_REQUEST)
+
+            if 'is_active' in requested_data:
+                if requested_data['is_active']:
+                    user.is_active = 1
+                else:
+                    user.is_active = 0
+                response_data['is_active'] = requested_data['is_active']
+
+            if 'is_superuser' in requested_data:
+                if requested_data['is_superuser']:
+                    user.is_superuser = 1
+                else:
+                    user.is_superuser = 0
+                response_data['is_superuser'] = requested_data['is_superuser']
+
+            if 'is_staff' in requested_data:
+                if requested_data['is_staff']:
+                    user.is_staff = 1
+                else:
+                    user.is_staff = 0
+                response_data['is_staff'] = requested_data['is_staff']
+
+            user.save()
+            user.groups.clear()
+            user.user_permissions.clear()
+
+        except Exception as e:
+            if str(e) == '':
+                return Response(response_data, status=status.HTTP_201_CREATED)
             else:
-                return Response(
-                    {'detail': 'Unknown task_id'},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+                return Response({
+                    'error': 'Account could not be created with received data.' + str(e)
+                }, status=status.HTTP_400_BAD_REQUEST)
 
-        username = kwargs['username']
+        return Response(response_data, status=status.HTTP_201_CREATED)
 
-        task = sync_kobocat_xforms.delay(
-            username=username,
-            quiet=True,
-            populate_xform_kpi_asset_uid=True,
-            sync_kobocat_form_media=True
-        )
+    def update(self, request, *args, **kwargs):
+        requested_data = request.data
+        response_data = {}
+        try:
+            user = self.get_object()
 
-        return Response(
-            {
-                'celery_task': reverse(
-                    'user-migrate',
-                    kwargs={
-                        'username': username,
-                        'task_id': task.task_id
-                    },
-                    request=request
-                )
-            }
-        )
+            if 'username' in requested_data:
+                if User.objects.filter(username=requested_data['username']).exclude(pk=user.id).count() > 0:
+                    return Response({
+                        'error': 'This username is already in use for other account.'
+                    }, status=status.HTTP_400_BAD_REQUEST)
+
+                user.username = requested_data['username']
+                response_data['username'] = requested_data['username']
+
+            if 'password' in requested_data:
+                user.set_password(requested_data['password'])
+                response_data['password'] = requested_data['password']
+
+            if 'first_name' in requested_data:
+                user.first_name = requested_data['first_name']
+                response_data['first_name'] = requested_data['first_name']
+
+            if 'last_name' in requested_data:
+                user.last_name = requested_data['last_name']
+                response_data['last_name'] = requested_data['last_name']
+
+            if 'email' in requested_data:
+                regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+                if re.fullmatch(regex, requested_data['email']):
+                    user.email = requested_data['email']
+                    response_data['email'] = requested_data['email']
+                else:
+                    return Response({
+                        'error': 'email address is invalid.'
+                    }, status=status.HTTP_400_BAD_REQUEST)
+
+            if 'is_active' in requested_data:
+                if requested_data['is_active']:
+                    user.is_active = 1
+                else:
+                    user.is_active = 0
+                response_data['is_active'] = requested_data['is_active']
+
+            if 'is_superuser' in requested_data:
+                if requested_data['is_superuser']:
+                    user.is_superuser = 1
+                else:
+                    user.is_superuser = 0
+                response_data['is_superuser'] = requested_data['is_superuser']
+
+            if 'is_staff' in requested_data:
+                if requested_data['is_staff']:
+                    user.is_staff = 1
+                else:
+                    user.is_staff = 0
+                response_data['is_staff'] = requested_data['is_staff']
+
+            if 'groups' in requested_data:
+                user.groups.clear()
+                for g in requested_data['groups']:
+                    g_pk = self.get_pk_from_url(g, 'groups/')
+                    if g_pk == -1:
+                        return Response({
+                            'error': 'Invalid "groups" is listed.'
+                        }, status=status.HTTP_400_BAD_REQUEST)
+                    user.groups.add(g_pk)
+                response_data['groups'] = requested_data['groups']
+
+            if 'user_permissions' in requested_data:
+                user.user_permissions.clear()
+                for p in requested_data['user_permissions']:
+                    p_pk = self.get_pk_from_url(p, 'user_permissions/')
+                    if p_pk == -1:
+                        return Response({
+                            'error': 'Invalid "user_permission" is listed.'
+                        }, status=status.HTTP_400_BAD_REQUEST)
+                    user.user_permissions.add(p_pk)
+                response_data['user_permissions'] = requested_data['user_permissions']
+
+            user.save()
+
+        except Exception as e:
+            if str(e) == '':
+                return Response(response_data, status=status.HTTP_200_OK)
+            else:
+                return Response({
+                    'error': 'Account could not be updated with received data.' + str(e)
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(response_data)
+    
+
+class GroupViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+
+
+class PermissionViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = Permission.objects.all()
+    serializer_class = PermissionSerializer
+


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Edited API endpoints to allow superusers to:
1. Retrieve a list of all users and their details via `GET` request at endpoint `/api/v2/users/`
2. Create users via `POST` request at endpoint `/api/v2/users/`
2. Edit users via `PUT` request at endpoint `/api/v2/users/<username>` for the following attributes which may be passed individually. 
  - `password`
  - `first_name`
  - `last_name`
  - `email`
  - `is_active`
  - `is_superuser`
  - `is_staff`
  - `groups`
  - `user_permissions`

## Related issues

Previously the only way to add users via API was to register an authorized application in Django admin panel and send a request to the `/authorized_application/users/` endpoint. However that had a bug as described in https://github.com/kobotoolbox/kpi/issues/3561. 

This PR provides a direct way to manage users without using `authorized_application`.