### PR TITLE
Make HEAD requests to OpenRosa endpoints return empty responses

### DIFF
--- a/kpi/tests/api/v2/test_api_asset_snapshots.py
+++ b/kpi/tests/api/v2/test_api_asset_snapshots.py
@@ -148,6 +148,28 @@ class TestAssetSnapshotList(KpiTestCase):
             detail_response = self.client.get(xml_url)
             self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
 
+    def test_head_requests_return_empty_responses(self):
+        """
+        HEAD requests sent to OpenRosa endpoints must return empty responses
+        with 204 status codes and the appropriate headers set
+        """
+        VIEW_NAMES_TO_TEST = [
+            'assetsnapshot-form-list',
+            'assetsnapshot-manifest',
+            'assetsnapshot-submission',
+        ]
+        creation_response = self._create_asset_snapshot_from_asset()
+        snapshot_uid = creation_response.data['uid']
+        self.client.login(username='someuser', password='someuser')
+        for view_name in VIEW_NAMES_TO_TEST:
+            url = reverse(self._get_endpoint(view_name), args=(snapshot_uid,))
+            response = self.client.head(url)
+            assert response.status_code == status.HTTP_204_NO_CONTENT
+            assert not response.data
+            assert 'X-OpenRosa-Accept-Content-Length' in response
+            assert 'X-OpenRosa-Version' in response
+
+
     def test_xml_renderer(self):
         """
         Make sure the API endpoint returns the same XML as the ORM

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -80,9 +80,13 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
     )
     def form_list(self, request, *args, **kwargs):
         """
+        Implements part of the OpenRosa Form List API.
         This route is used by Enketo when it fetches external resources.
         It let us specify manifests for preview
         """
+        if request.method == 'HEAD':
+            return self.get_response_for_head_request()
+
         snapshot = self.get_object()
         context = {'request': request}
         serializer = FormListSerializer([snapshot], many=True, context=context)
@@ -95,10 +99,14 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
     )
     def manifest(self, request, *args, **kwargs):
         """
+        Implements part of the OpenRosa Form List API.
         This route is used by Enketo when it fetches external resources.
         It returns form media files location in order to display them within
         Enketo preview
         """
+        if request.method == 'HEAD':
+            return self.get_response_for_head_request()
+
         snapshot = self.get_object()
         asset = snapshot.asset
         form_media_files = list(
@@ -121,6 +129,7 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
 
     @action(detail=True, renderer_classes=[renderers.TemplateHTMLRenderer])
     def preview(self, request, *args, **kwargs):
+        # **Not** part of the OpenRosa API
         snapshot = self.get_object()
         if snapshot.details.get('status') == 'success':
             data = {
@@ -171,14 +180,9 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         ],
     )
     def submission(self, request, *args, **kwargs):
+        """ Implements the OpenRosa Form Submission API """
         if request.method == 'HEAD':
-            # Return an empty response with OpenRosa headers
-            # See https://docs.getodk.org/openrosa-form-submission/#extended-transmission-considerations
-            return Response(
-                '',
-                headers=self.get_headers(),
-                status=status.HTTP_204_NO_CONTENT,
-            )
+            return self.get_response_for_head_request()
 
         asset_snapshot = self.get_object()
 
@@ -211,6 +215,7 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
         This route will render the XForm into syntax-highlighted HTML.
         It is useful for debugging pyxform transformations
         """
+        # **Not** part of the OpenRosa API
         snapshot = self.get_object()
         response_data = copy.copy(snapshot.details)
         options = {

--- a/kpi/views/v2/open_rosa.py
+++ b/kpi/views/v2/open_rosa.py
@@ -3,9 +3,11 @@ from datetime import datetime
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
-    from backports.zoneinfo import ZoneInfo 
+    from backports.zoneinfo import ZoneInfo
 
 from django.conf import settings
+from rest_framework import status
+from rest_framework.response import Response
 
 
 class OpenRosaViewSetMixin:
@@ -20,3 +22,30 @@ class OpenRosaViewSetMixin:
             'X-OpenRosa-Accept-Content-Length': settings.OPEN_ROSA_DEFAULT_CONTENT_LENGTH,
             'Content-Type': 'text/xml; charset=utf-8',
         }
+
+    def get_response_for_head_request(self):
+        # Supporting HEAD requests is required by OpenRosa specification, e.g.
+        # https://docs.getodk.org/openrosa-form-submission/#extended-transmission-considerations
+        # …and the OpenRosa specification contradicts the HTTP specification:
+        #     ODK Collect also requires a 204 (No Content) status code in the
+        #     HEAD response.
+        # (https://httpwg.org/specs/rfc7231.html#status.200 explicitly lists
+        # 200 as a valid response status code for a HEAD.)
+        #
+        # Other requirements laid out by the HTTP specification for responses
+        # to HEADs should be followed:
+        #     The HEAD method is identical to GET except that the server MUST
+        #     NOT send a message body in the response (i.e., the response
+        #     terminates at the end of the header section). The server SHOULD
+        #     send the same header fields in response to a HEAD request as it
+        #     would have sent if the request had been a GET, except that the
+        #     payload header fields (Section 3.3) MAY be omitted.
+        #     (https://httpwg.org/specs/rfc7231.html#HEAD)
+        #
+        # TODO: Should this return the same `Content-Length` that would've been
+        # returned in response to a GET? Currently, it returns
+        # `Content-Length: 0` due to Django's `CommonMiddleware`
+        # (https://docs.djangoproject.com/en/3.2/ref/middleware/#module-django.middleware.common)
+        return Response(
+            headers=self.get_headers(), status=status.HTTP_204_NO_CONTENT
+        )


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Hopefully fixes the `Parse Error: Expected HTTP/` seen in Enketo when NGINX is not used, e.g. in local development environments