### PR TITLE
Replace deprecated constants in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ stages:
   - build
   - test
   - deploy
-  
+
 include:
   - template: SAST.gitlab-ci.yml
 
@@ -11,7 +11,7 @@ build:
   services:
     - docker:dind
   before_script:
-    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.gitlab.com
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
     - docker pull $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} || true
     - docker build --cache-from $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} .


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixed an issue that was causing GitLab CI to fail during the build step.

## Related issues

## Notes
`$CI_BUILD_TOKEN` deprecation notice is [here](https://docs.gitlab.com/ee/update/deprecations.html#ci_build_-predefined-variables).

Failed jobs: [1](https://gitlab.com/kobo_toolbox/kpi/-/pipelines/857517544/failures), [2](https://gitlab.com/kobo_toolbox/kpi/-/pipelines/857392562/failures), [3](https://gitlab.com/kobo_toolbox/kpi/-/pipelines/855985031/failures).