### PR TITLE
Make `name` field required by default

### DIFF
--- a/kobo/apps/accounts/tests/test_email_content.py
+++ b/kobo/apps/accounts/tests/test_email_content.py
@@ -45,6 +45,7 @@ class EmailContentModelTestCase(TestCase):
         username = 'user001'
         email = username + '@example.com'
         data = {
+            'name': 'username',
             'email': email,
             'password1': username,
             'password2': username,
@@ -92,6 +93,7 @@ class EmailContentModelTestCase(TestCase):
         username = 'user002'
         email = username + '@example.com'
         data = {
+            'name': username,
             'email': email,
             'password1': username,
             'password2': username,
@@ -136,6 +138,7 @@ class EmailContentModelTestCase(TestCase):
         username = 'user003'
         email = username + '@example.com'
         data = {
+            'name': username,
             'email': email,
             'password1': username,
             'password2': username,

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -281,7 +281,7 @@ CONSTANCE_CONFIG = {
     ),
     'USER_METADATA_FIELDS': (
         LazyJSONSerializable([
-            {'name': 'name', 'required': False},
+            {'name': 'name', 'required': True},
             {'name': 'organization', 'required': False},
             {'name': 'organization_website', 'required': False},
             {'name': 'sector', 'required': False},

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -1,5 +1,3 @@
-import json
-
 from constance import config
 from django.db import migrations
 

--- a/kpi/migrations/0053_set_user_fullname_required_by_default.py
+++ b/kpi/migrations/0053_set_user_fullname_required_by_default.py
@@ -1,0 +1,33 @@
+from constance import config
+from django.db import migrations
+
+from kobo.apps.constance_backends.utils import to_python_object
+from kpi.utils.json import LazyJSONSerializable
+
+
+def make_fullname_required_by_default(apps, schema_editor):
+    user_metadata_fields = to_python_object(config.USER_METADATA_FIELDS)
+    for field in user_metadata_fields:
+        if field['name'] == 'name':
+            field['required'] = True
+            break
+
+    setattr(
+        config,
+        'USER_METADATA_FIELDS',
+        LazyJSONSerializable(user_metadata_fields),
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kpi', '0052_add_deployment_status_to_asset'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            make_fullname_required_by_default,
+            migrations.RunPython.noop,
+        )
+    ]

--- a/kpi/tests/test_registration.py
+++ b/kpi/tests/test_registration.py
@@ -12,6 +12,7 @@ class RegistrationTestCase(TestCase):
     def valid_data(self):
         User = get_user_model()
         return {
+            'name': 'alice',
             User.USERNAME_FIELD: 'alice',
             'email': 'alice@example.com',
             'password1': 'swordfish',


### PR DESCRIPTION
## Description

It brings back to previous behaviour, i.e. Full name is required all the time when users create a new account.

## Notes

`name` has been added to the customizable field in the `USER_META_FIELDS` variable in Admin > Constance. 
The field is mandatory and cannot be removed from the list but its `required` property is now set to `True` (like it was before `2.023.37` release 