### PR TITLE
Upgraded to latest django-storages and inserted azure blob settings

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -6,8 +6,6 @@
 #
 -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
-    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@7c5cf0596da54546b67cbb7fd4c486f2a7761c4e#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
@@ -26,6 +24,10 @@ attrs==21.4.0
     # via
     #   jsonschema
     #   pytest
+azure-core==1.23.1
+    # via azure-storage-blob
+azure-storage-blob==12.11.0
+    # via django-storages
 backcall==0.2.0
     # via ipython
 bcrypt==3.2.0
@@ -38,8 +40,8 @@ billiard==3.6.4.0
     #   celery
 boto3==1.21.35
     # via
-    #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
+    #   django-storages
 botocore==1.24.35
     # via
     #   boto3
@@ -49,7 +51,9 @@ celery[redis]==5.2.6
     #   -r dependencies/pip/requirements.in
     #   django-celery-beat
 certifi==2021.10.8
-    # via requests
+    # via
+    #   msrest
+    #   requests
 cffi==1.15.0
     # via
     #   bcrypt
@@ -78,6 +82,7 @@ coveralls==3.3.1
     # via -r dependencies/pip/dev_requirements.in
 cryptography==36.0.2
     # via
+    #   azure-storage-blob
     #   jwcrypto
     #   paramiko
     #   pyopenssl
@@ -165,6 +170,8 @@ django-request-cache==1.2
     # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1
     # via -r dependencies/pip/requirements.in
+django-storages[azure,boto3]==1.12.3
+    # via -r dependencies/pip/requirements.in
 django-taggit==2.1.0
     # via -r dependencies/pip/requirements.in
 django-timezone-field==4.2.3
@@ -207,6 +214,8 @@ invoke==1.7.0
     # via fabric
 ipython==8.2.0
     # via -r dependencies/pip/dev_requirements.in
+isodate==0.6.1
+    # via msrest
 jedi==0.18.1
     # via ipython
 jmespath==1.0.0
@@ -238,12 +247,15 @@ mock==4.0.3
     # via -r dependencies/pip/dev_requirements.in
 mongomock==4.0.0
     # via -r dependencies/pip/dev_requirements.in
+msrest==0.6.21
+    # via azure-storage-blob
 ndg-httpsclient==0.5.1
     # via -r dependencies/pip/requirements.in
 oauthlib==3.2.0
     # via
     #   -r dependencies/pip/requirements.in
     #   django-oauth-toolkit
+    #   requests-oauthlib
 openpyxl==3.0.9
     # via
     #   -r dependencies/pip/requirements.in
@@ -348,12 +360,17 @@ redis==4.2.2
 requests==2.27.1
     # via
     #   -r dependencies/pip/requirements.in
+    #   azure-core
     #   coveralls
     #   django-oauth-toolkit
+    #   msrest
+    #   requests-oauthlib
     #   responses
     #   smsapi-client
     #   twilio
     #   yubico-client
+requests-oauthlib==1.3.1
+    # via msrest
 responses==0.20.0
     # via -r dependencies/pip/requirements.in
 s3transfer==0.5.2
@@ -365,8 +382,10 @@ shortuuid==1.0.8
 six==1.16.0
     # via
     #   asttokens
+    #   azure-core
     #   bcrypt
     #   click-repl
+    #   isodate
     #   mongomock
     #   paramiko
     #   pathlib2
@@ -398,6 +417,8 @@ traitlets==5.1.1
     #   matplotlib-inline
 twilio==7.8.0
     # via django-trench
+typing-extensions==4.2.0
+    # via azure-core
 unicodecsv==0.14.1
     # via -r dependencies/pip/requirements.in
 urllib3==1.26.9

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -6,8 +6,6 @@
 #
 -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
-    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@7c5cf0596da54546b67cbb7fd4c486f2a7761c4e#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
@@ -22,6 +20,10 @@ async-timeout==4.0.2
     # via redis
 attrs==21.4.0
     # via jsonschema
+azure-core==1.23.1
+    # via azure-storage-blob
+azure-storage-blob==12.11.0
+    # via django-storages
 begins==0.9
     # via formpack
 billiard==3.6.4.0
@@ -30,8 +32,8 @@ billiard==3.6.4.0
     #   celery
 boto3==1.21.35
     # via
-    #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
+    #   django-storages
 botocore==1.24.35
     # via
     #   boto3
@@ -42,6 +44,7 @@ celery[redis]==5.2.6
     #   django-celery-beat
 certifi==2021.10.8
     # via
+    #   msrest
     #   requests
     #   sentry-sdk
 cffi==1.15.0
@@ -62,6 +65,7 @@ click-repl==0.2.0
     # via celery
 cryptography==36.0.2
     # via
+    #   azure-storage-blob
     #   jwcrypto
     #   pyopenssl
 cssselect==1.1.0
@@ -146,6 +150,8 @@ django-request-cache==1.2
     # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1
     # via -r dependencies/pip/requirements.in
+django-storages[azure,boto3]==1.12.3
+    # via -r dependencies/pip/requirements.in
 django-taggit==2.1.0
     # via -r dependencies/pip/requirements.in
 django-timezone-field==4.2.3
@@ -178,6 +184,8 @@ idna==3.3
     # via requests
 importlib-metadata==4.11.3
     # via path-py
+isodate==0.6.1
+    # via msrest
 jmespath==1.0.0
     # via
     #   boto3
@@ -201,12 +209,15 @@ markdown==3.3.6
     # via
     #   -r dependencies/pip/requirements.in
     #   django-markdownx
+msrest==0.6.21
+    # via azure-storage-blob
 ndg-httpsclient==0.5.1
     # via -r dependencies/pip/requirements.in
 oauthlib==3.2.0
     # via
     #   -r dependencies/pip/requirements.in
     #   django-oauth-toolkit
+    #   requests-oauthlib
 openpyxl==3.0.9
     # via
     #   -r dependencies/pip/requirements.in
@@ -270,11 +281,16 @@ redis==4.2.2
 requests==2.27.1
     # via
     #   -r dependencies/pip/requirements.in
+    #   azure-core
     #   django-oauth-toolkit
+    #   msrest
+    #   requests-oauthlib
     #   responses
     #   smsapi-client
     #   twilio
     #   yubico-client
+requests-oauthlib==1.3.1
+    # via msrest
 responses==0.20.0
     # via -r dependencies/pip/requirements.in
 s3transfer==0.5.2
@@ -285,7 +301,9 @@ shortuuid==1.0.8
     # via -r dependencies/pip/requirements.in
 six==1.16.0
     # via
+    #   azure-core
     #   click-repl
+    #   isodate
     #   python-dateutil
 smsapi-client==2.5.0
     # via django-trench
@@ -304,6 +322,8 @@ tabulate==0.8.9
     # via -r dependencies/pip/requirements.in
 twilio==7.8.0
     # via django-trench
+typing-extensions==4.2.0
+    # via azure-core
 unicodecsv==0.14.1
     # via -r dependencies/pip/requirements.in
 urllib3==1.26.9

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -12,17 +12,12 @@
 # ssrf protect
 -e git+https://github.com/kobotoolbox/ssrf-protect@9b97d3f0fd8f737a38dd7a6b64efeffc03ab3cdd#egg=ssrf_protect
 
-# Necessary to use this fork until the resolution of
-# https://github.com/jschneier/django-storages/issues/566
--e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
-
 # Regular PyPI packages
 Django>=2.2,<2.3
 Markdown
 Pygments
 amqp
 billiard
-boto3
 celery
 celery[redis]
 dict2xml
@@ -38,6 +33,7 @@ django-filter
 django-extensions
 django-oauth-toolkit
 django-registration-redux
+django-storages[azure,boto3]
 django-amazon-ses
 django-webpack-loader
 django-loginas

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -6,8 +6,6 @@
 #
 -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/jnm/django-storages@s3boto3_accurate_tell#egg=django_storages
-    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@7c5cf0596da54546b67cbb7fd4c486f2a7761c4e#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
@@ -22,6 +20,10 @@ async-timeout==4.0.2
     # via redis
 attrs==21.4.0
     # via jsonschema
+azure-core==1.23.1
+    # via azure-storage-blob
+azure-storage-blob==12.11.0
+    # via django-storages
 begins==0.9
     # via formpack
 billiard==3.6.4.0
@@ -30,8 +32,8 @@ billiard==3.6.4.0
     #   celery
 boto3==1.21.35
     # via
-    #   -r dependencies/pip/requirements.in
     #   django-amazon-ses
+    #   django-storages
 botocore==1.24.35
     # via
     #   boto3
@@ -41,7 +43,9 @@ celery[redis]==5.2.6
     #   -r dependencies/pip/requirements.in
     #   django-celery-beat
 certifi==2021.10.8
-    # via requests
+    # via
+    #   msrest
+    #   requests
 cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
@@ -60,6 +64,7 @@ click-repl==0.2.0
     # via celery
 cryptography==36.0.2
     # via
+    #   azure-storage-blob
     #   jwcrypto
     #   pyopenssl
 cssselect==1.1.0
@@ -144,6 +149,8 @@ django-request-cache==1.2
     # via -r dependencies/pip/requirements.in
 django-reversion==3.0.1
     # via -r dependencies/pip/requirements.in
+django-storages[azure,boto3]==1.12.3
+    # via -r dependencies/pip/requirements.in
 django-taggit==2.1.0
     # via -r dependencies/pip/requirements.in
 django-timezone-field==4.2.3
@@ -174,6 +181,8 @@ geojson-rewind==1.0.2
     #   formpack
 idna==3.3
     # via requests
+isodate==0.6.1
+    # via msrest
 jmespath==1.0.0
     # via
     #   boto3
@@ -197,12 +206,15 @@ markdown==3.3.6
     # via
     #   -r dependencies/pip/requirements.in
     #   django-markdownx
+msrest==0.6.21
+    # via azure-storage-blob
 ndg-httpsclient==0.5.1
     # via -r dependencies/pip/requirements.in
 oauthlib==3.2.0
     # via
     #   -r dependencies/pip/requirements.in
     #   django-oauth-toolkit
+    #   requests-oauthlib
 openpyxl==3.0.9
     # via
     #   -r dependencies/pip/requirements.in
@@ -268,11 +280,16 @@ redis==4.2.2
 requests==2.27.1
     # via
     #   -r dependencies/pip/requirements.in
+    #   azure-core
     #   django-oauth-toolkit
+    #   msrest
+    #   requests-oauthlib
     #   responses
     #   smsapi-client
     #   twilio
     #   yubico-client
+requests-oauthlib==1.3.1
+    # via msrest
 responses==0.20.0
     # via -r dependencies/pip/requirements.in
 s3transfer==0.5.2
@@ -281,7 +298,9 @@ shortuuid==1.0.8
     # via -r dependencies/pip/requirements.in
 six==1.16.0
     # via
+    #   azure-core
     #   click-repl
+    #   isodate
     #   python-dateutil
 smsapi-client==2.5.0
     # via django-trench
@@ -300,6 +319,8 @@ tabulate==0.8.9
     # via -r dependencies/pip/requirements.in
 twilio==7.8.0
     # via django-trench
+typing-extensions==4.2.0
+    # via azure-core
 unicodecsv==0.14.1
     # via -r dependencies/pip/requirements.in
 urllib3==1.26.9

--- a/kobo/apps/storage_backends/s3boto3.py
+++ b/kobo/apps/storage_backends/s3boto3.py
@@ -1,0 +1,46 @@
+# Workaround for https://github.com/jschneier/django-storages/issues/566
+
+import logging
+
+from storages.backends.s3boto3 import S3Boto3Storage as BaseS3Boto3Storage
+from storages.backends.s3boto3 import \
+    S3Boto3StorageFile as BaseS3Boto3StorageFile
+
+
+class S3Boto3StorageFile(BaseS3Boto3StorageFile):
+    def __init__(self, name, mode, storage, buffer_size=None):
+        super().__init__(name, mode, storage, buffer_size)
+        self._remote_file_size = 0
+    
+    def seek(self, *args, **kwargs):
+        logging.warning('seek() called on S3Boto3StorageFile; may break tell()')
+        return super().seek(*args, **kwargs)
+    
+    def tell(self):
+        return self._remote_file_size + self.file.tell()
+    
+    def _flush_write_buffer(self):
+        if self._buffer_file_size:
+            self._write_counter += 1
+            self._remote_file_size += self._buffer_file_size
+            self.file.seek(0)
+            part = self._multipart.Part(self._write_counter)
+            response = part.upload(Body=self.file.read())
+            self._parts.append({
+                'ETag': response['ETag'],
+                'PartNumber': self._write_counter
+            })
+            self.file.seek(0)
+            self.file.truncate()
+
+
+class S3Boto3Storage(BaseS3Boto3Storage):
+    def _open(self, name, mode='rb'):
+        name = self._normalize_name(self._clean_name(name))
+        try:
+            f = S3Boto3StorageFile(name, mode, self)
+        except ClientError as err:
+            if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                raise FileNotFoundError('File does not exist: %s' % name)
+            raise  # Let it bubble up if it was some other error
+        return f

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -640,10 +640,14 @@ if os.environ.get('AWS_ACCESS_KEY_ID'):
     AWS_SES_REGION_ENDPOINT = os.environ.get('AWS_SES_REGION_ENDPOINT')
 
 
+
 ''' Storage configuration '''
 if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
-    # To use S3 storage, set this to `storages.backends.s3boto3.S3Boto3Storage`
+    # To use S3 storage, set this to `kobo.apps.storage_backends.s3boto3.S3Boto3Storage`
     DEFAULT_FILE_STORAGE = os.environ.get('KPI_DEFAULT_FILE_STORAGE')
+    if DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
+        # Force usage of custom S3 tellable Storage
+        DEFAULT_FILE_STORAGE = 'kobo.apps.storage_backends.s3boto3.S3Boto3Storage'
     if 'KPI_AWS_STORAGE_BUCKET_NAME' in os.environ:
         AWS_STORAGE_BUCKET_NAME = os.environ.get('KPI_AWS_STORAGE_BUCKET_NAME')
         AWS_DEFAULT_ACL = 'private'
@@ -655,6 +659,12 @@ if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
         # Proxy S3 through our application instead of redirecting to bucket
         # URLs with query parameter authentication
         PRIVATE_STORAGE_S3_REVERSE_PROXY = True
+    if 'AZURE_ACCOUNT_NAME' in os.environ:
+        AZURE_ACCOUNT_NAME = env.str('AZURE_ACCOUNT_NAME')
+        AZURE_ACCOUNT_KEY = env.str('AZURE_ACCOUNT_KEY')
+        AZURE_CONTAINER = env.str('AZURE_CONTAINER')
+        AZURE_URL_EXPIRATION_SECS = env.int('AZURE_URL_EXPIRATION_SECS', None)
+
 
 if 'KOBOCAT_DEFAULT_FILE_STORAGE' in os.environ:
     # To use S3 storage, set this to `storages.backends.s3boto3.S3Boto3Storage`

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -671,7 +671,6 @@ if 'KOBOCAT_DEFAULT_FILE_STORAGE' in os.environ:
     KOBOCAT_DEFAULT_FILE_STORAGE = os.environ.get('KOBOCAT_DEFAULT_FILE_STORAGE')
     if 'KOBOCAT_AWS_STORAGE_BUCKET_NAME' in os.environ:
         KOBOCAT_AWS_STORAGE_BUCKET_NAME = os.environ.get('KOBOCAT_AWS_STORAGE_BUCKET_NAME')
-    KOBOCAT_AZURE_CONTAINER = env.str('KOBOCAT_AZURE_CONTAINER', None)
 else:
     KOBOCAT_DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
     KOBOCAT_MEDIA_PATH = os.environ.get('KOBOCAT_MEDIA_PATH', '/srv/src/kobocat/media')

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -671,6 +671,7 @@ if 'KOBOCAT_DEFAULT_FILE_STORAGE' in os.environ:
     KOBOCAT_DEFAULT_FILE_STORAGE = os.environ.get('KOBOCAT_DEFAULT_FILE_STORAGE')
     if 'KOBOCAT_AWS_STORAGE_BUCKET_NAME' in os.environ:
         KOBOCAT_AWS_STORAGE_BUCKET_NAME = os.environ.get('KOBOCAT_AWS_STORAGE_BUCKET_NAME')
+    KOBOCAT_AZURE_CONTAINER = env.str('KOBOCAT_AZURE_CONTAINER', None)
 else:
     KOBOCAT_DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
     KOBOCAT_MEDIA_PATH = os.environ.get('KOBOCAT_MEDIA_PATH', '/srv/src/kobocat/media')

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -29,7 +29,7 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.datetime import one_minute_from_now
 from .storage import (
     get_kobocat_storage,
-    KobocatS3Boto3Storage,
+    KobocatFileSystemStorage,
 )
 
 
@@ -591,7 +591,7 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, MP3ConverterMixin):
             content = self.get_mp3_content()
             kobocat_storage.save(self.mp3_storage_path, ContentFile(content))
 
-        if not isinstance(kobocat_storage, KobocatS3Boto3Storage):
+        if isinstance(kobocat_storage, KobocatFileSystemStorage):
             return f'{self.media_file.path}.{self.CONVERSION_AUDIO_FORMAT}'
 
         return kobocat_storage.url(self.mp3_storage_path)
@@ -602,7 +602,7 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, MP3ConverterMixin):
         Return the absolute path on local file system of the attachment.
         Otherwise, return the AWS url (e.g. https://...)
         """
-        if not isinstance(get_kobocat_storage(), KobocatS3Boto3Storage):
+        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
             return self.media_file.path
 
         return self.media_file.url
@@ -626,7 +626,7 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, MP3ConverterMixin):
         else:
             attachment_file_path = self.absolute_path
 
-        if not isinstance(get_kobocat_storage(), KobocatS3Boto3Storage):
+        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
             # Django normally sanitizes accented characters in file names during
             # save on disk but some languages have extra letters
             # (out of ASCII character set) and must be encoded to let NGINX serve

--- a/kpi/deployment_backends/kc_access/storage.py
+++ b/kpi/deployment_backends/kc_access/storage.py
@@ -2,6 +2,7 @@
 from django.conf import settings as django_settings
 from django.core.files.storage import FileSystemStorage
 from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.azure_storage import AzureStorage
 
 
 def get_kobocat_storage():
@@ -9,11 +10,10 @@ def get_kobocat_storage():
     Return an instance of a storage object depending on the setting
     `KOBOCAT_DEFAULT_FILE_STORAGE` value
     """
-    if (
-        django_settings.KOBOCAT_DEFAULT_FILE_STORAGE
-        == 'storages.backends.s3boto3.S3Boto3Storage'
-    ):
+    if django_settings.KOBOCAT_DEFAULT_FILE_STORAGE.endswith('S3Boto3Storage'):
         return KobocatS3Boto3Storage()
+    elif django_settings.KOBOCAT_DEFAULT_FILE_STORAGE.endswith('AzureStorage'):
+        return KobocatAzureStorage()
     else:
         return KobocatFileSystemStorage()
 
@@ -40,6 +40,12 @@ class KobocatFileSystemStorage(FileSystemStorage):
 
 class KobocatS3Boto3Storage(S3Boto3Storage):
 
-    def __init__(self, acl=None, bucket=None, **settings):
+    def __init__(self, *args, **kwargs):
         bucket = django_settings.KOBOCAT_AWS_STORAGE_BUCKET_NAME
-        super().__init__(acl=None, bucket=bucket, **settings)
+        super().__init__(*args, **kwargs)
+
+
+class KobocatAzureStorage(AzureStorage):
+    def __init__(self, *args, **kwargs):
+        azure_container = django_settings.KOBOCAT_AZURE_CONTAINER
+        super().__init__(*args, **kwargs)

--- a/kpi/deployment_backends/kc_access/storage.py
+++ b/kpi/deployment_backends/kc_access/storage.py
@@ -13,7 +13,7 @@ def get_kobocat_storage():
     if django_settings.KOBOCAT_DEFAULT_FILE_STORAGE.endswith('S3Boto3Storage'):
         return KobocatS3Boto3Storage()
     elif django_settings.KOBOCAT_DEFAULT_FILE_STORAGE.endswith('AzureStorage'):
-        return KobocatAzureStorage()
+        return AzureStorage()
     else:
         return KobocatFileSystemStorage()
 
@@ -39,13 +39,7 @@ class KobocatFileSystemStorage(FileSystemStorage):
 
 
 class KobocatS3Boto3Storage(S3Boto3Storage):
-
-    def __init__(self, *args, **kwargs):
-        bucket = django_settings.KOBOCAT_AWS_STORAGE_BUCKET_NAME
-        super().__init__(*args, **kwargs)
-
-
-class KobocatAzureStorage(AzureStorage):
-    def __init__(self, *args, **kwargs):
-        azure_container = django_settings.KOBOCAT_AZURE_CONTAINER
-        super().__init__(*args, **kwargs)
+    def __init__(self, **settings):
+        # This allows KoboCat to have a different bucket name, which is not recommended
+        settings["bucket_name"] = django_settings.KOBOCAT_AWS_STORAGE_BUCKET_NAME
+        super().__init__(**settings)


### PR DESCRIPTION
## Description

- [x] Upgrade to latest django-storages and port tellable storage workaround
- [x] Add support for Azure blob storage
- [x] Test in Azure
- [x] Test in S3

This PR does not address django-private-storage continuing to use only S3. Therefor this PR only partially support Azure. 

Related to  https://github.com/kobotoolbox/kobocat/pull/816