### PR TITLE
Cache service usage endpoint

### DIFF
--- a/jsapp/js/account/usage.api.ts
+++ b/jsapp/js/account/usage.api.ts
@@ -1,6 +1,5 @@
-import {fetchGet, fetchPost} from 'jsapp/js/api';
+import {fetchWithHeaders} from 'jsapp/js/api';
 import {getOrganization} from 'js/account/stripe.api';
-import {createContext} from 'react';
 
 interface AssetUsage {
   asset: string;
@@ -36,9 +35,9 @@ const USAGE_URL = '/api/v2/service_usage/';
 
 export async function getUsage(organization_id: string | null = null) {
   if (organization_id) {
-    return fetchGet<UsageResponse>(`${USAGE_URL}${organization_id}/`);
+    return fetchWithHeaders<UsageResponse>(`${USAGE_URL}${organization_id}/`);
   }
-  return fetchGet<UsageResponse>(USAGE_URL);
+  return fetchWithHeaders<UsageResponse>(USAGE_URL);
 }
 
 export async function getUsageForOrganization() {

--- a/jsapp/js/account/usage.api.ts
+++ b/jsapp/js/account/usage.api.ts
@@ -32,10 +32,14 @@ export interface UsageResponse {
 }
 
 const USAGE_URL = '/api/v2/service_usage/';
+const ORGANIZATION_USAGE_URL =
+  '/api/v2/organizations/##ORGANIZATION_ID##/service_usage/';
 
 export async function getUsage(organization_id: string | null = null) {
   if (organization_id) {
-    return fetchWithHeaders<UsageResponse>(`${USAGE_URL}${organization_id}/`);
+    return fetchWithHeaders<UsageResponse>(
+      ORGANIZATION_USAGE_URL.replace('##ORGANIZATION_ID##', organization_id)
+    );
   }
   return fetchWithHeaders<UsageResponse>(USAGE_URL);
 }

--- a/jsapp/js/account/usage.api.ts
+++ b/jsapp/js/account/usage.api.ts
@@ -36,7 +36,7 @@ const USAGE_URL = '/api/v2/service_usage/';
 
 export async function getUsage(organization_id: string | null = null) {
   if (organization_id) {
-    return fetchPost<UsageResponse>(USAGE_URL, {organization_id});
+    return fetchGet<UsageResponse>(`${USAGE_URL}${organization_id}/`);
   }
   return fetchGet<UsageResponse>(USAGE_URL);
 }

--- a/jsapp/js/account/usage.component.tsx
+++ b/jsapp/js/account/usage.component.tsx
@@ -12,7 +12,6 @@ import styles from './usage.module.scss';
 import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {UsageContext, useUsage} from 'js/account/useUsage.hook';
-import InlineMessage from 'js/components/common/inlineMessage';
 
 interface LimitState {
   storageByteLimit: number | 'unlimited';
@@ -173,13 +172,6 @@ export default function Usage() {
           />
         </div>
       </div>
-      <InlineMessage
-        classNames={[styles.footer]}
-        type={'default'}
-        message={t(
-          'Usage information is updated periodically. If your recent submissions are not showing, please check again later.'
-        )}
-      />
     </div>
   );
 }

--- a/jsapp/js/account/usage.component.tsx
+++ b/jsapp/js/account/usage.component.tsx
@@ -116,7 +116,17 @@ export default function Usage() {
 
   return (
     <div className={styles.root}>
-      <h2>{t('Your account total use')}</h2>
+      <header className={styles.header}>
+        <h2>{t('Your account total use')}</h2>
+        {typeof usage.lastUpdated === 'string' && (
+          <p className={styles.updated}>
+            {t('Last update: ##LAST_UPDATE_TIME##').replace(
+              '##LAST_UPDATE_TIME##',
+              usage.lastUpdated
+            )}
+          </p>
+        )}
+      </header>
       <UsageContext.Provider value={usage}>
         <LimitNotifications usagePage />
       </UsageContext.Provider>

--- a/jsapp/js/account/usage.component.tsx
+++ b/jsapp/js/account/usage.component.tsx
@@ -12,6 +12,7 @@ import styles from './usage.module.scss';
 import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {UsageContext, useUsage} from 'js/account/useUsage.hook';
+import InlineMessage from 'js/components/common/inlineMessage';
 
 interface LimitState {
   storageByteLimit: number | 'unlimited';
@@ -172,6 +173,13 @@ export default function Usage() {
           />
         </div>
       </div>
+      <InlineMessage
+        classNames={[styles.footer]}
+        type={'default'}
+        message={t(
+          'Usage information is updated periodically. If your recent submissions are not showing, please check again later.'
+        )}
+      />
     </div>
   );
 }

--- a/jsapp/js/account/usage.module.scss
+++ b/jsapp/js/account/usage.module.scss
@@ -15,6 +15,19 @@ h2 {
   }
 }
 
+.header {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.updated {
+  border-radius: 0.25em;
+  background-color: colors.$kobo-cloud;
+  padding: 0.5em;
+}
+
 .row {
   display: flex;
   justify-content: center;

--- a/jsapp/js/account/usage.module.scss
+++ b/jsapp/js/account/usage.module.scss
@@ -51,3 +51,9 @@ h2 {
   display: block;
   font-size: sizes.$x14;
 }
+
+.footer {
+  background-color: colors.$kobo-mid-blue;
+  position: absolute;
+  bottom: 5em;
+}

--- a/jsapp/js/account/usage.module.scss
+++ b/jsapp/js/account/usage.module.scss
@@ -51,9 +51,3 @@ h2 {
   display: block;
   font-size: sizes.$x14;
 }
-
-.footer {
-  background-color: colors.$kobo-mid-blue;
-  position: absolute;
-  bottom: 5em;
-}

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -192,6 +192,14 @@ export function formatSeconds(seconds: number) {
   ).padStart(2, '0')}`;
 }
 
+export function formatRelativeTime(timeStr: string, localize = true): string {
+  let myMoment = moment.utc(timeStr);
+  if (localize) {
+    myMoment = myMoment.local();
+  }
+  return myMoment.fromNow();
+}
+
 // works universally for v1 and v2 urls
 export function getUsernameFromUrl(userUrl: string): string | null {
   const matched = userUrl.match(/\/users\/(.*)\//);

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -35,15 +35,16 @@ class Organization(AbstractOrganization):
         # Only check for subscriptions if Stripe is enabled
         if settings.STRIPE_ENABLED:
             return Organization.objects.prefetch_related('djstripe_customers').filter(
-                djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-                djstripe_customers__subscriber=self.id,
-            ).order_by(
-                '-djstripe_customers__subscriptions__start_date'
-            ).values(
-                billing_cycle_anchor=F('djstripe_customers__subscriptions__billing_cycle_anchor'),
-                current_period_start=F('djstripe_customers__subscriptions__current_period_start'),
-                recurring_interval=F('djstripe_customers__subscriptions__items__price__recurring__interval'),
-            )[0]
+                    djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                    djstripe_customers__subscriber=self.id,
+                ).order_by(
+                    '-djstripe_customers__subscriptions__start_date'
+                ).values(
+                    billing_cycle_anchor=F('djstripe_customers__subscriptions__billing_cycle_anchor'),
+                    current_period_start=F('djstripe_customers__subscriptions__current_period_start'),
+                    recurring_interval=F('djstripe_customers__subscriptions__items__price__recurring__interval'),
+                ).first()
+
         return None
 
 

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -80,8 +80,12 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         ### CURRENT ENDPOINT
         """
 
+        context = {
+            'organization_id': kwargs.get('id', None),
+            **ServiceUsageViewSet.get_serializer_context(self)
+        }
         serializer = ServiceUsageSerializer(
             get_database_user(request.user),
-            context=ServiceUsageViewSet.get_serializer_context(self, kwargs.get('id', None)),
+            context=context,
         )
         return Response(data=serializer.data)

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -81,9 +81,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         """
 
         context = {
-            'organization_id': kwargs.get('id', None),
-            **ServiceUsageViewSet.get_serializer_context(self)
+            # Commented out until the Enterprise plan is implemented
+            #   'organization_id': kwargs.get('id', None),
+            **self.get_serializer_context(),
         }
+
         serializer = ServiceUsageSerializer(
             get_database_user(request.user),
             context=context,

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -1,12 +1,23 @@
+from django.conf import settings
 from django.db.models import QuerySet
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_cookie
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from kpi.permissions import IsAuthenticated
+from kpi.serializers.v2.service_usage import ServiceUsageSerializer
+from kpi.utils.object_permission import get_database_user
+from kpi.views.v2.service_usage import ServiceUsageViewSet
 from .models import Organization, create_organization
 from .permissions import IsOrgAdminOrReadOnly
 from .serializers import OrganizationSerializer
 
 
+@method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='service_usage')
+@method_decorator(vary_on_cookie, name='service_usage')
 class OrganizationViewSet(viewsets.ModelViewSet):
     """
     Organizations are groups of users with assigned permissions and configurations
@@ -30,3 +41,45 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             create_organization(user, f"{user.username}'s organization")
             queryset = queryset.all()  # refresh
         return queryset
+
+    @action(detail=True, methods=['get'])
+    def service_usage(self, request, pk=None, *args, **kwargs):
+        """
+        ## Organization Usage Tracker
+        <p>Tracks the total usage of different services for each account in the current user's organization</p>
+        <p>Tracks the submissions and NLP seconds/characters for the current month/year/all time</p>
+        <p>Tracks the current total storage used</p>
+
+        <pre class="prettyprint">
+        <b>GET</b> /api/v2/organizations/{organization_id}/service_usage/
+        </pre>
+
+        > Example
+        >
+        >       curl -X GET https://[kpi]/api/v2/organizations/{organization_id}/service_usage/
+        >       {
+        >           "total_nlp_usage": {
+        >               "asr_seconds_current_month": {integer},
+        >               "asr_seconds_current_year": {integer},
+        >               "asr_seconds_all_time": {integer},
+        >               "mt_characters_current_month": {integer},
+        >               "mt_characters_current_year": {integer},
+        >               "mt_characters_all_time": {integer},
+        >           },
+        >           "total_storage_bytes": {integer},
+        >           "total_submission_count": {
+        >               "current_month": {integer},
+        >               "current_year": {integer},
+        >               "all_time": {integer},
+        >           },
+        >           "current_month_start": {string (date), YYYY-MM-DD format},
+        >           "current_year_start": {string (date), YYYY-MM-DD format},
+        >       }
+        ### CURRENT ENDPOINT
+        """
+
+        serializer = ServiceUsageSerializer(
+            get_database_user(request.user),
+            context=ServiceUsageViewSet.get_serializer_context(self, pk),
+        )
+        return Response(data=serializer.data)

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -46,9 +46,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def service_usage(self, request, pk=None, *args, **kwargs):
         """
         ## Organization Usage Tracker
-        <p>Tracks the total usage of different services for each account in the current user's organization</p>
+        <p>Tracks the total usage of different services for each account in an organization</p>
         <p>Tracks the submissions and NLP seconds/characters for the current month/year/all time</p>
         <p>Tracks the current total storage used</p>
+        <p>If no organization is found with the provided ID, returns the usage for the logged-in user</p>
+        <strong>This endpoint is cached for an amount of time determined by ENDPOINT_CACHE_DURATION</strong>
 
         <pre class="prettyprint">
         <b>GET</b> /api/v2/organizations/{organization_id}/service_usage/
@@ -80,6 +82,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
         serializer = ServiceUsageSerializer(
             get_database_user(request.user),
-            context=ServiceUsageViewSet.get_serializer_context(self, pk),
+            context=ServiceUsageViewSet.get_serializer_context(self, kwargs.get('id', None)),
         )
         return Response(data=serializer.data)

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -312,6 +312,7 @@ class SubscriptionViewSet(viewsets.ReadOnlyModelViewSet):
 class ProductViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     """
     Returns Product and Price Lists, sorted from the product with the lowest price to highest
+    <strong>This endpoint is cached for an amount of time determined by ENDPOINT_CACHE_DURATION</strong>
 
     <pre class="prettyprint">
     <b>GET</b> /api/v2/stripe/products/

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -229,6 +229,7 @@ class CheckoutLinkView(APIView):
             }
         return stripe.checkout.Session.create(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
+            allow_promotion_codes=True,
             automatic_tax={'enabled': False},
             billing_address_collection='required',
             customer=customer_id,

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -308,7 +308,7 @@ class SubscriptionViewSet(viewsets.ReadOnlyModelViewSet):
         )
 
 
-@method_decorator(cache_page(60 * 30), name='list')
+@method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='list')
 class ProductViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     """
     Returns Product and Price Lists, sorted from the product with the lowest price to highest

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1363,6 +1363,9 @@ CACHES = {
     'default': env.cache(default='redis://redis_cache:6380/3'),
 }
 
+# How long to retain cached responses for kpi endpoints
+ENDPOINT_CACHE_DURATION = env.str('ENDPOINT_CACHE_DURATION', 60 * 15)  # 15 minutes
+
 ENV = None
 
 # The maximum size in bytes that a request body may be before a

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1364,7 +1364,7 @@ CACHES = {
 }
 
 # How long to retain cached responses for kpi endpoints
-ENDPOINT_CACHE_DURATION = env.str('ENDPOINT_CACHE_DURATION', 60 * 15)  # 15 minutes
+ENDPOINT_CACHE_DURATION = env.int('ENDPOINT_CACHE_DURATION', 60 * 15)  # 15 minutes
 
 ENV = None
 

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -8,7 +8,6 @@ from rest_framework.fields import empty
 from kobo.apps.organizations.models import Organization
 from kobo.apps.project_views.models.assignment import User
 from kobo.apps.trackers.models import NLPUsageCounter
-from kpi.constants import ASSET_TYPE_SURVEY
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatXForm,
     ReadOnlyKobocatDailyXFormSubmissionCounter,
@@ -249,9 +248,9 @@ class ServiceUsageSerializer(serializers.Serializer):
         return self._anchor_date.replace(year=self._now.year)
 
     def _get_organization_details(self):
-        # Get the organization ID passed in from the query parameters
-        organization_id = self.context['request'].query_params.get(
-            'organization_id'
+        # Get the organization ID from the request
+        organization_id = self.context.get(
+            'organization_id', None
         )
 
         if not organization_id:
@@ -267,8 +266,10 @@ class ServiceUsageSerializer(serializers.Serializer):
             return
 
         # If the user is in an organization, get all org users so we can query their total org usage
-        self._user_ids = User.objects.values_list('pk', flat=True).filter(
-            organizations_organization__id=organization_id
+        self._user_ids = list(
+            User.objects.values_list('pk', flat=True).filter(
+                organizations_organization__id=organization_id
+            )
         )
 
         # If they have a subscription, use its start date to calculate beginning of current month/year's usage

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -66,7 +66,6 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
             owner=owner,
             asset_type='survey',
         )
-        print(owner)
 
         self.asset.deploy(backend='mock', active=True)
         self.asset.save()

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -8,8 +8,10 @@ from django.contrib.auth.models import User
 from django.db import connection
 from django.urls import reverse
 from django.utils import timezone
+from model_bakery import baker
 from rest_framework import status
 
+from kobo.apps.organizations.models import Organization
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatXForm,
@@ -36,11 +38,13 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         super().setUp()
         self.client.login(username='anotheruser', password='anotheruser')
         self.anotheruser = User.objects.get(username='anotheruser')
+        self.someuser = User.objects.get(username='someuser')
         with connection.schema_editor() as schema_editor:
             for unmanaged_model in self.unmanaged_models:
                 schema_editor.create_model(unmanaged_model)
 
-    def __create_asset(self):
+    def __create_asset(self, user=None):
+        owner = user or self.anotheruser
         content_source_asset = {
             'survey': [
                 {
@@ -59,9 +63,10 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         }
         self.asset = Asset.objects.create(
             content=content_source_asset,
-            owner=self.anotheruser,
+            owner=owner,
             asset_type='survey',
         )
+        print(owner)
 
         self.asset.deploy(backend='mock', active=True)
         self.asset.save()
@@ -292,6 +297,38 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         assert response.data['total_submission_count']['all_time'] == 3
         assert response.data['total_storage_bytes'] == (
             self.__expected_file_size() * 3
+        )
+
+    def test_usage_for_organization(self):
+        """
+        Test that the endpoint aggregates usage for each user in the organization
+        when viewing /service_usage/{organization_id}/
+        """
+        self.client.login(username='anotheruser', password='anotheruser')
+        organization = baker.make(Organization, id='orgAKWMFskafsngf', name='test organization')
+        organization.add_user(self.anotheruser, is_admin=True)
+        organization.save()
+        self.__create_asset()
+        self.__add_submission()
+
+        url = reverse(self._get_endpoint('service-usage-list'))
+        detail_url = f'{url}{organization.id}/'
+        response = self.client.get(detail_url)
+        assert response.data['total_submission_count']['current_month'] == 1
+        assert response.data['total_submission_count']['all_time'] == 1
+        assert response.data['total_storage_bytes'] == (
+            self.__expected_file_size()
+        )
+
+        organization.add_user(self.someuser, is_admin=False)
+        self.someuser.save()
+        self.__create_asset(self.someuser)
+        self.__add_submission()
+        response = self.client.get(detail_url)
+        assert response.data['total_submission_count']['current_month'] == 2
+        assert response.data['total_submission_count']['all_time'] == 2
+        assert response.data['total_storage_bytes'] == (
+            self.__expected_file_size() * 2
         )
 
     def test_no_data(self):

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -313,8 +313,8 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         self.__create_asset()
         self.__add_submission()
 
-        url = reverse(self._get_endpoint('service-usage-list'))
-        detail_url = f'{url}{organization.id}/'
+        url = reverse(self._get_endpoint('organizations-list'))
+        detail_url = f'{url}{organization.id}/service_usage/'
         response = self.client.get(detail_url)
         assert response.data['total_submission_count']['current_month'] == 1
         assert response.data['total_submission_count']['all_time'] == 1

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -310,7 +310,6 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         self.client.login(username='anotheruser', password='anotheruser')
         organization = baker.make(Organization, id='orgAKWMFskafsngf', name='test organization')
         organization.add_user(self.anotheruser, is_admin=True)
-        organization.save()
         self.__create_asset()
         self.__add_submission()
 
@@ -324,7 +323,6 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         )
 
         organization.add_user(self.someuser, is_admin=False)
-        self.someuser.save()
         self.__create_asset(self.someuser)
         self.__add_submission()
         response = self.client.get(detail_url)

--- a/kpi/views/v2/service_usage.py
+++ b/kpi/views/v2/service_usage.py
@@ -22,6 +22,7 @@ class ServiceUsageViewSet(viewsets.ViewSet):
     <p>Tracks the total usage of different services for the logged-in user</p>
     <p>Tracks the submissions and NLP seconds/characters for the current month/year/all time</p>
     <p>Tracks the current total storage used</p>
+    <strong>This endpoint is cached for an amount of time determined by ENDPOINT_CACHE_DURATION</strong>
 
     <pre class="prettyprint">
     <b>GET</b> /api/v2/service_usage/

--- a/kpi/views/v2/service_usage.py
+++ b/kpi/views/v2/service_usage.py
@@ -14,9 +14,9 @@ from kpi.serializers.v2.service_usage import ServiceUsageSerializer
 from kpi.utils.object_permission import get_database_user
 
 
-@method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='list')
-@method_decorator(vary_on_cookie, name='list')
-class ServiceUsageViewSet(viewsets.ViewSet):
+# @method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='list')
+# @method_decorator(vary_on_cookie, name='list')
+class ServiceUsageViewSet(viewsets.GenericViewSet):
     """
     ## Service Usage Tracker
     <p>Tracks the total usage of different services for the logged-in user</p>
@@ -61,20 +61,9 @@ class ServiceUsageViewSet(viewsets.ViewSet):
     pagination_class = None
     permission_classes = (IsAuthenticated,)
 
-    @staticmethod
-    def get_serializer_context(cls):
-        """
-        Extra context provided to the serializer class.
-        """
-        return {
-            'request': cls.request,
-            'format': cls.format_kwarg,
-            'view': cls,
-        }
-
     def list(self, request, *args, **kwargs):
         serializer = ServiceUsageSerializer(
             get_database_user(request.user),
-            context=self.get_serializer_context(self),
+            context=self.get_serializer_context(),
         )
         return Response(data=serializer.data)

--- a/kpi/views/v2/service_usage.py
+++ b/kpi/views/v2/service_usage.py
@@ -62,7 +62,7 @@ class ServiceUsageViewSet(viewsets.ViewSet):
     permission_classes = (IsAuthenticated,)
 
     @staticmethod
-    def get_serializer_context(cls, organization_id=None):
+    def get_serializer_context(cls):
         """
         Extra context provided to the serializer class.
         """
@@ -70,7 +70,6 @@ class ServiceUsageViewSet(viewsets.ViewSet):
             'request': cls.request,
             'format': cls.format_kwarg,
             'view': cls,
-            'organization_id': organization_id,
         }
 
     def list(self, request, *args, **kwargs):

--- a/kpi/views/v2/service_usage.py
+++ b/kpi/views/v2/service_usage.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
@@ -13,8 +14,8 @@ from kpi.serializers.v2.service_usage import ServiceUsageSerializer
 from kpi.utils.object_permission import get_database_user
 
 
-@method_decorator(cache_page(60 * 30), name='retrieve')
-@method_decorator(cache_page(60 * 30), name='list')
+@method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='retrieve')
+@method_decorator(cache_page(settings.ENDPOINT_CACHE_DURATION), name='list')
 @method_decorator(vary_on_cookie, name='retrieve')
 @method_decorator(vary_on_cookie, name='list')
 class ServiceUsageViewSet(viewsets.ViewSet):


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Caches the `api/v2/service_usage` endpoint to prevent slowdown on sites with a large number of users/projects. Adds a 'last updated' widget to the Usage page. Allows promotion codes to be used when checking out for a Plan.

## Notes

* Added a new setting/env var, `ENDPOINT_CACHE_DURATION`.
* Refactored `service_usage` endpoint to use a detail view (`/api/v2/organizations/{ORGANIZATION_ID}/service_usage/`) instead of POSTing the organization ID.
* The badge on the usage page is based on the cached age of the response from the service usage endpoint (user or organization). To reset it, log out and back in.