### PR TITLE
Fix 500 error when previewing multilanguage forms with disclaimer message

### DIFF
--- a/kobo/apps/form_disclaimer/models.py
+++ b/kobo/apps/form_disclaimer/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Q
 from django.db.models.constraints import UniqueConstraint
@@ -66,13 +67,15 @@ class FormDisclaimer(AbstractMarkdownxModel):
 
         with transaction.atomic():
             super().save(*args, **kwargs)
-            KobocatFormDisclaimer.sync(self)
+            if not settings.TESTING:
+                KobocatFormDisclaimer.sync(self)
 
     def delete(self, using=None, keep_parents=False):
         pk = self.pk
         with transaction.atomic():
             value = super().delete(using, keep_parents)
-            KobocatFormDisclaimer.objects.filter(pk=pk).delete()
+            if not settings.TESTING:
+                KobocatFormDisclaimer.objects.filter(pk=pk).delete()
         return value
 
 

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -320,8 +320,6 @@ class XMLFormWithDisclaimer:
 
         for n in self._root_node.getElementsByTagName('itext')[0].childNodes:
             if n.nodeType == Node.ELEMENT_NODE and n.tagName == 'translation':
-                languages.append(n.getAttribute('lang'))
-                translation_nodes.append(n)
                 disclaimer_translation = self._root_node.createElement('text')
                 disclaimer_translation.setAttribute(
                     'id',


### PR DESCRIPTION
## Notes
Fixes a bug introduced with [this commit](https://github.com/kobotoolbox/kpi/commit/8acb465e29ab0b356906754c1fcd414300d8c8b0) 
It only happened with multi languages forms and previews. This bug did not occur with Kobocat OpenRosa response.