### PR TITLE
Serve synchronous exports without redirecting for some ill-behaved user agents

### DIFF
--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -433,3 +433,23 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
             user=anotheruser
         )
         assert len(exported_submissions) == len(actual_submissions)
+
+    def test_synchronous_csv_export_bad_user_agent_does_not_redirect(self):
+        es = self._create_export_settings()
+
+        self.client.login(username='someuser', password='someuser')
+        synchronous_exports_url = reverse(
+            self._get_endpoint('asset-export-settings-synchronous-data'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'uid': es.uid,
+                'format': 'csv',
+            },
+        )
+        synchronous_export_response = self.client.get(
+            synchronous_exports_url,
+            HTTP_USER_AGENT='Microsoft.Data.Mashup (https://go.microsoft.com/fwlink/?LinkID=304225)'
+        )
+        assert synchronous_export_response.status_code == status.HTTP_200_OK
+        first_line = next(synchronous_export_response.streaming_content)
+        assert b'Do_you_descend_from_unicellular_organism' in first_line


### PR DESCRIPTION
* Microsoft Power BI Desktop Version: 2.103.881.0 64-bit (March 2022)
* Microsoft Excel Home and Student 2019 (version 2202)
* LibreOffice Calc 7.1.4.2

Something tells me this list will grow in the future.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Synchronous.20exports.20.28consolidated.29/near/96537

## Description

Work around limitations in some clients (Power BI, Excel, LibreOffice) by avoiding HTTP 302 redirects when serving synchronous CSV exports