### PR TITLE
Allow filtering by country in projects list

### DIFF
--- a/jsapp/js/components/common/koboSelect.stories.tsx
+++ b/jsapp/js/components/common/koboSelect.stories.tsx
@@ -18,17 +18,17 @@ export default {
 const Template: ComponentStory<typeof KoboSelect> = (args: any) => {
   const options = [
     {
-      id: 'one',
+      value: 'one',
       label: 'One',
       icon: args.demoOptionsWithIcons ? 'alert' : undefined,
     },
     {
-      id: 'two',
+      value: 'two',
       label: 'Two',
       icon: args.demoOptionsWithIcons ? 'qt-audio' : undefined,
     },
     {
-      id: 'last',
+      value: 'last',
       label: 'The last one here with a very long label',
       icon: args.demoOptionsWithIcons ? 'globe-alt' : undefined,
     },

--- a/jsapp/js/components/common/koboSelect.tsx
+++ b/jsapp/js/components/common/koboSelect.tsx
@@ -41,7 +41,7 @@ export interface KoboSelectOption {
   icon?: IconName;
   label: string;
   /** Needs to be unique! */
-  id: string;
+  value: string;
 }
 
 interface KoboSelectProps {
@@ -61,7 +61,7 @@ interface KoboSelectProps {
   /** Changes the appearance to display spinner. */
   isPending?: boolean;
   options: KoboSelectOption[];
-  /** Pass the id or null for no selection. */
+  /** Pass the value or null for no selection. */
   selectedOption: string | null;
   /**
    * Callback function telling which option is selected now. Passes either
@@ -174,7 +174,7 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
   renderTrigger() {
     const foundSelectedOption = this.props.options.find((option) => (
       this.props.selectedOption !== null &&
-      option.id === this.props.selectedOption
+      option.value === this.props.selectedOption
     ));
 
     // When one of the options is selected, we display it inside the trigger.
@@ -249,7 +249,7 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
   renderSearchBox() {
     const foundSelectedOption = this.props.options.find((option) => (
       this.props.selectedOption !== null &&
-      option.id === this.props.selectedOption
+      option.value === this.props.selectedOption
     ));
 
     return (
@@ -278,13 +278,13 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
       <bem.KoboSelect__menu>
         {filteredOptions.map((option) => (
           <bem.KoboSelect__option
-            key={option.id}
-            onClick={this.onOptionClick.bind(this, option.id)}
+            key={option.value}
+            onClick={this.onOptionClick.bind(this, option.value)}
             title={option.label}
             m={{
               'selected': (
                 this.props.selectedOption !== null &&
-                this.props.selectedOption === option.id
+                this.props.selectedOption === option.value
               ),
             }}
           >

--- a/jsapp/js/components/common/wrappedSelect.tsx
+++ b/jsapp/js/components/common/wrappedSelect.tsx
@@ -24,9 +24,6 @@ class WrappedSelect extends React.Component<WrappedSelectProps> {
       classNames.push('kobo-select--limited-height');
     }
 
-    console.log('select props');
-    console.log(this.props.value);
-
     return (
       <bem.KoboSelect__wrapper
         m={{'error': Boolean(this.props.error)}}

--- a/jsapp/js/components/common/wrappedSelect.tsx
+++ b/jsapp/js/components/common/wrappedSelect.tsx
@@ -24,6 +24,9 @@ class WrappedSelect extends React.Component<WrappedSelectProps> {
       classNames.push('kobo-select--limited-height');
     }
 
+    console.log('select props');
+    console.log(this.props.value);
+
     return (
       <bem.KoboSelect__wrapper
         m={{'error': Boolean(this.props.error)}}

--- a/jsapp/js/components/languages/regionSelector.tsx
+++ b/jsapp/js/components/languages/regionSelector.tsx
@@ -104,7 +104,7 @@ export default class RegionSelector extends React.Component<
         if (serviceLanguageCode && label) {
           outcome.push({
             label: label,
-            id: serviceLanguageCode,
+            value: serviceLanguageCode,
           });
         }
       }

--- a/jsapp/js/components/processing/singleProcessingHeader.tsx
+++ b/jsapp/js/components/processing/singleProcessingHeader.tsx
@@ -101,7 +101,7 @@ class SingleProcessingHeader extends React.Component<
               0
             );
             options.push({
-              id: qpath,
+              value: qpath,
               label: translatedLabel !== null ? translatedLabel : rowName,
               icon: getRowTypeIcon(questionData.type),
             });

--- a/jsapp/js/components/processing/transxSelector.tsx
+++ b/jsapp/js/components/processing/transxSelector.tsx
@@ -60,11 +60,11 @@ export default class TransxSelector extends React.Component<
           // for the response.
           if (
             this.props.languageCodes?.includes(languageCode) &&
-            this.state.options?.find((option) => option.id === languageCode) === undefined
+            this.state.options?.find((option) => option.value === languageCode) === undefined
           ) {
             const newOptions = this.state.options || [];
             newOptions.push({
-              id: languageCode,
+              value: languageCode,
               label: getLanguageDisplayLabel(languageName, languageCode),
             });
             this.setState({options: newOptions});

--- a/jsapp/js/projects/projectViews/projectsFilter.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilter.tsx
@@ -108,7 +108,7 @@ export default function ProjectsFilter(props: ProjectsFilterProps) {
       <KoboModal
         isOpen={isModalOpen}
         onRequestClose={toggleModal}
-        size='medium'
+        size='large'
       >
         <KoboModalHeader
           icon='filter'

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -154,6 +154,7 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
               type='outline'
               size='m'
               isClearable
+              isSearchable
               placeholder={t('Country')}
               selectedOption={props.filter.value || ''}
               options={COUNTRIES}

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -68,7 +68,7 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
         (filterDefinition) => filterDefinition.availableConditions.length >= 1
       )
       .map((filterDefinition) => {
-        return {label: filterDefinition.label, id: filterDefinition.name};
+        return {label: filterDefinition.label, value: filterDefinition.name};
       });
 
   const getConditionSelectorOptions = () => {
@@ -79,22 +79,13 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
     return fieldDefinition.availableConditions.map(
       (condition: FilterConditionName) => {
         const conditionDefinition = FILTER_CONDITIONS[condition];
-        return {label: conditionDefinition.label, id: conditionDefinition.name};
+        return {label: conditionDefinition.label, value: conditionDefinition.name};
       }
     );
   };
 
-  const codeToCountry = (code: string) => {
-    let matchedCountry = 'Canada'; // Default to just show something
-
-    COUNTRIES.forEach((item) => {
-      if (item.value === code) {
-        matchedCountry = item.label;
-      }
-    });
-
-    return matchedCountry;
-  };
+  const isCountryFilterSelected = () =>
+    props.filter.fieldName && props.filter.fieldName === 'countries';
 
   return (
     <div className={styles.root}>
@@ -138,34 +129,40 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
 
       {/* Filter value */}
       <div className={styles.column}>
-        {/*
         {!props.hideLabels && (
-          <span className={styles.label}>{t('Value')}</span>
+          <span className={styles.label}>
+            {isCountryFilterSelected() ? t('Select country') : t('Value')}
+          </span>
         )}
+
         {!isFilterConditionValueRequired(props.filter.condition) && <div />}
-        {isFilterConditionValueRequired(props.filter.condition) && (
-          <TextBox
-            customModifiers='on-white'
-            value={props.filter.value || ''}
-            onChange={onFilterValueChange}
-            placeholder={t('Enter value')}
-            // Requires field to be selected first
-            disabled={!props.filter.fieldName}
-          />
-        )}
-          */}
-        <WrappedSelect
-          label={t('Country')}
-          // Process the corrent string here
-          value={codeToCountry(props.filter.value || '')}
-          // To avoid changes to current types, I want to send the code still
-          onChange={(country: any) => {onFilterValueChange(country.value)}}
-          options={COUNTRIES}
-          isLimitedHeight
-          menuPlacement='top'
-          isClearable
-          data-cy='country'
-        />
+        {isFilterConditionValueRequired(props.filter.condition) &&
+          !isCountryFilterSelected() && (
+            <TextBox
+              customModifiers='on-white'
+              value={props.filter.value || ''}
+              onChange={onFilterValueChange}
+              placeholder={t('Enter value')}
+              // Requires field to be selected first
+              disabled={!props.filter.fieldName}
+            />
+          )}
+        {isFilterConditionValueRequired(props.filter.condition) &&
+          isCountryFilterSelected() && (
+            <KoboSelect
+              name={generateUid()}
+              type='outline'
+              size='m'
+              isClearable
+              placeholder={t('Country')}
+              selectedOption={props.filter.value || ''}
+              options={COUNTRIES}
+              onChange={(code: string | null) => {
+                onFilterValueChange(code || '');
+              }}
+              data-cy='country'
+            />
+          )}
       </div>
 
       <div className={styles.column}>

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -84,8 +84,7 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
     );
   };
 
-  const isCountryFilterSelected = () =>
-    props.filter.fieldName && props.filter.fieldName === 'countries';
+  const isCountryFilterSelected = props.filter.fieldName && props.filter.fieldName === 'countries';
 
   return (
     <div className={styles.root}>
@@ -129,15 +128,11 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
 
       {/* Filter value */}
       <div className={styles.column}>
-        {!props.hideLabels && (
-          <span className={styles.label}>
-            {isCountryFilterSelected() ? t('Select country') : t('Value')}
-          </span>
-        )}
+        <span className={styles.label}>{t('Value')}</span>
 
         {!isFilterConditionValueRequired(props.filter.condition) && <div />}
         {isFilterConditionValueRequired(props.filter.condition) &&
-          !isCountryFilterSelected() && (
+          !isCountryFilterSelected && (
             <TextBox
               customModifiers='on-white'
               value={props.filter.value || ''}
@@ -148,7 +143,7 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
             />
           )}
         {isFilterConditionValueRequired(props.filter.condition) &&
-          isCountryFilterSelected() && (
+          isCountryFilterSelected && (
             <KoboSelect
               name={generateUid()}
               type='outline'

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -128,7 +128,9 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
 
       {/* Filter value */}
       <div className={styles.column}>
-        <span className={styles.label}>{t('Value')}</span>
+        {!props.hideLabels && (
+          <span className={styles.label}>{t('Value')}</span>
+        )}
 
         {!isFilterConditionValueRequired(props.filter.condition) && <div />}
         {isFilterConditionValueRequired(props.filter.condition) &&

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -10,6 +10,8 @@ import type {
 } from './constants';
 import {FILTER_CONDITIONS, PROJECT_FIELDS} from './constants';
 import {isFilterConditionValueRequired} from './utils';
+import envStore from 'js/envStore';
+import WrappedSelect from 'js/components/common/wrappedSelect';
 import styles from './projectsFilterEditor.module.scss';
 
 interface ProjectsFilterEditorProps {
@@ -19,6 +21,8 @@ interface ProjectsFilterEditorProps {
   onFilterChange: (filter: ProjectsFilterDefinition) => void;
   onDelete: () => void;
 }
+
+const COUNTRIES = envStore.data.country_choices;
 
 export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
   const onFilterValueChange = (newValue: string) => {
@@ -80,6 +84,18 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
     );
   };
 
+  const codeToCountry = (code: string) => {
+    let matchedCountry = 'Canada'; // Default to just show something
+
+    COUNTRIES.forEach((item) => {
+      if (item.value === code) {
+        matchedCountry = item.label;
+      }
+    });
+
+    return matchedCountry;
+  };
+
   return (
     <div className={styles.root}>
       {/* Filter field selector */}
@@ -122,6 +138,7 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
 
       {/* Filter value */}
       <div className={styles.column}>
+        {/*
         {!props.hideLabels && (
           <span className={styles.label}>{t('Value')}</span>
         )}
@@ -136,6 +153,19 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
             disabled={!props.filter.fieldName}
           />
         )}
+          */}
+        <WrappedSelect
+          label={t('Country')}
+          // Process the corrent string here
+          value={codeToCountry(props.filter.value || '')}
+          // To avoid changes to current types, I want to send the code still
+          onChange={(country: any) => {onFilterValueChange(country.value)}}
+          options={COUNTRIES}
+          isLimitedHeight
+          menuPlacement='top'
+          isClearable
+          data-cy='country'
+        />
       </div>
 
       <div className={styles.column}>


### PR DESCRIPTION
Also changed `KoboSelect` to use `value` instead of `id` for consistency (with older code and backend). 

## Description
Users can now select country by full name in projects filter list.

## Related issues

Fixes #4176 