### PR TITLE
Update helm version and namespace for "beta" staging environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,11 +21,11 @@ build:
 deploy-beta:
   stage: deploy
   image:
-    name: alpine/helm:3.7.2
+    name: alpine/helm:3.12.0
     entrypoint: [""]
   script:
     - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
-    - helm -n beta upgrade kobo-beta kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+    - helm -n kobo-dev upgrade kobo-beta kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
   environment:
     name: beta
     url: https://kf.beta.kobotoolbox.org


### PR DESCRIPTION
Update beta staging environment CI step. Perhaps should be merged directly into public-beta instead or both?
Post-merge edit: additional change needed https://github.com/kobotoolbox/kpi/commit/529553aae81d45c88d27c7672527102d0d97ffe6