### PR TITLE
Manage celery autocale via environment variables instead of constance

### DIFF
--- a/docker/run_celery.bash
+++ b/docker/run_celery.bash
@@ -7,6 +7,9 @@ source /etc/profile
 # according to the user's preference saved by django-constance
 cd "${KPI_SRC_DIR}"
 
+AUTOSCALE_MIN="${CELERY_AUTOSCALE_MIN:-2}"
+AUTOSCALE_MAX="${CELERY_AUTOSCALE_MAX:-2}"
+
 exec celery -A kobo worker --loglevel=info \
     --hostname=kpi_main_worker@%h \
     --logfile=${KPI_LOGS_DIR}/celery.log \
@@ -14,4 +17,4 @@ exec celery -A kobo worker --loglevel=info \
     --exclude-queues=sync_kobocat_xforms_queue \
     --uid=${UWSGI_USER} \
     --gid=${UWSGI_GROUP} \
-    --autoscale 2,2
+    --autoscale ${AUTOSCALE_MIN},${AUTOSCALE_MAX}

--- a/docker/run_celery.bash
+++ b/docker/run_celery.bash
@@ -8,7 +8,7 @@ source /etc/profile
 cd "${KPI_SRC_DIR}"
 
 AUTOSCALE_MIN="${CELERY_AUTOSCALE_MIN:-2}"
-AUTOSCALE_MAX="${CELERY_AUTOSCALE_MAX:-2}"
+AUTOSCALE_MAX="${CELERY_AUTOSCALE_MAX:-6}"
 
 exec celery -A kobo worker --loglevel=info \
     --hostname=kpi_main_worker@%h \

--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -11,23 +11,6 @@ class KpiConfig(AppConfig):
     name = 'kpi'
 
     def ready(self, *args, **kwargs):
-        # Register signals only when the app is ready to avoid issues with models
-        # not loaded yet.
-        import kpi.signals
-
-        # Once it's okay to read from the database, apply the user-desired
-        # autoscaling configuration for Celery workers
-        from kobo.celery import update_concurrency_from_constance
-        try:
-            # Push this onto the task queue with `delay()` instead of calling
-            # it directly because a direct call in the absence of any Celery
-            # workers hangs indefinitely
-            update_concurrency_from_constance.delay()
-        except kombu.exceptions.OperationalError as e:
-            # It's normal for Django to start without access to a message
-            # broker, e.g. while running `./manage.py collectstatic`
-            # during a Docker image build
-            pass
         return super().ready(*args, **kwargs)
 
 

--- a/kobo/apps/__init__.py
+++ b/kobo/apps/__init__.py
@@ -11,6 +11,10 @@ class KpiConfig(AppConfig):
     name = 'kpi'
 
     def ready(self, *args, **kwargs):
+        # Register signals only when the app is ready to avoid issues with models
+        # not loaded yet.
+        import kpi.signals
+
         return super().ready(*args, **kwargs)
 
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -189,20 +189,6 @@ CONSTANCE_CONFIG = {
         False,
         'Display information about the running commit to non-superusers',
     ),
-    'CELERY_WORKER_MAX_CONCURRENCY': (
-        '',
-        'Maximum number of asynchronous worker processes to run. When '
-        'unspecified, the default is the number of CPU cores on your server, '
-        'down to a minimum of 2 and up to a maximum of 6. You may override '
-        'here with larger values',
-        # Omit type specification because int doesn't allow an empty default
-    ),
-    'CELERY_WORKER_MIN_CONCURRENCY': (
-        2,
-        'Minimum number of asynchronous worker processes to run. If larger '
-        'than the maximum, the maximum will be ignored',
-        int
-    ),
     'FRONTEND_MIN_RETRY_TIME': (
         2,
         'Minimum number of seconds the front end waits before retrying a '

--- a/kpi/signals.py
+++ b/kpi/signals.py
@@ -8,7 +8,6 @@ from rest_framework.authtoken.models import Token
 from taggit.models import Tag
 
 from kobo.apps.hook.models.hook import Hook
-from kobo.celery import update_concurrency_from_constance
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatToken,
     KobocatUser,
@@ -16,15 +15,6 @@ from kpi.deployment_backends.kc_access.shadow_models import (
 from kpi.deployment_backends.kc_access.utils import grant_kc_model_level_perms
 from kpi.models import Asset, TagUid
 from kpi.utils.permissions import grant_default_model_level_perms
-
-
-@receiver(config_updated)
-def constance_updated(sender, key, old_value, new_value, **kwargs):
-    if key in (
-        'CELERY_WORKER_MAX_CONCURRENCY',
-        'CELERY_WORKER_MIN_CONCURRENCY',
-    ):
-        update_concurrency_from_constance()
 
 
 @receiver(post_save, sender=User)


### PR DESCRIPTION
## Description

When managing Celery autoscaling, previously this would be set by a Django Constance setting in the Database. This was set during application startup using a Celery task to apply the setting. This logic would always run at app startup, slowing it down. It would also run multiple times in multiple server deployments.

This change makes it possible to set Celery autoscaling min/max using the new environment variables `CELERY_AUTOSCALE_MIN` and `CELERY_AUTOSCALE_MAX` which both default to `2`. Most users can ignore this entirely. However large deployments that set this, need to migrate to the new settings.

## Alternative Solutions

` update_concurrency_from_constance.apply_async(ignore_result=True)` would greatly speed up ignoring the error when redis isn't present, such as during a CI build. However it would still take some time to attempt the network connection.  

## Implementation

Celery supports some environment variables out of box, but does not support autoscale min/max. I tried to make up my own env var names based on the CELERY_ prefix. We should prefer upstream names when supported.

## Related issues

Fixes https://github.com/kobotoolbox/kpi/issues/3820