### PR TITLE
Use account security URL in email verification…

### DIFF
--- a/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
@@ -5,7 +5,7 @@
 {{ activate_url }}
 
 {% blocktrans %}This link will expire in one hour. To request a new verification link, please go to your account settings and re-enter your new email address:{% endblocktrans %}
-{% accounts_settings %}
+{% account_security %}
 
 {% blocktrans %}Best,{% endblocktrans %}
 KoboToolbox

--- a/kobo/apps/accounts/templatetags/url_creation.py
+++ b/kobo/apps/accounts/templatetags/url_creation.py
@@ -4,6 +4,7 @@ from django.conf import settings
 register = template.Library()
 
 @register.simple_tag
-def accounts_settings():
-    account_settings = settings.KOBOFORM_URL + '/#/account/settings'
-    return account_settings
+def account_security():
+    # Not using `reverse()` because this is a route within the SPA
+    account_security = settings.KOBOFORM_URL + '/#/account/security'
+    return account_security


### PR DESCRIPTION
message, jumping directly to the place where email addresses are configured