### PR TITLE
Add 'options' property to schema for choices in qualitative analysis select multiple questions

### DIFF
--- a/kobo/apps/subsequences/advanced_features_params_schema.py
+++ b/kobo/apps/subsequences/advanced_features_params_schema.py
@@ -87,6 +87,7 @@ ADVANCED_FEATURES_PARAMS_SCHEMA['$defs'] = {
         'properties': {
             'labels': {'$ref': '#/$defs/qualLabels'},
             'uuid': {'$ref': '#/$defs/qualUuid'},
+            'options': {'type': 'object'},
         },
         'required': ['labels', 'uuid'],
     },


### PR DESCRIPTION
## Description

Qualitative analysis questions already had an `options` property, but choices did not. This modifies the schema to allow `options` for both. We'll use `options` to store a deletion marker instead of purging questions and choices from the database when they are deleted in the UI.

## Notes

The `options` object is not currently validated by the back end's schema. However, I'd suggest using `"options": {"deleted": true}` as the deletion flag for both questions and choices. Full example:
```json
{
  "advanced_features": {
    "qual": {
      "qual_survey": [
        {
          "uuid": "73fae086-1249-4f97-a7eb-e0d3456c0015",
          "type": "qual_select_multiple",
          "labels": {
            "_default": "this is a select multiple question label"
          },
          "choices": [
            {
              "uuid": "260488e0-0dc7-4faa-85fb-bc1806c0d74e",
              "labels": {
                "_default": "this is a select multiple choice label 1"
              }
            },
            {
              "uuid": "953a8b6d-4b63-4bb1-be05-d25a2dbbd1d0",
              "labels": {
                "_default": "this is a select multiple deleted choice label"
              },
              "options": {
                "deleted": true
              }
            }
          ],
          "scope": "by_question#survey",
          "qpath": "source_question_path"
        },
        {
          "uuid": "507dc90d-2b66-4433-aa03-7a5bb28a1580",
          "type": "qual_text",
          "labels": {
            "_default": "this is a deleted text question label"
          },
          "scope": "by_question#survey",
          "qpath": "source_question_path",
          "options": {
            "deleted": true
          }
        }
      ]
    }
  }
}
```

## Related issues

Fixes #4625