### PR TITLE
Switch to Stripe prices instead of plans

### DIFF
--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -1,5 +1,11 @@
 from django.core.exceptions import SuspiciousOperation
-from djstripe.models import Customer, Plan, Product, Subscription
+from djstripe.models import (
+    Customer,
+    Price,
+    Product,
+    Subscription,
+    SubscriptionItem,
+)
 from rest_framework import serializers
 
 
@@ -9,30 +15,53 @@ class BaseProductSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'description', 'type', 'metadata')
 
 
-class PlanSerializer(serializers.ModelSerializer):
+class BasePriceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Price
+        fields = (
+            "id",
+            "nickname",
+            "currency",
+            "type",
+            "unit_amount",
+            "human_readable_price",
+            "metadata",
+        )
 
+
+class PriceSerializer(BasePriceSerializer):
     product = BaseProductSerializer()
 
-    class Meta:
-        model = Plan
-        exclude = ('djstripe_id',)
+    class Meta(BasePriceSerializer.Meta):
+        fields = (
+            "id",
+            "nickname",
+            "currency",
+            "unit_amount",
+            "human_readable_price",
+            "metadata",
+            "product",
+        )
 
 
 class ProductSerializer(BaseProductSerializer):
-    plans = PlanSerializer(many=True, source="plan_set")
+    prices = BasePriceSerializer(many=True)
 
     class Meta(BaseProductSerializer.Meta):
-        fields = ("id", "name", "description", "type", "plans", "metadata")
+        fields = ("id", "name", "description", "type", "prices", "metadata")
+
+
+class SubscriptionItemSerializer(serializers.ModelSerializer):
+    price = PriceSerializer()
+
+    class Meta:
+        model = SubscriptionItem
+        fields = ("id", "price")
 
 
 class SubscriptionSerializer(serializers.ModelSerializer):
-
-    plan = serializers.SerializerMethodField()
+    items = SubscriptionItemSerializer(many=True)
 
     class Meta:
         model = Subscription
         exclude = ('djstripe_id',)
-
-    def get_plan(self, subscription):
-        plan = Plan.objects.get(id=subscription.plan.id)
-        return PlanSerializer(plan, many=False, context=self.context).data

--- a/kobo/apps/stripe/tests/test_product_api.py
+++ b/kobo/apps/stripe/tests/test_product_api.py
@@ -1,4 +1,5 @@
 from django.shortcuts import reverse
+from djstripe.enums import BillingScheme
 from model_bakery import baker
 
 from kpi.tests.kpi_test_case import BaseTestCase
@@ -6,22 +7,22 @@ from kpi.tests.kpi_test_case import BaseTestCase
 
 class ProductAPITestCase(BaseTestCase):
     def test_product_list(self):
-        plan = baker.make(
-            "djstripe.Plan",
-            amount=0,
+        price = baker.make(
+            'djstripe.Price',
+            billing_scheme=BillingScheme.per_unit,
             livemode=False,
             active=True,
             product__active=True,
             product__livemode=False,
         )
-        inactive_plan = baker.make(
-            "djstripe.Plan",
-            amount=0,
+        inactive_price = baker.make(
+            'djstripe.Price',
+            billing_scheme=BillingScheme.per_unit,
             livemode=False,
             active=False,
             product__active=False,
             product__livemode=False,
         )
-        res = self.client.get(reverse("product-list"))
-        self.assertContains(res, plan.id)
-        self.assertNotContains(res, inactive_plan.id)
+        res = self.client.get(reverse('product-list'))
+        self.assertContains(res, price.id)
+        self.assertNotContains(res, inactive_price.id)

--- a/kobo/apps/stripe/tests/test_subscription_api.py
+++ b/kobo/apps/stripe/tests/test_subscription_api.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.urls import reverse
-
-from djstripe.models import Customer, Plan, Subscription
+from djstripe.enums import BillingScheme
+from djstripe.models import Customer
 from model_bakery import baker
 from rest_framework import status
 
@@ -22,11 +22,11 @@ class SubscriptionAPITestCase(BaseTestCase):
         organization = baker.make(Organization)
         organization.add_user(self.someuser, is_admin=True)
         customer = baker.make(Customer, subscriber=organization)
-        plan = baker.make(Plan)
         self.subscription = baker.make(
-            Subscription,
+            'djstripe.Subscription',
             customer=customer,
-            plan=plan,
+            items__price__livemode=False,
+            items__price__billing_scheme=BillingScheme.per_unit,
             livemode=False,
         )
         self.url_detail = reverse(


### PR DESCRIPTION
## Description

Switch Stripe integration from (legacy) plans to prices model.

## Details

Both Stripe and djstripe recommend using Prices instead of Plans

- https://dj-stripe.dev/usage/subscribing_customers/
- https://stripe.com/docs/api/plans

While there is no set deprecation, it would be easier to make this switch now instead of later.