### PR TITLE
[TASK-93] Remove gender from signup form by default

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -285,7 +285,6 @@ CONSTANCE_CONFIG = {
             {'name': 'organization', 'required': False},
             {'name': 'organization_website', 'required': False},
             {'name': 'sector', 'required': False},
-            {'name': 'gender', 'required': False},
             {'name': 'bio', 'required': False},
             {'name': 'city', 'required': False},
             {'name': 'country', 'required': False},


### PR DESCRIPTION
## Description

By default, don't include the gender field in the user sign up and profile forms. It can still be added in Django admin through constance config.