### PR TITLE
Allow duplicate choices in snapshots

### DIFF
--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -112,8 +112,8 @@
                   "kuid": "def"
                 }
             ]},
-            "date_created": "2015-02-12T19:52:14.406Z",
-            "date_modified": "2015-02-12T19:52:14.406Z",
+            "date_created": "2022-04-05T21:00:22.402Z",
+            "date_modified": "2022-04-05T21:00:33.946Z",
             "owner": 2,
             "uid": "aPEANgNgTH3xzhJGcctURu"
         }

--- a/kpi/models/asset_snapshot.py
+++ b/kpi/models/asset_snapshot.py
@@ -17,6 +17,7 @@ from kpi.mixins import (
 from kpi.utils.hash import calculate_hash
 from kpi.utils.log import logging
 from kpi.utils.models import DjangoModelABCMetaclass
+from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 
 
 class AbstractFormList(
@@ -196,6 +197,8 @@ class AssetSnapshot(
         self._expand_kobo_qs(source_copy)
         self._populate_fields_with_autofields(source_copy)
         self._strip_kuids(source_copy)
+
+        allow_choice_duplicates(source_copy)
 
         warnings = []
         details = {}

--- a/kpi/tests/api/v1/test_api_imports.py
+++ b/kpi/tests/api/v1/test_api_imports.py
@@ -23,7 +23,7 @@ class AssetImportTaskTest(BaseTestCase):
     def setUp(self):
         self.client.login(username='someuser', password='someuser')
         self.user = User.objects.get(username='someuser')
-        self.asset = Asset.objects.first()
+        self.asset = Asset.objects.get(pk=1)
 
     def _assert_assets_contents_equal(self, a1, a2, sheet='survey'):
         def _prep_row_for_comparison(row):

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -81,7 +81,7 @@ class AssetListApiTests(BaseAssetTestCase):
 
     def test_assets_hash(self):
         another_user = User.objects.get(username="anotheruser")
-        user_asset = Asset.objects.first()
+        user_asset = Asset.objects.get(pk=1)
         user_asset.save()
         user_asset.assign_perm(another_user, "view_asset")
 
@@ -257,7 +257,7 @@ class AssetVersionApiTests(BaseTestCase):
 
     def setUp(self):
         self.client.login(username='someuser', password='someuser')
-        self.asset = Asset.objects.first()
+        self.asset = Asset.objects.get(pk=1)
         self.asset.save()
         self.version = self.asset.asset_versions.first()
         self.version_list_url = reverse(self._get_endpoint('asset-version-list'),

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -23,7 +23,7 @@ class AssetImportTaskTest(BaseTestCase):
     def setUp(self):
         self.client.login(username='someuser', password='someuser')
         self.user = User.objects.get(username='someuser')
-        self.asset = Asset.objects.first()
+        self.asset = Asset.objects.get(pk=1)
 
     def _assert_assets_contents_equal(self, a1, a2, sheet='survey'):
         def _prep_row_for_comparison(row):

--- a/kpi/tests/test_asset_snapshots.py
+++ b/kpi/tests/test_asset_snapshots.py
@@ -55,3 +55,23 @@ class CreateAssetSnapshots(AssetSnapshotsTestCase):
         asset = Asset.objects.create(asset_type='survey', content=content)
         _snapshot = asset.snapshot
         self.assertEqual(_snapshot.source.get('settings')['form_title'], 'no_title_asset')
+
+    def test_snapshots_allow_choice_duplicates(self):
+        """
+        Choice duplicates should be allowed here but *not* when deploying
+        a survey
+        """
+        content = {
+            'survey': [
+                {'type': 'select_multiple',
+                 'select_from_list_name': 'xxx',
+                 'label': 'pick one'},
+            ],
+            'choices': [
+                {'list_name': 'xxx', 'label': 'ABC', 'name': 'ABC'},
+                {'list_name': 'xxx', 'label': 'Also ABC', 'name': 'ABC'},
+            ],
+            'settings': {},
+        }
+        snap = AssetSnapshot.objects.create(source=content)
+        assert snap.xml.count('<value>ABC</value>') == 2

--- a/kpi/utils/pyxform_compatibility.py
+++ b/kpi/utils/pyxform_compatibility.py
@@ -1,0 +1,15 @@
+from pyxform.constants import ALLOW_CHOICE_DUPLICATES
+
+def allow_choice_duplicates(content: dict) -> None:
+    """
+    Modify `content` to include `allow_choice_duplicates=Yes` in the settings
+    so long as that setting does not already exist.
+    This should *not* be done for content that's being newly updated by a user,
+    but rather *only* for internal conversions of existing content, e.g. when
+    generating XML for an `AssetVersion` that was created prior to pyxform
+    prohibiting duplicate choice values (aka choice names).
+    See https://github.com/kobotoolbox/kpi/issues/3751
+    """
+    settings = content.setdefault('settings', {})
+    if ALLOW_CHOICE_DUPLICATES not in settings:
+        settings[ALLOW_CHOICE_DUPLICATES] = 'yes'


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Relaxes the pyxform [requirement](https://github.com/XLSForm/pyxform/issues/23) for uniqueness among choice values (also called choice names) for existing forms. This prevents failures when trying to edit submissions for these forms or retrieve these forms' XForm XML.

## Related issues
Fixes #3751