### PR TITLE
Fix python build failure during CI unit-tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ['3.8', '3.10']
     services:
       postgres:
-        image: postgis/postgis:9.5-2.5
+        image: postgis/postgis:14-3.2
         env:
           POSTGRES_USER: kobo
           POSTGRES_PASSWORD: kobo
@@ -32,7 +32,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis_cache:
-        image: redis:3.2
+        image: redis:6.2
         ports:
           - 6379:6379
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -56,7 +56,7 @@ jobs:
       run: >-
         sudo DEBIAN_FRONTEND=noninteractive apt-get -y install
         gdal-bin gettext libproj-dev postgresql-client ffmpeg
-        gcc libc-dev
+        gcc libc-dev build-essential
     - name: Install Python dependencies
       run: pip-sync dependencies/pip/dev_requirements.txt
     - name: Install JavaScript dependencies

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -544,7 +544,7 @@ urllib3==1.26.9
     #   requests
     #   responses
     #   sentry-sdk
-uwsgi==2.0.20
+uwsgi==2.0.21
     # via -r dependencies/pip/requirements.in
 vine==5.0.0
     # via

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -443,7 +443,7 @@ urllib3==1.26.9
     #   requests
     #   responses
     #   sentry-sdk
-uwsgi==2.0.20
+uwsgi==2.0.21
     # via -r dependencies/pip/requirements.in
 vine==5.0.0
     # via


### PR DESCRIPTION
## Description

Make GitHub Actions pass on pip uWSGI dependency install

## Additional info

Installing `build-essentials` and upgrading uWSGI to `2.021` (instead of `2.020` previously) helps pip to install uWSGI successfully instead of raising these errors: 

- `gcc: fatal error: cannot execute 'cc1': execvp: No such file or directory`
- `python setup.py bdist_wheel did not run successfully.`


