### PR TITLE
Add `mfa_code_length` to environment API test

### DIFF
--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -3,6 +3,7 @@
 import json
 
 import constance
+from django.conf import settings
 from django.urls import reverse
 from django.http import HttpRequest
 from markdown import markdown
@@ -71,7 +72,8 @@ class EnvironmentTests(BaseTestCase):
                         constance.config.SUPPORT_EMAIL
                     )
                 ).items()
-            }
+            },
+            'mfa_code_length': settings.TRENCH_AUTH['CODE_LENGTH'],
         }
 
     def _check_response_dict(self, response_dict):


### PR DESCRIPTION
(intended audience: developers)

pytest has been failing for a while on the `beta` branch (and branches created from it), i think because #3674 adds `mfa_code_length` to the API endpoint without changing the environment test case to expect it.

i'm the bad reviewer of #3674 :raised_hand_with_fingers_splayed:

(high priority because we should get CI tests working again and wait for them to pass before merging PRs)