### PR TITLE
Moved audit block, updated style

### DIFF
--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -235,6 +235,19 @@ export default class MetadataEditor extends React.Component {
           </bem.FormBuilderMeta__column>
         </bem.FormBuilderMeta__columns>
 
+        {this.isAuditEnabled() && (
+          <bem.FormBuilderMeta__row>
+            <TextBox
+              customModifiers='on-white'
+              label={this.renderAuditInputLabel()}
+              value={this.getAuditParameters()}
+              disabled={this.props.isDisabled}
+              onChange={this.onAuditParametersChange}
+              placeholder={t('Enter audit settings here')}
+            />
+          </bem.FormBuilderMeta__row>
+        )}
+
         <bem.FormBuilderMeta__row m='background-audio'>
           <bem.FormBuilderAside__header>
             {this.renderBackgroundAudioLabel()}
@@ -263,18 +276,7 @@ export default class MetadataEditor extends React.Component {
               }
             />
           </bem.FormModal__item>
-        </bem.FormBuilderMeta__row>
-
-        {this.isAuditEnabled() && (
-          <bem.FormBuilderMeta__row>
-            <TextBox
-              label={this.renderAuditInputLabel()}
-              value={this.getAuditParameters()}
-              disabled={this.props.isDisabled}
-              onChange={this.onAuditParametersChange}
-            />
-          </bem.FormBuilderMeta__row>
-        )}
+         </bem.FormBuilderMeta__row>
 
         {this.isBackgroundAudioEnabled() && (
           <bem.FormBuilderMeta__row>


### PR DESCRIPTION
## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->
Audit settings was in the wrong spot in the form builder sidebar. Moved it directly under the checkboxes. Also modernized the styles.
## Related issues
Fixes #3808 
<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
