### PR TITLE
Fix submission edit authentication loop

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -903,7 +903,7 @@ class Asset(ObjectPermissionMixin,
         self, version_uid: str, root_node_name: Optional[str] = None
     ) -> AssetSnapshot:
         return self._snapshot(
-            regenerate=True,
+            regenerate=False,
             version_uid=version_uid,
             root_node_name=root_node_name,
         )

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1071,6 +1071,46 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         with pytest.raises(KeyError) as e:
             req = self.client.post(url)
 
+    @responses.activate
+    def test_get_multiple_edit_links_and_attempt_submit_edits(self):
+        """
+        Ensure that opening multiple edits allows for all to be submitted
+        without the snapshot being recreated and rejecting any of the edits.
+        """
+        ee_url = (
+            f'{settings.ENKETO_URL}/{settings.ENKETO_EDIT_INSTANCE_ENDPOINT}'
+        )
+        # Mock Enketo response
+        responses.add_callback(
+            responses.POST, ee_url,
+            callback=enketo_edit_instance_response,
+            content_type='application/json',
+        )
+
+        # open several submissions for editing and store their submission URLs
+        # for POSTing to later
+        submission_urls = []
+        for _ in range(2):
+            submission = self.get_random_submission(self.asset.owner)
+            edit_url = reverse(
+                self._get_endpoint('submission-enketo-edit'),
+                kwargs={
+                    'parent_lookup_asset': self.asset.uid,
+                    'pk': submission['_id'],
+                },
+            )
+            self.client.get(edit_url, {'format': 'json'})
+            url = reverse(
+                self._get_endpoint('assetsnapshot-submission'),
+                args=(self.asset.snapshot.uid,),
+            )
+            submission_urls.append(url)
+        # Post all edits to their submission URLs. There is no valid XML being
+        # sent, so we expect a KeyError exeption if all is good
+        for url in submission_urls:
+            with pytest.raises(KeyError) as e:
+                res = self.client.post(url)
+
 
 class SubmissionViewApiTests(BaseSubmissionTestCase):
 


### PR DESCRIPTION
## Description

Fix the case where attempts to submit edits to a submission get caught in an authentication loop. This loop can initiate if two or more submissions of the same project have been opened for editing. Only the most recently opened submission will submit successfully — all others will be stuck in an authentication loop and the edits will be lost.

## Related issues

closes #3876 