### PR TITLE
Debug toolbar enable

### DIFF
--- a/kobo/settings/dev.py
+++ b/kobo/settings/dev.py
@@ -10,8 +10,9 @@ LOGGING['handlers']['console'] = {
 INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
 MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
-# Comment out the line below to use `Django Debug Toolbar`
-# INTERNAL_IPS = ['172.28.0.4']  # Change IP to KPI container's IP
+def show_toolbar(request):
+    return env.bool("DEBUG_TOOLBAR", False)
+DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": show_toolbar}
 
 ENV = 'dev'
 

--- a/kobo/settings/dev.py
+++ b/kobo/settings/dev.py
@@ -10,9 +10,12 @@ LOGGING['handlers']['console'] = {
 INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
 MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
 
+
 def show_toolbar(request):
-    return env.bool("DEBUG_TOOLBAR", False)
-DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": show_toolbar}
+    return env.bool('DEBUG_TOOLBAR', False)
+
+
+DEBUG_TOOLBAR_CONFIG = {'SHOW_TOOLBAR_CALLBACK': show_toolbar}
 
 ENV = 'dev'
 


### PR DESCRIPTION
## Description

Currently one must look up their internal IP address as seen by the docker container to enable django debug toolbar. Which is only ever enabled in dev anyway. Instead, we can control this via a environment variable. In dev, set `DEBUG_TOOLBAR` to "True" to enable it. This does not work in other environments, where debug toolbar isn't enabled at all.