### PR TITLE
Avoid redundant building steps on container start-up

### DIFF
--- a/docker/init.bash
+++ b/docker/init.bash
@@ -3,7 +3,7 @@ set -e
 
 source /etc/profile
 
-echo 'KoBoForm initializing...'
+echo 'KPI initializing…'
 
 cd "${KPI_SRC_DIR}"
 
@@ -17,18 +17,18 @@ fi
 KPI_WEB_SERVER="${KPI_WEB_SERVER:-uWSGI}"
 if [[ "${KPI_WEB_SERVER,,}" == 'uwsgi' ]]; then
     # `diff` returns exit code 1 if it finds a difference between the files
-    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/requirements.txt" "/srv/tmp/pip_dependencies.txt"
+    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/requirements.txt" "${TMP_DIR}/pip_dependencies.txt"
     then
-        echo "Syncing production pip dependencies..."
+        echo "Syncing production pip dependencies…"
         pip-sync dependencies/pip/requirements.txt 1>/dev/null
-        cp "dependencies/pip/requirements.txt" "/srv/tmp/pip_dependencies.txt"
+        cp "dependencies/pip/requirements.txt" "${TMP_DIR}/pip_dependencies.txt"
     fi
 else
-    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"
+    if ! diff -q "${KPI_SRC_DIR}/dependencies/pip/dev_requirements.txt" "${TMP_DIR}/pip_dependencies.txt"
     then
-        echo "Syncing development pip dependencies..."
+        echo "Syncing development pip dependencies…"
         pip-sync dependencies/pip/dev_requirements.txt 1>/dev/null
-        cp "dependencies/pip/dev_requirements.txt" "/srv/tmp/pip_dependencies.txt"
+        cp "dependencies/pip/dev_requirements.txt" "${TMP_DIR}/pip_dependencies.txt"
     fi
 fi
 
@@ -36,10 +36,10 @@ fi
 /bin/bash "${INIT_PATH}/wait_for_mongo.bash"
 /bin/bash "${INIT_PATH}/wait_for_postgres.bash"
 
-echo 'Running migrations...'
+echo 'Running migrations…'
 gosu "${UWSGI_USER}" python manage.py migrate --noinput
 
-echo 'Creating superuser...'
+echo 'Creating superuser…'
 gosu "${UWSGI_USER}" python manage.py create_kobo_superuser
 
 if [[ ! -d "${KPI_SRC_DIR}/staticfiles" ]] || ! python "${KPI_SRC_DIR}/docker/check_kpi_prefix_outdated.py"; then
@@ -48,25 +48,26 @@ if [[ ! -d "${KPI_SRC_DIR}/staticfiles" ]] || ! python "${KPI_SRC_DIR}/docker/ch
         # Create folder to be sure following `rsync` command does not fail
         mkdir -p "${KPI_SRC_DIR}/staticfiles"
     else
-        echo "Syncing \`npm\` packages..."
+        echo "Cleaning old build…"
+        rm -rf "${KPI_SRC_DIR}/jsapp/fonts" && \
+        rm -rf "${KPI_SRC_DIR}/jsapp/compiled"
+
+        echo "Syncing \`npm\` packages…"
         check-dependencies --install
 
-        # Clean up folders
-        rm -rf "${KPI_SRC_DIR}/jsapp/fonts" && \
-        rm -rf "${KPI_SRC_DIR}/jsapp/compiled" && \
-        echo "Rebuilding client code..."
-        npm run copy-fonts && npm run build
+        echo "Rebuilding client code…"
+        npm run build
 
-        echo "Building static files from live code..."
+        echo "Building static files from live code…"
         python manage.py collectstatic --noinput
     fi
 fi
 
-echo "Copying static files to nginx volume..."
+echo "Copying static files to nginx volume…"
 rsync -aq --delete --chown=www-data "${KPI_SRC_DIR}/staticfiles/" "${NGINX_STATIC_DIR}/"
 
 if [[ ! -d "${KPI_SRC_DIR}/locale" ]] || [[ -z "$(ls -A ${KPI_SRC_DIR}/locale)" ]]; then
-    echo "Fetching translations..."
+    echo "Fetching translations…"
     git submodule init && \
     git submodule update --remote && \
     python manage.py compilemessages
@@ -78,7 +79,7 @@ if [[ -d /srv/pydev_orig && -n "${KPI_PATH_FROM_ECLIPSE_TO_PYTHON_PAIRS}" ]]; th
     "${KPI_SRC_DIR}/docker/setup_pydev.bash"
 fi
 
-echo 'Cleaning up Celery PIDs...'
+echo 'Cleaning up Celery PIDs…'
 rm -rf /tmp/celery*.pid
 
 echo 'Restore permissions on Celery logs folder'
@@ -89,6 +90,6 @@ chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_LOGS_DIR}"
 # do it themselves
 chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_MEDIA_DIR}"
 
-echo 'KoBoForm initialization completed.'
+echo 'KPI initialization completed.'
 
 exec /usr/bin/runsvdir "${SERVICES_DIR}"


### PR DESCRIPTION
## Description

Remove manual calls of `npm run copy-fonts` (because `npm` post-install calls it automatically) and also copy `pip-dependencies.txt` in the last build step to avoid calling `pip-sync` when the dependencies are the same.
