### PR TITLE
Use new field `date_deployed` to retrieve deployed assets faster

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -110,16 +110,9 @@ class AssetManager(models.Manager):
 
     def deployed(self):
         """
-        Filter for deployed assets (i.e. assets having at least one deployed
-        version) in an efficient way that doesn't involve joining or counting.
-        https://docs.djangoproject.com/en/2.2/ref/models/expressions/#django.db.models.Exists
+        Filter for deployed assets (i.e. assets without a null value for `date_deployed`)
         """
-        deployed_versions = AssetVersion.objects.filter(
-            asset=OuterRef('pk'), deployed=True
-        )
-        return self.annotate(deployed=Exists(deployed_versions)).filter(
-            deployed=True
-        )
+        return self.exclude(date_deployed__isnull=True)
 
     def filter_by_tag_name(self, tag_name):
         return self.filter(tags__name=tag_name)


### PR DESCRIPTION
…ed assets

## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)


## Description

Remove subquery on `AssetVersion` to filter deployed assets.

