### PR TITLE
Fix "different root names" Enketo error when editing a submission

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -906,10 +906,6 @@ class Asset(ObjectPermissionMixin,
             self.create_version()
 
     @property
-    def snapshot(self):
-        return self._snapshot(regenerate=False)
-
-    @property
     def tag_string(self):
         try:
             tag_list = self.prefetched_tags
@@ -1031,21 +1027,6 @@ class Asset(ObjectPermissionMixin,
 
         return f'{count} {self.date_modified:(%Y-%m-%d %H:%M:%S)}'
 
-    # TODO: take leading underscore off of `_snapshot()` and call it directly?
-    # we would also have to remove or rename the `snapshot` property
-    def versioned_snapshot(self,
-        version_uid: str,
-        root_node_name: Optional[str] = None,
-        submission_uuid: Optional[str] = None,
-    ) -> AssetSnapshot:
-        # Always regenerate a new snapshot when editing.
-        return self._snapshot(
-            regenerate=True,
-            version_uid=version_uid,
-            submission_uuid=submission_uuid,
-            root_node_name=root_node_name,
-        )
-
     def _populate_report_styles(self):
         default = self.report_styles.get(DEFAULT_REPORTS_KEY, {})
         specifieds = self.report_styles.get(SPECIFIC_REPORTS_KEY, {})
@@ -1075,9 +1056,9 @@ class Asset(ObjectPermissionMixin,
         self.summary = analyzer.summary
 
     @transaction.atomic
-    def _snapshot(
+    def snapshot(
         self,
-        regenerate: bool = True,
+        regenerate: bool = False,
         version_uid: Optional[str] = None,
         submission_uuid: Optional[str] = None,
         root_node_name: Optional[str] = None,

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 import json
 import re
+from collections.abc import Callable
 from io import StringIO
+
 
 from dict2xml import dict2xml
 from django.utils.xmlutils import SimplerXMLGenerator
@@ -242,7 +244,10 @@ class XMLRenderer(DRFXMLRenderer):
             # from this relationship.
             # e.g. obj is `Asset`, relationship can be `snapshot`
             if relationship is not None and hasattr(obj, relationship):
-                return getattr(obj, relationship).xml
+                var_or_callable = getattr(obj, relationship)
+                if isinstance(var_or_callable, Callable):
+                    return var_or_callable().xml
+                return var_or_callable.xml
             return add_xml_declaration(obj.xml)
         else:
             return super().render(data=data,

--- a/kpi/serializers/v2/asset_snapshot.py
+++ b/kpi/serializers/v2/asset_snapshot.py
@@ -69,7 +69,7 @@ class AssetSnapshotSerializer(serializers.HyperlinkedModelSerializer):
         else:
             # asset.snapshot pulls, by default, a snapshot for the latest
             # version.
-            snapshot = asset.snapshot
+            snapshot = asset.snapshot()
 
         if not snapshot.xml:
             raise serializers.ValidationError(snapshot.details)

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -15,9 +15,9 @@ import responses
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.utils.datastructures import MultiValueDictKeyError
 from django_digest.test import Client as DigestClient
 from rest_framework import status
+
 
 from kpi.constants import (
     PERM_CHANGE_ASSET,
@@ -28,13 +28,17 @@ from kpi.constants import (
     PERM_VALIDATE_SUBMISSIONS,
     PERM_VIEW_ASSET,
     PERM_VIEW_SUBMISSIONS,
+    SUBMISSION_FORMAT_TYPE_JSON,
+    SUBMISSION_FORMAT_TYPE_XML,
 )
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseTestCase
+from kpi.tests.utils.xml import get_form_and_submission_tag_names
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.object_permission import get_anonymous_user
 from kpi.tests.utils.mock import (
     enketo_edit_instance_response,
+    enketo_edit_instance_response_with_root_name_validation,
     enketo_view_instance_response,
 )
 
@@ -1026,7 +1030,7 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
     def test_edit_submission_with_digest_credentials(self):
         url = reverse(
             self._get_endpoint('assetsnapshot-submission-alias'),
-            args=(self.asset.snapshot.uid,),
+            args=(self.asset.snapshot().uid,),
         )
         self.client.logout()
         client = DigestClient()
@@ -1061,7 +1065,7 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
     def test_edit_submission_with_authenticated_session_but_no_digest(self):
         url = reverse(
             self._get_endpoint('assetsnapshot-submission-alias'),
-            args=(self.asset.snapshot.uid,),
+            args=(self.asset.snapshot().uid,),
         )
         self.login_as_other_user('anotheruser', 'anotheruser')
         # Try to edit someuser's submission by anotheruser who has no
@@ -1109,7 +1113,7 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
             self.client.get(edit_url, {'format': 'json'})
             url = reverse(
                 self._get_endpoint('assetsnapshot-submission'),
-                args=(self.asset.snapshot.uid,),
+                args=(self.asset.snapshot().uid,),
             )
             submission_urls.append(url)
 
@@ -1118,6 +1122,66 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
         for url in submission_urls:
             with pytest.raises(KeyError) as e:
                 res = self.client.post(url)
+
+    @responses.activate
+    def test_edit_submission_with_different_root_name(self):
+
+        # Mock Enketo response
+        ee_url = (
+            f'{settings.ENKETO_URL}/{settings.ENKETO_EDIT_INSTANCE_ENDPOINT}'
+        )
+        responses.add_callback(
+            responses.POST, ee_url,
+            callback=enketo_edit_instance_response_with_root_name_validation,
+            content_type='application/json',
+        )
+
+        # Force random name to create a different root name for already submitted
+        # data
+        self.asset.content['settings']['name'] = 'different_root_name'
+        self.asset.content['settings']['id_string'] = 'different_root_name'
+        self.asset.save()  # Create a new version
+        self.asset.deploy(backend='mock', active=True)
+
+        xml_submission = self.asset.deployment.get_submission(
+            self.submission['_id'], self.asset.owner, SUBMISSION_FORMAT_TYPE_XML
+        )
+
+        # Create a snapshot without specifying the root name. The default root
+        # name will be the name saved in the settings of the asset version.
+        snapshot = self.asset.snapshot
+
+        (
+            form_root_name,
+            submission_root_name,
+        ) = get_form_and_submission_tag_names(snapshot.xml, xml_submission)
+
+        # Asset uid should be different from the name stored in settings
+        assert self.asset.uid != self.asset.content['settings']['name']
+        # submission tag name should equal the asset uid
+        assert submission_root_name == self.asset.uid
+        # form tag name should equal 'different_root_name'
+        # (i.e.: `self.asset.content['settings']['name']`), thus different from
+        # submission tag name
+        assert form_root_name == self.asset.content['settings']['name']
+        assert form_root_name != submission_root_name
+
+        # Enketo will raise the error
+        # > "Error trying to parse XML record. Different root nodes"
+        # if submission and form root nodes do not match.
+        # To avoid this error, the XML of the form is always regenerated with
+        # a submission root name on edit.
+        # The mock response of Enketo simulates Enketo response and validates
+        # that both root nodes match.
+        # See `enketo_edit_instance_response_with_root_name_validation()`
+        response = self.client.get(self.submission_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+        # Validate a new snapshot has been generated for the same criteria
+        new_snapshot = self.asset.snapshot(
+            version_uid=self.asset.latest_deployed_version_uid,
+            submission_uuid=f"uuid:{self.submission['_uuid']}"
+        )
+        assert new_snapshot.pk != snapshot.pk
 
 
 class SubmissionViewApiTests(BaseSubmissionTestCase):

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -28,7 +28,6 @@ from kpi.constants import (
     PERM_VALIDATE_SUBMISSIONS,
     PERM_VIEW_ASSET,
     PERM_VIEW_SUBMISSIONS,
-    SUBMISSION_FORMAT_TYPE_JSON,
     SUBMISSION_FORMAT_TYPE_XML,
 )
 from kpi.models import Asset
@@ -1149,7 +1148,10 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
 
         # Create a snapshot without specifying the root name. The default root
         # name will be the name saved in the settings of the asset version.
-        snapshot = self.asset.snapshot
+        snapshot = self.asset.snapshot(
+            version_uid=self.asset.latest_deployed_version_uid,
+            submission_uuid=f"uuid:{self.submission['_uuid']}"
+        )
 
         (
             form_root_name,

--- a/kpi/tests/test_asset_snapshots.py
+++ b/kpi/tests/test_asset_snapshots.py
@@ -56,7 +56,7 @@ class CreateAssetSnapshots(AssetSnapshotsTestCase):
         content = {'settings': [{'id_string': 'no_title_asset'}],
                    'survey': [{'label': 'Q1 Label.', 'type': 'decimal'}]}
         asset = Asset.objects.create(asset_type='survey', content=content)
-        _snapshot = asset.snapshot
+        _snapshot = asset.snapshot()
         self.assertEqual(_snapshot.source.get('settings')['form_title'], 'no_title_asset')
 
     def test_snapshots_allow_choice_duplicates(self):
@@ -94,7 +94,8 @@ class AssetSnapshotHousekeeping(AssetSnapshotsTestCase):
         old_snapshot.date_created = yesterday
         old_snapshot.save(update_fields=['date_created'])
         # versioned snapshots are always regenerated
-        versioned_snapshot = self.asset.versioned_snapshot(
+        versioned_snapshot = self.asset.snapshot(
+            regenerate=True,
             version_uid=self.asset.latest_deployed_version_uid
         )
         snapshot_uids = list(AssetSnapshot.objects.filter(

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -474,7 +474,7 @@ class AssetScoreTestCase(TestCase):
             'settings': {},
         }
         a1 = Asset.objects.create(content=_matrix_score, asset_type='survey')
-        _snapshot = a1.snapshot
+        _snapshot = a1.snapshot()
         self.assertNotEqual(_snapshot.xml, '')
         self.assertNotEqual(_snapshot.details['status'], 'failure')
 
@@ -490,7 +490,7 @@ class AssetSnapshotXmlTestCase(AssetSettingsTests):
         self.assertTrue(None not in choices_kuids)
         # asset.snapshot.xml generates a document that does not have any
         # "$kuid" or "<$kuid>x</$kuid>" elements
-        _xml = asset.snapshot.xml
+        _xml = asset.snapshot().xml
         # as is in every xform:
         self.assertTrue('<instance>' in _xml)
         # specific to this cascading select form:
@@ -504,7 +504,7 @@ class AssetSnapshotXmlTestCase(AssetSettingsTests):
         a1 = Asset.objects.create(content=self._content('abcxyz'),
                                   owner=self.user,
                                   asset_type='survey')
-        export = a1.snapshot
+        export = a1.snapshot()
         self.assertTrue('<h:title>abcxyz</h:title>' in export.xml)
         self.assertTrue(f'<{a1.uid} id="xid_stringx">' in export.xml)
 

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -11,6 +11,8 @@ from django.core.files import File
 from rest_framework import status
 
 from kpi.mixins.audio_transcoding import AudioTranscodingMixin
+from kpi.models.asset_snapshot import AssetSnapshot
+from kpi.tests.utils.xml import get_form_and_submission_tag_names
 
 
 def enketo_edit_instance_response(request):
@@ -19,6 +21,32 @@ def enketo_edit_instance_response(request):
     """
     # Decode `x-www-form-urlencoded` data
     body = {k: v[0] for k, v in parse_qs(unquote(request.body)).items()}
+
+    resp_body = {
+        'edit_url': (
+            f"{settings.ENKETO_URL}/edit/{body['instance_id']}"
+        )
+    }
+    headers = {}
+    return status.HTTP_201_CREATED, headers, json.dumps(resp_body)
+
+
+def enketo_edit_instance_response_with_root_name_validation(request):
+    """
+    Simulate Enketo response and validate root names
+    """
+    # Decode `x-www-form-urlencoded` data
+    body = {k: v[0] for k, v in parse_qs(unquote(request.body)).items()}
+
+    submission = body['instance']
+    snapshot = AssetSnapshot.objects.get(uid=body['form_id'])
+
+    (
+        form_root_name,
+        submission_root_name,
+    ) = get_form_and_submission_tag_names(snapshot.xml, submission)
+
+    assert form_root_name == submission_root_name
 
     resp_body = {
         'edit_url': (

--- a/kpi/tests/utils/xml.py
+++ b/kpi/tests/utils/xml.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from lxml import etree
+
+
+def get_form_and_submission_tag_names(form: str, submission: str) -> tuple[str, str]:
+    submission_root_name = etree.fromstring(submission).tag
+    tree = etree.ElementTree(etree.fromstring(form))
+    root = tree.getroot()
+    # We cannot use `root.nsmap` directly because the default namespace key is
+    # `None`, and `find()` cannot search a namespace with equals `None`.
+    #
+    namespaces = {
+        'default': root.nsmap[None]
+    }
+    element = root.find('.//default:instance', namespaces=namespaces)[0]
+    form_root_name = element.tag.replace(f"{{{namespaces['default']}}}", '')
+
+    return form_root_name, submission_root_name

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import re
 from typing import Optional, Union, List
 from lxml import etree
 

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -385,20 +385,6 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         # `retrieve()` don't need Django Queryset, we only need return `None`.
         return None
 
-    def get_submission(self):
-        # Perform the lookup filtering.
-        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
-
-        assert lookup_url_kwarg in self.kwargs, (
-                'Expected view %s to be called with a URL keyword argument '
-                'named "%s". Fix your URL conf, or set the `.lookup_field` '
-                'attribute on the view correctly.' %
-                (self.__class__.__name__, lookup_url_kwarg)
-        )
-
-        filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
-        print('FILTER KWARGS', filter_kwargs)
-
     def list(self, request, *args, **kwargs):
         format_type = kwargs.get('format', request.GET.get('format', 'json'))
         deployment = self._get_deployment()
@@ -640,7 +626,8 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         # of the submission disappears between the call to `build_formpack()`
         # and here, but allow a 500 error in that case because there's nothing
         # the client can do about it
-        snapshot = self.asset.versioned_snapshot(
+        snapshot = self.asset.snapshot(
+            regenerate=True,
             root_node_name=xml_root_node_name,
             version_uid=version_uid,
             submission_uuid=submission_uuid,


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Always regenerate (and update the root of the `<instance>` node) of the XML of the form when editing a submission to match the submission root name.

## Related issues

Closes #3996
