### PR TITLE
Support animated pictures on drap&drop upload with Admin markdown editor.

### DIFF
--- a/kobo/apps/markdownx_uploader/forms.py
+++ b/kobo/apps/markdownx_uploader/forms.py
@@ -23,3 +23,10 @@ class MarkdownxUploaderImageForm(ImageForm):
         return reverse(
             'markdownx-uploader-file-content', args=(image_object.content.name,)
         )
+
+    @staticmethod
+    def _process_raster(image, extension):
+        """
+        Bypass markdownx resizing and upload image as-is
+        """
+        return image


### PR DESCRIPTION
## Description

`Gif` and `webp` files can be uploaded without losing their animation.

## Notes

Markdownx resizes images by default. Since markdown editor is only available in admin, there is no need to control upload size and weight. We rely on the super user's decision.

## Related issues

fixes #4657 