### PR TITLE
Use new counters to display users' submission statistics in Admin interface

### DIFF
--- a/kobo/apps/superuser_stats/admin.py
+++ b/kobo/apps/superuser_stats/admin.py
@@ -7,7 +7,8 @@ from django.contrib import admin
 from django.contrib.admin import DateFieldListFilter
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Value, F, DateField
+from django.db.models.functions import Cast, Concat
 from django.utils import timezone
 
 from kobo.static_lists import COUNTRIES
@@ -52,7 +53,15 @@ class TimePeriodFilter(admin.SimpleListFilter):
         if self.__model == Asset:
             condition = {'date_created__gte': from_date}
         else:
-            condition = {'timestamp__gte': from_date}
+            queryset = queryset.annotate(
+                date=Cast(
+                    Concat(
+                        F('year'), Value('-'), F('month'), Value('-'), 1
+                    ),
+                    DateField(),
+                )
+            )
+            condition = {'date__gte': from_date}
 
         return queryset.filter(**condition)
 

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -15,7 +15,6 @@ from django.db import (
     models,
     router,
 )
-from django.db.models.constants import UniqueContraint
 from django.utils import timezone
 from django.utils.http import urlquote
 from django_digest.models import PartialDigest
@@ -300,30 +299,6 @@ class KobocatPermission(ShadowModel):
             str(self.name))
 
 
-class KobocatSubmissionCounter(ShadowModel):
-    user = models.ForeignKey('shadow_model.KobocatUser', on_delete=models.CASCADE)
-    count = models.IntegerField(default=0)
-    timestamp = models.DateField()
-
-    class Meta(ShadowModel.Meta):
-        app_label = 'superuser_stats'
-        db_table = 'logger_submissioncounter'
-        verbose_name_plural = 'User Statistics'
-
-    @classmethod
-    def sync(cls, user):
-        """
-        Creates rows when the user is created so that the Admin UI doesn't freak
-        out because it's looking for a row that doesn't exist
-        """
-        today = date.today()
-        first = today.replace(day=1)
-
-        queryset = cls.objects.filter(user_id=user.pk, timestamp=first)
-        if not queryset.exists():
-            # Todo: Handle race conditions
-            cls.objects.create(user_id=user.pk, timestamp=first)
-
 class KobocatUser(ShadowModel):
 
     username = models.CharField('username', max_length=30, unique=True)
@@ -369,10 +344,6 @@ class KobocatUser(ShadowModel):
         # Update django-digest `PartialDigest`s in KoBoCAT.  This is only
         # necessary if the user's password has changed, but we do it always
         KobocatDigestPartial.sync(kc_auth_user)
-
-        # Add the user to the table to prevent the errors in the admin page
-        # and to ensure the user has a counter started for reporting
-        KobocatSubmissionCounter.sync(kc_auth_user)
 
 
 class KobocatUserObjectPermission(ShadowModel):
@@ -502,7 +473,7 @@ class KobocatToken(ShadowModel):
     def sync(cls, auth_token):
         try:
             # Token use a One-to-One relationship on User.
-            # Thus, we can retrieve tokens from users' id. 
+            # Thus, we can retrieve tokens from users' id.
             kc_auth_token = cls.objects.get(user_id=auth_token.user_id)
         except KobocatToken.DoesNotExist:
             kc_auth_token = cls(pk=auth_token.pk, user_id=auth_token.user_id)
@@ -648,34 +619,16 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, MP3ConverterMixin):
         return str(self.media_file)
 
 
-class ReadOnlyDailyXFormSubmissionCounter(ReadOnlyModel):
+class ReadOnlyKobocatDailyXFormSubmissionCounter(ReadOnlyModel):
     date = models.DateField()
-    xform = models.ForeignKey(KobocatXForm, related_name='xforms', on_delete=models.CASCADE)
+    xform = models.ForeignKey(
+        KobocatXForm, related_name='daily_counts', on_delete=models.CASCADE
+    )
     counter = models.IntegerField(default=0)
 
     class Meta(ReadOnlyModel.Meta):
         db_table = 'logger_dailyxformsubmissioncounter'
-        unique_together = (('date', 'xform'))
-
-
-class ReadOnlyMonthlyXFormSubmissionCounter(ReadOnlyModel):
-    year = models.IntegerField()
-    month = models.IntegerField()
-    user = models.ForeignKey(KobocatUser, related_name='users', on_delete=models.DO_NOTHING)
-    xform = models.ForeignKey('logger.KobocatXForm', null=True, on_delete=models.SET_NULL)
-    counter = models.IntegerField(default=0)
-
-    class Meta:
-        db_table = 'logger_monthlyxformsubmissioncounter'
-        contraints = [
-            UniqueContraint(fields=['year', 'month', 'user', 'xform'],
-                            name='unique_with_xform'),
-            UniqueContraint(fields=['year', 'month', 'user', 'xform'],
-                            name='unique_without_xform')
-        ]
-        indexes = [
-            models.Index(fields=('year', 'month', 'user'))
-        ]
+        unique_together = ('date', 'xform')
 
 
 class ReadOnlyKobocatInstance(ReadOnlyModel):
@@ -696,6 +649,25 @@ class ReadOnlyKobocatInstance(ReadOnlyModel):
     status = models.CharField(max_length=20,
                               default='submitted_via_web')
     uuid = models.CharField(max_length=249, default='')
+
+
+class ReadOnlyKobocatMonthlyXFormSubmissionCounter(ReadOnlyModel):
+    year = models.IntegerField()
+    month = models.IntegerField()
+    user = models.ForeignKey(
+        'shadow_model.KobocatUser',
+        related_name='monthly_counts',
+        on_delete=models.DO_NOTHING,
+    )
+    xform = models.ForeignKey(
+        'shadow_model.KobocatXForm', null=True, on_delete=models.SET_NULL
+    )
+    counter = models.IntegerField(default=0)
+
+    class Meta:
+        app_label = 'superuser_stats'
+        db_table = 'logger_monthlyxformsubmissioncounter'
+        verbose_name_plural = 'User Statistics'
 
 
 def safe_kc_read(func):

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 import copy
 import io
 import json


### PR DESCRIPTION
## Description

Fixes the error saying `django.db.utils.ProgrammingError: relation "logger_submissioncounter" does not exist`.

## Additional info
Port part of @JacquelineMorrissette's PR #3985 into `beta`
