### PR TITLE
Optimize code to avoid loading not required fields 

### DIFF
--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -108,6 +108,7 @@ def build_formpack(asset, submission_stream=None, use_all_form_versions=True):
     return pack, submission_stream
 
 
+# TODO validate if this function is still in used.
 def _vnames(asset, cache=False):
     if not cache or not hasattr(asset, '_available_report_uids'):
         content = deepcopy(asset.content)

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -19,6 +19,10 @@ class AbstractPropertyError(NotImplementedError):
         )
 
 
+class AssetAdjustContentError(Exception):
+    pass
+
+
 class AttachmentNotFoundException(Exception):
     pass
 

--- a/kpi/mixins/object_permission.py
+++ b/kpi/mixins/object_permission.py
@@ -209,8 +209,8 @@ class ObjectPermissionMixin:
         # Add the calculated `delete_` permission for the owner
         content_type = ContentType.objects.get_for_model(self)
         if (
-            self.owner is not None
-            and (user is None or user.pk == self.owner.pk)
+            self.owner_id is not None
+            and (user is None or user.pk == self.owner_id)
             and (codename is None or codename.startswith('delete_'))
         ):
             matching_permissions = self.__get_permissions_for_content_type(
@@ -229,7 +229,7 @@ class ObjectPermissionMixin:
                     # doesn't match exactly. Necessary because `Asset` has
                     # `delete_submissions` in addition to `delete_asset`
                     continue
-                effective_perms.add((self.owner.pk, perm_pk))
+                effective_perms.add((self.owner_id, perm_pk))
 
         # We may have calculated more permissions for anonymous users
         # than they are allowed to have. Remove them.
@@ -280,7 +280,7 @@ class ObjectPermissionMixin:
             # if we use it when we're not supposed to
             objects_to_return = []
         # The owner gets every assignable permission
-        if self.owner is not None:
+        if self.owner_id is not None:
             for perm in Permission.objects.filter(
                 content_type=content_type,
                 codename__in=self.get_assignable_permissions(

--- a/kpi/models/paired_data.py
+++ b/kpi/models/paired_data.py
@@ -161,7 +161,9 @@ class PairedData(OpenRosaManifestInterface,
         # Avoid circular import
         Asset = self.asset.__class__  # noqa
         try:
-            source_asset = Asset.objects.get(uid=self.source_uid)
+            source_asset = Asset.objects.only(
+                'asset_type', 'data_sharing', 'owner_id', '_deployment_data'
+            ).get(uid=self.source_uid)
         except Asset.DoesNotExist:
             return None
 
@@ -280,4 +282,3 @@ class PairedData(OpenRosaManifestInterface,
             setattr(self, key, value)
 
         self.void_external_xml_cache()
-

--- a/kpi/utils/viewset_mixins.py
+++ b/kpi/utils/viewset_mixins.py
@@ -9,7 +9,9 @@ class AssetNestedObjectViewsetMixin:
     @property
     def asset(self):
         if not hasattr(self, '_asset'):
-            asset = get_object_or_404(Asset, uid=self.asset_uid)
+            asset = get_object_or_404(
+                Asset.objects.defer('content'), uid=self.asset_uid
+            )
             setattr(self, '_asset', asset)
         return self._asset
 

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -46,6 +46,11 @@ class AssetSnapshotViewSet(OpenRosaViewSetMixin, NoUpdateModelViewSet):
     @property
     def asset(self):
         asset_snapshot = self.get_object()
+        # Calling `snapshot.asset.__class__` instead of `Asset` to avoid circular
+        # import
+        asset_snapshot.asset = asset_snapshot.asset.__class__.objects.defer(
+            'content'
+        ).get(pk=asset_snapshot.asset_id)
         return asset_snapshot.asset
 
     def filter_queryset(self, queryset):


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Avoid slow queries when loading (not required) large data from DB.

## Additional info

None of the objects related to a parent Asset object (`AssetSnapsnot`, `AssetFile` etc...)  use its parent `content` field. Therefore, when the parent is loaded in memory, `content` is deferred. 
It avoids putting more pressure on PostgreSQL when it is not required. 

## Related issues

Part of #3967 