### PR TITLE
Duplicate attachments with duplicated submissions

### DIFF
--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1353,6 +1353,7 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         assert submission['_id'] != duplicate_submission['_id']
         assert duplicate_submission['_id'] == expected_next_id
         assert submission['meta/instanceID'] != duplicate_submission['meta/instanceID']
+        assert submission['meta/instanceID'] == duplicate_submission['meta/deprecatedID']
         assert submission['start'] != duplicate_submission['start']
         assert submission['end'] != duplicate_submission['end']
 


### PR DESCRIPTION
## Description

Ensure that attachments are duplicated along with duplicated submissions. This was not included in the original work done in #2897.

## Related issues

extending #2894

## Additional details

- Discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Duplicate.20attachments.20with.20duplicated.20submissions/near/157642
- Notion: https://www.notion.so/kobotoolbox/submission-duplication-feature-doesn-t-duplicate-attachments-cd7c122403be43f483e79650f232579b