### PR TITLE
Fix move to collection feature

### DIFF
--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -1,6 +1,6 @@
 import React from 'react';
 import reactMixin from 'react-mixin';
-import { observer } from 'mobx-react';
+import {when} from 'mobx';
 import autoBind from 'react-autobind';
 import Reflux from 'reflux';
 import clonedeep from 'lodash.clonedeep';
@@ -55,7 +55,7 @@ export class LibraryAssetFormComponent extends React.Component {
   }
 
   componentDidMount() {
-    observer(sessionStore, () => {
+    when(() => sessionStore.isInitialLoadComplete, () => {
       this.setState({isSessionLoaded: true});
     });
     this.unlisteners.push(

--- a/jsapp/js/components/modalForms/libraryNewItemForm.es6
+++ b/jsapp/js/components/modalForms/libraryNewItemForm.es6
@@ -15,7 +15,7 @@ import {ROUTES} from 'js/router/routerConstants';
 import mixins from 'js/mixins';
 import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
 import {withRouter} from 'js/router/legacy';
-import { observer } from 'mobx-react';
+import {when} from 'mobx';
 
 class LibraryNewItemForm extends React.Component {
   constructor(props) {
@@ -28,7 +28,7 @@ class LibraryNewItemForm extends React.Component {
   }
 
   componentDidMount() {
-    observer(sessionStore, () => {
+    when(() => sessionStore.isInitialLoadComplete, () => {
       this.setState({isSessionLoaded: true});
     });
   }

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
-import { observer } from 'mobx-react';
+import {when} from 'mobx';
 import Reflux from 'reflux';
 import Dropzone from 'react-dropzone';
 import Button from 'js/components/common/button';
@@ -106,10 +106,8 @@ class ProjectSettings extends React.Component {
 
   componentDidMount() {
     this.setInitialStep();
-    observer(sessionStore, () => {
-      this.setState({
-        isSessionLoaded: true,
-      });
+    when(() => sessionStore.isInitialLoadComplete, () => {
+      this.setState({isSessionLoaded: true});
     });
     this.unlisteners.push(
       actions.resources.loadAsset.completed.listen(this.onLoadAssetCompleted.bind(this)),


### PR DESCRIPTION
## Description

All user owned collection now will appear in more actions menu under "Move to" section.

## Code review notes

This was introduced during router6 upgrade. Route changes and session changes turned out to be important for `ownedCollectionsStore` :) I've added few comments to be more clear. I also found a good use for [`when`](https://mobx.js.org/reactions.html#when) function and I've updated few other components that should've been using it instead of wrongly using `observer()`.

## Related issues

Fixes #4288 