### PR TITLE
Consider user auth requirement as `False` when user has no extra settings

### DIFF
--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -1,7 +1,9 @@
 # coding: utf-8
+from django.contrib.auth.models import User
 from django.http import Http404
 from rest_framework import exceptions, permissions
 
+from hub.models import ExtraUserDetail
 from kpi.constants import (
     PERM_ADD_SUBMISSIONS,
     PERM_PARTIAL_SUBMISSIONS,
@@ -371,7 +373,7 @@ class XMLExternalDataPermission(permissions.BasePermission):
         # Check whether `asset` owner's account requires authentication:
         try:
             require_auth = obj.asset.owner.extra_details.data['require_auth']
-        except KeyError:
+        except (User.extra_details.RelatedObjectDoesNotExist, KeyError):
             require_auth = False
 
         # If authentication is required, `request.user` should have

--- a/kpi/tests/api/v2/test_api_paired_data.py
+++ b/kpi/tests/api/v2/test_api_paired_data.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.exceptions import ErrorDetail
 
+from hub.models import ExtraUserDetail
 from kpi.constants import (
     PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_ASSET,
@@ -390,6 +391,19 @@ class PairedDataExternalApiTests(BasePairedDataTestCase):
         # When owner's destination asset does not require any authentications,
         # everybody can see their data
         self.client.logout()
+        response = self.client.get(self.external_xml_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_external_from_owner_with_extra_detail(self):
+        self.deploy_source()
+        # When owner's destination asset does not require any authentications,
+        # everybody can see their data
+        self.client.logout()
+
+        # Remove owner's extra detail
+        ExtraUserDetail.objects.filter(user=self.anotheruser).delete()
+        self.anotheruser.refresh_from_db()
+
         response = self.client.get(self.external_xml_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
When a form is using another form as `xml-external` data, make the authentication requirement check pass even if parent's owner does not have extra settings set.

## Related issues

Close #3726