### PR TITLE
Deleted misused render condition for navigation controls

### DIFF
--- a/jsapp/js/components/submissions/submissionModal.es6
+++ b/jsapp/js/components/submissions/submissionModal.es6
@@ -441,53 +441,47 @@ class SubmissionModal extends React.Component {
 
           <bem.FormModal__group>
 
-            {this.state.isEditingDuplicate &&
-              <div className='preserveFlexCSS'/>
-            }
+            <div className='submission-pager'>
+              {/* don't display previous button if `previous` is -1 */}
+              {this.state.previous > -1 &&
+                <a
+                  onClick={this.switchSubmission.bind(this, this.state.previous)}
+                  className='mdl-button mdl-button--colored'
+                >
+                  <i className='k-icon k-icon-angle-left' />
+                  {t('Previous')}
+                </a>
+              }
+              {this.state.previous === -2 &&
+                <a
+                  onClick={this.prevTablePage}
+                  className='mdl-button mdl-button--colored'
+                >
+                  <i className='k-icon k-icon-angle-left' />
+                  {t('Previous')}
+                </a>
+              }
 
-            {!this.state.isEditingDuplicate &&
-              <div className='submission-pager'>
-                {/* don't display previous button if `previous` is -1 */}
-                {this.state.previous > -1 &&
-                  <a
-                    onClick={this.switchSubmission.bind(this, this.state.previous)}
-                    className='mdl-button mdl-button--colored'
-                  >
-                    <i className='k-icon k-icon-angle-left' />
-                    {t('Previous')}
-                  </a>
-                }
-                {this.state.previous === -2 &&
-                  <a
-                    onClick={this.prevTablePage}
-                    className='mdl-button mdl-button--colored'
-                  >
-                    <i className='k-icon k-icon-angle-left' />
-                    {t('Previous')}
-                  </a>
-                }
-
-                {/* don't display next button if `next` is -1 */}
-                {this.state.next > -1 &&
-                  <a
-                    onClick={this.switchSubmission.bind(this, this.state.next)}
-                    className='mdl-button mdl-button--colored'
-                  >
-                    {t('Next')}
-                    <i className='k-icon k-icon-angle-right' />
-                  </a>
-                }
-                {this.state.next === -2 &&
-                  <a
-                    onClick={this.nextTablePage}
-                    className='mdl-button mdl-button--colored'
-                  >
-                    {t('Next')}
-                    <i className='k-icon k-icon-angle-right' />
-                  </a>
-                }
-              </div>
-            }
+              {/* don't display next button if `next` is -1 */}
+              {this.state.next > -1 &&
+                <a
+                  onClick={this.switchSubmission.bind(this, this.state.next)}
+                  className='mdl-button mdl-button--colored'
+                >
+                  {t('Next')}
+                  <i className='k-icon k-icon-angle-right' />
+                </a>
+              }
+              {this.state.next === -2 &&
+                <a
+                  onClick={this.nextTablePage}
+                  className='mdl-button mdl-button--colored'
+                >
+                  {t('Next')}
+                  <i className='k-icon k-icon-angle-right' />
+                </a>
+              }
+            </div>
 
             <div className='submission-actions'>
               <Checkbox


### PR DESCRIPTION

1. [Not added] If you've added code that should be tested, add tests
2. [ Not changed] If you've changed APIs, update (or create!) the documentation
3. [ please provide help if there are tests for this part of the code] Ensure the tests pass
4. [ done ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ done ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ there aren't ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [  not needed] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

for fixing bug https://github.com/kobotoolbox/kpi/issues/4090 and let the entries navigation buttons be shown, there was a condition to render the buttons that looked up to the state isEditingDuplicate, but this state was needed only when the duplicate button is used. So I deleted the render condition (and also deleted a blank div that was attached to this condition too), so the navigation buttons doesn't disappear when the edit button is clicked.  All the code to be rendered was then moved some lines up and 2 spaces left to comply with the indentation. 

## Related issues

Fixes bug 4090
