### PR TITLE
Use latest deployed version of a form when editing a submission

### DIFF
--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -546,14 +546,20 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
             submission_id, user, request=request
         )
 
-        # TODO: un-nest `_infer_version_id()` from `build_formpack()` and move
-        # it into some utility file
-        _, submissions_stream = build_formpack(
-            self.asset,
-            submission_stream=[submission_json],
-            use_all_form_versions=True
-        )
-        version_uid = list(submissions_stream)[0][INFERRED_VERSION_ID_KEY]
+        # Do not use version_uid from the submission until UI gives users the
+        # possibility to choose which version they want to use
+
+        # # TODO: un-nest `_infer_version_id()` from `build_formpack()` and move
+        # # it into some utility file
+        # _, submissions_stream = build_formpack(
+        #     self.asset,
+        #     submission_stream=[submission_json],
+        #     use_all_form_versions=True
+        # )
+        # version_uid = list(submissions_stream)[0][INFERRED_VERSION_ID_KEY]
+
+        # Let's use the latest version uid temporarily
+        version_uid = self.asset.latest_version.uid
 
         # Retrieve the XML root node name from the submission. The instance's
         # root node name specified in the form XML (i.e. the first child of


### PR DESCRIPTION
## Description

Release 2.022.08 (see #3689) changed the Enketo editing feature to open submissions in the version of the form that was in effect when they were originally created, as opposed to shoehorning the submitted data into the latest deployed version of the form (see also enketo/enketo-express#253).

Unfortunately, this broke some workflows; therefore, this PR reverts to the pre-2.022.08 behavior and once again always uses the latest version of the form when editing. A future release will add a UI to select which version to use when editing.
