### PR TITLE
Remove extra 'Primary Sector' label

### DIFF
--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -243,10 +243,6 @@ export class LibraryAssetForm extends React.Component {
           </bem.FormModal__item>
 
           <bem.FormModal__item>
-
-            <label htmlFor='sector'>
-              {t('Primary Sector')}
-            </label>
             <WrappedSelect
               label={t('Primary Sector')}
               value={this.state.fields.sector}


### PR DESCRIPTION
## Description

Remove extra 'Primary Sector' label when creating a new Template or Collection in the library.

## Screenshots
<img width="736" alt="Before Fix" src="https://user-images.githubusercontent.com/3514715/202285749-fd4042ae-b1df-4d5c-865a-c31774295e39.png">
<img width="749" alt="After Fix" src="https://user-images.githubusercontent.com/3514715/202285746-9aedc7f0-0342-43ab-89cb-aa6ba6adb2b6.png">