### PR TITLE
Validate usernames the same way in Django Admin and registration form

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -1,13 +1,48 @@
 # coding: utf-8
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.forms import (
+    UserCreationForm as DjangoUserCreationForm,
+    UserChangeForm as DjangoUserChangeForm,
+)
 from django.contrib.auth.models import User
+from django.db.models import Count, Sum
+from django.forms import CharField
+from django.utils import timezone
 
+from kobo.apps.accounts.validators import (
+    USERNAME_MAX_LENGTH,
+    USERNAME_INVALID_MESSAGE,
+    username_validators,
+)
+from kpi.deployment_backends.kc_access.shadow_models import (
+    ReadOnlyKobocatMonthlyXFormSubmissionCounter,
+)
 from kpi.deployment_backends.kc_access.utils import delete_kc_users
 from .models import SitewideMessage, ConfigurationFile, PerUserSetting
 
 
-class UserDeleteAdmin(UserAdmin):
+class UserChangeForm(DjangoUserChangeForm):
+
+    username = CharField(
+        label='username',
+        max_length=USERNAME_MAX_LENGTH,
+        help_text=USERNAME_INVALID_MESSAGE,
+        validators=username_validators,
+    )
+
+
+class UserCreationForm(DjangoUserCreationForm):
+
+    username = CharField(
+        label='username',
+        max_length=USERNAME_MAX_LENGTH,
+        help_text=USERNAME_INVALID_MESSAGE,
+        validators=username_validators,
+    )
+
+
+class ExtendedUserAdmin(UserAdmin):
     """
     Deleting users used to a two-step process since KPI and KoBoCAT
     shared the same database, but it's not the case anymore.
@@ -22,8 +57,33 @@ class UserDeleteAdmin(UserAdmin):
     Then, KoBoCAT objects related to the user (in KoBoCAT database) except
     `XForm` and `Instance`. We do not want to delete data without owner's
     permission
-
     """
+
+    form = UserChangeForm
+    add_form = UserCreationForm
+
+    list_display = UserAdmin.list_display + ('date_joined',)
+    list_filter = UserAdmin.list_filter + ('date_joined',)
+    readonly_fields = UserAdmin.readonly_fields + (
+        'deployed_forms_count',
+        'monthly_submission_count',
+    )
+    fieldsets = UserAdmin.fieldsets + (
+        (
+            'Deployed forms and Submissions Counts',
+            {'fields': ('deployed_forms_count', 'monthly_submission_count')},
+        ),
+    )
+
+    def deployed_forms_count(self, obj):
+        """
+        Gets the count of deployed forms to be displayed on the
+        Django admin user changelist page
+        """
+        assets_count = obj.assets.filter(
+            _deployment_data__active=True
+        ).aggregate(count=Count('pk'))
+        return assets_count['count']
 
     def delete_queryset(self, request, queryset):
         """
@@ -72,9 +132,24 @@ class UserDeleteAdmin(UserAdmin):
                 messages.ERROR
             )
 
+    def monthly_submission_count(self, obj):
+        """
+        Gets the number of this month's submissions a user has to be
+        displayed in the Django admin user changelist page
+        """
+        today = timezone.now().date()
+        instances = ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.filter(
+            user_id=obj.id,
+            year=today.year,
+            month=today.month,
+        ).aggregate(
+            counter=Sum('counter')
+        )
+        return instances.get('counter')
+
 
 admin.site.register(SitewideMessage)
 admin.site.register(ConfigurationFile)
 admin.site.register(PerUserSetting)
 admin.site.unregister(User)
-admin.site.register(User, UserDeleteAdmin)
+admin.site.register(User, ExtendedUserAdmin)

--- a/hub/admin.py
+++ b/hub/admin.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import (
@@ -131,6 +132,15 @@ class ExtendedUserAdmin(UserAdmin):
                 'interface and delete them from there.',
                 messages.ERROR
             )
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+
+        # Exclude only for autocomplete
+        if request.path == '/admin/autocomplete/':
+            queryset = queryset.exclude(pk=settings.ANONYMOUS_USER_ID)
+
+        return queryset, use_distinct
 
     def monthly_submission_count(self, obj):
         """

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from allauth.account.models import EmailAddress
+
+from .models import EmailAddressAdmin
+
+admin.site.unregister(EmailAddress)
+admin.site.register(EmailAddress, EmailAddressAdmin)

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -10,11 +10,6 @@ from django.utils.translation import gettext_lazy as t
 from kobo.static_lists import COUNTRIES
 
 
-USERNAME_INVALID_MESSAGE = t(
-    'Usernames must be between 2 and 30 characters in length, '
-    'and may only consist of lowercase letters, numbers, '
-    'and underscores, where the first character must be a letter.'
-)
 # Only these fields can be controlled by constance.config.USER_METADATA_FIELDS
 CONFIGURABLE_METADATA_FIELDS = (
     'organization',

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -1,4 +1,5 @@
 from allauth.account.signals import email_confirmed
+from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
 

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -1,7 +1,14 @@
+from allauth.account.admin import EmailAddressAdmin as BaseEmailAddressAdmin
 from allauth.account.signals import email_confirmed
 from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
+
+
+class EmailAddressAdmin(BaseEmailAddressAdmin):
+
+    search_fields = ('user__username',)
+    autocomplete_fields = ['user']
 
 
 class ImportedVerification(models.Model):

--- a/kobo/apps/superuser_stats/admin.py
+++ b/kobo/apps/superuser_stats/admin.py
@@ -1,58 +1,7 @@
 # coding: utf-8
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.models import User
-from django.db.models import Count, Sum
-from django.utils import timezone
 
-from kpi.deployment_backends.kc_access.shadow_models import (
-    ReadOnlyKobocatMonthlyXFormSubmissionCounter,
-)
 from .models import SuperuserStatsModel
-
-
-class ExtendUserAdmin(UserAdmin):
-    """
-    This extends the changelist view of the User Model on the
-    Django admin page
-    """
-    list_display = UserAdmin.list_display + ('date_joined',)
-    list_filter = UserAdmin.list_filter + ('date_joined',)
-    readonly_fields = UserAdmin.readonly_fields + (
-        'deployed_forms_count',
-        'monthly_submission_count',
-    )
-    fieldsets = UserAdmin.fieldsets + (
-        (
-            'Deployed forms and Submissions Counts',
-            {'fields': ('deployed_forms_count', 'monthly_submission_count')},
-        ),
-    )
-
-    def deployed_forms_count(self, obj):
-        """
-        Gets the count of deployed forms to be displayed on the
-        Django admin user changelist page
-        """
-        assets_count = obj.assets.filter(
-            _deployment_data__active=True
-        ).aggregate(count=Count('pk'))
-        return assets_count['count']
-
-    def monthly_submission_count(self, obj):
-        """
-        Gets the number of this month's submissions a user has to be
-        displayed in the Django admin user changelist page
-        """
-        today = timezone.now().date()
-        instances = ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.filter(
-            user_id=obj.id,
-            year=today.year,
-            month=today.month,
-        ).aggregate(
-            counter=Sum('counter')
-        )
-        return instances.get('counter')
 
 
 class SuperuserStatsAdmin(admin.ModelAdmin):
@@ -70,5 +19,3 @@ class SuperuserStatsAdmin(admin.ModelAdmin):
 
 
 admin.site.register(SuperuserStatsModel, SuperuserStatsAdmin)
-admin.site.unregister(User)
-admin.site.register(User, ExtendUserAdmin)


### PR DESCRIPTION
## Checklist

1. [] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Allow usernames between 2 to 30 characters in lowercase which can contain numbers and underscores. 
The first character must be a letter.

# Additional infos

There were ModelAdmin for registered  `User` model. The last one was overriding the first one.
It has been refactored to use only one model in the `hub` Django application.  

## Related issues

Related to #4277 and even if it does not fix the problem exposed by #4277, this PR should close it because usernames with dot (or dashes) will not be allowed.