### PR TITLE
Temporarily hide links to future routes in sidebar

### DIFF
--- a/jsapp/js/components/account/accountSidebar.tsx
+++ b/jsapp/js/components/account/accountSidebar.tsx
@@ -55,6 +55,21 @@ export default class AccountSidebar extends React.Component<
     if (this.state.isLoading) {
       return <LoadingSpinner />
     } else {
+      {/* temporary workaround to hide future sidebar routes */}
+      return (
+        <bem.FormSidebar m={sidebarModifier}>
+          <bem.FormSidebar__label
+            m={{selected: this.isAccountSelected()}}
+            href={'#' + ROUTES.ACCOUNT_SETTINGS}
+          >
+            <Icon name='settings' size='xl'/>
+            <bem.FormSidebar__labelText>
+              {t('Account Settings')}
+            </bem.FormSidebar__labelText>
+          </bem.FormSidebar__label>
+        </bem.FormSidebar>
+      )
+      {/* end temporary workaround */}
       return (
         <bem.FormSidebar m={sidebarModifier}>
           <bem.FormSidebar__label


### PR DESCRIPTION
This is a temporary hack to hide some disabled links before a release to avoid confusing people. It's of interest to developers only and should be reverted soon.