### PR TITLE
Initial PR for switching `alertify` with `react-hot-toast` notification handlers

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -96,7 +96,7 @@ export default class App extends React.Component {
             </bem.PageWrapper__content>
           </bem.PageWrapper>
 
-          {/* Default posiiton of all notificaitons, page specific ones can be overwritten*/}
+          {/* Default position of all notifications, page specific ones can be overwritten */}
           <Toaster
             position='bottom-left'
           />

--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -20,6 +20,7 @@ import IntercomHandler from 'js/components/support/intercomHandler';
 import PermValidator from 'js/components/permissions/permValidator';
 import {assign} from 'utils';
 import BigModal from 'js/components/bigModal/bigModal';
+import {Toaster} from 'react-hot-toast';
 
 export default class App extends React.Component {
   constructor(props) {
@@ -94,6 +95,11 @@ export default class App extends React.Component {
               {this.props.children}
             </bem.PageWrapper__content>
           </bem.PageWrapper>
+
+          {/* Default posiiton of all notificaitons, page specific ones can be overwritten*/}
+          <Toaster
+            position='bottom-left'
+          />
         </React.Fragment>
       </DocumentTitle>
     );

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -25,16 +25,33 @@ alertify.defaults.notifier.closeButton = true;
 const cookies = new Cookies();
 
 export function notify(msg: string, atype = 'success') {
+  // To avoid changing too much, the default remains 'success' if unspecified.
+  //   e.g. notify('yay!') // success
+
   switch (atype) {
-    case 'empty':
-      toast(msg); // No icon
+
+    case 'success':
+      toast.success(msg);
       break;
+
     case 'error':
       toast.error(msg);
       break;
-    // To avoid changing too much default remains 'success'
+
+    case 'warning':
+      toast(msg, {icon: '⚠️'});
+      break;
+
+    case 'empty':
+      toast(msg); // No icon
+      break;
+
+    // Defensively render empty if we're passed an unknown atype,
+    // in case we missed something.
+    //   e.g. notify('mystery!', '?') //
     default:
-      toast.success(msg);
+      toast(msg); // No icon
+      break;
   }
 }
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -9,6 +9,7 @@
 
 import moment from 'moment';
 import alertify from 'alertifyjs';
+import {toast} from 'react-hot-toast';
 import {Cookies} from 'react-cookie';
 // importing whole constants, as we override ROOT_URL in tests
 import constants from 'js/constants';
@@ -24,7 +25,17 @@ alertify.defaults.notifier.closeButton = true;
 const cookies = new Cookies();
 
 export function notify(msg: string, atype = 'success') {
-  alertify.notify(msg, atype);
+  switch (atype) {
+    case 'empty':
+      toast(msg); // No icon
+      break;
+    case 'error':
+      toast.error(msg);
+      break;
+    // To avoid changing too much default remains 'success'
+    default:
+      toast.success(msg);
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "react-document-title": "^2.0.3",
         "react-dom": "^16.13.1",
         "react-dropzone": "^5.1.1",
+        "react-hot-toast": "^2.3.0",
         "react-mixin": "^5.0.0",
         "react-router": "^3.2.1",
         "react-select": "^5.3.0",
@@ -9156,6 +9157,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.3.0.tgz",
+      "integrity": "sha512-/RxV+bfjld7tSJR1SCLzMAXgFuNW7fCpK6+vbYqfmbGSWcqTMz2rizrvfWKvtcPH5HK0NqxmBaC5SrAy1F42zA==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4538,8 +4538,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.2",
-      "license": "MIT"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "node_modules/csv2geojson": {
       "version": "5.0.2",
@@ -6203,6 +6204,14 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg=="
+    },
+    "node_modules/goober": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.10.tgz",
+      "integrity": "sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
@@ -16009,7 +16018,9 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "csstype": {
-      "version": "3.0.2"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
     "csv2geojson": {
       "version": "5.0.2",
@@ -17125,6 +17136,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg=="
+    },
+    "goober": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.10.tgz",
+      "integrity": "sha512-7PpuQMH10jaTWm33sQgBQvz45pHR8N4l3Cu3WMGEWmHShAcTuuP7I+5/DwKo39fwti5A80WAjvqgz6SSlgWmGA==",
+      "requires": {}
     },
     "graceful-fs": {
       "version": "4.2.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19010,6 +19010,14 @@
         }
       }
     },
+    "react-hot-toast": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.3.0.tgz",
+      "integrity": "sha512-/RxV+bfjld7tSJR1SCLzMAXgFuNW7fCpK6+vbYqfmbGSWcqTMz2rizrvfWKvtcPH5HK0NqxmBaC5SrAy1F42zA==",
+      "requires": {
+        "goober": "^2.1.10"
+      }
+    },
     "react-is": {
       "version": "16.13.1"
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-document-title": "^2.0.3",
     "react-dom": "^16.13.1",
     "react-dropzone": "^5.1.1",
+    "react-hot-toast": "^2.3.0",
     "react-mixin": "^5.0.0",
     "react-router": "^3.2.1",
     "react-select": "^5.3.0",


### PR DESCRIPTION
## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->
Moving from `alertify` to `react-hot-toast` due to reasons outlined in #3837. This PR just adds the library and replaces the utility method `notify` which handles a lot of global notifications.

Work that needs to be done to complete the switch:
- Find page specific `alertify` overrides and replace them with `notify`
- Add override cases to `notify` or a similar utility function
- We use `alertify` to show dialogs as well, so we need to:
  - Create an extendable component for dialogs
  - Move the CSS over <-- might be a good time to update the styles and standardize them

## Related issues
Part of #3837 

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
