### PR TITLE
Frontend: Support customized metadata for user profiles and project details

### DIFF
--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -38,13 +38,13 @@ interface Form {
   fields: {
     full_name: string;
     organization: string;
-    organizationWebsite: string;
+    organization_website: string;
     sector: string;
     gender: string;
     bio: string;
     city: string;
     country: string;
-    requireAuth: boolean;
+    require_auth: boolean;
     twitter: string;
     linkedin: string;
     instagram: string;
@@ -53,13 +53,13 @@ interface Form {
     extra_details?: {
       full_name?: string;
       organization?: string;
-      organizationWebsite?: string;
+      organization_website?: string;
       sector?: string;
       gender?: string;
       bio?: string;
       city?: string;
       country?: string;
-      requireAuth?: string;
+      require_auth?: string;
       twitter?: string;
       linkedin?: string;
       instagram?: string;
@@ -95,13 +95,13 @@ const AccountSettings = observer(() => {
     fields: {
       full_name: '',
       organization: '',
-      organizationWebsite: '',
+      organization_website: '',
       sector: '',
       gender: '',
       bio: '',
       city: '',
       country: '',
-      requireAuth: false,
+      require_auth: false,
       twitter: '',
       linkedin: '',
       instagram: '',
@@ -132,14 +132,14 @@ const AccountSettings = observer(() => {
         fields: {
           full_name: currentAccount.extra_details.full_name,
           organization: currentAccount.extra_details.organization,
-          organizationWebsite:
+          organization_website:
             currentAccount.extra_details.organization_website,
           sector: currentAccount.extra_details.sector,
           gender: currentAccount.extra_details.gender,
           bio: currentAccount.extra_details.bio,
           city: currentAccount.extra_details.city,
           country: currentAccount.extra_details.country,
-          requireAuth: currentAccount.extra_details.require_auth,
+          require_auth: currentAccount.extra_details.require_auth,
           twitter: currentAccount.extra_details.twitter,
           linkedin: currentAccount.extra_details.linkedin,
           instagram: currentAccount.extra_details.instagram,
@@ -159,13 +159,13 @@ const AccountSettings = observer(() => {
       extra_details: {
         full_name: form.fields.full_name || '',
         organization: form.fields.organization || '',
-        organization_website: form.fields.organizationWebsite || '',
+        organization_website: form.fields.organization_website || '',
         sector: form.fields.sector || '',
         gender: form.fields.gender || '',
         bio: form.fields.bio || '',
         city: form.fields.city || '',
         country: form.fields.country || '',
-        require_auth: form.fields.requireAuth ? true : false, // false if empty
+        require_auth: form.fields.require_auth ? true : false, // false if empty
         twitter: form.fields.twitter || '',
         linkedin: form.fields.linkedin || '',
         instagram: form.fields.instagram || '',
@@ -255,12 +255,12 @@ const AccountSettings = observer(() => {
 
               {/* Require authentication to see forms and submit data */}
               <Checkbox
-                checked={form.fields.requireAuth}
+                checked={form.fields.require_auth}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
-                  'requireAuth'
+                  fieldNames.require_auth
                 )}
-                name='requireAuth'
+                name={fieldNames.require_auth}
                 label={t('Require authentication to see forms and submit data')}
               />
             </bem.AccountSettings__item>
@@ -273,7 +273,10 @@ const AccountSettings = observer(() => {
                   getFieldLabel(fieldNames.full_name),
                   isFieldRequired(fieldNames.full_name)
                 )}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'full_name')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.full_name
+                )}
                 value={form.fields.full_name}
                 errors={form.fieldsWithErrors.extra_details?.full_name}
                 placeholder={t(
@@ -292,7 +295,7 @@ const AccountSettings = observer(() => {
                 )}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
-                  'organization'
+                  fieldNames.organization
                 )}
                 value={form.fields.organization}
                 errors={form.fieldsWithErrors.extra_details?.organization}
@@ -307,13 +310,13 @@ const AccountSettings = observer(() => {
                   getFieldLabel(fieldNames.organization_website),
                   isFieldRequired(fieldNames.organization_website)
                 )}
-                value={form.fields.organizationWebsite}
+                value={form.fields.organization_website}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
-                  'organizationWebsite'
+                  fieldNames.organization_website
                 )}
                 errors={
-                  form.fieldsWithErrors.extra_details?.organizationWebsite
+                  form.fieldsWithErrors.extra_details?.organization_website
                 }
               />
             </bem.AccountSettings__item>
@@ -326,7 +329,10 @@ const AccountSettings = observer(() => {
                   isFieldRequired(fieldNames.sector)
                 )}
                 value={sectorValue}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'sector')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.sector
+                )}
                 options={form.sectorChoices}
                 error={form.fieldsWithErrors.extra_details?.sector}
               />
@@ -340,7 +346,10 @@ const AccountSettings = observer(() => {
                   isFieldRequired(fieldNames.gender)
                 )}
                 value={choiceToSelectOptions(form.fields.gender, genderChoices)}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'gender')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.gender
+                )}
                 options={genderSelectOptions}
                 error={form.fieldsWithErrors.extra_details?.gender}
               />
@@ -355,7 +364,10 @@ const AccountSettings = observer(() => {
                   isFieldRequired(fieldNames.bio)
                 )}
                 value={form.fields.bio}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'bio')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.bio
+                )}
                 errors={form.fieldsWithErrors.extra_details?.bio}
               />
             </bem.AccountSettings__item>
@@ -368,7 +380,10 @@ const AccountSettings = observer(() => {
                   isFieldRequired(fieldNames.country)
                 )}
                 value={countryValue}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'country')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.country
+                )}
                 options={form.countryChoices}
                 error={form.fieldsWithErrors.extra_details?.country}
               />
@@ -383,7 +398,10 @@ const AccountSettings = observer(() => {
                   isFieldRequired(fieldNames.city)
                 )}
                 value={form.fields.city}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'city')}
+                onChange={onAnyFieldChange.bind(
+                  onAnyFieldChange,
+                  fieldNames.city
+                )}
                 errors={form.fieldsWithErrors.extra_details?.city}
               />
             </bem.AccountSettings__item>
@@ -403,7 +421,10 @@ const AccountSettings = observer(() => {
                     isFieldRequired(fieldNames.twitter)
                   )}
                   value={form.fields.twitter}
-                  onChange={onAnyFieldChange.bind(onAnyFieldChange, 'twitter')}
+                  onChange={onAnyFieldChange.bind(
+                    onAnyFieldChange,
+                    fieldNames.twitter
+                  )}
                   errors={form.fieldsWithErrors.extra_details?.twitter}
                 />
               </label>
@@ -419,7 +440,10 @@ const AccountSettings = observer(() => {
                     isFieldRequired(fieldNames.linkedin)
                   )}
                   value={form.fields.linkedin}
-                  onChange={onAnyFieldChange.bind(onAnyFieldChange, 'linkedin')}
+                  onChange={onAnyFieldChange.bind(
+                    onAnyFieldChange,
+                    fieldNames.linkedin
+                  )}
                   errors={form.fieldsWithErrors.extra_details?.linkedin}
                 />
               </label>
@@ -437,7 +461,7 @@ const AccountSettings = observer(() => {
                   value={form.fields.instagram}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,
-                    'instagram'
+                    fieldNames.instagram
                   )}
                   errors={form.fieldsWithErrors.extra_details?.instagram}
                 />

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -19,7 +19,7 @@ bem.AccountSettings__item = makeBem(bem.FormModal, 'item');
 bem.AccountSettings__actions = makeBem(bem.AccountSettings, 'actions');
 
 const fieldNames = {
-  full_name: 'full_name',
+  name: 'name',
   organization: 'organization',
   organization_website: 'organization_website',
   sector: 'sector',
@@ -36,7 +36,7 @@ const fieldNames = {
 interface Form {
   isPristine: boolean;
   fields: {
-    full_name: string;
+    name: string;
     organization: string;
     organization_website: string;
     sector: string;
@@ -51,7 +51,7 @@ interface Form {
   };
   fieldsWithErrors: {
     extra_details?: {
-      full_name?: string;
+      name?: string;
       organization?: string;
       organization_website?: string;
       sector?: string;
@@ -93,7 +93,7 @@ const AccountSettings = observer(() => {
   const [form, setForm] = useState<Form>({
     isPristine: true,
     fields: {
-      full_name: '',
+      name: '',
       organization: '',
       organization_website: '',
       sector: '',
@@ -130,7 +130,7 @@ const AccountSettings = observer(() => {
       setForm({
         ...form,
         fields: {
-          full_name: currentAccount.extra_details.full_name,
+          name: currentAccount.extra_details.name,
           organization: currentAccount.extra_details.organization,
           organization_website:
             currentAccount.extra_details.organization_website,
@@ -157,7 +157,7 @@ const AccountSettings = observer(() => {
     // ensure that we send empty strings if the field is left blank.
     const profilePatchData = {
       extra_details: {
-        full_name: form.fields.full_name || '',
+        name: form.fields.name || '',
         organization: form.fields.organization || '',
         organization_website: form.fields.organization_website || '',
         sector: form.fields.sector || '',
@@ -266,19 +266,19 @@ const AccountSettings = observer(() => {
             </bem.AccountSettings__item>
 
             {/* Full name */}
-            {metadata.full_name && <bem.AccountSettings__item>
+            {metadata.name && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.full_name),
-                  isFieldRequired(fieldNames.full_name)
+                  getFieldLabel(fieldNames.name),
+                  isFieldRequired(fieldNames.name)
                 )}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
-                  fieldNames.full_name
+                  fieldNames.name
                 )}
-                value={form.fields.full_name}
-                errors={form.fieldsWithErrors.extra_details?.full_name}
+                value={form.fields.name}
+                errors={form.fieldsWithErrors.extra_details?.name}
                 placeholder={t(
                   'Use this to display your real name to other users'
                 )}

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -19,10 +19,25 @@ bem.AccountSettings__right = makeBem(bem.AccountSettings, 'right');
 bem.AccountSettings__item = makeBem(bem.FormModal, 'item');
 bem.AccountSettings__actions = makeBem(bem.AccountSettings, 'actions');
 
+const fieldNames = {
+  full_name: 'full_name',
+  organization: 'organization',
+  organization_website: 'organization_website',
+  sector: 'sector',
+  gender: 'gender',
+  bio: 'bio',
+  city: 'city',
+  country: 'country',
+  require_auth: 'require_auth',
+  twitter: 'twitter',
+  linkedin: 'linkedin',
+  instagram: 'instagram',
+};
+
 interface Form {
   isPristine: boolean;
   fields: {
-    name: string;
+    full_name: string;
     organization: string;
     organizationWebsite: string;
     sector: string;
@@ -37,7 +52,7 @@ interface Form {
   };
   fieldsWithErrors: {
     extra_details?: {
-      name?: string;
+      full_name?: string;
       organization?: string;
       organizationWebsite?: string;
       sector?: string;
@@ -79,7 +94,7 @@ const AccountSettings = observer(() => {
   const [form, setForm] = useState<Form>({
     isPristine: true,
     fields: {
-      name: '',
+      full_name: '',
       organization: '',
       organizationWebsite: '',
       sector: '',
@@ -116,7 +131,7 @@ const AccountSettings = observer(() => {
       setForm({
         ...form,
         fields: {
-          name: currentAccount.extra_details.name,
+          full_name: currentAccount.extra_details.full_name,
           organization: currentAccount.extra_details.organization,
           organizationWebsite:
             currentAccount.extra_details.organization_website,
@@ -143,7 +158,7 @@ const AccountSettings = observer(() => {
     // ensure that we send empty strings if the field is left blank.
     const profilePatchData = {
       extra_details: {
-        name: form.fields.name || '',
+        full_name: form.fields.full_name || '',
         organization: form.fields.organization || '',
         organization_website: form.fields.organizationWebsite || '',
         sector: form.fields.sector || '',
@@ -202,6 +217,10 @@ const AccountSettings = observer(() => {
     const field = environment.getUserMetadataField(fieldName);
     return field && (field as EnvStoreFieldItem).required;
   };
+  const userMetadataFieldDict = environment.getUserMetadataFieldsAsSimpleDict();
+  const getFieldLabel = (fieldName: string): string =>
+    userMetadataFieldDict[fieldName]?.label ||
+    (console.error(`No label for fieldname "${fieldName}"`), fieldName);
   const sectorValue = form.sectorChoices.find(
     (sectorChoice) => sectorChoice.value === form.fields.sector
   );
@@ -233,9 +252,11 @@ const AccountSettings = observer(() => {
 
         {sessionStore.isInitialLoadComplete && (
           <bem.AccountSettings__item m='fields'>
+            {/* Privacy */}
             <bem.AccountSettings__item>
               <label>{t('Privacy')}</label>
 
+              {/* Require authentication to see forms and submit data */}
               <Checkbox
                 checked={form.fields.requireAuth}
                 onChange={onAnyFieldChange.bind(
@@ -247,25 +268,30 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* Full name */}
             <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
-                label={t('Name')}
-                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'name')}
-                value={form.fields.name}
-                errors={form.fieldsWithErrors.extra_details?.name}
+                label={addRequiredToLabel(
+                  getFieldLabel(fieldNames.full_name),
+                  isFieldRequired(fieldNames.full_name)
+                )}
+                onChange={onAnyFieldChange.bind(onAnyFieldChange, 'full_name')}
+                value={form.fields.full_name}
+                errors={form.fieldsWithErrors.extra_details?.full_name}
                 placeholder={t(
                   'Use this to display your real name to other users'
                 )}
               />
             </bem.AccountSettings__item>
 
+            {/* Organization */}
             <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
-                  t('Organization'),
-                  isFieldRequired('organization')
+                  getFieldLabel(fieldNames.organization),
+                  isFieldRequired(fieldNames.organization)
                 )}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -276,12 +302,13 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* Organization Website */}
             <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
-                  t('Organization Website'),
-                  isFieldRequired('organization_website')
+                  getFieldLabel(fieldNames.organization_website),
+                  isFieldRequired(fieldNames.organization_website)
                 )}
                 value={form.fields.organizationWebsite}
                 onChange={onAnyFieldChange.bind(
@@ -294,11 +321,12 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* Primary Sector */}
             <bem.AccountSettings__item m='primary-sector'>
               <WrappedSelect
                 label={addRequiredToLabel(
-                  t('Primary Sector'),
-                  isFieldRequired('sector')
+                  getFieldLabel(fieldNames.sector),
+                  isFieldRequired(fieldNames.sector)
                 )}
                 value={sectorValue}
                 onChange={onAnyFieldChange.bind(onAnyFieldChange, 'sector')}
@@ -307,11 +335,12 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* Gender */}
             <bem.AccountSettings__item m='gender'>
               <WrappedSelect
                 label={addRequiredToLabel(
-                  t('Gender'),
-                  isFieldRequired('gender')
+                  getFieldLabel(fieldNames.gender),
+                  isFieldRequired(fieldNames.gender)
                 )}
                 value={choiceToSelectOptions(form.fields.gender, genderChoices)}
                 onChange={onAnyFieldChange.bind(onAnyFieldChange, 'gender')}
@@ -320,21 +349,26 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* Bio */}
             <bem.AccountSettings__item m='bio'>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(t('Bio'), isFieldRequired('bio'))}
+                label={addRequiredToLabel(
+                  getFieldLabel(fieldNames.bio),
+                  isFieldRequired(fieldNames.bio)
+                )}
                 value={form.fields.bio}
                 onChange={onAnyFieldChange.bind(onAnyFieldChange, 'bio')}
                 errors={form.fieldsWithErrors.extra_details?.bio}
               />
             </bem.AccountSettings__item>
 
+            {/* Country */}
             <bem.AccountSettings__item m='country'>
               <WrappedSelect
                 label={addRequiredToLabel(
-                  t('Country'),
-                  isFieldRequired('country')
+                  getFieldLabel(fieldNames.country),
+                  isFieldRequired(fieldNames.country)
                 )}
                 value={countryValue}
                 onChange={onAnyFieldChange.bind(onAnyFieldChange, 'country')}
@@ -343,43 +377,66 @@ const AccountSettings = observer(() => {
               />
             </bem.AccountSettings__item>
 
+            {/* City */}
             <bem.AccountSettings__item m='city'>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(t('City'), isFieldRequired('city'))}
+                label={addRequiredToLabel(
+                  getFieldLabel(fieldNames.city),
+                  isFieldRequired(fieldNames.city)
+                )}
                 value={form.fields.city}
                 onChange={onAnyFieldChange.bind(onAnyFieldChange, 'city')}
                 errors={form.fieldsWithErrors.extra_details?.city}
               />
             </bem.AccountSettings__item>
 
+            {/* Social */}
             <bem.AccountSettings__item m='social'>
               <label>{t('Social')}</label>
+
+              {/* Twitter */}
               <label>
                 <i className='k-icon k-icon-logo-twitter' />
 
                 <TextBox
                   customModifiers='on-white'
+                  placeholder={addRequiredToLabel(
+                    getFieldLabel(fieldNames.twitter),
+                    isFieldRequired(fieldNames.twitter)
+                  )}
                   value={form.fields.twitter}
                   onChange={onAnyFieldChange.bind(onAnyFieldChange, 'twitter')}
                   errors={form.fieldsWithErrors.extra_details?.twitter}
                 />
               </label>
+
+              {/* LinkedIn */}
               <label>
                 <i className='k-icon k-icon-logo-linkedin' />
 
                 <TextBox
                   customModifiers='on-white'
+                  placeholder={addRequiredToLabel(
+                    getFieldLabel(fieldNames.linkedin),
+                    isFieldRequired(fieldNames.linkedin)
+                  )}
                   value={form.fields.linkedin}
                   onChange={onAnyFieldChange.bind(onAnyFieldChange, 'linkedin')}
                   errors={form.fieldsWithErrors.extra_details?.linkedin}
                 />
               </label>
+
+              {/* Instagram */}
               <label>
                 <i className='k-icon k-icon-logo-instagram' />
 
                 <TextBox
                   customModifiers='on-white'
+                  placeholder={addRequiredToLabel(
+                    getFieldLabel(fieldNames.instagram),
+                    isFieldRequired(fieldNames.instagram)
+                  )}
                   value={form.fields.instagram}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -7,7 +7,6 @@ import './accountSettings.scss';
 import Checkbox from '../components/common/checkbox';
 import TextBox from '../components/common/textBox';
 import {addRequiredToLabel, notify, stringToColor} from '../utils';
-import type {EnvStoreFieldItem} from '../envStore';
 import envStore from '../envStore';
 import WrappedSelect from '../components/common/wrappedSelect';
 import {dataInterface} from '../dataInterface';
@@ -213,14 +212,12 @@ const AccountSettings = observer(() => {
   const initialsStyle = {
     background: `#${stringToColor(accountName)}`,
   };
-  const isFieldRequired = (fieldName: string): boolean => {
-    const field = environment.getUserMetadataField(fieldName);
-    return field && (field as EnvStoreFieldItem).required;
-  };
   const userMetadataFieldDict = environment.getUserMetadataFieldsAsSimpleDict();
   const getFieldLabel = (fieldName: string): string =>
     userMetadataFieldDict[fieldName]?.label ||
     (console.error(`No label for fieldname "${fieldName}"`), fieldName);
+  const isFieldRequired = (fieldName: string): boolean =>
+    userMetadataFieldDict[fieldName]?.required || false;
   const sectorValue = form.sectorChoices.find(
     (sectorChoice) => sectorChoice.value === form.fields.sector
   );

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -212,12 +212,12 @@ const AccountSettings = observer(() => {
   const initialsStyle = {
     background: `#${stringToColor(accountName)}`,
   };
-  const userMetadataFieldDict = environment.getUserMetadataFieldsAsSimpleDict();
+  const metadata = environment.getUserMetadataFieldsAsSimpleDict();
   const getFieldLabel = (fieldName: string): string =>
-    userMetadataFieldDict[fieldName]?.label ||
+    metadata[fieldName]?.label ||
     (console.error(`No label for fieldname "${fieldName}"`), fieldName);
   const isFieldRequired = (fieldName: string): boolean =>
-    userMetadataFieldDict[fieldName]?.required || false;
+    metadata[fieldName]?.required || false;
   const sectorValue = form.sectorChoices.find(
     (sectorChoice) => sectorChoice.value === form.fields.sector
   );
@@ -266,7 +266,7 @@ const AccountSettings = observer(() => {
             </bem.AccountSettings__item>
 
             {/* Full name */}
-            <bem.AccountSettings__item>
+            {metadata.full_name && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
@@ -283,10 +283,10 @@ const AccountSettings = observer(() => {
                   'Use this to display your real name to other users'
                 )}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Organization */}
-            <bem.AccountSettings__item>
+            {metadata.organization && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
@@ -300,10 +300,10 @@ const AccountSettings = observer(() => {
                 value={form.fields.organization}
                 errors={form.fieldsWithErrors.extra_details?.organization}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Organization Website */}
-            <bem.AccountSettings__item>
+            {metadata.organization_website && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
@@ -319,10 +319,10 @@ const AccountSettings = observer(() => {
                   form.fieldsWithErrors.extra_details?.organization_website
                 }
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Primary Sector */}
-            <bem.AccountSettings__item m='primary-sector'>
+            {metadata.sector && <bem.AccountSettings__item m='primary-sector'>
               <WrappedSelect
                 label={addRequiredToLabel(
                   getFieldLabel(fieldNames.sector),
@@ -336,10 +336,10 @@ const AccountSettings = observer(() => {
                 options={form.sectorChoices}
                 error={form.fieldsWithErrors.extra_details?.sector}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Gender */}
-            <bem.AccountSettings__item m='gender'>
+            {metadata.gender && <bem.AccountSettings__item m='gender'>
               <WrappedSelect
                 label={addRequiredToLabel(
                   getFieldLabel(fieldNames.gender),
@@ -353,10 +353,10 @@ const AccountSettings = observer(() => {
                 options={genderSelectOptions}
                 error={form.fieldsWithErrors.extra_details?.gender}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Bio */}
-            <bem.AccountSettings__item m='bio'>
+            {metadata.bio && <bem.AccountSettings__item m='bio'>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
@@ -370,10 +370,10 @@ const AccountSettings = observer(() => {
                 )}
                 errors={form.fieldsWithErrors.extra_details?.bio}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Country */}
-            <bem.AccountSettings__item m='country'>
+            {metadata.country && <bem.AccountSettings__item m='country'>
               <WrappedSelect
                 label={addRequiredToLabel(
                   getFieldLabel(fieldNames.country),
@@ -387,10 +387,10 @@ const AccountSettings = observer(() => {
                 options={form.countryChoices}
                 error={form.fieldsWithErrors.extra_details?.country}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* City */}
-            <bem.AccountSettings__item m='city'>
+            {metadata.city && <bem.AccountSettings__item m='city'>
               <TextBox
                 customModifiers='on-white'
                 label={addRequiredToLabel(
@@ -404,14 +404,14 @@ const AccountSettings = observer(() => {
                 )}
                 errors={form.fieldsWithErrors.extra_details?.city}
               />
-            </bem.AccountSettings__item>
+            </bem.AccountSettings__item>}
 
             {/* Social */}
-            <bem.AccountSettings__item m='social'>
+            {(metadata.twitter || metadata.linkedin || metadata.instagram) && <bem.AccountSettings__item m='social'>
               <label>{t('Social')}</label>
 
               {/* Twitter */}
-              <label>
+              {metadata.twitter && <label>
                 <i className='k-icon k-icon-logo-twitter' />
 
                 <TextBox
@@ -427,10 +427,10 @@ const AccountSettings = observer(() => {
                   )}
                   errors={form.fieldsWithErrors.extra_details?.twitter}
                 />
-              </label>
+              </label>}
 
               {/* LinkedIn */}
-              <label>
+              {metadata.linkedin && <label>
                 <i className='k-icon k-icon-logo-linkedin' />
 
                 <TextBox
@@ -446,10 +446,10 @@ const AccountSettings = observer(() => {
                   )}
                   errors={form.fieldsWithErrors.extra_details?.linkedin}
                 />
-              </label>
+              </label>}
 
               {/* Instagram */}
-              <label>
+              {metadata.instagram && <label>
                 <i className='k-icon k-icon-logo-instagram' />
 
                 <TextBox
@@ -465,8 +465,8 @@ const AccountSettings = observer(() => {
                   )}
                   errors={form.fieldsWithErrors.extra_details?.instagram}
                 />
-              </label>
-            </bem.AccountSettings__item>
+              </label>}
+            </bem.AccountSettings__item>}
           </bem.AccountSettings__item>
         )}
       </bem.AccountSettings__item>

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -225,11 +225,13 @@ const AccountSettings = observer(() => {
     background: `#${stringToColor(accountName)}`,
   };
   const metadata = environment.getUserMetadataFieldsAsSimpleDict();
-  const getFieldLabel = (fieldName: string): string =>
-    metadata[fieldName]?.label ||
-    (console.error(`No label for fieldname "${fieldName}"`), fieldName);
-  const isFieldRequired = (fieldName: string): boolean =>
-    metadata[fieldName]?.required || false;
+  /** Get label and (required) for a given user metadata fieldname */
+  const getLabel = (fieldName: string): string => {
+    const label = metadata[fieldName]?.label || (console.error(`No label for fieldname "${fieldName}"`), fieldName);
+    const required = metadata[fieldName]?.required || false;
+    return addRequiredToLabel(label, required);
+  };
+
   const sectorValue = form.sectorChoices.find(
     (sectorChoice) => sectorChoice.value === form.fields.sector
   );
@@ -281,10 +283,7 @@ const AccountSettings = observer(() => {
             {metadata.name && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.name),
-                  isFieldRequired(fieldNames.name)
-                )}
+                label={getLabel(fieldNames.name)}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
                   fieldNames.name
@@ -301,10 +300,7 @@ const AccountSettings = observer(() => {
             {metadata.organization && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.organization),
-                  isFieldRequired(fieldNames.organization)
-                )}
+                label={getLabel(fieldNames.organization)}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
                   fieldNames.organization
@@ -318,10 +314,7 @@ const AccountSettings = observer(() => {
             {metadata.organization_website && <bem.AccountSettings__item>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.organization_website),
-                  isFieldRequired(fieldNames.organization_website)
-                )}
+                label={getLabel(fieldNames.organization_website)}
                 value={form.fields.organization_website}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -336,10 +329,7 @@ const AccountSettings = observer(() => {
             {/* Primary Sector */}
             {metadata.sector && <bem.AccountSettings__item m='primary-sector'>
               <WrappedSelect
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.sector),
-                  isFieldRequired(fieldNames.sector)
-                )}
+                label={getLabel(fieldNames.sector)}
                 value={sectorValue}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -353,10 +343,7 @@ const AccountSettings = observer(() => {
             {/* Gender */}
             {metadata.gender && <bem.AccountSettings__item m='gender'>
               <WrappedSelect
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.gender),
-                  isFieldRequired(fieldNames.gender)
-                )}
+                label={getLabel(fieldNames.gender)}
                 value={choiceToSelectOptions(form.fields.gender, genderChoices)}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -371,10 +358,7 @@ const AccountSettings = observer(() => {
             {metadata.bio && <bem.AccountSettings__item m='bio'>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.bio),
-                  isFieldRequired(fieldNames.bio)
-                )}
+                label={getLabel(fieldNames.bio)}
                 value={form.fields.bio}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -387,10 +371,7 @@ const AccountSettings = observer(() => {
             {/* Country */}
             {metadata.country && <bem.AccountSettings__item m='country'>
               <WrappedSelect
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.country),
-                  isFieldRequired(fieldNames.country)
-                )}
+                label={getLabel(fieldNames.country)}
                 value={countryValue}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -405,10 +386,7 @@ const AccountSettings = observer(() => {
             {metadata.city && <bem.AccountSettings__item m='city'>
               <TextBox
                 customModifiers='on-white'
-                label={addRequiredToLabel(
-                  getFieldLabel(fieldNames.city),
-                  isFieldRequired(fieldNames.city)
-                )}
+                label={getLabel(fieldNames.city)}
                 value={form.fields.city}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
@@ -428,10 +406,7 @@ const AccountSettings = observer(() => {
 
                 <TextBox
                   customModifiers='on-white'
-                  placeholder={addRequiredToLabel(
-                    getFieldLabel(fieldNames.twitter),
-                    isFieldRequired(fieldNames.twitter)
-                  )}
+                  placeholder={getLabel(fieldNames.twitter)}
                   value={form.fields.twitter}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,
@@ -447,10 +422,7 @@ const AccountSettings = observer(() => {
 
                 <TextBox
                   customModifiers='on-white'
-                  placeholder={addRequiredToLabel(
-                    getFieldLabel(fieldNames.linkedin),
-                    isFieldRequired(fieldNames.linkedin)
-                  )}
+                  placeholder={getLabel(fieldNames.linkedin)}
                   value={form.fields.linkedin}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,
@@ -466,10 +438,7 @@ const AccountSettings = observer(() => {
 
                 <TextBox
                   customModifiers='on-white'
-                  placeholder={addRequiredToLabel(
-                    getFieldLabel(fieldNames.instagram),
-                    isFieldRequired(fieldNames.instagram)
-                  )}
+                  placeholder={getLabel(fieldNames.instagram)}
                   value={form.fields.instagram}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -515,19 +515,6 @@ $modal-custom-header-height: sizes.$x60;
     pointer-events: none;
   }
 
-  // override two columns to rows
-  &.project-settings--narrow {
-    .form-modal__item--sector,
-    .form-modal__item--country {
-      width: 100%;
-      float: none;
-
-      .kobo-select {
-        margin-right: 0;
-      }
-    }
-  }
-
   $buttons-spacing: 10px;
 
   .form-modal__item--form-source-buttons {

--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -14,6 +14,7 @@ import {dataInterface} from 'js/dataInterface';
 import {formatTime} from 'js/utils';
 import AssetStatusBadge from './common/assetStatusBadge';
 import Avatar from './common/avatar';
+import envStore from 'js/envStore';
 
 interface FormSummaryProjectInfoProps {
   asset: AssetResponse;
@@ -47,6 +48,9 @@ export default function FormSummaryProjectInfo(
   const lastDeployedDate =
     props.asset.deployed_versions?.results?.[0]?.date_modified;
 
+  // Support custom labels for project metadata, if defined
+  const metadata = envStore.data.getProjectMetadataFieldsAsSimpleDict();
+
   return (
     <bem.FormView__row>
       <bem.FormView__cell m={['label', 'first']}>
@@ -57,7 +61,9 @@ export default function FormSummaryProjectInfo(
         <bem.FormView__group m='items'>
           {/* description - takes whole row */}
           <bem.FormView__cell m='padding'>
-            <bem.FormView__label>{t('Description')}</bem.FormView__label>
+            <bem.FormView__label>
+              {metadata.description?.label ?? t('Description')}
+            </bem.FormView__label>
             {props.asset.settings.description || '-'}
           </bem.FormView__cell>
         </bem.FormView__group>
@@ -113,13 +119,17 @@ export default function FormSummaryProjectInfo(
         <bem.FormView__group m='items'>
           {/* sector */}
           <bem.FormView__cell m='padding'>
-            <bem.FormView__label>{t('Sector')}</bem.FormView__label>
+            <bem.FormView__label>
+              {metadata.sector?.label ?? t('Sector')}
+            </bem.FormView__label>
             {getSectorDisplayString(props.asset)}
           </bem.FormView__cell>
 
           {/* countries */}
           <bem.FormView__cell m='padding'>
-            <bem.FormView__label>{t('Countries')}</bem.FormView__label>
+            <bem.FormView__label>
+              {metadata.country?.label ?? t('Countries')}
+            </bem.FormView__label>
             {getCountryDisplayString(props.asset)}
           </bem.FormView__cell>
         </bem.FormView__group>
@@ -146,7 +156,8 @@ export default function FormSummaryProjectInfo(
             {props.asset.settings.operational_purpose && (
               <bem.FormView__cell m='padding'>
                 <bem.FormView__label>
-                  {t('Operational purpose of data')}
+                  {metadata.operational_purpose?.label ??
+                    t('Operational purpose of data')}
                 </bem.FormView__label>
                 {props.asset.settings.operational_purpose.label}
               </bem.FormView__cell>
@@ -154,7 +165,8 @@ export default function FormSummaryProjectInfo(
             {props.asset.settings.collects_pii && (
               <bem.FormView__cell m='padding'>
                 <bem.FormView__label>
-                  {t('Collects personally identifiable information')}
+                  {metadata.collects_pii?.label ??
+                    t('Collects personally identifiable information')}
                 </bem.FormView__label>
                 {props.asset.settings.collects_pii.label}
               </bem.FormView__cell>

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -897,6 +897,7 @@ class ProjectSettings extends React.Component {
           </bem.Modal__footer>
         }
 
+        {/* Project Name */}
         <bem.FormModal__item m='wrapper'>
           {/* form builder displays name in different place */}
           {this.props.context !== PROJECT_SETTINGS_CONTEXTS.BUILDER &&
@@ -913,6 +914,7 @@ class ProjectSettings extends React.Component {
             </bem.FormModal__item>
           }
 
+          {/* Description */}
           {descriptionField &&
           <bem.FormModal__item>
             <TextBox
@@ -921,17 +923,18 @@ class ProjectSettings extends React.Component {
               value={this.state.fields.description}
               onChange={this.onDescriptionChange.bind(this)}
               errors={this.hasFieldError('description') ? t('Please enter a description for your project') : false}
-              label={addRequiredToLabel(t('Description'), descriptionField.required)}
+              label={addRequiredToLabel(descriptionField.label, descriptionField.required)}
               placeholder={t('Enter short description here')}
               data-cy='description'
             />
           </bem.FormModal__item>
           }
 
+          {/* Sector */}
           {sectorField &&
             <bem.FormModal__item m={bothCountryAndSector ? 'sector' : null}>
               <WrappedSelect
-                label={addRequiredToLabel(t('Sector'), sectorField.required)}
+                label={addRequiredToLabel(sectorField.label, sectorField.required)}
                 value={this.state.fields.sector}
                 onChange={this.onAnyFieldChange.bind(this, 'sector')}
                 options={sectors}
@@ -944,10 +947,11 @@ class ProjectSettings extends React.Component {
             </bem.FormModal__item>
           }
 
+          {/* Country */}
           {countryField &&
             <bem.FormModal__item m={bothCountryAndSector ? 'country' : null}>
               <WrappedSelect
-                label={addRequiredToLabel(t('Country'), countryField.required)}
+                label={addRequiredToLabel(countryField.label, countryField.required)}
                 isMulti
                 value={this.state.fields.country}
                 onChange={this.onAnyFieldChange.bind(this, 'country')}
@@ -961,10 +965,11 @@ class ProjectSettings extends React.Component {
             </bem.FormModal__item>
           }
 
+          {/* Operational Purpose of Data */}
           {operationalPurposeField &&
             <bem.FormModal__item>
               <WrappedSelect
-                label={addRequiredToLabel(t('Operational Purpose of Data'), operationalPurposeField.required)}
+                label={addRequiredToLabel(operationalPurposeField.label, operationalPurposeField.required)}
                 value={this.state.fields.operational_purpose}
                 onChange={this.onAnyFieldChange.bind(this, 'operational_purpose')}
                 options={operationalPurposes}
@@ -975,10 +980,11 @@ class ProjectSettings extends React.Component {
             </bem.FormModal__item>
           }
 
+          {/* Does this project collect personally identifiable information? */}
           {collectsPiiField &&
             <bem.FormModal__item>
               <WrappedSelect
-                label={addRequiredToLabel(t('Does this project collect personally identifiable information?'), collectsPiiField.required)}
+                label={addRequiredToLabel(collectsPiiField.label, collectsPiiField.required)}
                 value={this.state.fields.collects_pii}
                 onChange={this.onAnyFieldChange.bind(this, 'collects_pii')}
                 options={[

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -661,6 +661,12 @@ class ProjectSettings extends React.Component {
 
     // superuser-configured metadata
     if (
+      envStore.data.getProjectMetadataField('description').required &&
+      !this.state.fields.description.trim()
+    ) {
+      fieldsWithErrors.push('description');
+    }
+    if (
       envStore.data.getProjectMetadataField('sector').required &&
       !this.state.fields.sector
     ) {
@@ -867,6 +873,7 @@ class ProjectSettings extends React.Component {
     const operationalPurposes = envStore.data.operational_purpose_choices;
     const collectsPiiField = envStore.data.getProjectMetadataField('collects_pii');
     const isSelfOwned = assetUtils.isSelfOwned(this.state.formAsset);
+    const descriptionField = envStore.data.getProjectMetadataField('description');
 
     return (
       <bem.FormModal__form
@@ -906,17 +913,20 @@ class ProjectSettings extends React.Component {
             </bem.FormModal__item>
           }
 
+          {descriptionField &&
           <bem.FormModal__item>
             <TextBox
               customModifiers='on-white'
               type='text-multiline'
               value={this.state.fields.description}
               onChange={this.onDescriptionChange.bind(this)}
-              label={t('Description')}
+              errors={this.hasFieldError('description') ? t('Please enter a description for your project') : false}
+              label={addRequiredToLabel(t('Description'), descriptionField.required)}
               placeholder={t('Enter short description here')}
               data-cy='description'
             />
           </bem.FormModal__item>
+          }
 
           {sectorField &&
             <bem.FormModal__item m={bothCountryAndSector ? 'sector' : null}>

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -659,7 +659,7 @@ export interface AccountResponse {
   is_staff: boolean;
   last_login: string;
   extra_details: {
-    full_name: string;
+    name: string;
     gender: string;
     sector: string;
     country: string;
@@ -690,7 +690,7 @@ export interface AccountResponse {
 export interface AccountRequest {
   email?: string;
   extra_details?: {
-    full_name?: string;
+    name?: string;
     organization?: string;
     organization_website?: string;
     sector?: string;

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -659,7 +659,7 @@ export interface AccountResponse {
   is_staff: boolean;
   last_login: string;
   extra_details: {
-    name: string;
+    full_name: string;
     gender: string;
     sector: string;
     country: string;
@@ -690,7 +690,7 @@ export interface AccountResponse {
 export interface AccountRequest {
   email?: string;
   extra_details?: {
-    name?: string;
+    full_name?: string;
     organization?: string;
     organization_website?: string;
     sector?: string;

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -835,6 +835,7 @@ export default assign({
             }
 
             {this.hasMetadataAndDetails() &&
+             envStore.data.project_metadata_fields.length > 0 &&
               <bem.FormBuilderAside__row>
                 <bem.FormBuilderAside__header>
                   {t('Details')}

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -18,6 +18,7 @@ import {makeAutoObservable} from 'mobx';
 export interface EnvStoreFieldItem {
   name: string;
   required: boolean;
+  label: string;
 }
 
 export interface SocialApp {
@@ -86,6 +87,15 @@ class EnvStoreData {
       }
     }
     return false;
+  }
+
+  public getUserMetadataFieldsAsSimpleDict() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dict: any = {};
+    for (const field of this.user_metadata_fields) {
+      dict[field.name] = field;
+    }
+    return dict;
   }
 }
 

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -80,18 +80,9 @@ class EnvStoreData {
     return false;
   }
 
-  public getUserMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
-    for (const f of this.user_metadata_fields) {
-      if (f.name === fieldName) {
-        return f;
-      }
-    }
-    return false;
-  }
-
   public getUserMetadataFieldsAsSimpleDict() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const dict: any = {};
+    // dict[name] => {name, required, label}
+    const dict: {[fieldName: string]: EnvStoreFieldItem} = {};
     for (const field of this.user_metadata_fields) {
       dict[field.name] = field;
     }

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -39,6 +39,13 @@ export interface FreeTierDisplay {
   feature_list: [string] | [];
 }
 
+type ProjectMetadataFieldKey =
+  | 'description'
+  | 'sector'
+  | 'country'
+  | 'operational_purpose'
+  | 'collects_pii';
+
 class EnvStoreData {
   public terms_of_service_url = '';
   public privacy_policy_url = '';
@@ -71,13 +78,26 @@ class EnvStoreData {
   };
   public free_tier_display: FreeTierDisplay = {name: null, feature_list: []};
 
-  getProjectMetadataField(fieldName: string): EnvStoreFieldItem | boolean {
+  getProjectMetadataField(
+    fieldName: ProjectMetadataFieldKey
+  ): EnvStoreFieldItem | boolean {
     for (const f of this.project_metadata_fields) {
       if (f.name === fieldName) {
         return f;
       }
     }
     return false;
+  }
+
+  public getProjectMetadataFieldsAsSimpleDict() {
+    // dict[name] => {name, required, label}
+    const dict: Partial<{
+      [fieldName in ProjectMetadataFieldKey]: EnvStoreFieldItem;
+    }> = {};
+    for (const field of this.project_metadata_fields) {
+      dict[field.name as keyof typeof dict] = field;
+    }
+    return dict;
   }
 
   public getUserMetadataFieldsAsSimpleDict() {

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -410,6 +410,9 @@ iframe {
 }
 
 
+
+// Flexbox helps us maintain a layout when some fields may be customized
+// or removed.
 // Place sector and country side-by-side, when both fields exist and we're
 // not in the narrow form builder sidebar. Similar to registration screen.
 .form-modal__form.project-settings--project-details:not(.project-settings--narrow) > .form-modal__item--wrapper {
@@ -419,12 +422,12 @@ iframe {
   align-items: flex-end;
   column-gap: 4%;
   .form-modal__item {
-    min-width: 75%;
-    flex: 1;
+    min-width: 75%; // Most rows are wide enough to get their own row,
+    flex: 1; // and when they do, they grow to occupy the full available width
   }
   .form-modal__item--sector,
   .form-modal__item--country {
-    min-width: 40%;
+    min-width: 40%; // These fields can sit next to each other in pairs.
   }
 }
 

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -409,6 +409,25 @@ iframe {
   border: none;
 }
 
+
+// Place sector and country side-by-side, when both fields exist and we're
+// not in the narrow form builder sidebar. Similar to registration screen.
+.form-modal__form.project-settings--project-details:not(.project-settings--narrow) > .form-modal__item--wrapper {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  column-gap: 4%;
+  .form-modal__item {
+    min-width: 75%;
+    flex: 1;
+  }
+  .form-modal__item--sector,
+  .form-modal__item--country {
+    min-width: 40%;
+  }
+}
+
 // modal forms
 .form-modal__item {
   &:not(:last-child) {
@@ -421,17 +440,6 @@ iframe {
       margin-bottom: 0;
       margin-right: 20px;
     }
-  }
-
-  &.form-modal__item--sector {
-    width: 50%;
-    margin-right: 4%;
-    float: left;
-  }
-
-  &.form-modal__item--country {
-    width: 46%;
-    float: left;
   }
 
   label {

--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -438,7 +438,7 @@
         min-width: 75%; // Most rows are wide enough to get their own row,
         flex: 1; // and when they do, they grow to occupy full available width.
       }
-      > .full_name,
+      > .name,
       > .organization,
       > .sector,
       > .country {

--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -250,20 +250,6 @@
     margin-left: 3px;
   }
 
-  .sector,
-  .full_name {
-    width: 48%;
-    float: left;
-    margin-top: 0px;
-  }
-
-  .country,
-  .organization {
-    width: 52%;
-    float: left;
-    padding-left: 4%;
-    margin-top: 0px;
-  }
 
   .password1 {
     margin-top: 10px;
@@ -440,6 +426,24 @@
     .registration__first-half {
       width: 52%;
       float: left;
+
+      // Flexbox helps us maintain a layout when some fields may be customized
+      // or removed.
+      display: flex;
+      flex-flow: row wrap;
+      justify-content: space-between;
+      align-items: flex-end;
+      column-gap: 4%;
+      > * {
+        min-width: 75%; // Most rows are wide enough to get their own row,
+        flex: 1; // and when they do, they grow to occupy full available width.
+      }
+      > .full_name,
+      > .organization,
+      > .sector,
+      > .country {
+        min-width: 40%; // These fields can sit next to each other in pairs.
+      }
     }
 
     .registration__second-half {


### PR DESCRIPTION
## Description

Display custom labels provided by the backend, and validate newly required fields.

## Details

#4586 makes user and project metadata fields more configurable in Constance.

This PR contains frontend changes necessary to support:

- Customized metadata labels
- Fields that can be required now (Full name, Project description)

Affecting these parts of the UI:

- New user registration, user profile settings
- Project creation, project settings, form builder details

Additionally, this PR improves layout handling when fields are removed.

## Related issues

Part of #4586
Expands on #3611

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a description of your work suitable for publishing on [our forum](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
