### PR TITLE
Bump tsconfig target from ES2016 to ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
       "scss/*": ["scss/*"],
       "test/*": ["test/*"],
     },
-    "target": "es2016",
+    "target": "es2017",
     "module": "es2020",
     "esModuleInterop": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Change TypeScript compilation target from ES2016 to ES2017.

## Notes

This is intended to make TypeScript recognize `Object.entries()` and `Object.values()`. See [kpi#4660](https://github.com/kobotoolbox/kpi/pull/4660) for an example of hacking the issue (using `as keyof {Type}`). ES2017 is at ~93% use in the wild based on caniuse.com stats, which satisfies our availability requirements.

This should (🙏🏽) be fully forward compatible. TypeScript doesn't complain at compile time and I haven't been able to make it spit any new errors at me from the SPA. But please do give it some testing.