### PR TITLE
Correct a typo in email verification template

### DIFF
--- a/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
@@ -4,7 +4,7 @@
 
 {{ activate_url }}
 
-{% blocktrans %}This link will expire in one hour. To request a new verification link, please go to your account settings and re-enter your new email address:"{% endblocktrans %}
+{% blocktrans %}This link will expire in one hour. To request a new verification link, please go to your account settings and re-enter your new email address:{% endblocktrans %}
 {% accounts_settings %}
 
 {% blocktrans %}Best,{% endblocktrans %}


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Remove an extra `"` left in the email verification template

## Related issues

