### PR TITLE
Update submission version with edit to match form version

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -131,6 +131,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         Returns:
             dict: formatted dict to be passed to a Response object
         """
+        version_uid = self.asset.latest_deployed_version.uid
+
         submission_ids = self.validate_access_with_partial_perms(
             user=user,
             perm=PERM_CHANGE_SUBMISSIONS,
@@ -182,6 +184,10 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             )
             deprecated_id_or_new.text = instance_id.text
             instance_id.text = uuid_formatted
+
+            # Update the `__version__` value in the submission to match the
+            # version of the form used for editing
+            xml_parsed.find('__version__').text = version_uid
 
             # If the form has been updated with new fields and earlier
             # submissions have been selected as part of the bulk update,

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -69,6 +69,8 @@ class MockDeploymentBackend(BaseDeploymentBackend):
     def bulk_update_submissions(
         self, data: dict, user: 'auth.User'
     ) -> dict:
+        version_uid = self.asset.latest_deployed_version.uid
+
         submission_ids = self.validate_access_with_partial_perms(
             user=user,
             perm=PERM_CHANGE_SUBMISSIONS,
@@ -111,6 +113,10 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             )
             deprecated_id_or_new.text = instance_id.text
             instance_id.text = uuid_formatted
+
+            # Update the `__version__` value in the submission to match the
+            # version of the form used for editing
+            xml_parsed.find('__version__').text = version_uid
 
             for path, value in update_data.items():
                 edit_submission_xml(xml_parsed, path, value)

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -755,9 +755,11 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         json_response = response.json()
         enketo_url = json_response.get(f'{action_}_url')
 
-        return Response(
-            {
-                'url': enketo_url,
-                'version_uid': version_uid,
-            }
-        )
+        response = {
+            'url': enketo_url,
+            'version_uid': version_uid,
+        }
+        if settings.TESTING:
+            response['submission_xml'] = submission_xml
+
+        return Response(response)

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -691,7 +691,13 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         # root node name specified in the form XML (i.e. the first child of
         # `<instance>`) must match the root node name of the submission XML,
         # otherwise Enketo will refuse to open the submission.
-        xml_root_node_name = ET.fromstring(submission_xml).tag
+        parsed_submission_xml = ET.fromstring(submission_xml)
+        xml_root_node_name = parsed_submission_xml.tag
+
+        # Update the `__version__` value in the submission to match the
+        # version of the form used for editing
+        parsed_submission_xml.find('__version__').text = version_uid
+        submission_xml = ET.tostring(parsed_submission_xml)
 
         # This will raise `AssetVersion.DoesNotExist` if the inferred version
         # of the submission disappears between the call to `build_formpack()`


### PR DESCRIPTION
## Description

Update the submission `__version__` value to use the latest deployed version of the form (#4033) for both single and bulk edit operations. This ensures that, if submissions are edited with a form version different to their original, the added data will be included in the export when `fields_from_all_versions` is set to `True`.

## Related issues

closes #4041 
