### PR TITLE
Fix saving and validation of extra user metadata

### DIFF
--- a/hub/tests/test_user_details.py
+++ b/hub/tests/test_user_details.py
@@ -10,6 +10,11 @@ class UserDetailTestCase(TestCase):
         self.user = User.objects.get(username='someuser')
 
     def test_user_automatically_has_extra_user_details(self):
+        """
+        See the calls to `standardize_json_field()` in `ExtraUserDetail.save()`
+        for an explanation of why `name` and `organization` are present for
+        brand-new users
+        """
         self.assertEqual(
             self.user.extra_details.data, {'name': '', 'organization': ''}
         )

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -139,23 +139,26 @@ const AccountSettings = observer(() => {
     !form.isPristine
   );
   const updateProfile = () => {
+    // To patch correctly with recent changes to the backend,
+    // ensure that we send empty strings if the field is left blank.
+    const profilePatchData = {
+      extra_details: {
+        name: form.fields.name || '',
+        organization: form.fields.organization || '',
+        organization_website: form.fields.organizationWebsite || '',
+        sector: form.fields.sector || '',
+        gender: form.fields.gender || '',
+        bio: form.fields.bio || '',
+        city: form.fields.city || '',
+        country: form.fields.country || '',
+        require_auth: form.fields.requireAuth ? true : false, // false if empty
+        twitter: form.fields.twitter || '',
+        linkedin: form.fields.linkedin || '',
+        instagram: form.fields.instagram || '',
+      },
+    };
     dataInterface
-      .patchProfile({
-        extra_details: {
-          name: form.fields.name,
-          organization: form.fields.organization,
-          organization_website: form.fields.organizationWebsite,
-          sector: form.fields.sector,
-          gender: form.fields.gender,
-          bio: form.fields.bio,
-          city: form.fields.city,
-          country: form.fields.country,
-          require_auth: form.fields.requireAuth,
-          twitter: form.fields.twitter,
-          linkedin: form.fields.linkedin,
-          instagram: form.fields.instagram,
-        },
-      })
+      .patchProfile(profilePatchData)
       .done(() => {
         onUpdateComplete();
       })

--- a/kobo/apps/accounts/tests/test_current_user.py
+++ b/kobo/apps/accounts/tests/test_current_user.py
@@ -1,5 +1,8 @@
+import json
+import constance
 from django.urls import reverse
 from model_bakery import baker
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 
@@ -21,3 +24,54 @@ class CurrentUserAPITestCase(APITestCase):
         for social_account in social_accounts:
             self.assertContains(res, social_account.uid)
         self.assertNotContains(res, other_social_account.uid)
+
+    def test_update_extra_detail(self):
+        extra_details = self.user.extra_details
+        extra_details.data['name'] = 'SpongeBob'
+        extra_details.save()
+        patch_data = {
+            'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}
+        }
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        response_extra_details = response.json()['extra_details']
+        # What we just set should obviously be there
+        assert (
+            response_extra_details['organization']
+            == 'Trap Remix 10 Hours, Inc.'
+        )
+        # …and what we didn't touch should still be there as well
+        assert response_extra_details['name'] == 'SpongeBob'
+
+    def test_validate_extra_detail(self):
+        constance.config.USER_METADATA_FIELDS = json.dumps([
+            {'name': 'organization', 'required': True}
+        ])
+
+        # Setting an unrelated field should not be subject to validation
+        patch_data = {'extra_details': {'name': 'SpongeBob'}}
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        response_extra_details = response.json()['extra_details']
+        assert response_extra_details['name'] == 'SpongeBob'
+
+        # Make sure the validator accepts reasonable values
+        patch_data = {
+            'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}
+        }
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        response_extra_details = response.json()['extra_details']
+        assert (
+            response_extra_details['organization']
+            == 'Trap Remix 10 Hours, Inc.'
+        )
+
+        # Make sure the validator, you know, validates and rejects empty
+        # strings for required fields
+        patch_data = {'extra_details': {'organization': ''}}
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'extra_details': {'organization': 'This field may not be blank.'}
+        }

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -121,27 +121,33 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         return rep
 
     def validate(self, attrs):
-        if self.instance:
+        if not self.instance:
+            return attrs
 
-            current_password = attrs.pop('current_password', False)
-            new_password = attrs.get('new_password', False)
+        current_password = attrs.pop('current_password', False)
+        new_password = attrs.get('new_password', False)
 
-            if all((current_password, new_password)):
-                if not self.instance.check_password(current_password):
-                    raise serializers.ValidationError({
-                        'current_password': t('Incorrect current password.')
-                    })
-            elif any((current_password, new_password)):
-                not_empty_field_name = 'current_password' \
-                    if current_password else 'new_password'
-                empty_field_name = 'current_password' \
-                    if new_password else 'new_password'
-                raise serializers.ValidationError({
-                    empty_field_name: t('`current_password` and `new_password` '
-                                        'must both be sent together; '
-                                        f'`{not_empty_field_name}` cannot be '
-                                        'sent individually.')
-                })
+        if all((current_password, new_password)):
+            if not self.instance.check_password(current_password):
+                raise serializers.ValidationError(
+                    {'current_password': t('Incorrect current password.')}
+                )
+        elif any((current_password, new_password)):
+            not_empty_field_name = (
+                'current_password' if current_password else 'new_password'
+            )
+            empty_field_name = (
+                'current_password' if new_password else 'new_password'
+            )
+            raise serializers.ValidationError(
+                {
+                    empty_field_name: t(
+                        '`current_password` and `new_password` must both be'
+                        f' sent together; `{not_empty_field_name}` cannot be'
+                        ' sent individually.'
+                    )
+                }
+            )
 
         return attrs
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

User metadata fields that are left empty in the user interface are now sent to the back end as empty strings (or `false`, in the case of `require_auth`) instead of being omitted from the request data altogether. The back end now validates only fields that are present in the request data, allowing for partial updates of `extra_details` instead of requiring that all fields be included with every request.

## Related issues

Needed for #4299 
