### PR TITLE
Changed public access warning to only show for surveys

### DIFF
--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -116,7 +116,7 @@ class SharingForm extends React.Component {
           {this.state.asset.name}
         </bem.Modal__subheader>
 
-        {stores.session.currentAccount.extra_details?.require_auth !== true && asset_type == 'survey' &&
+        {stores.session.currentAccount.extra_details?.require_auth !== true && asset_type == ASSET_TYPES.survey.id &&
           <bem.FormModal__item>
             <bem.FormView__cell m='warning'>
               <i className='k-icon k-icon-alert' />

--- a/jsapp/js/components/permissions/sharingForm.es6
+++ b/jsapp/js/components/permissions/sharingForm.es6
@@ -116,7 +116,7 @@ class SharingForm extends React.Component {
           {this.state.asset.name}
         </bem.Modal__subheader>
 
-        {stores.session.currentAccount.extra_details?.require_auth !== true &&
+        {stores.session.currentAccount.extra_details?.require_auth !== true && asset_type == 'survey' &&
           <bem.FormModal__item>
             <bem.FormView__cell m='warning'>
               <i className='k-icon k-icon-alert' />


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Changed the public access warning so it would only be visible for surveys and not library items

## Related issues

closes #3721 
