### PR TITLE
Fix autonaming for KoboRank and KoboScore

### DIFF
--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -263,6 +263,22 @@ def test_remove_empty_expressions():
     assert _r1(c1) == {}
 
 
+def test_autoname_handles_non_latin_labels_with_kobo_score_and_kobo_rank():
+    a = Asset(asset_type='survey', content={})
+    content = {
+        'survey': [
+            {'type': 'score__row', 'label': ['नमस्ते']},
+            {'type': 'rank__level', 'label': ['नमस्ते']},
+        ]
+    }
+    a._standardize(content)
+    a._strip_empty_rows(content)
+    a._assign_kuids(content)
+    a._autoname(content)
+    for row in content['survey']:
+        assert row['$autoname'].startswith('select_one')
+
+
 def test_save_transformations():
     a1 = Asset(asset_type='survey', content={})
 

--- a/kpi/utils/autoname.py
+++ b/kpi/utils/autoname.py
@@ -137,9 +137,15 @@ def autoname_fields_in_place(surv_content, destination_key):
                     _assign_row_to_name(row, _name)
                     continue
 
-        # if no labels can be used, then use a combination of type (which is
-        # always available) and kuid, which should always be unique
+        # If no labels can be used (such as with non-Latin characters), then
+        # use a combination of type (which is always available) and kuid, which
+        # should always be unique. In the case of KoboRank and KoboScore, use
+        # `select_one` as the type rather than `score__row` and `rank__level`
+        # respectively, otherwise it does not match up with the transformed
+        # asset content passed to kobocat.
         _slug = row['type']
+        if _slug in ['score__row', 'rank__level']:
+            _slug = 'select_one'
         if '$kuid' in row:
             _slug += ('_' + row['$kuid'])
         _assign_row_to_name(row, sluggify_label(


### PR DESCRIPTION
## Description

Fix autonaming for non-Latin characters for KoboRank and KoboScore questions.

## Related issues

closes #3729 
