### PR TITLE
Fix app crashing when quickly switching routes between form sub routes

### DIFF
--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -1014,7 +1014,7 @@ mixins.permissions = {
 
     // Owners cannot have partial permissions because they have full permissions.
     // Both are contradictory.
-    if (asset.owner__username === currentUsername) {
+    if (asset?.owner__username === currentUsername) {
       return false;
     }
 


### PR DESCRIPTION
## Description

Fix crash when quickly switching form routes (Summary, Form, Data, and Settings tabs)

## Related issues

Fixes #4276

## Implementation

This inserts a null check in mixins.ts userCanPartially's logic. It doesn't attempt make drastic changes to fundamentally solve this class of problem. Eventually, mixins should no longer be used and state should be managed in a way that lets TypeScript ensure this entire class of problem cannot happen. As is, userCanPartially is being fed an incorrect non-null type and so we could say the type definition is simply inaccurate.

This fix depends on a fairly hard to reproduce situation and would benefit from careful testing.