### PR TITLE
Fix comment in .browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,5 @@
 # Browsers that we support:
-# https://browserl.ist/?q=last+2+major+versions%2C+%3E+1%25%2C+not+dead%2C+IE+11%2C+Firefox+ESR
+# https://browsersl.ist/#q=last+2+major+versions%2C%3E+1%25%2Cnot+dead%2CFirefox+ESR
 
 last 2 major versions
 > 1%


### PR DESCRIPTION
It still included IE11, contradicting the actual content of the file :blush:

## Description

It contained an outdated URL