### PR TITLE
Replace `curl | bash` with nodesource Debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,13 @@ RUN mkdir -p "${NGINX_STATIC_DIR}" && \
 # jnm (or the current on-call sysadmin). Thanks.
 
 RUN apt-get -qq update && \
-    apt-get -qq -y install curl && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get -qq -y install ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" \
+        | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get -qq update && \
     apt-get -qq -y install --no-install-recommends \
         ffmpeg \
         gdal-bin \
@@ -67,7 +72,7 @@ RUN apt-get -qq update && \
         less \
         libproj-dev \
         locales \
-        nodejs=$(apt-cache show nodejs | grep 'Version: .*nodesource' | cut -f 2 -d ' ') \
+        nodejs=$(apt-cache show nodejs | grep -F 'Version: 16.15.0' | cut -f 2 -d ' ') \
         postgresql-client \
         procps \
         rsync \


### PR DESCRIPTION
## Description

Removes a 60-second delay caused by Nodesource's deprecation of their `curl | bash` installation method.

## Related issues

Fixes #4643