### PR TITLE
Usage limits release fixes

### DIFF
--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -127,11 +127,13 @@ export async function getAccountLimits() {
     ACTIVE_STRIPE_STATUSES.includes(subscription.status)
   );
   let metadata;
+  let hasFreeTier = false;
   if (activeSubscriptions.length) {
-    // get limit data from the user's subscription
+    // get metadata from the user's subscription
     metadata = activeSubscriptions[0].items[0].price.product.metadata;
   } else {
     // the user has no subscription, so get limits from the free monthly price
+    hasFreeTier = true;
     try {
       const products = await getProducts();
       const freeProduct = products.results.filter((product) =>
@@ -157,27 +159,22 @@ export async function getAccountLimits() {
     storage_bytes_limit: 'unlimited',
   };
 
-  // overwrite unlimited with whatever free tier limits exist
-  await when(() => envStore.isReady);
-  const thresholds = envStore.data.free_tier_thresholds;
-  thresholds.storage
-    ? (limits['storage_bytes_limit'] = thresholds.storage)
-    : null;
-  thresholds.data ? (limits['submission_limit'] = thresholds.data) : null;
-  thresholds.translation_chars
-    ? (limits['nlp_character_limit'] = thresholds.translation_chars)
-    : null;
-  thresholds.transcription_minutes
-    ? (limits['nlp_seconds_limit'] = thresholds.transcription_minutes * 60)
-    : null;
-
-
-  // give the final say to any limits from the user's subscription
+  // get the limits from the metadata
   for (const [key, value] of Object.entries(metadata)) {
     if (Object.keys(limits).includes(key)) {
       limits[key as keyof AccountLimit] =
         value === 'unlimited' ? value : parseInt(value);
     }
+  }
+
+  // if the user is on the free tier, overwrite their limits with whatever free tier limits exist
+  if (hasFreeTier) {
+    await when(() => envStore.isReady);
+    const thresholds = envStore.data.free_tier_thresholds;
+    thresholds.storage && (limits['storage_bytes_limit'] = thresholds.storage);
+    thresholds.data && (limits['submission_limit'] = thresholds.data);
+    thresholds.translation_chars && (limits['nlp_character_limit'] = thresholds.translation_chars);
+    thresholds.transcription_minutes && (limits['nlp_seconds_limit'] = thresholds.transcription_minutes * 60);
   }
 
   return limits;

--- a/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
@@ -22,13 +22,13 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
   return (
     <div
       className={cx(styles.limitBannerContainer, {
-        [styles.warningBanner]: /* props.warning */ true, // red is too scary for now
+        [styles.warningBanner]: props.warning,
       })}
     >
       <Icon
-        name={props.warning ? 'alert' : 'warning'} // less scary icon for now
+        name={props.warning ? 'alert' : 'warning'}
         size='m'
-        color={props.warning ? 'amber' : 'red'} // less scary color for now
+        color={props.warning ? 'amber' : 'red'}
       />
       <div className={styles.bannerContent}>
         {props.warning
@@ -111,7 +111,6 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
       {(!props.warning || props.usagePage) && (
         <Button
           type={'frame'}
-          /* color={'dark-red'} Perhaps should change permanently? */
           color={'dark-blue'}
           endIcon='arrow-right'
           size='s'

--- a/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
@@ -20,16 +20,8 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
   }
 
   return (
-    <div
-      className={cx(styles.limitBannerContainer, {
-        [styles.warningBanner]: props.warning,
-      })}
-    >
-      <Icon
-        name={props.warning ? 'alert' : 'warning'}
-        size='m'
-        color={props.warning ? 'amber' : 'red'}
-      />
+    <div className={cx(styles.limitBannerContainer, styles.warningBanner)}>
+      <Icon name={'alert'} size='m' color={'amber'} />
       <div className={styles.bannerContent}>
         {props.warning
           ? t('You are approaching your')

--- a/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
@@ -19,9 +19,6 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
     return null;
   }
 
-  // disable all banners for now
-  return <></>;
-
   return (
     <div
       className={cx(styles.limitBannerContainer, {

--- a/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitBanner.component.tsx
@@ -26,9 +26,9 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
       })}
     >
       <Icon
-        name={props.warning || true ? 'alert' : 'warning'} // less scary icon for now
+        name={props.warning ? 'alert' : 'warning'} // less scary icon for now
         size='m'
-        color={props.warning || true ? 'amber' : 'red'} // less scary color for now
+        color={props.warning ? 'amber' : 'red'} // less scary color for now
       />
       <div className={styles.bannerContent}>
         {props.warning
@@ -71,9 +71,14 @@ const OverLimitBanner = (props: OverLimitBannerProps) => {
           <>
             <a href={`#${ACCOUNT_ROUTES.PLAN}`} className={styles.bannerLink}>
               {t('upgrade your plan')}
-            </a>{' as soon as possible or ' /* tone down the language for now */}
-            <a href="https://www.kobotoolbox.org/contact/" target="_blank" className={styles.bannerLink}>
-            {'contact us'}
+            </a>
+            {' as soon as possible or ' /* tone down the language for now */}
+            <a
+              href='https://www.kobotoolbox.org/contact/'
+              target='_blank'
+              className={styles.bannerLink}
+            >
+              {'contact us'}
             </a>
             {' to speak with our team'}
             {!props.usagePage && (

--- a/jsapp/js/components/usageLimits/overLimitModal.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitModal.component.tsx
@@ -81,7 +81,9 @@ function OverLimitModal(props: OverLimitModalProps) {
               </a>
               {'.'}
             </div>
-            <p className={cx(limitBannerContainer, styles.consequences)}>
+            {
+              // removed to make the message less scary
+              /* <p className={cx(limitBannerContainer, styles.consequences)}>
               <Icon
                 name='warning'
                 size='m'
@@ -93,7 +95,8 @@ function OverLimitModal(props: OverLimitModalProps) {
                   'Users who have exceeded their submission or storage limits may be temporarily blocked from collecting data. Repeatedly exceeding usage limits may result in account suspension.'
                 )}
               </span>
-            </p>
+            </p> */
+            }
           </div>
         </KoboModalContent>
 

--- a/jsapp/js/components/usageLimits/overLimitModal.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitModal.component.tsx
@@ -38,9 +38,6 @@ function OverLimitModal(props: OverLimitModalProps) {
     setShow(props.show);
   }, [props.show]);
 
-  // disable modal entirely for now
-  return <></>;
-
   return (
     <div>
       <KoboModal isOpen={show} onRequestClose={toggleModal} size='medium'>

--- a/jsapp/js/components/usageLimits/overLimitModal.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitModal.component.tsx
@@ -68,8 +68,12 @@ function OverLimitModal(props: OverLimitModalProps) {
                 {t('upgrade your plan')}
               </a>{' '}
               {'as soon as possible or ' /* tone down the language for now */}
-              <a href="https://www.kobotoolbox.org/contact/" target="_blank" className={styles.link}>
-              {'contact us'}
+              <a
+                href='https://www.kobotoolbox.org/contact/'
+                target='_blank'
+                className={styles.link}
+              >
+                {'contact us'}
               </a>
               {' to speak with our team. You can '}
               <a href={`#${ACCOUNT_ROUTES.USAGE}`} className={styles.link}>
@@ -77,7 +81,6 @@ function OverLimitModal(props: OverLimitModalProps) {
               </a>
               {'.'}
             </div>
-            {/* remove consequences for now; too scary
             <p className={cx(limitBannerContainer, styles.consequences)}>
               <Icon
                 name='warning'
@@ -91,7 +94,6 @@ function OverLimitModal(props: OverLimitModalProps) {
                 )}
               </span>
             </p>
-            */}
           </div>
         </KoboModalContent>
 

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -1,6 +1,6 @@
-import {useState, useMemo, useReducer, useContext} from 'react';
+import {useState, useReducer, useContext, useEffect} from 'react';
 import type {BaseSubscription, BasePrice} from '../../account/stripe.api';
-import {getProducts} from '../../account/stripe.api';
+import {getAccountLimits, getProducts} from '../../account/stripe.api';
 import type {FreeTierThresholds} from 'js/envStore';
 import envStore from 'js/envStore';
 import {USAGE_WARNING_RATIO} from 'js/constants';
@@ -40,91 +40,32 @@ export const useExceedingLimits = () => {
   const [subscribedTranslationChars, setTranslationChars] = useState<
     number | string
   >();
+  const [areLimitsLoaded, setAreLimitsLoaded] = useState(false);
 
   // Get products and get default limits for community plan
   useWhenStripeIsEnabled(() => {
-    getProducts().then((products) => {
-      const freeProduct = products.results.find((products) =>
-        products.prices.find(
-          (price: BasePrice) =>
-            price.unit_amount === 0 && price.recurring?.interval === 'month'
-        )
-      );
-      setSubscribedSubmissionLimit(
-        Number(freeProduct?.metadata.submission_limit)
-      );
-      setSubscribedStorageLimit(
-        Number(freeProduct?.metadata.storage_bytes_limit)
-      );
-      setTranscriptionMinutes(Number(freeProduct?.metadata.nlp_seconds_limit));
-      setTranslationChars(Number(freeProduct?.metadata.nlp_character_limit));
-
-      type FreeTierThresholdsArray = [keyof FreeTierThresholds, number | null];
-      // Check Thresholds
-      const thresholds = envStore.data.free_tier_thresholds;
-      const thresholdsArray = Object.entries(
-        thresholds
-      ) as FreeTierThresholdsArray[];
-      thresholdsArray.forEach(([key, value]) => {
-        if (value && value > 0) {
-          setLimitThresholds(key, value);
-        }
-        if (value && value <= 0) {
-          setLimitThresholds(key, 'unlimited');
-        }
-      });
+    getAccountLimits().then((limits) => {
+      setSubscribedSubmissionLimit(limits.submission_limit);
+      setSubscribedStorageLimit(limits.storage_bytes_limit);
+      setTranscriptionMinutes(Number(limits.nlp_seconds_limit));
+      setTranslationChars(Number(limits.nlp_character_limit));
+      setAreLimitsLoaded(true);
     });
   }, []);
 
   // Get subscription data
-  useWhenStripeIsEnabled(() => {
-    return when(
-      () => subscriptionStore.isInitialised,
-      () => {
-        dispatch({
-          prodData: subscriptionStore.subscriptionResponse,
-        });
-      }
-    );
-  }, []);
-
-  function setLimitThresholds(
-    limitName: keyof FreeTierThresholds,
-    limitValue: string | number
-  ) {
-    const limitMap = {
-      storage: 'storage_bytes_limit',
-      data: 'submission_limit',
-      translation_chars: 'nlp_character_limit',
-      transcription_minutes: 'nlp_seconds_limit',
-    };
-    let limit = limitValue;
-    // If user is subscribed to a plan assign limit for that plan
-    if (limit === '') {
-      const metadataKey = limitMap[limitName];
-      limit =
-        state.subscribedProduct?.[0].items[0].price.product.metadata[
-          metadataKey
-        ];
-    }
-
-    switch (limitName) {
-      case 'storage':
-        setSubscribedStorageLimit(limit);
-        break;
-      case 'data':
-        setSubscribedSubmissionLimit(limit);
-        break;
-      case 'translation_chars':
-        setTranslationChars(limit);
-        break;
-      case 'transcription_minutes':
-        setTranscriptionMinutes(limit);
-        break;
-      default:
-        break;
-    }
-  }
+  useWhenStripeIsEnabled(
+    () =>
+      when(
+        () => subscriptionStore.isInitialised,
+        () => {
+          dispatch({
+            prodData: subscriptionStore.subscriptionResponse,
+          });
+        }
+      ),
+    []
+  );
 
   function isOverLimit(
     subscribedLimit: number | string | undefined,
@@ -145,7 +86,10 @@ export const useExceedingLimits = () => {
   }
 
   // Check if usage is more than limit
-  useMemo(() => {
+  useEffect(() => {
+    if (!usage.isLoaded || !areLimitsLoaded) {
+      return;
+    }
     isOverLimit(subscribedStorageLimit, usage.storage, 'storage');
     isOverLimit(subscribedSubmissionLimit, usage.submissions, 'submission');
     isOverLimit(
@@ -158,7 +102,7 @@ export const useExceedingLimits = () => {
       usage.translationChars,
       'machine translation'
     );
-  }, [usage]);
+  }, [usage.isLoaded, areLimitsLoaded]);
 
   return {exceedList, warningList};
 };


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes a bug where users on the Professional plan were showing usage limits from the Legacy plan.

## Notes

1. Refactors `getAccountLimits()` so `FREE_TIER_THRESHOLDS` only applies to users without a plan
1. Fixes `FREE_TIER_THRESHOLDS` not being applied to eligible users (see [here](https://github.com/kobotoolbox/kpi/commit/0825305c39d661c025de64d8992b6b96aa4473e8))
1. Changes `response.results[0]?.plan?.product` to `response.results[0]?.items[0]?.price?.product` in `onFetchSubscriptionInfoDone()`
1. Removes [stopgap](https://github.com/kobotoolbox/kpi/commit/32505586c4aa016e81a0a48b11e4d1fe1a6167e2) that prevents warnings/modals from showing
1. Prevent usage banners/modals displaying when they shouldn't by refactoring `useExceedingLimits` to use `getAccountLimits()`

