### PR TITLE
Support Django Constance settings with translatable strings 

### DIFF
--- a/hub/utils/i18n.py
+++ b/hub/utils/i18n.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 from django.db.models.functions import Length
 from django.utils.translation import get_language, gettext as t
 
+from kobo.apps.constance_backends.utils import to_python_object
 from kpi.utils.log import logging
 from ..models import SitewideMessage
 
@@ -55,7 +56,9 @@ class I18nUtils:
         language = lang if lang else get_language()
 
         try:
-            messages_dict = json.loads(constance.config.MFA_LOCALIZED_HELP_TEXT)
+            messages_dict = to_python_object(
+                constance.config.MFA_LOCALIZED_HELP_TEXT
+            )
         except json.JSONDecodeError:
             logging.error(
                 'Configuration value for MFA_LOCALIZED_HELP_TEXT has invalid '

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -8,8 +8,8 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import gettext_lazy as t
 
+from kobo.apps.constance_backends.utils import to_python_object
 from kobo.static_lists import COUNTRIES
-
 
 # Only these fields can be controlled by constance.config.USER_METADATA_FIELDS
 CONFIGURABLE_METADATA_FIELDS = (
@@ -78,7 +78,7 @@ class KoboSignupMixin(forms.Form):
 
         # It's easier to _remove_ unwanted fields here in the constructor
         # than to add a new fields *shrug*
-        desired_metadata_fields = json.loads(
+        desired_metadata_fields = to_python_object(
             constance.config.USER_METADATA_FIELDS
         )
         desired_metadata_fields = {

--- a/kobo/apps/constance_backends/utils.py
+++ b/kobo/apps/constance_backends/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+
+from typing import Union
+from kpi.utils.json import LazyJSONSerializable
+
+
+def to_python_object(
+    object_or_str: Union['LazyJSONSerializable', str]
+) -> Union[list, dict]:
+    """
+    Returns a python object from `object_or_str`.
+    """
+    # If a Constance setting is a `LazyJSONSerializable` object,
+    # `constance.config.SETTING` does not return the same type of object depending
+    # on whether the setting was saved in its back end or not. From the back end,
+    # it returns the string representation. Otherwise, it returns the
+    # `LazyJSONSerializable` object itself.
+    if isinstance(object_or_str, LazyJSONSerializable):
+        return object_or_str.object
+
+    return json.loads(object_or_str)

--- a/kobo/apps/constance_backends/utils.py
+++ b/kobo/apps/constance_backends/utils.py
@@ -12,11 +12,8 @@ def to_python_object(
     """
     Returns a python object from `object_or_str`.
     """
-    # If a Constance setting is a `LazyJSONSerializable` object,
-    # `constance.config.SETTING` does not return the same type of object depending
-    # on whether the setting was saved in its back end or not. From the back end,
-    # it returns the string representation. Otherwise, it returns the
-    # `LazyJSONSerializable` object itself.
+    # Make constance.config.SETTING return a consistent value when SETTING is a
+    # LazyJSONSerializable object
     if isinstance(object_or_str, LazyJSONSerializable):
         return object_or_str.object
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -333,7 +333,7 @@ CONSTANCE_CONFIG = {
         'minutes of transcription, '
         'number of translation characters',
         # Use custom field for schema validation
-        'free_tier_threshold_jsonschema'
+        'free_tier_threshold_jsonschema',
     ),
     'FREE_TIER_DISPLAY': (
         LazyJSONSerializable({

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import json
 import logging
 import os
 import re
@@ -16,6 +15,7 @@ from django.urls import reverse_lazy
 from django.utils.translation import get_language_info, gettext_lazy as t
 from pymongo import MongoClient
 
+from kpi.utils.json import LazyJSONSerializable
 from ..static_lists import EXTRA_LANG_INFO, SECTOR_CHOICE_DEFAULTS
 
 env = environ.Env()
@@ -233,11 +233,8 @@ CONSTANCE_CONFIG = {
         'Enable two-factor authentication'
     ),
     'MFA_LOCALIZED_HELP_TEXT': (
-        json.dumps({
-            'default': (
-                # It's terrible, but if you change this, you must also change
-                # `MFA_DEFAULT_HELP_TEXT` in `static_lists.py` so that
-                # translators receive the new string
+        LazyJSONSerializable({
+            'default': t(
                 'If you cannot access your authenticator app, please enter one '
                 'of your backup codes instead. If you cannot access those '
                 'either, then you will need to request assistance by '
@@ -248,7 +245,7 @@ CONSTANCE_CONFIG = {
                 'a valid language code, but this entry is here to show you '
                 'an example of adding another message in a different language.'
             )
-        }, indent=0),  # `indent=0` at least adds newlines
+        }),
         (
             'JSON object of guidance messages presented to users when they '
             'click the "Problems with the token" link after being prompted for '
@@ -260,7 +257,7 @@ CONSTANCE_CONFIG = {
             'for French).'
         ),
         # Use custom field for schema validation
-        'mfa_help_text_fields_jsonschema'
+        'i18n_text_jsonfield_schema'
     ),
     'ASR_MT_INVITEE_USERNAMES': (
         '',
@@ -275,7 +272,7 @@ CONSTANCE_CONFIG = {
         'authentication mechanism'
     ),
     'USER_METADATA_FIELDS': (
-        json.dumps([
+        LazyJSONSerializable([
             {'name': 'organization', 'required': False},
             {'name': 'organization_website', 'required': False},
             {'name': 'sector', 'required': False},
@@ -293,10 +290,10 @@ CONSTANCE_CONFIG = {
         "'sector', 'gender', 'bio', 'city', 'country', 'twitter', 'linkedin', "
         "and 'instagram'",
         # Use custom field for schema validation
-        'metadata_fields_jsonschema'
+        'long_metadata_fields_jsonschema'
     ),
     'PROJECT_METADATA_FIELDS': (
-        json.dumps([
+        LazyJSONSerializable([
             {'name': 'sector', 'required': False},
             {'name': 'country', 'required': False},
             # {'name': 'operational_purpose', 'required': False},
@@ -311,7 +308,8 @@ CONSTANCE_CONFIG = {
     ),
     'SECTOR_CHOICES': (
         '\n'.join((s[0] for s in SECTOR_CHOICE_DEFAULTS)),
-        "Options available for the 'sector' metadata field, one per line."
+        "Options available for the 'sector' metadata field, one per line.",
+        'long_textfield'
     ),
     'OPERATIONAL_PURPOSE_CHOICES': (
         '',
@@ -324,7 +322,7 @@ CONSTANCE_CONFIG = {
         'positive_int'
     ),
     'FREE_TIER_THRESHOLDS': (
-        json.dumps({
+        LazyJSONSerializable({
             'storage': None,
             'data': None,
             'transcription_minutes': None,
@@ -338,12 +336,10 @@ CONSTANCE_CONFIG = {
         'free_tier_threshold_jsonschema'
     ),
     'FREE_TIER_DISPLAY': (
-        json.dumps(
-            {
-                'name': None,
-                'feature_list': [],
-            }
-        ),
+        LazyJSONSerializable({
+            'name': None,
+            'feature_list': [],
+        }),
         'Free tier frontend settings: name to use for the free tier, '
         'array of text strings to display on the feature list of the Plans page',
         'free_tier_display_jsonschema',
@@ -373,13 +369,31 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'kpi.fields.jsonschema_form_field.FreeTierDisplayField',
         {'widget': 'django.forms.Textarea'},
     ],
+    'i18n_text_jsonfield_schema': [
+        'kpi.fields.jsonschema_form_field.I18nTextJSONField',
+        {'widget': 'django.forms.Textarea'},
+    ],
     'metadata_fields_jsonschema': [
         'kpi.fields.jsonschema_form_field.MetadataFieldsListField',
         {'widget': 'django.forms.Textarea'},
     ],
-    'mfa_help_text_fields_jsonschema': [
-        'kpi.fields.jsonschema_form_field.MfaHelpTextField',
-        {'widget': 'django.forms.Textarea'},
+    'long_metadata_fields_jsonschema': [
+        'kpi.fields.jsonschema_form_field.MetadataFieldsListField',
+        {
+            'widget': 'django.forms.Textarea',
+            'widget_kwargs': {
+                'attrs': {'rows': 45}
+            }
+        },
+    ],
+    'long_textfield': [
+        'django.forms.fields.CharField',
+        {
+            'widget': 'django.forms.Textarea',
+            'widget_kwargs': {
+                'attrs': {'rows': 30}
+            }
+        },
     ],
     'positive_int': ['django.forms.fields.IntegerField', {
         'min_value': 0

--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -38,8 +38,9 @@ ENKETO_INTERNAL_URL = 'http://enketo.mock'
 # Do not use cache with Constance in tests to avoid overwriting production
 # cached values
 CONSTANCE_DATABASE_CACHE_BACKEND = None
-if "djstripe" not in INSTALLED_APPS:
-    INSTALLED_APPS += ('djstripe', "kobo.apps.stripe")
+
+if 'djstripe' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('djstripe', 'kobo.apps.stripe')
 STRIPE_ENABLED = True
 
 WEBPACK_LOADER['DEFAULT'][

--- a/kobo/static_lists.py
+++ b/kobo/static_lists.py
@@ -339,13 +339,3 @@ EXTRA_LANG_INFO = {
         'name_local': 'Nyanja',
     },
 }
-
-MFA_DEFAULT_HELP_TEXT = t(
-    # It's terrible, but this duplicates the default value from
-    # `MFA_LOCALIZED_HELP_TEXT` in django-constance because it's impossible to
-    # use `gettext()` or `gettext_lazy()` there.
-    'If you cannot access your authenticator app, please enter one '
-    'of your backup codes instead. If you cannot access those '
-    'either, then you will need to request assistance by '
-    'contacting [##support email##](mailto:##support email##).'
-)

--- a/kpi/fields/jsonschema_form_field.py
+++ b/kpi/fields/jsonschema_form_field.py
@@ -101,7 +101,7 @@ class MetadataFieldsListField(JsonSchemaFormField):
         super().__init__(*args, schema=schema, **kwargs)
 
 
-class MfaHelpTextField(JsonSchemaFormField):
+class I18nTextJSONField(JsonSchemaFormField):
     """
     Validates that the input is an object which contains at least the 'default'
     key.

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -3,6 +3,8 @@ import json
 from constance import config
 from django.db import migrations
 
+from kpi.utils.json import LazyJSONSerializable
+
 
 def reset_free_tier_thresholds(apps, schema_editor):
     # The constance defaults for FREE_TIER_THRESHOLDS changed, so we set existing config to the new default value
@@ -12,7 +14,7 @@ def reset_free_tier_thresholds(apps, schema_editor):
         'transcription_minutes': None,
         'translation_chars': None,
     }
-    setattr(config, 'FREE_TIER_THRESHOLDS', json.dumps(thresholds))
+    setattr(config, 'FREE_TIER_THRESHOLDS', LazyJSONSerializable(thresholds))
 
 
 class Migration(migrations.Migration):

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 import datetime
-import json
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
@@ -15,6 +14,7 @@ from rest_framework import serializers
 
 from hub.models import ExtraUserDetail
 from kobo.apps.accounts.serializers import SocialAccountSerializer
+from kobo.apps.constance_backends.utils import to_python_object
 from kpi.deployment_backends.kc_access.utils import get_kc_profile_data
 from kpi.deployment_backends.kc_access.utils import set_kc_require_auth
 from kpi.fields import WritableJSONField
@@ -151,7 +151,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
         return attrs
 
     def validate_extra_details(self, value):
-        desired_metadata_fields = json.loads(
+        desired_metadata_fields = to_python_object(
             constance.config.USER_METADATA_FIELDS
         )
 

--- a/kpi/templates/admin/constance/change_list.html
+++ b/kpi/templates/admin/constance/change_list.html
@@ -1,0 +1,7 @@
+{% extends "admin/constance/change_list.html" %}
+{% load static %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link href="{% static 'admin/constance/css/kobo-constance.css' %}" rel="stylesheet" type="text/css" />
+{% endblock %}

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 # 😇
-import json
-
 import constance
 import mock
 from constance.test import override_config
@@ -15,9 +13,10 @@ from markdown import markdown
 from model_bakery import baker
 from rest_framework import status
 
+from hub.utils.i18n import I18nUtils
 from kobo.apps.accounts.mfa.models import MfaAvailableToUser
+from kobo.apps.constance_backends.utils import to_python_object
 from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
-from kobo.static_lists import MFA_DEFAULT_HELP_TEXT
 from kpi.tests.base_test_case import BaseTestCase
 
 
@@ -37,10 +36,11 @@ class EnvironmentTests(BaseTestCase):
             'frontend_max_retry_time': constance.config.FRONTEND_MAX_RETRY_TIME,
             'project_metadata_fields': lambda x: self.assertEqual(
                 len(x),
-                len(json.loads(constance.config.PROJECT_METADATA_FIELDS)),
+                len(to_python_object(constance.config.PROJECT_METADATA_FIELDS)),
             ) and self.assertIn({'name': 'organization', 'required': False}, x),
             'user_metadata_fields': lambda x: self.assertEqual(
-                len(x), len(json.loads(constance.config.USER_METADATA_FIELDS))
+                len(x),
+                len(to_python_object(constance.config.USER_METADATA_FIELDS))
             ) and self.assertIn({'name': 'sector', 'required': False}, x),
             'sector_choices': lambda x: self.assertGreater(
                 len(x), 10
@@ -62,7 +62,7 @@ class EnvironmentTests(BaseTestCase):
             'asr_mt_features_enabled': False,
             'mfa_enabled': constance.config.MFA_ENABLED,
             'mfa_localized_help_text': markdown(
-                MFA_DEFAULT_HELP_TEXT.replace(
+                I18nUtils.get_mfa_help_text().replace(
                     '##support email##', constance.config.SUPPORT_EMAIL
                 )
             ),
@@ -70,10 +70,12 @@ class EnvironmentTests(BaseTestCase):
             'stripe_public_key': (
                 settings.STRIPE_PUBLIC_KEY if settings.STRIPE_ENABLED else None
             ),
-            'free_tier_thresholds': json.loads(
+            'free_tier_thresholds': to_python_object(
                 constance.config.FREE_TIER_THRESHOLDS
             ),
-            'free_tier_display': json.loads(constance.config.FREE_TIER_DISPLAY),
+            'free_tier_display': to_python_object(
+                constance.config.FREE_TIER_DISPLAY
+            ),
             'social_apps': [],
         }
 
@@ -109,6 +111,11 @@ class EnvironmentTests(BaseTestCase):
 
     def test_mfa_help_text_default_translation(self):
         MOCK_TRANSLATION_STRING = 'hello from gettext'
+        messages_dict = to_python_object(
+            constance.config.MFA_LOCALIZED_HELP_TEXT
+        )
+        default_translation = messages_dict['default']
+
         with mock.patch(
             'hub.utils.i18n.t', return_value=MOCK_TRANSLATION_STRING
         ) as mock_t:
@@ -116,7 +123,7 @@ class EnvironmentTests(BaseTestCase):
             assert response.json()['mfa_localized_help_text'] == markdown(
                 MOCK_TRANSLATION_STRING
             )
-            assert mock_t.call_args.args[0] == MFA_DEFAULT_HELP_TEXT
+            assert mock_t.call_args.args[0] == default_translation._proxy____args[0]
 
     @override_config(MFA_ENABLED=True)
     def test_mfa_value_globally_enabled(self):

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -109,22 +109,6 @@ class EnvironmentTests(BaseTestCase):
         result = template.render(context)
         self.assertEqual(result, constance.config.TERMS_OF_SERVICE_URL)
 
-    def test_mfa_help_text_default_translation(self):
-        MOCK_TRANSLATION_STRING = 'hello from gettext'
-        messages_dict = to_python_object(
-            constance.config.MFA_LOCALIZED_HELP_TEXT
-        )
-        default_translation = messages_dict['default']
-
-        with mock.patch(
-            'hub.utils.i18n.t', return_value=MOCK_TRANSLATION_STRING
-        ) as mock_t:
-            response = self.client.get(self.url, format='json')
-            assert response.json()['mfa_localized_help_text'] == markdown(
-                MOCK_TRANSLATION_STRING
-            )
-            assert mock_t.call_args.args[0] == default_translation._proxy____args[0]
-
     @override_config(MFA_ENABLED=True)
     def test_mfa_value_globally_enabled(self):
         self.client.login(username='someuser', password='someuser')

--- a/kpi/utils/json.py
+++ b/kpi/utils/json.py
@@ -22,21 +22,21 @@ class LazyJSONSerializable:
     It can be JSON serialized.
     """
     def __init__(self, o):
-        self._object = o
+        self.object = o
 
     def __repr__(self):
-        return self.__str__()
+        return f'<LazyJSONSerializable object={type(self.object)}>'
 
     def __eq__(self, *args, **kwargs):
         other_object = args[0]
         if isinstance(other_object, str):
             return other_object == self.__str__()
-        return other_object == self._object
+        return other_object == self.object
 
     def __str__(self):
         try:
-            value = json.dumps(self._object, indent=2, cls=LazyJSONEncoder)
+            value = json.dumps(self.object, indent=2, cls=LazyJSONEncoder)
         except json.JSONDecodeError:
-            return self._object
+            return self.object
 
         return normalize_newlines(value)

--- a/kpi/utils/json.py
+++ b/kpi/utils/json.py
@@ -1,0 +1,42 @@
+import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.functional import Promise
+from django.utils.encoding import force_str
+from django.utils.text import normalize_newlines
+
+
+class LazyJSONEncoder(DjangoJSONEncoder):
+
+    def default(self, obj):
+        if isinstance(obj, Promise):
+            return force_str(obj)
+        return super().default(obj)
+
+
+class LazyJSONSerializable:
+    """
+    Wrapper for python objects (such as lists or dicts) which contain lazy gettext
+    objects and could not be interpreted when the application loads.
+
+    It can be JSON serialized.
+    """
+    def __init__(self, o):
+        self._object = o
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, *args, **kwargs):
+        other_object = args[0]
+        if isinstance(other_object, str):
+            return other_object == self.__str__()
+        return other_object == self._object
+
+    def __str__(self):
+        try:
+            value = json.dumps(self._object, indent=2, cls=LazyJSONEncoder)
+        except json.JSONDecodeError:
+            return self._object
+
+        return normalize_newlines(value)

--- a/kpi/utils/json.py
+++ b/kpi/utils/json.py
@@ -25,7 +25,7 @@ class LazyJSONSerializable:
         self.object = o
 
     def __repr__(self):
-        return f'<LazyJSONSerializable object={type(self.object)}>'
+        return self.__str__()
 
     def __eq__(self, *args, **kwargs):
         other_object = args[0]

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -12,8 +12,9 @@ from allauth.socialaccount.models import SocialApp
 
 from hub.utils.i18n import I18nUtils
 from kobo.static_lists import COUNTRIES
-from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
 from kobo.apps.accounts.mfa.models import MfaAvailableToUser
+from kobo.apps.constance_backends.utils import to_python_object
+from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
 from kpi.utils.object_permission import get_database_user
 
 
@@ -65,7 +66,7 @@ class EnvironmentView(APIView):
         for key in cls.JSON_CONFIGS:
             value = getattr(constance.config, key)
             try:
-                value = json.loads(value)
+                value = to_python_object(value)
             except json.JSONDecodeError:
                 logging.error(
                     f'Configuration value for `{key}` has invalid JSON'

--- a/static/admin/constance/css/kobo-constance.css
+++ b/static/admin/constance/css/kobo-constance.css
@@ -1,0 +1,5 @@
+#content-main.constance #changelist-form #results tr td:nth-child(2) p {
+  display: block;
+  unicode-bidi: embed;
+  white-space: break-spaces;
+}


### PR DESCRIPTION
## Description

Add a wrapper class to be used python objects such as `dict` or `list` with translatable strings