### PR TITLE
Add Nyanja language to supported Django languages

### DIFF
--- a/kobo/static_lists.py
+++ b/kobo/static_lists.py
@@ -326,4 +326,10 @@ EXTRA_LANG_INFO = {
         'name': 'Kurdish',
         'name_local': 'كوردی',
     },
+    'ny': {
+        'bidi': False,
+        'code': 'ny',
+        'name': 'Nyanja',
+        'name_local': 'Nyanja',
+    },
 }


### PR DESCRIPTION
## Description

Add Nyanja/Chewa language to extra languages

## Related issues

Fixes broken PR #4444 
