### PR TITLE
Project Summary Details improvement

### DIFF
--- a/jsapp/js/components/common/assetStatusBadge.tsx
+++ b/jsapp/js/components/common/assetStatusBadge.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Badge from 'js/components/common/badge';
+import type {AssetResponse, ProjectViewAsset} from 'js/dataInterface';
+
+interface AssetStatusBadgeProps {
+  asset: AssetResponse | ProjectViewAsset;
+}
+
+/**
+ * Displays a small colorful badge with an icon. The badge tells whether
+ * the project is draft, deployed, or archived.
+ */
+export default function AssetStatusBadge(props: AssetStatusBadgeProps) {
+  if (props.asset.has_deployment && !props.asset.deployment__active) {
+    return (
+      <Badge
+        color='light-amber'
+        size='s'
+        icon='project-archived'
+        label={t('archived')}
+      />
+    );
+  } else if (props.asset.has_deployment) {
+    return (
+      <Badge
+        color='light-blue'
+        size='s'
+        icon='project-deployed'
+        label={t('deployed')}
+      />
+    );
+  } else {
+    return (
+      <Badge
+        color='light-teal'
+        size='s'
+        icon='project-draft'
+        label={t('draft')}
+      />
+    );
+  }
+}

--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -351,9 +351,11 @@ class FormSummary extends React.Component {
       <DocumentTitle title={`${docTitle} | KoboToolbox`}>
         <bem.FormView m='summary'>
           <bem.FormView__column m='left'>
-            <FormSummaryProjectInfo
-              asset={this.state}
-            />
+            {/* We only want to pass an actual asset object, but because this
+            component uses `mixins.dmix`, we have to add this little check. */}
+            {this.state.uid &&
+              <FormSummaryProjectInfo asset={this.state}/>
+            }
 
             {/* Submissions graph */}
             {this.renderSubmissionsGraph()}

--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -375,10 +375,6 @@ class FormSummary extends React.Component {
       )
     );
 
-    // if (!this.state.permissions) {
-    //   return (<LoadingSpinner/>);
-    // }
-
     return (
       <DocumentTitle title={`${docTitle} | KoboToolbox`}>
         <bem.FormView m='summary'>

--- a/jsapp/js/components/formSummary.es6
+++ b/jsapp/js/components/formSummary.es6
@@ -13,9 +13,7 @@ import Icon from 'js/components/common/icon';
 import moment from 'moment';
 import Chart from 'chart.js';
 import {getFormDataTabs} from './formViewTabs';
-import assetUtils from 'js/assetUtils';
 import {
-  formatTime,
   formatDate,
   stringToColor,
   getUsernameFromUrl,
@@ -26,6 +24,7 @@ import {
 } from 'js/constants';
 import './formSummary.scss';
 import {userCan} from 'js/components/permissions/utils';
+import FormSummaryProjectInfo from './formSummaryProjectInfo';
 
 class FormSummary extends React.Component {
   constructor(props) {
@@ -33,7 +32,6 @@ class FormSummary extends React.Component {
     this.state = {
       subsCurrentPeriod: '',
       subsPreviousPeriod: '',
-      lastSubmission: false,
       chartVisible: false,
       chart: {},
       chartPeriod: 'week',
@@ -52,7 +50,6 @@ class FormSummary extends React.Component {
   prep() {
     if (this.state.permissions && userCan('view_submissions', this.state)) {
       const uid = this._getAssetUid();
-      this.getLatestSubmissionTime(uid);
       this.prepSubmissions(uid);
     }
   }
@@ -139,14 +136,7 @@ class FormSummary extends React.Component {
     });
 
   }
-  getLatestSubmissionTime(assetid) {
-    const fq = ['_id', 'end'];
-    const sort = [{id: '_id', desc: true}];
-    dataInterface.getSubmissions(assetid, 1, 0, sort, fq).done((data) => {
-      const results = data.results;
-      if (data.count) {this.setState({lastSubmission: results[0]['end']});} else {this.setState({lastSubmission: false});}
-    });
-  }
+
   renderSubmissionsGraph() {
     if (!this.state.permissions || !userCan('view_submissions', this.state)) {
       return null;
@@ -356,120 +346,17 @@ class FormSummary extends React.Component {
   }
   render () {
     const docTitle = this.state.name || t('Untitled');
-    const hasCountry = (
-      this.state.settings?.country &&
-      (
-        !Array.isArray(this.state.settings?.country) ||
-        !!this.state.settings?.country.length
-      )
-    );
-    const hasSector = Boolean(this.state.settings?.sector?.value);
-    const hasProjectInfo = (
-      this.state.settings &&
-      (
-        this.state.settings.description ||
-        hasCountry ||
-        hasSector ||
-        this.state.settings.operational_purpose ||
-        this.state.settings.collects_pii
-      )
-    );
 
     return (
       <DocumentTitle title={`${docTitle} | KoboToolbox`}>
         <bem.FormView m='summary'>
           <bem.FormView__column m='left'>
-            {/* Project information */}
-            {hasProjectInfo &&
-              <bem.FormView__row m='summary-description'>
-                <bem.FormView__cell m={['label', 'first']}>
-                  {t('Project information')}
-                </bem.FormView__cell>
-                <bem.FormView__cell m='box'>
-                  {(hasCountry || hasSector) &&
-                    <bem.FormView__group m={['items', 'description-cols']}>
-                      {hasCountry &&
-                        <bem.FormView__cell m='padding'>
-                          <bem.FormView__label m='country'>{t('Country')}</bem.FormView__label>
-                          {assetUtils.getCountryDisplayString(this.state)}
-                        </bem.FormView__cell>
-                      }
-                      {hasSector &&
-                        <bem.FormView__cell m='padding'>
-                          <bem.FormView__label m='sector'>{t('Sector')}</bem.FormView__label>
-                          {assetUtils.getSectorDisplayString(this.state)}
-                        </bem.FormView__cell>
-                      }
-                    </bem.FormView__group>
-                  }
-                  {(this.state.settings.operational_purpose || this.state.settings.collects_pii) &&
-                    <bem.FormView__group m={['items', 'description-cols']}>
-                      {this.state.settings.operational_purpose &&
-                        <bem.FormView__cell m='padding'>
-                          <bem.FormView__label m='operational-purpose'>{t('Operational purpose of data')}</bem.FormView__label>
-                          {this.state.settings.operational_purpose.label}
-                        </bem.FormView__cell>
-                      }
-                      {this.state.settings.collects_pii &&
-                        <bem.FormView__cell m='padding'>
-                          <bem.FormView__label m='collects-pii'>{t('Collects personally identifiable information')}</bem.FormView__label>
-                          {this.state.settings.collects_pii.label}
-                        </bem.FormView__cell>
-                      }
-                    </bem.FormView__group>
-                  }
-                  {this.state.settings.description &&
-                    <bem.FormView__group m='items'>
-                      <bem.FormView__cell m={['padding', 'description']}>
-                        <bem.FormView__label m='description'>{t('Description')}</bem.FormView__label>
-                        <p>{this.state.settings.description}</p>
-                      </bem.FormView__cell>
-                    </bem.FormView__group>
-                  }
-                </bem.FormView__cell>
-              </bem.FormView__row>
-            }
+            <FormSummaryProjectInfo
+              asset={this.state}
+            />
 
             {/* Submissions graph */}
             {this.renderSubmissionsGraph()}
-
-            {/* Form details */}
-            <bem.FormView__row m='summary-details'>
-              <bem.FormView__cell m={['label', 'first']}>
-                {t('Form details')}
-              </bem.FormView__cell>
-              <bem.FormView__cell m={['box']}>
-                <bem.FormView__group m='summary-details-cols'>
-                  <bem.FormView__cell>
-                    <bem.FormView__label>{t('Last modified')}</bem.FormView__label>
-                    {formatTime(this.state.date_modified)}
-                  </bem.FormView__cell>
-                  {this.state.lastSubmission &&
-                    <bem.FormView__cell>
-                      <bem.FormView__label>{t('Latest submission')}</bem.FormView__label>
-                      {formatTime(this.state.lastSubmission)}
-                    </bem.FormView__cell>
-                  }
-                  {this.state.summary &&
-                    <bem.FormView__cell>
-                      <bem.FormView__label>{t('Questions')}</bem.FormView__label>
-                      {this.state.summary.row_count}
-                    </bem.FormView__cell>
-                  }
-
-                  {this.state.summary && this.state.summary.languages && this.state.summary.languages.length > 1 &&
-                    <bem.FormView__cell>
-                      <bem.FormView__label>{t('Languages')}</bem.FormView__label>
-                      {this.state.summary.languages.map((l, i) => (
-                          <bem.FormView__cell key={`lang-${i}`} data-index={i}>
-                            {l}
-                          </bem.FormView__cell>
-                        ))}
-                    </bem.FormView__cell>
-                  }
-                </bem.FormView__group>
-              </bem.FormView__cell>
-            </bem.FormView__row>
           </bem.FormView__column>
 
           <bem.FormView__column m='right'>

--- a/jsapp/js/components/formSummary.scss
+++ b/jsapp/js/components/formSummary.scss
@@ -9,36 +9,6 @@
   }
 }
 
-.form-view__row--summary-description {
-  .form-view__cell--description:not(:first-child) {
-    border-top: 1px solid colors.$kobo-gray-92;
-  }
-
-  .form-view__cell--description p {
-    white-space: pre-wrap;
-    margin: 0;
-  }
-}
-
-.form-view__group.form-view__group--summary-details-cols {
-  display: flex;
-  align-items: flex-start;
-
-  > .form-view__cell {
-    padding: 15px 20px;
-    flex-grow: 1;
-
-    &:first-child {
-      flex-grow: 2;
-    }
-
-    .form-view__label {
-      font-size: 12px;
-      opacity: 0.6;
-    }
-  }
-}
-
 .form-view__cell.form-view__cell--subs-graph {
   padding: 30px;
   padding-bottom: 0px;

--- a/jsapp/js/components/formSummary.scss
+++ b/jsapp/js/components/formSummary.scss
@@ -1,14 +1,5 @@
 @use '~kobo-common/src/styles/colors';
 
-.form-view__group.form-view__group--description-cols {
-  padding: 20px;
-  display: flex;
-
-  > .form-view__cell {
-    width: 50%;
-  }
-}
-
 .form-view__group.form-view__group--items {
   > .form-view__cell {
     .form-view__label {

--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -1,0 +1,129 @@
+import React, {useState, useEffect} from 'react';
+import bem from 'js/bem';
+import {
+  getCountryDisplayString,
+  getSectorDisplayString,
+} from 'js/assetUtils';
+import type {AssetResponse, PaginatedResponse, SubmissionResponse} from 'js/dataInterface';
+import {dataInterface} from 'js/dataInterface';
+import {formatTime} from 'js/utils';
+
+interface FormSummaryProjectInfoProps {
+  asset: AssetResponse;
+}
+
+export default function FormSummaryProjectInfo(
+  props: FormSummaryProjectInfoProps
+) {
+  const [latestSubmissionDate, setLatestSubmissionDate] = useState<string | undefined>();
+
+  useEffect(() => {
+    dataInterface.getSubmissions(props.asset.uid, 1, 0, [{id: '_id', desc: true}], ['_id', 'end']).done((response: PaginatedResponse<SubmissionResponse>) => {
+      if (response.count) {
+        setLatestSubmissionDate(response.results[0]['end']);
+      }
+    });
+  }, [props.asset.uid]);
+
+  const hasCountry = (
+    props.asset.settings?.country &&
+    (
+      !Array.isArray(props.asset.settings?.country) ||
+      !!props.asset.settings?.country.length
+    )
+  );
+  const hasSector = Boolean(props.asset.settings?.sector?.value);
+  const hasProjectInfo = (
+    props.asset.settings &&
+    (
+      props.asset.settings.description ||
+      hasCountry ||
+      hasSector ||
+      props.asset.settings.operational_purpose ||
+      props.asset.settings.collects_pii
+    )
+  );
+
+  if (!hasProjectInfo) {
+    return null;
+  }
+
+  return (
+    <bem.FormView__row m='summary-description'>
+      <bem.FormView__cell m={['label', 'first']}>
+        {t('Project information')}
+      </bem.FormView__cell>
+      <bem.FormView__cell m='box'>
+        {(hasCountry || hasSector) &&
+          <bem.FormView__group m={['items']}>
+            {hasCountry &&
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label m='country'>{t('Country')}</bem.FormView__label>
+                {getCountryDisplayString(props.asset)}
+              </bem.FormView__cell>
+            }
+            {hasSector &&
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label m='sector'>{t('Sector')}</bem.FormView__label>
+                {getSectorDisplayString(props.asset)}
+              </bem.FormView__cell>
+            }
+          </bem.FormView__group>
+        }
+        {(props.asset.settings.operational_purpose || props.asset.settings.collects_pii) &&
+          <bem.FormView__group m={['items']}>
+            {props.asset.settings.operational_purpose &&
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label m='operational-purpose'>{t('Operational purpose of data')}</bem.FormView__label>
+                {props.asset.settings.operational_purpose.label}
+              </bem.FormView__cell>
+            }
+            {props.asset.settings.collects_pii &&
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label m='collects-pii'>{t('Collects personally identifiable information')}</bem.FormView__label>
+                {props.asset.settings.collects_pii.label}
+              </bem.FormView__cell>
+            }
+          </bem.FormView__group>
+        }
+        {props.asset.settings.description &&
+          <bem.FormView__group m='items'>
+            <bem.FormView__cell m={['padding', 'description']}>
+              <bem.FormView__label m='description'>{t('Description')}</bem.FormView__label>
+              <p>{props.asset.settings.description}</p>
+            </bem.FormView__cell>
+          </bem.FormView__group>
+        }
+        <bem.FormView__group m='summary-details-cols'>
+          <bem.FormView__cell>
+            <bem.FormView__label>{t('Last modified')}</bem.FormView__label>
+            {formatTime(props.asset.date_modified)}
+          </bem.FormView__cell>
+          {latestSubmissionDate &&
+            <bem.FormView__cell>
+              <bem.FormView__label>{t('Latest submission')}</bem.FormView__label>
+              {formatTime(latestSubmissionDate)}
+            </bem.FormView__cell>
+          }
+          {props.asset.summary &&
+            <bem.FormView__cell>
+              <bem.FormView__label>{t('Questions')}</bem.FormView__label>
+              {props.asset.summary.row_count}
+            </bem.FormView__cell>
+          }
+
+          {props.asset.summary?.languages && props.asset.summary.languages.length > 1 &&
+            <bem.FormView__cell>
+              <bem.FormView__label>{t('Languages')}</bem.FormView__label>
+              {props.asset.summary.languages.map((l, i) => (
+                  <bem.FormView__cell key={`lang-${i}`} data-index={i}>
+                    {l}
+                  </bem.FormView__cell>
+                ))}
+            </bem.FormView__cell>
+          }
+        </bem.FormView__group>
+      </bem.FormView__cell>
+    </bem.FormView__row>
+  );
+}

--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -3,10 +3,17 @@ import bem from 'js/bem';
 import {
   getCountryDisplayString,
   getSectorDisplayString,
+  isSelfOwned,
 } from 'js/assetUtils';
-import type {AssetResponse, PaginatedResponse, SubmissionResponse} from 'js/dataInterface';
+import type {
+  AssetResponse,
+  PaginatedResponse,
+  SubmissionResponse,
+} from 'js/dataInterface';
 import {dataInterface} from 'js/dataInterface';
 import {formatTime} from 'js/utils';
+import AssetStatusBadge from './common/assetStatusBadge';
+import Avatar from './common/avatar';
 
 interface FormSummaryProjectInfoProps {
   asset: AssetResponse;
@@ -15,114 +22,145 @@ interface FormSummaryProjectInfoProps {
 export default function FormSummaryProjectInfo(
   props: FormSummaryProjectInfoProps
 ) {
-  const [latestSubmissionDate, setLatestSubmissionDate] = useState<string | undefined>();
+  // NOTE: this will only work with forms that have `end` meta question enabled
+  const [latestSubmissionDate, setLatestSubmissionDate] = useState<
+    string | undefined
+  >();
 
   useEffect(() => {
-    dataInterface.getSubmissions(props.asset.uid, 1, 0, [{id: '_id', desc: true}], ['_id', 'end']).done((response: PaginatedResponse<SubmissionResponse>) => {
-      if (response.count) {
-        setLatestSubmissionDate(response.results[0]['end']);
-      }
-    });
-  }, [props.asset.uid]);
+    // Fetches one last submission, and only two fields for it.
+    dataInterface
+      .getSubmissions(
+        props.asset?.uid,
+        1,
+        0,
+        [{id: '_id', desc: true}],
+        ['_id', 'end']
+      )
+      .done((response: PaginatedResponse<SubmissionResponse>) => {
+        if (response.count) {
+          setLatestSubmissionDate(response.results[0]['end']);
+        }
+      });
+  }, []);
 
-  const hasCountry = (
-    props.asset.settings?.country &&
-    (
-      !Array.isArray(props.asset.settings?.country) ||
-      !!props.asset.settings?.country.length
-    )
-  );
-  const hasSector = Boolean(props.asset.settings?.sector?.value);
-  const hasProjectInfo = (
-    props.asset.settings &&
-    (
-      props.asset.settings.description ||
-      hasCountry ||
-      hasSector ||
-      props.asset.settings.operational_purpose ||
-      props.asset.settings.collects_pii
-    )
-  );
-
-  if (!hasProjectInfo) {
-    return null;
-  }
+  const lastDeployedDate =
+    props.asset.deployed_versions?.results[0].date_modified;
 
   return (
-    <bem.FormView__row m='summary-description'>
+    <bem.FormView__row>
       <bem.FormView__cell m={['label', 'first']}>
         {t('Project information')}
       </bem.FormView__cell>
+
       <bem.FormView__cell m='box'>
-        {(hasCountry || hasSector) &&
-          <bem.FormView__group m={['items']}>
-            {hasCountry &&
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label m='country'>{t('Country')}</bem.FormView__label>
-                {getCountryDisplayString(props.asset)}
-              </bem.FormView__cell>
-            }
-            {hasSector &&
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label m='sector'>{t('Sector')}</bem.FormView__label>
-                {getSectorDisplayString(props.asset)}
-              </bem.FormView__cell>
-            }
-          </bem.FormView__group>
-        }
-        {(props.asset.settings.operational_purpose || props.asset.settings.collects_pii) &&
-          <bem.FormView__group m={['items']}>
-            {props.asset.settings.operational_purpose &&
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label m='operational-purpose'>{t('Operational purpose of data')}</bem.FormView__label>
-                {props.asset.settings.operational_purpose.label}
-              </bem.FormView__cell>
-            }
-            {props.asset.settings.collects_pii &&
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label m='collects-pii'>{t('Collects personally identifiable information')}</bem.FormView__label>
-                {props.asset.settings.collects_pii.label}
-              </bem.FormView__cell>
-            }
-          </bem.FormView__group>
-        }
-        {props.asset.settings.description &&
-          <bem.FormView__group m='items'>
-            <bem.FormView__cell m={['padding', 'description']}>
-              <bem.FormView__label m='description'>{t('Description')}</bem.FormView__label>
-              <p>{props.asset.settings.description}</p>
-            </bem.FormView__cell>
-          </bem.FormView__group>
-        }
-        <bem.FormView__group m='summary-details-cols'>
-          <bem.FormView__cell>
+        <bem.FormView__group m='items'>
+          {/* description - takes whole row */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Description')}</bem.FormView__label>
+            {props.asset.settings.description || '-'}
+          </bem.FormView__cell>
+        </bem.FormView__group>
+
+        <bem.FormView__group m='items'>
+          {/* status */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Status')}</bem.FormView__label>
+            <AssetStatusBadge asset={props.asset} />
+          </bem.FormView__cell>
+
+          {/* questions count */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Questions')}</bem.FormView__label>
+            {props.asset.summary.row_count || '-'}
+          </bem.FormView__cell>
+
+          {/* owner */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Owner')}</bem.FormView__label>
+            {isSelfOwned(props.asset) && t('me')}
+            {!isSelfOwned(props.asset) && (
+              <Avatar username={props.asset.owner__username} />
+            )}
+          </bem.FormView__cell>
+        </bem.FormView__group>
+
+        <bem.FormView__group m='items'>
+          {/* date modified */}
+          <bem.FormView__cell m='padding'>
             <bem.FormView__label>{t('Last modified')}</bem.FormView__label>
             {formatTime(props.asset.date_modified)}
           </bem.FormView__cell>
-          {latestSubmissionDate &&
-            <bem.FormView__cell>
-              <bem.FormView__label>{t('Latest submission')}</bem.FormView__label>
+
+          {/* date deployed */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Last deployed')}</bem.FormView__label>
+            {lastDeployedDate && formatTime(lastDeployedDate)}
+            {!lastDeployedDate && '-'}
+          </bem.FormView__cell>
+
+          {/* date of last submission */}
+          {latestSubmissionDate && (
+            <bem.FormView__cell m='padding'>
+              <bem.FormView__label>
+                {t('Latest submission')}
+              </bem.FormView__label>
               {formatTime(latestSubmissionDate)}
             </bem.FormView__cell>
-          }
-          {props.asset.summary &&
-            <bem.FormView__cell>
-              <bem.FormView__label>{t('Questions')}</bem.FormView__label>
-              {props.asset.summary.row_count}
-            </bem.FormView__cell>
-          }
+          )}
+        </bem.FormView__group>
 
-          {props.asset.summary?.languages && props.asset.summary.languages.length > 1 &&
-            <bem.FormView__cell>
-              <bem.FormView__label>{t('Languages')}</bem.FormView__label>
-              {props.asset.summary.languages.map((l, i) => (
-                  <bem.FormView__cell key={`lang-${i}`} data-index={i}>
-                    {l}
+        <bem.FormView__group m='items'>
+          {/* sector */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Sector')}</bem.FormView__label>
+            {getSectorDisplayString(props.asset)}
+          </bem.FormView__cell>
+
+          {/* countries */}
+          <bem.FormView__cell m='padding'>
+            <bem.FormView__label>{t('Countries')}</bem.FormView__label>
+            {getCountryDisplayString(props.asset)}
+          </bem.FormView__cell>
+        </bem.FormView__group>
+
+        {/* languages */}
+        {props.asset.summary?.languages &&
+          props.asset.summary.languages.length > 1 && (
+            <bem.FormView__group m='items'>
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>{t('Languages')}</bem.FormView__label>
+                {props.asset.summary.languages.map((language, index) => (
+                  <bem.FormView__cell key={`lang-${index}`} data-index={index}>
+                    {language}
                   </bem.FormView__cell>
                 ))}
-            </bem.FormView__cell>
-          }
-        </bem.FormView__group>
+              </bem.FormView__cell>
+            </bem.FormView__group>
+          )}
+
+        {/* operational purpose and PII */}
+        {(props.asset.settings.operational_purpose ||
+          props.asset.settings.collects_pii) && (
+          <bem.FormView__group m='items'>
+            {props.asset.settings.operational_purpose && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {t('Operational purpose of data')}
+                </bem.FormView__label>
+                {props.asset.settings.operational_purpose.label}
+              </bem.FormView__cell>
+            )}
+            {props.asset.settings.collects_pii && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {t('Collects personally identifiable information')}
+                </bem.FormView__label>
+                {props.asset.settings.collects_pii.label}
+              </bem.FormView__cell>
+            )}
+          </bem.FormView__group>
+        )}
       </bem.FormView__cell>
     </bem.FormView__row>
   );

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -1505,7 +1505,7 @@ export const dataInterface: DataInterface = {
     sort: Array<{desc: boolean; id: string}> = [],
     fields: string[] = [],
     filter = ''
-  ): JQuery.jqXHR<any> {
+  ): JQuery.jqXHR<PaginatedResponse<SubmissionResponse>> {
     const query = `limit=${pageSize}&start=${page}`;
     let s = '&sort={"_id":-1}'; // default sort
     let f = '';
@@ -1522,7 +1522,7 @@ export const dataInterface: DataInterface = {
     });
   },
 
-  getSubmission(uid: string, sid: string): JQuery.jqXHR<any> {
+  getSubmission(uid: string, sid: string): JQuery.jqXHR<SubmissionResponse> {
     return $ajax({
       url: `${ROOT_URL}/api/v2/assets/${uid}/data/${sid}/`,
       method: 'GET',

--- a/jsapp/js/projects/projectsTable/projectsTableRow.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableRow.tsx
@@ -9,6 +9,7 @@ import type {
 import Badge from 'js/components/common/badge';
 import Avatar from 'js/components/common/avatar';
 import AssetName from 'js/components/common/assetName';
+import AssetStatusBadge from 'js/components/common/assetStatusBadge';
 import {formatTime} from 'js/utils';
 import type {AssetResponse, ProjectViewAsset} from 'js/dataInterface';
 import assetUtils, {isSelfOwned} from 'js/assetUtils';
@@ -46,34 +47,7 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
       case 'description':
         return props.asset.settings.description;
       case 'status':
-        if (props.asset.has_deployment && !props.asset.deployment__active) {
-          return (
-            <Badge
-              color='light-amber'
-              size='s'
-              icon='project-archived'
-              label={t('archived')}
-            />
-          );
-        } else if (props.asset.has_deployment) {
-          return (
-            <Badge
-              color='light-blue'
-              size='s'
-              icon='project-deployed'
-              label={t('deployed')}
-            />
-          );
-        } else {
-          return (
-            <Badge
-              color='light-teal'
-              size='s'
-              icon='project-draft'
-              label={t('draft')}
-            />
-          );
-        }
+        return <AssetStatusBadge asset={props.asset} />;
       case 'ownerUsername':
         if (isSelfOwned(props.asset)) {
           return t('me');


### PR DESCRIPTION
## Description

Merges together two boxes of information on project from Project Summary route. Adds few missing pieces of information to it too.

## Code review notes

This merely moves thigns around and places them in similar fashion to what we already had. There is a plan to improve upon this change soon - improve styles, and re-use this component in the library item route - but these changes will be done in separate PR.

## Related issues

Fixes #4233
Requires #4219 to be reviewed first