### PR TITLE
Use `python3` for `npm copy-fonts` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "check-types": "tsc -p tsconfig.json --noEmit",
     "show-icons": "opn jsapp/fonts/k-icons.html",
     "generate-icons": "node ./scripts/generate_icons.js",
-    "copy-fonts": "python ./scripts/copy_fonts.py && npm run generate-icons",
+    "copy-fonts": "python3 ./scripts/copy_fonts.py && npm run generate-icons",
     "hint": "node ./scripts/hints.js",
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build"


### PR DESCRIPTION
Some environments do not automatically link `python` to `python3`, but all environments with Python 3 installed _should_ have `python3` present--hopefully!

@magicznyleszek can you check please if this causes any problems with your environment and merge if all is okay?