### PR TITLE
Fix mini audio play button requiring two clicks to play

### DIFF
--- a/jsapp/js/components/common/miniAudioPlayer.scss
+++ b/jsapp/js/components/common/miniAudioPlayer.scss
@@ -10,6 +10,10 @@
   flex-wrap: nowrap;
   color: colors.$kobo-blue;
   height: button.$button-height-s;
+
+  > audio {
+    display: none;
+  }
 }
 
 .mini-audio-player.mini-audio-player--is-loading {

--- a/jsapp/js/components/common/miniAudioPlayer.tsx
+++ b/jsapp/js/components/common/miniAudioPlayer.tsx
@@ -65,23 +65,7 @@ class MiniAudioPlayer extends React.Component<
   }
 
   componentDidMount() {
-    // NOTE: 'metadata' causes an immediate download of part of the file (to get
-    // the metadata), usually requires around 30-50KB, but it may vary. Some
-    // browser may simply download whole file.
-
-    // Set up listeners for audio component.
-
-    // We know that audioRef will not be null when these run.
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    this.audioRef.current!.addEventListener(
-      'loadedmetadata',
-      this.onAudioLoadedBound
-    );
-    this.audioRef.current!.addEventListener('error', this.onAudioErrorBound);
-    this.audioRef.current!.addEventListener(
-      'timeupdate',
-      this.onAudioTimeUpdatedBound
-    );
+    // Set up listener for custom event
     document.addEventListener(
       PLAYER_STARTED_EVENT,
       this.onAnyPlayerStartedBound
@@ -89,18 +73,13 @@ class MiniAudioPlayer extends React.Component<
   }
 
   componentWillUnmount() {
+    // We know that audioRef will be ready each time we use audioRef.current
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    // (But you may wish to re-enable this rule while working on this file.)
+
     // Pausing makes it subject to garbage collection.
     this.audioRef.current!.pause();
 
-    this.audioRef.current!.removeEventListener(
-      'loadedmetadata',
-      this.onAudioLoadedBound
-    );
-    this.audioRef.current!.removeEventListener('error', this.onAudioErrorBound);
-    this.audioRef.current!.removeEventListener(
-      'timeupdate',
-      this.onAudioTimeUpdatedBound
-    );
     document.removeEventListener(
       PLAYER_STARTED_EVENT,
       this.onAnyPlayerStartedBound
@@ -243,7 +222,13 @@ class MiniAudioPlayer extends React.Component<
         <audio
           ref={this.audioRef}
           src={this.props.mediaURL}
+          // NOTE: 'metadata' causes an immediate download of part of the file
+          // (to get the metadata), usually requires around 30-50KB, but it may
+          // vary. Some browser may simply download whole file.
           preload={this.props.preload ? 'metadata' : 'none'}
+          onLoadedMetadata={this.onAudioLoadedBound}
+          onTimeUpdate={this.onAudioTimeUpdatedBound}
+          onError={this.onAudioErrorBound}
         />
         {this.state.isLoading && this.renderLoading()}
         {!this.state.isLoading && this.state.isBroken && this.renderError()}


### PR DESCRIPTION
## Checklist

1. If you've added code that should be tested, add tests
2. If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix a problem with the audio question play button in the data table

## Notes

While testing #4487 in my browser (Chrome on KDE / X), I noticed a glitch with the MiniAudioPlayer component (present on local and production).

The glitch was you'd have to click the play button twice to get it to play.

- In production it would log an error to the console.
- In dev the first click would also show a full page blocking splash screen, which was pretty disruptive for testing.

![blast](https://github.com/kobotoolbox/kpi/assets/3514715/54e1f83f-0873-4e07-b6d7-3610c35d6215)

> **AbortError**
> The [play() request was interrupted](https://developer.chrome.com/blog/play-request-was-interrupted/) because the media was **removed from the document**.

The word "removed" here was a little misleading — it was never even added.

By attaching the `<audio>` element to the DOM and accessing its methods with a ref, instead of holding it as an unattached element, this problem went away. As a bonus, we could then simplify some of the event handling code (using React's SyntheticEvents system)

When I told Sara about this she couldn't reproduce the original glitch in her browser. So it might not have a broad impact, but at least it's a nice clean up.

## Related issues

Follow-up on #4487
