### PR TITLE
Hide "Security" tab entirely if it is useless

### DIFF
--- a/jsapp/js/components/account/accountSidebar.tsx
+++ b/jsapp/js/components/account/accountSidebar.tsx
@@ -78,16 +78,19 @@ export default class AccountSidebar extends React.Component<
           </bem.FormSidebar__label>
           }
 
-          <bem.FormSidebar__label
-            m={{selected: this.isSecuritySelected()}}
-            href={'#' + ROUTES.SECURITY}
-            disabled={ !(envStore.isReady && envStore.data.mfa_enabled) }
-          >
-            <Icon name='lock-alt' size='xl'/>
-            <bem.FormSidebar__labelText>
-              {t('Security')}
-            </bem.FormSidebar__labelText>
-          </bem.FormSidebar__label>
+          { /* hide "Security" entirely if nothing there is available */
+            envStore.isReady && envStore.data.mfa_enabled &&
+            <bem.FormSidebar__label
+              m={{selected: this.isSecuritySelected()}}
+              href={'#' + ROUTES.SECURITY}
+              disabled={ !(envStore.isReady && envStore.data.mfa_enabled) }
+            >
+              <Icon name='lock-alt' size='xl'/>
+              <bem.FormSidebar__labelText>
+                {t('Security')}
+              </bem.FormSidebar__labelText>
+            </bem.FormSidebar__label>
+          }
         </bem.FormSidebar>
       );
     }


### PR DESCRIPTION
## Description

In account settings, hide "Security" entirely when it is not useful instead of leaving it visible but disabled.