### PR TITLE
Hide meta/rootUuid from table view

### DIFF
--- a/jsapp/js/components/submissions/tableConstants.ts
+++ b/jsapp/js/components/submissions/tableConstants.ts
@@ -21,6 +21,7 @@ export const EXCLUDED_COLUMNS = [
   'formhub/uuid',
   '_tags',
   '_geolocation',
+  'meta/rootUuid',
   'meta/instanceID',
   'meta/deprecatedID',
   '_validation_status',


### PR DESCRIPTION
## Description
This field is not ready for general use yet, but curious people have [discovered](https://community.kobotoolbox.org/t/new-column-in-table-view-meta-rootuuid/43454) it.

When (if) it comes back, it should be positioned at the end of the table.