### PR TITLE
Improve redeployment logic

### DIFF
--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -152,7 +152,8 @@ class MockDeploymentBackend(BaseDeploymentBackend):
                 'downloadable': active,
                 'has_kpi_hook': self.asset.has_active_hooks,
                 'kpi_asset_uid': self.asset.uid
-            }
+            },
+            'version': self.asset.version_id,
         })
 
     @property

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1767,16 +1767,34 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
             0
         ]
         assert asset_response.data['version_id'] == deployed_version['uid']
-        # why does this fail?
-        '''
         assert(
             asset_response.data['deployed_version_id']
             == deployed_version['uid']
         )
-        '''
 
-        # Redeploy, despite no changes. A more realistic test would be to
-        # update a form media file while leaving the asset content unchanged
+        # Add a form media file to this asset
+        crab_png_b64 = (
+            'iVBORw0KGgoAAAANSUhEUgAAABIAAAAPAgMAAACU6HeBAAAADFBMVEU7PTqv'
+            'OD/m6OX////GxYKhAAAAR0lEQVQI1y2MMQrAMAwD9Ul5yJQ1+Y8zm0Ig9iur'
+            'kmo4xAmEUgJpaYE9y0VLBrwVO9ZzUnSODidlthgossXf73pNDltav88X3Ncm'
+            'NcRl6K8AAAAASUVORK5CYII='
+        )
+        asset_file_list_url = reverse(
+            self._get_endpoint('asset-file-list'), args=[self.asset.uid]
+        )
+        asset_file_post_data = {
+            'file_type': AssetFile.FORM_MEDIA,
+            'description': 'I have pincers',
+            'base64Encoded': 'data:image/png;base64,' + crab_png_b64,
+            'metadata': json.dumps({'filename': 'crab.png'}),
+        }
+        asset_file_response = self.client.post(
+            asset_file_list_url, asset_file_post_data
+        )
+        assert asset_file_response.status_code == status.HTTP_201_CREATED
+
+        # Redeploy with the new media file, which is a change that occurs
+        # without creating a new `AssetVersion`
         deployment_url = reverse(
             self._get_endpoint('asset-deployment'),
             kwargs={'uid': self.asset_uid},

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1850,3 +1850,30 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
             response2.data['deployment_status']
             == AssetDeploymentStatus.ARCHIVED.value
         )
+
+    def test_archive_asset_does_not_modify_date_deployed(self):
+        self.test_asset_deployment()
+        self.asset.refresh_from_db()
+        original_date_deployed = self.asset.date_deployed
+
+        deployment_url = reverse(self._get_endpoint('asset-deployment'),
+                                 kwargs={'uid': self.asset_uid})
+
+
+        # archive
+        response = self.client.patch(deployment_url, {
+            'backend': 'mock',
+            'active': False,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        self.asset.refresh_from_db()
+        assert self.asset.date_deployed == original_date_deployed
+
+        # unarchive
+        response = self.client.patch(deployment_url, {
+            'backend': 'mock',
+            'active': True,
+        })
+        assert response.status_code == status.HTTP_200_OK
+        self.asset.refresh_from_db()
+        assert self.asset.date_deployed == original_date_deployed


### PR DESCRIPTION
Redeploy unconditionally, even when `version` in the `_deployment_data` has not changed. See internal discussion at https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Deployment.20date.20feedback/near/245527.

Always update `date_deployed` on the asset even if the version has not been modified. Likewise, do not update `date_modified` on the version when deploying if that same version is already deployed.

## Description

Always update "Date deployed" when "REDEPLOY" is clicked, even if the form version is the same (i.e. the content has not been changed). Other things about the project may have changed, e.g. form media files.