### PR TITLE
Send `.xlsx` file extension to kobocat for XLSForm (re)deployments

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -261,7 +261,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 raise Exception('The identifier is not properly formatted.')
 
         url = self.external_to_internal_url('{}/api/v1/forms'.format(kc_server))
-        xls_io = self.asset.to_xls_io(
+        xlsx_io = self.asset.to_xlsx_io(
             versioned=True, append={
                 'settings': {
                     'id_string': id_string,
@@ -281,7 +281,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'has_kpi_hook': self.asset.has_active_hooks,
             'kpi_asset_uid': self.asset.uid
         }
-        files = {'xls_file': ('{}.xls'.format(id_string), xls_io)}
+        files = {'xls_file': ('{}.xlsx'.format(id_string), xlsx_io)}
         json_response = self._kobocat_request(
             'POST', url, data=payload, files=files)
         self.store_data({
@@ -819,7 +819,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             active = self.active
         url = self.external_to_internal_url(self.backend_response['url'])
         id_string = self.backend_response['id_string']
-        xls_io = self.asset.to_xls_io(
+        xlsx_io = self.asset.to_xlsx_io(
             versioned=True, append={
                 'settings': {
                     'id_string': id_string,
@@ -832,7 +832,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'title': self.asset.name,
             'has_kpi_hook': self.asset.has_active_hooks
         }
-        files = {'xls_file': ('{}.xls'.format(id_string), xls_io)}
+        files = {'xls_file': ('{}.xlsx'.format(id_string), xlsx_io)}
         try:
             json_response = self._kobocat_request(
                 'PATCH', url, data=payload, files=files)

--- a/kpi/mixins/xls_exportable.py
+++ b/kpi/mixins/xls_exportable.py
@@ -35,7 +35,7 @@ class XlsExportableMixin:
         )
         return content
 
-    def to_xls_io(self, versioned=False, **kwargs):
+    def to_xlsx_io(self, versioned=False, **kwargs):
         """
         To append rows to one or more sheets, pass `append` as a
         dictionary of lists of dictionaries in the following format:

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -273,5 +273,5 @@ class XlsRenderer(renderers.BaseRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         asset = renderer_context['view'].get_object()
-        return asset.to_xls_io(versioned=self.versioned,
+        return asset.to_xlsx_io(versioned=self.versioned,
                                kobo_specific_types=self.kobo_specific_types)

--- a/kpi/tests/api/v1/test_api_imports.py
+++ b/kpi/tests/api/v1/test_api_imports.py
@@ -59,7 +59,7 @@ class AssetImportTaskTest(BaseTestCase):
         mock_xls_url = 'http://mock.kbtdev.org/form.xls'
         responses.add(responses.GET, mock_xls_url,
                       content_type='application/xls',
-                      body=self.asset.to_xls_io().read())
+                      body=self.asset.to_xlsx_io().read())
         task_data = {
             'url': mock_xls_url,
             'name': 'I was imported via URL!',
@@ -67,7 +67,7 @@ class AssetImportTaskTest(BaseTestCase):
         self._post_import_task_and_compare_created_asset_to_source(task_data,
                                                                    self.asset)
     def test_import_asset_base64_xls(self):
-        encoded_xls = base64.b64encode(self.asset.to_xls_io().read())
+        encoded_xls = base64.b64encode(self.asset.to_xlsx_io().read())
         task_data = {
             'base64Encoded': 'base64:{}'.format(to_str(encoded_xls)),
             'name': 'I was imported via base64-encoded XLS!',
@@ -211,9 +211,9 @@ class AssetImportTaskTest(BaseTestCase):
         )
 
     def test_import_asset_xls(self):
-        xls_io = self.asset.to_xls_io()
+        xlsx_io = self.asset.to_xlsx_io()
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         self._post_import_task_and_compare_created_asset_to_source(task_data,
@@ -261,9 +261,9 @@ class AssetImportTaskTest(BaseTestCase):
         self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
 
     def test_import_xls_with_default_language_but_no_translations(self):
-        xls_io = self.asset.to_xls_io(append={"settings": {"default_language": "English (en)"}})
+        xlsx_io = self.asset.to_xlsx_io(append={"settings": {"default_language": "English (en)"}})
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         post_url = reverse('importtask-list')
@@ -275,11 +275,11 @@ class AssetImportTaskTest(BaseTestCase):
 
     def test_import_xls_with_default_language_not_in_translations(self):
         asset = Asset.objects.get(pk=2)
-        xls_io = asset.to_xls_io(append={
+        xlsx_io = asset.to_xlsx_io(append={
             "settings": {"default_language": "English (en)"}
         })
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         post_url = reverse('importtask-list')

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -117,7 +117,7 @@ class AssetImportTaskTest(BaseTestCase):
         mock_xls_url = 'http://mock.kbtdev.org/form.xls'
         responses.add(responses.GET, mock_xls_url,
                       content_type='application/xls',
-                      body=self.asset.to_xls_io().read())
+                      body=self.asset.to_xlsx_io().read())
         task_data = {
             'url': mock_xls_url,
             'name': 'I was imported via URL!',
@@ -125,7 +125,7 @@ class AssetImportTaskTest(BaseTestCase):
         self._post_import_task_and_compare_created_asset_to_source(task_data,
                                                                    self.asset)
     def test_import_asset_base64_xls(self):
-        encoded_xls = base64.b64encode(self.asset.to_xls_io().read())
+        encoded_xls = base64.b64encode(self.asset.to_xlsx_io().read())
         task_data = {
             'base64Encoded': 'base64:{}'.format(to_str(encoded_xls)),
             'name': 'I was imported via base64-encoded XLS!',
@@ -885,9 +885,9 @@ class AssetImportTaskTest(BaseTestCase):
         )
 
     def test_import_asset_xls(self):
-        xls_io = self.asset.to_xls_io()
+        xlsx_io = self.asset.to_xlsx_io()
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         self._post_import_task_and_compare_created_asset_to_source(task_data,
@@ -935,9 +935,9 @@ class AssetImportTaskTest(BaseTestCase):
         self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
 
     def test_import_xls_with_default_language_but_no_translations(self):
-        xls_io = self.asset.to_xls_io(append={"settings": {"default_language": "English (en)"}})
+        xlsx_io = self.asset.to_xlsx_io(append={"settings": {"default_language": "English (en)"}})
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         post_url = reverse('api_v2:importtask-list')
@@ -949,11 +949,11 @@ class AssetImportTaskTest(BaseTestCase):
 
     def test_import_xls_with_default_language_not_in_translations(self):
         asset = Asset.objects.get(pk=2)
-        xls_io = asset.to_xls_io(append={
+        xlsx_io = asset.to_xlsx_io(append={
             "settings": {"default_language": "English (en)"}
         })
         task_data = {
-            'file': xls_io,
+            'file': xlsx_io,
             'name': 'I was imported via XLS!',
         }
         post_url = reverse('api_v2:importtask-list')

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -309,7 +309,7 @@ class AssetContentTests(AssetsTestCase):
         self.assertEqual(_c['settings'][0]['asdf'], 'jkl')
         self.assertEqual(_c['survey'][-1]['type'], 'note')
 
-    def test_to_xls_io_versioned_appended(self):
+    def test_to_xlsx_io_versioned_appended(self):
         append = {
             'survey': [
                 {'type': 'note', 'label': ['wee'
@@ -320,8 +320,8 @@ class AssetContentTests(AssetsTestCase):
                 'asdf': 'jkl',
             }
         }
-        xls_io = self.asset.to_xls_io(versioned=True, append=append)
-        workbook = openpyxl.load_workbook(xls_io)
+        xlsx_io = self.asset.to_xlsx_io(versioned=True, append=append)
+        workbook = openpyxl.load_workbook(xlsx_io)
 
         survey_sheet = workbook['survey']
         # `versioned=True` should add a calculate question to the the last row.
@@ -350,11 +350,11 @@ class AssetContentTests(AssetsTestCase):
         xls_form_title_col = [row[0].value for row in settings_sheet.iter_rows(max_row=2)]
         assert xls_form_title_col == ['form_title', self.asset.name or None]
 
-    def test_to_xls_io_includes_version_number_and_date(self):
+    def test_to_xlsx_io_includes_version_number_and_date(self):
         date_string = '2021-03-17 11:12:13'
         self.asset.date_modified = datetime.datetime.fromisoformat(date_string)
-        xls_io = self.asset.to_xls_io(versioned=True)
-        workbook = openpyxl.load_workbook(xls_io)
+        xlsx_io = self.asset.to_xlsx_io(versioned=True)
+        workbook = openpyxl.load_workbook(xlsx_io)
         settings_sheet = workbook['settings']
         version_col = [cell.value for cell in settings_sheet[1]].index(
             'version'


### PR DESCRIPTION
KPI is [always generating `xlsx` files](https://github.com/kobotoolbox/kpi/blob/ef46058d9ffa570d409ea1d6d9ee50e4f9e6b494/kpi/mixins/xls_exportable.py#L86-L89) before [(re)deploying to kobocat](https://github.com/kobotoolbox/kpi/blob/ef46058d9ffa570d409ea1d6d9ee50e4f9e6b494/kpi/deployment_backends/kobocat_backend.py#L284), so ensure that the `.xlsx` extension is used and rename the method to `to_xlsx_io()` for clarity.

## Description

Pyxform `1.9.0` requires that we differentiate between `xls` and `xlsx` files explicitly. Ensure this is happening when kpi sends XLSForm contents to kobocat.

## Related issues

required change from https://github.com/kobotoolbox/kobocat/pull/809
closes #3778 
