### PR TITLE
Fixes annual price showing as a large monthly amount

### DIFF
--- a/jsapp/js/account/plan.component.tsx
+++ b/jsapp/js/account/plan.component.tsx
@@ -510,9 +510,12 @@ export default function Plan() {
                     <div className={styles.priceTitle}>
                       {!price.prices?.unit_amount
                         ? t('Free')
+                        : price.prices?.recurring?.interval === 'year'
+                        ? `$${(price.prices?.unit_amount / 100 / 12).toFixed(
+                            2
+                          )} USD/month`
                         : price.prices.human_readable_price}
                     </div>
-
                     <ul className={styles.featureContainer}>
                       {Object.keys(price.metadata).map(
                         (featureItem: string) =>


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
This fixes the current state of the annual toggle on the plans page which has a high monthly rate when it should show a cheaper monthly amount. By users subscribing to an annual plan they get a cheaper monthly rate compared to subscribing to a monthly plan. 
