### PR TITLE
Update radio and checkbox styles

### DIFF
--- a/jsapp/js/bemComponents.ts
+++ b/jsapp/js/bemComponents.ts
@@ -280,21 +280,11 @@ bem.TextBox__input = makeBem(bem.TextBox, 'input', 'input');
 bem.TextBox__description = makeBem(bem.TextBox, 'description');
 bem.TextBox__error = makeBem(bem.TextBox, 'error');
 
-bem.Checkbox = makeBem(null, 'checkbox');
-bem.Checkbox__wrapper = makeBem(bem.Checkbox, 'wrapper', 'label');
-bem.Checkbox__input = makeBem(bem.Checkbox, 'input', 'input');
-bem.Checkbox__label = makeBem(bem.Checkbox, 'label', 'span');
-
 bem.ToggleSwitch = makeBem(null, 'toggle-switch');
 bem.ToggleSwitch__wrapper = makeBem(bem.ToggleSwitch, 'wrapper', 'label');
 bem.ToggleSwitch__input = makeBem(bem.ToggleSwitch, 'input', 'input');
 bem.ToggleSwitch__slider = makeBem(bem.ToggleSwitch, 'slider', 'span');
 bem.ToggleSwitch__label = makeBem(bem.ToggleSwitch, 'label', 'span');
-
-bem.Radio = makeBem(null, 'radio');
-bem.Radio__row = makeBem(bem.Radio, 'row', 'label');
-bem.Radio__input = makeBem(bem.Radio, 'input', 'input');
-bem.Radio__label = makeBem(bem.Radio, 'label', 'span');
 
 bem.PasswordStrength = makeBem(null, 'password-strength');
 bem.PasswordStrength__title = makeBem(bem.PasswordStrength, 'title');

--- a/jsapp/js/components/common/checkbox.scss
+++ b/jsapp/js/components/common/checkbox.scss
@@ -1,0 +1,94 @@
+@use '~kobo-common/src/styles/colors';
+@use 'scss/_variables';
+@use 'scss/sizes';
+
+.checkbox {
+  .checkbox__wrapper {
+    padding: 0;
+    cursor: pointer;
+    display: block;
+
+    &:hover .checkbox__input:not([disabled]) {
+      &:checked::after { opacity: 0.8; }
+      &:not(:checked)::after { opacity: 0.1; }
+    }
+
+    &:active .checkbox__input:not([disabled]) {
+      &:checked::after { opacity: 0.6; }
+      &:not(:checked)::after { opacity: 0.3; }
+    }
+  }
+
+  &.checkbox--disabled .checkbox__wrapper {
+    cursor: default;
+  }
+
+  .checkbox__input,
+  .checkbox__label {
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .checkbox__label {
+    max-width: calc(100% - sizes.$x32);
+    color: colors.$kobo-gray-24;
+    font-size: variables.$base-font-size;
+  }
+
+  .checkbox__input + .checkbox__label {
+    margin-left: sizes.$x8;
+  }
+
+  .checkbox__input {
+    border-radius: sizes.$x2;
+
+    &::after {
+      content: "✓";
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: sizes.$x18;
+      height: sizes.$x18;
+      color: colors.$kobo-white;
+      background-color: colors.$kobo-blue;
+      text-align: center;
+      line-height: sizes.$x18;
+      font-size: sizes.$x18;
+    }
+  }
+
+  .checkbox__input {
+    appearance: none;
+    position: relative;
+    margin: 0;
+    border: sizes.$x1 solid colors.$kobo-gray-40;
+    width: sizes.$x20;
+    height: sizes.$x20;
+    outline: 0;
+    background-color: colors.$kobo-white;
+    color: colors.$kobo-gray-40;
+    cursor: pointer;
+    overflow: hidden; // HACK FIX to not cause scrollbar when near the edge
+
+    &::after {
+      display: block;
+      position: absolute;
+      opacity: 0;
+    }
+
+    &:checked {
+      border-color: colors.$kobo-blue;
+
+      &::after { opacity: 1; }
+    }
+
+    &[disabled] {
+      pointer-events: none;
+      opacity: 0.5;
+
+      & + .checkbox__label {
+        opacity: 0.5;
+      }
+    }
+  }
+}

--- a/jsapp/js/components/common/checkbox.scss
+++ b/jsapp/js/components/common/checkbox.scss
@@ -2,6 +2,9 @@
 @use 'scss/_variables';
 @use 'scss/sizes';
 
+// Note: we can't change this into a CSS Module, because some Data Table and
+// `utils.ts` code relies on `.checkbox__input` being available.
+
 .checkbox {
   .checkbox__wrapper {
     padding: 0;

--- a/jsapp/js/components/common/checkbox.scss
+++ b/jsapp/js/components/common/checkbox.scss
@@ -78,6 +78,7 @@
     cursor: pointer;
     overflow: hidden; // HACK FIX to not cause scrollbar when near the edge
 
+    // This is the CSS checkbox :)
     &::after {
       display: block;
       position: absolute;
@@ -92,6 +93,7 @@
       width: sizes.$x10;
       height: sizes.$x4;
       background-color: transparent;
+      border-radius: sizes.$x1;
     }
 
     &:checked {
@@ -99,7 +101,7 @@
       border-color: colors.$kobo-blue;
       background-color: colors.$kobo-blue;
 
-      &::after { opacity: 1; }
+      &::after {opacity: 1;}
     }
   }
 }

--- a/jsapp/js/components/common/checkbox.scss
+++ b/jsapp/js/components/common/checkbox.scss
@@ -7,20 +7,42 @@
     padding: 0;
     cursor: pointer;
     display: block;
+  }
 
-    &:hover .checkbox__input:not([disabled]) {
-      &:checked::after { opacity: 0.8; }
-      &:not(:checked)::after { opacity: 0.1; }
+  // Disabled state
+  &.checkbox--disabled {
+    pointer-events: none;
+
+    .checkbox__wrapper {
+      cursor: default;
     }
 
-    &:active .checkbox__input:not([disabled]) {
-      &:checked::after { opacity: 0.6; }
-      &:not(:checked)::after { opacity: 0.3; }
+    .checkbox__input,
+    .checkbox__label {
+      opacity: 0.5;
+    }
+
+    .checkbox__input:checked {
+      color: colors.$kobo-white;
+      border-color: colors.$kobo-gray-40;
+      background-color: colors.$kobo-gray-40;
     }
   }
 
-  &.checkbox--disabled .checkbox__wrapper {
-    cursor: default;
+  // Hover states
+  .checkbox__wrapper:hover {
+    // Unchecked
+    .checkbox__input:not(:checked) {
+      border-color: colors.$kobo-gray-40;
+      background-color: colors.$kobo-light-blue;
+    }
+
+    // Checked
+    .checkbox__input:checked {
+      color: colors.$kobo-white;
+      border-color: colors.$kobo-alt-blue;
+      background-color: colors.$kobo-alt-blue;
+    }
   }
 
   .checkbox__input,
@@ -36,37 +58,20 @@
   }
 
   .checkbox__input + .checkbox__label {
-    margin-left: sizes.$x8;
+    margin-left: sizes.$x6;
   }
 
   .checkbox__input {
-    border-radius: sizes.$x2;
-
-    &::after {
-      content: "✓";
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: sizes.$x18;
-      height: sizes.$x18;
-      color: colors.$kobo-white;
-      background-color: colors.$kobo-blue;
-      text-align: center;
-      line-height: sizes.$x18;
-      font-size: sizes.$x18;
-    }
-  }
-
-  .checkbox__input {
+    border-radius: sizes.$x4;
     appearance: none;
     position: relative;
     margin: 0;
-    border: sizes.$x1 solid colors.$kobo-gray-40;
+    color: colors.$kobo-gray-65;
+    border: sizes.$x1 solid colors.$kobo-gray-65;
+    background-color: colors.$kobo-white;
     width: sizes.$x20;
     height: sizes.$x20;
     outline: 0;
-    background-color: colors.$kobo-white;
-    color: colors.$kobo-gray-40;
     cursor: pointer;
     overflow: hidden; // HACK FIX to not cause scrollbar when near the edge
 
@@ -74,21 +79,24 @@
       display: block;
       position: absolute;
       opacity: 0;
+      content: '';
+      top: calc(50% - sizes.$x5);
+      left: calc(50% - sizes.$x6);
+      transform: rotate(-45deg);
+      border: sizes.$x3 solid currentColor;
+      border-top: none;
+      border-right: none;
+      width: sizes.$x10;
+      height: sizes.$x4;
+      background-color: transparent;
     }
 
     &:checked {
+      color: colors.$kobo-white;
       border-color: colors.$kobo-blue;
+      background-color: colors.$kobo-blue;
 
       &::after { opacity: 1; }
-    }
-
-    &[disabled] {
-      pointer-events: none;
-      opacity: 0.5;
-
-      & + .checkbox__label {
-        opacity: 0.5;
-      }
     }
   }
 }

--- a/jsapp/js/components/common/checkbox.tsx
+++ b/jsapp/js/components/common/checkbox.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import autoBind from 'react-autobind';
-import bem from 'js/bem';
+import bem, {makeBem} from 'js/bem';
 import './checkbox.scss';
+
+bem.Checkbox = makeBem(null, 'checkbox');
+bem.Checkbox__wrapper = makeBem(bem.Checkbox, 'wrapper', 'label');
+bem.Checkbox__input = makeBem(bem.Checkbox, 'input', 'input');
+bem.Checkbox__label = makeBem(bem.Checkbox, 'label', 'span');
 
 interface CheckboxProps {
   checked: boolean;

--- a/jsapp/js/components/common/checkbox.tsx
+++ b/jsapp/js/components/common/checkbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import autoBind from 'react-autobind';
 import bem from 'js/bem';
-import './checkbox-and-radio.scss';
+import './checkbox.scss';
 
 interface CheckboxProps {
   checked: boolean;

--- a/jsapp/js/components/common/radio.scss
+++ b/jsapp/js/components/common/radio.scss
@@ -1,31 +1,26 @@
 @use '~kobo-common/src/styles/colors';
-@use "scss/_variables";
-@use "scss/sizes";
+@use 'scss/_variables';
+@use 'scss/sizes';
 
-.radio,
-.checkbox {
-  .radio__row,
-  .checkbox__wrapper {
+.radio {
+  .radio__row {
     padding: 0;
     cursor: pointer;
     display: block;
 
-    &:hover .radio__input:not([disabled]),
-    &:hover .checkbox__input:not([disabled]) {
+    &:hover .radio__input:not([disabled]) {
       &:checked::after { opacity: 0.8; }
       &:not(:checked)::after { opacity: 0.1; }
     }
 
-    &:active .radio__input:not([disabled]),
-    &:active .checkbox__input:not([disabled]) {
+    &:active .radio__input:not([disabled]) {
       &:checked::after { opacity: 0.6; }
       &:not(:checked)::after { opacity: 0.3; }
     }
   }
 
   .radio__row.radio__row--title,
-  &.radio--disabled .radio__row,
-  &.checkbox--disabled .checkbox__wrapper {
+  &.radio--disabled .radio__row {
     cursor: default;
   }
 
@@ -34,22 +29,18 @@
   }
 
   .radio__input,
-  .checkbox__input,
-  .radio__label,
-  .checkbox__label {
+  .radio__label {
     display: inline-block;
     vertical-align: top;
   }
 
-  .radio__label,
-  .checkbox__label {
+  .radio__label {
     max-width: calc(100% - sizes.$x32);
     color: colors.$kobo-gray-24;
     font-size: variables.$base-font-size;
   }
 
-  .radio__input + .radio__label,
-  .checkbox__input + .checkbox__label {
+  .radio__input + .radio__label {
     margin-left: sizes.$x8;
   }
 
@@ -57,7 +48,7 @@
     border-radius: 50%;
 
     &::after {
-      content: "";
+      content: '';
       top: sizes.$x4;
       left: sizes.$x4;
       border-radius: 50%;
@@ -67,26 +58,7 @@
     }
   }
 
-  .checkbox__input {
-    border-radius: sizes.$x2;
-
-    &::after {
-      content: "✓";
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: sizes.$x18;
-      height: sizes.$x18;
-      color: colors.$kobo-white;
-      background-color: colors.$kobo-blue;
-      text-align: center;
-      line-height: sizes.$x18;
-      font-size: sizes.$x18;
-    }
-  }
-
-  .radio__input,
-  .checkbox__input {
+  .radio__input {
     appearance: none;
     position: relative;
     margin: 0;
@@ -115,8 +87,7 @@
       pointer-events: none;
       opacity: 0.5;
 
-      & + .radio__label,
-      & + .checkbox__label {
+      & + .radio__label {
         opacity: 0.5;
       }
     }

--- a/jsapp/js/components/common/radio.scss
+++ b/jsapp/js/components/common/radio.scss
@@ -2,6 +2,9 @@
 @use 'scss/_variables';
 @use 'scss/sizes';
 
+// Note: we can't change this into a CSS Module, because some Form Builder code
+// relies on `.radio__input` being available.
+
 .radio {
   .radio__row {
     padding: sizes.$x4 0;

--- a/jsapp/js/components/common/radio.scss
+++ b/jsapp/js/components/common/radio.scss
@@ -4,28 +4,50 @@
 
 .radio {
   .radio__row {
-    padding: 0;
+    padding: sizes.$x4 0;
     cursor: pointer;
     display: block;
 
-    &:hover .radio__input:not([disabled]) {
-      &:checked::after { opacity: 0.8; }
-      &:not(:checked)::after { opacity: 0.1; }
-    }
-
-    &:active .radio__input:not([disabled]) {
-      &:checked::after { opacity: 0.6; }
-      &:not(:checked)::after { opacity: 0.3; }
+    &.radio__row--title {
+      cursor: default;
     }
   }
 
-  .radio__row.radio__row--title,
-  &.radio--disabled .radio__row {
-    cursor: default;
+  // Disabled state
+  &.radio--disabled {
+    .radio__row {
+      cursor: default;
+    }
+
+    .radio__input,
+    .radio__label {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    .radio__input:checked {
+      color: colors.$kobo-white;
+      border-color: colors.$kobo-gray-40;
+      background-color: colors.$kobo-gray-40;
+    }
   }
 
-  .radio__row {
-    padding: sizes.$x4 0;
+  // Hover states
+  .radio__row:hover {
+    // Unchecked
+    .radio__input:not(:checked) {
+      border-color: colors.$kobo-gray-40;
+      background-color: colors.$kobo-light-blue;
+    }
+
+    // Checked
+    .radio__input:checked {
+      border-color: colors.$kobo-alt-blue;
+
+      &::after {
+        background-color: colors.$kobo-alt-blue;
+      }
+    }
   }
 
   .radio__input,
@@ -41,13 +63,27 @@
   }
 
   .radio__input + .radio__label {
-    margin-left: sizes.$x8;
+    margin-left: sizes.$x6;
   }
 
   .radio__input {
     border-radius: 50%;
+    appearance: none;
+    position: relative;
+    margin: 0;
+    color: colors.$kobo-gray-65;
+    border: sizes.$x1 solid colors.$kobo-gray-65;
+    background-color: colors.$kobo-white;
+    width: sizes.$x20;
+    height: sizes.$x20;
+    outline: 0;
+    cursor: pointer;
+    overflow: hidden; // HACK FIX to not cause scrollbar when near the edge
 
     &::after {
+      display: block;
+      position: absolute;
+      opacity: 0;
       content: '';
       top: sizes.$x4;
       left: sizes.$x4;
@@ -56,40 +92,11 @@
       height: sizes.$x10;
       background-color: colors.$kobo-blue;
     }
-  }
-
-  .radio__input {
-    appearance: none;
-    position: relative;
-    margin: 0;
-    border: sizes.$x1 solid colors.$kobo-gray-40;
-    width: sizes.$x20;
-    height: sizes.$x20;
-    outline: 0;
-    background-color: colors.$kobo-white;
-    color: colors.$kobo-gray-40;
-    cursor: pointer;
-    overflow: hidden; // HACK FIX to not cause scrollbar when near the edge
-
-    &::after {
-      display: block;
-      position: absolute;
-      opacity: 0;
-    }
 
     &:checked {
       border-color: colors.$kobo-blue;
 
       &::after { opacity: 1; }
-    }
-
-    &[disabled] {
-      pointer-events: none;
-      opacity: 0.5;
-
-      & + .radio__label {
-        opacity: 0.5;
-      }
     }
   }
 }

--- a/jsapp/js/components/common/radio.tsx
+++ b/jsapp/js/components/common/radio.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import autoBind from 'react-autobind';
-import bem from 'js/bem';
+import bem, {makeBem} from 'js/bem';
 import './radio.scss';
+
+bem.Radio = makeBem(null, 'radio');
+bem.Radio__row = makeBem(bem.Radio, 'row', 'label');
+bem.Radio__input = makeBem(bem.Radio, 'input', 'input');
+bem.Radio__label = makeBem(bem.Radio, 'label', 'span');
 
 export interface RadioOption {
   label: string;

--- a/jsapp/js/components/common/radio.tsx
+++ b/jsapp/js/components/common/radio.tsx
@@ -21,6 +21,8 @@ interface RadioProps {
   selected: string;
   /** Disables whole radio component. */
   isDisabled?: boolean;
+  /** This is `false` by default */
+  isClearable?: boolean;
   'data-cy'?: string;
 }
 
@@ -35,7 +37,17 @@ class Radio extends React.Component<RadioProps> {
   }
 
   onChange(evt: React.ChangeEvent<HTMLInputElement>) {
-    this.props.onChange(evt.currentTarget.value, evt.currentTarget.name);
+    this.props.onChange(evt.currentTarget.value, this.props.name);
+  }
+
+  onClick(evt: React.ChangeEvent<HTMLInputElement>) {
+    // For clearable radio, we unselect checked option when clicked
+    if (
+      this.props.isClearable &&
+      evt.currentTarget.checked
+    ) {
+      this.props.onChange('', this.props.name);
+    }
   }
 
   render() {
@@ -51,6 +63,7 @@ class Radio extends React.Component<RadioProps> {
                 value={option.value}
                 name={this.props.name}
                 onChange={this.onChange.bind(this)}
+                onClick={this.onClick.bind(this)}
                 checked={this.props.selected === option.value}
                 disabled={this.props.isDisabled || option.isDisabled}
                 data-cy={this.props['data-cy']}

--- a/jsapp/js/components/common/radio.tsx
+++ b/jsapp/js/components/common/radio.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import autoBind from 'react-autobind';
 import bem from 'js/bem';
+import './radio.scss';
 
 export interface RadioOption {
   label: string;

--- a/jsapp/js/components/submissions/table.scss
+++ b/jsapp/js/components/submissions/table.scss
@@ -1,6 +1,6 @@
 @use '~kobo-common/src/styles/colors';
 @use 'scss/z-indexes';
-@use "js/components/common/checkbox-and-radio";
+@use 'js/components/common/checkbox';
 
 // These are custom styles for Table View table.
 
@@ -142,7 +142,7 @@ $s-data-table-font: 13px;
             margin-top: 10px;
 
             .popover-menu__toggle::after {
-              content: "\25BC";
+              content: '\25BC';
               font-size: 16px;
               display: inline-block;
               vertical-align: 1px;

--- a/jsapp/scss/stylesheets/partials/form_builder/_mandatory_setting.scss
+++ b/jsapp/scss/stylesheets/partials/form_builder/_mandatory_setting.scss
@@ -11,7 +11,7 @@
         display: block;
       }
 
-      .radio__input:not(:checked) ~ .text-box {
+      input[type='radio']:not(:checked) ~ .text-box {
         visibility: hidden;
         height: 0;
         overflow: hidden;


### PR DESCRIPTION
## Description

Simplified and more modern styles for checkboxes and radio inputs

## Code Review Notes

Few things here
- I decided to split the shared styles file, as there was not much gain from it and it was blocking us from moving forward and making the SCSS code harder to grasp
- I didn't drop BEM, as unfortunately both `<Radio>` and `<Checkbox>` components are being used in few Old Code™ places 
- Added `isClearable` option to `<Radio>`, to make it optionally unselectable. The default value is keeping current status quo

## Related issues

Fixes #4306