### PR TITLE
Update ChangePlanView

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -42,6 +42,7 @@ class Organization(AbstractOrganization):
                 ).values(
                     billing_cycle_anchor=F('djstripe_customers__subscriptions__billing_cycle_anchor'),
                     current_period_start=F('djstripe_customers__subscriptions__current_period_start'),
+                    current_period_end=F('djstripe_customers__subscriptions__current_period_end'),
                     recurring_interval=F('djstripe_customers__subscriptions__items__price__recurring__interval'),
                 ).first()
 

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -75,6 +75,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         >           },
         >           "current_month_start": {string (date), YYYY-MM-DD format},
         >           "current_year_start": {string (date), YYYY-MM-DD format},
+        >           "billing_period_end": {string (date), YYYY-MM-DD format}|{None},
         >       }
         ### CURRENT ENDPOINT
         """

--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -78,14 +78,24 @@ class ChangePlanSerializer(PriceIdSerializer):
 
 class CustomerPortalSerializer(serializers.Serializer):
     organization_id = serializers.CharField(required=True)
+    price_id = serializers.SlugRelatedField(
+        'id',
+        queryset=Price.objects.all(),
+        required=False,
+        allow_empty=True,
+    )
 
     def validate_organization_id(self, organization_id):
         if organization_id.startswith('org'):
             return organization_id
         raise ValidationError('Invalid organization ID')
 
+    class Meta:
+        model = Price
+        fields = ('id',)
 
-class CheckoutLinkSerializer(PriceIdSerializer, CustomerPortalSerializer):
+
+class CheckoutLinkSerializer(PriceIdSerializer):
     organization_id = serializers.CharField(required=False)
 
 

--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -4,7 +4,7 @@ from djstripe.models import (
     Product,
     Session,
     Subscription,
-    SubscriptionItem,
+    SubscriptionItem, SubscriptionSchedule,
 )
 from rest_framework import serializers
 
@@ -42,6 +42,7 @@ class BasePriceSerializer(serializers.ModelSerializer):
             'recurring',
             'unit_amount',
             'human_readable_price',
+            'active',
             'metadata',
         )
 
@@ -100,6 +101,7 @@ class PriceSerializer(BasePriceSerializer):
             'unit_amount',
             'human_readable_price',
             'metadata',
+            'active',
             'product',
         )
 
@@ -119,8 +121,16 @@ class SubscriptionItemSerializer(serializers.ModelSerializer):
         fields = ('id', 'price')
 
 
+class SubscriptionScheduleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = SubscriptionSchedule
+        fields = ('phases', 'status')
+
+
 class SubscriptionSerializer(serializers.ModelSerializer):
     items = SubscriptionItemSerializer(many=True)
+    schedule = SubscriptionScheduleSerializer()
 
     class Meta:
         model = Subscription

--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -4,7 +4,8 @@ from djstripe.models import (
     Product,
     Session,
     Subscription,
-    SubscriptionItem, SubscriptionSchedule,
+    SubscriptionItem,
+    SubscriptionSchedule,
 )
 from rest_framework import serializers
 

--- a/kobo/apps/stripe/tests/test_customer_portal_api.py
+++ b/kobo/apps/stripe/tests/test_customer_portal_api.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 
-from djstripe.models import Customer
+from djstripe.models import Customer, Subscription, Price, Product
 from model_bakery import baker
 from rest_framework import status
 from urllib.parse import urlencode
@@ -16,6 +16,8 @@ from kpi.tests.kpi_test_case import BaseTestCase
 
 @patch('djstripe.models.Customer.objects.get')
 @patch('stripe.billing_portal.Session.create')
+@patch('stripe.billing_portal.Configuration.list')
+@patch('stripe.billing_portal.Configuration.create')
 class TestCustomerPortalAPITestCase(BaseTestCase):
 
     fixtures = ['test_data']
@@ -29,39 +31,125 @@ class TestCustomerPortalAPITestCase(BaseTestCase):
         url = reverse('portallinks')
         return f'{url}?{urlencode(query_params)}'
 
-    def _create_customer_organization(self):
-        organization = baker.make(Organization, id='orgSALFMLFMSDGmgdlsgmsd')
-        customer = baker.make(Customer, subscriber=organization)
-        return customer, organization
+    def _create_stripe_data(self, create_subscription=True, product_type='plan'):
+        self.organization = baker.make(Organization, id='orgSALFMLFMSDGmgdlsgmsd')
+        self.customer = baker.make(Customer, subscriber=self.organization, livemode=False)
+        self.product = baker.make(
+            Product,
+            metadata={'product_type': product_type}
+        )
+        self.price = baker.make(Price, product=self.product)
+        if create_subscription:
+            self.subscription = baker.make(
+                Subscription,
+                status='active',
+                customer=self.customer,
+            )
 
-    def _post_expected_request(self):
-        customer, organization = self._create_customer_organization()
-        organization.add_user(self.some_user, is_admin=True)
-        url = self._get_url({'organization_id': organization.id})
-        return self.client.post(url)
+    def _get_url_for_expected_request(self, create_subscription=True, product_type='plan'):
+        self._create_stripe_data(create_subscription, product_type)
+        self.organization.add_user(self.some_user, is_admin=True)
+        return self._get_url({'organization_id': self.organization.id, 'price_id': self.price.id})
 
-    def test_generates_url(self, stripe_billing_session_create_mock, customer_objects_get_mock):
-        stripe_billing_session_create_mock.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
-        response = self._post_expected_request()
+    def test_generates_url(self, create_config, list_config, session_create, get_customer):
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        url = self._get_url_for_expected_request()
+        list_config.return_value = [
+            {
+                'metadata': {
+                    'portal_price': self.price.id,
+                },
+            },
+        ]
+        response = self.client.post(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.data['url'].startswith('https://billing.stripe.com/')
 
-    def test_needs_organization_id(self, stripe_billing_session_create_mock, customer_objects_get_mock):
-        stripe_billing_session_create_mock.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+    def test_needs_organization_id(self, create_config, list_config, session_create, get_customer):
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
         url = self._get_url({'organization_id': ''})
         response = self.client.post(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_user_must_be_owner(self, stripe_billing_session_create_mock, customer_objects_get_mock):
-        stripe_billing_session_create_mock.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
-        customer, organization = self._create_customer_organization()
-        customer_objects_get_mock.return_value = customer
-        url = self._get_url({'organization_id': organization.id})
-        with self.assertRaises(ObjectDoesNotExist):
-            self.client.post(url)
+    def test_user_must_be_owner(self, create_config, list_config, session_create, get_customer):
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        self._create_stripe_data()
+        get_customer.return_value = self.customer
+        url = self._get_url({'organization_id': self.organization.id})
+        response = self.client.post(url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_anonymous_user(self, stripe_billing_session_create_mock, customer_objects_get_mock):
-        stripe_billing_session_create_mock.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+    def test_gets_portal_configuration_for_price(self, create_config, list_config, session_create, get_customer):
+        """
+        If the billing portal isn't configured to switch to the price provided,
+        it first tries to get a matching portal from Stripe. Test that this works
+        correctly with a dummy billing configuration.
+        """
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        url = self._get_url_for_expected_request(product_type='addon')
+        list_config.return_value = [
+            {
+                'id': 'test',
+                'metadata': {
+                    'portal_price': self.price.id,
+                },
+                'active': True,
+                'livemode': False,
+            },
+        ]
+        create_config.return_value = {'id': 'test'}
+        response = self.client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['url'].startswith('https://billing.stripe.com/')
+
+    def test_generates_portal_configuration(self, create_config, list_config, session_create, get_customer):
+        """
+        If there isn't a matching portal configuration for the price in Stripe,
+        the endpoint attempts to create a new one. Test that nothing breaks, using a dummy config.
+        """
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        url = self._get_url_for_expected_request(product_type='addon')
+        list_config.return_value = [
+            {
+                'id': 'test',
+                'metadata': {
+                    'portal_price': 'nope',
+                },
+                'features': {
+                    'subscription_update': {
+                        'products': []
+                    }
+                },
+                'business_profile': None,
+                'is_default': True,
+                'active': True,
+                'livemode': False,
+            },
+        ]
+        create_config.return_value = {'id': 'test'}
+        response = self.client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['url'].startswith('https://billing.stripe.com/')
+
+    def test_generates_link_without_price(self, create_config, list_config, session_create, get_customer):
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        self._create_stripe_data()
+        self.organization.add_user(self.some_user, is_admin=True)
+        url = self._get_url({'organization_id': self.organization.id})
+        list_config.return_value = [
+            {
+                'metadata': {
+                    'portal_price': self.price.id,
+                },
+            },
+        ]
+        response = self.client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['url'].startswith('https://billing.stripe.com/')
+
+    def test_anonymous_user(self, create_config, list_config, session_create, get_customer):
+        session_create.return_value = {'url': 'https://billing.stripe.com/p/session/test_YWNjdF8x'}
+        url = self._get_url_for_expected_request()
         self.client.logout()
-        response = self._post_expected_request()
+        response = self.client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/kobo/apps/stripe/tests/test_customer_portal_api.py
+++ b/kobo/apps/stripe/tests/test_customer_portal_api.py
@@ -56,9 +56,10 @@ class TestCustomerPortalAPITestCase(BaseTestCase):
         url = self._get_url_for_expected_request()
         list_config.return_value = [
             {
-                'metadata': {
-                    'portal_price': self.price.id,
-                },
+                'id': 'test config',
+                'is_default': True,
+                'active': True,
+                'livemode': False,
             },
         ]
         response = self.client.post(url)

--- a/kobo/apps/stripe/tests/test_modify_subscription_api.py
+++ b/kobo/apps/stripe/tests/test_modify_subscription_api.py
@@ -56,6 +56,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
     @patch("stripe.SubscriptionSchedule.create")
     @patch("stripe.SubscriptionSchedule.modify")
     def _modify_price(self, price_from, price_to, schedule_modify, subscription_schedule_create, subscription_modify):
+        subscription_modify.return_value = {}
         customer, organization = self._create_customer_organization()
         organization.add_user(self.someuser, is_admin=True)
         subscription = self._subscribe_organization(organization, customer, price_from)

--- a/kobo/apps/stripe/tests/test_modify_subscription_api.py
+++ b/kobo/apps/stripe/tests/test_modify_subscription_api.py
@@ -74,7 +74,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
             }
         ])
         subscription_schedule_create.return_value = subscription_schedule
-        return self.client.post(url)
+        return self.client.get(url)
 
     def test_upgrades_subscription(self):
         response = self._modify_price(self.low_price, self.high_price)
@@ -86,7 +86,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
 
     def test_rejects_invalid_query_params(self):
         url = self._get_url({'price_id': 'test', 'subscription_id': 'test'})
-        response = self.client.post(url)
+        response = self.client.get(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_doesnt_modify_subscription_if_not_owner(self):

--- a/kobo/apps/stripe/tests/test_modify_subscription_api.py
+++ b/kobo/apps/stripe/tests/test_modify_subscription_api.py
@@ -75,7 +75,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
             }
         ])
         subscription_schedule_create.return_value = subscription_schedule
-        return self.client.get(url)
+        return self.client.post(url)
 
     def test_upgrades_subscription(self):
         response = self._modify_price(self.low_price, self.high_price)
@@ -87,7 +87,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
 
     def test_rejects_invalid_query_params(self):
         url = self._get_url({'price_id': 'test', 'subscription_id': 'test'})
-        response = self.client.get(url)
+        response = self.client.post(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_doesnt_modify_subscription_if_not_owner(self):

--- a/kobo/apps/stripe/tests/test_modify_subscription_api.py
+++ b/kobo/apps/stripe/tests/test_modify_subscription_api.py
@@ -56,7 +56,7 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
     @patch("stripe.SubscriptionSchedule.create")
     @patch("stripe.SubscriptionSchedule.modify")
     def _modify_price(self, price_from, price_to, schedule_modify, subscription_schedule_create, subscription_modify):
-        subscription_modify.return_value = {}
+        subscription_modify.return_value = {'pending_update': None}
         customer, organization = self._create_customer_organization()
         organization.add_user(self.someuser, is_admin=True)
         subscription = self._subscribe_organization(organization, customer, price_from)

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -149,7 +149,7 @@ class ChangePlanView(APIView):
         )
         return Response({'status': 'scheduled'})
 
-    def post(self, request):
+    def get(self, request):
         serializer = ChangePlanSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         price = serializer.validated_data.get('price_id')

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -160,7 +160,7 @@ class ChangePlanView(APIView):
         )
         return Response({'status': 'scheduled'})
 
-    def get(self, request):
+    def post(self, request):
         serializer = ChangePlanSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         price = serializer.validated_data.get('price_id')

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -54,12 +54,12 @@ class ChangePlanView(APIView):
     If the user is downgrading to a lower price, it will schedule the change at the end of the current billing period.
 
     <pre class="prettyprint">
-    <b>GET</b> /api/v2/stripe/change-plan/?subscription_id=<code>{subscription_id}</code>&price_id=<code>{price_id}</code>
+    <b>POST</b> /api/v2/stripe/change-plan/?subscription_id=<code>{subscription_id}</code>&price_id=<code>{price_id}</code>
     </pre>
 
     > Example
     >
-    >       curl -X GET https://[kpi]/api/v2/stripe/change-plan/
+    >       curl -X POST https://[kpi]/api/v2/stripe/change-plan/
 
     > **Payload**
     >

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -107,9 +107,8 @@ class ChangePlanView(APIView):
             # Upgraded successfully!
             else:
                 return Response({
-                    'url': f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
+                    'price_id': price.id,
                     'status': 'success',
-                    'stripe_object': stripe_response,
                 })
 
         # We're downgrading the subscription, schedule a subscription change at the end of the current period

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -307,7 +307,9 @@ class CustomerPortalView(APIView):
             if not len(all_configs):
                 return Response({'error': "Missing Stripe billing configuration."}, status=status.HTTP_502_BAD_GATEWAY)
 
-            if price.product.metadata['product_type'] == 'addon':
+            is_price_for_addon = price.product.metadata.get('product_type', '') == 'addon'
+
+            if is_price_for_addon:
                 """
                 Recurring add-ons aren't included in the default billing configuration.
                 This lets us hide them as an 'upgrade' option for paid plan users.
@@ -317,7 +319,7 @@ class CustomerPortalView(APIView):
                     (config for config in all_configs if (
                             config['active'] and
                             config['livemode'] == settings.STRIPE_LIVE_MODE and
-                            config['metadata'].get('portal_price', None) == price.id
+                            config['metadata'].get('portal_price', '') == price.id
                     )), None
                 )
 
@@ -331,7 +333,7 @@ class CustomerPortalView(APIView):
                     )), None
                 )
 
-                if price.product.metadata['product_type'] == 'addon':
+                if is_price_for_addon:
                     """
                     we couldn't find a custom configuration, let's try making a new one
                     add the price we're switching into to the list of prices that allow subscription updates
@@ -386,7 +388,7 @@ class CustomerPortalView(APIView):
     def post(self, request):
         serializer = CustomerPortalSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
-        organization_id = serializer.validated_data['organization_id']
+        organization_id = serializer.validated_data.get('organization_id', None)
         price = serializer.validated_data.get('price_id', None)
         response = self.generate_portal_link(request.user, organization_id, price)
         return response

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -1,3 +1,5 @@
+import http
+
 import stripe
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -288,6 +290,12 @@ class CustomerPortalView(APIView):
             'id', 'subscriptions__id', 'subscriptions__items__id'
         ).first()
 
+        if not customer:
+            return Response(
+                {'error': f"Couldn't find customer with organization id {organization_id}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         portal_kwargs = {}
 
         # if we're generating a portal link for an add-on, generate a custom portal configuration
@@ -296,9 +304,17 @@ class CustomerPortalView(APIView):
                 api_key=djstripe_settings.STRIPE_SECRET_KEY,
                 limit=100,
             )
+
+            if not len(all_configs):
+                return Response({'error': "Missing Stripe billing configuration."}, status=status.HTTP_502_BAD_GATEWAY)
+
             # get the portal configuration that lets us switch to the provided price
             current_config = next(
-                (config for config in all_configs if config.metadata.get('portal_price', None) == price.id), None
+                (config for config in all_configs if (
+                        config['active'] and
+                        config['livemode'] == settings.STRIPE_LIVE_MODE and
+                        config['metadata'].get('portal_price', None) == price.id
+                )), None
             )
 
             # we couldn't find the right configuration, let's try making a new one
@@ -306,25 +322,24 @@ class CustomerPortalView(APIView):
                 # get the active default configuration
                 current_config = next(
                     (config for config in all_configs if (
-                        config.is_default and
-                        config.active and
-                        config.livemode == settings.STRIPE_LIVE_MODE
+                        config['is_default'] and
+                        config['active'] and
+                        config['livemode'] == settings.STRIPE_LIVE_MODE
                     )), None
                 )
                 # add the price we're switching into to the list of prices that allow subscription updates
-                new_products = [
+                new_product = [
                     {
                         'prices': [price.id],
                         'product': price.product.id,
                     },
-                    *current_config['features']['subscription_update'].get('products', []),
                 ]
-                current_config['features']['subscription_update']['products'] = new_products
+                current_config['features']['subscription_update']['products'].append(new_product)
                 # create the billing configuration on Stripe, so it's ready when we send the customer to check out
                 current_config = stripe.billing_portal.Configuration.create(
                     api_key=djstripe_settings.STRIPE_SECRET_KEY,
                     business_profile=current_config['business_profile'],
-                    features=current_config.features,
+                    features=current_config['features'],
                     metadata={
                         'portal_price': price.id,
                     }
@@ -346,21 +361,21 @@ class CustomerPortalView(APIView):
                 },
             }
 
-        session = stripe.billing_portal.Session.create(
+        stripe_response = stripe.billing_portal.Session.create(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             customer=customer['id'],
             return_url=f'{settings.KOBOFORM_URL}/#/account/plan',
             **portal_kwargs,
         )
-        return session
+        return Response({'url': stripe_response['url']})
 
     def post(self, request):
         serializer = CustomerPortalSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         organization_id = serializer.validated_data['organization_id']
         price = serializer.validated_data.get('price_id', None)
-        session = self.generate_portal_link(request.user, organization_id, price)
-        return Response({'url': session['url']})
+        response = self.generate_portal_link(request.user, organization_id, price)
+        return response
 
 
 class SubscriptionViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -20,6 +20,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from kobo.apps.organizations.models import Organization
+from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 from kobo.apps.stripe.serializers import (
     ChangePlanSerializer,
     CheckoutLinkSerializer,
@@ -277,17 +278,79 @@ class CustomerPortalView(APIView):
     permission_classes = (IsAuthenticated,)
 
     @staticmethod
-    def generate_portal_link(user, organization_id):
-        organization = Organization.objects.get(
-            id=organization_id, owner__organization_user__user_id=user
-        )
-        customer = Customer.objects.get(
-            subscriber=organization, livemode=settings.STRIPE_LIVE_MODE
-        )
+    def generate_portal_link(user, organization_id, price):
+        customer = Customer.objects.filter(
+            subscriber_id=organization_id,
+            subscriber__owner__organization_user__user_id=user,
+            subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+            livemode=settings.STRIPE_LIVE_MODE,
+        ).values(
+            'id', 'subscriptions__id', 'subscriptions__items__id'
+        ).first()
+
+        portal_kwargs = {}
+
+        # if we're generating a portal link for an add-on, generate a custom portal configuration
+        if price and price.product.metadata['product_type'] == 'addon':
+            all_configs = stripe.billing_portal.Configuration.list(
+                api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                limit=100,
+            )
+            # get the portal configuration that lets us switch to the provided price
+            current_config = next(
+                (config for config in all_configs if config.metadata.get('portal_price', None) == price.id), None
+            )
+
+            # we couldn't find the right configuration, let's try making a new one
+            if not current_config:
+                # get the active default configuration
+                current_config = next(
+                    (config for config in all_configs if (
+                        config.is_default and
+                        config.active and
+                        config.livemode == settings.STRIPE_LIVE_MODE
+                    )), None
+                )
+                # add the price we're switching into to the list of prices that allow subscription updates
+                new_products = [
+                    {
+                        'prices': [price.id],
+                        'product': price.product.id,
+                    },
+                    *current_config['features']['subscription_update'].get('products', []),
+                ]
+                current_config['features']['subscription_update']['products'] = new_products
+                # create the billing configuration on Stripe, so it's ready when we send the customer to check out
+                current_config = stripe.billing_portal.Configuration.create(
+                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                    business_profile=current_config['business_profile'],
+                    features=current_config.features,
+                    metadata={
+                        'portal_price': price.id,
+                    }
+                )
+
+            portal_kwargs = {
+                'configuration': current_config['id'],
+                'flow_data': {
+                    'type': 'subscription_update_confirm',
+                    'subscription_update_confirm': {
+                        'items': [
+                            {
+                                'id': customer['subscriptions__items__id'],
+                                'price': price.id,
+                            },
+                        ],
+                        'subscription': customer['subscriptions__id'],
+                    }
+                },
+            }
+
         session = stripe.billing_portal.Session.create(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
-            customer=customer.id,
+            customer=customer['id'],
             return_url=f'{settings.KOBOFORM_URL}/#/account/plan',
+            **portal_kwargs,
         )
         return session
 
@@ -295,7 +358,8 @@ class CustomerPortalView(APIView):
         serializer = CustomerPortalSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         organization_id = serializer.validated_data['organization_id']
-        session = self.generate_portal_link(request.user, organization_id)
+        price = serializer.validated_data.get('price_id', None)
+        session = self.generate_portal_link(request.user, organization_id, price)
         return Response({'url': session['url']})
 
 

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -1,5 +1,3 @@
-import http
-
 import stripe
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -298,8 +296,9 @@ class CustomerPortalView(APIView):
 
         portal_kwargs = {}
 
-        # if we're generating a portal link for an add-on, generate a custom portal configuration
-        if price and price.product.metadata['product_type'] == 'addon':
+        # if we're generating a portal link for a price change, find or generate a matching portal configuration
+        if price:
+            current_config = None
             all_configs = stripe.billing_portal.Configuration.list(
                 api_key=djstripe_settings.STRIPE_SECRET_KEY,
                 limit=100,
@@ -308,18 +307,22 @@ class CustomerPortalView(APIView):
             if not len(all_configs):
                 return Response({'error': "Missing Stripe billing configuration."}, status=status.HTTP_502_BAD_GATEWAY)
 
-            # get the portal configuration that lets us switch to the provided price
-            current_config = next(
-                (config for config in all_configs if (
-                        config['active'] and
-                        config['livemode'] == settings.STRIPE_LIVE_MODE and
-                        config['metadata'].get('portal_price', None) == price.id
-                )), None
-            )
+            if price.product.metadata['product_type'] == 'addon':
+                """
+                Recurring add-ons aren't included in the default billing configuration.
+                This lets us hide them as an 'upgrade' option for paid plan users.
+                Here, we try getting the portal configuration that lets us switch to the provided price.
+                """
+                current_config = next(
+                    (config for config in all_configs if (
+                            config['active'] and
+                            config['livemode'] == settings.STRIPE_LIVE_MODE and
+                            config['metadata'].get('portal_price', None) == price.id
+                    )), None
+                )
 
-            # we couldn't find the right configuration, let's try making a new one
             if not current_config:
-                # get the active default configuration
+                # get the active default configuration - we'll use this if our product is a 'plan'
                 current_config = next(
                     (config for config in all_configs if (
                         config['is_default'] and
@@ -327,23 +330,28 @@ class CustomerPortalView(APIView):
                         config['livemode'] == settings.STRIPE_LIVE_MODE
                     )), None
                 )
-                # add the price we're switching into to the list of prices that allow subscription updates
-                new_product = [
-                    {
-                        'prices': [price.id],
-                        'product': price.product.id,
-                    },
-                ]
-                current_config['features']['subscription_update']['products'].append(new_product)
-                # create the billing configuration on Stripe, so it's ready when we send the customer to check out
-                current_config = stripe.billing_portal.Configuration.create(
-                    api_key=djstripe_settings.STRIPE_SECRET_KEY,
-                    business_profile=current_config['business_profile'],
-                    features=current_config['features'],
-                    metadata={
-                        'portal_price': price.id,
-                    }
-                )
+
+                if price.product.metadata['product_type'] == 'addon':
+                    """
+                    we couldn't find a custom configuration, let's try making a new one
+                    add the price we're switching into to the list of prices that allow subscription updates
+                    """
+                    new_products = [
+                        {
+                            'prices': [price.id],
+                            'product': price.product.id,
+                        },
+                    ]
+                    current_config['features']['subscription_update']['products'] = new_products
+                    # create the billing configuration on Stripe, so it's ready when we send the customer to check out
+                    current_config = stripe.billing_portal.Configuration.create(
+                        api_key=djstripe_settings.STRIPE_SECRET_KEY,
+                        business_profile=current_config['business_profile'],
+                        features=current_config['features'],
+                        metadata={
+                            'portal_price': price.id,
+                        }
+                    )
 
             portal_kwargs = {
                 'configuration': current_config['id'],
@@ -357,7 +365,13 @@ class CustomerPortalView(APIView):
                             },
                         ],
                         'subscription': customer['subscriptions__id'],
-                    }
+                    },
+                    'after_completion': {
+                        'type': 'redirect',
+                        'redirect': {
+                            'return_url': f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
+                        },
+                    },
                 },
             }
 

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -99,11 +99,19 @@ class ChangePlanView(APIView):
                     }
                 ],
             )
-            return Response({
-                'url': f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
-                'status': 'success',
-                'stripe_object': stripe_response,
-            })
+            # If there are pending updates, there was a problem scheduling the change to their plan
+            if stripe_response['pending_update']:
+                return Response({
+                    'status': 'pending',
+                })
+            # Upgraded successfully!
+            else:
+                return Response({
+                    'url': f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
+                    'status': 'success',
+                    'stripe_object': stripe_response,
+                })
+
         # We're downgrading the subscription, schedule a subscription change at the end of the current period
         return ChangePlanView.schedule_subscription_change(
             subscription, subscription_item, price.id

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -98,6 +98,7 @@ class ServiceUsageSerializer(serializers.Serializer):
     total_submission_count = serializers.SerializerMethodField()
     current_month_start = serializers.SerializerMethodField()
     current_year_start = serializers.SerializerMethodField()
+    billing_period_end = serializers.SerializerMethodField()
     _now = timezone.now().date()
 
     def __init__(self, instance=None, data=empty, **kwargs):
@@ -110,6 +111,7 @@ class ServiceUsageSerializer(serializers.Serializer):
         self._current_year_start = None
         self._anchor_date = None
         self._period_start = None
+        self._period_end = None
         self._subscription_interval = None
         self._get_per_asset_usage(instance)
 
@@ -127,6 +129,9 @@ class ServiceUsageSerializer(serializers.Serializer):
 
     def get_current_year_start(self, user):
         return self._current_year_start
+
+    def get_billing_period_end(self, user):
+        return self._period_end
 
     def _get_current_month_start_date(self):
         # No subscription info, just use the first day of current month
@@ -227,6 +232,7 @@ class ServiceUsageSerializer(serializers.Serializer):
         if billing_details:
             self._anchor_date = billing_details['billing_cycle_anchor'].date()
             self._period_start = billing_details['current_period_start'].date()
+            self._period_end = billing_details['current_period_end'].date()
             self._subscription_interval = billing_details['recurring_interval']
 
     def _get_per_asset_usage(self, user):


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [X] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Update Stripe backend to allow purchasing recurring storage add-ons.

## Notes

This PR also changes how the billing page works. Originally, it used the `ChangePlanView` endpoint to modify a subscription from our backend when upgrading/downgrading. Now, if a customer is upgrading, they're sent to Stripe to change plans, using the `CustomerPortalView` endpoint to generate a checkout link that works for any two prices (even if they're not included in the default Stripe portal configuration.)

A future PR (branch: real-stripe-tests) will include testing for endpoints using real (testmode) Stripe data, since the current tests are limited by the amount of Stripe functions that are being mocked.

## Related issues

Sub-PR of [kpi#4692](https://github.com/kobotoolbox/kpi/pull/4692/commits)
