### PR TITLE
Allow Enketo editing to use existing KPI authentication

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -245,11 +245,6 @@ CONSTANCE_CONFIG = {
         "Options available for the 'operational purpose of data' metadata "
         'field, one per line.'
     ),
-    'ENKETO_AUTH_COOKIE_MAX_AGE': (
-        30 * 24 * 60 * 60,  # one month
-        'In seconds. It should match what Enketo Express sets.\n'
-        '(see https://tinyurl.com/mtc7zr2y)'
-    ),
 }
 CONSTANCE_ADDITIONAL_FIELDS = {
     'metadata_fields_jsonschema': [
@@ -483,8 +478,6 @@ ENKETO_SURVEY_ENDPOINT = 'api/v2/survey/all'
 ENKETO_PREVIEW_ENDPOINT = 'api/v2/survey/preview/iframe'
 ENKETO_EDIT_INSTANCE_ENDPOINT = 'api/v2/instance'
 ENKETO_VIEW_INSTANCE_ENDPOINT = 'api/v2/instance/view'
-
-ENKETO_AUTH_COOKIE_NAME = '__enketo_meta_username'
 
 
 ''' Celery configuration '''

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -245,6 +245,11 @@ CONSTANCE_CONFIG = {
         "Options available for the 'operational purpose of data' metadata "
         'field, one per line.'
     ),
+    'ENKETO_AUTH_COOKIE_MAX_AGE': (
+        30 * 24 * 60 * 60,  # one month
+        'In seconds. It should match what Enketo Express sets.\n'
+        '(see https://tinyurl.com/mtc7zr2y)'
+    ),
 }
 CONSTANCE_ADDITIONAL_FIELDS = {
     'metadata_fields_jsonschema': [
@@ -478,6 +483,8 @@ ENKETO_SURVEY_ENDPOINT = 'api/v2/survey/all'
 ENKETO_PREVIEW_ENDPOINT = 'api/v2/survey/preview/iframe'
 ENKETO_EDIT_INSTANCE_ENDPOINT = 'api/v2/instance'
 ENKETO_VIEW_INSTANCE_ENDPOINT = 'api/v2/instance/view'
+
+ENKETO_AUTH_COOKIE_NAME = '__enketo_meta_username'
 
 
 ''' Celery configuration '''

--- a/kpi/constants.py
+++ b/kpi/constants.py
@@ -107,3 +107,7 @@ ASSET_SEARCH_DEFAULT_FIELD_LOOKUPS = [
     'tags__name__icontains',
     'uid__icontains',
 ]
+
+
+# Things hard-coded in Enketo Express
+ENKETO_CSRF_COOKIE_NAME = '__csrf'

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from kpi.constants import (
+    ENKETO_CSRF_COOKIE_NAME,
     PERM_CHANGE_ASSET,
     PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_SUBMISSIONS,
@@ -956,6 +957,23 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         url = f"{settings.ENKETO_URL}/edit/{submission['_uuid']}"
         expected_response = {'url': url}
         self.assertEqual(response.data, expected_response)
+
+    @responses.activate
+    def test_get_edit_link_response_includes_csrf_cookie(self):
+        ee_url = (
+            f'{settings.ENKETO_URL}/{settings.ENKETO_EDIT_INSTANCE_ENDPOINT}'
+        )
+        # Mock Enketo response
+        responses.add_callback(
+            responses.POST, ee_url,
+            callback=enketo_edit_instance_response,
+            content_type='application/json',
+        )
+        response = self.client.get(self.submission_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+        # Just make sure the cookie is present and has a non-empty value
+        assert ENKETO_CSRF_COOKIE_NAME in response.cookies
+        assert response.cookies[ENKETO_CSRF_COOKIE_NAME].value
 
 
 class SubmissionViewApiTests(BaseSubmissionTestCase):

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -9,10 +9,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from kpi.authentication import (
-    DigestAuthentication,
-    EnketoCookieAuthentication,
-)
+from kpi.authentication import DigestAuthentication, EnketoSessionAuthentication
 from kpi.exceptions import SubmissionIntegrityError
 from kpi.filters import RelatedAssetPermissionsFilter
 from kpi.highlighters import highlight_xform
@@ -157,7 +154,7 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         methods=['HEAD', 'POST'],
         authentication_classes=[
             DigestAuthentication,
-            EnketoCookieAuthentication,
+            EnketoSessionAuthentication,
         ],
     )
     def submission(self, request, *args, **kwargs):

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -5,12 +5,14 @@ import requests
 from django.http import HttpResponseRedirect
 from django.conf import settings
 from rest_framework import renderers, serializers, status
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from kpi.authentication import DigestAuthentication
+from kpi.authentication import (
+    DigestAuthentication,
+    EnketoCookieAuthentication,
+)
 from kpi.exceptions import SubmissionIntegrityError
 from kpi.filters import RelatedAssetPermissionsFilter
 from kpi.highlighters import highlight_xform
@@ -153,7 +155,10 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         detail=True,
         permission_classes=[EditSubmissionPermission],
         methods=['HEAD', 'POST'],
-        authentication_classes=[DigestAuthentication],
+        authentication_classes=[
+            DigestAuthentication,
+            EnketoCookieAuthentication,
+        ],
     )
     def submission(self, request, *args, **kwargs):
         if request.method == 'HEAD':


### PR DESCRIPTION
Enketo already passes through the `kobonaut` session cookie with its OpenRosa requests, but KPI was denying it with 403 because its POSTs did not include a CSRF token. This takes advantage of enketo/enketo-express#191 to supply Enketo with the CSRF token via cookie and verify that it's sent back properly in the POST data.

## Description

Avoid an extra prompt for username and password when editing submissions.

## Related issues

#3689, kobotoolbox/kobocat#786