### PR TITLE
Account for null XForm instances in service_usage endpoint

### DIFF
--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -604,6 +604,7 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
 class ReadOnlyKobocatDailyXFormSubmissionCounter(ReadOnlyModel):
 
     date = models.DateField()
+    user = models.ForeignKey(KobocatUser, null=True, on_delete=models.CASCADE)
     xform = models.ForeignKey(
         KobocatXForm, related_name='daily_counts', on_delete=models.CASCADE
     )
@@ -611,7 +612,7 @@ class ReadOnlyKobocatDailyXFormSubmissionCounter(ReadOnlyModel):
 
     class Meta(ReadOnlyModel.Meta):
         db_table = 'logger_dailyxformsubmissioncounter'
-        unique_together = ('date', 'xform')
+        unique_together = ('date', 'xform', 'user')
 
 
 class ReadOnlyKobocatInstance(ReadOnlyModel):

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -606,13 +606,13 @@ class ReadOnlyKobocatDailyXFormSubmissionCounter(ReadOnlyModel):
     date = models.DateField()
     user = models.ForeignKey(KobocatUser, null=True, on_delete=models.CASCADE)
     xform = models.ForeignKey(
-        KobocatXForm, related_name='daily_counts', on_delete=models.CASCADE
+        KobocatXForm, related_name='daily_counts', null=True, on_delete=models.CASCADE
     )
     counter = models.IntegerField(default=0)
 
     class Meta(ReadOnlyModel.Meta):
         db_table = 'logger_dailyxformsubmissioncounter'
-        unique_together = ('date', 'xform', 'user')
+        unique_together = [['date', 'xform', 'user'], ['date', 'user']]
 
 
 class ReadOnlyKobocatInstance(ReadOnlyModel):

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -141,7 +141,7 @@ class ServiceUsageSerializer(serializers.Serializer):
 
         # Only use fields we need to improve SQL query speed
         user_assets = (
-            Asset.objects.only(
+            Asset.all_objects.only(
                 'pk',
                 'uid',
                 '_deployment_data',

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -155,10 +155,10 @@ class ServiceUsageSerializer(serializers.Serializer):
                 asset_type=ASSET_TYPE_SURVEY,
                 # Make sure we're only getting assets that are deployed
                 _deployment_data__has_key='backend',
-            ).values('uid')
+            )
         )
 
-        asset_list = [asset['uid'] for asset in user_assets]
+        asset_list = [asset.uid for asset in user_assets]
 
         xforms = KobocatXForm.objects.only('bytes_sum', 'id', 'kpi_asset_uid').filter(
             kpi_asset_uid__in=asset_list,

--- a/kpi/tests/api/v2/test_api_asset_usage.py
+++ b/kpi/tests/api/v2/test_api_asset_usage.py
@@ -197,6 +197,6 @@ class AssetUsageAPITestCase(BaseAssetTestCase):
             asset_type='survey',
         )
         self.client.login(username='anotheruser', password='anotheruser')
-        url = reverse(self._get_endpoint('service-usage-list'))
+        url = reverse(self._get_endpoint('asset-usage-list'))
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix `/api/v2/service_usage/` calculating NLP and submission counts incorrectly.

## Notes

Deleting a form with submissions currently causes the submission counter to decrement. The endpoint previously did handle this correctly, but it was refactored as part of `feature/usage-limits`, which introduced this regression. See [kobocat#895](kpi/deployment_backends/kc_access/shadow_models.py) for additional background.

## Related issues

### Depends on kobotoolbox/kobocat#895

See [issue](https://github.com/orgs/kobotoolbox/projects/60/views/1?pane=issue&itemId=38370697) on Release 2.023.37 QA board.
