### PR TITLE
404 error fix when using the "Login as" button in Admin interface

### DIFF
--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -9,9 +9,9 @@ from kobo.apps.service_health.views import service_health
 admin.autodiscover()
 
 urlpatterns = [
-    re_path(r'^admin/', admin.site.urls),
     # https://github.com/stochastic-technologies/django-loginas
     re_path(r'^admin/', include('loginas.urls')),
+    re_path(r'^admin/', admin.site.urls),
     re_path(r'^', include('kpi.urls')),
     re_path(r'^markdownx/', include('markdownx.urls')),
     re_path(r'^markitup/', include('markitup.urls')),


### PR DESCRIPTION
## Description

When a super user tries to log in another user account, they do not receive a `Page not found` anymore.