### PR TITLE
Avoid using cache for dynamic settings while running unit tests

### DIFF
--- a/kobo/apps/hook/tests/test_api_hook.py
+++ b/kobo/apps/hook/tests/test_api_hook.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import json
 
-import constance
 import responses
+from constance.test import override_config
 from django.contrib.auth.models import User
 from django.urls import reverse
 from mock import patch
@@ -277,22 +277,21 @@ class ApiHookTestCase(HookTestCase):
 
         self.assertEqual(first_hooklog_response.get('status_code'),
                          status.HTTP_200_OK)
-        self.assertEqual(json.loads(first_hooklog_response.get('message')), 
+        self.assertEqual(json.loads(first_hooklog_response.get('message')),
                          expected_response)
 
+    @override_config(ALLOW_UNSECURED_HOOK_ENDPOINTS=False)
     def test_unsecured_endpoint_validation(self):
-
-        constance.config.ALLOW_UNSECURED_HOOK_ENDPOINTS = False
 
         response = self._create_hook(return_response_only=True)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         expected_response = {"endpoint": ["Unsecured endpoint is not allowed"]}
         self.assertEqual(response.data, expected_response)
-    
+
     def test_payload_template_validation(self):
 
         # Test invalid JSON
-        response = self._create_hook(payload_template='foo', 
+        response = self._create_hook(payload_template='foo',
                                      return_response_only=True)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         expected_response = {
@@ -309,7 +308,7 @@ class ApiHookTestCase(HookTestCase):
         self.asset.save()
 
         payload_template = '{{"fields": {}}}'.format(SUBMISSION_PLACEHOLDER)
-        response = self._create_hook(payload_template=payload_template, 
+        response = self._create_hook(payload_template=payload_template,
                                      format_type=Hook.XML,
                                      return_response_only=True)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/kobo/apps/hook/tests/test_ssrf.py
+++ b/kobo/apps/hook/tests/test_ssrf.py
@@ -1,6 +1,7 @@
 # coding: utf-8
-import constance
+
 import responses
+from constance.test import override_config
 from mock import patch
 from rest_framework import status
 
@@ -15,10 +16,10 @@ class SSRFHookTestCase(HookTestCase):
 
     @patch('ssrf_protect.ssrf_protect.SSRFProtect._get_ip_address',
            new=MockSSRFProtect._get_ip_address)
+    @override_config(SSRF_DENIED_IP_ADDRESS='1.2.3.4')
     @responses.activate
     def test_send_with_ssrf_options(self):
         # Create first hook
-        constance.config.SSRF_DENIED_IP_ADDRESS = '1.2.3.4'
 
         hook = self._create_hook()
 

--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -31,3 +31,7 @@ MONGO_DB = MONGO_CONNECTION['formhub_test']
 
 ENKETO_URL = 'http://enketo.mock'
 ENKETO_INTERNAL_URL = 'http://enketo.mock'
+
+# Do not use cache with Constance in tests to avoid overwriting production
+# cached values
+CONSTANCE_DATABASE_CACHE_BACKEND = None


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Deactivate cache system for Constance config values in testing environment