### PR TITLE
Endpoint to list purchased one-time add-ons

### DIFF
--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -1,12 +1,23 @@
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from djstripe.models import (
-    Customer,
+    Session,
     Price,
     Product,
     Subscription,
     SubscriptionItem,
 )
 from rest_framework import serializers
+
+
+class OneTimeAddOnSerializer(serializers.ModelSerializer):
+    payment_intent = serializers.SlugRelatedField(
+        slug_field='status',
+        read_only=True,
+        many=False,
+    )
+    class Meta:
+        model = Session
+        fields = ('metadata', 'created', 'payment_intent',)
 
 
 class BaseProductSerializer(serializers.ModelSerializer):

--- a/kobo/apps/stripe/tests/test_one_time_addons_api.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_api.py
@@ -1,0 +1,75 @@
+from django.contrib.auth.models import User
+from django.urls import reverse
+from djstripe.enums import BillingScheme
+from djstripe.models import Customer, PaymentIntent
+from model_bakery import baker
+from rest_framework import status
+
+from kobo.apps.organizations.models import Organization
+from kpi.tests.kpi_test_case import BaseTestCase
+
+
+class OneTimeAddOnAPITestCase(BaseTestCase):
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.someuser = User.objects.get(username='someuser')
+        self.client.force_login(self.someuser)
+        self.url = reverse('addons-list')
+        self.price_id = 'price_305dfs432ltnjw'
+
+    def _insert_data(self):
+        self.organization = baker.make(Organization)
+        self.organization.add_user(self.someuser, is_admin=True)
+        self.customer = baker.make(Customer, subscriber=self.organization)
+
+    def _create_session_and_payment_intent(self):
+        payment_intent = baker.make(
+            PaymentIntent,
+            customer=self.customer,
+            status='succeeded',
+            payment_method_types=["card"],
+            livemode=False,
+        )
+        session = baker.make(
+            'djstripe.Session',
+            customer=self.customer,
+            metadata={
+                'organization_uid': self.organization.uid,
+                'price_id': self.price_id,
+            },
+            mode='payment',
+            payment_intent=payment_intent,
+            payment_method_types=["card"],
+            items__price__livemode=False,
+            items__price__billing_scheme=BillingScheme.per_unit,
+            livemode=False,
+        )
+
+    def test_no_addons(self):
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'] == []
+
+    def test_get_endpoint(self):
+        self._insert_data()
+        self._create_session_and_payment_intent()
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+
+    def test_anonymous_user(self):
+        self._insert_data()
+        self._create_session_and_payment_intent()
+        self.client.logout()
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_not_own_addon(self):
+        self._insert_data()
+        self._create_session_and_payment_intent()
+        self.client.force_login(User.objects.get(username='anotheruser'))
+        response_get_list = self.client.get(self.url)
+        assert response_get_list.status_code == status.HTTP_200_OK
+        assert response_get_list.data['results'] == []

--- a/kobo/apps/stripe/urls.py
+++ b/kobo/apps/stripe/urls.py
@@ -2,11 +2,12 @@ from django.urls import include, re_path
 from rest_framework.routers import SimpleRouter
 
 
-from kobo.apps.stripe.views import SubscriptionViewSet, CheckoutLinkView, CustomerPortalView, ProductViewSet
+from kobo.apps.stripe.views import SubscriptionViewSet, CheckoutLinkView, CustomerPortalView, OneTimeAddOnViewSet, ProductViewSet
 
 router = SimpleRouter()
 router.register(r'subscriptions', SubscriptionViewSet, basename='subscriptions')
 router.register(r'products', ProductViewSet)
+router.register(r'addons', OneTimeAddOnViewSet)
 
 
 urlpatterns = [

--- a/kobo/apps/stripe/urls.py
+++ b/kobo/apps/stripe/urls.py
@@ -7,7 +7,7 @@ from kobo.apps.stripe.views import SubscriptionViewSet, CheckoutLinkView, Custom
 router = SimpleRouter()
 router.register(r'subscriptions', SubscriptionViewSet, basename='subscriptions')
 router.register(r'products', ProductViewSet)
-router.register(r'addons', OneTimeAddOnViewSet)
+router.register(r'addons', OneTimeAddOnViewSet, basename='addons')
 
 
 urlpatterns = [

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -26,6 +26,7 @@ from kobo.apps.organizations.models import (
 )
 
 
+# Lists the one-time purchases made by the organization that the logged-in user owns
 class OneTimeAddOnViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
@@ -42,14 +43,6 @@ class OneTimeAddOnViewSet(
             mode='payment',
             payment_intent__status__in=['succeeded', 'processing']
         ).prefetch_related('payment_intent')
-
-    def get(self, request):
-        serializer = OneTimeAddOnSerializer(context=request.user)
-        serializer.is_valid(raise_exception=True)
-        add_ons = serializer.validated_data.get('addons')
-        return Response({'add_ons': add_ons})
-
-
 
 
 class CheckoutLinkView(

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -3,7 +3,7 @@ import stripe
 from django.conf import settings
 from django.db.models import Prefetch
 
-from djstripe.models import Customer, Price, Product, Subscription, SubscriptionItem
+from djstripe.models import Customer, Price, Product, Session, Subscription, SubscriptionItem
 from djstripe.settings import djstripe_settings
 
 from organizations.utils import create_organization
@@ -17,12 +17,39 @@ from kobo.apps.stripe.serializers import (
     SubscriptionSerializer,
     CheckoutLinkSerializer,
     CustomerPortalSerializer,
+    OneTimeAddOnSerializer,
     ProductSerializer,
 )
 
 from kobo.apps.organizations.models import (
     Organization
 )
+
+
+class OneTimeAddOnViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    permission_classes = (IsAuthenticated,)
+    serializer_class = OneTimeAddOnSerializer
+    queryset = Session.objects.all()
+
+    def get_queryset(self):
+        return self.queryset.filter(
+            livemode=settings.STRIPE_LIVE_MODE,
+            customer__subscriber__owner__organization_user__user=self.request.user,
+            mode='payment',
+            payment_intent__status__in=['succeeded', 'processing']
+        ).prefetch_related('payment_intent')
+
+    def get(self, request):
+        serializer = OneTimeAddOnSerializer(context=request.user)
+        serializer.is_valid(raise_exception=True)
+        add_ons = serializer.validated_data.get('addons')
+        return Response({'add_ons': add_ons})
+
+
 
 
 class CheckoutLinkView(
@@ -68,7 +95,8 @@ class CheckoutLinkView(
                 },
             ],
             metadata={
-                'organization_uid': organization_uid
+                'organization_uid': organization_uid,
+                'price_id': price_id,
             },
             mode="subscription",
             payment_method_types=["card"],


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

Adds a new internal endpoint at `api/v2/stripe/addons` that lists any one-time add-ons purchased by the logged-in user's owned organization. Needed for the "Your Active Add-ons" section of the Plans page.

## Sample API response:
![image](https://user-images.githubusercontent.com/7819986/226381287-cfb13253-fe7c-4293-ad71-5d9b9722b580.png)
```
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "metadata": {
                "price_id": "price_1MmO5sAR39rDI89sfdKUjter",
                "organization_uid": "orgPDBt2kqPpuG9a5bYsCd4S"
            },
            "created": "2023-03-20T14:06:13Z",
            "payment_intent": "succeeded"
        }
    ]
}
```

## Note
This PR will only list add-ons purchased through a Stripe checkout session initiated from the Plans page (or using the `api/v2/checkout-link` endpoint.) This is because it stores the price metadata on the checkout Session.

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
