### PR TITLE
Fix `ImportError` with Python 3.8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
       REDIS_SESSION_URL: redis://localhost:6379
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.10']
     services:
       postgres:
         image: postgis/postgis:9.5-2.5

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -30,6 +30,8 @@ azure-storage-blob==12.11.0
     # via django-storages
 backcall==0.2.0
     # via ipython
+backports-zoneinfo==0.2.1
+    # via -r dependencies/pip/requirements.in
 bcrypt==3.2.0
     # via paramiko
 begins==0.9

--- a/dependencies/pip/external_services.txt
+++ b/dependencies/pip/external_services.txt
@@ -24,6 +24,8 @@ azure-core==1.23.1
     # via azure-storage-blob
 azure-storage-blob==12.11.0
     # via django-storages
+backports-zoneinfo==0.2.1
+    # via -r dependencies/pip/requirements.in
 begins==0.9
     # via formpack
 billiard==3.6.4.0

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -86,3 +86,6 @@ deepmerge
 
 # MFA
 django-trench==0.2.3
+
+# Python 3.8 support
+backports.zoneinfo

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -24,6 +24,8 @@ azure-core==1.23.1
     # via azure-storage-blob
 azure-storage-blob==12.11.0
     # via django-storages
+backports-zoneinfo==0.2.1
+    # via -r dependencies/pip/requirements.in
 begins==0.9
     # via formpack
 billiard==3.6.4.0

--- a/kobo/apps/help/views.py
+++ b/kobo/apps/help/views.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 import datetime
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from django.db.models import Q
 from markdownx.views import ImageUploadView

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -10,7 +10,10 @@ from datetime import datetime
 from typing import Generator, Optional, Union
 from urllib.parse import urlparse
 from xml.etree import ElementTree as ET
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import requests
 from django.conf import settings

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -7,7 +7,10 @@ import uuid
 from datetime import datetime
 from typing import Optional, Union
 from xml.etree import ElementTree as ET
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from deepmerge import always_merger
 from dict2xml import dict2xml

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -9,7 +9,10 @@ from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
 from typing import List, Dict, Optional, Tuple, Generator
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import constance
 import requests

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 import datetime
 import json
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import constance
 from django.contrib.auth import update_session_auth_hash

--- a/kpi/serializers/v2/user.py
+++ b/kpi/serializers/v2/user.py
@@ -1,5 +1,8 @@
 # coding: utf-8
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -5,7 +5,10 @@ import string
 import time
 import uuid
 from datetime import datetime
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import pytest
 import responses

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -2,7 +2,10 @@
 import os
 import zipfile
 from collections import defaultdict
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 import datetime
 import mock

--- a/kpi/views/v2/open_rosa.py
+++ b/kpi/views/v2/open_rosa.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from datetime import datetime
-from zoneinfo import ZoneInfo
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo 
 
 from django.conf import settings
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Bring back Python 3.8 support for users who do not use kobo-docker/docker containers.

## Additional info

Starting from Python 3.9, `pytz` has been replaced by `zoneinfo`. Unfortunately, it is not supported by Python 3.8 and below.

```python
try:
    from zoneinfo import ZoneInfo
except ImportError:
    from backports.zoneinfo import ZoneInfo
```

## Related issues

