### PR TITLE
Add check that `SOCIALACCOUNT_PROVIDERS` don't use kobo as ID

### DIFF
--- a/kobo/apps/accounts/apps.py
+++ b/kobo/apps/accounts/apps.py
@@ -1,4 +1,6 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.checks import Error, register
 
 
 # Config to set custom name for app in django admin UI
@@ -6,3 +8,29 @@ from django.apps import AppConfig
 class AccountExtrasConfig(AppConfig):
     name = "kobo.apps.accounts"
     verbose_name = "Account Extras"
+
+
+@register()
+def check_socialaccount_providers(app_configs, **kwargs):
+    """
+    Don't allow `kobo` to be set as the `id` value in `SOCIALACCOUNT_PROVIDERS` 
+    settings because it breaks the login page redirect when language is changed.
+    """
+    errors = []
+    social_app_ids = [
+        apps['id']
+        for apps in settings.SOCIALACCOUNT_PROVIDERS['openid_connect'][
+            'SERVERS'
+        ]
+    ]
+    if 'kobo' in social_app_ids:
+        errors.append(
+            Error(
+                f'Please do not use `kobo` as the `id` value in '
+                '`SOCIALACCOUNT_PROVIDERS` settings.',
+                hint='`kobo` is not a valid value for this setting.',
+                obj=settings,
+                id='kobo.apps.accounts.E001',
+            )
+        )
+    return errors


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes
Using `kobo` as the social app provider ID causes a conflicting view named `kobo-login` to be created which causes issues with translation, account login and SSO.
xref: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Language.20selector.20redirects.20to.20SSO.20Login/near/275179