### PR TITLE
Enforce `Default` when only one form disclaimer is set

### DIFF
--- a/kobo/apps/form_disclaimer/forms.py
+++ b/kobo/apps/form_disclaimer/forms.py
@@ -19,10 +19,13 @@ class FormDisclaimerForm(ModelForm):
         default = self.cleaned_data['default']
         if (
             not default
-            and not FormDisclaimer.objects.filter(default=True).exists()
+            and not FormDisclaimer.objects.filter(default=True)
+            .exclude(pk=self.instance.pk)
+            .exists()
         ):
             raise ValidationError(
-                'You need to use at least one language as default', 'no_default_error'
+                'You need to use at least one language as default',
+                'no_default_error',
             )
 
         return default
@@ -34,7 +37,9 @@ class FormDisclaimerForm(ModelForm):
 
         if (
             default
-            and FormDisclaimer.objects.exclude(pk=self.instance.pk).exists()
+            and FormDisclaimer.objects.filter(default=True)
+            .exclude(pk=self.instance.pk)
+            .exists()
         ):
             FormDisclaimer.objects.filter(default=True).update(default=False)
             KobocatFormDisclaimer.objects.filter(default=True).update(default=False)

--- a/kobo/apps/form_disclaimer/forms.py
+++ b/kobo/apps/form_disclaimer/forms.py
@@ -81,6 +81,14 @@ class OverriddenFormDisclaimerForm(ModelForm):
         message = self.cleaned_data.get('message', '')
         asset = self.cleaned_data.get('asset', None)
 
+        if not FormDisclaimer.objects.filter(
+            asset__isnull=True
+        ).exists():
+            raise ValidationError(
+                'You must set a global disclaimer first.',
+                'no_global_disclaimer',
+            )
+
         if not hidden and (not language or not message):
             raise ValidationError(
                 'You must specify a language and a message if the disclaimer '


### PR DESCRIPTION
## Description

A validation error is raised if default is unchecked and there is only one form disclaimer set

## Notes

It always already set on creation but not on edit.
