### PR TITLE
Fix spacing for customizable email template

### DIFF
--- a/kobo/apps/accounts/templates/account/email/email_confirmation_signup_message.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_signup_message.txt
@@ -8,17 +8,24 @@
 {% convert_placeholders content.section_one activate_url user %}
 {% else %}
 {% blocktrans %}Thanks for signing up with KoboToolbox!{% endblocktrans %}
+
 {% blocktrans %}Confirming your account will give you access to KoboToolbox applications. Please visit the following URL to finish activation of your new account.{% endblocktrans %}
+
 {{ activate_url }}
+
 {% blocktrans %}Your username is: {% endblocktrans %}{{ user }}
+
 {% endif %}
 {% endspaceless %}
+
 {% spaceless %}
 {% if content.section_two or content.section_two == '' %}
 {% convert_placeholders content.section_two activate_url user %}
 {% else %}
 {% blocktrans %}For help getting started, check out the KoboToolbox user documentation: https://support.kobotoolbox.com {% endblocktrans %}
+
 {% blocktrans %}You can also join the KoboToolbox community forum to ask questions, share solutions, and chat with thousands of users: https://community.kobotoolbox.org{% endblocktrans %}
+
 {% blocktrans %}Best,{% endblocktrans %}
 KoboToolbox
 {% endif %}


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Fix the registration email template spacing