### PR TITLE
Resize all image elements to fit in their container by default

### DIFF
--- a/jsapp/scss/stylesheets/partials/_base.scss
+++ b/jsapp/scss/stylesheets/partials/_base.scss
@@ -65,6 +65,11 @@ video {
   vertical-align: middle;
 }
 
+img {
+  max-width: 100%;
+  object-fit: contain;
+}
+
 fieldset {
   border: 0;
   margin: 0;


### PR DESCRIPTION
## Description

Prevent large images from stretching across table cell boundaries in the single submission modal.

## Related issues

Fixes #3945

## Developers

Introduces new global css on `img` tags.

```scss
img {
  max-width: 100%;
  object-fit: contain;
}
```

We can override this as needed on individual components, but it's a good default. ([ref](https://github.com/kobotoolbox/kpi/issues/3945#issuecomment-1191152571))

## Screenshots
<details>
  <summary>Before</summary>
  <img width="929" alt="Large image breaks the layout" src="https://user-images.githubusercontent.com/3514715/181395944-ee999875-389d-472a-88b0-4b29bdf43bbd.png">
</details>
<details>
  <summary>After</summary>
  <img width="931" alt="Large image is contained in the table" src="https://user-images.githubusercontent.com/3514715/181396003-1c3dba92-c678-4608-be57-3f65b1c2656d.png">
</details>