### PR TITLE
Make Usage page show correct date for single users with a Plan

### DIFF
--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from kpi.permissions import IsAuthenticated
 from kpi.serializers.v2.service_usage import ServiceUsageSerializer
 from kpi.utils.object_permission import get_database_user
-from kpi.views.v2.service_usage import ServiceUsageViewSet
 from .models import Organization, create_organization
 from .permissions import IsOrgAdminOrReadOnly
 from .serializers import OrganizationSerializer

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -81,8 +81,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         """
 
         context = {
-            # Commented out until the Enterprise plan is implemented
-            #   'organization_id': kwargs.get('id', None),
+            'organization_id': kwargs.get('id', None),
             **self.get_serializer_context(),
         }
 

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -211,12 +211,16 @@ class ServiceUsageSerializer(serializers.Serializer):
             # Couldn't find organization, proceed as normal
             return
 
+        """
+        Commented out until the Enterprise plan is implemented
+
         # If the user is in an organization, get all org users so we can query their total org usage
         self._user_ids = list(
             User.objects.values_list('pk', flat=True).filter(
                 organizations_organization__id=organization_id
             )
         )
+        """
 
         # If they have a subscription, use its start date to calculate beginning of current month/year's usage
         billing_details = organization.active_subscription_billing_details

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -322,6 +322,9 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
             self.__expected_file_size()
         )
 
+        """
+        Commented out until the Enterprise plan is implemented
+
         organization.add_user(self.someuser, is_admin=False)
         self.__create_asset(self.someuser)
         self.__add_submission()
@@ -331,6 +334,7 @@ class ServiceUsageAPITestCase(BaseAssetTestCase):
         assert response.data['total_storage_bytes'] == (
             self.__expected_file_size() * 2
         )
+        """
 
     def test_service_usages_with_projects_in_trash_bin(self):
         self.test_multiple_forms()


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The Usage page now shows the correct date for single users in an organization.

## Notes

This change is being made as part of requirement that only Enterprise plan users are allowed to create/use organizations.

This was initially implemented by not sending the `organization_id` to `ServiceUsageSerializer` ([ref](https://github.com/kobotoolbox/kpi/pull/4666/files#diff-7a5e6d20c817968927e472d4d68e54e3e05e17bf508fbf3728063a0be30e96f0R84-R85)). That wasn't ideal, because the serializer needs the ID to get the subscription's start date. Instead, this PR just skips the query to get the additional users in the org. Once the Enterprise plan is implemented, this code will be re-used, so it's only commented out for now.

Affects the usage page, the over-limit banners and modals, and the `/service_usage/` endpoint.

## Testing
* Find/create two new users and make submissions for each. Note how many submissions each user has on the Projects list.
* Add both users to an organization.
* Log in as one of those users.
* Verify that the Usage page (`/#/account/usage/`) only shows submissions for the logged-in user.
* If necessary, set up Stripe (internal documentation link [here](https://www.notion.so/kobotoolbox/Stripe-for-KoboToolbox-9a958a84d6324ec8a4ca887b820eb8cf))
* Purchase a test subscription from the Plans page (`/#/account/usage/`)
* Verify that the Usage page (`/#/account/usage/`) only shows submissions for the logged-in user.
* Verify that the start date (on the left in the below image) on the Usage page is today's date
![image](https://github.com/kobotoolbox/kpi/assets/7819986/054c8349-dac4-42e9-bf1f-9722c499207b)
