### PR TITLE
Clarify where (re)deployment writes to database

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -327,6 +327,7 @@ class BaseDeploymentBackend(abc.ABC):
         return self.get_data('status')
 
     def store_data(self, values: dict):
+        """ Saves in memory only; writes nothing to the database """
         self.__stored_data_key = ShortUUID().random(24)
         values['_stored_data_key'] = self.__stored_data_key
         self.asset._deployment_data.update(values)  # noqa

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -257,6 +257,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         """
         `POST` initial survey content to KoBoCAT and create a new project.
         Store results in deployment data.
+        CAUTION: Does not save deployment data to the database!
         """
         # If no identifier was provided, construct one using
         # `settings.KOBOCAT_URL` and the uid of the asset
@@ -1005,7 +1006,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     def redeploy(self, active=None):
         """
         Replace (overwrite) the deployment, keeping the same identifier, and
-        optionally changing whether the deployment is active
+        optionally changing whether the deployment is active.
+        CAUTION: Does not save deployment data to the database!
         """
         if active is None:
             active = self.active

--- a/kpi/serializers/v2/deployment.py
+++ b/kpi/serializers/v2/deployment.py
@@ -68,6 +68,6 @@ class DeploymentSerializer(serializers.Serializer):
             deployment.set_active(active)
             # If we (re)activate the asset, let's synchronize its media files
             if active:
-                asset.async_media_files(force=False)
+                asset.sync_media_files_async(always=False)
 
         return deployment


### PR DESCRIPTION
This stuff helps me understand how `Asset._deployment_data` gets written to the database during the deployment process.

Merging into `feature/my-projects` because `kpi/serializers/v2/deployment.py` does not exist in the `beta` branch.