### PR TITLE
Use deleted flag for removing analysis questions

### DIFF
--- a/jsapp/js/components/processing/analysis/analysis.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysis.component.tsx
@@ -98,7 +98,6 @@ export default function Analysis() {
     singleProcessingStore.setAnalysisTabHasUnsavedChanges(state.hasUnsavedWork);
   }, [state.hasUnsavedWork]);
 
-
   if (!isInitialised) {
     return <LoadingSpinner hideMessage />;
   }

--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -85,12 +85,15 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
       return {
         ...state,
         isPending: true,
-        // Here we immediately remove the question from the list and wait for
-        // a successful API call that will return new questions list (without
-        // the deleted question).
-        questions: state.questions.filter(
-          (question) => question.uuid !== action.payload.uuid
-        ),
+        // Here we immediately mark the question as `deleted` and wait for
+        // a successful API call that will return new questions list (to ensure
+        // the deletion went as expected).
+        questions: state.questions.map((question) => {
+          if (question.uuid === action.payload.uuid) {
+            question.deleted = true;
+          }
+          return question;
+        }),
       };
     }
     case 'deleteQuestionCompleted': {

--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -97,7 +97,10 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
         // the deletion went as expected).
         questions: state.questions.map((question) => {
           if (question.uuid === action.payload.uuid) {
-            question.deleted = true;
+            if (typeof question.options !== 'object') {
+              question.options = {};
+            }
+            question.options.deleted = true;
           }
           return question;
         }),

--- a/jsapp/js/components/processing/analysis/constants.ts
+++ b/jsapp/js/components/processing/analysis/constants.ts
@@ -21,9 +21,24 @@ interface AnalysisLabels {
   [langCode: string]: string;
 }
 
+/**
+ * Options object used by questions and choices. We mainly use it for marking
+ * things as deleted.
+ */
+interface AnalysisQuestionOptions {
+  /**
+   * We mark questions as deleted instead of removing them, because we still
+   * need them to understand the data (e.g. we store `qual_select_one` responses
+   * as `uuid`s of given choice, so without the question definition, there is no
+   * way to understand what was selected).
+   */
+  deleted?: boolean;
+}
+
 interface AnalysisQuestionChoice {
   labels: AnalysisLabels;
   uuid: string;
+  options?: AnalysisQuestionOptions;
 }
 
 /**
@@ -51,13 +66,7 @@ export interface AnalysisQuestionBase {
   type: AnalysisQuestionType;
   labels: AnalysisLabels;
   uuid: string;
-  /**
-   * We mark questions as deleted instead of removing them, because we still
-   * need them to understand the data (e.g. we store `qual_select_one` responses
-   * as `uuid`s of given choice, so without the question definition, there is no
-   * way to understand what was selected).
-   */
-  deleted?: boolean;
+  options?: AnalysisQuestionOptions;
 }
 
 /** Analysis question definition from the asset's schema (i.e. from Back end) */

--- a/jsapp/js/components/processing/analysis/constants.ts
+++ b/jsapp/js/components/processing/analysis/constants.ts
@@ -51,6 +51,13 @@ export interface AnalysisQuestionBase {
   type: AnalysisQuestionType;
   labels: AnalysisLabels;
   uuid: string;
+  /**
+   * We mark questions as deleted instead of removing them, because we still
+   * need them to understand the data (e.g. we store `qual_select_one` responses
+   * as `uuid`s of given choice, so without the question definition, there is no
+   * way to understand what was selected).
+   */
+  deleted?: boolean;
 }
 
 /** Analysis question definition from the asset's schema (i.e. from Back end) */

--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -52,9 +52,12 @@ export default function AnalysisQuestionEditor(
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [additionalFieldsErrorMessage, setAdditionalFieldsErrorMessage] =
     useState<string | undefined>();
+  // We need to clone `additionalFields` here to avoid mutating it
   const [additionalFields, setAdditionalFields] = useState<
     AdditionalFields | undefined
-  >(question.additionalFields ? question.additionalFields : undefined);
+  >(
+    question.additionalFields ? clonedeep(question.additionalFields) : undefined
+  );
 
   function onTextBoxChange(newLabel: string) {
     setLabel(newLabel);
@@ -162,7 +165,7 @@ export default function AnalysisQuestionEditor(
       <header className={styles.header}>
         <form className={styles.headerForm} onSubmit={onSubmit}>
           <div className={commonStyles.headerIcon}>
-          <Icon name={qaDefinition.icon} size='xl' />
+            <Icon name={qaDefinition.icon} size='xl' />
           </div>
 
           <TextBox
@@ -199,7 +202,7 @@ export default function AnalysisQuestionEditor(
         <section className={commonStyles.content}>
           {question.type === 'qual_auto_keyword_count' && (
             <KeywordSearchFieldsEditor
-              uuid={question.uuid}
+              questionUuid={question.uuid}
               fields={additionalFields || {source: '', keywords: []}}
               onFieldsChange={onAdditionalFieldsChange}
             />
@@ -208,7 +211,7 @@ export default function AnalysisQuestionEditor(
           {(question.type === 'qual_select_one' ||
             question.type === 'qual_select_multiple') && (
             <SelectXFieldsEditor
-              uuid={question.uuid}
+              questionUuid={question.uuid}
               fields={additionalFields || {choices: []}}
               onFieldsChange={onAdditionalFieldsChange}
             />

--- a/jsapp/js/components/processing/analysis/editors/keywordSearchFieldsEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/keywordSearchFieldsEditor.component.tsx
@@ -9,7 +9,7 @@ import type {LanguageCode} from 'js/components/languages/languagesStore';
 import AnalysisQuestionsContext from 'js/components/processing/analysis/analysisQuestions.context';
 
 interface KeywordSearchFieldsEditorProps {
-  uuid: string;
+  questionUuid: string;
   fields: AdditionalFields;
   onFieldsChange: (fields: AdditionalFields) => void;
 }

--- a/jsapp/js/components/processing/analysis/editors/selectXFieldsEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/selectXFieldsEditor.component.tsx
@@ -87,6 +87,7 @@ export default function SelectXFieldsEditor(props: SelectXFieldsEditorProps) {
     }
   }
 
+  // We hide questions marked as deleted
   const choicesToDisplay =
     props.fields.choices?.filter((item) => {
       if (item.options?.deleted) {

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
@@ -36,6 +36,11 @@ export default function AnalysisQuestionsList() {
             return null;
           }
 
+          // We hide questions marked as deleted
+          if (question.deleted) {
+            return null;
+          }
+
           return (
             <AnalysisQuestionRow
               uuid={question.uuid}

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
@@ -37,7 +37,7 @@ export default function AnalysisQuestionsList() {
           }
 
           // We hide questions marked as deleted
-          if (question.deleted) {
+          if (question.options?.deleted) {
             return null;
           }
 

--- a/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
@@ -70,7 +70,10 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
     // Step 2: set `deleted` flag on the question
     newQuestions.forEach((item: AnalysisQuestionInternal) => {
       if (item.uuid === props.uuid) {
-        item.deleted = true;
+        if (typeof item.options !== 'object') {
+          item.options = {};
+        }
+        item.options.deleted = true;
       }
     });
 

--- a/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useContext} from 'react';
+import clonedeep from 'lodash.clonedeep';
 import Icon from 'js/components/common/icon';
 import Button from 'js/components/common/button';
 import commonStyles from './common.module.scss';
@@ -62,21 +63,26 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
 
     setIsDeletePromptOpen(false);
 
-    // Step 1: get current questions list, and remove question from it
-    const updatedQuestions: AnalysisQuestionInternal[] =
-      analysisQuestions?.state.questions.filter(
-        (item) => item.uuid !== props.uuid
-      ) || [];
+    // Step 1: ensure no mutations happen
+    const newQuestions: AnalysisQuestionInternal[] =
+      clonedeep(analysisQuestions?.state.questions) || [];
+
+    // Step 2: set `deleted` flag on the question
+    newQuestions.forEach((item: AnalysisQuestionInternal) => {
+      if (item.uuid === props.uuid) {
+        item.deleted = true;
+      }
+    });
 
     try {
-      // Step 2: update asset endpoint with new questions
+      // Step 3: update asset endpoint with new questions
       const response = await updateSurveyQuestions(
         singleProcessingStore.currentAssetUid,
         singleProcessingStore.currentQuestionQpath,
-        updatedQuestions
+        newQuestions
       );
 
-      // Step 3: update reducer's state with new list after the call finishes
+      // Step 4: update reducer's state with new list after the call finishes
       analysisQuestions?.dispatch({
         type: 'deleteQuestionCompleted',
         payload: {

--- a/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
@@ -70,13 +70,24 @@ export default function SelectMultipleResponseForm(
 
   function getCheckboxes(): MultiCheckboxItem[] {
     if (question?.additionalFields?.choices) {
-      return question?.additionalFields?.choices.map((choice) => {
-        return {
-          name: choice.uuid,
-          label: choice.labels._default,
-          checked: response.includes(choice.uuid),
-        };
-      });
+      return (
+        question?.additionalFields?.choices
+          // We hide all choices flaged as deleted.
+          .filter((item) => {
+            if (item.options?.deleted) {
+              return false;
+            }
+            return true;
+          })
+          // And then we produce checkbox object of each choice left.
+          .map((choice) => {
+            return {
+              name: choice.uuid,
+              label: choice.labels._default,
+              checked: response.includes(choice.uuid),
+            };
+          })
+      );
     }
     return [];
   }

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -66,6 +66,7 @@ export function convertQuestionsFromInternalToSchema(
       uuid: question.uuid,
       type: question.type,
       labels: question.labels,
+      options: question.options,
       choices: question.additionalFields?.choices,
       scope: 'by_question#survey',
       qpath: qpath,
@@ -86,6 +87,7 @@ export function convertQuestionsFromSchemaToInternal(
       uuid: question.uuid,
       type: question.type,
       labels: question.labels,
+      options: question.options,
       response: '',
     };
     if (question.choices) {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Front-end code now uses a `deleted` flag as a non-destructive way of removing analysis questions and choices.

## Notes

This contains only Front-end changes, Back-end changes are already there.

We need this `deleted` flag to keep the question and choices labels for deciphering the stored data. We store `uuid`s of question and choices, and we need the definitions to still be there to link the `uuid`s with the labels.

## Related issues

Closes #4626 