### PR TITLE
Add prometheus django and flower for observability

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -58,6 +58,7 @@ celery[redis]==5.2.6
     # via
     #   -r dependencies/pip/requirements.in
     #   django-celery-beat
+    #   flower
 certifi==2021.10.8
     # via
     #   msrest
@@ -184,6 +185,8 @@ django-picklefield==3.0.1
     # via django-constance
 django-private-storage==3.0
     # via -r dependencies/pip/requirements.in
+django-prometheus==2.2.0
+    # via -r dependencies/pip/requirements.in
 django-redis==5.2.0
     # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.2
@@ -223,6 +226,8 @@ executing==0.8.3
     # via stack-data
 fabric==2.7.0
     # via -r dependencies/pip/dev_requirements.in
+flower==1.2.0
+    # via -r dependencies/pip/requirements.in
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==1.0.2
@@ -275,6 +280,8 @@ httplib2==0.20.4
     # via
     #   google-api-python-client
     #   google-auth-httplib2
+humanize==4.6.0
+    # via flower
 idna==3.3
     # via requests
 iniconfig==1.1.1
@@ -358,6 +365,10 @@ pillow==9.1.0
     # via django-markdownx
 pluggy==1.0.0
     # via pytest
+prometheus-client==0.16.0
+    # via
+    #   django-prometheus
+    #   flower
 prompt-toolkit==3.0.29
     # via
     #   click-repl
@@ -445,6 +456,7 @@ pytz==2022.1
     #   django
     #   django-timezone-field
     #   djangorestframework
+    #   flower
     #   twilio
 pyxform==1.9.0
     # via
@@ -525,6 +537,8 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
+tornado==6.2
+    # via flower
 traitlets==5.1.1
     # via
     #   ipython

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -44,6 +44,7 @@ django-amazon-ses
 django-webpack-loader
 django-loginas
 django-markdownx
+django-prometheus
 
 django-markitup
 django-mptt
@@ -56,6 +57,7 @@ djangorestframework-xml
 django-redis-sessions
 django-request-cache
 drf-extensions
+flower
 future
 geojson-rewind
 google-api-python-client

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -50,6 +50,7 @@ celery[redis]==5.2.6
     # via
     #   -r dependencies/pip/requirements.in
     #   django-celery-beat
+    #   flower
 certifi==2021.10.8
     # via
     #   msrest
@@ -162,6 +163,8 @@ django-picklefield==3.0.1
     # via django-constance
 django-private-storage==3.0
     # via -r dependencies/pip/requirements.in
+django-prometheus==2.2.0
+    # via -r dependencies/pip/requirements.in
 django-redis==5.2.0
     # via -r dependencies/pip/requirements.in
 django-redis-sessions==0.6.2
@@ -195,6 +198,8 @@ drf-extensions==0.7.1
     # via -r dependencies/pip/requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
+flower==1.2.0
+    # via -r dependencies/pip/requirements.in
 future==0.18.2
     # via -r dependencies/pip/requirements.in
 geojson-rewind==1.0.2
@@ -247,6 +252,8 @@ httplib2==0.20.4
     # via
     #   google-api-python-client
     #   google-auth-httplib2
+humanize==4.6.0
+    # via flower
 idna==3.3
     # via requests
 isodate==0.6.1
@@ -299,6 +306,10 @@ path-py==12.5.0
     # via formpack
 pillow==9.1.0
     # via django-markdownx
+prometheus-client==0.16.0
+    # via
+    #   django-prometheus
+    #   flower
 prompt-toolkit==3.0.29
     # via click-repl
 proto-plus==1.20.6
@@ -362,6 +373,7 @@ pytz==2022.1
     #   django
     #   django-timezone-field
     #   djangorestframework
+    #   flower
     #   twilio
 pyxform==1.9.0
     # via
@@ -428,6 +440,8 @@ stripe==4.1.0
     # via dj-stripe
 tabulate==0.8.9
     # via -r dependencies/pip/requirements.in
+tornado==6.2
+    # via flower
 twilio==7.8.2
     # via django-trench
 typing-extensions==4.2.0

--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -35,3 +35,6 @@ urlpatterns = [
         RedirectView.as_view(url=settings.KOBOCAT_URL, permanent=True),
     ),
 ]
+
+if settings.ENABLE_METRICS:
+    urlpatterns.append(path('', include('django_prometheus.urls')),)

--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -37,4 +37,6 @@ urlpatterns = [
 ]
 
 if settings.ENABLE_METRICS:
-    urlpatterns.append(path('', include('django_prometheus.urls')),)
+    urlpatterns.append(
+        path('', include('django_prometheus.urls')),
+    )


### PR DESCRIPTION
## Description

Adds optional celery monitoring via flower and metrics endpoint for prometheus

## Details

![image](https://user-images.githubusercontent.com/739307/221030005-76f1e204-7b58-4e2d-8ac1-b89f58a838c5.png)

- Add django-prometheus package and enable it via ENABLE_METRICS environment variable
- While the package is always a django app, the middleware and url is only enabled when ENABLE_METRICS is true. This keeps a more consistent installed apps while ensuring the metrics software isn't running when disabled.
- Adds flower package for celery monitoring. This is intended to run on it's own docker container.
- Lowers default sentry traces rate from 5% to 1%. Even 5% consumes a lot of disk space.

### How to test this

Set ENABLE_METRICS to "true". Go to `/metrics/`. Note that /metrics is a Prometheus convention.

Add to docker compose an alternative command and open port 5555

```
command: celery -A kobo flower
ports:
  - "5555:5555"
   ```
   
Run a celery task and monitor it on localhost:5555