### PR TITLE
Fix timeout when superusers try to open MFA user's details Admin UI

### DIFF
--- a/kobo/apps/mfa/models.py
+++ b/kobo/apps/mfa/models.py
@@ -93,4 +93,8 @@ class MfaMethod(TrenchMFAMethod):
 
 class MfaMethodAdmin(TrenchMFAMethodAdmin):
 
-    search_fields = ['user__username']
+    search_fields = ('user__username',)
+    autocomplete_fields = ['user']
+
+    def has_add_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Use a (paginated) autocomplete field instead of select box (which loads all users at once).

## Related issues

Closes #4142 