### PR TITLE
Ensure the XLSForm file has .xlsx extension

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -282,7 +282,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'has_kpi_hook': self.asset.has_active_hooks,
             'kpi_asset_uid': self.asset.uid
         }
-        files = {'xls_file': ('{}.xls'.format(id_string), xls_io)}
+        files = {'xls_file': ('{}.xlsx'.format(id_string), xls_io)}
         json_response = self._kobocat_request(
             'POST', url, data=payload, files=files)
         self.store_data({
@@ -827,7 +827,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             'title': self.asset.name,
             'has_kpi_hook': self.asset.has_active_hooks
         }
-        files = {'xls_file': ('{}.xls'.format(id_string), xls_io)}
+        files = {'xls_file': ('{}.xlsx'.format(id_string), xls_io)}
         try:
             json_response = self._kobocat_request(
                 'PATCH', url, data=payload, files=files)


### PR DESCRIPTION
The pyxform library will reject a .xls file extension.

Reference https://github.com/XLSForm/pyxform/pull/575

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
