### PR TITLE
feat: Allow disabling user editing SSO signup email address

### DIFF
--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -5,6 +5,7 @@ from allauth.account.forms import LoginForm as BaseLoginForm
 from allauth.account.forms import SignupForm as BaseSignupForm
 from allauth.socialaccount.forms import SignupForm as BaseSocialSignupForm
 from django import forms
+from django.conf import settings
 from django.utils.translation import gettext_lazy as t
 
 from kobo.static_lists import COUNTRIES
@@ -125,7 +126,8 @@ class SocialSignupForm(KoboSignupMixin, BaseSocialSignupForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['email'].widget.attrs['readonly'] = True
+        if settings.UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE:
+            self.fields['email'].widget.attrs['readonly'] = True
         self.label_suffix = ""
 
 

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -1,0 +1,27 @@
+from django.test import TestCase, override_settings
+from model_bakery import baker
+from pyquery import PyQuery
+from kobo.apps.accounts.forms import SocialSignupForm
+
+
+class AccountFormsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = baker.make('auth.User')
+        cls.sociallogin = baker.make(
+            "socialaccount.SocialAccount", user=cls.user
+        )
+
+    @override_settings(UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE=True)
+    def test_social_signup_form_not_email_disabled(self):
+        form = SocialSignupForm(sociallogin=self.sociallogin)
+        pq = PyQuery(str(form))
+        assert (email_input := pq("[name=email]"))
+        assert "readonly" in email_input[0].attrib
+
+    @override_settings(UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE=False)
+    def test_social_signup_form_not_email_not_disabled(self):
+        form = SocialSignupForm(sociallogin=self.sociallogin)
+        pq = PyQuery(str(form))
+        assert (email_input := pq("[name=email]"))
+        assert "readonly" not in email_input[0].attrib

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -727,8 +727,8 @@ SOCIALACCOUNT_FORMS = {
     'signup': 'kobo.apps.accounts.forms.SocialSignupForm',
 }
 # For SSO, the signup form is prepopulated with the account email
-# If set True, users signing up through SSO cannot edit their signup email
-UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE = os.environ.get(
+# If set True, the email field in the SSO signup form will be readonly
+UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE = env.bool(
     "UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE", False
 )
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -726,6 +726,11 @@ SOCIALACCOUNT_AUTO_SIGNUP = False
 SOCIALACCOUNT_FORMS = {
     'signup': 'kobo.apps.accounts.forms.SocialSignupForm',
 }
+# For SSO, the signup form is prepopulated with the account email
+# If set True, users signing up through SSO cannot edit their signup email
+UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE = os.environ.get(
+    "UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE", False
+)
 
 # See https://django-allauth.readthedocs.io/en/latest/configuration.html
 # Map env vars to upstream dict values, include exact case. Underscores for delimiter.


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Add settings option to disallow SSO users from editing signup email address.

## Additional info

Previous default was for users to not be able to edit the email used. While dealing with the bug with the upstream django-allauth library where the user's email wasn't populated with their SSO account email, @bufke suggested that the default allow the user to edit their email on signup. This default can be changed in the settings (or via the corresponding env variable) to disallow email editing. This PR implements this behaviour.

## Related issues

Fixes #4261