### PR TITLE
Azure private storage

### DIFF
--- a/kobo/apps/storage_backends/private_azure_storage.py
+++ b/kobo/apps/storage_backends/private_azure_storage.py
@@ -23,7 +23,6 @@ class PrivateAzureStorage(AzureStorage):
     def get_modified_time(self, name):
         # workaround https://github.com/jschneier/django-storages/issues/1131
         # If fixed upstream, delete this function
-        print("!!!")
         properties = self.client.get_blob_client(
             self._get_valid_path(name)
         ).get_blob_properties(

--- a/kobo/apps/storage_backends/private_azure_storage.py
+++ b/kobo/apps/storage_backends/private_azure_storage.py
@@ -1,0 +1,41 @@
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.deconstruct import deconstructible
+from private_storage import appconfig
+from storages.backends.azure_storage import AzureStorage
+from storages.utils import setting
+
+
+@deconstructible
+class PrivateAzureStorage(AzureStorage):
+    """
+    Ported from PrivateS3BotoStorage
+    """
+    def url(self, name, *args, **kwargs):
+        # S3_REVERSE_PROXY because Azure doesn't exist in private_storage.appconfig
+        if appconfig.PRIVATE_STORAGE_S3_REVERSE_PROXY or not self.querystring_auth:
+            # There is no direct URL possible, return our streaming view instead.
+            return reverse('serve_private_file', kwargs={'path': name})
+        else:
+            # The S3Boto3Storage can generate a presigned URL that is temporary available.
+            return super().url(name, *args, **kwargs)
+
+    def get_modified_time(self, name):
+        # workaround https://github.com/jschneier/django-storages/issues/1131
+        # If fixed upstream, delete this function
+        print("!!!")
+        properties = self.client.get_blob_client(
+            self._get_valid_path(name)
+        ).get_blob_properties(
+            timeout=self.timeout
+        )
+        if not setting('USE_TZ', False):
+            return timezone.make_naive(properties.last_modified)
+
+        tz = timezone.get_current_timezone()
+        if timezone.is_naive(properties.last_modified):
+            return timezone.make_aware(properties.last_modified, tz)
+
+        # `last_modified` is in UTC time_zone, we
+        # must convert it to settings time_zone
+        return properties.last_modified.astimezone(tz)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -659,11 +659,15 @@ if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
         # Proxy S3 through our application instead of redirecting to bucket
         # URLs with query parameter authentication
         PRIVATE_STORAGE_S3_REVERSE_PROXY = True
-    if 'AZURE_ACCOUNT_NAME' in os.environ:
+    if DEFAULT_FILE_STORAGE.endswith("AzureStorage"):
+        PRIVATE_STORAGE_CLASS = \
+            'kobo.apps.storage_backends.private_azure_storage.PrivateAzureStorage'
+        PRIVATE_STORAGE_S3_REVERSE_PROXY = True  # Yes S3
         AZURE_ACCOUNT_NAME = env.str('AZURE_ACCOUNT_NAME')
         AZURE_ACCOUNT_KEY = env.str('AZURE_ACCOUNT_KEY')
         AZURE_CONTAINER = env.str('AZURE_CONTAINER')
         AZURE_URL_EXPIRATION_SECS = env.int('AZURE_URL_EXPIRATION_SECS', None)
+        AZURE_OVERWRITE_FILES = True
 
 
 if 'KOBOCAT_DEFAULT_FILE_STORAGE' in os.environ:


### PR DESCRIPTION
## Description

Adds support for Azure in django-private-storage

## Hacky things

- I didn't feel like overriding private_storage.appconfig so I'm reusing PRIVATE_STORAGE_S3_REVERSE_PROXY which is silly.
- https://github.com/jschneier/django-storages/issues/1131 should be fixed upstream. We could use this as the regular AzureStorage class instead or only on private.
- We could contribute PrivateAzureStorage upstream to django-private-storage but I would need to support all the overrides they support (which I don't really understand why that's necessary).

## Weird things

- PrivateS3BotoStorage [overrides](https://github.com/edoburu/django-private-storage/blob/master/private_storage/storage/s3boto3.py#L24) a bunch of defaults of S3BotoStorage but I don't know why. Most of the overrides don't seem relevant. It's already being set in the base class. The claimed "differs from base class" are not accurate. AWS_PRIVATE_DEFAULT_ACL is None by default which uses the S3 default of private.

## Related issues

Related to https://github.com/kobotoolbox/kpi/pull/3794
