### PR TITLE
Store UI language for usage statistics

### DIFF
--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -138,7 +138,7 @@ const AccountSettings = observer(() => {
   const updateProfile = () => {
     dataInterface
       .patchProfile({
-        extra_details: JSON.stringify({
+        extra_details: {
           name: form.fields.name,
           organization: form.fields.organization,
           organization_website: form.fields.organizationWebsite,
@@ -151,7 +151,7 @@ const AccountSettings = observer(() => {
           twitter: form.fields.twitter,
           linkedin: form.fields.linkedin,
           instagram: form.fields.instagram,
-        }),
+        },
       })
       .done(() => {
         onUpdateComplete();

--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -146,9 +146,7 @@ actions.misc.updateProfile.listen(function(data, callbacks={}){
       }
     });
 });
-actions.misc.updateProfile.completed.listen(function(){
-  notify(t('updated profile successfully'));
-});
+
 actions.misc.updateProfile.failed.listen(function(data) {
   let hadFieldsErrors = false;
   for (const [errorProp, errorValue] of Object.entries(data.responseJSON)){

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -655,8 +655,10 @@ export interface AccountResponse {
     linkedin: string;
     instagram: string;
     project_views_settings: ProjectViewsSettings;
+    /** We store this for usage statistics only. */
+    last_ui_language?: string;
     // JSON values are the backend reality, but we make assumptions
-    [key: string]: Json | ProjectViewsSettings;
+    [key: string]: Json | ProjectViewsSettings | undefined;
   };
   git_rev: {
     short: string;
@@ -665,6 +667,28 @@ export interface AccountResponse {
     tag: boolean;
   };
   social_accounts: SocialAccount[];
+}
+
+export interface AccountRequest {
+  email?: string;
+  extra_details?: {
+    name?: string;
+    organization?: string;
+    organization_website?: string;
+    sector?: string;
+    gender?: string;
+    bio?: string;
+    city?: string;
+    country?: string;
+    require_auth?: boolean;
+    twitter?: string;
+    linkedin?: string;
+    instagram?: string;
+    project_views_settings?: ProjectViewsSettings;
+    last_ui_language?: string;
+  };
+  current_password?: string;
+  new_password?: string;
 }
 
 interface UserNotLoggedInResponse {
@@ -762,6 +786,7 @@ interface ExternalServiceRequestData {
 }
 
 interface DataInterface {
+  patchProfile: (data: AccountRequest) => JQuery.jqXHR<AccountResponse>;
   [key: string]: Function;
 }
 
@@ -803,25 +828,7 @@ export const dataInterface: DataInterface = {
     return d.promise();
   },
 
-  patchProfile(data: {
-    email?: string;
-    extra_details?: {
-      name?: string;
-      organization?: string;
-      organization_website?: string;
-      sector?: string;
-      gender?: string;
-      bio?: string;
-      city?: string;
-      country?: string;
-      require_auth?: boolean;
-      twitter?: string;
-      linkedin?: string;
-      instagram?: string;
-    };
-    current_password?: string;
-    new_password?: string;
-  }): JQuery.jqXHR<AccountResponse> {
+  patchProfile(data: AccountRequest): JQuery.jqXHR<AccountResponse> {
     return $ajax({
       url: `${ROOT_URL}/me/`,
       method: 'PATCH',

--- a/jsapp/js/stores/session.ts
+++ b/jsapp/js/stores/session.ts
@@ -1,10 +1,11 @@
 import {action, makeAutoObservable} from 'mobx';
 import {ANON_USERNAME} from 'js/constants';
 import {dataInterface} from 'js/dataInterface';
-import type {AccountResponse} from 'js/dataInterface';
-import {log} from 'js/utils';
+import type {AccountResponse, FailResponse} from 'js/dataInterface';
+import {log, currentLang} from 'js/utils';
 import type {Json} from 'js/components/common/common.interfaces';
 import type {ProjectViewsSettings} from 'js/projects/customViewStore';
+import cloneDeep from 'lodash.clonedeep';
 
 class SessionStore {
   currentAccount: AccountResponse | {username: string} = {
@@ -34,11 +35,15 @@ class SessionStore {
           if ('email' in account) {
             this.currentAccount = account;
             this.isLoggedIn = true;
+            // Save UI language to Back-end for language usage statistics.
+            // Logging in causes the whole page to be reloaded, so we don't need
+            // to do it more than once.
+            this.saveUiLanguage();
           }
           this.isAuthStateKnown = true;
         }
       ),
-      action('verifyLoginFailure', (xhr: any) => {
+      action('verifyLoginFailure', (xhr: FailResponse) => {
         this.isPending = false;
         log('login not verified', xhr.status, xhr.statusText);
       })
@@ -63,15 +68,23 @@ class SessionStore {
   /** Updates one of the `extra_details`. */
   public setDetail(detailName: string, value: Json | ProjectViewsSettings) {
     dataInterface.patchProfile({extra_details: {[detailName]: value}}).then(
-      action(
-        'setDetailSuccess',
-        (account: AccountResponse) => {
-          if ('email' in account) {
-            this.currentAccount = account;
-          }
+      action('setDetailSuccess', (account: AccountResponse) => {
+        if ('email' in account) {
+          this.currentAccount = account;
         }
-      )
+      })
     );
+  }
+
+  private saveUiLanguage() {
+    // We want to save the language if it differs from the one we saved or if
+    // none is saved yet.
+    if (
+      'extra_details' in this.currentAccount &&
+      this.currentAccount.extra_details.last_ui_language !== currentLang()
+    ) {
+      this.setDetail('last_ui_language', currentLang());
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Stores currently selected language on `/me` endpoint for internal statistics on language usage.

## Code review notes

During app initialization, for logged in user, there is a call being made that stores the language being used (in `/me` in `extra_details.last_ui_language`). It doesn't make a call if language is same as currently stored. Also improves `AccountRequest` types so the `dataInterface.patchProfile` is handled in safer way.

## Related issues

Fixes #3640 
Supersedes #3932 
