### PR TITLE
Set `regenerate=False` as default for snapshots

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -778,7 +778,7 @@ class Asset(ObjectPermissionMixin,
 
     @property
     def snapshot(self):
-        return self._snapshot(regenerate=False)
+        return self._snapshot()
 
     @property
     def tag_string(self):
@@ -903,7 +903,6 @@ class Asset(ObjectPermissionMixin,
         self, version_uid: str, root_node_name: Optional[str] = None
     ) -> AssetSnapshot:
         return self._snapshot(
-            regenerate=False,
             version_uid=version_uid,
             root_node_name=root_node_name,
         )
@@ -939,10 +938,14 @@ class Asset(ObjectPermissionMixin,
     @transaction.atomic
     def _snapshot(
         self,
-        regenerate: bool = True,
+        regenerate: bool = False,
         version_uid: Optional[str] = None,
         root_node_name: Optional[str] = None,
     ) -> AssetSnapshot:
+        """
+        `regenerate` should only be set to `True` under careful consideration as
+        it can break submission editing: kpi#3876.
+        """
         if version_uid:
             asset_version = self.asset_versions.get(uid=version_uid)
         else:

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -760,7 +760,7 @@ class AssetViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     @action(detail=True, renderer_classes=[renderers.TemplateHTMLRenderer])
     def xform(self, request, *args, **kwargs):
         asset = self.get_object()
-        export = asset._snapshot(regenerate=True)
+        export = asset._snapshot()
         # TODO-- forward to AssetSnapshotViewset.xform
         response_data = copy.copy(export.details)
         options = {


### PR DESCRIPTION
## Description

Regenerating snapshots has the side effect of sending submission edits into an authentication loop (#3876). Rather default to not regenerating them.

## Related issues

closes #3880 