### PR TITLE
Fix table view fullscreen functionality

### DIFF
--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -35,7 +35,9 @@ $side-tabs-width-mobile: 70px;
   background: $kobo-gray-96;
 
   &.form-view--fullscreen {
-    position: fixed;
+    // We force the position to avoid problems with stronger specificity
+    // breaking the fullscreen functionality.
+    position: fixed !important;
     z-index: $z-fullscreen;
     top: 0;
     left: 0;


### PR DESCRIPTION
## Description

Fixes broken fullscreen styles for Table View. When used, the table was placed after the fold instead of taking the whole screen area.