### PR TITLE
Use cache to display number of submissions per project

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -302,8 +302,9 @@ class BaseDeploymentBackend(abc.ABC):
         return self.__stored_data_key
 
     @property
+    @abc.abstractmethod
     def submission_count(self):
-        return self.calculated_submission_count(self.asset.owner)
+        pass
 
     @property
     @abc.abstractmethod

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -215,9 +215,9 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         return self.__prepare_bulk_update_response(kc_responses)
 
     def calculated_submission_count(self, user: 'auth.User', **kwargs) -> int:
-        params = self.validate_submission_list_params(user,
-                                                      validate_count=True,
-                                                      **kwargs)
+        params = self.validate_submission_list_params(
+            user, validate_count=True, **kwargs
+        )
         return MongoHelper.get_count(self.mongo_userform_id, **params)
 
     def connect(self, identifier=None, active=False):
@@ -1049,6 +1049,16 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         return self.__prepare_as_drf_response_signature(kc_response)
 
     @property
+    def submission_count(self):
+        id_string = self.backend_response['id_string']
+        # avoid migrations from being created for kc_access mocked models
+        # there should be a better way to do this, right?
+        return instance_count(
+            xform_id_string=id_string,
+            user_id=self.asset.owner.pk,
+        )
+
+    @property
     def submission_list_url(self):
         url = '{kc_base}/api/v1/data/{formid}'.format(
             kc_base=settings.KOBOCAT_INTERNAL_URL,
@@ -1246,15 +1256,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         id_string = self.backend_response['id_string']
         return last_submission_time(
             xform_id_string=id_string, user_id=self.asset.owner.pk)
-
-    def _submission_count(self):
-        id_string = self.backend_response['id_string']
-        # avoid migrations from being created for kc_access mocked models
-        # there should be a better way to do this, right?
-        return instance_count(
-            xform_id_string=id_string,
-            user_id=self.asset.owner.pk,
-        )
 
     def __delete_kc_metadata(
         self, kc_file_: dict, file_: Union[AssetFile, PairedData] = None

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -567,6 +567,7 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         _uuid = str(uuid.uuid4())
         return _uuid, f'uuid:{_uuid}'
 
+    @property
     def submission_count(self):
         return self.calculated_submission_count(self.asset.owner)
 

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -233,7 +233,7 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             'end': updated_time,
             'meta/instanceID': f'uuid:{uuid.uuid4()}'
         })
-        
+
         settings.MONGO_DB.instances.insert_one(duplicated_submission)
         return duplicated_submission
 
@@ -507,7 +507,7 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         Examples:
             {"submission_ids": [1, 2, 3]}
             {"query":{"_validation_status.uid":"validation_status_not_approved"}
-        
+
         """
 
         submission_ids = self.validate_access_with_partial_perms(
@@ -566,6 +566,9 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         """
         _uuid = str(uuid.uuid4())
         return _uuid, f'uuid:{_uuid}'
+
+    def submission_count(self):
+        return self.calculated_submission_count(self.asset.owner)
 
     @property
     def submission_list_url(self):

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -310,8 +310,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 return obj.deployment.submission_count
 
             if obj.has_perm(user, PERM_PARTIAL_SUBMISSIONS):
-                return obj.deployment.calculated_submission_count(
-                    user=user)
+                return obj.deployment.calculated_submission_count(user=user)
         except KeyError:
             pass
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Get the number of all submissions from a pre-calculated field instead of calculating it each time for users who can view all submissions of a project.

## Additional info

It used to be this way before implementing partial permissions. Users with partial permissions still cannot benefit of the cache value because filters for partial permissions are different from one user to another. 
