### PR TITLE
Allow GET to `/token/` to create a new API token if none exists

### DIFF
--- a/kpi/views/token.py
+++ b/kpi/views/token.py
@@ -30,13 +30,16 @@ class TokenView(APIView):
         return user
 
     def get(self, request, *args, **kwargs):
-        """ Retrieve an existing token only """
+        """ Retrieve an existing token, or create and retrieve a new one """
         user = self._which_user(request)
-        token = get_object_or_404(Token, user=user)
+        token, _ = Token.objects.get_or_create(user=user)
         return Response({'token': token.key})
 
     def post(self, request, *args, **kwargs):
-        """ Return a token, creating a new one if none exists """
+        """
+        Return a token, creating a new one if none exists. Unnecessary now that
+        GET also creates a token, but left here for API stability
+        """
         user = self._which_user(request)
         token, created = Token.objects.get_or_create(user=user)
         return Response(


### PR DESCRIPTION
The old behavior of POST is unchanged for the sake of API stability.

Something in releases prior to 2.023.37 was creating these tokens implicitly. It's not happening anymore, meaning that new accounts are left without API tokens, and the front end has never had any facility to send anything other than a GET to the token endpoint. To avoid the hassle of backfilling tokens for accounts that have none, or of rewriting the front end to send POST whenever GET returns a 404, this change simply allows a GET request to create a token implicitly if none exists.