### PR TITLE
Do NOT enable `verbose = true` for Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [tool.black]
-verbose = true
+# Do not enable `verbose = true` unless Black changes their behavior to respect
+# `--quiet` on the command line properly
+# verbose = true
 line-length = 80
 skip-string-normalization = true
 [tool.isort]


### PR DESCRIPTION
It unconditionally overrides the `--quiet` command-line argument and breaks any workflows using Black in a pipe.