### PR TITLE
Implement react lazy to reduce bundle size

### DIFF
--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -11,15 +11,17 @@ import mixins from '../mixins';
 import DocumentTitle from 'react-document-title';
 import SharingForm from './permissions/sharingForm';
 import ProjectSettings from './modalForms/projectSettings';
-import ConnectProjects from 'js/components/dataAttachments/connectProjects';
 import FormMedia from './modalForms/formMedia';
-import DataTable from 'js/components/submissions/table';
-import ProjectDownloads from 'js/components/projectDownloads/projectDownloads';
 import {PROJECT_SETTINGS_CONTEXTS} from '../constants';
 import FormMap from './map';
 import RESTServices from './RESTServices';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {ROUTES} from 'js/router/routerConstants';
+
+
+const ConnectProjects = React.lazy(() => import('js/components/dataAttachments/connectProjects'));
+const DataTable = React.lazy(() => import('js/components/submissions/table'));
+const ProjectDownloads = React.lazy(() => import('js/components/projectDownloads/projectDownloads'));
 
 export class FormSubScreens extends React.Component {
   constructor(props){

--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import autoBind from 'react-autobind';
 import {
   IndexRoute,
@@ -18,18 +18,9 @@ import {envStore} from 'js/envStore'; // initializing it
 import MyLibraryRoute from 'js/components/library/myLibraryRoute';
 import PublicCollectionsRoute from 'js/components/library/publicCollectionsRoute';
 import AssetRoute from 'js/components/library/assetRoute';
-import Reports from 'js/components/reports/reports';
-import FormLanding from 'js/components/formLanding';
-import FormSummary from 'js/components/formSummary';
-import FormSubScreens from 'js/components/formSubScreens';
 import AccountSettings from 'js/components/account/accountSettingsRoute';
 import DataStorage from 'js/components/account/dataStorageRoute';
 import Security from 'js/components/account/securityRoute';
-import ChangePassword from 'js/components/changePassword';
-import SectionNotFound from 'js/components/sectionNotFound';
-import FormNotFound from 'js/components/formNotFound';
-import FormXform from 'js/components/formXform';
-import FormJson from 'js/components/formJson';
 import FormsSearchableList from 'js/lists/forms';
 import {ROUTES} from 'js/router/routerConstants';
 import permConfig from 'js/components/permissions/permConfig';
@@ -41,6 +32,16 @@ import {
 import AuthProtectedRoute from 'js/router/authProtectedRoute';
 import PermProtectedRoute from 'js/router/permProtectedRoute';
 import {PERMISSIONS_CODENAMES} from 'js/constants';
+
+const Reports = React.lazy(() => import('js/components/reports/reports'));
+const FormLanding = React.lazy(() => import('js/components/formLanding'));
+const FormSummary = React.lazy(() => import('js/components/formSummary'));
+const FormSubScreens = React.lazy(() => import('js/components/formSubScreens'));
+const ChangePassword = React.lazy(() => import('js/components/changePassword'));
+const FormXform = React.lazy(() => import('js/components/formXform'));
+const FormJson = React.lazy(() => import('js/components/formJson'));
+const SectionNotFound = React.lazy(() => import('js/components/sectionNotFound'));
+const FormNotFound = React.lazy(() => import('js/components/formNotFound'));
 
 export default class AllRoutes extends React.Component {
   constructor(props) {
@@ -113,6 +114,7 @@ export default class AllRoutes extends React.Component {
    */
   getRoutes() {
     return (
+
       <Route name='home' path={ROUTES.ROOT} component={App}>
         <IndexRedirect to={ROUTES.FORMS} />
 
@@ -343,11 +345,13 @@ export default class AllRoutes extends React.Component {
     }
 
     return (
+      <Suspense fallback={<div/>}>
       <Router
         history={hashHistory}
         ref={(ref) => this.router = ref}
         routes={this.getRoutes()}
       />
+      </Suspense>
     );
   }
 }

--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -40,7 +40,9 @@ const FormSubScreens = React.lazy(() => import('js/components/formSubScreens'));
 const ChangePassword = React.lazy(() => import('js/components/changePassword'));
 const FormXform = React.lazy(() => import('js/components/formXform'));
 const FormJson = React.lazy(() => import('js/components/formJson'));
-const SectionNotFound = React.lazy(() => import('js/components/sectionNotFound'));
+const SectionNotFound = React.lazy(() =>
+  import('js/components/sectionNotFound')
+);
 const FormNotFound = React.lazy(() => import('js/components/formNotFound'));
 
 export default class AllRoutes extends React.Component {
@@ -114,7 +116,6 @@ export default class AllRoutes extends React.Component {
    */
   getRoutes() {
     return (
-
       <Route name='home' path={ROUTES.ROOT} component={App}>
         <IndexRedirect to={ROUTES.FORMS} />
 
@@ -346,11 +347,11 @@ export default class AllRoutes extends React.Component {
 
     return (
       <Suspense fallback={<div/>}>
-      <Router
-        history={hashHistory}
-        ref={(ref) => this.router = ref}
-        routes={this.getRoutes()}
-      />
+        <Router
+          history={hashHistory}
+          ref={(ref) => this.router = ref}
+          routes={this.getRoutes()}
+        />
       </Suspense>
     );
   }

--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -346,7 +346,7 @@ export default class AllRoutes extends React.Component {
     }
 
     return (
-      <Suspense fallback={<div/>}>
+      <Suspense fallback={null}>
         <Router
           history={hashHistory}
           ref={(ref) => this.router = ref}


### PR DESCRIPTION
## Description

Measured in Firefox JS only. Go to `/#/forms/<asset id>/summary` which loads main and one additional chunk

Before: 4.77 MB
After: 4.34 MB 

### Design decisions

- Split based on route. React Lazy does not require router based code splitting. However it's the easiest mental modal and most often good enough.
- My main goal is provide a new best practice on using lazy loaded routes. I could be more aggressive on what to lazy load. I didn't lazy load any of the nested Routes. I want to stop the bundle from always growing with a new default way to load routes. We can inspect the massive vendors.js later.
- Suspense renders nothing. IMO the benefit of initial load time greatly outweighs slightly greater per page load time. Flashing "Loading" I think looks unpolished. If we had infinite dev time, I would suggest loading API data and JS at the same time and showing a fancy app shell. That's out of scope and largely unnecessary. The API loading issue is almost certainly a bigger issue because the api server response time is going to be higher than loading static js files.
- I am not prefetching chunks. This will benefit users who might be exposed to data caps or very limited bandwidth. The amount of per page slowdown it adds is very small.

## Risks

Webpack is pretty smart about how it lazy loads. I would say the risk of breaking something is low but it's possible. I could imagine the usage of necessary unused imports causing a problem (but I think still unlikely) and the only one of those I'm aware of is for state which should be obvious if broken. 

## Related issues

Fixes #3756 
