### PR TITLE
Freeze `npm` version to `8.5.5`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,8 @@ COPY . "${KPI_SRC_DIR}"
 
 RUN python3 -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install  --quiet pip==22.0.4 && \
-    pip install  --quiet pip-tools
+RUN pip install --quiet pip==22.0.4 && \
+    pip install --quiet pip-tools
 COPY ./dependencies/pip/external_services.txt "${TMP_DIR}/pip_dependencies.txt"
 RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null && \
     rm -rf ~/.cache/pip
@@ -101,6 +101,7 @@ RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null && \
 WORKDIR ${KPI_SRC_DIR}/
 
 RUN rm -rf ${KPI_NODE_PATH} && \
+    npm install -g npm@8.5.5 && \
     npm install -g check-dependencies && \
     npm install --quiet && \
     npm cache clean --force

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,10 @@
         "webpack-cli": "^3.3.11",
         "webpack-dev-server": "^3.11.0",
         "webpack-extract-translation-keys-plugin": "^5.0.2"
+      },
+      "engines": {
+        "node": "~16.15.0",
+        "npm": "~8.5.5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "kpi",
   "version": "2.0.0",
   "description": "KoboToolbox frontend interface.",
+  "engines": {
+    "node": "~16.15.0",
+    "npm": "~8.5.5"
+  },
   "dependencies": {
     "@fontsource/roboto": "^4.4.2",
     "@fontsource/roboto-mono": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kpi",
   "version": "2.0.0",
   "description": "KoboToolbox frontend interface.",
+  "engineStrict" : true,
   "engines": {
     "node": "~16.15.0",
     "npm": "~8.5.5"


### PR DESCRIPTION
## Description

Fix broken build when using a newer version of `npm`. 

## Related Info
DockerFile installs the LTS version of node which is, as per today (2022-06-07), 16.5.1. The related version of `npm` is `8.11` and breaks the build of asset files. 

