### PR TITLE
update django allauth version from 0.52.0 -> 0.54.0

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -145,7 +145,7 @@ django==3.2.15
     #   jsonfield
     #   kobo-service-account
     #   model-bakery
-django-allauth==0.52.0
+django-allauth==0.54.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -123,7 +123,7 @@ django==3.2.15
     #   djangorestframework
     #   jsonfield
     #   kobo-service-account
-django-allauth==0.52.0
+django-allauth==0.54.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Updated django-allauth, fixing an issue where OpenID Connect social providers wouldn't pre-populate the email field at signup.

## Related issues

Fixes #4399 and #4258 (tested using Google OIDC)