### PR TITLE
Add Organization Owner's email to Organization model

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -15,12 +15,10 @@ class Organization(AbstractOrganization):
     @property
     def email(self):
         """
-        This exists to make dj-stripe happy
+        As organization is our customer model for Stripe, Stripe requires that
+        it has an email address attribute
         """
-        return self.owner.organization_user.user.emailaddress_set.get(
-            primary=True,
-            verified=True
-        )
+        return self.owner.organization_user.user.email
 
 
 class OrganizationUser(AbstractOrganizationUser):

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -12,6 +12,16 @@ from organizations.abstract import (AbstractOrganization,
 class Organization(AbstractOrganization):
     uid = KpiUidField(uid_prefix='org')
 
+    @property
+    def email(self):
+        """
+        This exists to make dj-stripe happy
+        """
+        return self.owner.organization_user.user.emailaddress_set.get(
+            primary=True,
+            verified=True
+        )
+
 
 class OrganizationUser(AbstractOrganizationUser):
     pass

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -575,7 +575,20 @@ STRIPE_ENABLED = False
 if env.str('STRIPE_TEST_SECRET_KEY', None) or env.str('STRIPE_LIVE_SECRET_KEY', None):
     STRIPE_ENABLED = True
 
+
+def organization_request_callback(request):
+    """
+    `DJSTRIPE_SUBSCRIBER_MODEL` needs a custom callback function because we aren't
+    using the default model `auth.user`
+    Gets an organization instance from the user passed through `request`
+    """
+    user = request.user
+    if user:
+        return user.organizations_organization.get()
+
+
 DJSTRIPE_SUBSCRIBER_MODEL = "organizations.Organization"
+DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK = organization_request_callback
 DJSTRIPE_FOREIGN_KEY_TO_FIELD = 'id'
 DJSTRIPE_USE_NATIVE_JSONFIELD = True
 STRIPE_PRICING_TABLE_ID = env.str("STRIPE_PRICING_TABLE_ID", None)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -575,20 +575,7 @@ STRIPE_ENABLED = False
 if env.str('STRIPE_TEST_SECRET_KEY', None) or env.str('STRIPE_LIVE_SECRET_KEY', None):
     STRIPE_ENABLED = True
 
-
-def organization_request_callback(request):
-    """
-    `DJSTRIPE_SUBSCRIBER_MODEL` needs a custom callback function because we aren't
-    using the default model `auth.user`
-    Gets an organization instance from the user passed through `request`
-    """
-    user = request.user
-    if user:
-        return user.organizations_organization.get()
-
-
 DJSTRIPE_SUBSCRIBER_MODEL = "organizations.Organization"
-DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK = organization_request_callback
 DJSTRIPE_FOREIGN_KEY_TO_FIELD = 'id'
 DJSTRIPE_USE_NATIVE_JSONFIELD = True
 STRIPE_PRICING_TABLE_ID = env.str("STRIPE_PRICING_TABLE_ID", None)
@@ -722,6 +709,7 @@ CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
 
 ''' Django allauth configuration '''
+# User.email should continue to be used instead of the EmailAddress model
 ACCOUNT_ADAPTER = 'kobo.apps.accounts.adapter.AccountAdapter'
 ACCOUNT_USERNAME_VALIDATORS = 'kobo.apps.accounts.validators.username_validators'
 ACCOUNT_EMAIL_REQUIRED = True


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Add the Organization Owner's email to the Organization model to allow it to meet `dj-stripe`'s requirements

## Other Notes
* All customer's are now syncing to the Customer Stripe Model
* This needs to be tested thoroughly on the billing staging server with the actual webhook, I tested it to the best of my ability locally, but I cannot test with the webhook
* This PR also add's the missing `DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK` and corresponding method to the settings file. Inspiration taken from David's work on GlitchTip
