### PR TITLE
Feature/sso signup set default email

### DIFF
--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -22,9 +22,12 @@ class AccountAdapter(DefaultAccountAdapter):
         return user
 
 
+# The following class is a work around for https://github.com/pennersr/django-allauth/issues/3257
+# Also see https://github.com/pennersr/django-allauth/issues/3241
+# PR fix: https://github.com/pennersr/django-allauth/pull/3242
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
     def populate_user(self, request, sociallogin, data):
         user = super().populate_user(request, sociallogin, data)
-        if sociallogin.email_addresses:
+        if not user.email and sociallogin.email_addresses:
             user.email = sociallogin.email_addresses[0].email
         return user

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -1,5 +1,6 @@
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.forms import SignupForm
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from constance import config
 from django.db import transaction
 
@@ -18,4 +19,12 @@ class AccountAdapter(DefaultAccountAdapter):
             user.extra_details.data.update(extra_data)
             if commit:
                 user.extra_details.save()
+        return user
+
+
+class SocialAccountAdapter(DefaultSocialAccountAdapter):
+    def populate_user(self, request, sociallogin, data):
+        user = super().populate_user(request, sociallogin, data)
+        if sociallogin.email_addresses:
+            user.email = sociallogin.email_addresses[0].email
         return user

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -67,6 +67,9 @@ class ProviderTestCase(APITestCase):
             "v4vfdWEoWMGPeIO",
         )
 
+        self.request = None  # request required but seems not to be used
+        self.provider = OpenIDConnectProvider(self.request)
+
     def tearDown(self):
         self.application.delete()
 
@@ -78,9 +81,14 @@ class ProviderTestCase(APITestCase):
             "family_name": "User",
         }
 
-        request = None  # request required but seems not to be used
-        provider = OpenIDConnectProvider(request=request)
-        sociallogin = provider.sociallogin_from_response(
-            request=request, response=payload
+        sociallogin = self.provider.sociallogin_from_response(
+            request=self.request, response=payload
         )
         assert sociallogin.user.email == "test@example.org"
+
+    def test_user_signup_email_not_populated_if_not_provided(self):
+        payload = {"sub": "60e1123a-3583-4f04-a0ef-1037e97c2276"}
+        sociallogin = self.provider.sociallogin_from_response(
+            request=self.request, response=payload
+        )
+        assert sociallogin.user.email == ""

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -1,4 +1,9 @@
+import contextlib
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.providers.openid_connect.provider import (
+    OpenIDConnectProvider,
+)
 from django.core import mail
 from django.urls import reverse
 from model_bakery import baker
@@ -29,3 +34,53 @@ class AccountsEmailTestCase(APITestCase):
         res = self.client.delete(url)
         self.assertEqual(res.status_code, 204)
         self.assertFalse(self.user.socialaccount_set.exists())
+
+
+class ProviderTestCase(APITestCase):
+    def setUp(self):
+        # modify settings to add test social account provider
+        with contextlib.ExitStack() as exit_stack:
+            self._updated_settings = exit_stack.enter_context(
+                self.settings(
+                    SOCIALACCOUNT_PROVIDERS={
+                        "openid_connect": {
+                            "SERVERS": [
+                                {
+                                    "id": "example",
+                                    "server_url": "https://example.org/oauth",
+                                    "name": "Example",
+                                }
+                            ]
+                        }
+                    }
+                )
+            )
+            self.addCleanup(exit_stack.pop_all().close)
+
+        # add corresponding SocialApp
+        self.application = SocialApp.objects.create(
+            provider="Example",
+            name="Example",
+            client_id="vW1RcAl7Mb0d5gyHNQIAcH110lWoOW2BmWJIero8",
+            secret="DZFpuNjRdt5xUEzxXovAp40bU3lQvoMvF3awEStn61RXWE0Ses"
+            "4RgzHWKJKTvUCHfRkhcBi3ebsEfSjfEO96vo2Sh6pZlxJ6f7KcUbhvqMMPoVxRw"
+            "v4vfdWEoWMGPeIO",
+        )
+
+    def tearDown(self):
+        self.application.delete()
+
+    def test_user_signup_email_populated(self):
+        payload = {
+            "sub": "60e1123a-3583-4f04-a0ef-1037e97c2276",  # random uuid4
+            "email": "test@example.org",
+            "given_name": "Test",
+            "family_name": "User",
+        }
+
+        request = None  # request required but seems not to be used
+        provider = OpenIDConnectProvider(request=request)
+        sociallogin = provider.sociallogin_from_response(
+            request=request, response=payload
+        )
+        assert sociallogin.user.email == "test@example.org"

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -707,6 +707,7 @@ SOCIALACCOUNT_AUTO_SIGNUP = False
 SOCIALACCOUNT_FORMS = {
     'signup': 'kobo.apps.accounts.forms.SocialSignupForm',
 }
+SOCIALACCOUNT_ADAPTER = "kobo.apps.accounts.adapter.SocialAccountAdapter"
 
 # See https://django-allauth.readthedocs.io/en/latest/configuration.html
 # Map env vars to upstream dict values, include exact case. Underscores for delimiter.

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -707,6 +707,7 @@ SOCIALACCOUNT_AUTO_SIGNUP = False
 SOCIALACCOUNT_FORMS = {
     'signup': 'kobo.apps.accounts.forms.SocialSignupForm',
 }
+# work around for https://github.com/pennersr/django-allauth/issues/3257
 SOCIALACCOUNT_ADAPTER = "kobo.apps.accounts.adapter.SocialAccountAdapter"
 
 # See https://django-allauth.readthedocs.io/en/latest/configuration.html


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
    - no change to APIs
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Override django-allauth library defaults to correctly populate user email on OpenID Connect signup

## Explanation

I ran into a problem setting up Kobo SSO signin with an OpenID Connect provider. Although the [OpenID userinfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) returns the user's email, it is not pre-populated in the user signup form. We would like to have it so the user does not need to re-enter their email at this step, so this PR adds the functionality to populate the email when provided.

The problem is actually not with the code in `kpi` itself, but with the OpenIDProvider in the `django-allauth` library. I fixed it by customizing the Adapter class. In the long term I'd like to submit a patch to the library to fix it this problem. However I'm not sure when this will be possible, and as I already found a pretty easy fix, I though I'd submit it here.

Please don't hesitate to point out any problems you see or if you would like to tackle this another way. I'm not super familiar with the kobo code base yet and I'm very open to suggestions!

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->

(Didn't create an issue for this, but I can if it's desired.)
