### PR TITLE
Remove build frontend code in pytest CI step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,12 +37,6 @@ jobs:
           - 6379:6379
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        # We need this particular version, as npm 8.5.5 is the last version
-        # that works with our package.json :sadface:.
-        node-version: '16.15.0'
-        cache: 'npm'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -59,8 +53,6 @@ jobs:
         gcc libc-dev build-essential
     - name: Install Python dependencies
       run: pip-sync dependencies/pip/dev_requirements.txt
-    - name: Install JavaScript dependencies
-      run: npm install
     - name: Update translations
       run: git submodule init && git submodule update --remote && python manage.py compilemessages
     - name: Test back-end code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,9 +63,6 @@ jobs:
       run: npm install
     - name: Update translations
       run: git submodule init && git submodule update --remote && python manage.py compilemessages
-    # Intercom tests in Python fail if the front-end code has not been built
-    - name: Build front-end code
-      run: SKIP_TS_CHECK=true npm run build
     - name: Test back-end code
       # Explicitly name the directories where coverage should be measured;
       # specifying just `--cov=.` includes `src`, which contains third-party packages

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -205,7 +205,7 @@ django-trench==0.3.1
     # via -r dependencies/pip/requirements.in
 django-userforeignkey==0.4.0
     # via django-request-cache
-django-webpack-loader==1.5.0
+django-webpack-loader==2.0.1
     # via -r dependencies/pip/requirements.in
 djangorestframework==3.13.1
     # via

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -183,7 +183,7 @@ django-trench==0.3.1
     # via -r dependencies/pip/requirements.in
 django-userforeignkey==0.4.0
     # via django-request-cache
-django-webpack-loader==1.5.0
+django-webpack-loader==2.0.1
     # via -r dependencies/pip/requirements.in
 djangorestframework==3.13.1
     # via

--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -6,8 +6,10 @@ from .base import *
 # For tests, don't use KoBoCAT's DB
 DATABASES = {
     'default': env.db_url(
-        'KPI_DATABASE_URL' if 'KPI_DATABASE_URL' in os.environ else 'DATABASE_URL',
-        default='sqlite:///%s/db.sqlite3' % BASE_DIR
+        'KPI_DATABASE_URL'
+        if 'KPI_DATABASE_URL' in os.environ
+        else 'DATABASE_URL',
+        default='sqlite:///%s/db.sqlite3' % BASE_DIR,
     ),
 }
 
@@ -26,7 +28,8 @@ CELERY_TASK_ALWAYS_EAGER = True
 
 MONGO_CONNECTION_URL = 'mongodb://fakehost/formhub_test'
 mongo_client = MockMongoClient(
-    MONGO_CONNECTION_URL, connect=False, journal=True, tz_aware=True)
+    MONGO_CONNECTION_URL, connect=False, journal=True, tz_aware=True
+)
 MONGO_DB = mongo_client['formhub_test']
 
 ENKETO_URL = 'http://enketo.mock'
@@ -38,3 +41,7 @@ CONSTANCE_DATABASE_CACHE_BACKEND = None
 if "djstripe" not in INSTALLED_APPS:
     INSTALLED_APPS += ('djstripe', "kobo.apps.stripe")
 STRIPE_ENABLED = True
+
+WEBPACK_LOADER['DEFAULT'][
+    'LOADER_CLASS'
+] = 'webpack_loader.loader.FakeWebpackLoader'


### PR DESCRIPTION
Do not build frontend assets when running CI pytest step. Upgrade django-webpack-loader so that FakeWebpackLoader can be used in tests.