### PR TITLE
Split out PasswordUpdateComponent

### DIFF
--- a/jsapp/js/account/changePasswordRoute.component.tsx
+++ b/jsapp/js/account/changePasswordRoute.component.tsx
@@ -2,15 +2,13 @@ import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {observer} from 'mobx-react';
 import sessionStore from 'js/stores/session';
-import {actions} from '../actions';
 import bem, {makeBem} from 'js/bem';
-import TextBox from 'js/components/common/textBox';
-import PasswordStrength from 'js/components/passwordStrength.component';
 import {stringToColor} from 'js/utils';
-import {ROOT_URL} from 'js/constants';
 import {withRouter} from 'js/router/legacy';
 import type {WithRouterProps} from 'jsapp/js/router/legacy';
 import './accountSettings.scss';
+import styles from './changePasswordRoute.module.scss';
+import UpdatePasswordForm from './security/password/updatePasswordForm.component';
 
 bem.AccountSettings = makeBem(null, 'account-settings');
 bem.AccountSettings__left = makeBem(bem.AccountSettings, 'left');
@@ -18,89 +16,9 @@ bem.AccountSettings__right = makeBem(bem.AccountSettings, 'right');
 bem.AccountSettings__item = makeBem(bem.FormModal, 'item');
 bem.AccountSettings__actions = makeBem(bem.AccountSettings, 'actions');
 
-interface PasswordErrors {
-  currentPassword?: string;
-  newPassword?: string;
-  verifyPassword?: string;
-}
-
-interface ChangePasswordRouteState {
-  errors: PasswordErrors;
-  currentPassword: string;
-  newPassword: string;
-  verifyPassword: string;
-}
-
-const FIELD_REQUIRED_ERROR = t('This field is required.');
-
-const ChangePasswordRoute = class ChangePassword extends React.Component<
-  WithRouterProps,
-  ChangePasswordRouteState
-> {
-  errors: PasswordErrors = {};
-
-  constructor(props: WithRouterProps) {
-    super(props);
-    this.errors = {};
-    this.state = {
-      errors: this.errors,
-      currentPassword: '',
-      newPassword: '',
-      verifyPassword: '',
-    };
-  }
-
+const ChangePasswordRoute = class ChangePassword extends React.Component<WithRouterProps> {
   close() {
     this.props.router.navigate(-1);
-  }
-
-  savePassword() {
-    this.errors = {};
-
-    if (!this.state.currentPassword) {
-      this.errors.currentPassword = FIELD_REQUIRED_ERROR;
-    }
-    if (!this.state.newPassword) {
-      this.errors.newPassword = FIELD_REQUIRED_ERROR;
-    }
-    if (!this.state.verifyPassword) {
-      this.errors.verifyPassword = FIELD_REQUIRED_ERROR;
-    }
-
-    if (this.state.newPassword !== this.state.verifyPassword) {
-      this.errors.newPassword = t(
-        'This field must match the Verify Password field.'
-      );
-    }
-    if (Object.keys(this.errors).length === 0) {
-      actions.auth.changePassword(
-        this.state.currentPassword,
-        this.state.newPassword
-      );
-    }
-    this.setState({errors: this.errors});
-  }
-
-  onChangePasswordFailed(jqXHR: JQuery.jqXHR) {
-    if (jqXHR.responseJSON.current_password) {
-      this.errors.currentPassword = jqXHR.responseJSON.current_password;
-    }
-    if (jqXHR.responseJSON.new_password) {
-      this.errors.newPassword = jqXHR.responseJSON.new_password;
-    }
-    this.setState({errors: this.errors});
-  }
-
-  onCurrentPasswordChange(val: string) {
-    this.setState({currentPassword: val});
-  }
-
-  onNewPasswordChange(val: string) {
-    this.setState({newPassword: val});
-  }
-
-  onVerifyPasswordChange(val: string) {
-    this.setState({verifyPassword: val});
   }
 
   render() {
@@ -115,10 +33,6 @@ const ChangePasswordRoute = class ChangePassword extends React.Component<
       <DocumentTitle title={`${accountName} | KoboToolbox`}>
         <bem.AccountSettings>
           <bem.AccountSettings__actions>
-            <bem.KoboButton onClick={this.savePassword.bind(this)} m='blue'>
-              {t('Save Password')}
-            </bem.KoboButton>
-
             <button
               onClick={this.close.bind(this)}
               className='account-settings-close mdl-button mdl-button--icon'
@@ -135,57 +49,9 @@ const ChangePasswordRoute = class ChangePassword extends React.Component<
               <h4>{accountName}</h4>
             </bem.AccountSettings__item>
 
-            <bem.AccountSettings__item m='fields'>
-              <bem.AccountSettings__item>
-                <h4>{t('Reset Password')}</h4>
-              </bem.AccountSettings__item>
-
-              <bem.AccountSettings__item>
-                <TextBox
-                  customModifiers='on-white'
-                  label={t('Current Password')}
-                  type='password'
-                  errors={this.state.errors.currentPassword}
-                  value={this.state.currentPassword}
-                  onChange={this.onCurrentPasswordChange.bind(this)}
-                />
-
-                <a
-                  className='account-settings-link'
-                  href={`${ROOT_URL}/accounts/password/reset/`}
-                >
-                  {t('Forgot Password?')}
-                </a>
-              </bem.AccountSettings__item>
-
-              <bem.AccountSettings__item>
-                <TextBox
-                  customModifiers='on-white'
-                  label={t('New Password')}
-                  type='password'
-                  errors={this.state.errors.newPassword}
-                  value={this.state.newPassword}
-                  onChange={this.onNewPasswordChange.bind(this)}
-                />
-              </bem.AccountSettings__item>
-
-              {this.state.newPassword !== '' && (
-                <bem.AccountSettings__item>
-                  <PasswordStrength password={this.state.newPassword} />
-                </bem.AccountSettings__item>
-              )}
-
-              <bem.AccountSettings__item>
-                <TextBox
-                  customModifiers='on-white'
-                  label={t('Verify Password')}
-                  type='password'
-                  errors={this.state.errors.verifyPassword}
-                  value={this.state.verifyPassword}
-                  onChange={this.onVerifyPasswordChange.bind(this)}
-                />
-              </bem.AccountSettings__item>
-            </bem.AccountSettings__item>
+            <div className={styles.fieldsWrapper}>
+              <UpdatePasswordForm />
+            </div>
           </bem.AccountSettings__item>
         </bem.AccountSettings>
       </DocumentTitle>

--- a/jsapp/js/account/changePasswordRoute.module.scss
+++ b/jsapp/js/account/changePasswordRoute.module.scss
@@ -1,0 +1,5 @@
+@use 'scss/sizes';
+
+.fieldsWrapper {
+  padding: 0 sizes.$x50 sizes.$x30;
+}

--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -1,0 +1,134 @@
+import React, {useState} from 'react';
+import sessionStore from 'js/stores/session';
+import TextBox from 'js/components/common/textBox';
+import PasswordStrength from 'js/components/passwordStrength.component';
+import {ROOT_URL} from 'js/constants';
+import styles from './updatePasswordForm.module.scss';
+import Button from 'js/components/common/button';
+import {fetchPatch} from 'js/api';
+import {endpoints} from 'js/api.endpoints';
+import {notify} from 'js/utils';
+
+const FIELD_REQUIRED_ERROR = t('This field is required.');
+
+export default function UpdatePasswordForm() {
+  const [isPending, setIsPending] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [currentPasswordError, setCurrentPasswordError] = useState<
+    string | undefined
+  >();
+  const [newPassword, setNewPassword] = useState('');
+  const [newPasswordError, setNewPasswordError] = useState<
+    string | undefined
+  >();
+  const [verifyPassword, setVerifyPassword] = useState('');
+  const [verifyPasswordError, setVerifyPasswordError] = useState<
+    string | undefined
+  >();
+
+  async function savePassword() {
+    let hasErrors = false;
+    setCurrentPasswordError(undefined);
+    setNewPasswordError(undefined);
+    setVerifyPasswordError(undefined);
+
+    // Any of the three inputs can't be empty
+    if (!currentPassword) {
+      setCurrentPasswordError(FIELD_REQUIRED_ERROR);
+      hasErrors = true;
+    }
+    if (!newPassword) {
+      setNewPasswordError(FIELD_REQUIRED_ERROR);
+      hasErrors = true;
+    }
+    if (!verifyPassword) {
+      setVerifyPasswordError(FIELD_REQUIRED_ERROR);
+      hasErrors = true;
+    }
+
+    // Verify password input must match the new password
+    if (newPassword !== verifyPassword) {
+      setNewPasswordError(
+        t('This field must match the Verify Password field.')
+      );
+      hasErrors = true;
+    }
+
+    if (!hasErrors) {
+      setIsPending(true);
+
+      try {
+        await fetchPatch(endpoints.ME_URL, {currentPassword, newPassword});
+        setIsPending(false);
+        setCurrentPassword('');
+        setNewPassword('');
+        setVerifyPassword('');
+        notify(t('changed password successfully'));
+      } catch (error) {
+        setIsPending(false);
+        notify(t('failed to change password'), 'error');
+      }
+    }
+  }
+
+  if (!sessionStore.isLoggedIn) {
+    return null;
+  }
+
+  return (
+    <form className={styles.foo}>
+      <div className={styles.row}>
+        <TextBox
+          customModifiers='on-white'
+          label={t('Current Password')}
+          type='password'
+          errors={currentPasswordError}
+          value={currentPassword}
+          onChange={setCurrentPassword}
+        />
+
+        <a
+          className='account-settings-link'
+          href={`${ROOT_URL}/accounts/password/reset/`}
+        >
+          {t('Forgot Password?')}
+        </a>
+      </div>
+
+      <div className={styles.row}>
+        <TextBox
+          customModifiers='on-white'
+          label={t('New Password')}
+          type='password'
+          errors={newPasswordError}
+          value={newPassword}
+          onChange={setNewPassword}
+        />
+
+        {newPassword !== '' && <PasswordStrength password={newPassword} />}
+      </div>
+
+      <div className={styles.row}>
+        <TextBox
+          customModifiers='on-white'
+          label={t('Verify Password')}
+          type='password'
+          errors={verifyPasswordError}
+          value={verifyPassword}
+          onChange={setVerifyPassword}
+        />
+      </div>
+
+      <div className={styles.row}>
+        <Button
+          type='full'
+          color='blue'
+          size='m'
+          onClick={savePassword}
+          label={t('Save Password')}
+          isPending={isPending}
+        />
+      </div>
+    </form>
+  );
+}

--- a/jsapp/js/account/security/password/updatePasswordForm.module.scss
+++ b/jsapp/js/account/security/password/updatePasswordForm.module.scss
@@ -1,0 +1,9 @@
+@use 'scss/sizes';
+
+.root {
+  width: 100%;
+}
+
+.row + .row {
+  margin-top: sizes.$x16;
+}

--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -1,4 +1,5 @@
 export const endpoints = {
+  ME_URL: '/me/',
   PRODUCTS_URL: '/api/v2/stripe/products/',
   SUBSCRIPTION_URL: '/api/v2/stripe/subscriptions/',
   ORGANIZATION_URL: '/api/v2/organizations/',


### PR DESCRIPTION
## Description

Code clenup.

## Code Review Notes

We need this before working on #4477. The password updating form will be reused in new place. I also moved the "save" button to different place, so it could become a part of the new component. I also dropped the sticky + scrollable layout of the `#/account/change-password` route as it didn't make a lot of sense.

## Related issues

Part of #4477
