### PR TITLE
Make DJANGO_LANGUAGE_CODES configurable

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -414,13 +414,29 @@ DATABASE_ROUTERS = ['kpi.db_routers.DefaultDatabaseRouter']
 
 django.conf.locale.LANG_INFO.update(EXTRA_LANG_INFO)
 
-DJANGO_LANGUAGE_CODES = [
-    'ar', 'cs', 'de-DE', 'en', 'es', 'fr', 'hi', 'ja',
-    'ku', 'pl', 'pt', 'ru', 'tr', 'uk', 'zh-hans',
-]
+DJANGO_LANGUAGE_CODES = env.str(
+    'DJANGO_LANGUAGE_CODES',
+    default=(
+        'ar '  # Arabic
+        'cs '  # Czech
+        'de-DE '  # German
+        'en '  # English
+        'es '  # Spanish
+        'fr '  # French
+        'hi '  # Hindi
+        'ja '  # Japanese
+        'ku '  # Kurdish
+        'pl '  # Polish
+        'pt '  # Portuguese
+        'ru '  # Russian
+        'tr '  # Turkish
+        'uk '  # Ukrainian
+        'zh-hans'  # Chinese Simplified
+    )
+)
 LANGUAGES = [
     (lang_code, get_language_info(lang_code)['name_local'])
-    for lang_code in DJANGO_LANGUAGE_CODES
+    for lang_code in DJANGO_LANGUAGE_CODES.split(' ')
 ]
 
 LANGUAGE_CODE = 'en-us'

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -52,9 +52,7 @@ class EnvironmentTests(BaseTestCase):
                     ('KEN', 'Kenya'), x
                 ),
             'interface_languages': lambda x: \
-                self.assertGreater(len(x), 5) and self.assertIn(
-                    ('ar', 'العربيّة'), x
-                ),
+                self.assertEqual(len(x), len(settings.LANGUAGES)),
             'submission_placeholder': SUBMISSION_PLACEHOLDER,
             'asr_mt_features_enabled': False,
             'mfa_enabled': constance.config.MFA_ENABLED,


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Make the available languages configurable via the `DJANGO_LANGUAGE_CODES` environment variable