### PR TITLE
Show correct UI on plans page when there are inactive/multiple plans

### DIFF
--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -119,7 +119,7 @@ export default function Plan() {
   }, [state.products]);
 
   // Filter prices based on plan interval
-  const filterPrices = (): Price[] => {
+  const filterPrices = useMemo((): Price[] => {
     const filterAmount = state.products.map((product: Product) => {
       const filteredPrices = product.prices.filter((price: BasePrice) => {
         const interval = price.human_readable_price.split('/')[1];
@@ -131,7 +131,7 @@ export default function Plan() {
       };
     });
     return filterAmount.filter((product: Product) => product.prices);
-  };
+  }, [state.products, state.intervalFilter]);
 
   const getSubscriptionForProductId = useCallback(
     (productId: String) => {
@@ -202,7 +202,7 @@ export default function Plan() {
   // Get feature items and matching icon boolean
   const getListItem = (listType: string, plan: string) => {
     const listItems: {icon: boolean; item: string}[] = [];
-    filterPrices().map((price) =>
+    filterPrices.map((price) =>
       Object.keys(price.metadata).map((featureItem: string) => {
         const numberItem = featureItem.lastIndexOf('_');
         const currentResult = featureItem.substring(numberItem + 1);
@@ -229,7 +229,7 @@ export default function Plan() {
   const hasMetaFeatures = () => {
     let expandBool = false;
     if (state.products.length >= 0) {
-      filterPrices().map((price) => {
+      filterPrices.map((price) => {
         for (const featureItem in price.metadata) {
           if (
             featureItem.includes('feature_support_') ||
@@ -333,7 +333,7 @@ export default function Plan() {
         </form>
 
         <div className={styles.allPlans}>
-          {filterPrices().map((price: Price) => (
+          {filterPrices.map((price: Price) => (
             <div className={styles.stripePlans} key={price.id}>
               {shouldShowManage(price) || isSubscribedProduct(price) ? (
                 <div className={styles.currentPlan}>{t('your plan')}</div>

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -397,7 +397,7 @@ export default function Plan() {
                       isDisabled={buttonsDisabled}
                     />
                   )}
-                {price.name === 'Community plan' && (
+                {price.prices.unit_amount === 0 && (
                   <div className={styles.btnSpacePlaceholder} />
                 )}
 

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -23,6 +23,8 @@ export interface BasePrice {
 export interface BaseSubscription {
   id: number;
   price: Product;
+  status: string;
+  items: [{price: {product: BaseProduct}}];
 }
 
 export interface Organization {
@@ -55,7 +57,9 @@ export async function getProducts() {
 }
 
 export async function getSubscription() {
-  return fetchGet<PaginatedResponse<BaseSubscription>>(endpoints.SUBSCRIPTION_URL);
+  return fetchGet<PaginatedResponse<BaseSubscription>>(
+    endpoints.SUBSCRIPTION_URL
+  );
 }
 
 export async function getOrganization() {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes an issue that caused the Plans page to falsely show the user as belonging to no plan when they had a subscription that wasn't active.

## Related issues

Fixes [this issue](https://github.com/kobotoolbox/kpi/pull/4385#issuecomment-1496438885) mentioned in #4385