### PR TITLE
Allow configuration of enketo csrf cookie name

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -54,6 +54,7 @@ if SESSION_COOKIE_DOMAIN:
     # The trusted CSRF origins must encompass Enketo's subdomain. See
     # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
     CSRF_TRUSTED_ORIGINS = [SESSION_COOKIE_DOMAIN]
+ENKETO_CSRF_COOKIE_NAME = env.str('ENKETO_CSRF_COOKIE_NAME', '__csrf')
 
 # Limit sessions to 1 week (the default is 2 weeks)
 SESSION_COOKIE_AGE = 604800

--- a/kpi/authentication.py
+++ b/kpi/authentication.py
@@ -12,7 +12,6 @@ from rest_framework.authentication import (
 )
 from rest_framework.exceptions import AuthenticationFailed
 
-from kpi.constants import ENKETO_CSRF_COOKIE_NAME
 from kpi.mixins.mfa import MFABlockerMixin
 
 
@@ -83,8 +82,8 @@ class EnketoSessionAuthentication(SessionAuthentication):
         POST data into the places expected by Django. Then, call the super-
         class to handle CSRF enforcement.
         """
-        enketo_post_data_token = request.POST.get(ENKETO_CSRF_COOKIE_NAME)
-        enketo_cookie_token = request.COOKIES.get(ENKETO_CSRF_COOKIE_NAME)
+        enketo_post_data_token = request.POST.get(settings.ENKETO_CSRF_COOKIE_NAME)
+        enketo_cookie_token = request.COOKIES.get(settings.ENKETO_CSRF_COOKIE_NAME)
         if enketo_post_data_token and enketo_cookie_token:
             request.META[settings.CSRF_HEADER_NAME] = enketo_post_data_token
             request.COOKIES[settings.CSRF_COOKIE_NAME] = enketo_cookie_token
@@ -100,7 +99,7 @@ class EnketoSessionAuthentication(SessionAuthentication):
         """
         csrf_token = context_processors.csrf(request)['csrf_token']
         response.set_cookie(
-            key=ENKETO_CSRF_COOKIE_NAME,
+            key=settings.ENKETO_CSRF_COOKIE_NAME,
             value=csrf_token,
             domain=settings.SESSION_COOKIE_DOMAIN,
             secure=settings.SESSION_COOKIE_SECURE or None,

--- a/kpi/constants.py
+++ b/kpi/constants.py
@@ -107,7 +107,3 @@ ASSET_SEARCH_DEFAULT_FIELD_LOOKUPS = [
     'tags__name__icontains',
     'uid__icontains',
 ]
-
-
-# Things hard-coded in Enketo Express
-ENKETO_CSRF_COOKIE_NAME = '__csrf'

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -17,7 +17,6 @@ from django_digest.test import Client as DigestClient
 from rest_framework import status
 
 from kpi.constants import (
-    ENKETO_CSRF_COOKIE_NAME,
     PERM_CHANGE_ASSET,
     PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_SUBMISSIONS,
@@ -1013,8 +1012,8 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         response = self.client.get(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_200_OK
         # Just make sure the cookie is present and has a non-empty value
-        assert ENKETO_CSRF_COOKIE_NAME in response.cookies
-        assert response.cookies[ENKETO_CSRF_COOKIE_NAME].value
+        assert settings.ENKETO_CSRF_COOKIE_NAME in response.cookies
+        assert response.cookies[settings.ENKETO_CSRF_COOKIE_NAME].value
 
     def test_edit_submission_with_digest_credentials(self):
         url = reverse(


### PR DESCRIPTION
## Description

Allow enketo csrf cookie name to be configurable. Defaults to standard __csrf. Thus not a breaking change.

## Related issues

- Requires fixing https://github.com/enketo/enketo-express/issues/418
- Docs https://github.com/kobotoolbox/kobotoolbox.github.io/commit/982cfbb7fe49af678690a8e44a34154b16e6b77f