### PR TITLE
Use `KPI_DATABASE_URL` in the settings for testing

### DIFF
--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -5,7 +5,10 @@ from .base import *
 
 # For tests, don't use KoBoCAT's DB
 DATABASES = {
-    'default': env.db(default="sqlite:///%s/db.sqlite3" % BASE_DIR),
+    'default': env.db_url(
+        'KPI_DATABASE_URL' if 'KPI_DATABASE_URL' in os.environ else 'DATABASE_URL',
+        default='sqlite:///%s/db.sqlite3' % BASE_DIR
+    ),
 }
 
 DATABASE_ROUTERS = ['kpi.db_routers.TestingDatabaseRouter']


### PR DESCRIPTION
…and fall back to `DATABASE_URL` if it's not there. Mirrors #3780