### PR TITLE
Allow registration from listed domains only

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -140,6 +140,11 @@ CONSTANCE_CONFIG = {
         True,
         'Allow new users to register accounts for themselves',
     ),
+    'REGISTRATION_ALLOWED_EMAIL_DOMAINS': (
+        '',
+        'Email domains allowed to register new accounts, one per line, '
+        'or blank to allow all email domains'
+    ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
     'PRIVACY_POLICY_URL': ('', 'URL for privacy policy'),
     'SOURCE_CODE_URL': (

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -145,6 +145,11 @@ CONSTANCE_CONFIG = {
         'Email domains allowed to register new accounts, one per line, '
         'or blank to allow all email domains'
     ),
+    'REGISTRATION_DOMAIN_NOT_ALLOWED_ERROR_MESSAGE': (
+        'This email domain is not allowed to create an account',
+        'Error message for emails not listed in REGISTRATION_ALLOWED_EMAIL_DOMAINS '
+        'if field is not blank'
+    ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
     'PRIVACY_POLICY_URL': ('', 'URL for privacy policy'),
     'SOURCE_CODE_URL': (

--- a/kpi/forms/registration.py
+++ b/kpi/forms/registration.py
@@ -118,5 +118,5 @@ class RegistrationForm(registration_forms.RegistrationForm):
             return email
         else:
             raise forms.ValidationError(
-                t('This email domain is not allowed to create an account')
+                constance.config.REGISTRATION_DOMAIN_NOT_ALLOWED_ERROR_MESSAGE
             )

--- a/kpi/forms/registration.py
+++ b/kpi/forms/registration.py
@@ -103,3 +103,20 @@ class RegistrationForm(registration_forms.RegistrationForm):
                 self.fields[field_name].required = desired_metadata_fields[
                     field_name
                 ].get('required', False)
+
+    def clean_email(self):
+        email = self.cleaned_data['email']
+        domain = email.split('@')[1].lower()
+        allowed_domains = (
+            constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
+        )
+        allowed_domain_list = [
+            domain.lower() for domain in allowed_domains.split('\n')
+        ]
+        # An empty domain list means all domains are allowed
+        if domain in allowed_domain_list or not allowed_domains:
+            return email
+        else:
+            raise forms.ValidationError(
+                t('This email domain is not allowed to create an account')
+            )

--- a/kpi/tests/test_registration.py
+++ b/kpi/tests/test_registration.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+import constance
+from constance.test import override_config
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils.translation import gettext as t
+
+
+class RegistrationTestCase(TestCase):
+    @property
+    def valid_data(self):
+        User = get_user_model()
+        return {
+            User.USERNAME_FIELD: "alice",
+            "email": "alice@example.com",
+            "password1": "swordfish",
+            "password2": "swordfish",
+        }
+
+    def test_empty_string_allows_all_domains(self):
+        self.assertEqual(
+            constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS, ''
+        )
+        response = self.client.post(
+            reverse("registration_register"), data=self.valid_data
+        )
+        self.assertRedirects(response, '/accounts/register/complete/')
+
+    @override_config(REGISTRATION_ALLOWED_EMAIL_DOMAINS='foo.bar\nexample.com')
+    def test_allowed_domain_can_register(self):
+        response = self.client.post(
+            reverse("registration_register"), data=self.valid_data
+        )
+        self.assertRedirects(response, '/accounts/register/complete/')
+
+    @override_config(REGISTRATION_ALLOWED_EMAIL_DOMAINS='foo.bar\nbaz.qux')
+    def test_disallowed_domain_cannot_register(self):
+        response = self.client.post(
+            reverse("registration_register"), data=self.valid_data
+        )
+        self.assertIn(
+            t('This email domain is not allowed to create an account').encode(),
+            response.content,
+        )

--- a/kpi/tests/test_registration.py
+++ b/kpi/tests/test_registration.py
@@ -12,10 +12,10 @@ class RegistrationTestCase(TestCase):
     def valid_data(self):
         User = get_user_model()
         return {
-            User.USERNAME_FIELD: "alice",
-            "email": "alice@example.com",
-            "password1": "swordfish",
-            "password2": "swordfish",
+            User.USERNAME_FIELD: 'alice',
+            'email': 'alice@example.com',
+            'password1': 'swordfish',
+            'password2': 'swordfish',
         }
 
     def test_empty_string_allows_all_domains(self):
@@ -23,21 +23,21 @@ class RegistrationTestCase(TestCase):
             constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS, ''
         )
         response = self.client.post(
-            reverse("registration_register"), data=self.valid_data
+            reverse('registration_register'), data=self.valid_data
         )
         self.assertRedirects(response, '/accounts/register/complete/')
 
     @override_config(REGISTRATION_ALLOWED_EMAIL_DOMAINS='foo.bar\nexample.com')
     def test_allowed_domain_can_register(self):
         response = self.client.post(
-            reverse("registration_register"), data=self.valid_data
+            reverse('registration_register'), data=self.valid_data
         )
         self.assertRedirects(response, '/accounts/register/complete/')
 
     @override_config(REGISTRATION_ALLOWED_EMAIL_DOMAINS='foo.bar\nbaz.qux')
     def test_disallowed_domain_cannot_register(self):
         response = self.client.post(
-            reverse("registration_register"), data=self.valid_data
+            reverse('registration_register'), data=self.valid_data
         )
         self.assertIn(
             t('This email domain is not allowed to create an account').encode(),


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Adds a feature which will only allow users with specified email domains to register for the the app. 

## Related issues
