### PR TITLE
Fix 500 error when loading projects list with PostgreSQL 13 and older

### DIFF
--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -33,7 +33,7 @@ from kpi.exceptions import (
     SearchQueryTooShortException,
 )
 from kpi.models.asset import AssetDeploymentStatus, UserAssetSubscription
-from kpi.utils.django_orm_helper import OrderRandom
+from kpi.utils.django_orm_helper import OrderCustom
 from kpi.utils.query_parser import get_parsed_parameters, parse, ParseError
 from kpi.utils.object_permission import (
     get_objects_for_user,
@@ -120,8 +120,10 @@ class AssetOrderingFilter(filters.OrderingFilter):
         else:
             # Default ordering
             return queryset.order_by(
-                OrderRandom(
-                    '_deployment_status', self.DEPLOYMENT_STATUS_DEFAULT_ORDER
+                OrderCustom(
+                    '_deployment_status',
+                    self.DEPLOYMENT_STATUS_DEFAULT_ORDER,
+                    array_type='varchar',
                 ),
                 '-date_modified',
             )

--- a/kpi/utils/django_orm_helper.py
+++ b/kpi/utils/django_orm_helper.py
@@ -1,5 +1,7 @@
-# coding: utf-8
+from __future__ import annotations
+
 import json
+from typing import Optional, Literal
 
 from django.db.models import Lookup, Field
 from django.db.models.expressions import Func, Value
@@ -44,7 +46,13 @@ class OrderCustom(Func):
     template = '%(function)s(ARRAY%(order_list)s, %(expressions)s)'
     arity = 1
 
-    def __init__(self, expression: str, order_list: list, array_type: str, **extra):
+    def __init__(
+        self,
+        expression: str,
+        order_list: list,
+        array_type: Optional[Literal['varchar']] = None,
+        **extra
+    ):
 
         # With PostgreSQL 13 (and older), `array_position` needs explicit type
         # casts to work. By default, `order_list` is treated as `text[]`

--- a/kpi/utils/django_orm_helper.py
+++ b/kpi/utils/django_orm_helper.py
@@ -38,13 +38,19 @@ class IncrementValue(Func):
         )
 
 
-class OrderRandom(Func):
+class OrderCustom(Func):
 
     function = 'array_position'
     template = '%(function)s(ARRAY%(order_list)s, %(expressions)s)'
     arity = 1
 
-    def __init__(self, expression: str, order_list: list, **extra):
+    def __init__(self, expression: str, order_list: list, array_type: str, **extra):
+
+        # With PostgreSQL 13 (and older), `array_position` needs explicit type
+        # casts to work. By default, `order_list` is treated as `text[]`
+        # TODO Remove this condition when PostgreSQL 13 becomes deprecated.
+        if array_type == 'varchar':
+            self.template = '%(function)s(ARRAY%(order_list)s::varchar[], %(expressions)s)'
 
         if expression.startswith('-'):
             order_list.reverse()


### PR DESCRIPTION
## Description

Make the default projects sorting (i.e. `deployed`, `draft`, `archive`) work with older versions of PostgreSQL.

## Notes 
`OrderRandom` ORM utility has been renamed to a more explicit name: `OrderCustom` 

Supersedes #4685 
