### PR TITLE
Adds 'unsaved changes' state and navigation block when editing QA questions

### DIFF
--- a/jsapp/js/components/processing/analysis/analysis.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysis.component.tsx
@@ -23,6 +23,7 @@ import InlineMessage from 'js/components/common/inlineMessage';
 import type {SubmissionProcessingDataResponse} from './constants';
 import type {FailResponse} from 'js/dataInterface';
 import {handleApiFail} from 'js/utils';
+import {unstable_usePrompt as usePrompt} from 'react-router-dom';
 
 /**
  * Displays content of the "Analysis" tab. This component is handling all of
@@ -90,6 +91,11 @@ export default function Analysis() {
     }
     setupQuestions();
   }, []);
+
+  usePrompt({
+    when: state.changesDetected,
+    message: t('You have unsaved changes. Leave Analysis tab without saving?'),
+  });
 
   if (!isInitialised) {
     return <LoadingSpinner hideMessage />;

--- a/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
@@ -99,8 +99,13 @@ export default function AnalysisHeader() {
       />
 
       <span>
+        {!analysisQuestions.state.isPending &&
+          analysisQuestions.state.changesDetected &&
+          t('Unsaved changes')}
         {analysisQuestions.state.isPending && t('Saving…')}
-        {!analysisQuestions.state.isPending && t('Saved')}
+        {!analysisQuestions.state.changesDetected &&
+          !analysisQuestions.state.isPending &&
+          t('Saved')}
       </span>
     </header>
   );

--- a/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
@@ -81,4 +81,8 @@ export type AnalysisQuestionsAction =
   | {
       type: 'initialiseSearchCompleted';
       payload: {questions: AnalysisQuestionInternal[]};
+    }
+  // There exist changes in frontend that differes from backend.
+  | {
+      type: 'changesDetected';
     };

--- a/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
@@ -3,6 +3,7 @@ import TextBox from 'js/components/common/textBox';
 import AnalysisQuestionsContext from 'js/components/processing/analysis/analysisQuestions.context';
 import {AUTO_SAVE_TYPING_DELAY} from 'js/components/processing/analysis/constants';
 import {
+  changesDetected,
   findQuestion,
   getQuestionTypeDefinition,
   updateResponseAndReducer,
@@ -64,6 +65,7 @@ export default function IntegerResponseForm(props: IntegerResponseFormProps) {
   }
 
   function onInputChange(newResponse: string) {
+    changesDetected(analysisQuestions?.dispatch);
     setResponse(newResponse);
     saveResponseDelayedAndQuietly();
   }

--- a/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
@@ -2,6 +2,7 @@ import React, {useContext, useState} from 'react';
 import CommonHeader from './commonHeader.component';
 import AnalysisQuestionsContext from 'js/components/processing/analysis/analysisQuestions.context';
 import {
+  changesDetected,
   findQuestion,
   getQuestionTypeDefinition,
   updateResponseAndReducer,
@@ -53,6 +54,8 @@ export default function SelectMultipleResponseForm(
     const newResponse = items
       .filter((item) => item.checked)
       .map((item) => item.name);
+
+    changesDetected(analysisQuestions?.dispatch);
 
     // Update local state
     setResponse(newResponse);

--- a/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
@@ -3,6 +3,7 @@ import TextBox from 'js/components/common/textBox';
 import AnalysisQuestionsContext from 'js/components/processing/analysis/analysisQuestions.context';
 import {AUTO_SAVE_TYPING_DELAY} from 'js/components/processing/analysis/constants';
 import {
+  changesDetected,
   findQuestion,
   getQuestionTypeDefinition,
   updateResponseAndReducer,
@@ -64,6 +65,7 @@ export default function TextResponseForm(props: TextResponseFormProps) {
   }
 
   function onInputChange(newResponse: string) {
+    changesDetected(analysisQuestions?.dispatch);
     setResponse(newResponse);
     saveResponseDelayedAndQuietly();
   }

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -287,3 +287,13 @@ export async function updateResponseAndReducer(
     dispatch({type: 'updateResponseFailed'});
   }
 }
+
+export function changesDetected(
+  dispatch: React.Dispatch<AnalysisQuestionsAction> | undefined
+) {
+  if (!dispatch) {
+    return;
+  }
+
+  dispatch({type: 'changesDetected'});
+}


### PR DESCRIPTION
## Description
Basic navigation block and replaces 'Saved' with 'Unsaved changes' if there are changes not yet uploaded.

WIP for tags input.
<!-- Describe your work here. If users will notice your changes, be sure to write in user-friendly language. -->

## Related issues

Fixes #4584 