### PR TITLE
Always regenerate secret when client activates MFA

### DIFF
--- a/kobo/apps/mfa/serializers.py
+++ b/kobo/apps/mfa/serializers.py
@@ -1,6 +1,26 @@
 # coding: utf-8
 from rest_framework import serializers
-from trench.utils import get_mfa_model
+from trench.serializers import RequestMFAMethodActivationSerializer
+from trench.utils import create_secret, get_mfa_model
+
+
+class ActivateMfaMethodSerializer(RequestMFAMethodActivationSerializer):
+     def create(self, validated_data):
+        """
+        When the client requests creation of a new MFA method, *always* create
+        a new secret. The default django-trench behavior reuses old secrets,
+        meaning that without this override, a given user would always see the
+        same QR code no matter how many times they enabled and disabled MFA.
+        That default behavior would create a security weakness if a user lost
+        their original device, because deactivating MFA and reconfiguring it on
+        a new device would not prevent the lost device from continuing to
+        generate valid TOTPs.
+        """
+        mfa_method, created = super().create(validated_data)
+        if not created:
+            mfa_method.secret = create_secret()
+            mfa_method.save()
+        return mfa_method, created
 
 
 class UserMfaMethodSerializer(serializers.ModelSerializer):

--- a/kobo/apps/mfa/serializers.py
+++ b/kobo/apps/mfa/serializers.py
@@ -5,7 +5,7 @@ from trench.utils import create_secret, get_mfa_model
 
 
 class ActivateMfaMethodSerializer(RequestMFAMethodActivationSerializer):
-     def create(self, validated_data):
+    def create(self, validated_data):
         """
         When the client requests creation of a new MFA method, *always* create
         a new secret. The default django-trench behavior reuses old secrets,

--- a/kobo/apps/mfa/tests/test_api.py
+++ b/kobo/apps/mfa/tests/test_api.py
@@ -2,6 +2,7 @@
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework import status
+from trench.settings import api_settings
 from trench.utils import get_mfa_model
 
 from kpi.tests.kpi_test_case import BaseTestCase
@@ -43,3 +44,26 @@ class MfaApiTestCase(BaseTestCase):
         ]
         for field in expected_fields:
             self.assertTrue(field in results[0])
+
+    def test_mfa_activation_always_creates_new_secret(self):
+        self.client.login(username='anotheruser', password='anotheruser')
+        mfa_methods = api_settings.MFA_METHODS.keys()
+        for method in mfa_methods:
+            first_response = self.client.post(
+                reverse('mfa-activate', args=(method,))
+            )
+            first_secret = (
+                get_mfa_model()
+                .objects.get(user__username='anotheruser', name=method)
+                .secret
+            )
+            second_response = self.client.post(
+                reverse('mfa-activate', args=(method,))
+            )
+            second_secret = (
+                get_mfa_model()
+                .objects.get(user__username='anotheruser', name=method)
+                .secret
+            )
+            assert first_secret != second_secret
+            assert first_response.json() != second_response.json()

--- a/kobo/apps/mfa/urls.py
+++ b/kobo/apps/mfa/urls.py
@@ -1,10 +1,20 @@
 # coding: utf-8
+from django.conf.urls import url
 from django.urls import path, include
+from trench.settings import api_settings
 
-from .views import MfaListUserMethodsView
+from .views import ActivateMfaMethodView, MfaListUserMethodsView
+
+
+mfa_methods_choices = '|'.join(api_settings.MFA_METHODS.keys())
 
 urlpatterns = [
     path('mfa/user-methods/', MfaListUserMethodsView.as_view(),
          name='mfa_list_user_methods'),
+    url(
+        r'^(?P<method>({}))/activate/$'.format(mfa_methods_choices),
+        ActivateMfaMethodView.as_view(),
+        name='mfa-activate',
+    ),
     path('', include('trench.urls')),
 ]

--- a/kobo/apps/mfa/views.py
+++ b/kobo/apps/mfa/views.py
@@ -5,12 +5,20 @@ from django.urls import reverse
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from trench.utils import get_mfa_model
+from trench.views import RequestMFAMethodActivationView
 
 from .forms import (
     MfaLoginForm,
     MfaTokenForm,
 )
-from .serializers import UserMfaMethodSerializer
+from .serializers import (
+    ActivateMfaMethodSerializer,
+    UserMfaMethodSerializer,
+)
+
+
+class ActivateMfaMethodView(RequestMFAMethodActivationView):
+    serializer_class = ActivateMfaMethodSerializer
 
 
 class MfaLoginView(LoginView):


### PR DESCRIPTION
When the client requests creation of a new MFA method, *always* create a new secret. The default django-trench behavior reuses old secrets, meaning that a given user would always see the same QR code no matter how many times they enabled and disabled MFA. That default behavior would create a security weakness if a user lost their original device, because deactivating MFA and reconfiguring it on a new device would not prevent the lost device from continuing to generate valid TOTPs.

## Description
Make sure a unique QR code or manual code is always shown when activating MFA, even if MFA was previously used and later deactivated.