### PR TITLE
Show storage add-ons in usage limits

### DIFF
--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -108,8 +108,7 @@ export async function getSubscriptionInterval() {
       subscriptionStore.fetchSubscriptionInfo();
     }
     await when(() => subscriptionStore.isInitialised);
-    const subscriptionList: SubscriptionInfo[] =
-      subscriptionStore.subscriptionResponse;
+    const subscriptionList: SubscriptionInfo[] = subscriptionStore.planResponse;
     const activeSubscription = subscriptionList.find((sub) =>
       ACTIVE_STRIPE_STATUSES.includes(sub.status)
     );
@@ -154,8 +153,8 @@ function getLimitsForMetadata(
 
 export async function getAccountLimits() {
   await when(() => subscriptionStore.isInitialised);
-  const subscriptions = [...subscriptionStore.subscriptionResponse];
-  const activeSubscriptions = subscriptions.filter((subscription) =>
+  const plans = [...subscriptionStore.planResponse];
+  const activeSubscriptions = plans.filter((subscription) =>
     ACTIVE_STRIPE_STATUSES.includes(subscription.status)
   );
   let metadata;

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -119,7 +119,7 @@ export async function getSubscriptionInterval() {
   return 'month';
 }
 
-const defaultLimits: AccountLimit = Object.freeze({
+const DEFAULT_LIMITS: AccountLimit = Object.freeze({
   submission_limit: 'unlimited',
   nlp_seconds_limit: 'unlimited',
   nlp_character_limit: 'unlimited',
@@ -143,7 +143,7 @@ function getLimitsForMetadata(
       }
     }
     // only use metadata needed for limit calculations
-    if (key in defaultLimits) {
+    if (key in DEFAULT_LIMITS) {
       limits[key as keyof AccountLimit] =
         value === 'unlimited' ? value : parseInt(value);
     }
@@ -223,7 +223,7 @@ export async function getAccountLimits() {
   const {metadata, hasFreeTier} = await getStripeMetadataAndFreeTierStatus();
 
   // initialize to unlimited
-  let limits: AccountLimit = {...defaultLimits};
+  let limits: AccountLimit = {...DEFAULT_LIMITS};
 
   // apply any limits from the metadata
   limits = {...limits, ...getLimitsForMetadata(metadata)};

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -182,12 +182,18 @@ const getFreeTierLimits = async (limits: AccountLimit) => {
   await when(() => envStore.isReady);
   const thresholds = envStore.data.free_tier_thresholds;
   const newLimits: AccountLimit = {...limits};
-  thresholds.storage && (newLimits['storage_bytes_limit'] = thresholds.storage);
-  thresholds.data && (newLimits['submission_limit'] = thresholds.data);
-  thresholds.translation_chars &&
-    (newLimits['nlp_character_limit'] = thresholds.translation_chars);
-  thresholds.transcription_minutes &&
-    (newLimits['nlp_seconds_limit'] = thresholds.transcription_minutes * 60);
+  if (thresholds.storage) {
+    newLimits['storage_bytes_limit'] = thresholds.storage;
+  }
+  if (thresholds.data) {
+    newLimits['submission_limit'] = thresholds.data;
+  }
+  if (thresholds.translation_chars) {
+    newLimits['nlp_character_limit'] = thresholds.translation_chars;
+  }
+  if (thresholds.transcription_minutes) {
+    newLimits['nlp_seconds_limit'] = thresholds.transcription_minutes * 60;
+  }
   return newLimits;
 };
 

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -151,9 +151,7 @@ function getLimitsForMetadata(
   limitsToCompare: false | AccountLimit = false
 ) {
   const limits: Partial<AccountLimit> = {};
-  for (const [key, value] of Object.entries(metadata) as Array<
-    [string | keyof AccountLimit, string]
-  >) {
+  for (const [key, value] of Object.entries(metadata)) {
     // if we need to compare limits, make sure we're not overwriting a higher limit from somewhere else
     if (limitsToCompare) {
       if (!(key in limitsToCompare)) {

--- a/jsapp/js/account/stripe.utils.ts
+++ b/jsapp/js/account/stripe.utils.ts
@@ -17,13 +17,13 @@ export async function hasActiveSubscription() {
   }
 
   await when(() => subscriptionStore.isInitialised);
-  const subscriptions = subscriptionStore.subscriptionResponse;
-  if (!subscriptions.length) {
+  const plans = subscriptionStore.planResponse;
+  if (!plans.length) {
     return false;
   }
 
   return (
-    subscriptions.filter(
+    plans.filter(
       (sub) =>
         ACTIVE_STRIPE_STATUSES.includes(sub.status) &&
         sub.items?.[0].price.unit_amount > 0

--- a/jsapp/js/account/subscriptionStore.ts
+++ b/jsapp/js/account/subscriptionStore.ts
@@ -92,6 +92,7 @@ export async function fetchProducts() {
 
 class SubscriptionStore {
   public subscriptionResponse: SubscriptionInfo[] = [];
+  public addOnsResponse: SubscriptionInfo[] = [];
   public subscribedProduct: BaseProduct | null = null;
   public productsResponse: Product[] | null = null;
   public isPending = false;
@@ -121,7 +122,14 @@ class SubscriptionStore {
   private onFetchSubscriptionInfoDone(
     response: PaginatedResponse<SubscriptionInfo>
   ) {
-    this.subscriptionResponse = response.results;
+    // get any plan subscriptions for the user
+    this.subscriptionResponse = response.results.filter(
+      (sub) => sub.items[0]?.price.product.metadata?.product_type == 'plan'
+    );
+    // get any recurring add-on subscriptions for the user
+    this.addOnsResponse = response.results.filter(
+      (sub) => sub.items[0]?.price.product.metadata?.product_type == 'addon'
+    );
     this.subscribedProduct = response.results[0]?.plan?.product || null;
     this.isPending = false;
     this.isInitialised = true;

--- a/jsapp/js/account/subscriptionStore.ts
+++ b/jsapp/js/account/subscriptionStore.ts
@@ -91,10 +91,9 @@ export async function fetchProducts() {
 }
 
 class SubscriptionStore {
-  public subscriptionResponse: SubscriptionInfo[] = [];
+  public planResponse: SubscriptionInfo[] = [];
   public addOnsResponse: SubscriptionInfo[] = [];
   public subscribedProduct: BaseProduct | null = null;
-  public productsResponse: Product[] | null = null;
   public isPending = false;
   public isInitialised = false;
 
@@ -123,14 +122,15 @@ class SubscriptionStore {
     response: PaginatedResponse<SubscriptionInfo>
   ) {
     // get any plan subscriptions for the user
-    this.subscriptionResponse = response.results.filter(
+    this.planResponse = response.results.filter(
       (sub) => sub.items[0]?.price.product.metadata?.product_type == 'plan'
     );
     // get any recurring add-on subscriptions for the user
     this.addOnsResponse = response.results.filter(
       (sub) => sub.items[0]?.price.product.metadata?.product_type == 'addon'
     );
-    this.subscribedProduct = response.results[0]?.plan?.product || null;
+    this.subscribedProduct =
+      this.planResponse[0]?.items[0]?.price.product || null;
     this.isPending = false;
     this.isInitialised = true;
   }

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -60,7 +60,7 @@ export const useExceedingLimits = () => {
         () => subscriptionStore.isInitialised,
         () => {
           dispatch({
-            prodData: subscriptionStore.subscriptionResponse,
+            prodData: subscriptionStore.planResponse,
           });
         }
       ),

--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -4,3 +4,15 @@ ACTIVE_STRIPE_STATUSES = [
     'past_due',
     'trialing',
 ]
+
+FREE_TIER_NO_THRESHOLDS = {
+    'storage': None,
+    'data': None,
+    'transcription_minutes': None,
+    'translation_chars': None,
+}
+
+FREE_TIER_EMPTY_DISPLAY = {
+    'name': None,
+    'feature_list': [],
+}

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -17,6 +17,7 @@ from django.utils.translation import get_language_info, gettext_lazy as t
 from pymongo import MongoClient
 
 from kpi.utils.json import LazyJSONSerializable
+from kobo.apps.stripe.constants import FREE_TIER_NO_THRESHOLDS, FREE_TIER_EMPTY_DISPLAY
 from ..static_lists import EXTRA_LANG_INFO, SECTOR_CHOICE_DEFAULTS
 
 env = environ.Env()
@@ -339,12 +340,7 @@ CONSTANCE_CONFIG = {
         'positive_int'
     ),
     'FREE_TIER_THRESHOLDS': (
-        LazyJSONSerializable({
-            'storage': None,
-            'data': None,
-            'transcription_minutes': None,
-            'translation_chars': None,
-        }),
+        LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS),
         'Free tier thresholds: storage in kilobytes, '
         'data (number of submissions), '
         'minutes of transcription, '
@@ -353,10 +349,7 @@ CONSTANCE_CONFIG = {
         'free_tier_threshold_jsonschema',
     ),
     'FREE_TIER_DISPLAY': (
-        LazyJSONSerializable({
-            'name': None,
-            'feature_list': [],
-        }),
+        LazyJSONSerializable(FREE_TIER_EMPTY_DISPLAY),
         'Free tier frontend settings: name to use for the free tier, '
         'array of text strings to display on the feature list of the Plans page',
         'free_tier_display_jsonschema',

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -3,18 +3,13 @@ import json
 from constance import config
 from django.db import migrations
 
+from kobo.apps.stripe.constants import FREE_TIER_NO_THRESHOLDS
 from kpi.utils.json import LazyJSONSerializable
 
 
 def reset_free_tier_thresholds(apps, schema_editor):
     # The constance defaults for FREE_TIER_THRESHOLDS changed, so we set existing config to the new default value
-    thresholds = {
-        'storage': None,
-        'data': None,
-        'transcription_minutes': None,
-        'translation_chars': None,
-    }
-    setattr(config, 'FREE_TIER_THRESHOLDS', LazyJSONSerializable(thresholds))
+    setattr(config, 'FREE_TIER_THRESHOLDS', LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS))
 
 
 class Migration(migrations.Migration):

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -177,9 +177,7 @@ class EnvironmentView(APIView):
 
         # If the user isn't eligible for the free tier override, don't send free tier data to the frontend
         if request.user.id:
-            # default to checking the user's join date
-            date_joined = request.user.date_joined.date()
-            # if the user is in an organization, use the organization owner's join date instead
+            # if the user is in an organization, use the organization owner's join date
             owner_join_dates = list(
                 OrganizationOwner.objects.filter(
                     organization__organization_users__user=request.user
@@ -187,6 +185,9 @@ class EnvironmentView(APIView):
             )
             if len(owner_join_dates):
                 date_joined = owner_join_dates[0].date()
+            else:
+                # default to checking the user's join date
+                date_joined = request.user.date_joined.date()
             # if they didn't register on/before FREE_TIER_CUTOFF_DATE, don't display the custom free tier
             if date_joined > constance.config.FREE_TIER_CUTOFF_DATE:
                 data['free_tier_thresholds'] = FREE_TIER_NO_THRESHOLDS

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -178,13 +178,11 @@ class EnvironmentView(APIView):
         # If the user isn't eligible for the free tier override, don't send free tier data to the frontend
         if request.user.id:
             # if the user is in an organization, use the organization owner's join date
-            owner_join_dates = list(
-                OrganizationOwner.objects.filter(
-                    organization__organization_users__user=request.user
-                ).values_list('organization_user__user__date_joined', flat=True)
-            )
-            if len(owner_join_dates):
-                date_joined = owner_join_dates[0].date()
+            owner_join_date = OrganizationOwner.objects.filter(
+                organization__organization_users__user=request.user
+            ).values_list('organization_user__user__date_joined', flat=True).first()
+            if owner_join_date:
+                date_joined = owner_join_date.date()
             else:
                 # default to checking the user's join date
                 date_joined = request.user.date_joined.date()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "scss/*": ["scss/*"],
       "test/*": ["test/*"],
     },
-    "target": "es2016",
+    "target": "es2017",
     "module": "es2020",
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Previously purchase storage add-ons are now used in usage limit calculations. Corrects some issues that were causing incorrect limits to be displayed.

## Notes

We previously determined whether to show the `FREE_TIER_THRESHOLDS` based on the logged-in user's join date. But for multi-user organizations, that meant each user in the organization could potentially see a different set of limits for their organization. This PR changes that so custom tiers are only shown if the _organization owner_ joined before `FREE_TIER_CUTOFF_DATE`. If the user isn't in an organization, it still defaults to checking the user's join date.