### PR TITLE
Fix wrong language (i.e. English) being picked instead of detected language in language selector

### DIFF
--- a/hub/middleware.py
+++ b/hub/middleware.py
@@ -1,5 +1,30 @@
-# coding: utf-8
+from django.conf import settings
+from django.middleware.locale import LocaleMiddleware as DjangoLocaleMiddleware
 from django.utils.deprecation import MiddlewareMixin
+
+
+class LocaleMiddleware(DjangoLocaleMiddleware):
+
+    def process_response(self, request, response):
+        response = super().process_response(request, response)
+        try:
+            request.COOKIES[settings.LANGUAGE_COOKIE_NAME]
+        except KeyError:
+            # If cookie does not exist, let's set it
+            # "Content-Language" attribute is set by `super()`
+            current_language = response['Content-Language']
+            response.set_cookie(
+                settings.LANGUAGE_COOKIE_NAME,
+                current_language,
+                max_age=settings.LANGUAGE_COOKIE_AGE,
+                path=settings.LANGUAGE_COOKIE_PATH,
+                domain=settings.LANGUAGE_COOKIE_DOMAIN,
+                secure=settings.LANGUAGE_COOKIE_SECURE,
+                httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
+                samesite=settings.LANGUAGE_COOKIE_SAMESITE,
+            )
+
+        return response
 
 
 class UsernameInResponseHeaderMiddleware(MiddlewareMixin):

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -60,6 +60,9 @@ ENKETO_CSRF_COOKIE_NAME = env.str('ENKETO_CSRF_COOKIE_NAME', '__csrf')
 # Limit sessions to 1 week (the default is 2 weeks)
 SESSION_COOKIE_AGE = env.int('DJANGO_SESSION_COOKIE_AGE', 604800)
 
+# Set language cookie age to same value as session cookie
+LANGUAGE_COOKIE_AGE = SESSION_COOKIE_AGE
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DJANGO_DEBUG", False)
 
@@ -130,7 +133,7 @@ MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    'hub.middleware.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
## Description

Always save detected language to Django language cookie when it does not exist already to avoid falling back on English

## Notes

Overload Django `LocaleMiddleware` to use the detected language by the middleware to set the cookie language when it is not present. It lets the front end load the correct value and set it when rendering the language dropdown menu. 
Moreover, it will update `extra_details.last_ui_language` with correct value to get more accurate statistics.

## Related issues

Fixes #2313 

