### PR TITLE
Do not install raven package at runtime. No longer necessary.

### DIFF
--- a/docker/init.bash
+++ b/docker/init.bash
@@ -30,10 +30,6 @@ else
         pip-sync dependencies/pip/dev_requirements.txt 1>/dev/null
         cp "dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"
     fi
-    if [[ -n "$RAVEN_DSN" ]]; then
-        echo "Sentry detected. Installing \`raven\` pip dependency..."
-        pip install raven
-    fi
 fi
 
 # Wait for databases to be up & running before going further


### PR DESCRIPTION
This has no end user impact, other than perhaps very slightly speeding up application start up. The python package raven is no longer used but was left in the init script to install at runtime. This is safe to remove and has been doing nothing for some time now.