### PR TITLE
Status filter for hook log API

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -86,6 +86,7 @@ django==2.2.7
     #   django-amazon-ses
     #   django-cors-headers
     #   django-debug-toolbar
+    #   django-filter
     #   django-markdownx
     #   django-mptt
     #   django-oauth-toolkit
@@ -111,6 +112,8 @@ django-debug-toolbar==2.1
 django-environ==0.8.1
     # via -r dependencies/pip/requirements.in
 django-extensions==2.2.5
+    # via -r dependencies/pip/requirements.in
+django-filter==21.1
     # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2
     # via django-mptt

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -64,6 +64,7 @@ django==2.2.7
     #   django-amazon-ses
     #   django-cors-headers
     #   django-debug-toolbar
+    #   django-filter
     #   django-markdownx
     #   django-mptt
     #   django-oauth-toolkit
@@ -89,6 +90,8 @@ django-debug-toolbar==2.1
 django-environ==0.8.1
     # via -r dependencies/pip/requirements.in
 django-extensions==2.2.5
+    # via -r dependencies/pip/requirements.in
+django-filter==21.1
     # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2
     # via django-mptt

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -34,6 +34,7 @@ django-constance[database]
 django-cors-headers
 django-debug-toolbar
 django-environ
+django-filter
 django-extensions
 django-oauth-toolkit
 django-registration-redux

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -62,6 +62,7 @@ django==2.2.7
     #   django-amazon-ses
     #   django-cors-headers
     #   django-debug-toolbar
+    #   django-filter
     #   django-markdownx
     #   django-mptt
     #   django-oauth-toolkit
@@ -87,6 +88,8 @@ django-debug-toolbar==2.1
 django-environ==0.8.1
     # via -r dependencies/pip/requirements.in
 django-extensions==2.2.5
+    # via -r dependencies/pip/requirements.in
+django-filter==21.1
     # via -r dependencies/pip/requirements.in
 django-js-asset==1.2.2
     # via django-mptt

--- a/kobo/apps/hook/constants.py
+++ b/kobo/apps/hook/constants.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from enum import Enum
 
 

--- a/kobo/apps/hook/constants.py
+++ b/kobo/apps/hook/constants.py
@@ -1,7 +1,15 @@
-# coding: utf-8
+from enum import Enum
+
+
 HOOK_LOG_FAILED = 0
 HOOK_LOG_PENDING = 1
 HOOK_LOG_SUCCESS = 2
+
+class HookLogStatus(Enum):
+    FAILED = HOOK_LOG_FAILED
+    PENDING = HOOK_LOG_PENDING
+    SUCCESS = HOOK_LOG_SUCCESS
+
 
 KOBO_INTERNAL_ERROR_STATUS_CODE = None
 

--- a/kobo/apps/hook/filters.py
+++ b/kobo/apps/hook/filters.py
@@ -1,5 +1,3 @@
-from django.utils.translation import gettext as t
-from rest_framework import serializers
 from django_filters import rest_framework as filters
 from .models import HookLog
 

--- a/kobo/apps/hook/filters.py
+++ b/kobo/apps/hook/filters.py
@@ -1,51 +1,15 @@
-from datetime import datetime, timezone
 from django.utils.translation import gettext as t
-from rest_framework import filters, serializers
+from rest_framework import serializers
+from django_filters import rest_framework as filters
+from .models import HookLog
 
-from .constants import HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS
 
+class HookLogFilter(filters.FilterSet):
+    start = filters.IsoDateTimeFilter(
+        field_name='date_modified', lookup_expr='gte')
+    end = filters.IsoDateTimeFilter(
+        field_name='date_modified', lookup_expr='lt')
 
-class HookLogFilter(filters.BaseFilterBackend):
-    VALID_STATUSES = [HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS]
-
-    def filter_queryset(self, request, queryset, view):
-        status = request.GET.get('status')
-        if status is not None:
-            if status not in map(str, self.VALID_STATUSES):
-                raise serializers.ValidationError(
-                    {
-                        'status': t(
-                            'Value must be one of: '
-                            + ', '.join(map(str, self.VALID_STATUSES))
-                        )
-                    }
-                )
-            else:
-                queryset = queryset.filter(status=status)
-
-        # Filter on date range
-        start = request.GET.get('start')
-        if start is not None:
-            try:
-                start_date = datetime.fromisoformat(start)
-                if not start_date.tzname():
-                    start_date = start_date.replace(tzinfo=timezone.utc)
-                queryset = queryset.filter(date_modified__gte=start_date)
-            except ValueError:
-                raise serializers.ValidationError(
-                    {'start': t('Value must be a valid ISO-8601 date')}
-                )
-
-        end = request.GET.get('end')
-        if end is not None:
-            try:
-                end_date = datetime.fromisoformat(end)
-                if not end_date.tzname():
-                    end_date = end_date.replace(tzinfo=timezone.utc)
-                queryset = queryset.filter(date_modified__lt=end_date)
-            except ValueError:
-                raise serializers.ValidationError(
-                    {'end': t('Value must be a valid ISO-8601 date')}
-                )
-
-        return queryset
+    class Meta:
+        model = HookLog
+        fields = ['status', 'start', 'end']

--- a/kobo/apps/hook/filters.py
+++ b/kobo/apps/hook/filters.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timezone
+from django.utils.translation import gettext as t
+from rest_framework import filters, serializers
+
+from .constants import HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS
+
+
+class HookLogFilter(filters.BaseFilterBackend):
+    VALID_STATUSES = [HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS]
+
+    def filter_queryset(self, request, queryset, view):
+        status = request.GET.get('status')
+        if status is not None:
+            if status not in map(str, self.VALID_STATUSES):
+                raise serializers.ValidationError(
+                    {
+                        'status': t(
+                            'Value must be one of: '
+                            + ', '.join(map(str, self.VALID_STATUSES))
+                        )
+                    }
+                )
+            else:
+                queryset = queryset.filter(status=status)
+
+        # Filter on date range
+        start = request.GET.get('start')
+        if start is not None:
+            try:
+                start_date = datetime.fromisoformat(start)
+                if not start_date.tzname():
+                    start_date = start_date.replace(tzinfo=timezone.utc)
+                queryset = queryset.filter(date_modified__gte=start_date)
+            except ValueError:
+                raise serializers.ValidationError(
+                    {'start': t('Value must be a valid ISO-8601 date')}
+                )
+
+        end = request.GET.get('end')
+        if end is not None:
+            try:
+                end_date = datetime.fromisoformat(end)
+                if not end_date.tzname():
+                    end_date = end_date.replace(tzinfo=timezone.utc)
+                queryset = queryset.filter(date_modified__lt=end_date)
+            except ValueError:
+                raise serializers.ValidationError(
+                    {'end': t('Value must be a valid ISO-8601 date')}
+                )
+
+        return queryset

--- a/kobo/apps/hook/serializers/v2/hook_log.py
+++ b/kobo/apps/hook/serializers/v2/hook_log.py
@@ -6,6 +6,7 @@ from kobo.apps.hook.models.hook_log import HookLog
 
 
 class HookLogSerializer(serializers.ModelSerializer):
+    status_str = serializers.CharField(source="get_status_display")
 
     class Meta:
         model = HookLog

--- a/kobo/apps/hook/serializers/v2/hook_log.py
+++ b/kobo/apps/hook/serializers/v2/hook_log.py
@@ -6,7 +6,7 @@ from kobo.apps.hook.models.hook_log import HookLog
 
 
 class HookLogSerializer(serializers.ModelSerializer):
-    status_str = serializers.CharField(source="get_status_display")
+    status_str = serializers.CharField(source='get_status_display')
 
     class Meta:
         model = HookLog

--- a/kobo/apps/hook/tests/test_api_hook.py
+++ b/kobo/apps/hook/tests/test_api_hook.py
@@ -437,7 +437,6 @@ class ApiHookTestCase(HookTestCase):
         tzoffset = '-02:00'
 
         # There should be a success log around now
-        print(f'{hook_log_url}?start={five_minutes_ago}&end={in_five_min}')
         response = self.client.get(f'{hook_log_url}?start={five_minutes_ago}&end={in_five_min}', format='json')
         self.assertEqual(response.data.get('count'), 1)
 

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -75,7 +75,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     permission_classes = (AssetEditorSubmissionViewerPermission,)
     pagination_class = TinyPaginated
 
-    def get_queryset(self, request):
+    def get_queryset(self):
         hook_uid = self.get_parents_query_dict().get("hook")
         queryset = self.model.objects.filter(hook__uid=hook_uid,
                                              hook__asset__uid=self.asset_uid)
@@ -85,7 +85,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # nested relations."
         queryset = queryset.select_related('hook__asset')
 
-        status = request.GET.get('status')
+        status = self.request.GET.get('status')
         if status is not None:
           queryset = queryset.filter(status=status)
         return queryset

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -39,10 +39,10 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     * `uid` - is the unique identifier of a specific log
 
     Use `status` query parameter to filter logs by numeric status:
-    * `status=0` - is the default value, means that the log is not yet processed
-    * `status=1` - means that the log is processed successfully
-    * `status=2` - means that the log is processed with errors
-    * `status=3` - means that the log is processed with warnings
+
+    * `status=0`: hook has failed after exhausting all retries
+    * `status=1`: hook is still pending
+    * `status=2`: hook has succeeded
 
     #### Retrieves a log
     <pre class="prettyprint">

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -38,6 +38,12 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     * `hook_uid` - is the unique identifier of a specific external service
     * `uid` - is the unique identifier of a specific log
 
+    Use `status` query parameter to filter logs by numeric status:
+    * `status=0` - is the default value, means that the log is not yet processed
+    * `status=1` - means that the log is processed successfully
+    * `status=2` - means that the log is processed with errors
+    * `status=3` - means that the log is processed with warnings
+
     #### Retrieves a log
     <pre class="prettyprint">
     <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/hooks/<code>{hook_uid}</code>/logs/<code>{uid}</code>/
@@ -78,6 +84,10 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # Django 1.9+, "select_related() prohibits non-relational fields for
         # nested relations."
         queryset = queryset.select_related('hook__asset')
+
+        status = self.get_parents_query_dict().get("status")
+        if status is not None:
+          queryset = queryset.filter(status=status)
         return queryset
 
     @action(detail=True, methods=["PATCH"])

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -94,10 +94,10 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
 
         status = self.request.GET.get('status')
         if status is not None:
-            if status not in VALID_STATUSES:
+            if status not in map(str,VALID_STATUSES):
                 raise serializers.ValidationError(
                     {'status': _('Value must be one of: ' +
-                                 ', '.join(VALID_STATUSES))}
+                                 ', '.join(map(str,VALID_STATUSES)))}
                 )
             else:
                 queryset = queryset.filter(status=status)

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 from django.utils.translation import gettext as t
-from datetime import datetime, timezone
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, mixins, status, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -80,7 +80,8 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     serializer_class = HookLogSerializer
     permission_classes = (AssetEditorSubmissionViewerPermission,)
     pagination_class = TinyPaginated
-    filter_backends = (HookLogFilter,)
+    filter_backends = (DjangoFilterBackend,)
+    filterset_class = HookLogFilter
 
     def get_queryset(self):
         hook_uid = self.get_parents_query_dict().get("hook")

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -5,17 +5,17 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from kobo.apps.hook.constants import KOBO_INTERNAL_ERROR_STATUS_CODE
 from kobo.apps.hook.models.hook_log import HookLog
 from kobo.apps.hook.serializers.v2.hook_log import HookLogSerializer
 from kpi.paginators import TinyPaginated
 from kpi.permissions import AssetEditorSubmissionViewerPermission
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
-from constants import (
+from kobo.apps.hook.constants import (
     HOOK_LOG_FAILED,
     HOOK_LOG_PENDING,
     HOOK_LOG_SUCCESS,
+    KOBO_INTERNAL_ERROR_STATUS_CODE,
 )
 VALID_STATUSES = [HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS]
 

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -6,19 +6,17 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from kobo.apps.hook.models.hook_log import HookLog
-from kobo.apps.hook.serializers.v2.hook_log import HookLogSerializer
-from kpi.paginators import TinyPaginated
-from kpi.permissions import AssetEditorSubmissionViewerPermission
-from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
-
 from kobo.apps.hook.constants import (
     HOOK_LOG_FAILED,
     HOOK_LOG_PENDING,
     HOOK_LOG_SUCCESS,
     KOBO_INTERNAL_ERROR_STATUS_CODE,
 )
-VALID_STATUSES = [HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS]
+from kobo.apps.hook.models.hook_log import HookLog
+from kobo.apps.hook.serializers.v2.hook_log import HookLogSerializer
+from kpi.paginators import TinyPaginated
+from kpi.permissions import AssetEditorSubmissionViewerPermission
+from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
 
 class HookLogViewSet(AssetNestedObjectViewsetMixin,
@@ -86,6 +84,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     serializer_class = HookLogSerializer
     permission_classes = (AssetEditorSubmissionViewerPermission,)
     pagination_class = TinyPaginated
+    VALID_STATUSES = [HOOK_LOG_FAILED, HOOK_LOG_PENDING, HOOK_LOG_SUCCESS]
 
     def get_queryset(self):
         hook_uid = self.get_parents_query_dict().get("hook")
@@ -100,10 +99,10 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # Filter on status
         status = self.request.GET.get('status')
         if status is not None:
-            if status not in map(str,VALID_STATUSES):
+            if status not in map(str,self.VALID_STATUSES):
                 raise serializers.ValidationError(
                     {'status': _('Value must be one of: ' +
-                                 ', '.join(map(str,VALID_STATUSES)))}
+                                 ', '.join(map(str,self.VALID_STATUSES)))}
                 )
             else:
                 queryset = queryset.filter(status=status)

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -99,10 +99,10 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # Filter on status
         status = self.request.GET.get('status')
         if status is not None:
-            if status not in map(str,self.VALID_STATUSES):
+            if status not in map(str, self.VALID_STATUSES):
                 raise serializers.ValidationError(
-                    {'status': _('Value must be one of: ' +
-                                 ', '.join(map(str,self.VALID_STATUSES)))}
+                    {'status': t('Value must be one of: ' +
+                                 ', '.join(map(str, self.VALID_STATUSES)))}
                 )
             else:
                 queryset = queryset.filter(status=status)
@@ -110,27 +110,27 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # Filter on date range
         start = self.request.GET.get('start')
         if start is not None:
-          try:
-            start_date = datetime.fromisoformat(start)
-            if not start_date.tzname():
-                start_date=start_date.replace(tzinfo=timezone.utc)
-            queryset = queryset.filter(date_modified__gte=start_date)
-          except ValueError:
-            raise serializers.ValidationError(
-                {'start': _('Value must be a valid ISO-8601 date')}
-            )
+            try:
+                start_date = datetime.fromisoformat(start)
+                if not start_date.tzname():
+                    start_date = start_date.replace(tzinfo=timezone.utc)
+                queryset = queryset.filter(date_modified__gte=start_date)
+            except ValueError:
+                raise serializers.ValidationError(
+                    {'start': t('Value must be a valid ISO-8601 date')}
+                )
 
         end = self.request.GET.get('end')
         if end is not None:
-          try:
-            end_date = datetime.fromisoformat(end)
-            if not end_date.tzname():
-                end_date=end_date.replace(tzinfo=timezone.utc)
-            queryset = queryset.filter(date_modified__lt=end_date)
-          except ValueError:
-            raise serializers.ValidationError(
-                {'end': _('Value must be a valid ISO-8601 date')}
-            )
+            try:
+                end_date = datetime.fromisoformat(end)
+                if not end_date.tzname():
+                    end_date = end_date.replace(tzinfo=timezone.utc)
+                queryset = queryset.filter(date_modified__lt=end_date)
+            except ValueError:
+                raise serializers.ValidationError(
+                    {'end': t('Value must be a valid ISO-8601 date')}
+                )
 
         return queryset
 
@@ -156,10 +156,12 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
                 response["detail"] = hook_log.message
                 response["status_code"] = hook_log.status_code
             else:
-                response["detail"] = t("An error has occurred when sending the data. Please try again later.")
+                response["detail"] = t(
+                    "An error has occurred when sending the data. Please try again later.")
                 status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         else:
-            response["detail"] = t("Data is being or has already been processed")
+            response["detail"] = t(
+                "Data is being or has already been processed")
             status_code = status.HTTP_400_BAD_REQUEST
 
         return Response(response, status=status_code)

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -75,7 +75,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
     permission_classes = (AssetEditorSubmissionViewerPermission,)
     pagination_class = TinyPaginated
 
-    def get_queryset(self):
+    def get_queryset(self, request):
         hook_uid = self.get_parents_query_dict().get("hook")
         queryset = self.model.objects.filter(hook__uid=hook_uid,
                                              hook__asset__uid=self.asset_uid)
@@ -85,7 +85,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         # nested relations."
         queryset = queryset.select_related('hook__asset')
 
-        status = self.get_parents_query_dict().get("status")
+        status = request.GET.get('status')
         if status is not None:
           queryset = queryset.filter(status=status)
         return queryset

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = (
     'registration',         # Order is important
     'kobo.apps.admin.NoLoginAdminConfig',  # Must come AFTER registration; replace `django.contrib.admin`
     'django_extensions',
+    'django_filters',
     'taggit',
     'rest_framework',
     'rest_framework.authtoken',


### PR DESCRIPTION
Follow up on https://github.com/kobotoolbox/kpi/pull/3595

# Changes since I took this over

- Hook log filter logic was moved to django-filter
- HookLogStatus enum refactor
- Let django-filter handle validation logic
- Fancy django-filter UI with human readable status mitigates the usage of numbers for status.

![image](https://user-images.githubusercontent.com/739307/159721940-c6707d21-4034-4711-8df0-1993b4025889.png)

# Current discussion points

- Support timezones? IMO there is no harm and it conforms to ISO 8601. I think a random JS dev working with the API would expect ISO 8601 to just work. Recommend keeping this.
- Change status from number to human readable string and remove status_str. I recommend we move this to another PR as it's a breaking change. IMO that is a much bigger change than the goal of this PR. Or alternatively save it for a some day v3 :(
- When we upgrade to Django 3.2, let's make use of IntegerChoices so that we can replace my enum list comprehension that generates choices 