### PR TITLE
Fix `sync_kobocat_xforms` Excel format issue

### DIFF
--- a/kpi/management/commands/sync_kobocat_xforms.py
+++ b/kpi/management/commands/sync_kobocat_xforms.py
@@ -14,7 +14,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from formpack.utils.xls_to_ss_structure import xls_to_dicts
+from formpack.utils.xls_to_ss_structure import xlsx_to_dicts
 from pyxform import xls2json_backends
 from rest_framework.authtoken.models import Token
 
@@ -113,7 +113,7 @@ def _xlsform_to_kpi_content_schema(xlsform):
     parses xlsform structure into json representation
     of spreadsheet structure.
     """
-    content = xls_to_dicts(xlsform)
+    content = xlsx_to_dicts(xlsform)
     # Remove the __version__ calculate question
     content['survey'] = [
         row for row in content['survey'] if not (


### PR DESCRIPTION
## Description

Fix `sync_kobocat_xforms` issue failing with `xlrd.biffh.XLRDError: Excel xlsx file; not supported`, resulting in forms not being synced between kobocat and kpi through the legacy interface's "SYNC FORMS" button.

## Related issues

closes #3854