### PR TITLE
Change 500 response to 400 when invalid source passed to v1 export API

### DIFF
--- a/kpi/utils/models.py
+++ b/kpi/utils/models.py
@@ -152,7 +152,10 @@ def disable_auto_field_update(kls, field_name):
 
 
 def remove_string_prefix(string, prefix):
-    return string[len(prefix):] if string.startswith(prefix) else string
+    if prefix and string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string
 
 
 def resolve_url_to_asset(item_path):

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -5,7 +5,7 @@ from rest_framework import exceptions, serializers, status
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
-from kpi.models import ExportTask
+from kpi.models import Asset, ExportTask
 from kpi.serializers import ExportTaskSerializer
 from kpi.tasks import export_in_background
 from kpi.utils.models import remove_string_prefix, resolve_url_to_asset
@@ -193,8 +193,11 @@ class ExportTaskViewSet(NoUpdateModelViewSet):
             raise serializers.ValidationError(
                 {'source': 'This field is required.'})
         # Get the source object
-        source = resolve_url_to_asset(
-            task_data['source'])
+        try:
+            source = resolve_url_to_asset(task_data['source'])
+        except Asset.DoesNotExist:
+            raise serializers.ValidationError(
+                {'source': 'The specified asset does not exist.'})
         # Complain if it's not deployed
         if not source.has_deployment:
             raise serializers.ValidationError(


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Requesting an export from the v1 API (`/exports/`) and providing an invalid `source`, e.g. an asset that had been deleted, a 500 error was previously returned. This change causes a 400 error to be returned instead in this scenario. Note that some malformed `source` URLs may cause a 404 error to be returned; that was an existing behavior and is not affected by this change.