### PR TITLE
3939 knowncols  regioncodes

### DIFF
--- a/jsapp/js/components/processing/processingActions.ts
+++ b/jsapp/js/components/processing/processingActions.ts
@@ -71,11 +71,13 @@ interface AutoTranscriptRequest {
   [qpath: string]: AutoTranscriptRequestQuestion | string | undefined;
   submission?: string;
 }
+interface AutoTranscriptRequestEngineParams {
+  status: 'requested';
+  languageCode?: string;
+  regionCode?: string;
+}
 interface AutoTranscriptRequestQuestion {
-  googlets: {
-    status: 'requested';
-    languageCode: string;
-  };
+  googlets: AutoTranscriptRequestEngineParams;
 }
 
 interface TranslationRequest {
@@ -334,7 +336,8 @@ processingActions.requestAutoTranscription.listen((
   assetUid: string,
   qpath: string,
   submissionEditId: string,
-  languageCode: string
+  languageCode?: string,
+  regionCode?: string,
 ) => {
   const processingUrl = getAssetProcessingUrl(assetUid);
   if (processingUrl === undefined) {
@@ -343,11 +346,15 @@ processingActions.requestAutoTranscription.listen((
     const data: AutoTranscriptRequest = {
       submission: submissionEditId,
     };
+    let autoparams: AutoTranscriptRequestEngineParams = {status: 'requested'};
+    if (languageCode) {
+      autoparams.languageCode = languageCode;
+    }
+    if (regionCode) {
+      autoparams.regionCode = regionCode;
+    }
     data[qpath] = {
-      googlets: {
-        status: 'requested',
-        languageCode: languageCode,
-      },
+      googlets: autoparams,
     };
 
     $.ajax({
@@ -371,7 +378,8 @@ processingActions.requestAutoTranscription.listen((
               assetUid,
               qpath,
               submissionEditId,
-              languageCode
+              languageCode,
+              regionCode,
             )
           , 5000);
         } else {

--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -634,13 +634,14 @@ class SingleProcessingStore extends Reflux.Store {
     this.trigger(this.data);
   }
 
-  requestAutoTranscription(languageCode: string) {
+  requestAutoTranscription(languageCode: string, regionCode?: string) {
     this.isFetchingData = true;
     processingActions.requestAutoTranscription(
       this.currentAssetUid,
       this.currentQuestionQpath,
       this.currentSubmissionEditId,
-      languageCode
+      languageCode,
+      regionCode,
     );
     this.trigger(this.data);
   }

--- a/jsapp/js/components/processing/transcriptTabContent.tsx
+++ b/jsapp/js/components/processing/transcriptTabContent.tsx
@@ -135,7 +135,7 @@ export default class TranscriptTabContent extends React.Component<{}> {
       draft?.value !== undefined
     ) {
       singleProcessingStore.setTranscript(
-        draft.regionCode || draft.languageCode,
+        draft.languageCode,
         draft.value
       );
     }
@@ -164,9 +164,7 @@ export default class TranscriptTabContent extends React.Component<{}> {
   renderLanguageAndDate() {
     const storeTranscript = singleProcessingStore.getTranscript();
     const draft = singleProcessingStore.getTranscriptDraft();
-    const valueLanguageCode = (
-      draft?.regionCode || draft?.languageCode || storeTranscript?.languageCode
-    );
+    const valueLanguageCode = draft?.languageCode || storeTranscript?.languageCode;
     if (valueLanguageCode === undefined) {
       return null;
     }

--- a/jsapp/js/components/processing/transcriptTabContent.tsx
+++ b/jsapp/js/components/processing/transcriptTabContent.tsx
@@ -82,12 +82,13 @@ export default class TranscriptTabContent extends React.Component<{}> {
   }
 
   requestAutoTranscription() {
-    const toLanguageCode = (
-      singleProcessingStore.getTranscriptDraft()?.regionCode ||
-      singleProcessingStore.getTranscriptDraft()?.languageCode
-    );
-    if (toLanguageCode) {
-      singleProcessingStore.requestAutoTranscription(toLanguageCode);
+    let draft = singleProcessingStore.getTranscriptDraft();
+    let languageCode = draft?.languageCode;
+    let regionCode = draft?.regionCode;
+    if (languageCode && regionCode) {
+      singleProcessingStore.requestAutoTranscription(languageCode, regionCode);
+    } else if (languageCode) {
+      singleProcessingStore.requestAutoTranscription(languageCode);
     }
   }
 

--- a/kobo/apps/subsequences/actions/automatic_transcription.py
+++ b/kobo/apps/subsequences/actions/automatic_transcription.py
@@ -47,6 +47,7 @@ class AutomaticTranscriptionAction(BaseAction):
                 self.DATE_MODIFIED_FIELD: {'type': 'string',
                                            'format': 'date-time'},
                 'languageCode': {'type': 'string'},
+                'regionCode': {'type': 'string'},
                 'revisions': {'type': 'array', 'items': {
                     '$ref': '#/definitions/transcriptRevision'
                 }}


### PR DESCRIPTION
These changes should only touch automatic transcriptions

* split out specification of `languageCode` and `regionCode` on the front end
* Pass both values to the back end when requesting automatic transcript
* transcript ends up in the column corresponding to the `languageCode`
