### PR TITLE
Always return a HTTP 401  on failure when editing a submission

### DIFF
--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -330,6 +330,15 @@ class EditSubmissionPermission(SubmissionPermission):
         'POST': ['%(app_label)s.change_%(model_name)s'],
     }
 
+    def has_permission(self, request, view):
+        try:
+            return super().has_permission(request, view)
+        except Http404:
+            # When we receive a 404, we want to force a 401 to let the user
+            # log in with different credentials. Enketo Express will prompt
+            # the credential form only if it receives a 401.
+            raise exceptions.AuthenticationFailed()
+
     def has_object_permission(self, request, view, obj):
         # Authentication validation has already been made in `has_permission()`
         # because we validate the permissions on the `obj`'s parent, i.e. the asset.

--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -323,21 +323,13 @@ class DuplicateSubmissionPermission(SubmissionPermission):
     }
 
 
-class EditSubmissionPermission(SubmissionPermission):
+class EditLinkSubmissionPermission(SubmissionPermission):
+
     perms_map = {
         'GET': ['%(app_label)s.change_%(model_name)s'],
         'HEAD': ['%(app_label)s.change_%(model_name)s'],
         'POST': ['%(app_label)s.change_%(model_name)s'],
     }
-
-    def has_permission(self, request, view):
-        try:
-            return super().has_permission(request, view)
-        except Http404:
-            # When we receive a 404, we want to force a 401 to let the user
-            # log in with different credentials. Enketo Express will prompt
-            # the credential form only if it receives a 401.
-            raise exceptions.AuthenticationFailed()
 
     def has_object_permission(self, request, view, obj):
         # Authentication validation has already been made in `has_permission()`
@@ -351,6 +343,18 @@ class EditSubmissionPermission(SubmissionPermission):
         #  - https://github.com/encode/django-rest-framework/blob/45082b39368729caa70534dde11b0788ef186a37/rest_framework/views.py#L190
         #  - https://github.com/encode/django-rest-framework/blob/45082b39368729caa70534dde11b0788ef186a37/rest_framework/views.py#L453-L456
         return not request.user.is_anonymous
+
+
+class EditSubmissionPermission(EditLinkSubmissionPermission):
+
+    def has_permission(self, request, view):
+        try:
+            return super().has_permission(request, view)
+        except Http404:
+            # When we receive a 404, we want to force a 401 to let the user
+            # log in with different credentials. Enketo Express will prompt
+            # the credential form only if it receives a 401.
+            raise exceptions.AuthenticationFailed()
 
 
 class ViewSubmissionPermission(SubmissionPermission):

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -131,6 +131,10 @@ class SubmissionEditApiTests(test_api_submissions.SubmissionEditApiTests):
 
     URL_NAMESPACE = None
 
+    @pytest.mark.skip(reason='Only usable in v2')
+    def test_edit_submission_with_wrong_digest_credentials(self):
+        pass
+
 
 class SubmissionValidationStatusApiTests(test_api_submissions.SubmissionValidationStatusApiTests):
 

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -132,7 +132,11 @@ class SubmissionEditApiTests(test_api_submissions.SubmissionEditApiTests):
     URL_NAMESPACE = None
 
     @pytest.mark.skip(reason='Only usable in v2')
-    def test_edit_submission_with_wrong_digest_credentials(self):
+    def test_edit_submission_with_digest_credentials(self):
+        pass
+
+    @pytest.mark.skip(reason='Only usable in v2')
+    def test_edit_submission_with_authenticated_session_but_no_digest(self):
         pass
 
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -990,16 +990,17 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         assert ENKETO_CSRF_COOKIE_NAME in response.cookies
         assert response.cookies[ENKETO_CSRF_COOKIE_NAME].value
 
-    def test_edit_submission_with_wrong_digest_credentials(self):
+    def test_edit_submission_with_digest_credentials(self):
         url = reverse(
             self._get_endpoint('assetsnapshot-submission-alias'),
             args=(self.asset.snapshot.uid,),
         )
+        self.client.logout()
         client = DigestClient()
         req = client.post(url)
         # With no credentials provided, Session Auth and Digest Auth should fail.
         # Thus, a 401 should be returned to give the user the opportunity to login.
-        self.assertEqual(req.status_code, 401)
+        self.assertEqual(req.status_code, status.HTTP_401_UNAUTHORIZED)
 
         # With correct credentials provided, Session Auth should fail, but
         # Digest Auth should work. But, because 'anotheruser' does not have
@@ -1008,19 +1009,41 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         # with different credentials.
         client.set_authorization('anotheruser', 'anotheruser', 'Digest')
         # Force PartialDigest creation to have match when authenticated is
-        # processed
+        # processed.
         self.anotheruser.set_password('anotheruser')
         self.anotheruser.save()
 
         req = client.post(url)
-        self.assertEqual(req.status_code, 401)
+        self.assertEqual(req.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # Give anotheruser permissions to edit submissions.
+        self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
 
         # The purpose of this test is to validate that the authentication works.
-        # We do not send a valid XML, therefore it should raise a KeyError if
-        # authentication works as expected
-        self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
-        with pytest.raises(MultiValueDictKeyError) as e:
+        # We do not send a valid XML, therefore it should raise a KeyError
+        # if authentication (and permissions) works as expected.
+        with pytest.raises(KeyError) as e:
             req = client.post(url)
+
+    def test_edit_submission_with_authenticated_session_but_no_digest(self):
+        url = reverse(
+            self._get_endpoint('assetsnapshot-submission-alias'),
+            args=(self.asset.snapshot.uid,),
+        )
+        self.login_as_other_user('anotheruser', 'anotheruser')
+        # Try to edit someuser's submission by anotheruser who has no
+        # permissions on someuser's asset.
+        req = self.client.post(url)
+        self.assertEqual(req.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # Give anotheruser permissions to edit submissions.
+        self.asset.assign_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
+
+        # The purpose of this test is to validate that the authentication works.
+        # We do not send a valid XML, therefore it should raise a KeyError
+        # if authentication (and permissions) works as expected.
+        with pytest.raises(KeyError) as e:
+            req = self.client.post(url)
 
 
 class SubmissionViewApiTests(BaseSubmissionTestCase):

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -152,6 +152,10 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         detail=True,
         permission_classes=[EditSubmissionPermission],
         methods=['HEAD', 'POST'],
+        # Order of authentication classes is important (to return a 401 instead of 403).
+        # See:
+        # - https://github.com/encode/django-rest-framework/blob/df92e57ad6c8394ca54654dfc7a2722f822ed8c8/rest_framework/views.py#L183-L190
+        # - https://github.com/encode/django-rest-framework/blob/df92e57ad6c8394ca54654dfc7a2722f822ed8c8/rest_framework/views.py#L455-L461
         authentication_classes=[
             DigestAuthentication,
             EnketoSessionAuthentication,

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -153,8 +153,8 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         permission_classes=[EditSubmissionPermission],
         methods=['HEAD', 'POST'],
         authentication_classes=[
-            EnketoSessionAuthentication,
             DigestAuthentication,
+            EnketoSessionAuthentication,
         ],
     )
     def submission(self, request, *args, **kwargs):

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -153,8 +153,8 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         permission_classes=[EditSubmissionPermission],
         methods=['HEAD', 'POST'],
         authentication_classes=[
-            DigestAuthentication,
             EnketoSessionAuthentication,
+            DigestAuthentication,
         ],
     )
     def submission(self, request, *args, **kwargs):

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -37,7 +37,7 @@ from kpi.models import Asset
 from kpi.paginators import DataPagination
 from kpi.permissions import (
     DuplicateSubmissionPermission,
-    EditSubmissionPermission,
+    EditLinkSubmissionPermission,
     SubmissionPermission,
     SubmissionValidationStatusPermission,
     ViewSubmissionPermission,
@@ -352,7 +352,7 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         detail=True,
         methods=['GET'],
         renderer_classes=[renderers.JSONRenderer],
-        permission_classes=[EditSubmissionPermission],
+        permission_classes=[EditLinkSubmissionPermission],
         url_path='(enketo\/)?edit',
     )
     def enketo_edit(self, request, pk, *args, **kwargs):


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Even if a user is trying to edit not granted submission, a 401 is returned to force Enketo Express display the credentials form.

## Related issues

Closes #3743 