### PR TITLE
Treat unmarked timezone as UTC, convert _submission_time from UTC to local

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -725,8 +725,7 @@ export class DataTable extends React.Component {
             }
             if (
               q.type === META_QUESTION_TYPES.start ||
-              q.type === META_QUESTION_TYPES.end ||
-              q.type === ADDITIONAL_SUBMISSION_PROPS._submission_time
+              q.type === META_QUESTION_TYPES.end
             ) {
               return (
                 <span className='trimmed-text'>
@@ -734,6 +733,13 @@ export class DataTable extends React.Component {
                 </span>
               );
             }
+          }
+          if (key === ADDITIONAL_SUBMISSION_PROPS._submission_time) {
+            return (
+              <span className='trimmed-text'>
+                {formatTimeDateShort(row.value)}
+              </span>
+            );
           }
           if (typeof(row.value) === 'object' || row.value === undefined) {
             const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -33,7 +33,7 @@ const unzonedTime = new RegExp(/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d$/);
  * Given a string like '2022-07-22T00:00:00', appends a 'Z' so it can be interpreted as UTC instead of "local".
  */
 function presumeUtc(timeStr: string): string {
-  // Expecting like	'2022-01-01T00:00:00', or that plus a timezone offset.
+  // Expecting like '2022-01-01T00:00:00', or that plus a timezone offset.
   if (unzonedTime.test(timeStr)) {
     return timeStr + 'Z';
   } else {

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -27,25 +27,11 @@ export function notify(msg: string, atype = 'success') {
   alertify.notify(msg, atype);
 }
 
-const unzonedTime = new RegExp(/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d$/);
-
-/**
- * Given a string like '2022-07-22T00:00:00', appends a 'Z' so it can be interpreted as UTC instead of "local".
- */
-function presumeUtc(timeStr: string): string {
-  // Expecting like '2022-01-01T00:00:00', or that plus a timezone offset.
-  if (unzonedTime.test(timeStr)) {
-    return timeStr + 'Z';
-  } else {
-    return timeStr;
-  }
-}
-
 /**
  * Returns something like "Today at 4:06 PM", "Yesterday at 5:46 PM", "Last Saturday at 5:46 PM" or "February 11, 2021"
  */
 export function formatTime(timeStr: string): string {
-  const myMoment = moment(presumeUtc(timeStr));
+  const myMoment = moment.utc(timeStr).local();
   return myMoment.calendar(null, {sameElse: 'LL'});
 }
 
@@ -53,7 +39,7 @@ export function formatTime(timeStr: string): string {
  * Returns something like "March 15, 2021 4:06 PM"
  */
 export function formatTimeDate(timeStr: string): string {
-  const myMoment = moment(presumeUtc(timeStr));
+  const myMoment = moment.utc(timeStr).local();
   return myMoment.format('LLL');
 }
 
@@ -61,7 +47,7 @@ export function formatTimeDate(timeStr: string): string {
  * Returns something like "Sep 4, 1986 8:30 PM"
  */
 export function formatTimeDateShort(timeStr: string): string {
-  const myMoment = moment(presumeUtc(timeStr));
+  const myMoment = moment.utc(timeStr).local();
   return myMoment.format('lll');
 }
 
@@ -69,7 +55,7 @@ export function formatTimeDateShort(timeStr: string): string {
  * Returns something like "Mar 15, 2021"
  */
 export function formatDate(timeStr: string): string {
-  const myMoment = moment(presumeUtc(timeStr));
+  const myMoment = moment.utc(timeStr).local();
   return myMoment.format('ll');
 }
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -27,11 +27,25 @@ export function notify(msg: string, atype = 'success') {
   alertify.notify(msg, atype);
 }
 
+const unzonedTime = new RegExp(/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d$/);
+
+/**
+ * Given a string like '2022-07-22T00:00:00', appends a 'Z' so it can be interpreted as UTC instead of "local".
+ */
+function presumeUtc(timeStr: string): string {
+  // Expecting like	'2022-01-01T00:00:00', or that plus a timezone offset.
+  if (unzonedTime.test(timeStr)) {
+    return timeStr + 'Z';
+  } else {
+    return timeStr;
+  }
+}
+
 /**
  * Returns something like "Today at 4:06 PM", "Yesterday at 5:46 PM", "Last Saturday at 5:46 PM" or "February 11, 2021"
  */
 export function formatTime(timeStr: string): string {
-  const myMoment = moment(timeStr);
+  const myMoment = moment(presumeUtc(timeStr));
   return myMoment.calendar(null, {sameElse: 'LL'});
 }
 
@@ -39,7 +53,7 @@ export function formatTime(timeStr: string): string {
  * Returns something like "March 15, 2021 4:06 PM"
  */
 export function formatTimeDate(timeStr: string): string {
-  const myMoment = moment(timeStr);
+  const myMoment = moment(presumeUtc(timeStr));
   return myMoment.format('LLL');
 }
 
@@ -47,7 +61,7 @@ export function formatTimeDate(timeStr: string): string {
  * Returns something like "Sep 4, 1986 8:30 PM"
  */
 export function formatTimeDateShort(timeStr: string): string {
-  const myMoment = moment(timeStr);
+  const myMoment = moment(presumeUtc(timeStr));
   return myMoment.format('lll');
 }
 
@@ -55,7 +69,7 @@ export function formatTimeDateShort(timeStr: string): string {
  * Returns something like "Mar 15, 2021"
  */
 export function formatDate(timeStr: string): string {
-  const myMoment = moment(timeStr);
+  const myMoment = moment(presumeUtc(timeStr));
   return myMoment.format('ll');
 }
 


### PR DESCRIPTION
## Description

Convert `_submission_time` from UTC to local time in the table view.

## Related issues

Fixes #3941