### PR TITLE
Make the list of sidebar assets scrollable

### DIFF
--- a/jsapp/scss/components/_kobo.drawer.sidebar.scss
+++ b/jsapp/scss/components/_kobo.drawer.sidebar.scss
@@ -86,6 +86,13 @@
       height: 0;
       overflow: hidden;
     }
+
+    // Makes the list scrollable if there are a lot of items.
+    &.form-sidebar__grouping--visible {
+      max-height: 30vh;
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
   }
 
   .form-sidebar__item {


### PR DESCRIPTION
## Description

Fixes a long list of assets (drafts or deployed) breaking the UI by spanning over the end of the screen.