### PR TITLE
Ignore env in docker and git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ locale
 deployments.json
 celerybeat-schedule
 src/
+env

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ celerybeat-schedule
 deployments.json
 .DS_Store
 jsapp/fonts
+env


### PR DESCRIPTION
## Description

This is a small quality of life improvement. It causes the env directory to be ignored by git and docker (in docker build). "env" is a common name used for a python virtual environment. This can be useful for developers who want to run lint tools or get package information into an IDE for autocomplete/etc. While the name of the virtual environment can be anything, many programs will look for "env" by default such as VS Code.