### PR TITLE
Remove 'metadata' field from the Account Settings UI

### DIFF
--- a/jsapp/js/components/account/accountSettingsRoute.es6
+++ b/jsapp/js/components/account/accountSettingsRoute.es6
@@ -92,7 +92,6 @@ export default class AccountSettings extends React.Component {
         twitter: currentAccount.extra_details.twitter,
         linkedin: currentAccount.extra_details.linkedin,
         instagram: currentAccount.extra_details.instagram,
-        metadata: currentAccount.extra_details.metadata,
       },
       fieldsWithErrors: {},
       languageChoices: environment.all_languages,
@@ -140,7 +139,6 @@ export default class AccountSettings extends React.Component {
           twitter: this.state.fields.twitter,
           linkedin: this.state.fields.linkedin,
           instagram: this.state.fields.instagram,
-          metadata: this.state.fields.metadata,
         }),
       },
       {
@@ -412,16 +410,6 @@ export default class AccountSettings extends React.Component {
                   }
                 </bem.AccountSettings__item>
               }
-
-              <bem.AccountSettings__item>
-                <TextBox
-                  customModifiers='on-white'
-                  label={t('Metadata')}
-                  errors={this.state.fieldsWithErrors.metadata}
-                  value={this.state.fields.metadata}
-                  onChange={this.onAnyFieldChange.bind(this, 'metadata')}
-                />
-              </bem.AccountSettings__item>
             </bem.AccountSettings__item>
           </bem.AccountSettings__item>
         </bem.AccountSettings>

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -588,7 +588,6 @@ export const dataInterface: DataInterface = {
       twitter?: string;
       linkedin?: string;
       instagram?: string;
-      metadata?: string;
     };
     current_password?: string;
     new_password?: string;


### PR DESCRIPTION
## Description

Remove 'metadata' field from the Account Settings UI.

## Related issues

Implements #4043 