### PR TITLE
Remove disabling of qualitative analysis UI when pending

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
@@ -87,8 +87,7 @@ export default function AnalysisHeader() {
         // possible until user stops editing
         isDisabled={
           !hasManagePermissions ||
-          analysisQuestions?.state.questionsBeingEdited.length !== 0 ||
-          analysisQuestions?.state.isPending
+          analysisQuestions?.state.questionsBeingEdited.length !== 0
         }
       />
 

--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -140,7 +140,6 @@ export default function AnalysisQuestionEditor(
           placeholder={t('Type question')}
           customModifiers='on-white'
           renderFocused
-          disabled={analysisQuestions?.state.isPending}
         />
 
         <Button

--- a/jsapp/js/components/processing/analysis/editors/keywordSearchFieldsEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/keywordSearchFieldsEditor.component.tsx
@@ -63,7 +63,6 @@ export default function KeywordSearchFieldsEditor(
           onlyUnique
           addOnBlur
           addOnPaste
-          disabled={analysisQuestions?.state.isPending}
         />
       </section>
 
@@ -74,7 +73,6 @@ export default function KeywordSearchFieldsEditor(
           languageCodes={singleProcessingStore.getSources()}
           selectedLanguage={props.fields.source}
           onChange={onSourceChange}
-          disabled={analysisQuestions?.state.isPending}
           // TODO: after PR https://github.com/kobotoolbox/kpi/pull/4423
           // is merged into feature/analysis branch, lets introduce size and
           // color props here, so we can use 'm' 'gray' here

--- a/jsapp/js/components/processing/analysis/editors/selectXFieldsEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/selectXFieldsEditor.component.tsx
@@ -63,7 +63,6 @@ export default function SelectXFieldsEditor(props: SelectXFieldsEditorProps) {
             placeholder={t('Type option name')}
             customModifiers='on-white'
             renderFocused
-            disabled={analysisQuestions?.state.isPending}
           />
 
           <Button

--- a/jsapp/js/components/processing/analysis/responseForms/defaultResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/defaultResponseForm.component.tsx
@@ -81,7 +81,6 @@ export default function DefaultResponseForm(props: DefaultResponseFormProps) {
           placeholder={t('Start typing your answer')}
           onBlur={saveResponse}
           customModifiers='on-white'
-          disabled={analysisQuestions?.state.isPending}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
@@ -71,7 +71,6 @@ export default function SelectMultipleResponseForm(
           type='bare'
           items={getCheckboxes()}
           onChange={onCheckboxesChange}
-          disabled={analysisQuestions?.state.isPending}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
@@ -71,7 +71,6 @@ export default function SelectOneResponseForm(
           onChange={onRadioChange}
           selected={response}
           isClearable
-          isDisabled={analysisQuestions?.state.isPending}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
@@ -61,7 +61,6 @@ export default function TagsResponseForm(props: TagsResponseFormProps) {
           onlyUnique
           addOnBlur
           addOnPaste
-          disabled={analysisQuestions?.state.isPending}
         />
       </section>
     </>


### PR DESCRIPTION
## Description

Removes the `disable` condition on qualitative analysis UI elements.

Seems to be ok. Reading the console logs with this new change yields an expected "queue" of requests if attempting to resend an edit while one is already uploading.

<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

<!-- Fixes #ISSUE -->
<!-- Blocked by #ISSUE -->
<!-- Part of #ISSUE -->
