### PR TITLE
Add `nlp_features_enabled` boolean to restrict ASR/MT usage for specified user list

### DIFF
--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -2,12 +2,47 @@ import json
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError as APIValidationError
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from jsonschema import validate
 
 from kpi.models import Asset
+from kpi.views.environment import _check_asr_mt_access_for_user
 from kobo.apps.subsequences.models import SubmissionExtras
+
+
+def _check_asr_mt_access_if_applicable(user, posted_data):
+    # This is for proof-of-concept testing and will be replaced with proper
+    # quotas and accounting
+    MAGIC_STATUS_VALUE = 'requested'
+    user_has_access = _check_asr_mt_access_for_user(user)
+    if user_has_access:
+        return True
+    # Oops, no access. But did they request ASR/MT in the first place?
+    for _, val in posted_data.items():
+        # e.g.
+        # {
+        #   "submission": "8b6c1fba-c9ef-477b-bfc0-873aa8bfd73f",
+        #   "record_speech": {
+        #     "googlets": {
+        #       "status": "requested",
+        #       "languageCode": "en"
+        #     }
+        #   }
+        # }
+        if not isinstance(val, dict):
+            continue
+        for _, child_val in val.items():
+            if not isinstance(child_val, dict):
+                continue
+            try:
+                asr_mt_request = child_val['status'] == MAGIC_STATUS_VALUE
+            except KeyError:
+                continue
+            else:
+                if asr_mt_request:
+                    raise PermissionDenied('ASR/MT features are not available')
 
 
 @api_view(['GET', 'POST', 'PATCH'])
@@ -25,6 +60,9 @@ def advanced_submission_post(request, asset_uid=None):
         validate(posted_data, schema)
     except SchemaValidationError as err:
         raise APIValidationError({'error': err})
+
+    _check_asr_mt_access_if_applicable(request.user, posted_data)
+
     submission = asset.update_submission_extra(posted_data)
     return Response(submission.content)
 

--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -42,6 +42,9 @@ def _check_asr_mt_access_if_applicable(user, posted_data):
                 continue
             else:
                 if asr_mt_request:
+                    # This is temporary code, and anyone here is trying to
+                    # abuse the API, so don't bother translators with the
+                    # message string
                     raise PermissionDenied('ASR/MT features are not available')
 
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -223,10 +223,11 @@ CONSTANCE_CONFIG = {
         True,
         'Enable two-factor authentication',
     ),
-    'NLP_USER_WHITELIST': (
+    'ASR_MT_INVITEE_USERNAMES': (
         '',
-        'List of whitelisted usernames who will have access to ASR/MT '
-        'automatic processing for NLP.\nOne per line.'
+        'List of invited usernames, one per line, who will have access to NLP '
+        'ASR/MT processing via external (costly) APIs. Enter * to invite '
+        'all users'
     ),
     'USER_METADATA_FIELDS': (
         json.dumps([

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -223,6 +223,11 @@ CONSTANCE_CONFIG = {
         True,
         'Enable two-factor authentication',
     ),
+    'NLP_USER_WHITELIST': (
+        '',
+        'List of whitelisted usernames who will have access to ASR/MT '
+        'automatic processing for NLP.\nOne per line.'
+    ),
     'USER_METADATA_FIELDS': (
         json.dumps([
             {'name': 'organization', 'required': False},

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -11,6 +11,16 @@ from kobo.static_lists import COUNTRIES, LANGUAGES
 from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
 
 
+def _check_asr_mt_access_for_user(user):
+    # This is for proof-of-concept testing and will be replaced with proper
+    # quotas and accounting
+    asr_mt_invitees = constance.config.ASR_MT_INVITEE_USERNAMES
+    return (
+        asr_mt_invitees.strip() == '*'
+        or user.username in asr_mt_invitees.split('\n')
+    )
+
+
 class EnvironmentView(APIView):
     """
     GET-only view for certain server-provided configuration data
@@ -58,9 +68,11 @@ class EnvironmentView(APIView):
                 value = processor(value)
             data[key.lower()] = value
 
-        nlp_whitelist = constance.config.NLP_USER_WHITELIST.split('\n')
+        asr_mt_invitees = constance.config.ASR_MT_INVITEE_USERNAMES
 
-        data['nlp_features_enabled'] = request.user.username in nlp_whitelist
+        data['asr_mt_features_enabled'] = _check_asr_mt_access_for_user(
+            request.user
+        )
         data['country_choices'] = COUNTRIES
         data['all_languages'] = LANGUAGES
         data['interface_languages'] = settings.LANGUAGES

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -58,6 +58,9 @@ class EnvironmentView(APIView):
                 value = processor(value)
             data[key.lower()] = value
 
+        nlp_whitelist = constance.config.NLP_USER_WHITELIST.split('\n')
+
+        data['nlp_features_enabled'] = request.user.username in nlp_whitelist
         data['country_choices'] = COUNTRIES
         data['all_languages'] = LANGUAGES
         data['interface_languages'] = settings.LANGUAGES


### PR DESCRIPTION
## Description

Allow for list of users to be added to the Constance config setting `NLP_USER_WHITELIST` through the Django admin interface. Add `nlp_features_enabled` boolean to `/environment` endpoint with value of `True` if the requesting user is in the specified whitelist, `False` otherwise.

## Related issues

part of #3818 