### PR TITLE
Use NLPUsageCounter date field to fix User Statistics report

### DIFF
--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -500,12 +500,9 @@ def generate_user_statistics_report(
 
     # get NLP statistics
     nlp_counters = (
-        NLPUsageCounter.objects.annotate(
-            date=Cast(
-                Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
-                DateField(),
-            ),
-        ).filter(date__range=(start_date, end_date)).values(
+        NLPUsageCounter.objects.filter(
+            date__range=(start_date, end_date)
+        ).values(
             'user_id',
         ).annotate(
             total_google_asr=Sum(


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Fix the  superusers `User statistics` report

## Notes
Adding the date field to the NLPUsageCounter broke the report, this PR fixes it :)
