### PR TITLE
Pass REDIS connection as an URL to `django-redis-session`

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -786,8 +786,12 @@ MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
 
 MONGO_DB_MAX_TIME_MS = CELERY_TASK_TIME_LIMIT * 1000
 
-SESSION_ENGINE = "redis_sessions.session"
-SESSION_REDIS = env.cache_url("REDIS_SESSION_URL", default="redis://redis_cache:6380/2")
+SESSION_ENGINE = 'redis_sessions.session'
+# django-redis-session expects a dictionary with `url`
+redis_session_url = env.cache_url(
+    'REDIS_SESSION_URL', default='redis://redis_cache:6380/2'
+)
+SESSION_REDIS = {'url': redis_session_url['LOCATION']}
 
 ENV = None
 


### PR DESCRIPTION
@bufke said:

> `SESSION_REDIS` is being set to
> ```
> {'BACKEND': 'django_redis.cache.RedisCache', 'LOCATION': 'redis://:xxxxxx@redis-cache.kobo.private:6380/2'}
> ```
> which is right for built in django things...but not django-redis-sessions. It wants `{'host': 'host', 'port': '6379', 'db': '1', 'password': '', 'prefix': 'session', 'socket_timeout': 1}`