### PR TITLE
Bump `pip-tools` version to 7.x.x

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pip-tools
-      run: python -m pip install pip-tools==6.\*
+      run: python -m pip install pip-tools==7.\*
     - name: Update Debian package lists
       run: sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
     - name: Install Debian dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV VIRTUAL_ENV=/opt/venv \
 
 RUN python -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install --quiet pip-tools==6.\*
+RUN pip install --quiet pip-tools==7.\*
 COPY ./dependencies/pip/requirements.txt "${TMP_DIR}/pip_dependencies.txt"
 RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null
 


### PR DESCRIPTION
## Description
Fixes broken GitHub CI Python unit tests because of conflicting version of `pip` and `pip-tools`. 

## Additional info
Error is 

> ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze'

CI installs `pip` 23.2 which is not supported by the version of `pip-tools` (6.x.x) frozen in YAML file.
Does not seem to affect `Dockerfile` in release/master branches because Python 3:10 docker image still comes with an older version of `pip` (i.e: 23.0.1)

