### PR TITLE
Fix project settings name not being able to be edited

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -893,8 +893,6 @@ class ProjectSettings extends React.Component {
                 errors={this.hasFieldError('name') ? t('Please enter a title for your project!') : false}
                 label={addRequiredToLabel(this.getNameInputLabel(this.state.fields.name))}
                 placeholder={t('Enter title of project here')}
-                value={this.state.name}
-                onChange={this.onNameChange}
                 data-cy='title'
               />
             </bem.FormModal__item>


### PR DESCRIPTION
## Description

Project name in the settings was not editable due to bad merge conflict resolving.

## Related issues

Fixes #4115