### PR TITLE
Exclude fields from My Projects route

### DIFF
--- a/jsapp/js/projects/customViewStore.ts
+++ b/jsapp/js/projects/customViewStore.ts
@@ -324,10 +324,10 @@ class CustomViewStore {
       if (savedViewData.filters) {
         this.filters = savedViewData.filters;
       }
-      if (savedViewData.order) {
+      if (savedViewData.order?.direction && savedViewData.order?.fieldName) {
         this.order = savedViewData.order;
       }
-      if (savedViewData.fields) {
+      if (savedViewData.fields && Array.isArray(savedViewData.fields)) {
         this.fields = savedViewData.fields;
       }
     }

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -10,6 +10,7 @@ import {
   HOME_VIEW,
   HOME_ORDERABLE_FIELDS,
   DEFAULT_VISIBLE_FIELDS,
+  HOME_EXCLUDED_FIELDS,
 } from './projectViews/constants';
 import ViewSwitcher from './projectViews/viewSwitcher';
 import ProjectsTable from 'js/projects/projectsTable/projectsTable';
@@ -19,7 +20,6 @@ import routeStyles from './myProjectsRoute.module.scss';
 import {toJS} from 'mobx';
 import {COMMON_QUERIES, ROOT_URL} from 'js/constants';
 import ProjectQuickActions from './projectsTable/projectQuickActions';
-import mixins from 'js/mixins';
 import Dropzone from 'react-dropzone';
 import {validFileTypes} from 'js/utils';
 import Icon from 'js/components/common/icon';
@@ -51,6 +51,14 @@ function MyProjectsRoute() {
     selectedRows.includes(asset.uid)
   );
 
+  /** Filters out excluded fields */
+  const getTableVisibleFields = () => {
+    const outcome = toJS(customView.fields) || DEFAULT_VISIBLE_FIELDS;
+    return outcome.filter(
+      (fieldName) => !HOME_EXCLUDED_FIELDS.includes(fieldName)
+    );
+  };
+
   return (
     <Dropzone
       onDrop={dropImportXLSForms}
@@ -72,11 +80,13 @@ function MyProjectsRoute() {
           <ProjectsFilter
             onFiltersChange={customView.setFilters.bind(customView)}
             filters={toJS(customView.filters)}
+            excludedFields={HOME_EXCLUDED_FIELDS}
           />
 
           <ProjectsFieldsSelector
             onFieldsChange={customView.setFields.bind(customView)}
             selectedFields={toJS(customView.fields)}
+            excludedFields={HOME_EXCLUDED_FIELDS}
           />
 
           {selectedAssets.length === 1 && (
@@ -90,7 +100,7 @@ function MyProjectsRoute() {
           assets={customView.assets}
           isLoading={!customView.isFirstLoadComplete}
           highlightedFields={getFilteredFieldsNames()}
-          visibleFields={toJS(customView.fields) || DEFAULT_VISIBLE_FIELDS}
+          visibleFields={getTableVisibleFields()}
           orderableFields={HOME_ORDERABLE_FIELDS}
           order={customView.order}
           onChangeOrderRequested={customView.setOrder.bind(customView)}

--- a/jsapp/js/projects/projectViews/constants.ts
+++ b/jsapp/js/projects/projectViews/constants.ts
@@ -340,3 +340,13 @@ export const DEFAULT_VISIBLE_FIELDS: ProjectFieldName[] = [
   'status',
   'submissions',
 ];
+
+/**
+ * These are fields not available on the `/api/v2/assets/` endpoint - there is
+ * no point in displaying them to the user.
+ */
+export const HOME_EXCLUDED_FIELDS: ProjectFieldName[] = [
+  'ownerEmail',
+  'ownerFullName',
+  'ownerOrganization',
+];

--- a/jsapp/js/projects/projectViews/projectsFieldsSelector.tsx
+++ b/jsapp/js/projects/projectViews/projectsFieldsSelector.tsx
@@ -19,17 +19,23 @@ interface ProjectsFieldsSelectorProps {
    * again through props.
    */
   onFieldsChange: (fields: ProjectFieldName[] | undefined) => void;
+  /** A list of fields that should not be available to user. */
+  excludedFields?: ProjectFieldName[];
 }
 
 export default function ProjectsFieldsSelector(
   props: ProjectsFieldsSelectorProps
 ) {
   const getInitialSelectedFields = () => {
+    let outcome: ProjectFieldName[] = [];
     if (!props.selectedFields || props.selectedFields.length === 0) {
-      return DEFAULT_VISIBLE_FIELDS;
+      outcome = DEFAULT_VISIBLE_FIELDS;
     } else {
-      return Array.from(props.selectedFields);
+      outcome = Array.from(props.selectedFields);
     }
+    return outcome.filter(
+      (fieldName) => !props.excludedFields?.includes(fieldName)
+    );
   };
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -65,15 +71,20 @@ export default function ProjectsFieldsSelector(
   };
 
   const getCheckboxes = (): MultiCheckboxItem[] =>
-    Object.values(PROJECT_FIELDS).map((field) => {
-      return {
-        name: field.name,
-        label: field.label,
-        // We ensure "name" field is always selected
-        checked: selectedFields.includes(field.name) || field.name === 'name',
-        disabled: field.name === 'name',
-      };
-    });
+    Object.values(PROJECT_FIELDS)
+      .filter(
+        (fieldDefinition) =>
+          !props.excludedFields?.includes(fieldDefinition.name)
+      )
+      .map((field) => {
+        return {
+          name: field.name,
+          label: field.label,
+          // We ensure "name" field is always selected
+          checked: selectedFields.includes(field.name) || field.name === 'name',
+          disabled: field.name === 'name',
+        };
+      });
 
   return (
     <div className={styles.root}>

--- a/jsapp/js/projects/projectViews/projectsFilter.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilter.tsx
@@ -4,7 +4,7 @@ import clonedeep from 'lodash.clonedeep';
 import Button from 'js/components/common/button';
 import KoboModal from 'js/components/modals/koboModal';
 import KoboModalHeader from 'js/components/modals/koboModalHeader';
-import type {ProjectsFilterDefinition} from './constants';
+import type {ProjectFieldName, ProjectsFilterDefinition} from './constants';
 import ProjectsFilterEditor from './projectsFilterEditor';
 import {removeIncorrectFilters} from './utils';
 import styles from './projectsFilter.module.scss';
@@ -21,6 +21,8 @@ interface ProjectsFilterProps {
    * new filters.
    */
   onFiltersChange: (filters: ProjectsFilterDefinition[]) => void;
+  /** A list of fields that should not be available to user. */
+  excludedFields?: ProjectFieldName[];
 }
 
 export default function ProjectsFilter(props: ProjectsFilterProps) {
@@ -132,6 +134,7 @@ export default function ProjectsFilter(props: ProjectsFilterProps) {
               onDelete={() => {
                 onFilterEditorDelete(filterIndex);
               }}
+              excludedFields={props.excludedFields}
             />
           ))}
 

--- a/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
+++ b/jsapp/js/projects/projectViews/projectsFilterEditor.tsx
@@ -20,6 +20,8 @@ interface ProjectsFilterEditorProps {
   /** Called on every change. */
   onFilterChange: (filter: ProjectsFilterDefinition) => void;
   onDelete: () => void;
+  /** A list of fields that should not be available to user. */
+  excludedFields?: ProjectFieldName[];
 }
 
 const COUNTRIES = envStore.data.country_choices;
@@ -66,6 +68,11 @@ export default function ProjectsFilterEditor(props: ProjectsFilterEditorProps) {
       // We don't want to display fields with zero filters available.
       .filter(
         (filterDefinition) => filterDefinition.availableConditions.length >= 1
+      )
+      // We don't want to display excluded fields.
+      .filter(
+        (filterDefinition) =>
+          !props.excludedFields?.includes(filterDefinition.name)
       )
       .map((filterDefinition) => {
         return {label: filterDefinition.label, value: filterDefinition.name};


### PR DESCRIPTION
## Description

Hide "Owner full name", "Owner email", and "Owner organization" columns for My Projects route. These pieces of information are not available for endpoint that is handling this route (in contrast to a custom Project View endpoint).

## Related issues

Fixes #4378
