### PR TITLE
Pin pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ COPY . "${KPI_SRC_DIR}"
 
 RUN python3 -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install  --quiet --upgrade pip && \
+RUN pip install  --quiet pip==22.0.4 && \
     pip install  --quiet pip-tools
 COPY ./dependencies/pip/external_services.txt "${TMP_DIR}/pip_dependencies.txt"
 RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null && \


### PR DESCRIPTION
Build failing due to https://github.com/jazzband/pip-tools/issues/1617, therefore pin to previous working version.