### PR TITLE
remove fields starting with $ from XLSForm exports

### DIFF
--- a/kpi/mixins/formpack_xlsform_utils.py
+++ b/kpi/mixins/formpack_xlsform_utils.py
@@ -116,13 +116,16 @@ class FormpackXLSFormUtilsMixin:
             if '$kuid' not in row:
                 row['$kuid'] = random_id(9)
 
-    def _strip_kuids(self, content):
+    def _strip_dollar_fields(self, content):
         # this is important when stripping out kobo-specific types because the
         # $kuid field in the xform prevents cascading selects from rendering
-        for row in content['survey']:
-            row.pop('$kuid', None)
-        for row in content.get('choices', []):
-            row.pop('$kuid', None)
+        # and other $fields end up in the exported XLSForm
+        startswithdollar = lambda key: key.startswith('$')
+        strip_row = lambda row, fields: [row.pop(key) for key in fields]
+        for sheet in ['survey', 'choices']:
+            for row in content.get(sheet, []):
+                dollar_fields = list(filter(startswithdollar, row.keys()))
+                strip_row(row, dollar_fields)
 
     def _link_list_items(self, content):
         arr = content['survey']

--- a/kpi/mixins/xls_exportable.py
+++ b/kpi/mixins/xls_exportable.py
@@ -27,7 +27,7 @@ class XlsExportableMixin:
             self._expand_kobo_qs(content)
             self._autoname(content)
             self._populate_fields_with_autofields(content)
-            self._strip_kuids(content)
+            self._strip_dollar_fields(content)
             revert_kobo_lock_structure(content)
         content = OrderedDict(content)
         self._xlsform_structure(

--- a/kpi/models/asset_snapshot.py
+++ b/kpi/models/asset_snapshot.py
@@ -212,7 +212,7 @@ class AssetSnapshot(
         source_copy = copy.deepcopy(source)
         self._expand_kobo_qs(source_copy)
         self._populate_fields_with_autofields(source_copy)
-        self._strip_kuids(source_copy)
+        self._strip_dollar_fields(source_copy)
 
         allow_choice_duplicates(source_copy)
 

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -830,7 +830,7 @@ def test_kuid_persists():
             {'type': 'text', 'name': 'def', '$kuid': initial_kuid_2},
         ],
     })
-    # kobo_specific_types=True avoids calling _strip_kuids
+    # kobo_specific_types=True avoids calling _strip_dollar_fields
     # so, can we assume that kuids are supposed to remain?
     content = asset.ordered_xlsform_content(kobo_specific_types=True)
     # kuids are stripped in "kobo_to_xlsform.to_xlsform_structure(...)"

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -98,7 +98,7 @@ class CreateAssetVersions(AssetsTestCase):
         # _kuid1 = _content['survey'][0]['$kuid']
         _content_copy = deepcopy(_content)
         # remove this next line when todo is fixed
-        self.asset._strip_kuids(_content_copy)
+        self.asset._strip_dollar_fields(_content_copy)
         _c1 = json.dumps(_content_copy, sort_keys=True)
         surv_l = len(_content['survey'])
         self.assertEqual(surv_l, 2)
@@ -116,7 +116,7 @@ class CreateAssetVersions(AssetsTestCase):
         aa = Asset.objects.get(uid=self.asset.uid)
         _content_copy2 = deepcopy(aa.content)
         # remove this next line when todo is fixed
-        self.asset._strip_kuids(_content_copy2)
+        self.asset._strip_dollar_fields(_content_copy2)
         _c3 = json.dumps(_content_copy2, sort_keys=True)
         # _kuid3 = aa.content['survey'][0]['$kuid']
         surv_l_3 = len(aa.content['survey'])
@@ -508,25 +508,6 @@ class AssetSnapshotXmlTestCase(AssetSettingsTests):
         self.assertTrue('<h:title>abcxyz</h:title>' in export.xml)
         self.assertTrue(f'<{a1.uid} id="xid_stringx">' in export.xml)
 
-
-# TODO: test values of "valid_xlsform_content"
-
-# class ReadAssetsTests(AssetsTestCase):
-#     def test_strip_kuids(self):
-#         sans_kuid = self.sa.to_ss_structure(content_tag='survey', strip_kuids=True)['survey']
-#         self.assertEqual(len(sans_kuid), 2)
-#         self.assertTrue('kuid' not in sans_kuid[0].keys())
-
-# class UpdateAssetsTest(AssetsTestCase):
-#     def test_add_settings(self):
-#         self.assertEqual(self.asset.settings, None)
-#         self.asset.settings = {'style':'grid-theme'}
-# self.assertEqual(self.asset.settings, {'style':'grid-theme'})
-#         ss_struct = self.asset.to_ss_structure()['settings']
-#         self.assertEqual(len(ss_struct), 1)
-#         self.assertEqual(ss_struct[0], {
-#                 'style': 'grid-theme',
-#             })
 
 class ShareAssetsTest(AssetsTestCase):
 


### PR DESCRIPTION
Removes fields starting with `$` from XLSForm exports