### PR TITLE
Fix compiled directory not existing on first run local dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 /src/
 kpi/static/components
 misc
-jsapp/compiled
 jsapp/tmp
 jsapp/js/libs/xlform.js
 jsapp/js/refactored.es6

--- a/jsapp/compiled/.gitignore
+++ b/jsapp/compiled/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
When a user runs npm outside of docker, if nothing created the jsapp/compiled directory, it will error. This change prevents that.

Use cases this improves

- I decided to run npm run watch before ./run.py
- I don't want to run kobo-install for local dev