### PR TITLE
Fix synchronous export failure on insufficient permissions

### DIFF
--- a/kpi/mixins/export_object.py
+++ b/kpi/mixins/export_object.py
@@ -10,7 +10,7 @@ from formpack.schema.fields import (
     TagsCopyField,
     ValidationStatusCopyField,
 )
-from rest_framework import exceptions
+from django.http import Http404
 
 from kobo.apps.reports.report_data import build_formpack
 from kpi.constants import (
@@ -70,13 +70,7 @@ class ExportObjectMixin:
             PERM_VIEW_SUBMISSIONS not in source_perms
             and PERM_PARTIAL_SUBMISSIONS not in source_perms
         ):
-            # Unsure if DRF exceptions make sense here since we're not
-            # returning a HTTP response
-            raise exceptions.PermissionDenied(
-                '{user} cannot export {source}'.format(
-                    user=self.user, source=source
-                )
-            )
+            raise Http404
 
         if not source.has_deployment:
             raise Exception('the source must be deployed prior to export')

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import JSONField as JSONBField
 from django.core.files.base import ContentFile
 from django.db import models, transaction
+from django.utils.translation import gettext as t
 from private_storage.fields import PrivateFileField
 from pyxform import xls2json_backends
 from rest_framework import exceptions
@@ -111,6 +112,10 @@ class ImportExportTask(models.Model):
             # This method must be implemented by a subclass
             self._run_task(msgs)
             self.status = self.COMPLETE
+        except ExportObjectMixin.InaccessibleData as e:
+            msgs['error_type'] = t('Cannot access data')
+            msg['error'] = str(e)
+            self.status = self.ERROR
         except Exception as err:
             msgs['error_type'] = type(err).__name__
             msgs['error'] = str(err)

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -309,6 +309,19 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
             name=settings_name,
             export_settings=export_settings,
         )
+
+        # test anonymous export gives 404
+        synchronous_exports_url = reverse(
+            self._get_endpoint('submission-exports'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'uid': es.uid,
+                'format': 'csv',
+            },
+        )
+        synchronous_export_response = self.client.get(synchronous_exports_url)
+        assert synchronous_export_response.status_code == status.HTTP_404_NOT_FOUND
+
         self.client.login(username='someuser', password='someuser')
         synchronous_exports_url = reverse(
             self._get_endpoint('submission-exports'),

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -348,7 +348,6 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
             line.decode() for line in export_content_response.streaming_content
         )
         assert synchronous_export_response.content.decode() == export_content
-        print(synchronous_export_response.content.decode())
 
     def test_synchronous_csv_export_anonymous_without_permission(self):
         es = self._create_export_settings()

--- a/kpi/utils/drf_exceptions.py
+++ b/kpi/utils/drf_exceptions.py
@@ -18,7 +18,12 @@ def custom_exception_handler(exc, context):
         MP3ConversionRenderer.format,
     ]
 
-    if context['request'].accepted_renderer.format in force_json_error_formats:
+    try:
+        accepted_renderer = context['request'].accepted_renderer
+    except AttributeError:
+        return response
+
+    if accepted_renderer.format in force_json_error_formats:
         context['request'].accepted_renderer = JSONRenderer()
 
     return response


### PR DESCRIPTION
## Description

Return `404` if user does not have sufficient permissions to create a synchronous export.

## Related issues

closes #3699 