### PR TITLE
Always recreate fonts when syncing npm dependencies in dev mode

### DIFF
--- a/docker/init.bash
+++ b/docker/init.bash
@@ -53,7 +53,11 @@ if [[ ! -d "${KPI_SRC_DIR}/staticfiles" ]] || ! python "${KPI_SRC_DIR}/docker/ch
         rm -rf "${KPI_SRC_DIR}/jsapp/compiled"
 
         echo "Syncing \`npm\` packages…"
-        check-dependencies --install
+        if ( ! check-dependencies ); then
+            npm install --quiet > /dev/null 2>&1
+        else
+            npm run postinstall > /dev/null 2>&1
+        fi
 
         echo "Rebuilding client code…"
         npm run build


### PR DESCRIPTION
## Description

Fix error when `/jsapp/fonts` folder is missing while building the front-end assets in dev mode.
