### PR TITLE
Align language selector dropdown with form beneath it

### DIFF
--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -404,11 +404,18 @@
     }
 
     form.registration--register,
-    form.registration--complete,
-    form.language-switcher {
+    form.registration--complete {
       width: 80%;
       max-width: 860px;
     }
+
+    form.language-switcher {
+      max-width: 400px;
+      &[data-path="/accounts/signup/"] {
+        max-width: 860px;
+      }
+    }
+
 
     form.registration--register {
       padding: 30px;

--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -411,11 +411,11 @@
 
     form.language-switcher {
       max-width: 400px;
+
       &[data-path="/accounts/signup/"] {
         max-width: 860px;
       }
     }
-
 
     form.registration--register {
       padding: 30px;

--- a/kobo/apps/accounts/templates/account/base.html
+++ b/kobo/apps/accounts/templates/account/base.html
@@ -26,7 +26,7 @@
 {% block language_selector %}
 {% load i18n %}
 {# This is the language switcher dropdown #}
-<form action="{% url 'set_language' %}" method="post" class="language-switcher">
+<form action="{% url 'set_language' %}" method="post" class="language-switcher" data-path="{{ request.path }}">
   {% csrf_token %}
 
   <input name="next" type="hidden" value="{{ redirect_to }}" />


### PR DESCRIPTION
## Notes

Always set the `max-width to 400px` but make an exception (`max-width: 860px` ) when media-query is above 768px for signup template.
