### PR TITLE
Add task to flush Enketo preview after some delay

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -497,6 +497,9 @@ ENKETO_SURVEY_ENDPOINT = 'api/v2/survey/all'
 ENKETO_PREVIEW_ENDPOINT = 'api/v2/survey/preview/iframe'
 ENKETO_EDIT_INSTANCE_ENDPOINT = 'api/v2/instance'
 ENKETO_VIEW_INSTANCE_ENDPOINT = 'api/v2/instance/view'
+ENKETO_FLUSH_CACHE_ENDPOINT = 'api/v2/survey/cache'
+# How long to wait before flushing an individual preview from Enketo's cache
+ENKETO_FLUSH_CACHED_PREVIEW_DELAY = 1800  # seconds
 
 
 ''' Celery configuration '''

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -491,10 +491,6 @@ ENKETO_VERSION = os.environ.get('ENKETO_VERSION', 'Legacy').lower()
 ENKETO_INTERNAL_URL = os.environ.get('ENKETO_INTERNAL_URL', ENKETO_URL)
 ENKETO_INTERNAL_URL = ENKETO_INTERNAL_URL.rstrip('/')  # Remove any trailing slashes
 
-# The number of hours to keep a kobo survey preview (generated for enketo)
-# around before purging it.
-KOBO_SURVEY_PREVIEW_EXPIRATION = os.environ.get('KOBO_SURVEY_PREVIEW_EXPIRATION', 24)
-
 ENKETO_API_TOKEN = os.environ.get('ENKETO_API_TOKEN', 'enketorules')
 # http://apidocs.enketo.org/v2/
 ENKETO_SURVEY_ENDPOINT = 'api/v2/survey/all'


### PR DESCRIPTION
## Description

Attempt to solve a persistent Redis memory exhaustion problem caused by the accumulation of many gigabytes of Enketo previews (specifically, cached transformations of their XML). Enketo stores these for 30 days, and that lifetime is not configurable. This change uses the Enketo API to remove each preview from the cache 30 minutes after it was created.

## Related issues

enketo/enketo-express#357