### PR TITLE
Remove constance windows style newlines

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -259,7 +259,7 @@ CONSTANCE_CONFIG = {
         'metadata_fields_jsonschema'
     ),
     'SECTOR_CHOICES': (
-        '\r\n'.join((s[0] for s in SECTOR_CHOICE_DEFAULTS)),
+        '\n'.join((s[0] for s in SECTOR_CHOICE_DEFAULTS)),
         "Options available for the 'sector' metadata field, one per line."
     ),
     'OPERATIONAL_PURPOSE_CHOICES': (

--- a/kpi/forms/registration.py
+++ b/kpi/forms/registration.py
@@ -81,7 +81,7 @@ class RegistrationForm(registration_forms.RegistrationForm):
         # Intentional t() call on dynamic string because the default choices
         # are translated (see static_lists.py)
         self.fields['sector'].choices = (('', ''),) + tuple(
-            (s, t(s)) for s in constance.config.SECTOR_CHOICES.split('\r\n')
+            (s.strip('\r'), t(s.strip('\r'))) for s in constance.config.SECTOR_CHOICES.split('\n')
         )
 
         # It's easier to _remove_ unwanted fields here in the constructor

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -31,11 +31,12 @@ class EnvironmentView(APIView):
             'SECTOR_CHOICES',
             # Intentional t() call on dynamic string because the default
             # choices are translated (see static_lists.py)
-            lambda text: tuple((line, t(line)) for line in text.split('\r\n')),
+            # Strip \r for legacy reasons
+            lambda text: tuple((line.strip('\r'), t(line.strip('\r'))) for line in text.split('\n')),
         ),
         (
             'OPERATIONAL_PURPOSE_CHOICES',
-            lambda text: tuple((line, line) for line in text.split('\r\n')),
+            lambda text: tuple((line.strip('\r'), line.strip('\r')) for line in text.split('\n')),
         ),
     ]
 


### PR DESCRIPTION
## Description

Fixed bug where constance config would incorrectly parse newlines

## Implementation

`\r\n` is a Windows style new line. It shouldn't be used anywhere and particularly so in unix, such as where a \n is expected. This removes it entirely and adds a legacy remover of `\r` for backwards compatibility or if somehow the windows style line gets in there.

It's not clear to me how this code used to work prior.