### PR TITLE
Add Bengali, Myanmar, Nyanja/Chewa to interface translations list

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -498,6 +498,7 @@ DJANGO_LANGUAGE_CODES = env.str(
         'ja '  # Japanese
         'ku '  # Kurdish
         'my '  # Burmese/Myanmar
+        'ny '  # Nyanja/Chewa
         'pl '  # Polish
         'pt '  # Portuguese
         'ru '  # Russian

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -486,6 +486,7 @@ DJANGO_LANGUAGE_CODES = env.str(
     default=(
         'am '  # Amharic
         'ar '  # Arabic
+        'bn '  # Bengali
         'cs '  # Czech
         'de '  # German
         'en '  # English
@@ -496,6 +497,7 @@ DJANGO_LANGUAGE_CODES = env.str(
         'hu '  # Hungarian
         'ja '  # Japanese
         'ku '  # Kurdish
+        'my '  # Burmese/Myanmar
         'pl '  # Polish
         'pt '  # Portuguese
         'ru '  # Russian


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Added the following languages to the interface translations list:
* Bengali
* Burmese/Myanmar
* Nyanja/Chewa
