### PR TITLE
Use Object.assign() instead of npm package 'object-assign'

### DIFF
--- a/jsapp/js/app.js
+++ b/jsapp/js/app.js
@@ -18,7 +18,6 @@ import Drawer from 'js/components/drawer';
 import FormViewSideTabs from 'js/components/formViewSideTabs';
 import ProjectTopTabs from 'js/project/projectTopTabs.component';
 import PermValidator from 'js/components/permissions/permValidator';
-import {assign} from 'utils';
 import BigModal from 'js/components/bigModal/bigModal';
 import ToasterConfig from './toasterConfig';
 import {withRouter, routerGetAssetId, router} from './router/legacy';
@@ -29,7 +28,7 @@ import InvalidatedPassword from 'js/router/invalidatedPassword.component';
 class App extends React.Component {
   constructor(props) {
     super(props);
-    this.state = assign({
+    this.state = Object.assign({
       pageState: stores.pageState.state,
     });
   }

--- a/jsapp/js/assetParserUtils.ts
+++ b/jsapp/js/assetParserUtils.ts
@@ -1,4 +1,3 @@
-import {assign} from 'js/utils';
 import {
   AssetResponse,
   AssetContentSettings
@@ -29,7 +28,7 @@ function parseSettings(asset: AssetResponse) {
 }
 
 export function parsed(asset: AssetResponse): AssetResponse {
-  return assign(
+  return Object.assign(
     asset,
     parseSettings(asset),
     parseTags(asset)

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -14,7 +14,6 @@ import LibrarySidebar from 'js/components/library/librarySidebar';
 import HelpBubble from 'js/components/support/helpBubble';
 import {COMMON_QUERIES, MODAL_TYPES} from '../constants';
 import {ROUTES} from 'js/router/routerConstants';
-import {assign} from 'utils';
 import SidebarFormsList from '../lists/sidebarForms';
 import envStore from 'js/envStore';
 import {router, routerIsActive, withRouter} from '../router/legacy';
@@ -36,14 +35,14 @@ const FormSidebar = observer(
   class FormSidebar extends Reflux.Component {
     constructor(props) {
       super(props);
-      this.state = assign(
+      this.state = Object.assign(
         {
           currentAssetId: false,
           files: [],
         },
         stores.pageState.state
       );
-      this.state = assign(INITIAL_STATE, this.state);
+      this.state = Object.assign(INITIAL_STATE, this.state);
 
       this.stores = [stores.pageState];
       autoBind(this);

--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -10,7 +10,6 @@ import mixins from '../mixins';
 import {PERMISSIONS_CODENAMES} from 'js/constants';
 import {ROUTES} from 'js/router/routerConstants';
 import {withRouter} from 'js/router/legacy';
-import {assign} from 'utils';
 import {userCan} from 'js/components/permissions/utils';
 
 export function getFormDataTabs(assetUid) {
@@ -58,7 +57,7 @@ class FormViewSideTabs extends Reflux.Component {
 
   assetLoad(data) {
     var asset = data[this.currentAssetID()];
-    this.setState(assign({asset: asset}));
+    this.setState(Object.assign({asset: asset}));
   }
 
   triggerRefresh(evt) {

--- a/jsapp/js/components/metadataEditor.es6
+++ b/jsapp/js/components/metadataEditor.es6
@@ -5,7 +5,6 @@ import TextBox from 'js/components/common/textBox';
 import Icon from 'js/components/common/icon';
 import ToggleSwitch from 'js/components/common/toggleSwitch';
 import Select from 'react-select';
-import {assign} from 'utils';
 import {
   META_QUESTION_TYPES,
   SURVEY_DETAIL_ATTRIBUTES,
@@ -54,7 +53,7 @@ export default class MetadataEditor extends React.Component {
     Object.keys(META_QUESTION_TYPES).forEach((metaType) => {
       const detail = this.getSurveyDetail(metaType);
       if (detail) {
-        newState.metaProperties.push(assign({}, detail.attributes));
+        newState.metaProperties.push(Object.assign({}, detail.attributes));
       }
     });
     this.setState(newState);

--- a/jsapp/js/components/permissions/userAssetPermsEditor.es6
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.es6
@@ -11,7 +11,6 @@ import bem from 'js/bem';
 import {permParser} from './permParser';
 import permConfig from './permConfig';
 import {
-  assign,
   notify,
   buildUserUrl,
 } from 'utils';
@@ -93,7 +92,7 @@ class UserAssetPermsEditor extends React.Component {
   applyPropsData() {
     if (this.props.permissions) {
       const formData = permParser.buildFormData(this.props.permissions);
-      this.state = this.applyValidityRules(assign(this.state, formData));
+      this.state = this.applyValidityRules(Object.assign(this.state, formData));
     }
 
     if (this.props.username) {

--- a/jsapp/js/components/reports/reportStyleSettings.es6
+++ b/jsapp/js/components/reports/reportStyleSettings.es6
@@ -4,7 +4,6 @@ import Radio from 'js/components/common/radio';
 import {actions} from 'js/actions';
 import bem from 'js/bem';
 import Modal from 'js/components/common/modal';
-import {assign} from 'utils';
 import ChartTypePicker from './chartTypePicker';
 import ChartColorsPicker from './chartColorsPicker';
 
@@ -35,7 +34,7 @@ export default class ReportStyleSettings extends React.Component {
 
   reportStyleChange(params, value) {
     let styles = this.state.reportStyle;
-    assign(styles, value);
+    Object.assign(styles, value);
     this.setState({reportStyle: styles});
   }
 
@@ -70,7 +69,7 @@ export default class ReportStyleSettings extends React.Component {
       actions.reports.setCustom(assetUid, report_custom);
     } else {
       let sett_ = this.props.parentState.reportStyles;
-      assign(sett_.default, this.state.ReportStyle);
+      Object.assign(sett_.default, this.state.ReportStyle);
       actions.reports.setStyle(assetUid, sett_);
     }
   }

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -5,7 +5,6 @@
  * NOTE: In future all the calls from here will be moved to appropriate stores.
  */
 
-import {assign} from 'js/utils';
 import {ROOT_URL, COMMON_QUERIES} from './constants';
 import type {EnvStoreFieldItem, FreeTierDisplay, SocialApp} from 'js/envStore';
 import type {LanguageCode} from 'js/components/languages/languagesStore';
@@ -829,7 +828,7 @@ interface DataInterface {
 }
 
 const $ajax = (o: {}) =>
-  $.ajax(assign({}, {dataType: 'json', method: 'GET'}, o));
+  $.ajax(Object.assign({}, {dataType: 'json', method: 'GET'}, o));
 
 export const dataInterface: DataInterface = {
   getProfile: () =>
@@ -1539,7 +1538,7 @@ export const dataInterface: DataInterface = {
     return $ajax({
       url: `${ROOT_URL}/tags/`,
       method: 'GET',
-      data: assign(
+      data: Object.assign(
         {
           // If this number is too big (e.g. 9999) it causes a deadly timeout
           // whenever Form Builder displays the aside Library search

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -10,7 +10,7 @@ import AssetNavigator from './assetNavigator';
 import alertify from 'alertifyjs';
 import ProjectSettings from '../components/modalForms/projectSettings';
 import MetadataEditor from 'js/components/metadataEditor';
-import {assign, escapeHtml} from '../utils';
+import {escapeHtml} from '../utils';
 import {
   ASSET_TYPES,
   AVAILABLE_FORM_STYLES,
@@ -73,7 +73,7 @@ const RECORDING_SUPPORT_URL = 'recording-interviews.html';
  * the `launchAppForSurveyContent` method below for all the magic.
  */
 
-export default assign({
+export default Object.assign({
   componentDidMount() {
     this.loadAsideSettings();
 

--- a/jsapp/js/libs/reactBemComponents.es6
+++ b/jsapp/js/libs/reactBemComponents.es6
@@ -38,7 +38,6 @@
 */
 import React from 'react';
 import classNames from 'classnames';
-import assign from 'object-assign';
 import PropTypes from 'prop-types';
 
 const reactCreateBemElement = function(base, el='div'){
@@ -65,7 +64,7 @@ const reactCreateBemElement = function(base, el='div'){
 
   class c extends React.Component {
     render () {
-      let props = assign({}, this.props);
+      const props = Object.assign({}, this.props);
 
       // allows modifiers to be a string, an array, or undefined (ignored)
       let modifier = [].concat(props.m)

--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -20,7 +20,7 @@ import {dataInterface} from 'js/dataInterface';
 import {stores} from './stores';
 import assetStore from 'js/assetStore';
 import {actions} from './actions';
-import {log, assign, notify, escapeHtml, join} from 'js/utils';
+import {log, notify, escapeHtml, join} from 'js/utils';
 import type {
   AssetResponse,
   CreateImportRequest,
@@ -234,7 +234,7 @@ const mixins: MixinsObject = {
       const uid = this._getAssetUid();
       const asset = data[uid];
       if (asset) {
-        this.setState(assign({}, data[uid]));
+        this.setState(Object.assign({}, data[uid]));
       }
     },
     _getAssetUid() {
@@ -272,7 +272,7 @@ const mixins: MixinsObject = {
       // this nice SSOT as described in TODO comment above.
       const uid = this._getAssetUid();
       if (uid && this.props.initialAssetLoadNotNeeded) {
-        this.setState(assign({}, assetStore.data[uid]));
+        this.setState(Object.assign({}, assetStore.data[uid]));
       } else if (uid) {
         actions.resources.loadAsset({id: uid});
       }
@@ -342,7 +342,7 @@ const mixins: MixinsObject = {
 
       const isLibrary = routerIsActive('library');
       const multipleFiles = params.totalFiles && totalFiles > 1 ? true : false;
-      params = assign({library: isLibrary}, params);
+      params = Object.assign({library: isLibrary}, params);
 
       if (params.base64Encoded) {
         stores.pageState.showModal({
@@ -358,7 +358,7 @@ const mixins: MixinsObject = {
       if (!isLibrary && params.base64Encoded) {
         const destination = params.destination || this.state.url;
         if (destination) {
-          params = assign({destination: destination}, params);
+          params = Object.assign({destination: destination}, params);
         }
       }
 
@@ -457,7 +457,7 @@ const mixins: MixinsObject = {
       files.map((file) => {
         const reader = new FileReader();
         reader.onload = () => {
-          const params = assign(
+          const params = Object.assign(
             {
               name: file.name,
               base64Encoded: reader.result,

--- a/jsapp/js/searches.es6
+++ b/jsapp/js/searches.es6
@@ -14,7 +14,6 @@ import {stores} from './stores';
 import sessionStore from './stores/session';
 import {actions} from './actions';
 import {dataInterface} from './dataInterface';
-import {assign} from 'utils';
 import {parsed} from './assetParserUtils';
 
 const emptySearchState = {
@@ -31,7 +30,7 @@ const emptySearchState = {
   parentName: false,
   allPublic: false,
 };
-const initialState = assign({
+const initialState = Object.assign({
   cleared: false,
 
   defaultQueryState: 'none',
@@ -190,7 +189,7 @@ function SearchContext(opts={}) {
       if (!items.cleared) {
         items.cleared = false;
       }
-      assign(this.state, items);
+      Object.assign(this.state, items);
     },
     filterTagQueryData () {
       if (this.filterTags) {
@@ -219,11 +218,11 @@ function SearchContext(opts={}) {
       if (this.state.allPublic === true) {
         params.allPublic = true;
       }
-      return assign({}, this.filterParams, params);
+      return Object.assign({}, this.filterParams, params);
     },
     toQueryData (dataObject) {
       var searchParams = dataObject || this.toDataObject(),
-          // _searchParamsClone = assign({}, searchParams),
+          // _searchParamsClone = Object.assign({}, searchParams),
           paramGroups = [],
           queryData = {};
 
@@ -305,7 +304,7 @@ function SearchContext(opts={}) {
     in the components' states.
     */
     var dataObject = searchStore.toDataObject();
-    var _dataObjectClone = assign({}, dataObject);
+    var _dataObjectClone = Object.assign({}, dataObject);
     var qData = searchStore.toQueryData(dataObject);
     var isSearch = !_opts.cacheAsDefaultSearch;
 
@@ -422,7 +421,7 @@ function SearchContext(opts={}) {
     if (jqxhrs.search) {
       jqxhrs.search.abort();
     }
-    searchStore.update(assign({
+    searchStore.update(Object.assign({
       cleared: true
     }, emptySearchState));
   });
@@ -461,7 +460,7 @@ function SearchContext(opts={}) {
       }
     },
     searchDefault: function () {
-      searchStore.quietUpdate(assign({
+      searchStore.quietUpdate(Object.assign({
         cleared: true,
         searchString: false,
       }, emptySearchState));
@@ -493,7 +492,7 @@ var commonMethods = {
     } else {
       ctx = getSearchContext(passedCtx);
     }
-    assign(this, ctx.mixin);
+    Object.assign(this, ctx.mixin);
   },
   searchTagsChange (tags) {
     this.quietUpdateStore({

--- a/jsapp/js/stores.es6
+++ b/jsapp/js/stores.es6
@@ -22,7 +22,6 @@ import {actions} from './actions';
 import {
   log,
   notify,
-  assign,
 } from 'utils';
 import { toast } from 'react-hot-toast';
 import {ANON_USERNAME} from 'js/constants';
@@ -65,7 +64,7 @@ stores.surveyState = Reflux.createStore({
   setState (state) {
     var chz = changes(this.state, state);
     if (chz) {
-      assign(this.state, state);
+      Object.assign(this.state, state);
       this.trigger(chz);
     }
   },
@@ -103,7 +102,7 @@ stores.translations = Reflux.createStore({
   setState (change) {
     const changed = changes(this.state, change);
     if (changed) {
-      assign(this.state, changed);
+      Object.assign(this.state, changed);
       this.trigger(changed);
     }
   },
@@ -124,7 +123,7 @@ stores.pageState = Reflux.createStore({
   setState (chz) {
     var changed = changes(this.state, chz);
     if (changed) {
-      assign(this.state, changed);
+      Object.assign(this.state, changed);
       this.trigger(changed);
     }
   },
@@ -132,7 +131,7 @@ stores.pageState = Reflux.createStore({
     var _changes = {};
     var newval = !this.state.showFixedDrawer;
     _changes.showFixedDrawer = newval;
-    assign(this.state, _changes);
+    Object.assign(this.state, _changes);
     this.trigger(_changes);
   },
   showModal (params) {
@@ -173,10 +172,10 @@ stores.snapshots = Reflux.createStore({
     this.listenTo(actions.resources.createSnapshot.failed, this.snapshotCreationFailed);
   },
   snapshotCreated (snapshot) {
-    this.trigger(assign({success: true}, snapshot));
+    this.trigger(Object.assign({success: true}, snapshot));
   },
   snapshotCreationFailed (jqxhr) {
-    this.trigger(assign({success: false}, jqxhr.responseJSON));
+    this.trigger(Object.assign({success: false}, jqxhr.responseJSON));
   },
 });
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -18,8 +18,6 @@ import type Raven from 'raven';
 
 export const LANGUAGE_COOKIE_NAME = 'django_language';
 
-export const assign = require('object-assign');
-
 const cookies = new Cookies();
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
         "mocha": "^7.1.2",
         "mocha-chrome": "^2.2.0",
         "moment": "^2.25.3",
-        "object-assign": "^4.1.1",
         "patch-package": "^6.5.1",
         "postcss": "^7.0.30",
         "postcss-loader": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "mocha": "^7.1.2",
     "mocha-chrome": "^2.2.0",
     "moment": "^2.25.3",
-    "object-assign": "^4.1.1",
     "patch-package": "^6.5.1",
     "postcss": "^7.0.30",
     "postcss-loader": "^4.2.0",


### PR DESCRIPTION
## Notes

This PR removes the npm package, ['object-assign'](http://npm.im/object-assign), from the kpi frontend.

- The built-in **Object.assign()** works in all the browsers/environments we now support
- There were about half a dozen instances of an unadorned Object.assign() in the frontend code already

I'm also removing this **assign()** alias (originally for compatibility)

```ts
// js/utils.ts
export const assign = require('object-assign')
```

Replacing these —

```ts
import {assign} from 'js/utils.ts';
  // ...
assign({}, defaults, overrides);
```

with these —

```ts
Object.assign({}, defaults, overrides);
```

It would be easy to keep the alias if we wanted to:

```ts
// js/utils.ts
export const assign = Object.assign;
```

but I don't think it's necessary.

## Checklist

1. If you've added code that should be tested, add tests
2. If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
    - **"I refrained from formatting or autofixing older files** in this set of commits."
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
