### PR TITLE
Add IP address to password reset email

### DIFF
--- a/kobo/apps/accounts/templates/account/email/password_reset_key_message.txt
+++ b/kobo/apps/accounts/templates/account/email/password_reset_key_message.txt
@@ -1,9 +1,11 @@
 {% load i18n %}
+{% load customize_email_content %}
 
 {% block content %}{% autoescape off %}
 {% blocktrans %}Hello from KoboToolbox,{% endblocktrans %}
 
 {% blocktrans %}We’ve received a password reset request for your user account.{% endblocktrans %}
+{% blocktrans %}The request was made from {% endblocktrans %}{% ip_address %}
 
 {% blocktrans %}To reset your password, click the link below.{% endblocktrans %}
 {{ password_reset_url }}

--- a/kobo/apps/accounts/templatetags/customize_email_content.py
+++ b/kobo/apps/accounts/templatetags/customize_email_content.py
@@ -37,3 +37,9 @@ def convert_placeholders(section_content, activate_url, user):
         '##activate_url##', activate_url
     ).replace('##user##', user.username).replace("&#x27;", "\'")
 
+
+@register.simple_tag(takes_context=True)
+def ip_address(context):
+    request = context['request']
+    address = request.META.get('REMOTE_ADDR')
+    return address


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Add the IP address of the user who requests a password reset email to the `password_reset_key_message` template. 