### PR TITLE
Fix anonymous access regression

### DIFF
--- a/jsapp/js/router/allRoutes.es6
+++ b/jsapp/js/router/allRoutes.es6
@@ -127,7 +127,7 @@ const AllRoutes = class AllRoutes extends React.Component {
         <Tracking />
         <Routes>
           <Route path={ROUTES.ROOT} element={<App />}>
-            <Route path='' element={<Navigate to={ROUTES.FORMS} replace />} />
+            <Route path={ROUTES.ROOT} element={<Navigate to={ROUTES.FORMS} replace />} />
             <Route path={ROUTES.ACCOUNT_ROOT}>{accountRoutes()}</Route>
             <Route path={ROUTES.PROJECTS_ROOT}>{projectsRoutes()}</Route>
             <Route path={ROUTES.LIBRARY}>

--- a/jsapp/js/router/routerConstants.ts
+++ b/jsapp/js/router/routerConstants.ts
@@ -10,7 +10,7 @@ export const FORM_PROCESSING_BASE = '/forms/:uid/data/processing'
 
 // List of React app routes (the # ones)
 export const ROUTES = Object.freeze({
-  ROOT: '/',
+  ROOT: '',
   ACCOUNT_ROOT: '/account',
   LIBRARY: '/library',
   MY_LIBRARY: '/library/my-library',

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -42,7 +42,8 @@ export function getCurrentPath(): string {
  */
 
 export function isRootRoute(): boolean {
-  return getCurrentPath() === ROUTES.ROOT || window.location.pathname === ROUTES.ROOT;
+  // Cannot rely on `window.location.pathname` while hash router still in use
+  return getCurrentPath() === ROUTES.ROOT;
 }
 
 export function isLibraryRoute(): boolean {


### PR DESCRIPTION
All routes, instead of only the root route, were being redirected to login whenever a session was not established. Fixes #4266.