### PR TITLE
Allow form builder to open forms using deprecated metadata, but then force those metadata to be disabled

### DIFF
--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -187,12 +187,12 @@ export default class MetadataEditor extends React.Component {
       META_QUESTION_TYPES.start,
       META_QUESTION_TYPES.end,
       META_QUESTION_TYPES.today,
-      META_QUESTION_TYPES.deviceid,
       META_QUESTION_TYPES.audit,
     ];
     const rightColumn = [
       META_QUESTION_TYPES.username,
       META_QUESTION_TYPES.phonenumber,
+      META_QUESTION_TYPES.deviceid,
     ];
 
     let backgroundAudioProp = this.getMetaProperty(

--- a/jsapp/xlform/src/model.aliases.coffee
+++ b/jsapp/xlform/src/model.aliases.coffee
@@ -78,6 +78,8 @@ module.exports = do ->
       ['start'],
       ['end'],
       ['today'],
+      ['simserial'],
+      ['subscriberid'],
       ['phonenumber', 'phone_number'],
       ['audit'],
     ]

--- a/jsapp/xlform/src/model.configs.coffee
+++ b/jsapp/xlform/src/model.configs.coffee
@@ -35,6 +35,18 @@ module.exports = do ->
       label: "username"
       description: "includes interviewer's username"
       default: false
+    simserial:
+      name: "simserial"
+      label: "sim serial"
+      description: "records the serial number of the network sim card"
+      default: false
+      deprecated: true
+    subscriberid:
+      name: "subscriberid"
+      label: "subscriber id"
+      description: "records the subscriber id of the sim card"
+      default: false
+      deprecated: true
     deviceid:
       name: "deviceid"
       label: "device id"
@@ -63,6 +75,8 @@ module.exports = do ->
         name: @get("name")
         label: @get("label")
         description: @get("description")
+        default: @get("default")
+        deprecated: @get("deprecated")
 
     class configs.SurveyDetailSchema extends Backbone.Collection
       model: SurveyDetailSchemaItem

--- a/jsapp/xlform/src/model.surveyDetail.coffee
+++ b/jsapp/xlform/src/model.surveyDetail.coffee
@@ -47,7 +47,12 @@ module.exports = do ->
       if (dtobj = @get(detail.type))
         if detail.parameters
           dtobj.set("parameters", detail.parameters)
-        dtobj.set("value", true)
+        if dtobj.get("deprecated")
+          # …unless the detail (aka metadata) is deprecated, in which case its
+          # value is forced to the default
+          dtobj.set("value", dtobj.get("default"))
+        else
+          dtobj.set("value", true)
       else
         throw new Error("SurveyDetail `#{key}` not loaded from schema. [Aliases have not been implemented]")
       return


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes: https://github.com/kobotoolbox/docs/issues/286

## Description

The `simserial` and `subscriberid` metadata cannot be read from contemporary devices (#2842) and were removed entirely from the form builder in #3836, but that caused an error when trying to load old forms that had already enabled these metadata. This change allows those forms to be loaded without error, but the obsolete metadata are then disabled as soon as the form is saved.

## Related issues

Part of #2842
Related to #3836
