### PR TITLE
Fix memory exhaustion when running `standardize_searchable_fields` management command

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -6,8 +6,6 @@
 #
 -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/django-request-cache@6a4c2615d661382ceac80a161f4dfdeac0a3bc40#egg=django_request_cache
-    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@43daf1d1bd9ffecaeb0e66f8ffb5a957a6e9b9e2#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/kobo-service-account.git@871762cdd099ed543d36f0a29bfbff1de4766a8b#egg=kobo-service-account
@@ -186,6 +184,8 @@ django-redis==5.2.0
 django-redis-sessions==0.6.2
     # via -r dependencies/pip/requirements.in
 django-registration-redux==2.10
+    # via -r dependencies/pip/requirements.in
+django-request-cache==1.4.0
     # via -r dependencies/pip/requirements.in
 django-reversion==5.0.0
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -15,11 +15,6 @@
 # ssrf protect
 -e git+https://github.com/kobotoolbox/ssrf-protect@9b97d3f0fd8f737a38dd7a6b64efeffc03ab3cdd#egg=ssrf_protect
 
-
-# Use a fork of django-request-cache until https://github.com/anexia/django-request-cache/pull/7
-# is merged
--e git+https://github.com/kobotoolbox/django-request-cache@6a4c2615d661382ceac80a161f4dfdeac0a3bc40#egg=django_request_cache
-
 # Regular PyPI packages
 Django>=3.2,<3.3
 Markdown
@@ -59,7 +54,7 @@ django-private-storage
 djangorestframework
 djangorestframework-xml
 django-redis-sessions
-# django-request-cache
+django-request-cache
 drf-extensions
 future
 geojson-rewind

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -6,8 +6,6 @@
 #
 -e git+https://github.com/dimagi/django-digest@419f7306443f9a800b07d832b2cc147941062d59#egg=django_digest
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/django-request-cache@6a4c2615d661382ceac80a161f4dfdeac0a3bc40#egg=django_request_cache
-    # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/formpack.git@43daf1d1bd9ffecaeb0e66f8ffb5a957a6e9b9e2#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/kobotoolbox/kobo-service-account.git@871762cdd099ed543d36f0a29bfbff1de4766a8b#egg=kobo-service-account
@@ -164,6 +162,8 @@ django-redis==5.2.0
 django-redis-sessions==0.6.2
     # via -r dependencies/pip/requirements.in
 django-registration-redux==2.10
+    # via -r dependencies/pip/requirements.in
+django-request-cache==1.4.0
     # via -r dependencies/pip/requirements.in
 django-reversion==5.0.0
     # via -r dependencies/pip/requirements.in

--- a/kpi/management/commands/standardize_searchable_fields.py
+++ b/kpi/management/commands/standardize_searchable_fields.py
@@ -2,38 +2,68 @@ from django.core.management.base import BaseCommand
 
 from hub.models import ExtraUserDetail
 from kpi.models.asset import Asset
+from kpi.constants import ASSET_TYPE_COLLECTION, ASSET_TYPE_SURVEY
 
 
 class Command(BaseCommand):
 
     help = "Standardize fields for search with query parser"
 
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument(
+            "--chunks",
+            default=2000,
+            type=int,
+            help="Update only records by batch of `chunks`.",
+        )
+
     def handle(self, *args, **options):
 
         self._verbosity = options['verbosity']
+        self._chunks = options['chunks']
         self.standardize_assets()
         self.standardize_extra_user_details()
 
     def standardize_assets(self):
-        assets = Asset.objects.only('settings', 'summary').all()
+        assets = Asset.objects.only('settings', 'summary')
         self.stdout.write(f'Updating assets...')
-        for asset in assets:
+        for asset in assets.iterator(chunk_size=self._chunks):
             if self._verbosity >= 1:
                 self.stdout.write(f'\tAsset {asset.uid}...')
-            asset.save(
-                update_fields=['settings', 'summary'],
-                create_version=False,
-                adjust_content=False,
+
+            if asset.asset_type in [ASSET_TYPE_COLLECTION, ASSET_TYPE_SURVEY]:
+                asset.standardize_json_field('settings', 'country', list)
+                asset.standardize_json_field(
+                    'settings',
+                    'country_codes',
+                    list,
+                    [c['value'] for c in asset.settings['country']],
+                    force_default=True
+                )
+                asset.standardize_json_field('settings', 'sector', dict)
+                asset.standardize_json_field('settings', 'description', str)
+
+            # No need to call `Asset._populate_summary` since `asset` is not
+            # a new one.
+            asset.standardize_json_field('summary', 'languages', list)
+            Asset.objects.filter(pk=asset.pk).update(
+                settings=asset.settings,
+                summary=asset.summary
             )
+
         if self._verbosity >= 1:
             self.stdout.write(f'Done!')
 
     def standardize_extra_user_details(self):
         extra_user_details = (
-            ExtraUserDetail.objects.only('data').prefetch_related('user').all()
+            ExtraUserDetail.objects.only('data').prefetch_related('user')
         )
         self.stdout.write(f'Updating users’ extra details...')
-        for extra_user_detail in extra_user_details:
+        for extra_user_detail in extra_user_details.iterator(
+            chunk_size=self._chunks
+        ):
             if self._verbosity >= 1:
                 self.stdout.write(f'\tUser {extra_user_detail.user.username}...')
             extra_user_detail.save(update_fields=['data'])

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -18,7 +18,6 @@ class AssetContentAnalyzer:
             self.default_translation = self.translations[0]
         self.summary = self.get_summary()
 
-
     def decide_name_quality(self, row):
         '''
         for any row from asset.content,
@@ -120,14 +119,16 @@ class AssetContentAnalyzer:
         # the column name of `kobo--locking-profile` is present in the "survey"
         # and there is at least one locking profile assigned, then `lock_any`
         # is set to `True`
-        if self.settings.get(KOBO_LOCK_ALL, False):
-            lock_all = True
-        if (
-            lock_all
-            or (KOBO_LOCK_COLUMN in columns and any(locks))
-            or self.settings.get(KOBO_LOCK_COLUMN, False)
-        ):
-            lock_any = True
+        if self.settings and isinstance(self.settings, dict):
+            if self.settings.get(KOBO_LOCK_ALL, False):
+                lock_all = True
+
+            if (
+                lock_all
+                or (KOBO_LOCK_COLUMN in columns and any(locks))
+                or self.settings.get(KOBO_LOCK_COLUMN, False)
+            ):
+                lock_any = True
 
         summary = {
             'row_count': row_count,

--- a/kpi/utils/query_parser/canopy_autogenerated_parser/__init__.py
+++ b/kpi/utils/query_parser/canopy_autogenerated_parser/__init__.py
@@ -13,10 +13,10 @@ Canopy to generate this Python code.
 
 
 class TreeNode(object):
-    def __init__(self, text, offset, elements=None):
+    def __init__(self, text, offset, elements):
         self.text = text
         self.offset = offset
-        self.elements = elements or []
+        self.elements = elements
 
     def __iter__(self):
         for el in self.elements:
@@ -74,10 +74,6 @@ class TreeNode8(TreeNode):
         self.name = elements[0]
 
 
-class ParseError(SyntaxError):
-    pass
-
-
 FAILURE = object()
 
 
@@ -85,9 +81,9 @@ class Grammar(object):
     REGEX_1 = re.compile('^[^\\s():]')
     REGEX_2 = re.compile('^[^"]')
     REGEX_3 = re.compile('^[^\']')
-    REGEX_4 = re.compile('^[a-zA-Z_]')
-    REGEX_5 = re.compile(r'[\w\-\[\]]')
-    REGEX_6 = re.compile(r'^\s')
+    REGEX_4 = re.compile('^[a-zA-Z_\\[\\]]')
+    REGEX_5 = re.compile('^[a-zA-Z0-9\\-_\\[\\]]')
+    REGEX_6 = re.compile('^[\\s]')
 
     def _read_query(self):
         address0, index0 = FAILURE, self._offset
@@ -97,13 +93,14 @@ class Grammar(object):
             return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
-        remaining0, index2, elements1, address2 = 0, self._offset, [], True
-        while address2 is not FAILURE:
+        index2, elements1, address2 = self._offset, [], None
+        while True:
             address2 = self._read__()
             if address2 is not FAILURE:
                 elements1.append(address2)
-                remaining0 -= 1
-        if remaining0 <= 0:
+            else:
+                break
+        if len(elements1) >= 0:
             address1 = TreeNode(self._input[index2:self._offset], index2, elements1)
             self._offset = self._offset
         else:
@@ -114,18 +111,19 @@ class Grammar(object):
             index3 = self._offset
             address3 = self._read_exp()
             if address3 is FAILURE:
-                address3 = TreeNode(self._input[index3:index3], index3)
+                address3 = TreeNode(self._input[index3:index3], index3, [])
                 self._offset = index3
             if address3 is not FAILURE:
                 elements0.append(address3)
                 address4 = FAILURE
-                remaining1, index4, elements2, address5 = 0, self._offset, [], True
-                while address5 is not FAILURE:
+                index4, elements2, address5 = self._offset, [], None
+                while True:
                     address5 = self._read__()
                     if address5 is not FAILURE:
                         elements2.append(address5)
-                        remaining1 -= 1
-                if remaining1 <= 0:
+                    else:
+                        break
+                if len(elements2) >= 0:
                     address4 = TreeNode(self._input[index4:self._offset], index4, elements2)
                     self._offset = self._offset
                 else:
@@ -161,17 +159,18 @@ class Grammar(object):
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index2, elements1, address3 = 0, self._offset, [], True
-            while address3 is not FAILURE:
+            index2, elements1, address3 = self._offset, [], None
+            while True:
                 index3, elements2 = self._offset, []
                 address4 = FAILURE
-                remaining1, index4, elements3, address5 = 1, self._offset, [], True
-                while address5 is not FAILURE:
+                index4, elements3, address5 = self._offset, [], None
+                while True:
                     address5 = self._read__()
                     if address5 is not FAILURE:
                         elements3.append(address5)
-                        remaining1 -= 1
-                if remaining1 <= 0:
+                    else:
+                        break
+                if len(elements3) >= 1:
                     address4 = TreeNode(self._input[index4:self._offset], index4, elements3)
                     self._offset = self._offset
                 else:
@@ -179,11 +178,11 @@ class Grammar(object):
                 if address4 is not FAILURE:
                     elements2.append(address4)
                     address6 = FAILURE
-                    chunk0 = None
-                    if self._offset < self._input_size:
-                        chunk0 = self._input[self._offset:self._offset + 2]
+                    chunk0, max0 = None, self._offset + 2
+                    if max0 <= self._input_size:
+                        chunk0 = self._input[self._offset:max0]
                     if chunk0 == 'OR':
-                        address6 = TreeNode(self._input[self._offset:self._offset + 2], self._offset)
+                        address6 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
                         self._offset = self._offset + 2
                     else:
                         address6 = FAILURE
@@ -191,17 +190,18 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('"OR"')
+                            self._expected.append(('Kobo.Query::exp', '"OR"'))
                     if address6 is not FAILURE:
                         elements2.append(address6)
                         address7 = FAILURE
-                        remaining2, index5, elements4, address8 = 1, self._offset, [], True
-                        while address8 is not FAILURE:
+                        index5, elements4, address8 = self._offset, [], None
+                        while True:
                             address8 = self._read__()
                             if address8 is not FAILURE:
                                 elements4.append(address8)
-                                remaining2 -= 1
-                        if remaining2 <= 0:
+                            else:
+                                break
+                        if len(elements4) >= 1:
                             address7 = TreeNode(self._input[index5:self._offset], index5, elements4)
                             self._offset = self._offset
                         else:
@@ -231,8 +231,9 @@ class Grammar(object):
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
-                    remaining0 -= 1
-            if remaining0 <= 0:
+                else:
+                    break
+            if len(elements1) >= 0:
                 address2 = TreeNode(self._input[index2:self._offset], index2, elements1)
                 self._offset = self._offset
             else:
@@ -265,20 +266,21 @@ class Grammar(object):
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index2, elements1, address3 = 0, self._offset, [], True
-            while address3 is not FAILURE:
+            index2, elements1, address3 = self._offset, [], None
+            while True:
                 index3, elements2 = self._offset, []
                 address4 = FAILURE
                 index4 = self._offset
                 index5, elements3 = self._offset, []
                 address5 = FAILURE
-                remaining1, index6, elements4, address6 = 1, self._offset, [], True
-                while address6 is not FAILURE:
+                index6, elements4, address6 = self._offset, [], None
+                while True:
                     address6 = self._read__()
                     if address6 is not FAILURE:
                         elements4.append(address6)
-                        remaining1 -= 1
-                if remaining1 <= 0:
+                    else:
+                        break
+                if len(elements4) >= 1:
                     address5 = TreeNode(self._input[index6:self._offset], index6, elements4)
                     self._offset = self._offset
                 else:
@@ -286,11 +288,11 @@ class Grammar(object):
                 if address5 is not FAILURE:
                     elements3.append(address5)
                     address7 = FAILURE
-                    chunk0 = None
-                    if self._offset < self._input_size:
-                        chunk0 = self._input[self._offset:self._offset + 3]
+                    chunk0, max0 = None, self._offset + 3
+                    if max0 <= self._input_size:
+                        chunk0 = self._input[self._offset:max0]
                     if chunk0 == 'AND':
-                        address7 = TreeNode(self._input[self._offset:self._offset + 3], self._offset)
+                        address7 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
                         self._offset = self._offset + 3
                     else:
                         address7 = FAILURE
@@ -298,7 +300,7 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('"AND"')
+                            self._expected.append(('Kobo.Query::andexp', '"AND"'))
                     if address7 is not FAILURE:
                         elements3.append(address7)
                     else:
@@ -313,18 +315,19 @@ class Grammar(object):
                     address4 = TreeNode(self._input[index5:self._offset], index5, elements3)
                     self._offset = self._offset
                 if address4 is FAILURE:
-                    address4 = TreeNode(self._input[index4:index4], index4)
+                    address4 = TreeNode(self._input[index4:index4], index4, [])
                     self._offset = index4
                 if address4 is not FAILURE:
                     elements2.append(address4)
                     address8 = FAILURE
-                    remaining2, index7, elements5, address9 = 1, self._offset, [], True
-                    while address9 is not FAILURE:
+                    index7, elements5, address9 = self._offset, [], None
+                    while True:
                         address9 = self._read__()
                         if address9 is not FAILURE:
                             elements5.append(address9)
-                            remaining2 -= 1
-                    if remaining2 <= 0:
+                        else:
+                            break
+                    if len(elements5) >= 1:
                         address8 = TreeNode(self._input[index7:self._offset], index7, elements5)
                         self._offset = self._offset
                     else:
@@ -333,11 +336,11 @@ class Grammar(object):
                         elements2.append(address8)
                         address10 = FAILURE
                         index8 = self._offset
-                        chunk1 = None
-                        if self._offset < self._input_size:
-                            chunk1 = self._input[self._offset:self._offset + 2]
+                        chunk1, max1 = None, self._offset + 2
+                        if max1 <= self._input_size:
+                            chunk1 = self._input[self._offset:max1]
                         if chunk1 == 'OR':
-                            address10 = TreeNode(self._input[self._offset:self._offset + 2], self._offset)
+                            address10 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
                             self._offset = self._offset + 2
                         else:
                             address10 = FAILURE
@@ -345,10 +348,10 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append('"OR"')
+                                self._expected.append(('Kobo.Query::andexp', '"OR"'))
                         self._offset = index8
                         if address10 is FAILURE:
-                            address10 = TreeNode(self._input[self._offset:self._offset], self._offset)
+                            address10 = TreeNode(self._input[self._offset:self._offset], self._offset, [])
                             self._offset = self._offset
                         else:
                             address10 = FAILURE
@@ -377,8 +380,9 @@ class Grammar(object):
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
-                    remaining0 -= 1
-            if remaining0 <= 0:
+                else:
+                    break
+            if len(elements1) >= 0:
                 address2 = TreeNode(self._input[index2:self._offset], index2, elements1)
                 self._offset = self._offset
             else:
@@ -408,11 +412,11 @@ class Grammar(object):
         index1 = self._offset
         index2, elements0 = self._offset, []
         address1 = FAILURE
-        chunk0 = None
-        if self._offset < self._input_size:
-            chunk0 = self._input[self._offset:self._offset + 3]
+        chunk0, max0 = None, self._offset + 3
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
         if chunk0 == 'NOT':
-            address1 = TreeNode(self._input[self._offset:self._offset + 3], self._offset)
+            address1 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
             self._offset = self._offset + 3
         else:
             address1 = FAILURE
@@ -420,17 +424,18 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('"NOT"')
+                self._expected.append(('Kobo.Query::groupexp', '"NOT"'))
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index3, elements1, address3 = 1, self._offset, [], True
-            while address3 is not FAILURE:
+            index3, elements1, address3 = self._offset, [], None
+            while True:
                 address3 = self._read__()
                 if address3 is not FAILURE:
                     elements1.append(address3)
-                    remaining0 -= 1
-            if remaining0 <= 0:
+                else:
+                    break
+            if len(elements1) >= 1:
                 address2 = TreeNode(self._input[index3:self._offset], index3, elements1)
                 self._offset = self._offset
             else:
@@ -459,11 +464,11 @@ class Grammar(object):
             self._offset = index1
             index4, elements2 = self._offset, []
             address5 = FAILURE
-            chunk1 = None
-            if self._offset < self._input_size:
-                chunk1 = self._input[self._offset:self._offset + 1]
+            chunk1, max1 = None, self._offset + 1
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
             if chunk1 == '(':
-                address5 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                address5 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                 self._offset = self._offset + 1
             else:
                 address5 = FAILURE
@@ -471,17 +476,18 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append('"("')
+                    self._expected.append(('Kobo.Query::groupexp', '"("'))
             if address5 is not FAILURE:
                 elements2.append(address5)
                 address6 = FAILURE
-                remaining1, index5, elements3, address7 = 0, self._offset, [], True
-                while address7 is not FAILURE:
+                index5, elements3, address7 = self._offset, [], None
+                while True:
                     address7 = self._read__()
                     if address7 is not FAILURE:
                         elements3.append(address7)
-                        remaining1 -= 1
-                if remaining1 <= 0:
+                    else:
+                        break
+                if len(elements3) >= 0:
                     address6 = TreeNode(self._input[index5:self._offset], index5, elements3)
                     self._offset = self._offset
                 else:
@@ -493,13 +499,14 @@ class Grammar(object):
                     if address8 is not FAILURE:
                         elements2.append(address8)
                         address9 = FAILURE
-                        remaining2, index6, elements4, address10 = 0, self._offset, [], True
-                        while address10 is not FAILURE:
+                        index6, elements4, address10 = self._offset, [], None
+                        while True:
                             address10 = self._read__()
                             if address10 is not FAILURE:
                                 elements4.append(address10)
-                                remaining2 -= 1
-                        if remaining2 <= 0:
+                            else:
+                                break
+                        if len(elements4) >= 0:
                             address9 = TreeNode(self._input[index6:self._offset], index6, elements4)
                             self._offset = self._offset
                         else:
@@ -507,11 +514,11 @@ class Grammar(object):
                         if address9 is not FAILURE:
                             elements2.append(address9)
                             address11 = FAILURE
-                            chunk2 = None
-                            if self._offset < self._input_size:
-                                chunk2 = self._input[self._offset:self._offset + 1]
+                            chunk2, max2 = None, self._offset + 1
+                            if max2 <= self._input_size:
+                                chunk2 = self._input[self._offset:max2]
                             if chunk2 == ')':
-                                address11 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                                address11 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                                 self._offset = self._offset + 1
                             else:
                                 address11 = FAILURE
@@ -519,7 +526,7 @@ class Grammar(object):
                                     self._failure = self._offset
                                     self._expected = []
                                 if self._offset == self._failure:
-                                    self._expected.append('")"')
+                                    self._expected.append(('Kobo.Query::groupexp', '")"'))
                             if address11 is not FAILURE:
                                 elements2.append(address11)
                             else:
@@ -565,11 +572,11 @@ class Grammar(object):
         if address2 is not FAILURE:
             elements1.append(address2)
             address3 = FAILURE
-            chunk0 = None
-            if self._offset < self._input_size:
-                chunk0 = self._input[self._offset:self._offset + 1]
+            chunk0, max0 = None, self._offset + 1
+            if max0 <= self._input_size:
+                chunk0 = self._input[self._offset:max0]
             if chunk0 == ':':
-                address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                 self._offset = self._offset + 1
             else:
                 address3 = FAILURE
@@ -577,7 +584,7 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append('":"')
+                    self._expected.append(('Kobo.Query::term', '":"'))
             if address3 is not FAILURE:
                 elements1.append(address3)
             else:
@@ -592,7 +599,7 @@ class Grammar(object):
             address1 = TreeNode8(self._input[index3:self._offset], index3, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
-            address1 = TreeNode(self._input[index2:index2], index2)
+            address1 = TreeNode(self._input[index2:index2], index2, [])
             self._offset = index2
         if address1 is not FAILURE:
             elements0.append(address1)
@@ -636,13 +643,13 @@ class Grammar(object):
         if cached:
             self._offset = cached[1]
             return cached[0]
-        remaining0, index1, elements0, address1 = 1, self._offset, [], True
-        while address1 is not FAILURE:
-            chunk0 = None
-            if self._offset < self._input_size:
-                chunk0 = self._input[self._offset:self._offset + 1]
+        index1, elements0, address1 = self._offset, [], None
+        while True:
+            chunk0, max0 = None, self._offset + 1
+            if max0 <= self._input_size:
+                chunk0 = self._input[self._offset:max0]
             if chunk0 is not None and Grammar.REGEX_1.search(chunk0):
-                address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                 self._offset = self._offset + 1
             else:
                 address1 = FAILURE
@@ -650,11 +657,12 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append('[^\\s():]')
+                    self._expected.append(('Kobo.Query::word', '[^\\s():]'))
             if address1 is not FAILURE:
                 elements0.append(address1)
-                remaining0 -= 1
-        if remaining0 <= 0:
+            else:
+                break
+        if len(elements0) >= 1:
             address0 = self._actions.word(self._input, index1, self._offset, elements0)
             self._offset = self._offset
         else:
@@ -671,11 +679,11 @@ class Grammar(object):
         index1 = self._offset
         index2, elements0 = self._offset, []
         address1 = FAILURE
-        chunk0 = None
-        if self._offset < self._input_size:
-            chunk0 = self._input[self._offset:self._offset + 1]
+        chunk0, max0 = None, self._offset + 1
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
         if chunk0 == '"':
-            address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+            address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
             address1 = FAILURE
@@ -683,20 +691,20 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('\'"\'')
+                self._expected.append(('Kobo.Query::string', '\'"\''))
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index3, elements1, address3 = 0, self._offset, [], True
-            while address3 is not FAILURE:
+            index3, elements1, address3 = self._offset, [], None
+            while True:
                 index4 = self._offset
                 index5, elements2 = self._offset, []
                 address4 = FAILURE
-                chunk1 = None
-                if self._offset < self._input_size:
-                    chunk1 = self._input[self._offset:self._offset + 1]
+                chunk1, max1 = None, self._offset + 1
+                if max1 <= self._input_size:
+                    chunk1 = self._input[self._offset:max1]
                 if chunk1 == '\\':
-                    address4 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                    address4 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                     self._offset = self._offset + 1
                 else:
                     address4 = FAILURE
@@ -704,12 +712,12 @@ class Grammar(object):
                         self._failure = self._offset
                         self._expected = []
                     if self._offset == self._failure:
-                        self._expected.append('"\\\\"')
+                        self._expected.append(('Kobo.Query::string', '"\\\\"'))
                 if address4 is not FAILURE:
                     elements2.append(address4)
                     address5 = FAILURE
                     if self._offset < self._input_size:
-                        address5 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                        address5 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                         self._offset = self._offset + 1
                     else:
                         address5 = FAILURE
@@ -717,7 +725,7 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('<any char>')
+                            self._expected.append(('Kobo.Query::string', '<any char>'))
                     if address5 is not FAILURE:
                         elements2.append(address5)
                     else:
@@ -733,11 +741,11 @@ class Grammar(object):
                     self._offset = self._offset
                 if address3 is FAILURE:
                     self._offset = index4
-                    chunk2 = None
-                    if self._offset < self._input_size:
-                        chunk2 = self._input[self._offset:self._offset + 1]
+                    chunk2, max2 = None, self._offset + 1
+                    if max2 <= self._input_size:
+                        chunk2 = self._input[self._offset:max2]
                     if chunk2 is not None and Grammar.REGEX_2.search(chunk2):
-                        address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                        address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                         self._offset = self._offset + 1
                     else:
                         address3 = FAILURE
@@ -745,13 +753,14 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('[^"]')
+                            self._expected.append(('Kobo.Query::string', '[^"]'))
                     if address3 is FAILURE:
                         self._offset = index4
                 if address3 is not FAILURE:
                     elements1.append(address3)
-                    remaining0 -= 1
-            if remaining0 <= 0:
+                else:
+                    break
+            if len(elements1) >= 0:
                 address2 = TreeNode(self._input[index3:self._offset], index3, elements1)
                 self._offset = self._offset
             else:
@@ -759,11 +768,11 @@ class Grammar(object):
             if address2 is not FAILURE:
                 elements0.append(address2)
                 address6 = FAILURE
-                chunk3 = None
-                if self._offset < self._input_size:
-                    chunk3 = self._input[self._offset:self._offset + 1]
+                chunk3, max3 = None, self._offset + 1
+                if max3 <= self._input_size:
+                    chunk3 = self._input[self._offset:max3]
                 if chunk3 == '"':
-                    address6 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                    address6 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                     self._offset = self._offset + 1
                 else:
                     address6 = FAILURE
@@ -771,7 +780,7 @@ class Grammar(object):
                         self._failure = self._offset
                         self._expected = []
                     if self._offset == self._failure:
-                        self._expected.append('\'"\'')
+                        self._expected.append(('Kobo.Query::string', '\'"\''))
                 if address6 is not FAILURE:
                     elements0.append(address6)
                 else:
@@ -792,11 +801,11 @@ class Grammar(object):
             self._offset = index1
             index6, elements3 = self._offset, []
             address7 = FAILURE
-            chunk4 = None
-            if self._offset < self._input_size:
-                chunk4 = self._input[self._offset:self._offset + 1]
+            chunk4, max4 = None, self._offset + 1
+            if max4 <= self._input_size:
+                chunk4 = self._input[self._offset:max4]
             if chunk4 == '\'':
-                address7 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                address7 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                 self._offset = self._offset + 1
             else:
                 address7 = FAILURE
@@ -804,20 +813,20 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append('"\'"')
+                    self._expected.append(('Kobo.Query::string', '"\'"'))
             if address7 is not FAILURE:
                 elements3.append(address7)
                 address8 = FAILURE
-                remaining1, index7, elements4, address9 = 0, self._offset, [], True
-                while address9 is not FAILURE:
+                index7, elements4, address9 = self._offset, [], None
+                while True:
                     index8 = self._offset
                     index9, elements5 = self._offset, []
                     address10 = FAILURE
-                    chunk5 = None
-                    if self._offset < self._input_size:
-                        chunk5 = self._input[self._offset:self._offset + 1]
+                    chunk5, max5 = None, self._offset + 1
+                    if max5 <= self._input_size:
+                        chunk5 = self._input[self._offset:max5]
                     if chunk5 == '\\':
-                        address10 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                        address10 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                         self._offset = self._offset + 1
                     else:
                         address10 = FAILURE
@@ -825,12 +834,12 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('"\\\\"')
+                            self._expected.append(('Kobo.Query::string', '"\\\\"'))
                     if address10 is not FAILURE:
                         elements5.append(address10)
                         address11 = FAILURE
                         if self._offset < self._input_size:
-                            address11 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                            address11 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                             self._offset = self._offset + 1
                         else:
                             address11 = FAILURE
@@ -838,7 +847,7 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append('<any char>')
+                                self._expected.append(('Kobo.Query::string', '<any char>'))
                         if address11 is not FAILURE:
                             elements5.append(address11)
                         else:
@@ -854,11 +863,11 @@ class Grammar(object):
                         self._offset = self._offset
                     if address9 is FAILURE:
                         self._offset = index8
-                        chunk6 = None
-                        if self._offset < self._input_size:
-                            chunk6 = self._input[self._offset:self._offset + 1]
+                        chunk6, max6 = None, self._offset + 1
+                        if max6 <= self._input_size:
+                            chunk6 = self._input[self._offset:max6]
                         if chunk6 is not None and Grammar.REGEX_3.search(chunk6):
-                            address9 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                            address9 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                             self._offset = self._offset + 1
                         else:
                             address9 = FAILURE
@@ -866,13 +875,14 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append('[^\']')
+                                self._expected.append(('Kobo.Query::string', '[^\']'))
                         if address9 is FAILURE:
                             self._offset = index8
                     if address9 is not FAILURE:
                         elements4.append(address9)
-                        remaining1 -= 1
-                if remaining1 <= 0:
+                    else:
+                        break
+                if len(elements4) >= 0:
                     address8 = TreeNode(self._input[index7:self._offset], index7, elements4)
                     self._offset = self._offset
                 else:
@@ -880,11 +890,11 @@ class Grammar(object):
                 if address8 is not FAILURE:
                     elements3.append(address8)
                     address12 = FAILURE
-                    chunk7 = None
-                    if self._offset < self._input_size:
-                        chunk7 = self._input[self._offset:self._offset + 1]
+                    chunk7, max7 = None, self._offset + 1
+                    if max7 <= self._input_size:
+                        chunk7 = self._input[self._offset:max7]
                     if chunk7 == '\'':
-                        address12 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                        address12 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                         self._offset = self._offset + 1
                     else:
                         address12 = FAILURE
@@ -892,7 +902,7 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append('"\'"')
+                            self._expected.append(('Kobo.Query::string', '"\'"'))
                     if address12 is not FAILURE:
                         elements3.append(address12)
                     else:
@@ -922,11 +932,11 @@ class Grammar(object):
             return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
-        chunk0 = None
-        if self._offset < self._input_size:
-            chunk0 = self._input[self._offset:self._offset + 1]
+        chunk0, max0 = None, self._offset + 1
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
         if chunk0 is not None and Grammar.REGEX_4.search(chunk0):
-            address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+            address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
             address1 = FAILURE
@@ -934,17 +944,17 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('[a-zA-Z_]')
+                self._expected.append(('Kobo.Query::name', '[a-zA-Z_\\[\\]]'))
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
-            remaining0, index2, elements1, address3 = 0, self._offset, [], True
-            while address3 is not FAILURE:
-                chunk1 = None
-                if self._offset < self._input_size:
-                    chunk1 = self._input[self._offset:self._offset + 1]
+            index2, elements1, address3 = self._offset, [], None
+            while True:
+                chunk1, max1 = None, self._offset + 1
+                if max1 <= self._input_size:
+                    chunk1 = self._input[self._offset:max1]
                 if chunk1 is not None and Grammar.REGEX_5.search(chunk1):
-                    address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+                    address3 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                     self._offset = self._offset + 1
                 else:
                     address3 = FAILURE
@@ -952,11 +962,12 @@ class Grammar(object):
                         self._failure = self._offset
                         self._expected = []
                     if self._offset == self._failure:
-                        self._expected.append(r'[\w\-\[\]]')
+                        self._expected.append(('Kobo.Query::name', '[a-zA-Z0-9\\-_\\[\\]]'))
                 if address3 is not FAILURE:
                     elements1.append(address3)
-                    remaining0 -= 1
-            if remaining0 <= 0:
+                else:
+                    break
+            if len(elements1) >= 0:
                 address2 = TreeNode(self._input[index2:self._offset], index2, elements1)
                 self._offset = self._offset
             else:
@@ -983,11 +994,11 @@ class Grammar(object):
         if cached:
             self._offset = cached[1]
             return cached[0]
-        chunk0 = None
-        if self._offset < self._input_size:
-            chunk0 = self._input[self._offset:self._offset + 1]
+        chunk0, max0 = None, self._offset + 1
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
         if chunk0 is not None and Grammar.REGEX_6.search(chunk0):
-            address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset)
+            address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
             address0 = FAILURE
@@ -995,7 +1006,7 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append('[\\s]')
+                self._expected.append(('Kobo.Query::_', '[\\s]'))
         self._cache['_'][index0] = (address0, self._offset)
         return address0
 
@@ -1017,22 +1028,36 @@ class Parser(Grammar):
             return tree
         if not self._expected:
             self._failure = self._offset
-            self._expected.append('<EOF>')
+            self._expected.append(('Kobo.Query', '<EOF>'))
         raise ParseError(format_error(self._input, self._failure, self._expected))
 
 
-def format_error(input, offset, expected):
-    lines, line_no, position = input.split('\n'), 0, 0
-    while position <= offset:
-        position += len(lines[line_no]) + 1
-        line_no += 1
-    message, line = 'Line ' + str(line_no) + ': expected ' + ', '.join(expected) + '\n', lines[line_no - 1]
-    message += line + '\n'
-    position -= len(line) + 1
-    message += ' ' * (offset - position)
-    return message + '^'
+class ParseError(SyntaxError):
+    pass
 
 
 def parse(input, actions=None, types=None):
     parser = Parser(input, actions, types)
     return parser.parse()
+
+def format_error(input, offset, expected):
+    lines = input.split('\n')
+    line_no, position = 0, 0
+
+    while position <= offset:
+        position += len(lines[line_no]) + 1
+        line_no += 1
+
+    line = lines[line_no - 1]
+    message = 'Line ' + str(line_no) + ': expected one of:\n\n'
+
+    for pair in expected:
+        message += '    - ' + pair[1] + ' from ' + pair[0] + '\n'
+
+    number = str(line_no)
+    while len(number) < 6:
+        number = ' ' + number
+
+    message += '\n' + number + ' | ' + line + '\n'
+    message += ' ' * (len(line) + 10 + offset - position)
+    return message + '^'

--- a/kpi/utils/query_parser/grammar.peg
+++ b/kpi/utils/query_parser/grammar.peg
@@ -32,5 +32,5 @@ grammar Kobo.Query
   word      <-  [^\s():]+                      %word
   string    <- '"' ("\\" . / [^"])* '"'        %string
              / "'" ("\\" . / [^'])* "'"        %string
-  name      <- [a-zA-Z_] [a-zA-Z0-9\-_]*       %name
+  name      <- [a-zA-Z_\[\]] [a-zA-Z0-9\-_\[\]]*       %name
   _ <- [\s]


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Decrease management command run time and improve its memory footprint.
