### PR TITLE
nlp - transcribe in progress status

### DIFF
--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -81,6 +81,7 @@ interface SubmissionsEditIds {
 interface SingleProcessingStoreData {
   transcript?: Transx;
   transcriptDraft?: TransxDraft;
+  transcriptIsSlow?: boolean;
   translations: Transx[];
   translationDraft?: TransxDraft;
   /** Being displayed on the left side of the screen during translation editing. */
@@ -117,10 +118,15 @@ class SingleProcessingStore extends Reflux.Store {
 
     this.data.transcript = undefined;
     this.data.transcriptDraft = undefined;
+    this.data.transcriptIsSlow = false;
     this.data.translations = [];
     this.data.translationDraft = undefined;
     this.data.source = undefined;
     this.data.activeTab = SingleProcessingTabs.Transcript;
+  }
+
+  public get transcriptIsSlow() {
+    return this.data.transcriptIsSlow;
   }
 
   public get currentAssetUid(): string {
@@ -174,6 +180,7 @@ class SingleProcessingStore extends Reflux.Store {
     processingActions.deleteTranscript.completed.listen(this.onDeleteTranscriptCompleted.bind(this));
     processingActions.deleteTranscript.failed.listen(this.onAnyCallFailed.bind(this));
     processingActions.requestAutoTranscription.completed.listen(this.onRequestAutoTranscriptionCompleted.bind(this));
+    processingActions.requestAutoTranscription.in_progress.listen(this.onRequestAutoTranscriptionInProgress.bind(this));
     processingActions.requestAutoTranscription.failed.listen(this.onAnyCallFailed.bind(this));
     processingActions.setTranslation.completed.listen(this.onSetTranslationCompleted.bind(this));
     processingActions.setTranslation.failed.listen(this.onAnyCallFailed.bind(this));
@@ -521,6 +528,11 @@ class SingleProcessingStore extends Reflux.Store {
     ) {
       this.data.transcriptDraft.value = googleTsResponse.value;
     }
+    this.trigger(this.data);
+  }
+
+  private onRequestAutoTranscriptionInProgress() {
+    this.data.transcriptIsSlow = true;
     this.trigger(this.data);
   }
 

--- a/jsapp/js/components/processing/transcriptTabContent.tsx
+++ b/jsapp/js/components/processing/transcriptTabContent.tsx
@@ -300,7 +300,7 @@ export default class TranscriptTabContent extends React.Component<{}> {
               type='full'
               color='blue'
               size='m'
-              label={t('create transcript')}
+              label={singleProcessingStore.transcriptIsSlow ? t('in progress') : t('create transcript')}
               onClick={this.requestAutoTranscription.bind(this)}
               isDisabled={singleProcessingStore.isFetchingData}
             />

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -5,9 +5,9 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.core.cache import cache
-from googleapiclient import discovery
 
 from google.cloud import speech, storage
+from googleapiclient import discovery
 
 from ...constants import GOOGLE_CACHE_TIMEOUT, make_async_cache_key
 from ...exceptions import AudioTooLongError, SubsequenceTimeoutError

--- a/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
+++ b/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
@@ -306,7 +306,7 @@ class GoogleTranscriptionSubmissionTest(APITestCase):
         }
         with self.assertNumQueries(21):
             res = self.client.post(url, data, format='json')
-        self.assertContains(res, "complete")
+        self.assertContains(res, 'complete')
         with self.assertNumQueries(17):
             self.client.post(url, data, format='json')
 
@@ -318,9 +318,9 @@ class GoogleTranscriptionSubmissionTest(APITestCase):
         """Tests when slow running operation has already started"""
         url = reverse('advanced-submission-post', args=[self.asset.uid])
         submission_id = 'abc123-def456'
-        xpath = "q1"
-        source = ""
-        operation_name = "testop"
+        xpath = 'q1'
+        source = ''
+        operation_name = 'testop'
         cache.set(make_async_cache_key(self.user.pk, submission_id, xpath, source), operation_name)
         submission = {
             '__version__': self.asset.latest_deployed_version.uid,
@@ -336,7 +336,7 @@ class GoogleTranscriptionSubmissionTest(APITestCase):
             'q1': {GOOGLETS: {'status': 'requested', 'languageCode': ''}}
         }
         res = self.client.post(url, data, format='json')
-        self.assertContains(res, "complete")
+        self.assertContains(res, 'complete')
 
 
     @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})


### PR DESCRIPTION
- Slow transcription requests now return 200 with in progress status. Frontend still does not automatically retry.
- Added test for fetching an existing operation
- Poll every 10 seconds for transcript completion
- Show "in progress" during longer poll

import order shuffle is from isort