### PR TITLE
Prevent Node.js 18 provided by Debian 12 from taking precedence over the Node.js 16 package provided by NodeSource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get -qq update && \
         less \
         libproj-dev \
         locales \
-        nodejs \
+        nodejs=$(apt-cache show nodejs | grep 'Version: .*nodesource' | cut -f 2 -d ' ') \
         postgresql-client \
         procps \
         rsync \


### PR DESCRIPTION
The Debian-provided `nodejs` package also does not include `npm`, although it's available as a separate Debian-provided package. As a consequence, this error may appear prior to including the change in this PR:
```
/bin/sh: 1: npm: not found
The command '/bin/sh -c rm -rf ${KPI_NODE_PATH} &&     npm install -g npm@8.5.5 &&     npm install -g check-dependencies &&     rm -rf "${KPI_SRC_DIR}/jsapp/fonts" &&     rm -rf "${KPI_SRC_DIR}/jsapp/compiled" &&     npm install --quiet &&     npm cache clean --force' returned a non-zero code: 127
ERROR: Service 'kpi' failed to build : Build failed
```

## Description
The `python:3.10` Docker base image has moved from Debian 11 to Debian 12, necessitating a workaround to continue using Node.js 16.