### PR TITLE
Fix Data Table header filter XML labels

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -223,6 +223,12 @@ export function getQuestionOrChoiceDisplayName(
   questionOrChoice: SurveyChoice | SurveyRow,
   translationIndex = 0
 ): string {
+  // The `translationIndex` is set to `-1` when user chooses to display xml
+  // values instead of labels
+  if (translationIndex === -1) {
+    return getRowName(questionOrChoice);
+  }
+
   if (questionOrChoice.label && Array.isArray(questionOrChoice.label)) {
     return questionOrChoice.label[translationIndex];
   } else if (questionOrChoice.label && !Array.isArray(questionOrChoice.label)) {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

When using "Display labels or XML values" Data Table setting to display "XML values", the header filter is now showing proper text instead of empty options.

## Notes

Fix takes place in a helper function and uses other helper function :)

## Related issues

Fixes #4412 