### PR TITLE
Add API endpoint for Stripe Products

### DIFF
--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -18,6 +18,13 @@ class PlanSerializer(serializers.ModelSerializer):
         exclude = ('djstripe_id',)
 
 
+class ProductSerializer(BaseProductSerializer):
+    plans = PlanSerializer(many=True, source="plan_set")
+
+    class Meta(BaseProductSerializer.Meta):
+        fields = ("id", "name", "description", "type", "plans", "metadata")
+
+
 class SubscriptionSerializer(serializers.ModelSerializer):
 
     plan = serializers.SerializerMethodField()

--- a/kobo/apps/stripe/tests/test_product_api.py
+++ b/kobo/apps/stripe/tests/test_product_api.py
@@ -1,0 +1,27 @@
+from django.shortcuts import reverse
+from model_bakery import baker
+
+from kpi.tests.kpi_test_case import BaseTestCase
+
+
+class ProductAPITestCase(BaseTestCase):
+    def test_product_list(self):
+        plan = baker.make(
+            "djstripe.Plan",
+            amount=0,
+            livemode=False,
+            active=True,
+            product__active=True,
+            product__livemode=False,
+        )
+        inactive_plan = baker.make(
+            "djstripe.Plan",
+            amount=0,
+            livemode=False,
+            active=False,
+            product__active=False,
+            product__livemode=False,
+        )
+        res = self.client.get(reverse("product-list"))
+        self.assertContains(res, plan.id)
+        self.assertNotContains(res, inactive_plan.id)

--- a/kobo/apps/stripe/urls.py
+++ b/kobo/apps/stripe/urls.py
@@ -1,11 +1,12 @@
 from django.urls import include, re_path
 from rest_framework.routers import SimpleRouter
 
-
-from kobo.apps.stripe.views import SubscriptionViewSet
+from kobo.apps.stripe.views import ProductViewSet, SubscriptionViewSet
 
 router = SimpleRouter()
 router.register(r'subscriptions', SubscriptionViewSet, basename='subscriptions')
+router.register(r'products', ProductViewSet)
+
 
 urlpatterns = [
     re_path(r'^', include(router.urls)),

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -35,5 +35,5 @@ class ProductViewSet(viewsets.ReadOnlyModelViewSet):
         plan__active=True,
     ).prefetch_related(
         Prefetch("plan_set", queryset=Plan.objects.filter(active=True))
-    )
+    ).distinct()
     serializer_class = ProductSerializer

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -14,7 +14,6 @@ class SubscriptionViewSet(
     mixins.RetrieveModelMixin,
     viewsets.GenericViewSet,
 ):
-
     queryset = Subscription.objects.all()
     serializer_class = SubscriptionSerializer
     lookup_field = 'id'
@@ -27,7 +26,7 @@ class SubscriptionViewSet(
         )
 
 
-class ProductViewSet(viewsets.ReadOnlyModelViewSet):
+class ProductViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     queryset = (
         Product.objects.filter(
             active=True,

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -6,7 +6,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from kobo.apps.stripe.serializers import SubscriptionSerializer
-
 from .serializers import ProductSerializer
 
 
@@ -29,11 +28,15 @@ class SubscriptionViewSet(
 
 
 class ProductViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Product.objects.filter(
-        active=True,
-        livemode=settings.STRIPE_LIVE_MODE,
-        plan__active=True,
-    ).prefetch_related(
-        Prefetch("plan_set", queryset=Plan.objects.filter(active=True))
-    ).distinct()
+    queryset = (
+        Product.objects.filter(
+            active=True,
+            livemode=settings.STRIPE_LIVE_MODE,
+            plan__active=True,
+        )
+        .prefetch_related(
+            Prefetch("plan_set", queryset=Plan.objects.filter(active=True))
+        )
+        .distinct()
+    )
     serializer_class = ProductSerializer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@
 line-length = 80
 skip-string-normalization = true
 [tool.isort]
-default_section = "THIRDPARTY"
+profile = "black"
 known_first_party = "kobo"
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+no_lines_before = ["LOCALFOLDER"]


### PR DESCRIPTION
## Description

Add API endpoint for Stripe Products. Used to increase limits on public servers such as kf.kobotoolbox.org

## Implementation

This is entirely public. It's just a list of known products. It doesn't even require user login. It filters out inactive plans and products.