### PR TITLE
Add CSP headers via django-csp

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -85,6 +85,7 @@ django==2.2.7
     #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
     #   django-cors-headers
+    #   django-csp
     #   django-debug-toolbar
     #   django-markdownx
     #   django-mptt
@@ -105,6 +106,8 @@ django-celery-beat==1.5.0
 django-constance[database]==2.4.0
     # via -r dependencies/pip/requirements.in
 django-cors-headers==3.1.1
+    # via -r dependencies/pip/requirements.in
+django-csp==3.7
     # via -r dependencies/pip/requirements.in
 django-debug-toolbar==2.1
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -61,6 +61,7 @@ django==2.2.7
     #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
     #   django-cors-headers
+    #   django-csp
     #   django-debug-toolbar
     #   django-markdownx
     #   django-mptt
@@ -81,6 +82,8 @@ django-celery-beat==1.5.0
 django-constance[database]==2.4.0
     # via -r dependencies/pip/requirements.in
 django-cors-headers==3.1.1
+    # via -r dependencies/pip/requirements.in
+django-csp==3.7
     # via -r dependencies/pip/requirements.in
 django-debug-toolbar==2.1
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -32,6 +32,7 @@ django-braces
 django-celery-beat
 django-constance[database]
 django-cors-headers
+django-csp
 django-debug-toolbar
 django-environ
 django-extensions

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -61,6 +61,7 @@ django==2.2.7
     #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
     #   django-cors-headers
+    #   django-csp
     #   django-debug-toolbar
     #   django-markdownx
     #   django-mptt
@@ -81,6 +82,8 @@ django-celery-beat==1.5.0
 django-constance[database]==2.4.0
     # via -r dependencies/pip/requirements.in
 django-cors-headers==3.1.1
+    # via -r dependencies/pip/requirements.in
+django-csp==3.7
     # via -r dependencies/pip/requirements.in
 django-debug-toolbar==2.1
     # via -r dependencies/pip/requirements.in

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -109,7 +109,6 @@ INSTALLED_APPS = (
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'csp.middleware.CSPMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -484,7 +483,17 @@ ENKETO_VIEW_INSTANCE_ENDPOINT = 'api/v2/instance/view'
 # Content Security Policy (CSP)
 # CSP should "just work" by allowing any possible configuration
 # however CSP_EXTRA_DEFAULT_SRC is provided to allow for custom additions
+if env.bool("ENABLE_CSP", False):
+    MIDDLEWARE.append('csp.middleware.CSPMiddleware')
+local_unsafe_allows = [
+    "'unsafe-eval'",
+    'http://localhost:3000',
+    'http://kf.kobo.local:3000',
+    'ws://kf.kobo.local:3000'
+]
 CSP_DEFAULT_SRC = env.list('CSP_EXTRA_DEFAULT_SRC', str, []) + ["'self'", KOBOCAT_URL, ENKETO_URL]
+if env.str("FRONTEND_DEV_MODE", None) == "host":
+    CSP_DEFAULT_SRC += local_unsafe_allows
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + ["'unsafe-inline'"]
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + ["'unsafe-inline'", '*.bootstrapcdn.com']

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -504,6 +504,7 @@ if RAVEN_JS_DSN_URL and RAVEN_JS_DSN_URL.scheme:
 csp_report_uri = env.url('CSP_REPORT_URI', None)
 if csp_report_uri:  # Let environ validate uri, but set as string
     CSP_REPORT_URI = csp_report_uri.geturl()
+CSP_REPORT_ONLY = env.bool("CSP_REPORT_ONLY", False)
 
 ''' Celery configuration '''
 # Celery 4.0 New lowercase settings.

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -42,10 +42,6 @@ if env.str('PUBLIC_REQUEST_SCHEME', '').lower() == 'https' or SECURE_PROXY_SSL_H
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', False)
 SECURE_HSTS_PRELOAD = env.bool('SECURE_HSTS_PRELOAD', False)
 SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 0)
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'",)
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "*.bootstrapcdn.com")
-CSP_FONT_SRC = ("'self'", "*.bootstrapcdn.com")
-CSP_IMG_SRC = ("'self'", "data:",)
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
@@ -482,6 +478,12 @@ ENKETO_PREVIEW_ENDPOINT = 'api/v2/survey/preview/iframe'
 ENKETO_EDIT_INSTANCE_ENDPOINT = 'api/v2/instance'
 ENKETO_VIEW_INSTANCE_ENDPOINT = 'api/v2/instance/view'
 
+# Content Security Policy (CSP)
+CSP_DEFAULT_SRC = ("'self'", KOBOCAT_URL)
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'",)
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", '*.bootstrapcdn.com')
+CSP_FONT_SRC = ("'self'", '*.bootstrapcdn.com')
+CSP_IMG_SRC = ("'self'", 'data:',)
 
 ''' Celery configuration '''
 # Celery 4.0 New lowercase settings.

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -39,16 +39,13 @@ if env.str('PUBLIC_REQUEST_SCHEME', '').lower() == 'https' or SECURE_PROXY_SSL_H
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
-<<<<<<< HEAD
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', False)
 SECURE_HSTS_PRELOAD = env.bool('SECURE_HSTS_PRELOAD', False)
 SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 0)
-=======
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'",)
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "*.bootstrapcdn.com")
 CSP_FONT_SRC = ("'self'", "*.bootstrapcdn.com")
 CSP_IMG_SRC = ("'self'", "data:",)
->>>>>>> 7a2c24b5f (Install django-csp)
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
@@ -115,11 +112,8 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
-<<<<<<< HEAD
     'django.middleware.security.SecurityMiddleware',
-=======
     'csp.middleware.CSPMiddleware',
->>>>>>> 7a2c24b5f (Install django-csp)
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -39,9 +39,16 @@ if env.str('PUBLIC_REQUEST_SCHEME', '').lower() == 'https' or SECURE_PROXY_SSL_H
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
+<<<<<<< HEAD
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', False)
 SECURE_HSTS_PRELOAD = env.bool('SECURE_HSTS_PRELOAD', False)
 SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 0)
+=======
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'",)
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "*.bootstrapcdn.com")
+CSP_FONT_SRC = ("'self'", "*.bootstrapcdn.com")
+CSP_IMG_SRC = ("'self'", "data:",)
+>>>>>>> 7a2c24b5f (Install django-csp)
 
 # Make Django use NginX $host. Useful when running with ./manage.py runserver_plus
 # It avoids adding the debugger webserver port (i.e. `:8000`) at the end of urls.
@@ -108,7 +115,11 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+<<<<<<< HEAD
     'django.middleware.security.SecurityMiddleware',
+=======
+    'csp.middleware.CSPMiddleware',
+>>>>>>> 7a2c24b5f (Install django-csp)
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
## Description

Adds CSP Headers via django-csp. Merits lots of testing.

It defaults to disabled.