### PR TITLE
Fixes reloading page on select all and empty import causing page crash in dynamic data attachments

### DIFF
--- a/jsapp/js/components/dataAttachments/connectProjects.es6
+++ b/jsapp/js/components/dataAttachments/connectProjects.es6
@@ -375,9 +375,9 @@ class ConnectProjects extends React.Component {
           />
 
           {this.state.fieldsErrors?.source &&
-            <bem.KoboSelect__errors>
+            <bem.KoboSelect__error>
               {this.state.fieldsErrors?.source}
-            </bem.KoboSelect__errors>
+            </bem.KoboSelect__error>
           }
         </bem.KoboSelect__wrapper>
       );

--- a/jsapp/js/components/dataAttachments/dataAttachmentColumnsForm.es6
+++ b/jsapp/js/components/dataAttachments/dataAttachmentColumnsForm.es6
@@ -91,13 +91,17 @@ class DataAttachmentColumnsForm extends React.Component {
   onAttachToSourceCompleted() {
     this.props.onModalClose();
   }
-  onBulkSelect() {
+  onBulkSelect(evt) {
+    evt.preventDefault();
+
     let newList = this.state.columnsToDisplay.map((item) => {
       return {label: item.label, checked: true}
     });
     this.setState({columnsToDisplay: newList})
   }
-  onBulkDeselect() {
+  onBulkDeselect(evt) {
+    evt.preventDefault();
+
     let newList = this.state.columnsToDisplay.map((item) => {
       return {label: item.label, checked: false}
     });


### PR DESCRIPTION
## Description
Fixes the following 2 issues:
- Page reload when pressing 'Select all'  or 'Deselect all' in the dynamic data attachments question select modal
- Page crashing when attempting to import project data without selecting a project
## Notes

Describe what you've changed and why. This should allow the reviewer to understand more easily the scope of the PR. It's good to be thorough here.

## Related issues
Zulip: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Dynamic.20data.20attachments/near/280428
