### PR TITLE
Enable optional settings for hsts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,6 @@ deploy-beta:
   only:
     refs:
       - master
-      - gitlab-ci-build
+      - enable-hsts-conf
     variables:
       - $CI_COMMIT_REF_PROTECTED

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,5 @@ deploy-beta:
   only:
     refs:
       - master
-      - enable-hsts-conf
     variables:
       - $CI_COMMIT_REF_PROTECTED

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -39,11 +39,9 @@ if env.str('PUBLIC_REQUEST_SCHEME', '').lower() == 'https' or SECURE_PROXY_SSL_H
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
-if os.environ.get("SECURE_HSTS_INCLUDE_SUBDOMAINS", "False") == "True":
-    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-if os.environ.get("SECURE_HSTS_PRELOAD", "False") == "True":
-    SECURE_HSTS_PRELOAD = True
-SECURE_HSTS_SECONDS = os.environ.get("SECURE_HSTS_SECONDS", 0)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', False)
+SECURE_HSTS_PRELOAD = env.bool('SECURE_HSTS_PRELOAD', False)
+SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 0)
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -39,6 +39,12 @@ if env.str('PUBLIC_REQUEST_SCHEME', '').lower() == 'https' or SECURE_PROXY_SSL_H
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
+if os.environ.get("SECURE_HSTS_INCLUDE_SUBDOMAINS", "False") == "True":
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+if os.environ.get("SECURE_HSTS_PRELOAD", "False") == "True":
+    SECURE_HSTS_PRELOAD = True
+SECURE_HSTS_SECONDS = os.environ.get("SECURE_HSTS_SECONDS", 0)
+
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
 USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", False)
@@ -104,6 +110,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
## Description

Enable optional (and off by default) HSTS headers. Controlled via environment variables.

### Potential Alternatives

- As we add more settings, I'd be interested in using django-environ. It would result in less code around determining what is a Boolean.
- Constance is used often, but doesn't feel appropriate for http headers
- Tell users to set this in their CDN or load balancer instead. But doing this in Django is likely easier for many people including our own managed instances.

### Problems

We don't document how to do this anywhere. But it shouldn't be enabled by default either. Adding to kobo-install seems excessive. I'd be in favor of having a place for server settings documentation. Users who look for this kind of think would find it.

### Testing

This isn't easy to test locally as it requires HTTPS. I tested it by pushing it to the beta instance and inspecting the response header. It works.