### PR TITLE
Add elemMatch support to mongo helper

### DIFF
--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -615,11 +615,11 @@ class SubmissionApiTests(BaseSubmissionTestCase):
 
         data = {
             'query': f'{{"{group}":{{"$elemMatch":{{"{group}/{question}":{{"$exists":true}}}}}}}}',
-            'format': 'json'
+            'format': 'json',
         }
         response = self.client.get(self.submission_list_url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data.get('count'), 1)
+        self.assertEqual(response.data[0].get('_uuid'), submission['_uuid'])
 
     def test_retrieve_submission_as_owner(self):
         """

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -599,6 +599,28 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         self.asset.remove_perm(anonymous_user, PERM_VIEW_ASSET)
         self.asset.remove_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
 
+    def test_list_query_elem_match(self):
+        """
+        Ensure query is able to filter on an array
+        """
+        submission = self.submissions[0]
+        group = 'group_lx4sf58'
+        question = 'q3'
+        submission[group] = [
+            {
+                f'{group}/{question}': 'whap.gif',
+            },
+        ]
+        self.asset.deployment.mock_submissions(self.submissions)
+
+        data = {
+            'query': f'{{"{group}":{{"$elemMatch":{{"{group}/{question}":{{"$exists":true}}}}}}}}',
+            'format': 'json'
+        }
+        response = self.client.get(self.submission_list_url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('count'), 1)
+
     def test_retrieve_submission_as_owner(self):
         """
         someuser is the owner of the project.

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -619,7 +619,11 @@ class SubmissionApiTests(BaseSubmissionTestCase):
         }
         response = self.client.get(self.submission_list_url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data[0].get('_uuid'), submission['_uuid'])
+        if isinstance(response.data, list):
+            response_count = len(response.data)
+        else:
+            response_count = response.data.get('count')
+        self.assertEqual(response_count, 1)
 
     def test_retrieve_submission_as_owner(self):
         """

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -1,7 +1,5 @@
 # coding: utf-8
-import contextlib
 import re
-import threading
 
 from django.conf import settings
 
@@ -50,6 +48,7 @@ class MongoHelper:
         '$regex',
         '$options',
         '$all',
+        '$elemMatch',
     ]
 
     ENCODING_SUBSTITUTIONS = [


### PR DESCRIPTION
- [x] Write unit test(s)

## Description

- Add $elemMatch support to mongo helper. Considering what we already allow, this is probably safe. However any modification of a query param to mongo workflow merits a higher level of security review as we could potentially allow injection attacks :rotating_light: 
- Handle mongo operation failure on data api with fallback. 

## Use Cases this solves

- I want to filter submissions to only show results for a specific question inside of a repeating group (which is an array). 
- I maybe want to do this for a future gallery update #1349

### Other thoughts

- What do you think of my handling of two semi related but not 100% related issues in one PR? It felt small enough to group
- Thoughts on my doing some very very mild refactoring while in the area? Technically removing an unused import isn't 100% guaranteed to be safe in case something is importing *. But we only do that in settings.
- I decided to catch the OperationFailure, check if it was some error I know about, and if not raise a warning and give a more generic message. I didn't want to display any messages right from mongo in case there is some way to force mongo to give out unwanted data via exception message.
- I'm only 80% sure we need elemMatch for future gallery update, but it seems good to support it as a standard alone addition to the data api.

## Related issues

Internal bug tracking: KPI-BACKEND-232K