### PR TITLE
Treat Enketo subdomain as a trusted CSRF origin

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -51,6 +51,9 @@ if os.getenv("USE_X_FORWARDED_HOST", "False") == "True":
 if os.environ.get('SESSION_COOKIE_DOMAIN'):
     SESSION_COOKIE_DOMAIN = os.environ['SESSION_COOKIE_DOMAIN']
     SESSION_COOKIE_NAME = 'kobonaut'
+    # The trusted CSRF origins must encompass Enketo's subdomain. See
+    # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
+    CSRF_TRUSTED_ORIGINS = [SESSION_COOKIE_DOMAIN]
 
 # Limit sessions to 1 week (the default is 2 weeks)
 SESSION_COOKIE_AGE = 604800


### PR DESCRIPTION
The change in #3707 requires that Enketo be able satisfy KPI's CSRF protection. This PR sets a CSRF origin that matches the session cookie domain (e.g. `.kobotoolbox.org` for `kf.kobotoolbox.org` and `ee.kobotoolbox.org`), so that Django does not reject Enketo's requests with messages like:
`CSRF Failed: Referer checking failed - [https://ee.kobotoolbox.org/edit/ckPYrJVx?instance_id=bec48ff4-5a9e-42a0-98d0-49351a601508&return_url=false]() does not match any trusted origins.`

See also #2658.