### PR TITLE
Show quick actions on narrow screens

### DIFF
--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -22,6 +22,7 @@ import {toJS} from 'mobx';
 import {ROOT_URL} from 'js/constants';
 import {fetchPostUrl} from 'js/api';
 import ProjectQuickActions from './projectsTable/projectQuickActions';
+import ProjectQuickActionsEmpty from './projectsTable/projectQuickActionsEmpty';
 
 function CustomViewRoute() {
   const {viewUid} = useParams();
@@ -100,8 +101,14 @@ function CustomViewRoute() {
           onClick={exportAllData}
         />
 
+        {selectedAssets.length === 0 && (
+          <div className={styles.actions}>
+            <ProjectQuickActionsEmpty />
+          </div>
+        )}
+
         {selectedAssets.length === 1 && (
-          <div className={styles.quickActions}>
+          <div className={styles.actions}>
             <ProjectQuickActions asset={selectedAssets[0]} />
           </div>
         )}

--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -21,8 +21,9 @@ import styles from './projectViews.module.scss';
 import {toJS} from 'mobx';
 import {ROOT_URL} from 'js/constants';
 import {fetchPostUrl} from 'js/api';
-import ProjectQuickActions from './projectsTable/projectQuickActions';
 import ProjectQuickActionsEmpty from './projectsTable/projectQuickActionsEmpty';
+import ProjectQuickActions from './projectsTable/projectQuickActions';
+import ProjectBulkActions from './projectsTable/projectBulkActions';
 
 function CustomViewRoute() {
   const {viewUid} = useParams();
@@ -112,13 +113,21 @@ function CustomViewRoute() {
             <ProjectQuickActions asset={selectedAssets[0]} />
           </div>
         )}
+
+        {selectedAssets.length > 1 && (
+          <div className={styles.actions}>
+            <ProjectBulkActions assets={selectedAssets} />
+          </div>
+        )}
       </header>
 
       <ProjectsTable
         assets={customView.assets}
         isLoading={!customView.isFirstLoadComplete}
         highlightedFields={getFilteredFieldsNames()}
-        visibleFields={toJS(customView.fields) || customView.defaultVisibleFields}
+        visibleFields={
+          toJS(customView.fields) || customView.defaultVisibleFields
+        }
         orderableFields={DEFAULT_ORDERABLE_FIELDS}
         order={customView.order}
         onChangeOrderRequested={customView.setOrder.bind(customView)}

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -19,6 +19,7 @@ import styles from './projectViews.module.scss';
 import routeStyles from './myProjectsRoute.module.scss';
 import {toJS} from 'mobx';
 import {COMMON_QUERIES, ROOT_URL} from 'js/constants';
+import ProjectQuickActionsEmpty from './projectsTable/projectQuickActionsEmpty';
 import ProjectQuickActions from './projectsTable/projectQuickActions';
 import ProjectBulkActions from './projectsTable/projectBulkActions';
 import Dropzone from 'react-dropzone';
@@ -124,6 +125,12 @@ function MyProjectsRoute() {
             selectedFields={toJS(customView.fields)}
             excludedFields={HOME_EXCLUDED_FIELDS}
           />
+
+          {selectedAssets.length === 0 && (
+            <div className={styles.actions}>
+              <ProjectQuickActionsEmpty />
+            </div>
+          )}
 
           {selectedAssets.length === 1 && (
             <div className={styles.actions}>

--- a/jsapp/js/projects/projectViews.module.scss
+++ b/jsapp/js/projects/projectViews.module.scss
@@ -9,8 +9,9 @@
 
 .header {
   @include mixins.centerRowFlex;
-  gap: sizes.$x30;
   padding: sizes.$x30 sizes.$x30 sizes.$x40;
+  gap: sizes.$x10 sizes.$x30;
+  flex-wrap: wrap;
 }
 
 .actions {

--- a/jsapp/js/projects/projectsTable/projectActions.module.scss
+++ b/jsapp/js/projects/projectsTable/projectActions.module.scss
@@ -5,19 +5,4 @@
 .root {
   @include mixins.centerRowFlex;
   gap: sizes.$x10;
-
-  // Override .k-button[disabled] styles to allow tooltips on disabled buttons
-  :global .k-button[disabled] {
-    pointer-events: auto; // Allow tooltips on disabled buttons
-    opacity: 1; // Make the tooltips fully opaque
-
-    // Make the button appear non-pressable
-    .k-icon {
-      opacity: 0.5;
-    }
-    cursor: default;
-    &:active {
-      transform: translateY(0); // Don't depress button when clicked
-    }
-  }
 }

--- a/jsapp/js/projects/projectsTable/projectActions.module.scss
+++ b/jsapp/js/projects/projectsTable/projectActions.module.scss
@@ -5,6 +5,21 @@
 .root {
   @include mixins.centerRowFlex;
   gap: sizes.$x10;
+
+  // Override .k-button[disabled] styles to allow tooltips on disabled buttons
+  :global .k-button[disabled] {
+    pointer-events: auto; // Allow tooltips on disabled buttons
+    opacity: 1; // Make the tooltips fully opaque
+
+    // Make the button appear non-pressable
+    .k-icon {
+      opacity: 0.5;
+    }
+    cursor: default;
+    &:active {
+      transform: translateY(0); // Don't depress button when clicked
+    }
+  }
 }
 
 .menu {

--- a/jsapp/js/projects/projectsTable/projectActions.module.scss
+++ b/jsapp/js/projects/projectsTable/projectActions.module.scss
@@ -21,15 +21,3 @@
     }
   }
 }
-
-.menu {
-  @include mixins.floatingRoundedBox;
-  padding: sizes.$x6;
-  min-width: sizes.$x180;
-
-  // There is a `isFullWidth` property on Button component, but it also has text
-  // centering styles on it, so we can't use it.
-  :global .k-button {
-    width: 100%;
-  }
-}

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -14,6 +14,8 @@ function userCanDeleteAssets(assets: Array<AssetResponse | ProjectViewAsset>) {
   return assets.every((asset) => userCan('manage_asset', asset));
 }
 
+/** "Bulk" Quick Actions buttons. Use these when two or more projects are
+ * selected in the Project Table. */
 export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
   const canBulkDelete = userCanDeleteAssets(props.assets);

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -14,6 +14,29 @@ export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
 
   return (
     <div className={actionsStyles.root}>
+      {/* Archive / Unarchive - Bulk action not supported yet */}
+      <Button
+        isDisabled
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='archived'
+        tooltip={t('Archive/Unarchive')}
+        classNames={['right-tooltip']}
+      />
+
+      {/* Share - Bulk action not supported yet */}
+      <Button
+        isDisabled
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='user-share'
+        tooltip={t('Share projects')}
+        classNames={['right-tooltip']}
+      />
+
+      {/* Delete */}
       <Button
         type='bare'
         color='storm'

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -14,8 +14,10 @@ function userCanDeleteAssets(assets: Array<AssetResponse | ProjectViewAsset>) {
   return assets.every((asset) => userCan('manage_asset', asset));
 }
 
-/** "Bulk" Quick Actions buttons. Use these when two or more projects are
- * selected in the Project Table. */
+/**
+ * "Bulk" Quick Actions buttons. Use these when two or more projects are
+ * selected in the Project Table.
+ */
 export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
   const canBulkDelete = userCanDeleteAssets(props.assets);

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -31,38 +31,38 @@ export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   return (
     <div className={actionsStyles.root}>
       {/* Archive / Unarchive - Bulk action not supported yet */}
-      <Button
-        isDisabled
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='archived'
-        tooltip={t('Archive/Unarchive')}
-        classNames={['right-tooltip']}
-      />
+      <span data-tip={t('Archive/Unarchive')} className='right-tooltip'>
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='archived'
+        />
+      </span>
 
       {/* Share - Bulk action not supported yet */}
-      <Button
-        isDisabled
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='user-share'
-        tooltip={t('Share projects')}
-        classNames={['right-tooltip']}
-      />
+      <span data-tip={t('Share projects')} className='right-tooltip'>
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='user-share'
+        />
+      </span>
 
       {/* Delete */}
-      <Button
-        isDisabled={!canBulkDelete}
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='trash'
-        tooltip={tooltipForDelete}
-        classNames={['right-tooltip']}
-        onClick={() => setIsDeletePromptOpen(true)}
-      />
+      <span data-tip={tooltipForDelete} className='right-tooltip'>
+        <Button
+          isDisabled={!canBulkDelete}
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='trash'
+          onClick={() => setIsDeletePromptOpen(true)}
+        />
+      </span>
 
       {isDeletePromptOpen && (
         <BulkDeletePrompt

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -18,6 +18,14 @@ export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
   const canBulkDelete = userCanDeleteAssets(props.assets);
 
+  let tooltipForDelete = t('Delete projects');
+  if (canBulkDelete) {
+    tooltipForDelete = t('Delete ##count## projects').replace(
+      '##count##',
+      String(props.assets.length)
+    );
+  }
+
   return (
     <div className={actionsStyles.root}>
       {/* Archive / Unarchive - Bulk action not supported yet */}
@@ -43,30 +51,16 @@ export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
       />
 
       {/* Delete */}
-      {canBulkDelete ? (
-        <Button
-          type='bare'
-          color='storm'
-          size='s'
-          startIcon='trash'
-          tooltip={t('Delete ##count## projects').replace(
-            '##count##',
-            String(props.assets.length)
-          )}
-          onClick={() => setIsDeletePromptOpen(true)}
-          classNames={['right-tooltip']}
-        />
-      ) : (
-        <Button
-          isDisabled
-          type='bare'
-          color='storm'
-          size='s'
-          startIcon='trash'
-          tooltip={t('Delete projects')}
-          classNames={['right-tooltip']}
-        />
-      )}
+      <Button
+        isDisabled={!canBulkDelete}
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='trash'
+        tooltip={tooltipForDelete}
+        classNames={['right-tooltip']}
+        onClick={() => setIsDeletePromptOpen(true)}
+      />
 
       {isDeletePromptOpen && (
         <BulkDeletePrompt

--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -3,14 +3,20 @@ import type {AssetResponse, ProjectViewAsset} from 'js/dataInterface';
 import Button from 'js/components/common/button';
 import actionsStyles from './projectActions.module.scss';
 import BulkDeletePrompt from './bulkActions/bulkDeletePrompt';
+import {userCan} from 'js/components/permissions/utils';
 
 interface ProjectBulkActionsProps {
   /** A list of selected assets for bulk operations. */
   assets: Array<AssetResponse | ProjectViewAsset>;
 }
 
+function userCanDeleteAssets(assets: Array<AssetResponse | ProjectViewAsset>) {
+  return assets.every((asset) => userCan('manage_asset', asset));
+}
+
 export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
+  const canBulkDelete = userCanDeleteAssets(props.assets);
 
   return (
     <div className={actionsStyles.root}>
@@ -37,18 +43,30 @@ export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
       />
 
       {/* Delete */}
-      <Button
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='trash'
-        tooltip={t('Delete ##count## projects').replace(
-          '##count##',
-          String(props.assets.length)
-        )}
-        onClick={() => setIsDeletePromptOpen(true)}
-        classNames={['right-tooltip']}
-      />
+      {canBulkDelete ? (
+        <Button
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='trash'
+          tooltip={t('Delete ##count## projects').replace(
+            '##count##',
+            String(props.assets.length)
+          )}
+          onClick={() => setIsDeletePromptOpen(true)}
+          classNames={['right-tooltip']}
+        />
+      ) : (
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='trash'
+          tooltip={t('Delete projects')}
+          classNames={['right-tooltip']}
+        />
+      )}
 
       {isDeletePromptOpen && (
         <BulkDeletePrompt

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -6,24 +6,14 @@ import type {
 } from 'js/dataInterface';
 import {ASSET_TYPES} from 'js/constants';
 import Button from 'js/components/common/button';
-import KoboDropdown from 'jsapp/js/components/common/koboDropdown';
 import styles from './projectActions.module.scss';
 import {getAssetDisplayName} from 'jsapp/js/assetUtils';
 import {
   archiveAsset,
   unarchiveAsset,
   deleteAsset,
-  openInFormBuilder,
   manageAssetSharing,
-  cloneAsset,
-  deployAsset,
-  replaceAssetForm,
-  manageAssetLanguages,
-  cloneAssetAsTemplate,
-  cloneAssetAsSurvey,
 } from 'jsapp/js/assetQuickActions';
-import {downloadUrl} from 'jsapp/js/utils';
-import type {IconName} from 'jsapp/fonts/k-icons';
 import {userCan} from 'js/components/permissions/utils';
 import customViewStore from 'js/projects/customViewStore';
 
@@ -41,19 +31,6 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
 
   return (
     <div className={styles.root}>
-      <Button
-        isDisabled={
-          !isChangingPossible ||
-          props.asset.asset_type !== ASSET_TYPES.survey.id
-        }
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='edit'
-        tooltip={t('Edit in Form Builder')}
-        onClick={() => openInFormBuilder(props.asset.uid)}
-      />
-
       {props.asset.deployment__active && (
         <Button
           isDisabled={
@@ -119,117 +96,6 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
               customViewStore.handleAssetsDeleted([deletedAssetUid]);
             }
           )
-        }
-      />
-
-      <KoboDropdown
-        name='project-quick-actions'
-        placement='down-right'
-        hideOnMenuClick
-        triggerContent={
-          <Button type='bare' color='storm' size='s' startIcon='more' />
-        }
-        menuContent={
-          <div className={styles.menu}>
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='duplicate'
-              onClick={() => cloneAsset(props.asset)}
-              label={t('Clone')}
-            />
-
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='deploy'
-              onClick={() =>
-                deployAsset(props.asset, (response: DeploymentResponse) => {
-                  customViewStore.handleAssetChanged(response.asset);
-                })
-              }
-              label={t('Deploy')}
-            />
-
-            <Button
-              isDisabled={!isChangingPossible}
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='replace'
-              onClick={() => replaceAssetForm(props.asset)}
-              label={t('Replace form')}
-            />
-
-            <Button
-              isDisabled={!isChangingPossible}
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='language'
-              onClick={() => manageAssetLanguages(props.asset.uid)}
-              label={t('Manage translations')}
-            />
-
-            {'downloads' in props.asset &&
-              props.asset.downloads.map((file) => {
-                let icon: IconName = 'file';
-                if (file.format === 'xml') {
-                  icon = 'file-xml';
-                } else if (file.format === 'xls') {
-                  icon = 'file-xls';
-                }
-
-                return (
-                  <Button
-                    key={file.format}
-                    type='bare'
-                    color='storm'
-                    size='s'
-                    startIcon={icon}
-                    onClick={() => downloadUrl(file.url)}
-                    label={
-                      <span>
-                        {t('Download')}&nbsp;
-                        {file.format.toString().toUpperCase()}
-                      </span>
-                    }
-                  />
-                );
-              })}
-
-            {props.asset.asset_type === ASSET_TYPES.survey.id && (
-              <Button
-                type='bare'
-                color='storm'
-                size='s'
-                startIcon='template'
-                onClick={cloneAssetAsTemplate.bind(
-                  null,
-                  props.asset.uid,
-                  getAssetDisplayName(props.asset).final
-                )}
-                label={t('Create template')}
-              />
-            )}
-
-            {props.asset.asset_type === ASSET_TYPES.template.id && (
-              <Button
-                type='bare'
-                color='storm'
-                size='s'
-                startIcon='projects'
-                onClick={cloneAssetAsSurvey.bind(
-                  null,
-                  props.asset.uid,
-                  getAssetDisplayName(props.asset).final
-                )}
-                label={t('Create project')}
-              />
-            )}
-          </div>
         }
       />
     </div>

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -36,92 +36,95 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
       {/* Archive / Unarchive */}
       {/* Archive a deployed project */}
       {props.asset.deployment_status === 'deployed' && (
-        <Button
-          isDisabled={
-            !isChangingPossible ||
-            props.asset.asset_type !== ASSET_TYPES.survey.id ||
-            !props.asset.has_deployment
-          }
-          type='bare'
-          color='storm'
-          size='s'
-          startIcon='archived'
-          tooltip={t('Archive project')}
-          onClick={() =>
-            archiveAsset(props.asset, (response: DeploymentResponse) => {
-              customViewStore.handleAssetChanged(response.asset);
-            })
-          }
-          classNames={['right-tooltip']}
-        />
+        <span data-tip={t('Archive project')} className='right-tooltip'>
+          <Button
+            isDisabled={
+              !isChangingPossible ||
+              props.asset.asset_type !== ASSET_TYPES.survey.id ||
+              !props.asset.has_deployment
+            }
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='archived'
+            onClick={() =>
+              archiveAsset(props.asset, (response: DeploymentResponse) => {
+                customViewStore.handleAssetChanged(response.asset);
+              })
+            }
+          />
+        </span>
       )}
       {/* Un-archive a deployed project */}
       {props.asset.deployment_status === 'archived' && (
-        <Button
-          isDisabled={
-            !isChangingPossible ||
-            props.asset.asset_type !== ASSET_TYPES.survey.id ||
-            !props.asset.has_deployment
-          }
-          type='bare'
-          color='storm'
-          size='s'
-          startIcon='archived'
-          tooltip={t('Unarchive project')}
-          onClick={() =>
-            unarchiveAsset(props.asset, (response: DeploymentResponse) => {
-              customViewStore.handleAssetChanged(response.asset);
-            })
-          }
-          classNames={['right-tooltip']}
-        />
+        <span data-tip={t('Unarchive project')} className='right-tooltip'>
+          <Button
+            isDisabled={
+              !isChangingPossible ||
+              props.asset.asset_type !== ASSET_TYPES.survey.id ||
+              !props.asset.has_deployment
+            }
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='archived'
+            onClick={() =>
+              unarchiveAsset(props.asset, (response: DeploymentResponse) => {
+                customViewStore.handleAssetChanged(response.asset);
+              })
+            }
+          />
+        </span>
       )}
       {/* Show tooltip, since drafts can't be archived/unarchived */}
       {props.asset.deployment_status === 'draft' && (
-        <Button
-          isDisabled
-          type='bare'
-          color='storm'
-          size='s'
-          startIcon='archived'
-          tooltip={t('Draft project selected')}
-          classNames={['right-tooltip']}
-        />
+        <span data-tip={t('Draft project selected')} className='right-tooltip'>
+          <Button
+            isDisabled
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='archived'
+          />
+        </span>
       )}
 
       {/* Share */}
-      <Button
-        isDisabled={!isManagingPossible}
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='user-share'
-        tooltip={t('Share project')}
-        onClick={() => manageAssetSharing(props.asset.uid)}
-        classNames={['right-tooltip']}
-      />
+      <span data-tip={t('Share project')} className='right-tooltip'>
+        <Button
+          isDisabled={!isManagingPossible}
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='user-share'
+          onClick={() => manageAssetSharing(props.asset.uid)}
+        />
+      </span>
 
       {/* Delete */}
-      <Button
-        isDisabled={!isChangingPossible}
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='trash'
-        tooltip={
+      <span
+        data-tip={
           isChangingPossible ? t('Delete 1 project') : t('Delete project')
         }
-        onClick={() =>
-          deleteAsset(
-            props.asset,
-            getAssetDisplayName(props.asset).final,
-            (deletedAssetUid: string) => {
-              customViewStore.handleAssetsDeleted([deletedAssetUid]);
-            }
-          )
-        }
-        classNames={['right-tooltip']}
-      />
+        className='right-tooltip'
+      >
+        <Button
+          isDisabled={!isChangingPossible}
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='trash'
+          onClick={() =>
+            deleteAsset(
+              props.asset,
+              getAssetDisplayName(props.asset).final,
+              (deletedAssetUid: string) => {
+                customViewStore.handleAssetsDeleted([deletedAssetUid]);
+              }
+            )
+          }
+        />
+      </span>
     </div>
   );
 }

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -21,6 +21,8 @@ interface ProjectQuickActionsProps {
   asset: AssetResponse | ProjectViewAsset;
 }
 
+/** Quick Actions (Archive, Share, Delete) buttons. Use these when a single
+ * project is selected in the Project Table. */
 export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
   // The `userCan` method requires `permissions` property to be present in the
   // `asset` object. For performance reasons `ProjectViewAsset` doesn't have

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -31,7 +31,9 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
 
   return (
     <div className={styles.root}>
-      {props.asset.deployment__active && (
+      {/* Archive / Unarchive */}
+      {/* Archive a deployed project */}
+      {props.asset.deployment_status === 'deployed' && (
         <Button
           isDisabled={
             !isChangingPossible ||
@@ -48,10 +50,11 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
               customViewStore.handleAssetChanged(response.asset);
             })
           }
+          classNames={['right-tooltip']}
         />
       )}
-
-      {!props.asset.deployment__active && (
+      {/* Un-archive a deployed project */}
+      {props.asset.deployment_status === 'archived' && (
         <Button
           isDisabled={
             !isChangingPossible ||
@@ -68,9 +71,23 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
               customViewStore.handleAssetChanged(response.asset);
             })
           }
+          classNames={['right-tooltip']}
+        />
+      )}
+      {/* Show tooltip, since drafts can't be archived/unarchived */}
+      {props.asset.deployment_status === 'draft' && (
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='archived'
+          tooltip={t('Draft project selected')}
+          classNames={['right-tooltip']}
         />
       )}
 
+      {/* Share */}
       <Button
         isDisabled={!isManagingPossible}
         type='bare'
@@ -79,8 +96,10 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         startIcon='user-share'
         tooltip={t('Share project')}
         onClick={() => manageAssetSharing(props.asset.uid)}
+        classNames={['right-tooltip']}
       />
 
+      {/* Delete */}
       <Button
         isDisabled={!isChangingPossible}
         type='bare'
@@ -97,6 +116,7 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
             }
           )
         }
+        classNames={['right-tooltip']}
       />
     </div>
   );

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -106,7 +106,9 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         color='storm'
         size='s'
         startIcon='trash'
-        tooltip={t('Delete 1 project')}
+        tooltip={
+          isChangingPossible ? t('Delete 1 project') : t('Delete project')
+        }
         onClick={() =>
           deleteAsset(
             props.asset,

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -21,8 +21,10 @@ interface ProjectQuickActionsProps {
   asset: AssetResponse | ProjectViewAsset;
 }
 
-/** Quick Actions (Archive, Share, Delete) buttons. Use these when a single
- * project is selected in the Project Table. */
+/**
+ * Quick Actions (Archive, Share, Delete) buttons. Use these when a single
+ * project is selected in the Project Table.
+ */
 export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
   // The `userCan` method requires `permissions` property to be present in the
   // `asset` object. For performance reasons `ProjectViewAsset` doesn't have

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -106,7 +106,7 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         color='storm'
         size='s'
         startIcon='trash'
-        tooltip={t('Delete')}
+        tooltip={t('Delete 1 project')}
         onClick={() =>
           deleteAsset(
             props.asset,

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Button from 'js/components/common/button';
+import styles from './projectActions.module.scss';
+
+const NO_PROJECT_SELECTED = t('No project selected');
+
+export default function ProjectQuickActions() {
+  return (
+    <div className={styles.root}>
+      <Button
+        isDisabled
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='archived'
+        tooltip={t('Archive/Unarchive') + ' – ' + NO_PROJECT_SELECTED}
+        classNames={['right-tooltip']}
+      />
+
+      <Button
+        isDisabled
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='user-share'
+        tooltip={t('Share project') + ' – ' + NO_PROJECT_SELECTED}
+        classNames={['right-tooltip']}
+      />
+
+      <Button
+        isDisabled
+        type='bare'
+        color='storm'
+        size='s'
+        startIcon='trash'
+        tooltip={t('Delete') + ' – ' + NO_PROJECT_SELECTED}
+        classNames={['right-tooltip']}
+      />
+    </div>
+  );
+}

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -10,37 +10,46 @@ export default function ProjectQuickActionsEmpty() {
   return (
     <div className={styles.root}>
       {/* Archive / Unarchive */}
-      <Button
-        isDisabled
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='archived'
-        tooltip={t('Archive/Unarchive') + ' – ' + NO_PROJECT_SELECTED}
-        classNames={['right-tooltip']}
-      />
+      <span
+        data-tip={t('Archive/Unarchive') + ' – ' + NO_PROJECT_SELECTED}
+        className='right-tooltip'
+      >
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='archived'
+        />
+      </span>
 
       {/* Share */}
-      <Button
-        isDisabled
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='user-share'
-        tooltip={t('Share project') + ' – ' + NO_PROJECT_SELECTED}
-        classNames={['right-tooltip']}
-      />
+      <span
+        data-tip={t('Share project') + ' – ' + NO_PROJECT_SELECTED}
+        className='right-tooltip'
+      >
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='user-share'
+        />
+      </span>
 
       {/* Delete */}
-      <Button
-        isDisabled
-        type='bare'
-        color='storm'
-        size='s'
-        startIcon='trash'
-        tooltip={t('Delete') + ' – ' + NO_PROJECT_SELECTED}
-        classNames={['right-tooltip']}
-      />
+      <span
+        data-tip={t('Delete') + ' – ' + NO_PROJECT_SELECTED}
+        className='right-tooltip'
+      >
+        <Button
+          isDisabled
+          type='bare'
+          color='storm'
+          size='s'
+          startIcon='trash'
+        />
+      </span>
     </div>
   );
 }

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -4,7 +4,7 @@ import styles from './projectActions.module.scss';
 
 const NO_PROJECT_SELECTED = t('No project selected');
 
-export default function ProjectQuickActions() {
+export default function ProjectQuickActionsEmpty() {
   return (
     <div className={styles.root}>
       {/* Archive / Unarchive */}

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -4,8 +4,10 @@ import styles from './projectActions.module.scss';
 
 const NO_PROJECT_SELECTED = t('No project selected');
 
-/** Inactive Quick Actions buttons. Show these when zero projects are selected
- * in the Project Table. */
+/**
+ * Inactive Quick Actions buttons. Show these when zero projects are selected
+ * in the Project Table.
+ */
 export default function ProjectQuickActionsEmpty() {
   return (
     <div className={styles.root}>

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -4,6 +4,8 @@ import styles from './projectActions.module.scss';
 
 const NO_PROJECT_SELECTED = t('No project selected');
 
+/** Inactive Quick Actions buttons. Show these when zero projects are selected
+ * in the Project Table. */
 export default function ProjectQuickActionsEmpty() {
   return (
     <div className={styles.root}>

--- a/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActionsEmpty.tsx
@@ -7,6 +7,7 @@ const NO_PROJECT_SELECTED = t('No project selected');
 export default function ProjectQuickActions() {
   return (
     <div className={styles.root}>
+      {/* Archive / Unarchive */}
       <Button
         isDisabled
         type='bare'
@@ -17,6 +18,7 @@ export default function ProjectQuickActions() {
         classNames={['right-tooltip']}
       />
 
+      {/* Share */}
       <Button
         isDisabled
         type='bare'
@@ -27,6 +29,7 @@ export default function ProjectQuickActions() {
         classNames={['right-tooltip']}
       />
 
+      {/* Delete */}
       <Button
         isDisabled
         type='bare'

--- a/jsapp/js/projects/projectsTable/projectsTable.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTable.tsx
@@ -44,7 +44,7 @@ interface ProjectsTableProps {
 }
 
 /**
- * Displays a table of assets.
+ * Displays a table of assets. Works with `survey` type.
  */
 export default function ProjectsTable(props: ProjectsTableProps) {
   // We ensure name is always visible:


### PR DESCRIPTION
## Description

Wrap the Projects View header so that quick action buttons show up on mobile devices.

Reduce quick actions to Sharing, Archive, Delete. 

Show the buttons even if the selection is empty, and show helpful tooltips on desktop even when actions are not possible.

## Related issues
Fixes #4583
Related to #4404

## Details

These are the Quick Actions now:

- Archive/Unarchive
- Sharing
- Delete

The 'Edit Project' button and the dropdown menu with other actions were removed.

Placeholder buttons for Archive, Sharing, Delete are now shown all the time. 

- The hover tooltips, which show on screens > 768px wide, provide special hints if your selection is empty or, in case of the Archive button, consists of 1 draft.

Bulk 'Delete' button is now enabled only if the user has management access to every selected project.

## Checklist

- [x] Wrap so that on narrow widths, you can still access every button
- [x]  Show (faded/disabled) versions of every button when they don't apply, instead of disappearing them
- [x]  Simplify options (Archive, Sharing, Delete)
- [x] Right-align tooltips so they are less likely to get cropped
- [x] Refine tooltips for clarity
- [x] Add a guard for Bulk Delete
- [x] Make custom view routes show bulk actions, too