### PR TITLE
Usage limits 2fa fixes

### DIFF
--- a/jsapp/js/account/security/mfa/mfaSection.component.tsx
+++ b/jsapp/js/account/security/mfa/mfaSection.component.tsx
@@ -15,6 +15,7 @@ import {MODAL_TYPES} from 'jsapp/js/constants';
 import envStore from 'js/envStore';
 import './mfaSection.scss';
 import {formatTime, formatDate} from 'js/utils';
+import {when} from "mobx";
 
 bem.SecurityRow = makeBem(null, 'security-row');
 bem.SecurityRow__header = makeBem(bem.SecurityRow, 'header');
@@ -85,7 +86,6 @@ export default class SecurityRoute extends React.Component<{}, SecurityState> {
     if (response.length) {
       this.setState({
         isMfaActive: response[0].is_active,
-        isMfaAllowed: response[0].mfa_available,
         dateDisabled: response[0].date_disabled,
         dateModified: response[0].date_modified,
       });
@@ -93,12 +93,10 @@ export default class SecurityRoute extends React.Component<{}, SecurityState> {
   }
 
   onGetActiveSubscription(response: boolean|null) {
-    // Only disable MFA settings if user doesn't have per-user availability set
-    if (!this.state.isMfaAllowed) {
-      this.setState({
-        isMfaAllowed: response || response === null,
-      });
-    }
+    // Determine whether MFA is allowed based on per-user availability and subscription status
+    this.setState({
+      isMfaAllowed: response || envStore.data.mfa_available_to_user,
+    });
   }
 
   mfaActivating(response: MfaActivatedResponse) {

--- a/jsapp/js/actions/mfaActions.ts
+++ b/jsapp/js/actions/mfaActions.ts
@@ -13,7 +13,6 @@ export type MfaUserMethodsResponse = [{
   name: 'app';
   is_primary: boolean;
   is_active: boolean;
-  mfa_available: boolean;
   date_created: string;
   date_modified: string;
   date_disabled: string;

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -740,6 +740,7 @@ export interface EnvironmentResponse {
   asr_mt_features_enabled: boolean;
   mfa_localized_help_text: { [name: string]: string };
   mfa_enabled: boolean;
+  mfa_available_to_user: boolean;
   mfa_code_length: number;
   stripe_public_key: string | null;
   social_apps: SocialApp[];

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -59,6 +59,7 @@ class EnvStoreData {
   public asr_mt_features_enabled = false;
   public mfa_localized_help_text: { [name: string]: string } = {};
   public mfa_enabled = false;
+  public mfa_available_to_user = false;
   public mfa_code_length = 6;
   public stripe_public_key: string | null = null;
   public social_apps: SocialApp[] = [];
@@ -126,6 +127,7 @@ class EnvStore {
     this.data.submission_placeholder = response.submission_placeholder;
     this.data.mfa_localized_help_text = response.mfa_localized_help_text;
     this.data.mfa_enabled = response.mfa_enabled;
+    this.data.mfa_available_to_user = response.mfa_available_to_user;
     this.data.mfa_code_length = response.mfa_code_length;
     this.data.stripe_public_key = response.stripe_public_key;
     this.data.social_apps = response.social_apps;

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -15,7 +15,9 @@ from .utils import user_has_paid_subscription
 
 
 class AccountAdapter(DefaultAccountAdapter):
+
     def pre_login(self, request, user, **kwargs):
+
         if parent_response := super().pre_login(request, user, **kwargs):
             # A response from the parent means the login process must be
             # interrupted, e.g. due to the user being inactive or not having
@@ -41,8 +43,9 @@ class AccountAdapter(DefaultAccountAdapter):
                 initial={'ephemeral_token': ephemeral_token_cache}
             )
 
-            next_url = kwargs.get('redirect_url') or resolve_url(
-                settings.LOGIN_REDIRECT_URL
+            next_url = (
+                kwargs.get('redirect_url')
+                or resolve_url(settings.LOGIN_REDIRECT_URL)
             )
 
             context = {

--- a/kobo/apps/accounts/mfa/serializers.py
+++ b/kobo/apps/accounts/mfa/serializers.py
@@ -5,9 +5,8 @@ from trench.utils import get_mfa_model
 
 class UserMfaMethodSerializer(serializers.ModelSerializer):
     """
-    Exposes user's MFA methods, per-user availability, and their created, modified and disabled dates
+    Exposes user's MFA methods and their created, modified and disabled dates
     """
-    mfa_available = serializers.BooleanField()
 
     class Meta:
         model = get_mfa_model()

--- a/kobo/apps/accounts/mfa/serializers.py
+++ b/kobo/apps/accounts/mfa/serializers.py
@@ -15,7 +15,6 @@ class UserMfaMethodSerializer(serializers.ModelSerializer):
             'name',
             'is_primary',
             'is_active',
-            'mfa_available',
             'date_created',
             'date_modified',
             'date_disabled',

--- a/kobo/apps/accounts/mfa/views.py
+++ b/kobo/apps/accounts/mfa/views.py
@@ -1,20 +1,14 @@
 # coding: utf-8
 from allauth.account.views import LoginView
-from django.conf import settings
-from django.contrib.auth import login, authenticate
 from django.contrib.auth.views import LoginView as DjangoLoginView
-from django.db.models import QuerySet, Exists
-from django.http import HttpResponseRedirect
-from django.shortcuts import resolve_url
+from django.db.models import QuerySet
 from django.urls import reverse
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 from trench.utils import get_mfa_model
 
 from .forms import MfaLoginForm, MfaTokenForm
-from .models import MfaAvailableToUser
 from .serializers import UserMfaMethodSerializer
-from ..utils import user_has_paid_subscription
 
 
 class MfaLoginView(LoginView):
@@ -47,39 +41,6 @@ class MfaLoginView(LoginView):
 
         return redirect_to
 
-    def login_if_user_has_subscription(self, form, context):
-        """
-        Check if the user has an active, paid subscription.
-        If they do, log the user in and return an HTTPResponse, skipping MFA token entry.
-        If they don't, return None and do nothing.
-        """
-        username = form.cleaned_data.get('login')
-        active_subscription = user_has_paid_subscription(username)
-
-        if not active_subscription:
-            next_url = context['redirect_field_value'] or resolve_url(
-                settings.LOGIN_REDIRECT_URL
-            )
-
-            password = form.cleaned_data.get('password')
-            authenticated_user = authenticate(
-                username=username, password=password
-            )
-
-            # When login is successful, `django.contrib.auth.login()` expects the
-            # authentication backend class to be provided.
-            # See https://github.com/django/django/blob/b87820668e7bd519dbc05f6ee46f551858fb1d6d/django/contrib/auth/__init__.py#L111
-            # Since we do not have a bullet-proof way to detect which authentication
-            # class is the good one, we use the first element of the list
-            backend = settings.AUTHENTICATION_BACKENDS[0]
-            login(self.request, authenticated_user, backend=backend)
-
-            return HttpResponseRedirect(
-                resolve_url(self.get_success_url() or next_url)
-            )
-
-        return None
-
 
 class MfaTokenView(DjangoLoginView):
     """
@@ -104,6 +65,4 @@ class MfaListUserMethodsView(ListAPIView):
 
     def get_queryset(self) -> QuerySet:
         mfa_model = get_mfa_model()
-        return mfa_model.objects.filter(user_id=self.request.user.id).annotate(
-            mfa_available=Exists(MfaAvailableToUser.objects.filter(user=self.request.user))
-        )
+        return mfa_model.objects.filter(user_id=self.request.user.id)

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -6,7 +6,6 @@ from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 def user_has_paid_subscription(username):
     return (
         User.objects.filter(
-            organizations_organization__djstripe_customers__subscriber__organization_users__user__username=username,
             organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
         )
         .exclude(

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -102,21 +102,21 @@ class EnvironmentTests(BaseTestCase):
         result = template.render(context)
         self.assertEqual(result, constance.config.TERMS_OF_SERVICE_URL)
 
-    @override_config(MFA_ENABLED=True)
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
     def test_mfa_value_globally_enabled(self):
         self.client.login(username='someuser', password='someuser')
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['mfa_enabled'])
 
-    @override_config(MFA_ENABLED=False)
+    @override_config(MFA_ENABLED=False, STRIPE_ENABLED=False)
     def test_mfa_value_globally_disabled(self):
         self.client.login(username='someuser', password='someuser')
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['mfa_enabled'])
 
-    @override_config(MFA_ENABLED=True)
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
     def test_mfa_per_user_availability_while_globally_enabled(self):
         # When MFA is globally enabled, it is allowed for everyone *until* the
         # first per-user allowance (`MfaAvailableToUser` instance) is created.
@@ -137,7 +137,7 @@ class EnvironmentTests(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['mfa_enabled'])
 
-    @override_config(MFA_ENABLED=True)
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
     def test_mfa_per_user_availability_while_globally_enabled_as_anonymous(self):
         # Enable MFA only for someuser, in order to enter per-user-allowance
         # mode. MFA should then appear to be disabled for everyone else
@@ -151,6 +151,32 @@ class EnvironmentTests(BaseTestCase):
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['mfa_enabled'])
+
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
+    def test_mfa_value_globally_enabled_as_user_with_no_paid_subscriptions(self):
+        self.client.login(username='someuser', password='someuser')
+        response = self.client.get(self.url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # User has no paid subscriptions, mfa should be disabled
+        self.assertFalse(response.data['mfa_enabled'])
+
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
+    def test_mfa_value_globally_enabled_as_user_with_paid_subscription(self):
+        # @TODO implement this test
+        #   mfa should be enabled
+        pass
+
+    @override_config(MFA_ENABLED=False, STRIPE_ENABLED=True)
+    def test_mfa_value_globally_disable_as_user_with_paid_subscription(self):
+        # @TODO implement this test
+        #   mfa should be disabled
+        pass
+
+    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
+    def test_mfa_per_user_availability_as_user_with_no_paid_subscriptions(self):
+        # @TODO implement this test
+        #   mfa should be enabled
+        pass
 
     @override_settings(SOCIALACCOUNT_PROVIDERS={})
     def test_social_apps(self):

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from kobo.apps.accounts.mfa.models import MfaAvailableToUser
 from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
 from kpi.tests.base_test_case import BaseTestCase
+from kpi.utils.object_permission import get_database_user
 
 
 class EnvironmentTests(BaseTestCase):
@@ -24,6 +25,8 @@ class EnvironmentTests(BaseTestCase):
 
     def setUp(self):
         self.url = reverse('environment')
+        self.user = User.objects.get(username='someuser')
+        self.password = 'someuser'
         self.dict_checks = {
             'terms_of_service_url': constance.config.TERMS_OF_SERVICE_URL,
             'privacy_policy_url': constance.config.PRIVACY_POLICY_URL,
@@ -56,6 +59,11 @@ class EnvironmentTests(BaseTestCase):
             'submission_placeholder': SUBMISSION_PLACEHOLDER,
             'asr_mt_features_enabled': False,
             'mfa_enabled': constance.config.MFA_ENABLED,
+            'mfa_available_to_user': lambda response: (
+                MfaAvailableToUser.objects.filter(
+                    user=get_database_user(self.user)
+                ).exists(),
+            ),
             'mfa_localized_help_text': lambda i18n_texts: {
                 lang: markdown(text)
                 for lang, text in json.loads(
@@ -102,81 +110,67 @@ class EnvironmentTests(BaseTestCase):
         result = template.render(context)
         self.assertEqual(result, constance.config.TERMS_OF_SERVICE_URL)
 
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
+    @override_config(MFA_ENABLED=True)
     def test_mfa_value_globally_enabled(self):
-        self.client.login(username='someuser', password='someuser')
+        self.client.login(username=self.user.username, password=self.password)
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['mfa_enabled'])
 
-    @override_config(MFA_ENABLED=False, STRIPE_ENABLED=False)
+    @override_config(MFA_ENABLED=False)
     def test_mfa_value_globally_disabled(self):
-        self.client.login(username='someuser', password='someuser')
+        self.client.login(username=self.user.username, password=self.password)
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['mfa_enabled'])
 
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
+    @override_config(MFA_ENABLED=True)
     def test_mfa_per_user_availability_while_globally_enabled(self):
         # When MFA is globally enabled, it is allowed for everyone *until* the
         # first per-user allowance (`MfaAvailableToUser` instance) is created.
 
         # Enable MFA only for someuser
-        someuser = User.objects.get(username='someuser')
-        MfaAvailableToUser.objects.create(user=someuser)
+        baker.make('MfaAvailableToUser', user=self.user)
 
-        # someuser should have mfa enabled
-        self.client.login(username='someuser', password='someuser')
+        # someuser should have per-user availability
+        self.assertTrue(
+            self.client.login(
+                username=self.user.username, password=self.password
+            )
+        )
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['mfa_enabled'])
+        self.assertTrue(response.data['mfa_available_to_user'])
+        self._check_response_dict(response.data)
 
-        # anotheruser should **NOT** have mfa enabled
-        self.client.login(username='anotheruser', password='anotheruser')
+        # anotheruser should **NOT** have per-user availability
+        self.user = User.objects.get(username='anotheruser')
+        self.password = 'anotheruser'
+        self.client.login(username=self.user.username, password=self.password)
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data['mfa_enabled'])
+        self.assertTrue(response.data['mfa_enabled'])
+        self.assertFalse(response.data['mfa_available_to_user'])
+        self._check_response_dict(response.data)
 
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=False)
-    def test_mfa_per_user_availability_while_globally_enabled_as_anonymous(self):
+    @override_config(MFA_ENABLED=True)
+    def test_mfa_per_user_availability_while_globally_enabled_as_anonymous(
+        self,
+    ):
         # Enable MFA only for someuser, in order to enter per-user-allowance
         # mode. MFA should then appear to be disabled for everyone else
         # (including anonymous users), even though MFA is globally enabled.
         someuser = User.objects.get(username='someuser')
-        MfaAvailableToUser.objects.create(user=someuser)
+        baker.make('MfaAvailableToUser', user=someuser)
 
         # Now, make sure that the application reports MFA to be disabled for
         # anonymous users
         self.client.logout()
         response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data['mfa_enabled'])
-
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
-    def test_mfa_value_globally_enabled_as_user_with_no_paid_subscriptions(self):
-        self.client.login(username='someuser', password='someuser')
-        response = self.client.get(self.url, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # User has no paid subscriptions, mfa should be disabled
-        self.assertFalse(response.data['mfa_enabled'])
-
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
-    def test_mfa_value_globally_enabled_as_user_with_paid_subscription(self):
-        # @TODO implement this test
-        #   mfa should be enabled
-        pass
-
-    @override_config(MFA_ENABLED=False, STRIPE_ENABLED=True)
-    def test_mfa_value_globally_disable_as_user_with_paid_subscription(self):
-        # @TODO implement this test
-        #   mfa should be disabled
-        pass
-
-    @override_config(MFA_ENABLED=True, STRIPE_ENABLED=True)
-    def test_mfa_per_user_availability_as_user_with_no_paid_subscriptions(self):
-        # @TODO implement this test
-        #   mfa should be enabled
-        pass
+        self.assertTrue(response.data['mfa_enabled'])
+        self.assertFalse(response.data['mfa_available_to_user'])
 
     @override_settings(SOCIALACCOUNT_PROVIDERS={})
     def test_social_apps(self):

--- a/kpi/utils/object_permission.py
+++ b/kpi/utils/object_permission.py
@@ -79,6 +79,7 @@ def get_anonymous_user():
     return user
 
 
+@cache_for_request
 def get_database_user(user: Union[User, AnonymousUser]) -> User:
     """
     Returns a real `User` object if `user` is an `AnonymousUser`, otherwise


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Small changes to how MFA configuration is sent to the browser.

## Notes

The frontend environment variable `mfa_allowed` has been split into two values: `mfa_allowed`, which tracks whether MFA is enabled on the server level, and `mfa_available_to_user`, which tracks whether the user's MFA per-user availability.