### PR TITLE
Add django language codes to KPI settings

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -414,9 +414,13 @@ DATABASE_ROUTERS = ['kpi.db_routers.DefaultDatabaseRouter']
 
 django.conf.locale.LANG_INFO.update(EXTRA_LANG_INFO)
 
+DJANGO_LANGUAGE_CODES = [
+    'ar', 'cs', 'de-DE', 'en', 'es', 'fr', 'hi', 'ja',
+    'ku', 'pl', 'pt', 'ru', 'tr', 'uk', 'zh-hans',
+]
 LANGUAGES = [
     (lang_code, get_language_info(lang_code)['name_local'])
-        for lang_code in env.str('DJANGO_LANGUAGE_CODES', 'en').split(' ')
+    for lang_code in DJANGO_LANGUAGE_CODES
 ]
 
 LANGUAGE_CODE = 'en-us'


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Add the supported language codes to the KPI settings so that 
Adds Japanese as a supported language

## Related issues

Related PR kobotoolbox/kobo-install#220