### PR TITLE
Anchor subscription cycles to first of the month/year

### DIFF
--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -232,7 +232,7 @@ class CheckoutLinkView(APIView):
         }
         # Set the billing cycle anchor date *only* if today's not the first day of the billing period
         date = timezone.now()
-        if date.day != 1:
+        if date.day != 1 and price.recurring:
             billing_cycle_anchor = 0
             if price.recurring['interval'] == 'month':
                 billing_cycle_anchor = next_first_day_of_the_month()

--- a/kpi/utils/datetime.py
+++ b/kpi/utils/datetime.py
@@ -18,3 +18,25 @@ def several_minutes_from_now(minutes: int):
 
 def ten_minutes_from_now():
     return several_minutes_from_now(10)
+
+
+def next_first_day_of_the_month():
+    """
+    Return a datetime object for first day of the next month. If today is the first, return today's date.
+    """
+    date = timezone.now()
+    if date.day != 1:
+        month = date.month + 1
+        if month > 12:
+            date = date.replace(year=date.year + 1)
+            month = month % 12
+        date = date.replace(day=1, month=month)
+    return date
+
+
+def next_first_day_of_the_year():
+    date = timezone.now()
+    next_year = date.year + 1
+    if date.day != 1 or date.month != 1:
+        date = date.replace(day=1, month=1, year=next_year)
+    return date


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [X] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Makes Stripe subscriptions anchor to the first day of the billing period (first of next month, first of next year) and prorates based on remaining days.

## Related issues

N/A

## Notes

You should notice the display in Stripe has changed:

![image](https://github.com/kobotoolbox/kpi/assets/7819986/3092d687-c69c-4c7e-b8d0-9c12cd117f92)

Anchors to today's date if it's the first of the month/year, to avoid Stripe complaining that we're trying to anchor to a date in the past.