### PR TITLE
Fix layout jumps when typing password in strength checker

### DIFF
--- a/jsapp/js/components/passwordStrength.es6
+++ b/jsapp/js/components/passwordStrength.es6
@@ -87,7 +87,7 @@ class PasswordStrength extends React.Component {
           <bem.PasswordStrength__indicator/>
         </bem.PasswordStrength__bar>
 
-        {(report.feedback.warning || report.feedback.suggestions.length > 0) &&
+        {(report.feedback.warning || report.feedback.suggestions.length > 0) ?
           <bem.PasswordStrength__messages>
             {report.feedback.warning &&
               <bem.PasswordStrength__message m='warning'>
@@ -104,7 +104,8 @@ class PasswordStrength extends React.Component {
                 )
               })
             }
-          </bem.PasswordStrength__messages>
+          </bem.PasswordStrength__messages> :
+          <bem.PasswordStrength__messages m='none' />
         }
       </bem.PasswordStrength>
     )

--- a/jsapp/js/components/passwordStrength.scss
+++ b/jsapp/js/components/passwordStrength.scss
@@ -63,3 +63,13 @@
     color: colors.$kobo-red;
   }
 }
+// reduce layout jumping while making password
+.password-strength__messages {
+  height: 80px; // fits up to 4 lines of text
+  transition: height 0.25s, margin-bottom 0.25s;
+}
+.password-strength__messages--none {
+  height: 2px;
+  margin-bottom: -12px;
+  transition: height 0.25s, margin-bottom 0.25s;
+}


### PR DESCRIPTION
## Description

Reduce layout jitter on the registration screen caused by the password strength checker.

## Details

While creating a password on the registration page, the password strength checker would output a variable number of messages, about 0-4 lines. These messages may lengthen or shorten the page while typing. The `background-position: cover;` on the background photo makes it even more noticeable/jarring.

**This "quick fix":**

- Pre-allocates enough height for 4 lines of password strength messages
- Animates transition between N lines and 0 lines, when the password strength reaches 4-5 (green or blue)
   - (This brings the password confirmation and "create account" button back on-screen if it had been pushed below the fold.)

A more robust fix would probably relocate password strength messages somewhere that wouldn't affect the page height. Either a tooltip/balloon message, or in their own column.

## Related issues

- Somewhat related to #2804
- "login" [(search)](https://github.com/kobotoolbox/kpi/issues?q=is%3Aissue+is%3Aopen+login)
