### PR TITLE
added calculate and barcode question types to enable filtering in table view

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -770,6 +770,8 @@ export class DataTable extends React.Component {
       QUESTION_TYPES.date.id,
       QUESTION_TYPES.time.id,
       QUESTION_TYPES.datetime.id,
+      QUESTION_TYPES.barcode.id,
+      QUESTION_TYPES.calculate.id,
       META_QUESTION_TYPES.start,
       META_QUESTION_TYPES.end,
       META_QUESTION_TYPES.username,


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

`calculate`  and `barcode` type questions are not 'filterable' in the table view by default. There is no reason why this can't be done, because the responses to these questions are always of type `TEXT`. This code addition has been tested in a production environment for several months and it works very well.

I cannot think of a situation where it is undesirable to have this option, but if there is some such case, the PR can be rejected.

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
