### PR TITLE
Support alias `t()` for `gettext` and `gettext_lazy`

### DIFF
--- a/kpi/management/commands/makemessages.py
+++ b/kpi/management/commands/makemessages.py
@@ -3,4 +3,11 @@ from django.core.management.commands import makemessages
 
 class Command(makemessages.Command):
 
-    xgettext_options = makemessages.Command.xgettext_options + ['--keyword=t']
+    xgettext_options = makemessages.Command.xgettext_options + [
+        '--keyword=t',
+        '--keyword=nt',
+    ]
+
+    def handle(self, *args, **options):
+        options['ignore_patterns'].append('node_modules*')
+        super().handle(*args, **options)

--- a/kpi/management/commands/makemessages.py
+++ b/kpi/management/commands/makemessages.py
@@ -10,4 +10,9 @@ class Command(makemessages.Command):
 
     def handle(self, *args, **options):
         options['ignore_patterns'].append('node_modules*')
+        options['ignore_patterns'].append('jsapp/compiled*')
+        options['ignore_patterns'].append('staticfiles*')
+        if options['domain'] == 'djangojs':
+            options['extensions'] = ['js', 'tsx', 'ts', 'es6']
+
         super().handle(*args, **options)

--- a/kpi/management/commands/makemessages.py
+++ b/kpi/management/commands/makemessages.py
@@ -1,0 +1,6 @@
+from django.core.management.commands import makemessages
+
+
+class Command(makemessages.Command):
+
+    xgettext_options = makemessages.Command.xgettext_options + ['--keyword=t']


### PR DESCRIPTION
## Description

Extract strings used with `t()` (and `nt()` for plural) alias(es) instead of expected Django alias: `_()` 