### PR TITLE
 Allow configurable session cookie name

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -51,7 +51,7 @@ USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST", False)
 # Domain must not exclude KoBoCAT when sharing sessions
 SESSION_COOKIE_DOMAIN = env.str('SESSION_COOKIE_DOMAIN', None)
 if SESSION_COOKIE_DOMAIN:
-    SESSION_COOKIE_NAME = 'kobonaut'
+    SESSION_COOKIE_NAME = env.str('SESSION_COOKIE_NAME', 'kobonaut')
     # The trusted CSRF origins must encompass Enketo's subdomain. See
     # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
     CSRF_TRUSTED_ORIGINS = [SESSION_COOKIE_DOMAIN]


### PR DESCRIPTION
## Description

This makes it possible to host multiple instances of kobo in the same domain.

## Related issues

Related to https://github.com/kobotoolbox/kobocat/pull/814
