### PR TITLE
Preload JS chunks. Use more Suspense to avoid using Suspense.

### DIFF
--- a/jsapp/js/components/formSubScreens.es6
+++ b/jsapp/js/components/formSubScreens.es6
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Suspense} from 'react';
 import PropTypes from 'prop-types';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
@@ -18,25 +18,35 @@ import RESTServices from './RESTServices';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {ROUTES} from 'js/router/routerConstants';
 
-
-const ConnectProjects = React.lazy(() => import('js/components/dataAttachments/connectProjects'));
-const DataTable = React.lazy(() => import('js/components/submissions/table'));
-const ProjectDownloads = React.lazy(() => import('js/components/projectDownloads/projectDownloads'));
+const ConnectProjects = React.lazy(() =>
+  import(
+    /* webpackPrefetch: true */ 'js/components/dataAttachments/connectProjects'
+  )
+);
+const DataTable = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/submissions/table')
+);
+const ProjectDownloads = React.lazy(() =>
+  import(
+    /* webpackPrefetch: true */ 'js/components/projectDownloads/projectDownloads'
+  )
+);
 
 export class FormSubScreens extends React.Component {
-  constructor(props){
+  constructor(props) {
     super(props);
     this.state = {};
     autoBind(this);
   }
-  componentDidMount () {
+  componentDidMount() {
     this.listenTo(assetStore, this.dmixAssetStoreChange);
-    var uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
+    var uid =
+      this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
       actions.resources.loadAsset({id: uid});
     }
   }
-  render () {
+  render() {
     if (!this.state.permissions) {
       return false;
     }
@@ -50,20 +60,31 @@ export class FormSubScreens extends React.Component {
         deployment__identifier = this.state.deployment__identifier;
         report__base = deployment__identifier.replace('/forms/', '/reports/');
       }
-      switch(this.props.location.pathname) {
+      switch (this.props.location.pathname) {
         case ROUTES.FORM_TABLE.replace(':uid', this.state.uid):
-          return <DataTable asset={this.state} />;
+          return (
+            <Suspense fallback={null}>
+              <DataTable asset={this.state} />
+            </Suspense>
+          );
         case ROUTES.FORM_GALLERY.replace(':uid', this.state.uid):
-          iframeUrl = deployment__identifier+'/photos';
+          iframeUrl = deployment__identifier + '/photos';
           break;
         case ROUTES.FORM_MAP.replace(':uid', this.state.uid):
           return <FormMap asset={this.state} />;
-        case ROUTES.FORM_MAP_BY
-            .replace(':uid', this.state.uid)
-            .replace(':viewby', this.props.params.viewby):
-          return <FormMap asset={this.state} viewby={this.props.params.viewby}/>;
+        case ROUTES.FORM_MAP_BY.replace(':uid', this.state.uid).replace(
+          ':viewby',
+          this.props.params.viewby
+        ):
+          return (
+            <FormMap asset={this.state} viewby={this.props.params.viewby} />
+          );
         case ROUTES.FORM_DOWNLOADS.replace(':uid', this.state.uid):
-          return <ProjectDownloads asset={this.state}/>;
+          return (
+            <Suspense fallback={null}>
+              <ProjectDownloads asset={this.state} />;
+            </Suspense>
+          );
         case ROUTES.FORM_SETTINGS.replace(':uid', this.state.uid):
           return this.renderSettingsEditor();
         case ROUTES.FORM_MEDIA.replace(':uid', this.state.uid):
@@ -74,12 +95,18 @@ export class FormSubScreens extends React.Component {
           return this.renderRecords();
         case ROUTES.FORM_REST.replace(':uid', this.state.uid):
           return <RESTServices asset={this.state} />;
-        case ROUTES.FORM_REST_HOOK
-            .replace(':uid', this.state.uid)
-            .replace(':hookUid', this.props.params.hookUid):
-          return <RESTServices asset={this.state} hookUid={this.props.params.hookUid}/>;
+        case ROUTES.FORM_REST_HOOK.replace(':uid', this.state.uid).replace(
+          ':hookUid',
+          this.props.params.hookUid
+        ):
+          return (
+            <RESTServices
+              asset={this.state}
+              hookUid={this.props.params.hookUid}
+            />
+          );
         case ROUTES.FORM_KOBOCAT.replace(':uid', this.state.uid):
-          iframeUrl = deployment__identifier+'/form_settings';
+          iframeUrl = deployment__identifier + '/form_settings';
           break;
         case ROUTES.FORM_RESET.replace(':uid', this.state.uid):
           return this.renderReset();
@@ -89,26 +116,26 @@ export class FormSubScreens extends React.Component {
     var docTitle = this.state.name || t('Untitled');
 
     return (
-        <DocumentTitle title={`${docTitle} | KoboToolbox`}>
-          <bem.FormView>
-            <bem.FormView__cell m='iframe'>
-              <iframe src={iframeUrl} />
-            </bem.FormView__cell>
-          </bem.FormView>
-        </DocumentTitle>
-      );
+      <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+        <bem.FormView>
+          <bem.FormView__cell m='iframe'>
+            <iframe src={iframeUrl} />
+          </bem.FormView__cell>
+        </bem.FormView>
+      </DocumentTitle>
+    );
   }
   renderSettingsEditor() {
     var docTitle = this.state.name || t('Untitled');
     return (
-        <DocumentTitle title={`${docTitle} | KoboToolbox`}>
-          <bem.FormView m='form-settings'>
-            <ProjectSettings
-              context={PROJECT_SETTINGS_CONTEXTS.EXISTING}
-              formAsset={this.state}
-            />
-          </bem.FormView>
-        </DocumentTitle>
+      <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+        <bem.FormView m='form-settings'>
+          <ProjectSettings
+            context={PROJECT_SETTINGS_CONTEXTS.EXISTING}
+            formAsset={this.state}
+          />
+        </bem.FormView>
+      </DocumentTitle>
     );
   }
   renderSharing() {
@@ -122,18 +149,18 @@ export class FormSubScreens extends React.Component {
   renderRecords() {
     return (
       <bem.FormView className='connect-projects'>
-        <ConnectProjects asset={this.state}/>
+        <Suspense fallback={null}>
+          <ConnectProjects asset={this.state} />
+        </Suspense>
       </bem.FormView>
     );
   }
   renderReset() {
-    return (<LoadingSpinner/>);
+    return <LoadingSpinner />;
   }
 
   renderUpload() {
-    return (
-      <FormMedia asset={this.state}/>
-    );
+    return <FormMedia asset={this.state} />;
   }
 }
 
@@ -143,7 +170,7 @@ reactMixin(FormSubScreens.prototype, mixins.permissions);
 reactMixin(FormSubScreens.prototype, mixins.contextRouter);
 
 FormSubScreens.contextTypes = {
-  router: PropTypes.object
+  router: PropTypes.object,
 };
 
 export default FormSubScreens;

--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, {Suspense} from 'react';
 import autoBind from 'react-autobind';
 import {
   IndexRoute,
@@ -8,10 +8,7 @@ import {
   Router,
 } from 'react-router';
 import App from 'js/app';
-import {
-  FormPage,
-  LibraryAssetEditor,
-} from 'js/components/formEditors';
+import {FormPage, LibraryAssetEditor} from 'js/components/formEditors';
 import {actions} from 'js/actions';
 import {stores} from 'js/stores';
 import {envStore} from 'js/envStore'; // initializing it
@@ -25,25 +22,38 @@ import FormsSearchableList from 'js/lists/forms';
 import {ROUTES} from 'js/router/routerConstants';
 import permConfig from 'js/components/permissions/permConfig';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
-import {
-  isRootRoute,
-  redirectToLogin,
-} from 'js/router/routerUtils';
+import {isRootRoute, redirectToLogin} from 'js/router/routerUtils';
 import AuthProtectedRoute from 'js/router/authProtectedRoute';
 import PermProtectedRoute from 'js/router/permProtectedRoute';
 import {PERMISSIONS_CODENAMES} from 'js/constants';
 
-const Reports = React.lazy(() => import('js/components/reports/reports'));
-const FormLanding = React.lazy(() => import('js/components/formLanding'));
-const FormSummary = React.lazy(() => import('js/components/formSummary'));
-const FormSubScreens = React.lazy(() => import('js/components/formSubScreens'));
-const ChangePassword = React.lazy(() => import('js/components/changePassword'));
-const FormXform = React.lazy(() => import('js/components/formXform'));
-const FormJson = React.lazy(() => import('js/components/formJson'));
-const SectionNotFound = React.lazy(() =>
-  import('js/components/sectionNotFound')
+const Reports = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/reports/reports')
 );
-const FormNotFound = React.lazy(() => import('js/components/formNotFound'));
+const FormLanding = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formLanding')
+);
+const FormSummary = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formSummary')
+);
+const FormSubScreens = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formSubScreens')
+);
+const ChangePassword = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/changePassword')
+);
+const FormXform = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formXform')
+);
+const FormJson = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formJson')
+);
+const SectionNotFound = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/sectionNotFound')
+);
+const FormNotFound = React.lazy(() =>
+  import(/* webpackPrefetch: true */ 'js/components/formNotFound')
+);
 
 export default class AllRoutes extends React.Component {
   constructor(props) {
@@ -116,225 +126,229 @@ export default class AllRoutes extends React.Component {
    */
   getRoutes() {
     return (
-      <Route name='home' path={ROUTES.ROOT} component={App}>
-        <IndexRedirect to={ROUTES.FORMS} />
+      <Suspense fallback={null}>
+        <Route name='home' path={ROUTES.ROOT} component={App}>
+          <IndexRedirect to={ROUTES.FORMS} />
 
-        {/* MISC */}
-        <Route path={ROUTES.SECURITY} component={Security} />
-        <Route path={ROUTES.DATA_STORAGE} component={DataStorage} />
-        <Route
-          path={ROUTES.ACCOUNT_SETTINGS}
-          component={AuthProtectedRoute}
-          protectedComponent={AccountSettings}
-        />
-        <Route
-          path={ROUTES.CHANGE_PASSWORD}
-          component={AuthProtectedRoute}
-          protectedComponent={ChangePassword}
-        />
-
-        {/* LIBRARY */}
-        <Route path={ROUTES.LIBRARY}>
-          <IndexRedirect to={ROUTES.MY_LIBRARY}/>
+          {/* MISC */}
+          <Route path={ROUTES.SECURITY} component={Security} />
+          <Route path={ROUTES.DATA_STORAGE} component={DataStorage} />
           <Route
-            path={ROUTES.MY_LIBRARY}
+            path={ROUTES.ACCOUNT_SETTINGS}
             component={AuthProtectedRoute}
-            protectedComponent={MyLibraryRoute}
+            protectedComponent={AccountSettings}
           />
-          <Route
-            path={ROUTES.PUBLIC_COLLECTIONS}
-            component={AuthProtectedRoute}
-            protectedComponent={PublicCollectionsRoute}
-          />
-          <Route
-            path={ROUTES.NEW_LIBRARY_ITEM}
-            component={AuthProtectedRoute}
-            protectedComponent={LibraryAssetEditor}
-          />
-          <Route
-            path={ROUTES.LIBRARY_ITEM}
-            component={PermProtectedRoute}
-            protectedComponent={AssetRoute}
-            requiredPermission={PERMISSIONS_CODENAMES.view_asset}
-          />
-          <Route
-            path={ROUTES.EDIT_LIBRARY_ITEM}
-            component={PermProtectedRoute}
-            protectedComponent={LibraryAssetEditor}
-            requiredPermission={PERMISSIONS_CODENAMES.change_asset}
-          />
-          <Route
-            path={ROUTES.NEW_LIBRARY_CHILD}
-            component={PermProtectedRoute}
-            protectedComponent={LibraryAssetEditor}
-            requiredPermission={PERMISSIONS_CODENAMES.change_asset}
-          />
-          <Route
-            path={ROUTES.LIBRARY_ITEM_JSON}
-            component={PermProtectedRoute}
-            protectedComponent={FormJson}
-            requiredPermission={PERMISSIONS_CODENAMES.view_asset}
-          />
-          <Route
-            path={ROUTES.LIBRARY_ITEM_XFORM}
-            component={PermProtectedRoute}
-            protectedComponent={FormXform}
-            requiredPermission={PERMISSIONS_CODENAMES.view_asset}
-          />
-        </Route>
-
-        {/* FORMS */}
-        <Route path={ROUTES.FORMS} >
-          <IndexRoute
-            component={AuthProtectedRoute}
-            protectedComponent={FormsSearchableList}
-          />
-
-          <Route path={ROUTES.FORM}>
-            <IndexRedirect to={ROUTES.FORM_LANDING} />
-
+          <Suspense fallback={null}>
             <Route
-              path={ROUTES.FORM_SUMMARY}
-              component={PermProtectedRoute}
-              protectedComponent={FormSummary}
-              requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+              path={ROUTES.CHANGE_PASSWORD}
+              component={AuthProtectedRoute}
+              protectedComponent={ChangePassword}
             />
+          </Suspense>
 
+          {/* LIBRARY */}
+          <Route path={ROUTES.LIBRARY}>
+            <IndexRedirect to={ROUTES.MY_LIBRARY} />
             <Route
-              path={ROUTES.FORM_LANDING}
+              path={ROUTES.MY_LIBRARY}
+              component={AuthProtectedRoute}
+              protectedComponent={MyLibraryRoute}
+            />
+            <Route
+              path={ROUTES.PUBLIC_COLLECTIONS}
+              component={AuthProtectedRoute}
+              protectedComponent={PublicCollectionsRoute}
+            />
+            <Route
+              path={ROUTES.NEW_LIBRARY_ITEM}
+              component={AuthProtectedRoute}
+              protectedComponent={LibraryAssetEditor}
+            />
+            <Route
+              path={ROUTES.LIBRARY_ITEM}
               component={PermProtectedRoute}
-              protectedComponent={FormLanding}
+              protectedComponent={AssetRoute}
               requiredPermission={PERMISSIONS_CODENAMES.view_asset}
             />
-
-            <Route path={ROUTES.FORM_DATA}>
-              <IndexRedirect to={ROUTES.FORM_TABLE} />
-              <Route
-                path={ROUTES.FORM_REPORT}
-                component={PermProtectedRoute}
-                protectedComponent={Reports}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_REPORT_OLD}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_TABLE}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_DOWNLOADS}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_GALLERY}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_MAP}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-              <Route
-                path={ROUTES.FORM_MAP_BY}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-              />
-            </Route>
-
-            <Route path={ROUTES.FORM_SETTINGS}>
-              <IndexRoute
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_MEDIA}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_SHARING}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_RECORDS}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_REST}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_REST_HOOK}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-              <Route
-                path={ROUTES.FORM_KOBOCAT}
-                component={PermProtectedRoute}
-                protectedComponent={FormSubScreens}
-                requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
-              />
-            </Route>
-
             <Route
-              path={ROUTES.FORM_JSON}
+              path={ROUTES.EDIT_LIBRARY_ITEM}
+              component={PermProtectedRoute}
+              protectedComponent={LibraryAssetEditor}
+              requiredPermission={PERMISSIONS_CODENAMES.change_asset}
+            />
+            <Route
+              path={ROUTES.NEW_LIBRARY_CHILD}
+              component={PermProtectedRoute}
+              protectedComponent={LibraryAssetEditor}
+              requiredPermission={PERMISSIONS_CODENAMES.change_asset}
+            />
+            <Route
+              path={ROUTES.LIBRARY_ITEM_JSON}
               component={PermProtectedRoute}
               protectedComponent={FormJson}
               requiredPermission={PERMISSIONS_CODENAMES.view_asset}
             />
             <Route
-              path={ROUTES.FORM_XFORM}
+              path={ROUTES.LIBRARY_ITEM_XFORM}
               component={PermProtectedRoute}
               protectedComponent={FormXform}
               requiredPermission={PERMISSIONS_CODENAMES.view_asset}
             />
-            <Route
-              path={ROUTES.FORM_EDIT}
-              component={PermProtectedRoute}
-              protectedComponent={FormPage}
-              requiredPermission={PERMISSIONS_CODENAMES.view_asset}
-            />
-
-            {/**
-              * TODO change this HACKFIX to a better solution
-              *
-              * Used to force refresh form sub routes. It's some kine of a weird
-              * way of introducing a loading screen during sub route refresh.
-              **/}
-            <Route
-              path={ROUTES.FORM_RESET}
-              component={PermProtectedRoute}
-              protectedComponent={FormSubScreens}
-              requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
-            />
           </Route>
 
-          <Route path='*' component={FormNotFound} />
-        </Route>
+          {/* FORMS */}
+          <Route path={ROUTES.FORMS}>
+            <IndexRoute
+              component={AuthProtectedRoute}
+              protectedComponent={FormsSearchableList}
+            />
 
-        <Route path='*' component={SectionNotFound} />
-      </Route>
+            <Route path={ROUTES.FORM}>
+              <IndexRedirect to={ROUTES.FORM_LANDING} />
+
+              <Route
+                path={ROUTES.FORM_SUMMARY}
+                component={PermProtectedRoute}
+                protectedComponent={FormSummary}
+                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+              />
+
+              <Route
+                path={ROUTES.FORM_LANDING}
+                component={PermProtectedRoute}
+                protectedComponent={FormLanding}
+                requiredPermission={PERMISSIONS_CODENAMES.view_asset}
+              />
+
+              <Route path={ROUTES.FORM_DATA}>
+                <IndexRedirect to={ROUTES.FORM_TABLE} />
+                <Route
+                  path={ROUTES.FORM_REPORT}
+                  component={PermProtectedRoute}
+                  protectedComponent={Reports}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_REPORT_OLD}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_TABLE}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_DOWNLOADS}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_GALLERY}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_MAP}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+                <Route
+                  path={ROUTES.FORM_MAP_BY}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+                />
+              </Route>
+
+              <Route path={ROUTES.FORM_SETTINGS}>
+                <IndexRoute
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_MEDIA}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_SHARING}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_RECORDS}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_REST}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_REST_HOOK}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+                <Route
+                  path={ROUTES.FORM_KOBOCAT}
+                  component={PermProtectedRoute}
+                  protectedComponent={FormSubScreens}
+                  requiredPermission={PERMISSIONS_CODENAMES.manage_asset}
+                />
+              </Route>
+
+              <Route
+                path={ROUTES.FORM_JSON}
+                component={PermProtectedRoute}
+                protectedComponent={FormJson}
+                requiredPermission={PERMISSIONS_CODENAMES.view_asset}
+              />
+              <Route
+                path={ROUTES.FORM_XFORM}
+                component={PermProtectedRoute}
+                protectedComponent={FormXform}
+                requiredPermission={PERMISSIONS_CODENAMES.view_asset}
+              />
+              <Route
+                path={ROUTES.FORM_EDIT}
+                component={PermProtectedRoute}
+                protectedComponent={FormPage}
+                requiredPermission={PERMISSIONS_CODENAMES.view_asset}
+              />
+
+              {/**
+               * TODO change this HACKFIX to a better solution
+               *
+               * Used to force refresh form sub routes. It's some kine of a weird
+               * way of introducing a loading screen during sub route refresh.
+               **/}
+              <Route
+                path={ROUTES.FORM_RESET}
+                component={PermProtectedRoute}
+                protectedComponent={FormSubScreens}
+                requiredPermission={PERMISSIONS_CODENAMES.view_submissions}
+              />
+            </Route>
+
+            <Route path='*' component={FormNotFound} />
+          </Route>
+
+          <Route path='*' component={SectionNotFound} />
+        </Route>
+      </Suspense>
     );
   }
 
@@ -342,17 +356,15 @@ export default class AllRoutes extends React.Component {
     // This is the place that stops any app rendering until all necessary
     // backend calls are done.
     if (!this.state.isPermsConfigReady || !this.state.isSessionReady) {
-      return (<LoadingSpinner/>);
+      return <LoadingSpinner />;
     }
 
     return (
-      <Suspense fallback={null}>
-        <Router
-          history={hashHistory}
-          ref={(ref) => this.router = ref}
-          routes={this.getRoutes()}
-        />
-      </Suspense>
+      <Router
+        history={hashHistory}
+        ref={(ref) => (this.router = ref)}
+        routes={this.getRoutes()}
+      />
     );
   }
 }

--- a/jsapp/js/router/authProtectedRoute.es6
+++ b/jsapp/js/router/authProtectedRoute.es6
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Suspense} from 'react';
 import {stores} from 'js/stores';
 import AccessDenied from 'js/router/accessDenied';
 
@@ -19,7 +19,9 @@ export default class AuthProtectedRoute extends React.Component {
 
   render() {
     if (stores.session.isLoggedIn) {
-      return <this.props.route.protectedComponent {...this.props}/>;
+      return <Suspense fallback={null}>
+        <this.props.route.protectedComponent {...this.props}/>;
+        </Suspense>
     }
     return <AccessDenied/>;
   }

--- a/jsapp/js/router/permProtectedRoute.es6
+++ b/jsapp/js/router/permProtectedRoute.es6
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Suspense} from 'react';
 import autoBind from 'react-autobind';
 import {actions} from 'js/actions';
 import {stores} from 'js/stores';
@@ -100,10 +100,12 @@ export default class PermProtectedRoute extends React.Component {
       return <LoadingSpinner/>;
     } else if (this.state.userHasRequiredPermission) {
       return (
-        <this.props.route.protectedComponent
-          {...this.props}
-          initialAssetLoadNotNeeded
-        />
+        <Suspense fallback={<LoadingSpinner/>}>
+          <this.props.route.protectedComponent
+            {...this.props}
+            initialAssetLoadNotNeeded
+          />
+        </Suspense>
       );
     } else {
       return <AccessDenied errorMessage={this.state.errorMessage}/>;


### PR DESCRIPTION
## Description

Problem: React lazy [forces](https://reactjs.org/docs/code-splitting.html) the usage of Suspense, it cannot be disabled. It's particularly bad that Suspense will render, for no reason, when the JS chunk is prefetched. This pointless flicker render is very visible and looks bad. We do not wish to render content (such as a loading spinner) when loading a JS chunk. Prior to this change, we added Suspense to the root level route component. But this exaggerates the flicker causing the entire page to remove the dom and then repaint it. 

> React has to hide its tree up to the closest <Suspense> boundary. 

Solution: We can instead render Suspense all over the place in routes to push it deeper into the dom tree. Technically it IS still flickering, but it's lower in the DOM tree and IMO not noticeable. Because of the number of changes involved, I've decided to apply prettier to all affected files. Note that even if we don't use prettier, the change in indents would still cause most lines to be marked as changed.

Additionally we now prefetch all JS chunks. This in theory cuts down in flicker/load time as well while keeping the main critical path bundle smaller. The exact behavior is left up to the browser to implement as a prefetch browser hint. In most cases, the browser will decide to download all JS after it finishes downloading critical JS.