### PR TITLE
Remove free tier threshold defaults, make Plans page respect custom free tiers

### DIFF
--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -114,28 +114,28 @@ export default function Plan() {
     if (envStore.isReady) {
       const thresholds = envStore.data.free_tier_thresholds;
       const feature_list_1 = thresholds?.data
-        ? t('##submissions## submissions/month').replace(
-            '##submissions##',
-            thresholds.data.toLocaleString()
-          )
+        ? t('##submissions## submissions per month').replace(
+          '##submissions##',
+          thresholds.data.toLocaleString()
+        )
         : null;
       const feature_list_2 = thresholds?.storage
         ? t('##storage_gb## GB file storage, up to 1 year').replace(
-            '##storage_gb##',
-            Math.floor(thresholds.storage / 1024).toString()
-          )
+          '##storage_gb##',
+          Math.floor(thresholds.storage / 1024).toString()
+        )
         : null;
       const feature_list_3 =
         thresholds?.translation_chars && thresholds?.transcription_minutes
           ? t('##nlp_mins## mins / ##nlp_chars## characters of NLP')
-              .replace(
-                '##nlp_mins##',
-                thresholds.transcription_minutes.toLocaleString()
-              )
-              .replace(
-                '##nlp_chars##',
-                thresholds.translation_chars.toLocaleString()
-              )
+            .replace(
+              '##nlp_mins##',
+              thresholds.transcription_minutes.toLocaleString()
+            )
+            .replace(
+              '##nlp_chars##',
+              thresholds.translation_chars.toLocaleString()
+            )
           : null;
       const freeTier = {
         name: envStore.data.free_tier_name,

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -28,8 +28,7 @@ import classnames from 'classnames';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {notify} from 'js/utils';
 import {BaseProduct} from 'js/account/subscriptionStore';
-import EnvStore, {FreeTierThresholds, FreeTierDisplay} from 'js/envStore';
-import envStore from 'js/envStore';
+import envStore, {FreeTierThresholds, FreeTierDisplay} from 'js/envStore';
 
 interface PlanState {
   subscribedProduct: null | BaseSubscription;

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -27,7 +27,9 @@ import Button from 'js/components/common/button';
 import classnames from 'classnames';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {notify} from 'js/utils';
-import {BaseProduct} from "js/account/subscriptionStore";
+import {BaseProduct} from 'js/account/subscriptionStore';
+import EnvStore, {FreeTierThresholds} from 'js/envStore';
+import envStore from 'js/envStore';
 
 interface PlanState {
   subscribedProduct: null | BaseSubscription;
@@ -42,6 +44,14 @@ interface PlanState {
 interface DataUpdates {
   type: string;
   prodData?: any;
+}
+
+interface FreeTierOverride extends FreeTierThresholds {
+  name?: string | null;
+  feature_list_1?: string | null;
+  feature_list_2?: string | null;
+  feature_list_3?: string | null;
+  feature_list_4?: string | null;
 }
 
 const initialState = {
@@ -100,8 +110,50 @@ export default function Plan() {
     [state.products, state.organization, state.subscribedProduct]
   );
 
-  const hasManageableStatus = useCallback((subscription: BaseSubscription) =>
-    activeSubscriptionStatuses.includes(subscription.status), []);
+  const freeTierOverride = useMemo((): FreeTierOverride | null => {
+    if (envStore.isReady) {
+      const thresholds = envStore.data.free_tier_thresholds;
+      const feature_list_1 = thresholds?.data
+        ? t('##submissions## submissions/month').replace(
+            '##submissions##',
+            thresholds.data.toLocaleString()
+          )
+        : null;
+      const feature_list_2 = thresholds?.storage
+        ? t('##storage_gb## GB file storage, up to 1 year').replace(
+            '##storage_gb##',
+            Math.floor(thresholds.storage / 1024).toString()
+          )
+        : null;
+      const feature_list_3 =
+        thresholds?.translation_chars && thresholds?.transcription_minutes
+          ? t('##nlp_mins## mins / ##nlp_chars## characters of NLP')
+              .replace(
+                '##nlp_mins##',
+                thresholds.transcription_minutes.toLocaleString()
+              )
+              .replace(
+                '##nlp_chars##',
+                thresholds.translation_chars.toLocaleString()
+              )
+          : null;
+      const freeTier = {
+        name: envStore.data.free_tier_name,
+        feature_list_1,
+        feature_list_2,
+        feature_list_3,
+        ...thresholds,
+      };
+      return freeTier;
+    }
+    return null;
+  }, [envStore.isReady]);
+
+  const hasManageableStatus = useCallback(
+    (subscription: BaseSubscription) =>
+      activeSubscriptionStatuses.includes(subscription.status),
+    []
+  );
 
   const hasActiveSubscription = useMemo(() => {
     if (state.subscribedProduct) {
@@ -113,9 +165,7 @@ export default function Plan() {
   }, [state.subscribedProduct]);
 
   useMemo(() => {
-    if (
-      state.subscribedProduct?.length > 0
-    ) {
+    if (state.subscribedProduct?.length > 0) {
       const subscribedFilter =
         state.subscribedProduct?.[0].items[0].price.recurring?.interval;
       if (!hasManageableStatus(state.subscribedProduct)) {
@@ -207,7 +257,10 @@ export default function Plan() {
       const filterAmount = state.products.map((product: Product) => {
         const filteredPrices = product.prices.filter((price: BasePrice) => {
           const interval = price.recurring?.interval;
-          return interval === state.intervalFilter && product.metadata.product_type === 'plan';
+          return (
+            interval === state.intervalFilter &&
+            product.metadata.product_type === 'plan'
+          );
         });
 
         return {
@@ -216,8 +269,12 @@ export default function Plan() {
         };
       });
 
-      return filterAmount.filter((product: Product) => product.prices)
-        .sort((priceA: Price, priceB: Price) => priceA.prices.unit_amount > priceB.prices.unit_amount);
+      return filterAmount
+        .filter((product: Product) => product.prices)
+        .sort(
+          (priceA: Price, priceB: Price) =>
+            priceA.prices.unit_amount > priceB.prices.unit_amount
+        );
     }
     return [];
   }, [state.products, state.intervalFilter]);
@@ -244,9 +301,10 @@ export default function Plan() {
       const subscriptions = getSubscriptionsForProductId(product.id);
 
       if (subscriptions.length > 0) {
-        return subscriptions.some((subscription: BaseSubscription) =>
-          subscription.items[0].price.id === product.prices.id &&
-          hasManageableStatus(subscription)
+        return subscriptions.some(
+          (subscription: BaseSubscription) =>
+            subscription.items[0].price.id === product.prices.id &&
+            hasManageableStatus(subscription)
         );
       }
       return false;
@@ -262,7 +320,7 @@ export default function Plan() {
       }
 
       return subscriptions.some((subscription: BaseSubscription) =>
-          hasManageableStatus(subscription)
+        hasManageableStatus(subscription)
       );
     },
     [state.subscribedProduct]
@@ -345,6 +403,19 @@ export default function Plan() {
       });
     }
     return expandBool;
+  };
+
+  const getFeatureMetadata = (price: Price, featureItem: string) => {
+    if (
+      price.prices.unit_amount === 0 &&
+      freeTierOverride &&
+      freeTierOverride[featureItem as keyof FreeTierOverride]
+    ) {
+      console.log(featureItem);
+      console.log(freeTierOverride);
+      return freeTierOverride[featureItem as keyof FreeTierOverride];
+    }
+    return price.prices.metadata?.[featureItem] || price.metadata[featureItem];
   };
 
   useEffect(() => {
@@ -453,7 +524,11 @@ export default function Plan() {
                       [styles.planContainer]: true,
                     })}
                   >
-                    <h1 className={styles.priceName}> {price.name} </h1>
+                    <h1 className={styles.priceName}>
+                      {price.prices?.unit_amount
+                        ? price.name
+                        : freeTierOverride?.name || price.name}
+                    </h1>
                     <div className={styles.priceTitle}>
                       {!price.prices?.unit_amount
                         ? t('Free')
@@ -476,8 +551,7 @@ export default function Plan() {
                                   }
                                 />
                               </div>
-                              {price.prices.metadata?.[featureItem] ||
-                                price.metadata[featureItem]}
+                              {getFeatureMetadata(price, featureItem)}
                             </li>
                           )
                       )}

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -122,7 +122,7 @@ export default function Plan() {
       const feature_list_2 = thresholds?.storage
         ? t('##storage_gb## GB file storage, up to 1 year').replace(
             '##storage_gb##',
-            Math.floor(thresholds.storage / 1024).toString()
+            Math.floor(thresholds.storage / (1024 * 1024)).toString()
           )
         : null;
       const feature_list_3 =

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -108,11 +108,11 @@ export default function Plan() {
 
   const freeTierOverride = useMemo((): FreeTierOverride | null => {
     if (envStore.isReady) {
-      const thresholds = envStore.data.free_tier_thresholds as FreeTierThresholds;
+      const thresholds = envStore.data.free_tier_thresholds;
       const display = envStore.data.free_tier_display as FreeTierDisplay;
       const featureList : {[key: string]: string | null} = {};
       display.feature_list.forEach((feature, key) => {
-        featureList[`feature_list_${key+1}`] = feature;
+        featureList[`feature_list_${key + 1}`] = feature;
       });
       return {
         name: display.name,

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -115,27 +115,27 @@ export default function Plan() {
       const thresholds = envStore.data.free_tier_thresholds;
       const feature_list_1 = thresholds?.data
         ? t('##submissions## submissions per month').replace(
-          '##submissions##',
-          thresholds.data.toLocaleString()
-        )
+            '##submissions##',
+            thresholds.data.toLocaleString()
+          )
         : null;
       const feature_list_2 = thresholds?.storage
         ? t('##storage_gb## GB file storage, up to 1 year').replace(
-          '##storage_gb##',
-          Math.floor(thresholds.storage / 1024).toString()
-        )
+            '##storage_gb##',
+            Math.floor(thresholds.storage / 1024).toString()
+          )
         : null;
       const feature_list_3 =
         thresholds?.translation_chars && thresholds?.transcription_minutes
           ? t('##nlp_mins## mins / ##nlp_chars## characters of NLP')
-            .replace(
-              '##nlp_mins##',
-              thresholds.transcription_minutes.toLocaleString()
-            )
-            .replace(
-              '##nlp_chars##',
-              thresholds.translation_chars.toLocaleString()
-            )
+              .replace(
+                '##nlp_mins##',
+                thresholds.transcription_minutes.toLocaleString()
+              )
+              .replace(
+                '##nlp_chars##',
+                thresholds.translation_chars.toLocaleString()
+              )
           : null;
       const freeTier = {
         name: envStore.data.free_tier_name,

--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -109,11 +109,13 @@ export default function Plan() {
   const freeTierOverride = useMemo((): FreeTierOverride | null => {
     if (envStore.isReady) {
       const thresholds = envStore.data.free_tier_thresholds;
-      const display = envStore.data.free_tier_display as FreeTierDisplay;
-      const featureList : {[key: string]: string | null} = {};
+      const display = envStore.data.free_tier_display;
+      const featureList: {[key: string]: string | null} = {};
+
       display.feature_list.forEach((feature, key) => {
         featureList[`feature_list_${key + 1}`] = feature;
       });
+
       return {
         name: display.name,
         ...thresholds,

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -10,7 +10,7 @@ import {
   ROOT_URL,
   COMMON_QUERIES,
 } from './constants';
-import type {EnvStoreFieldItem, SocialApp} from 'js/envStore';
+import type {EnvStoreFieldItem, FreeTierDisplay, SocialApp} from 'js/envStore';
 import type {LanguageCode} from 'js/components/languages/languagesStore';
 import type {
   AssetTypeName,
@@ -730,7 +730,7 @@ export interface EnvironmentResponse {
   stripe_public_key: string | null;
   social_apps: SocialApp[];
   free_tier_thresholds: FreeTierThresholds;
-  free_tier_name: string;
+  free_tier_display: FreeTierDisplay;
 }
 
 export interface AssetSubscriptionsResponse {

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -20,6 +20,7 @@ import type {
 } from 'js/constants';
 import type {Json} from './components/common/common.interfaces';
 import type {ProjectViewsSettings} from './projects/customViewStore';
+import {FreeTierThresholds} from "js/envStore";
 
 interface AssetsRequestData {
   q?: string;
@@ -723,11 +724,13 @@ export interface EnvironmentResponse {
   frontend_min_retry_time: number;
   frontend_max_retry_time: number;
   asr_mt_features_enabled: boolean;
-  mfa_localized_help_text: {[name: string]: string};
+  mfa_localized_help_text: { [name: string]: string };
   mfa_enabled: boolean;
   mfa_code_length: number;
   stripe_public_key: string | null;
   social_apps: SocialApp[];
+  free_tier_thresholds: FreeTierThresholds;
+  free_tier_name: string;
 }
 
 export interface AssetSubscriptionsResponse {

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -33,6 +33,11 @@ export interface FreeTierThresholds {
   translation_chars?: number | null;
 }
 
+export interface FreeTierDisplay {
+  name: string | null;
+  feature_list: [string];
+}
+
 class EnvStoreData {
   public terms_of_service_url = '';
   public privacy_policy_url = '';
@@ -58,7 +63,7 @@ class EnvStoreData {
   public stripe_public_key: string | null = null;
   public social_apps: SocialApp[] = [];
   public free_tier_thresholds: FreeTierThresholds = {};
-  public free_tier_name: string = '';
+  public free_tier_display: FreeTierDisplay | {} = {};
 
   getProjectMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
     for (const f of this.project_metadata_fields) {
@@ -120,7 +125,7 @@ class EnvStore {
     this.data.stripe_public_key = response.stripe_public_key;
     this.data.social_apps = response.social_apps;
     this.data.free_tier_thresholds = response.free_tier_thresholds;
-    this.data.free_tier_name = response.free_tier_name;
+    this.data.free_tier_display = response.free_tier_display;
 
     if (response.sector_choices) {
       this.data.sector_choices = response.sector_choices.map(this.nestedArrToChoiceObjs);

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -26,6 +26,13 @@ export interface SocialApp {
   client_id: string;
 }
 
+export interface FreeTierThresholds {
+  storage?: number | null;
+  data?: number | null;
+  transcription_minutes?: number | null;
+  translation_chars?: number | null;
+}
+
 class EnvStoreData {
   public terms_of_service_url = '';
   public privacy_policy_url = '';
@@ -45,11 +52,13 @@ class EnvStoreData {
   public translation_languages: TransxLanguages = {};
   public submission_placeholder = '';
   public asr_mt_features_enabled = false;
-  public mfa_localized_help_text: {[name: string]: string} = {};
+  public mfa_localized_help_text: { [name: string]: string } = {};
   public mfa_enabled = false;
   public mfa_code_length = 6;
   public stripe_public_key: string | null = null;
   public social_apps: SocialApp[] = [];
+  public free_tier_thresholds: FreeTierThresholds = {};
+  public free_tier_name: string = '';
 
   getProjectMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
     for (const f of this.project_metadata_fields) {
@@ -59,6 +68,7 @@ class EnvStoreData {
     }
     return false;
   }
+
   public getUserMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
     for (const f of this.user_metadata_fields) {
       if (f.name === fieldName) {
@@ -109,6 +119,8 @@ class EnvStore {
     this.data.mfa_code_length = response.mfa_code_length;
     this.data.stripe_public_key = response.stripe_public_key;
     this.data.social_apps = response.social_apps;
+    this.data.free_tier_thresholds = response.free_tier_thresholds;
+    this.data.free_tier_name = response.free_tier_name;
 
     if (response.sector_choices) {
       this.data.sector_choices = response.sector_choices.map(this.nestedArrToChoiceObjs);

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -27,15 +27,15 @@ export interface SocialApp {
 }
 
 export interface FreeTierThresholds {
-  storage?: number | null;
-  data?: number | null;
-  transcription_minutes?: number | null;
-  translation_chars?: number | null;
+  storage: number | null;
+  data: number | null;
+  transcription_minutes: number | null;
+  translation_chars: number | null;
 }
 
 export interface FreeTierDisplay {
   name: string | null;
-  feature_list: [string];
+  feature_list: [string] | [];
 }
 
 class EnvStoreData {
@@ -62,8 +62,13 @@ class EnvStoreData {
   public mfa_code_length = 6;
   public stripe_public_key: string | null = null;
   public social_apps: SocialApp[] = [];
-  public free_tier_thresholds: FreeTierThresholds = {};
-  public free_tier_display: FreeTierDisplay | {} = {};
+  public free_tier_thresholds: FreeTierThresholds = {
+    storage: null,
+    data: null,
+    transcription_minutes: null,
+    translation_chars: null
+  };
+  public free_tier_display: FreeTierDisplay = {name: null, feature_list: []};
 
   getProjectMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
     for (const f of this.project_metadata_fields) {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -334,10 +334,16 @@ CONSTANCE_CONFIG = {
         # Use custom field for schema validation
         'free_tier_threshold_jsonschema'
     ),
-    'FREE_TIER_NAME': (
-        '',
-        'Display name to use for the free tier',
-        str,
+    'FREE_TIER_DISPLAY': (
+        json.dumps(
+            {
+                'name': None,
+                'feature_list': [],
+            }
+        ),
+        'Free tier frontend settings: name to use for the free tier, '
+        'array of text strings to display on the feature list of the Plans page',
+        'free_tier_display_jsonschema',
     ),
     'PROJECT_TRASH_GRACE_PERIOD': (
         7,
@@ -358,6 +364,10 @@ CONSTANCE_CONFIG = {
 CONSTANCE_ADDITIONAL_FIELDS = {
     'free_tier_threshold_jsonschema': [
         'kpi.fields.jsonschema_form_field.FreeTierThresholdField',
+        {'widget': 'django.forms.Textarea'},
+    ],
+    'free_tier_display_jsonschema': [
+        'kpi.fields.jsonschema_form_field.FreeTierDisplayField',
         {'widget': 'django.forms.Textarea'},
     ],
     'metadata_fields_jsonschema': [
@@ -391,8 +401,6 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'EXPOSE_GIT_REV',
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
-        'FREE_TIER_THRESHOLDS',
-        'FREE_TIER_NAME',
     ),
     'Rest Services': (
         'ALLOW_UNSECURED_HOOK_ENDPOINTS',
@@ -419,6 +427,10 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'ASSET_SNAPSHOT_DAYS_RETENTION',
         'ACCOUNT_TRASH_GRACE_PERIOD',
         'PROJECT_TRASH_GRACE_PERIOD',
+    ),
+    'Tier settings': (
+        'FREE_TIER_THRESHOLDS',
+        'FREE_TIER_DISPLAY',
     ),
 }
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -322,10 +322,10 @@ CONSTANCE_CONFIG = {
     ),
     'FREE_TIER_THRESHOLDS': (
         json.dumps({
-            'storage': int(1 * 1024 * 1024 * 1024),  # 1 GB
-            'data': 1000,
-            'transcription_minutes': 10,
-            'translation_chars': 6000,
+            'storage': None,
+            'data': None,
+            'transcription_minutes': None,
+            'translation_chars': None,
         }),
         'Free tier thresholds: storage in kilobytes, '
         'data (number of submissions), '

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -334,6 +334,11 @@ CONSTANCE_CONFIG = {
         # Use custom field for schema validation
         'free_tier_threshold_jsonschema'
     ),
+    'FREE_TIER_NAME': (
+        '',
+        'Display name to use for the free tier',
+        str,
+    ),
     'PROJECT_TRASH_GRACE_PERIOD': (
         7,
         'Number of days to keep projects in trash after users (soft-)deleted '
@@ -387,6 +392,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
         'FREE_TIER_THRESHOLDS',
+        'FREE_TIER_NAME',
     ),
     'Rest Services': (
         'ALLOW_UNSECURED_HOOK_ENDPOINTS',

--- a/kpi/fields/jsonschema_form_field.py
+++ b/kpi/fields/jsonschema_form_field.py
@@ -29,15 +29,16 @@ class FreeTierThresholdField(JsonSchemaFormField):
     """
     Validates that the input has required properties with expected types
     """
+
     def __init__(self, *args, **kwargs):
         schema = {
             'type': 'object',
             'uniqueItems': True,
             'properties': {
-                'storage': {'type': 'integer'},
-                'data': {'type': 'integer'},
-                'transcription_minutes': {'type': 'integer'},
-                'translation_chars': {'type': 'integer'},
+                'storage': {'type': ['integer', 'null']},
+                'data': {'type': ['integer', 'null']},
+                'transcription_minutes': {'type': ['integer', 'null']},
+                'translation_chars': {'type': ['integer', 'null']},
             },
             'required': [
                 'storage',
@@ -60,6 +61,7 @@ class MetadataFieldsListField(JsonSchemaFormField):
             …
         ]
     """
+
     def __init__(self, *args, **kwargs):
         schema = {
             'type': 'array',
@@ -82,6 +84,7 @@ class MfaHelpTextField(JsonSchemaFormField):
     Validates that the input is an object which contains at least the 'default'
     key.
     """
+
     def __init__(self, *args, **kwargs):
         schema = {
             'type': 'object',

--- a/kpi/fields/jsonschema_form_field.py
+++ b/kpi/fields/jsonschema_form_field.py
@@ -51,6 +51,28 @@ class FreeTierThresholdField(JsonSchemaFormField):
         super().__init__(*args, schema=schema, **kwargs)
 
 
+class FreeTierDisplayField(JsonSchemaFormField):
+    """
+    Validates that the input has required properties with expected types
+    """
+
+    def __init__(self, *args, **kwargs):
+        schema = {
+            'type': 'object',
+            'uniqueItems': True,
+            'properties': {
+                'name': {'type': ['string', 'null']},
+                'feature_list': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                },
+            },
+            'required': ['name', 'feature_list'],
+            'additionalProperties': False,
+        }
+        super().__init__(*args, schema=schema, **kwargs)
+
+
 class MetadataFieldsListField(JsonSchemaFormField):
     """
     Validates that the input is an array of objects with "name" and "required"

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -16,7 +16,7 @@ def reset_free_tier_thresholds(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('kpi', '0050_add_indexes_to_import_and_export'),
+        ('kpi', '0050_add_indexes_to_import_and_export_tasks'),
     ]
 
     operations = [

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -1,3 +1,5 @@
+import json
+
 from constance import config
 from django.db import migrations
 
@@ -10,7 +12,7 @@ def reset_free_tier_thresholds(apps, schema_editor):
         'transcription_minutes': None,
         'translation_chars': None,
     }
-    setattr(config, 'FREE_TIER_THRESHOLDS', thresholds)
+    setattr(config, 'FREE_TIER_THRESHOLDS', json.dumps(thresholds))
 
 
 class Migration(migrations.Migration):

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -1,0 +1,27 @@
+from constance import config
+from django.db import migrations
+
+
+def reset_free_tier_thresholds(apps, schema_editor):
+    # The constance defaults for FREE_TIER_THRESHOLDS changed, so we set existing config to the new default value
+    thresholds = {
+        'storage': None,
+        'data': None,
+        'transcription_minutes': None,
+        'translation_chars': None,
+    }
+    setattr(config, 'FREE_TIER_THRESHOLDS', thresholds)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kpi', '0050_add_indexes_to_import_and_export'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            reset_free_tier_thresholds,
+            migrations.RunPython.noop,
+        )
+    ]

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -70,6 +70,7 @@ class EnvironmentTests(BaseTestCase):
             'free_tier_thresholds': json.loads(
                 constance.config.FREE_TIER_THRESHOLDS
             ),
+            'free_tier_name': constance.config.FREE_TIER_NAME,
             'social_apps': [],
         }
 
@@ -157,7 +158,7 @@ class EnvironmentTests(BaseTestCase):
     def test_social_apps(self):
         # GET mutates state, call it first to test num queries later
         self.client.get(self.url, format='json')
-        queries = 18
+        queries = 19
         with self.assertNumQueries(queries):
             response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -67,7 +67,7 @@ class EnvironmentTests(BaseTestCase):
             },
             'mfa_code_length': settings.TRENCH_AUTH['CODE_LENGTH'],
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None,
-            'free_tier_thresholds': constance.config.FREE_TIER_THRESHOLDS,
+            'free_tier_thresholds': json.loads(constance.config.FREE_TIER_THRESHOLDS),
             'free_tier_name': constance.config.FREE_TIER_NAME,
             'social_apps': [],
         }

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -67,9 +67,7 @@ class EnvironmentTests(BaseTestCase):
             },
             'mfa_code_length': settings.TRENCH_AUTH['CODE_LENGTH'],
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None,
-            'free_tier_thresholds': json.loads(
-                constance.config.FREE_TIER_THRESHOLDS
-            ),
+            'free_tier_thresholds': constance.config.FREE_TIER_THRESHOLDS,
             'free_tier_name': constance.config.FREE_TIER_NAME,
             'social_apps': [],
         }

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -68,7 +68,7 @@ class EnvironmentTests(BaseTestCase):
             'mfa_code_length': settings.TRENCH_AUTH['CODE_LENGTH'],
             'stripe_public_key': settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None,
             'free_tier_thresholds': json.loads(constance.config.FREE_TIER_THRESHOLDS),
-            'free_tier_name': constance.config.FREE_TIER_NAME,
+            'free_tier_display': json.loads(constance.config.FREE_TIER_DISPLAY),
             'social_apps': [],
         }
 

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -43,7 +43,7 @@ class EnvironmentView(APIView):
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
         'FREE_TIER_NAME',
-        'FREE_TIER_THRESHOLDS',
+        ('FREE_TIER_THRESHOLDS', lambda value, request: json.loads(value)),
         ('PROJECT_METADATA_FIELDS', lambda value, request: json.loads(value)),
         ('USER_METADATA_FIELDS', lambda value, request: json.loads(value)),
         (

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -80,16 +80,15 @@ class EnvironmentView(APIView):
         (
             'MFA_ENABLED',
             # MFA is enabled if it is enabled globally…
-            lambda value, request: value
-                                   and (
-                                       # but if per-user activation is enabled (i.e. at least one
-                                       # record in the table)…
-                                       not MfaAvailableToUser.objects.all().exists()
-                                       # global setting is overwritten by request user setting.
-                                       or MfaAvailableToUser.objects.filter(
-                                       user=get_database_user(request.user)
-                                   ).exists()
-                                   ),
+            lambda value, request: value and (
+                # but if per-user activation is enabled (i.e. at least one
+                # record in the table)…
+                not MfaAvailableToUser.objects.all().exists()
+                # global setting is overwritten by request user setting.
+                or MfaAvailableToUser.objects.filter(
+                    user=get_database_user(request.user)
+                ).exists()
+            )
         ),
     ]
 

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -42,6 +42,7 @@ class EnvironmentView(APIView):
         'COMMUNITY_URL',
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
+        'FREE_TIER_NAME',
         ('FREE_TIER_THRESHOLDS', lambda value, request: json.loads(value)),
         ('PROJECT_METADATA_FIELDS', lambda value, request: json.loads(value)),
         ('USER_METADATA_FIELDS', lambda value, request: json.loads(value)),
@@ -79,8 +80,8 @@ class EnvironmentView(APIView):
                 not MfaAvailableToUser.objects.all().exists()
                 # global setting is overwritten by request user setting.
                 or MfaAvailableToUser.objects.filter(
-                    user=get_database_user(request.user)
-                ).exists()
+                user=get_database_user(request.user)
+            ).exists()
             )
         ),
     ]

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -42,7 +42,7 @@ class EnvironmentView(APIView):
         'COMMUNITY_URL',
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
-        'FREE_TIER_NAME',
+        ('FREE_TIER_DISPLAY', lambda value, request: json.loads(value)),
         ('FREE_TIER_THRESHOLDS', lambda value, request: json.loads(value)),
         ('PROJECT_METADATA_FIELDS', lambda value, request: json.loads(value)),
         ('USER_METADATA_FIELDS', lambda value, request: json.loads(value)),
@@ -54,11 +54,17 @@ class EnvironmentView(APIView):
             # Starting in 2.8, new lines are saved as just "\n". In order to ensure compatibility
             # for data saved in older versions, we treat \n as the way to split lines. Then,
             # strip the \r off. There is no reason to do this for new constance settings
-            lambda text, request: tuple((line.strip('\r'), t(line.strip('\r'))) for line in text.split('\n')),
+            lambda text, request: tuple(
+                (line.strip('\r'), t(line.strip('\r')))
+                for line in text.split('\n')
+            ),
         ),
         (
             'OPERATIONAL_PURPOSE_CHOICES',
-            lambda text, request: tuple((line.strip('\r'), line.strip('\r')) for line in text.split('\n')),
+            lambda text, request: tuple(
+                (line.strip('\r'), line.strip('\r'))
+                for line in text.split('\n')
+            ),
         ),
         (
             'MFA_LOCALIZED_HELP_TEXT',
@@ -74,15 +80,16 @@ class EnvironmentView(APIView):
         (
             'MFA_ENABLED',
             # MFA is enabled if it is enabled globally…
-            lambda value, request: value and (
-                # but if per-user activation is enabled (i.e. at least one
-                # record in the table)…
-                not MfaAvailableToUser.objects.all().exists()
-                # global setting is overwritten by request user setting.
-                or MfaAvailableToUser.objects.filter(
-                user=get_database_user(request.user)
-            ).exists()
-            )
+            lambda value, request: value
+                                   and (
+                                       # but if per-user activation is enabled (i.e. at least one
+                                       # record in the table)…
+                                       not MfaAvailableToUser.objects.all().exists()
+                                       # global setting is overwritten by request user setting.
+                                       or MfaAvailableToUser.objects.filter(
+                                       user=get_database_user(request.user)
+                                   ).exists()
+                                   ),
         ),
     ]
 
@@ -131,6 +138,8 @@ class EnvironmentView(APIView):
         data['interface_languages'] = settings.LANGUAGES
         data['submission_placeholder'] = SUBMISSION_PLACEHOLDER
         data['mfa_code_length'] = settings.TRENCH_AUTH['CODE_LENGTH']
-        data['stripe_public_key'] = settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None
+        data['stripe_public_key'] = (
+            settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None
+        )
         data['social_apps'] = social_apps
         return Response(data)

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -43,7 +43,7 @@ class EnvironmentView(APIView):
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
         'FREE_TIER_NAME',
-        ('FREE_TIER_THRESHOLDS', lambda value, request: json.loads(value)),
+        'FREE_TIER_THRESHOLDS',
         ('PROJECT_METADATA_FIELDS', lambda value, request: json.loads(value)),
         ('USER_METADATA_FIELDS', lambda value, request: json.loads(value)),
         (


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Adds the ability to rename the default free plan.

## Notes

The default properties of `FREE_TIER_THRESHOLDS` have been all set to None, since those values should be configured on a per-server basis.

The free tier on the Plans page has also been updated to reflect the values in `FREE_TIER_DISPLAY`.

In the admin (under Constance -> Config):
![image](https://github.com/kobotoolbox/kpi/assets/7819986/37474243-f8e0-4949-b58e-1f3f88162683)

On `/#/account/plan`:
![image](https://github.com/kobotoolbox/kpi/assets/7819986/7f7b7ea5-9287-47c6-88d0-73db2bb5da10)