### PR TITLE
Fix modal header close button color

### DIFF
--- a/jsapp/js/components/common/modal.es6
+++ b/jsapp/js/components/common/modal.es6
@@ -3,6 +3,7 @@ import autoBind from 'react-autobind';
 import {KEY_CODES} from 'js/constants';
 import bem from 'js/bem';
 import classNames from 'classnames';
+import Button from 'js/components/common/button';
 import './modal.scss';
 
 /**
@@ -64,9 +65,13 @@ export default class Modal extends React.Component {
   renderClose() {
     if (this.props.isDuplicated) {
       return(
-        <a className='modal__done' type='button' onClick={this.props.onClose}>
-          {t('DONE')}
-        </a>
+        <Button
+          type='bare'
+          color='blue'
+          size='l'
+          label={t('DONE')}
+          onClick={this.props.onClose}
+        />
       );
     } else {
       return(

--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -120,7 +120,7 @@ $z-modal-x: 10;
 
 .modal__x {
   z-index: $z-modal-x;
-  color: colors.$kobo-gray-55;
+  color: colors.$kobo-white;
   background-color: inherit;
   padding: 8px;
   margin: 11px 15px 11px 11px;
@@ -134,15 +134,14 @@ $z-modal-x: 10;
   }
 
   &:hover {opacity: 0.7;}
-}
 
-.modal__done {
-  @extend .modal__x;
-  padding: 24px;
-  margin: 0px;
-  font-size: 18px;
-  font-weight: 600;
-  color: colors.$kobo-blue;
+  // Some modals have light background for the header, so we need some other
+  // color than white
+  .modal-submission &,
+  .modal--media-preview &,
+  .modal--mfa-setup & {
+    color: colors.$kobo-gray-55;
+  }
 }
 
 // NOTE: Subheader element is weirdly positioned because it is inside a padded


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Tiny and quick UI improvement. To simplify styles I also used the `<Button>` component instead of that one shot `modal__done` that was extending `modal__x`. Both `bigModal.es6` and `modal.es6` are deprecated, so no need to fix this further.
