### PR TITLE
Omit fields in form summary if omitted from project metadata config

### DIFF
--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -158,31 +158,28 @@ export default function FormSummaryProjectInfo(
           )}
 
         {/* operational purpose and PII */}
-        {(metadata.operational_purpose || metadata.collects_pii) &&
-          (props.asset.settings.operational_purpose ||
-            props.asset.settings.collects_pii) && (
-            <bem.FormView__group m='items'>
-              {metadata.operational_purpose &&
-                props.asset.settings.operational_purpose && (
-                  <bem.FormView__cell m='padding'>
-                    <bem.FormView__label>
-                      {metadata.operational_purpose?.label ??
-                        t('Operational purpose of data')}
-                    </bem.FormView__label>
-                    {props.asset.settings.operational_purpose.label}
-                  </bem.FormView__cell>
-                )}
-              {metadata.collects_pii && props.asset.settings.collects_pii && (
-                <bem.FormView__cell m='padding'>
-                  <bem.FormView__label>
-                    {metadata.collects_pii?.label ??
-                      t('Collects personally identifiable information')}
-                  </bem.FormView__label>
-                  {props.asset.settings.collects_pii.label}
-                </bem.FormView__cell>
-              )}
-            </bem.FormView__group>
-          )}
+        {(metadata.operational_purpose || metadata.collects_pii) && (
+          <bem.FormView__group m='items'>
+            {metadata.operational_purpose && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {metadata.operational_purpose?.label ??
+                    t('Operational purpose of data')}
+                </bem.FormView__label>
+                {props.asset.settings.operational_purpose?.label ?? '-'}
+              </bem.FormView__cell>
+            )}
+            {metadata.collects_pii && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {metadata.collects_pii?.label ??
+                    t('Collects personally identifiable information')}
+                </bem.FormView__label>
+                {props.asset.settings.collects_pii?.label ?? '-'}
+              </bem.FormView__cell>
+            )}
+          </bem.FormView__group>
+        )}
       </bem.FormView__cell>
     </bem.FormView__row>
   );

--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -58,15 +58,17 @@ export default function FormSummaryProjectInfo(
       </bem.FormView__cell>
 
       <bem.FormView__cell m='box'>
-        <bem.FormView__group m='items'>
-          {/* description - takes whole row */}
-          <bem.FormView__cell m='padding'>
-            <bem.FormView__label>
-              {metadata.description?.label ?? t('Description')}
-            </bem.FormView__label>
-            {props.asset.settings.description || '-'}
-          </bem.FormView__cell>
-        </bem.FormView__group>
+        {metadata.description && (
+          <bem.FormView__group m='items'>
+            {/* description - takes whole row */}
+            <bem.FormView__cell m='padding'>
+              <bem.FormView__label>
+                {metadata.description?.label ?? t('Description')}
+              </bem.FormView__label>
+              {props.asset.settings.description || '-'}
+            </bem.FormView__cell>
+          </bem.FormView__group>
+        )}
 
         <bem.FormView__group m='items'>
           {/* status */}
@@ -116,23 +118,29 @@ export default function FormSummaryProjectInfo(
           )}
         </bem.FormView__group>
 
-        <bem.FormView__group m='items'>
-          {/* sector */}
-          <bem.FormView__cell m='padding'>
-            <bem.FormView__label>
-              {metadata.sector?.label ?? t('Sector')}
-            </bem.FormView__label>
-            {getSectorDisplayString(props.asset)}
-          </bem.FormView__cell>
+        {(metadata.sector || metadata.country) && (
+          <bem.FormView__group m='items'>
+            {/* sector */}
+            {metadata.sector && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {metadata.sector?.label ?? t('Sector')}
+                </bem.FormView__label>
+                {getSectorDisplayString(props.asset)}
+              </bem.FormView__cell>
+            )}
 
-          {/* countries */}
-          <bem.FormView__cell m='padding'>
-            <bem.FormView__label>
-              {metadata.country?.label ?? t('Countries')}
-            </bem.FormView__label>
-            {getCountryDisplayString(props.asset)}
-          </bem.FormView__cell>
-        </bem.FormView__group>
+            {/* countries */}
+            {metadata.country && (
+              <bem.FormView__cell m='padding'>
+                <bem.FormView__label>
+                  {metadata.country?.label ?? t('Countries')}
+                </bem.FormView__label>
+                {getCountryDisplayString(props.asset)}
+              </bem.FormView__cell>
+            )}
+          </bem.FormView__group>
+        )}
 
         {/* languages */}
         {props.asset.summary?.languages &&
@@ -150,29 +158,31 @@ export default function FormSummaryProjectInfo(
           )}
 
         {/* operational purpose and PII */}
-        {(props.asset.settings.operational_purpose ||
-          props.asset.settings.collects_pii) && (
-          <bem.FormView__group m='items'>
-            {props.asset.settings.operational_purpose && (
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label>
-                  {metadata.operational_purpose?.label ??
-                    t('Operational purpose of data')}
-                </bem.FormView__label>
-                {props.asset.settings.operational_purpose.label}
-              </bem.FormView__cell>
-            )}
-            {props.asset.settings.collects_pii && (
-              <bem.FormView__cell m='padding'>
-                <bem.FormView__label>
-                  {metadata.collects_pii?.label ??
-                    t('Collects personally identifiable information')}
-                </bem.FormView__label>
-                {props.asset.settings.collects_pii.label}
-              </bem.FormView__cell>
-            )}
-          </bem.FormView__group>
-        )}
+        {(metadata.operational_purpose || metadata.collects_pii) &&
+          (props.asset.settings.operational_purpose ||
+            props.asset.settings.collects_pii) && (
+            <bem.FormView__group m='items'>
+              {metadata.operational_purpose &&
+                props.asset.settings.operational_purpose && (
+                  <bem.FormView__cell m='padding'>
+                    <bem.FormView__label>
+                      {metadata.operational_purpose?.label ??
+                        t('Operational purpose of data')}
+                    </bem.FormView__label>
+                    {props.asset.settings.operational_purpose.label}
+                  </bem.FormView__cell>
+                )}
+              {metadata.collects_pii && props.asset.settings.collects_pii && (
+                <bem.FormView__cell m='padding'>
+                  <bem.FormView__label>
+                    {metadata.collects_pii?.label ??
+                      t('Collects personally identifiable information')}
+                  </bem.FormView__label>
+                  {props.asset.settings.collects_pii.label}
+                </bem.FormView__cell>
+              )}
+            </bem.FormView__group>
+          )}
       </bem.FormView__cell>
     </bem.FormView__row>
   );


### PR DESCRIPTION
## Description

Omit fields in form summary if omitted from project metadata config.
Show placeholders for fields that are included in project metadata, but missing from the asset.

## Details

Affected fields:

- Description
- Sector
- Country
- Operational purpose ('operational_purpose')
- Collects personally identifiable information ('collects_pii')

## Related issues

Follow-up on #4591

---

## Examples

### omit all `PROJECT_METADATA_FIELDS`

```json
[]
```

<img width="516" alt="empty-config" src="https://github.com/kobotoolbox/kpi/assets/3514715/b1147987-334c-4f20-b757-eca283912f4d">

### include all `PROJECT_METADATA_FIELDS`
```json
[
  { "name": "description",         "required": false },
  { "name": "sector",              "required": false },
  { "name": "country",             "required": false },
  { "name": "operational_purpose", "required": false },
  { "name": "collects_pii",        "required": false }
]
```

<img width="512" alt="all-fields" src="https://github.com/kobotoolbox/kpi/assets/3514715/dea2578c-d943-452d-a77e-f11e98171f78">


