### PR TITLE
Allow AWS S3 region to be set through environment variables

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -645,12 +645,16 @@ if os.environ.get('EMAIL_USE_TLS'):
 
 
 ''' AWS configuration (email and storage) '''
-if os.environ.get('AWS_ACCESS_KEY_ID'):
-    AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
-    AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
-    AWS_SES_REGION_NAME = os.environ.get('AWS_SES_REGION_NAME')
-    AWS_SES_REGION_ENDPOINT = os.environ.get('AWS_SES_REGION_ENDPOINT')
+if env.str('AWS_ACCESS_KEY_ID', False):
+    AWS_ACCESS_KEY_ID = env.str('AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = env.str('AWS_SECRET_ACCESS_KEY')
+    AWS_SES_REGION_NAME = env.str('AWS_SES_REGION_NAME', None)
+    AWS_SES_REGION_ENDPOINT = env.str('AWS_SES_REGION_ENDPOINT', None)
 
+    AWS_S3_SIGNATURE_VERSION = env.str('AWS_S3_SIGNATURE_VERSION', 's3v4')
+    # Only set the region if it is present in environment.
+    if region := env.str('AWS_S3_REGION_NAME', False):
+        AWS_S3_REGION_NAME = region
 
 ''' Storage configuration '''
 if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

`AWS_S3_REGION_NAME` environment variable can be used to set the region.


## Related issues

Related to kobotoolbox/kobocat#823
