### PR TITLE
Fix metadata handling in user details export

### DIFF
--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -576,7 +576,7 @@ def generate_user_details_report(output_filename: str):
         writer = csv.writer(f)
         writer.writerow(columns)
         for row in data:
-            metadata = row.pop('metadata', {})
+            metadata = row.pop('metadata', {}) or {}
             flatten_metadata_inplace(metadata)
             row.update(metadata)
             flat_row = [get_row_value(row, col) for col in columns]


### PR DESCRIPTION
## Description

Fix the user details export that was broken in [this change](https://github.com/kobotoolbox/kpi/pull/3976/commits/0bc077845ce2a73b0cae85148a33b6914b36981a#diff-6ad552ff8c1cf97c94e6797f8bb1b856180a0a967e12963e59593a71578ec7f2R235) as it no longer handled the case of `metadata` being `None`.

## Related issues

fix #3976
