### PR TITLE
Define routes for projects views

### DIFF
--- a/jsapp/js/components/common/koboDropdown.tsx
+++ b/jsapp/js/components/common/koboDropdown.tsx
@@ -31,6 +31,8 @@ interface KoboDropdownProps {
    */
   name: string;
   'data-cy'?: string;
+  /** Alternative way of getting the opened status of the menu. */
+  onMenuVisibilityChange?: (isOpened: boolean) => void;
 }
 
 interface KoboDropdownState {
@@ -107,6 +109,9 @@ export default class KoboDropdown extends React.Component<
   showMenu() {
     this.setState({isMenuVisible: true});
     koboDropdownActions.menuVisibilityChange(this.props.name, true);
+    if (this.props.onMenuVisibilityChange) {
+      this.props.onMenuVisibilityChange(true);
+    }
     // Hides menu when user clicks outside it.
     this.registerEscKeyListener();
     // Hides menu when opened and user uses Escape key.
@@ -116,6 +121,9 @@ export default class KoboDropdown extends React.Component<
   hideMenu() {
     this.setState({isMenuVisible: false});
     koboDropdownActions.menuVisibilityChange(this.props.name, false);
+    if (this.props.onMenuVisibilityChange) {
+      this.props.onMenuVisibilityChange(false);
+    }
     this.cancelEscKeyListener();
     this.cancelOutsideClickListener();
   }

--- a/jsapp/js/projects/customViewsRoute.tsx
+++ b/jsapp/js/projects/customViewsRoute.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function CustomViewsRoute() {
+  return (
+    <div>
+      <h1>Custom Views route</h1>
+    </div>
+  );
+}

--- a/jsapp/js/projects/customViewsRoute.tsx
+++ b/jsapp/js/projects/customViewsRoute.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ViewSwitcher from './projectsView/viewSwitcher';
 
 export default function CustomViewsRoute() {
   return (
     <div>
-      <h1>Custom Views route</h1>
+      <ViewSwitcher viewUid='1' viewCount={15}/>
+      TBD Custom View 1
     </div>
   );
 }

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ViewSwitcher from './projectsView/viewSwitcher';
 
 export default function MyProjectsRoute() {
   return (
     <div>
-      <h1>My Projects route</h1>
+      <ViewSwitcher viewUid='kobo_my_projects' viewCount={999}/>
+      TBD My Projects
     </div>
   );
 }

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function MyProjectsRoute() {
+  return (
+    <div>
+      <h1>My Projects route</h1>
+    </div>
+  );
+}

--- a/jsapp/js/projects/projectsView/viewSwitcher.module.scss
+++ b/jsapp/js/projects/projectsView/viewSwitcher.module.scss
@@ -1,0 +1,63 @@
+@use 'sass:color';
+@use 'scss/sizes';
+@use 'scss/colors';
+@use 'scss/mixins';
+@use 'js/components/common/button';
+
+.root {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.trigger-icon {
+  margin-left: sizes.$x5;
+}
+
+.root.is-menu-visible .trigger-icon {
+  color: colors.$kobo-blue;
+}
+
+.trigger {
+  @include mixins.buttonReset;
+  @include mixins.centerRowFlex;
+  font-size: sizes.$x20;
+  font-weight: 800;
+  color: colors.$kobo-gray-24;
+  padding: sizes.$x6 sizes.$x16;
+}
+
+.trigger-badge {
+  margin-left: sizes.$x14;
+  font-size: sizes.$x13;
+  line-height: sizes.$x16;
+  background-color: colors.$kobo-cloud;
+  border-radius: sizes.$x14;
+  padding: sizes.$x6 sizes.$x14;
+}
+
+.menu {
+  display: block;
+  width: 100%;
+  min-width: sizes.$x300;
+  max-height: sizes.$x200;
+  max-width: sizes.$x300;
+  overflow-x: auto;
+  padding: sizes.$x20 0;
+  border-radius: button.$button-border-radius;
+  background-color: colors.$kobo-white;
+  box-shadow: 0 0 sizes.$x6 color.change(colors.$kobo-storm, $alpha: 0.3);
+}
+
+.menu-option {
+  @include mixins.buttonReset;
+  @include mixins.textEllipsis;
+  font-size: sizes.$x16;
+  font-weight: 500;
+  padding: sizes.$x10 sizes.$x30;
+  width: 100%;
+  text-align: left;
+
+  &:hover {
+    color: colors.$kobo-blue;
+  }
+}

--- a/jsapp/js/projects/projectsView/viewSwitcher.tsx
+++ b/jsapp/js/projects/projectsView/viewSwitcher.tsx
@@ -67,6 +67,7 @@ export default function ViewSwitcher(props: ViewSwitcherProps) {
           <div className={styles.menu}>
             {DEFINED_VIEWS.map((view) =>
               <button
+                key={view.uid}
                 className={styles['menu-option']}
                 onClick={() => onOptionClick(view.uid)}
               >

--- a/jsapp/js/projects/projectsView/viewSwitcher.tsx
+++ b/jsapp/js/projects/projectsView/viewSwitcher.tsx
@@ -1,0 +1,81 @@
+import React, {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import classNames from 'classnames';
+import Icon from 'js/components/common/icon';
+import KoboDropdown, {KoboDropdownPlacements} from 'js/components/common/koboDropdown';
+import {PROJECTS_ROUTES} from 'js/projects/routes';
+import styles from './viewSwitcher.module.scss';
+
+// TODO get this list from backend:
+const DEFINED_VIEWS = [
+  {
+    uid: 'kobo_my_projects',
+    label: t('My Projects'),
+  },
+  {
+    uid: '1',
+    label: 'Custom View 1',
+  },
+];
+
+interface ViewSwitcherProps {
+  viewUid: string;
+  /** Total number of asset of current view. */
+  viewCount?: number;
+  disabled?: boolean;
+}
+
+export default function ViewSwitcher(props: ViewSwitcherProps) {
+  // We track the menu visibility for the trigger icon.
+  const [isMenuVisible, setIsMenuVisible] = useState(false);
+  const navigate = useNavigate();
+
+  const onOptionClick = (viewUid: string) => {
+    console.log(viewUid);
+    if (viewUid === 'kobo_my_projects' || viewUid === null) {
+      navigate(PROJECTS_ROUTES.MY_PROJECTS);
+    } else {
+      navigate(PROJECTS_ROUTES.CUSTOM_VIEW.replace(':viewUid', viewUid));
+    }
+  };
+
+  return (
+    <div className={classNames({
+      [styles.root]: true,
+      [styles['is-menu-visible']]: isMenuVisible,
+    })}>
+      <KoboDropdown
+        name='projects_view_switcher'
+        placement={KoboDropdownPlacements['down-left']}
+        isDisabled={props.disabled || false}
+        hideOnMenuClick
+        onMenuVisibilityChange={setIsMenuVisible}
+        triggerContent={
+          <button className={styles.trigger}>
+            {DEFINED_VIEWS.find((view) => view.uid === props.viewUid)?.label}
+            {props.viewCount !== undefined &&
+              <span className={styles['trigger-badge']}>{props.viewCount}</span>
+            }
+            <Icon
+              classNames={[styles['trigger-icon']]}
+              size='xxs'
+              name={isMenuVisible ? 'caret-up' : 'caret-down'}
+            />
+          </button>
+        }
+        menuContent={
+          <div className={styles.menu}>
+            {DEFINED_VIEWS.map((view) =>
+              <button
+                className={styles['menu-option']}
+                onClick={() => onOptionClick(view.uid)}
+              >
+                {view.label}
+              </button>
+            )}
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/jsapp/js/projects/routes.tsx
+++ b/jsapp/js/projects/routes.tsx
@@ -12,7 +12,7 @@ const CustomViewsRoute = React.lazy(
 
 export const PROJECTS_ROUTES: {readonly [key: string]: string} = {
   MY_PROJECTS: ROUTES.PROJECTS_ROOT + '/my',
-  CUSTOM_VIEWS: ROUTES.PROJECTS_ROOT + '/custom/:viewuid',
+  CUSTOM_VIEW: ROUTES.PROJECTS_ROOT + '/custom/:viewUid',
 };
 
 export default function routes() {
@@ -31,7 +31,7 @@ export default function routes() {
         }
       />
       <Route
-        path={PROJECTS_ROUTES.CUSTOM_VIEWS}
+        path={PROJECTS_ROUTES.CUSTOM_VIEW}
         element={
           <RequireAuth>
             <CustomViewsRoute/>

--- a/jsapp/js/projects/routes.tsx
+++ b/jsapp/js/projects/routes.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {Navigate, Route} from 'react-router-dom';
+import RequireAuth from 'js/router/requireAuth';
+import {ROUTES} from 'js/router/routerConstants';
+
+const MyProjectsRoute = React.lazy(
+  () => import(/* webpackPrefetch: true */ './myProjectsRoute')
+);
+const CustomViewsRoute = React.lazy(
+  () => import(/* webpackPrefetch: true */ './customViewsRoute')
+);
+
+export const PROJECTS_ROUTES: {readonly [key: string]: string} = {
+  MY_PROJECTS: ROUTES.PROJECTS_ROOT + '/my',
+  CUSTOM_VIEWS: ROUTES.PROJECTS_ROOT + '/custom/:viewuid',
+};
+
+export default function routes() {
+  return (
+    <>
+      <Route
+        path=''
+        element={<Navigate to={PROJECTS_ROUTES.MY_PROJECTS} replace />}
+      />
+      <Route
+        path={PROJECTS_ROUTES.MY_PROJECTS}
+        element={
+          <RequireAuth>
+            <MyProjectsRoute/>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path={PROJECTS_ROUTES.CUSTOM_VIEWS}
+        element={
+          <RequireAuth>
+            <CustomViewsRoute/>
+          </RequireAuth>
+        }
+      />
+    </>
+  );
+}

--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -21,6 +21,7 @@ import sessionStore from 'js/stores/session';
 import {Tracking} from './useTracking';
 import {history} from './historyRouter';
 import accountRoutes from 'js/account/routes';
+import projectsRoutes from 'js/projects/routes';
 
 // Workaround https://github.com/remix-run/react-router/issues/8139
 import {unstable_HistoryRouter as HistoryRouter, Route} from 'react-router-dom';
@@ -128,6 +129,7 @@ const AllRoutes = class AllRoutes extends React.Component {
           <Route path={ROUTES.ROOT} element={<App />}>
             <Route path='' element={<Navigate to={ROUTES.FORMS} replace />} />
             <Route path={ROUTES.ACCOUNT_ROOT}>{accountRoutes()}</Route>
+            <Route path={ROUTES.PROJECTS_ROOT}>{projectsRoutes()}</Route>
             <Route path={ROUTES.LIBRARY}>
               <Route path='' element={<Navigate to={ROUTES.MY_LIBRARY} />} />
               <Route

--- a/jsapp/js/router/routerConstants.ts
+++ b/jsapp/js/router/routerConstants.ts
@@ -19,6 +19,7 @@ export const ROUTES = Object.freeze({
   NEW_LIBRARY_CHILD: '/library/asset/:uid/new',
   LIBRARY_ITEM_JSON: '/library/asset/:uid/json',
   LIBRARY_ITEM_XFORM: '/library/asset/:uid/xform',
+  PROJECTS_ROOT: '/projects',
   FORMS: '/forms',
   FORM: '/forms/:uid',
   FORM_JSON: '/forms/:uid/json',


### PR DESCRIPTION
## Description

Defines `/projects/my` and `/projects/custom/:viewuid` routes with a dropdown/switcher for upcoming feature.

## Notes for reviewer

- This establishes the `js/projects` as the feature directory. 
- Defines two routes that the feature will be using 
  - On of the routes - `/projects/my` - might end up not being used (depends if we have enought time), but the plan is for it to replace existing `/forms` with it
  - Both routes components are empty stubs prepared for further PRs
- A new component `ViewSwitcher` that is being used for switching between those routes is almost finished:
  - the list of available views is hardcoded
  - all the looks of it are final

## Related issues

Part of #4062
