### PR TITLE
Move background tasks for REST Services to their own queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN mkdir -p "${NGINX_STATIC_DIR}" && \
     mkdir -p ${CELERY_PID_DIR} && \
     mkdir -p ${SERVICES_DIR}/uwsgi && \
     mkdir -p ${SERVICES_DIR}/celery && \
+    mkdir -p ${SERVICES_DIR}/celery_low_priority && \
     mkdir -p ${SERVICES_DIR}/celery_beat && \
     mkdir -p "${INIT_PATH}"
 
@@ -155,6 +156,7 @@ RUN rm -rf /etc/runit/runsvdir/default/getty-tty*
 # Create symlinks for runsv services
 RUN ln -s "${KPI_SRC_DIR}/docker/run_uwsgi.bash" "${SERVICES_DIR}/uwsgi/run" && \
     ln -s "${KPI_SRC_DIR}/docker/run_celery.bash" "${SERVICES_DIR}/celery/run" && \
+    ln -s "${KPI_SRC_DIR}/docker/run_celery_low_priority.bash" "${SERVICES_DIR}/celery_low_priority/run" && \
     ln -s "${KPI_SRC_DIR}/docker/run_celery_beat.bash" "${SERVICES_DIR}/celery_beat/run"
 
 

--- a/docker/run_celery_low_priority.bash
+++ b/docker/run_celery_low_priority.bash
@@ -2,17 +2,17 @@
 set -e
 source /etc/profile
 
-# Run the main Celery worker (will not process low priority jobs).
+# Run the main Celery worker (will process only low priority jobs).
 # Start 2 processes by default; this will be overridden later, in Python code,
 # according to the user's preference saved by django-constance
 cd "${KPI_SRC_DIR}"
 
 exec celery -A kobo worker --loglevel=info \
     --hostname=kpi_main_worker@%h \
-    --logfile=${KPI_LOGS_DIR}/celery.log \
-    --pidfile=/tmp/celery.pid \
-    --queues=kpi_queue \
-    --exclude-queues=kpi_low_priority_queue \
+    --logfile=${KPI_LOGS_DIR}/celery_low_priority.log \
+    --pidfile=/tmp/celery_low_priority.pid \
+    --queues=kpi_low_priority_queue \
+    --exclude-queues=kpi_queue \
     --uid=${UWSGI_USER} \
     --gid=${UWSGI_GROUP} \
     --autoscale 2,2

--- a/kobo/apps/hook/tests/test_email.py
+++ b/kobo/apps/hook/tests/test_email.py
@@ -34,7 +34,7 @@ class EmailTestCase(HookTestCase):
     def test_notifications(self):
         self._create_periodic_task()
         first_log_response = self._send_and_fail()
-        failures_reports.delay()
+        failures_reports.apply_async(queue='kpi_low_priority_queue')
         self.assertEqual(len(mail.outbox), 1)
 
         expected_record = {

--- a/kobo/apps/hook/utils.py
+++ b/kobo/apps/hook/utils.py
@@ -25,6 +25,8 @@ class HookUtils:
                 submission_id=submission_id, hook_id=hook_id
             ).exists():
                 success = True
-                service_definition_task.delay(hook_id, submission_id)
+                service_definition_task.apply_async(
+                    queue='kpi_low_priority_queue', args=(hook_id, submission_id)
+                )
 
         return success

--- a/kobo/apps/hook/views/v2/hook.py
+++ b/kobo/apps/hook/views/v2/hook.py
@@ -192,7 +192,9 @@ class HookViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
                 # Mark all logs as PENDING
                 HookLog.objects.filter(id__in=hooklogs_ids).update(status=HOOK_LOG_PENDING)
                 # Delegate to Celery
-                retry_all_task.delay(hooklogs_ids)
+                retry_all_task.apply_async(
+                    queue='kpi_low_priority_queue', args=(hooklogs_ids,)
+                )
                 response.update({
                     "pending_uids": hooklogs_uids
                 })

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -613,7 +613,7 @@ CELERY_BEAT_SCHEDULE = {
     "send-hooks-failures-reports": {
         "task": "kobo.apps.hook.tasks.failures_reports",
         "schedule": crontab(hour=0, minute=0),
-        'options': {'queue': 'kpi_queue'}
+        'options': {'queue': 'kpi_low_priority_queue'}
     },
 }
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Use a different queue to send submissions to REST Services external servers to avoid blocking imports and exports running in the background.

## Related issues

Part of #3988 