### PR TITLE
Explain django-constance newline handling

### DIFF
--- a/kpi/forms/registration.py
+++ b/kpi/forms/registration.py
@@ -80,6 +80,7 @@ class RegistrationForm(registration_forms.RegistrationForm):
 
         # Intentional t() call on dynamic string because the default choices
         # are translated (see static_lists.py)
+        # Strip "\r" for legacy data created prior to django-constance 2.7.
         self.fields['sector'].choices = (('', ''),) + tuple(
             (s.strip('\r'), t(s.strip('\r'))) for s in constance.config.SECTOR_CHOICES.split('\n')
         )

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -31,7 +31,10 @@ class EnvironmentView(APIView):
             'SECTOR_CHOICES',
             # Intentional t() call on dynamic string because the default
             # choices are translated (see static_lists.py)
-            # Strip \r for legacy reasons
+            # \n vs \r\n - In django-constance <2.7.0, new lines were saved as "\r\n"
+            # Starting in 2.8, new lines are saved as just "\n". In order to ensure compatibility
+            # for data saved in older versions, we treat \n as the way to split lines. Then,
+            # strip the \r off. There is no reason to do this for new constance settings
             lambda text: tuple((line.strip('\r'), t(line.strip('\r'))) for line in text.split('\n')),
         ),
         (


### PR DESCRIPTION
This change better explains the reasoning for new line handling, necessary with django-constance 2.7+

## Related issues

Related to https://github.com/kobotoolbox/kpi/pull/3825
