### PR TITLE
Shorten toast notification duration to 5 seconds

### DIFF
--- a/jsapp/js/app.es6
+++ b/jsapp/js/app.es6
@@ -105,7 +105,7 @@ export default class App extends React.Component {
                 background: '#1e2129', //$kobo-gray-14
                 color: '#fff',
               },
-              duration: 10000,
+              duration: 5000, // 5 seconds
             }}
           />
         </React.Fragment>


### PR DESCRIPTION
## Description

Show toast notifications for 5 seconds, rather than 10 seconds.

## Related issues

Follow-up to #3972
Part of #3837

## Discussion

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/7-UX.2FUI/topic/new.20alert.20toast/near/157903