### PR TITLE
Default CSP img src should include domains used for mapping

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -526,7 +526,12 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + ["'unsafe-inline'"]
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + ["'unsafe-inline'", '*.bootstrapcdn.com']
 CSP_FONT_SRC = CSP_DEFAULT_SRC + ['*.bootstrapcdn.com']
-CSP_IMG_SRC = CSP_DEFAULT_SRC + ['data:']
+CSP_IMG_SRC = CSP_DEFAULT_SRC + [
+    'data:',
+    'https://*.openstreetmap.org',
+    'https://*.opentopomap.org',
+    'https://*.arcgisonline.com'
+]
 
 if GOOGLE_ANALYTICS_TOKEN:
     google_domain = '*.google-analytics.com'


### PR DESCRIPTION
## Description

When CSP is enabled (not default), always allow map related domains including open street map and arcgis.

## Related issues

Follow up of adding CSP headers https://github.com/kobotoolbox/kpi/pull/3710