### PR TITLE
Add error handling to email section

### DIFF
--- a/jsapp/js/account/security/email/emailSection.api.ts
+++ b/jsapp/js/account/security/email/emailSection.api.ts
@@ -7,6 +7,10 @@ export interface EmailResponse {
   verified: boolean;
 }
 
+export interface EmailError {
+  email: string[];
+}
+
 const LIST_URL = '/me/emails/';
 
 export async function getUserEmails() {
@@ -14,7 +18,7 @@ export async function getUserEmails() {
 }
 
 export async function setUserEmail(newEmail: string) {
-  return fetchPost<EmailResponse>(LIST_URL, {email: newEmail});
+  return fetchPost<EmailResponse | EmailError>(LIST_URL, {email: newEmail});
 }
 
 /** Removes all unverified/non-primary emails (there should only be one anyway)*/

--- a/jsapp/js/account/security/email/emailSection.component.tsx
+++ b/jsapp/js/account/security/email/emailSection.component.tsx
@@ -13,6 +13,7 @@ interface EmailState {
   newEmail: string;
   refreshedEmail: boolean;
   refreshedEmailDate: string;
+  fieldErrors: string[];
 }
 
 export default function EmailSection() {
@@ -23,6 +24,7 @@ export default function EmailSection() {
     newEmail: '',
     refreshedEmail: false,
     refreshedEmailDate: '',
+    fieldErrors: [],
   });
 
   useEffect(() => {
@@ -35,14 +37,26 @@ export default function EmailSection() {
   }, []);
 
   function setNewUserEmail(newEmail: string) {
-    setUserEmail(newEmail).then(() => {
-      getUserEmails().then((data) => {
+    setEmail({
+      ...email,
+      fieldErrors: [],
+    });
+
+    setUserEmail(newEmail).then((response) => {
+      if ('primary' in response) {
+        getUserEmails().then((data) => {
+          setEmail({
+            ...email,
+            emails: data.results,
+            newEmail: '',
+          });
+        });
+      } else {
         setEmail({
           ...email,
-          emails: data.results,
-          newEmail: '',
+          fieldErrors: response.email,
         });
-      });
+      }
     });
   }
 
@@ -84,7 +98,9 @@ export default function EmailSection() {
   }
 
   const currentAccount = session.currentAccount;
-  const unverifiedEmail = email.emails.find((userEmail) => !userEmail.verified && !userEmail.primary);
+  const unverifiedEmail = email.emails.find(
+    (userEmail) => !userEmail.verified && !userEmail.primary
+  );
 
   return (
     <div className={style.root}>
@@ -140,11 +156,14 @@ export default function EmailSection() {
                 />
               </div>
 
-              {email.refreshedEmail &&
+              {email.refreshedEmail && (
                 <label>
-                  {t('Email was sent again: ##TIMESTAMP##').replace('##TIMESTAMP##', email.refreshedEmailDate)}
+                  {t('Email was sent again: ##TIMESTAMP##').replace(
+                    '##TIMESTAMP##',
+                    email.refreshedEmailDate
+                  )}
                 </label>
-              }
+              )}
             </>
           )}
       </div>
@@ -164,13 +183,17 @@ export default function EmailSection() {
           onChange={onTextFieldChange.bind(onTextFieldChange)}
         />
 
-        <Button
-          label='Change'
-          size='m'
-          color='blue'
-          type='frame'
-          onClick={setNewUserEmail.bind(setNewUserEmail, email.newEmail)}
-        />
+        <div className={style.optionsSectionButtons}>
+          <label>{email.fieldErrors}</label>
+
+          <Button
+            label='Change'
+            size='m'
+            color='blue'
+            type='frame'
+            onClick={setNewUserEmail.bind(setNewUserEmail, email.newEmail)}
+          />
+        </div>
       </form>
     </div>
   );

--- a/jsapp/js/account/security/email/emailSection.module.scss
+++ b/jsapp/js/account/security/email/emailSection.module.scss
@@ -52,6 +52,17 @@
   }
 }
 
+.optionsSectionButtons {
+  > * {
+    display: inline-block;
+  }
+
+  label {
+    margin-right: sizes.$x12;
+    color: colors.$kobo-red;
+  }
+}
+
 .currentEmail {
   font-weight: bold;
   margin-top: 0;


### PR DESCRIPTION
Reasoning for implementing this way:
-  I didn't want to change any of the `fetchData` code in `api.ts` and because of the [how `fetch` throw errors](https://stackoverflow.com/questions/14425568/interface-type-check-with-typescript) so I do the check in the response handler
- I didn't want to make a function to [just check the type](https://stackoverflow.com/questions/14425568/interface-type-check-with-typescript) so I opted for an attribute check

## Description
When a bad email is sent the user isn't notified, this adds a basic error to let the user know.
<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->
