### PR TITLE
Always use autocomplete inputs for `User` field in Django Admin

### DIFF
--- a/hub/admin.py
+++ b/hub/admin.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import (
@@ -131,6 +132,15 @@ class ExtendedUserAdmin(UserAdmin):
                 'interface and delete them from there.',
                 messages.ERROR
             )
+
+    def get_search_results(self, request, queryset, search_term):
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+
+        # Exclude only for autocomplete
+        if request.path == '/admin/autocomplete/':
+            queryset = queryset.exclude(pk=settings.ANONYMOUS_USER_ID)
+
+        return queryset, use_distinct
 
     def monthly_submission_count(self, obj):
         """

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from allauth.account.models import EmailAddress
+
+from .models import EmailAddressAdmin
+
+admin.site.unregister(EmailAddress)
+admin.site.register(EmailAddress, EmailAddressAdmin)

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -1,7 +1,14 @@
+from allauth.account.admin import EmailAddressAdmin as BaseEmailAddressAdmin
 from allauth.account.signals import email_confirmed
 from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
+
+
+class EmailAddressAdmin(BaseEmailAddressAdmin):
+
+    search_fields = ('user__username',)
+    autocomplete_fields = ['user']
 
 
 class ImportedVerification(models.Model):


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Make user assignment to other objects more user-friendly. 

## Additional info

Remove anonymous user from search and autocomplete inputs

## Related issues

Blocked by #4281
