### PR TITLE
[ TASK-164 ] Do not use soft deleted attachments

### DIFF
--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -521,6 +521,12 @@ class ReadOnlyModel(ShadowModel):
         abstract = True
 
 
+class ReadOnlyKobocatAttachmentManager(models.Manager):
+
+    def get_queryset(self):
+        return super().get_queryset().exclude(replaced_at__isnull=False)
+
+
 class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
 
     class Meta(ReadOnlyModel.Meta):
@@ -541,9 +547,8 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
     mimetype = models.CharField(
         max_length=100, null=False, blank=True, default=''
     )
-    # TODO: hide attachments that were deleted or replaced; see
-    # kobotoolbox/kobocat#792
-    # replaced_at = models.DateTimeField(blank=True, null=True)
+    replaced_at = models.DateTimeField(blank=True, null=True)
+    objects = ReadOnlyKobocatAttachmentManager()
 
     @property
     def absolute_mp3_path(self):

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -524,7 +524,7 @@ class ReadOnlyModel(ShadowModel):
 class ReadOnlyKobocatAttachmentManager(models.Manager):
 
     def get_queryset(self):
-        return super().get_queryset().exclude(replaced_at__isnull=False)
+        return super().get_queryset().exclude(deleted_at__isnull=False)
 
 
 class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
@@ -547,7 +547,7 @@ class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
     mimetype = models.CharField(
         max_length=100, null=False, blank=True, default=''
     )
-    replaced_at = models.DateTimeField(blank=True, null=True)
+    deleted_at = models.DateTimeField(blank=True, null=True, db_index=True)
     objects = ReadOnlyKobocatAttachmentManager()
 
     @property

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -158,14 +158,12 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         )
 
         # If `submission_ids` is not empty, user has partial permissions.
-        # Otherwise, they have have full access.
+        # Otherwise, they have full access.
         if submission_ids:
-            partial_perms = True
             # Reset query, because all the submission ids have been already
             # retrieve
             data['query'] = {}
         else:
-            partial_perms = False
             submission_ids = data['submission_ids']
 
         submissions = self.get_submissions(
@@ -694,14 +692,10 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 raise XPathNotFoundException
 
             filters = {
-                # TODO: hide attachments that were deleted or replaced; see
-                # kobotoolbox/kobocat#792
-                # 'replaced_at': None,
                 'media_file_basename': attachment_filename,
             }
         else:
             filters = {
-                # 'replaced_at': None,
                 'pk': attachment_id,
             }
 


### PR DESCRIPTION
## Description

Avoid showing attachments that have been replaced or deleted when editing a submission

## Notes

Use a custom model manager to always filter Attachment objects based on the `replaced_at` flag. 

## Related issues

Blocked by kobotoolbox/kobocat#792

