### PR TITLE
Make Button component more closely follow ARIA conventions

### DIFF
--- a/jsapp/js/components/common/button.scss
+++ b/jsapp/js/components/common/button.scss
@@ -184,7 +184,7 @@ $button-border-radius: sizes.$x6;
   justify-content: center;
 }
 
-.k-button[disabled] {
+.k-button[aria-disabled=true] {
   pointer-events: none;
   opacity: 0.5;
 }

--- a/jsapp/js/components/common/button.tsx
+++ b/jsapp/js/components/common/button.tsx
@@ -158,7 +158,7 @@ const Button = (props: ButtonProps) => {
       className={classNames.join(' ')}
       type={props.isSubmit ? 'submit' : 'button'}
       aria-disabled={props.isDisabled}
-      onClick={props.onClick}
+      onClick={handleClick}
       onKeyUp={onKeyUp}
       {...additionalButtonAttributes}
     >

--- a/jsapp/js/components/common/button.tsx
+++ b/jsapp/js/components/common/button.tsx
@@ -43,7 +43,7 @@ ButtonToIconAloneMap.set('s', 'm');
 ButtonToIconAloneMap.set('m', 'l');
 ButtonToIconAloneMap.set('l', 'l');
 
-interface ButtonProps {
+export interface ButtonProps {
   type: ButtonType;
   color: ButtonColor;
   /** Note: this size will also be carried over to the icon. */
@@ -141,12 +141,25 @@ const Button = (props: ButtonProps) => {
     additionalButtonAttributes['data-cy'] = props['data-cy'];
   }
 
+  const handleClick = (event: React.BaseSyntheticEvent) => {
+    if (!props.isDisabled && props.onClick) {
+      props.onClick(event);
+    }
+  };
+
+  const onKeyUp = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event?.key === 'space' || event?.key === 'enter') {
+      handleClick(event);
+    }
+  };
+
   return (
     <button
       className={classNames.join(' ')}
       type={props.isSubmit ? 'submit' : 'button'}
-      disabled={props.isDisabled}
+      aria-disabled={props.isDisabled}
       onClick={props.onClick}
+      onKeyUp={onKeyUp}
       {...additionalButtonAttributes}
     >
       {props.startIcon && <Icon name={props.startIcon} size={iconSize} />}


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Make buttons in kpi click in response to the space bar or or enter key.

## Notes

The Button element was focusable, but not able to be activated by users navigating with the keyboard. Buttons now activate their `onClick` handler in response to `keyUp` events.

Also, the entire `<button/>` was disabled when `isDisabled` was set - this has been changed to using [`aria-disabled`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) to keep the element focusable, retaining the same styling.

## Related issues

Sub-PR of [kpi#4692](https://github.com/kobotoolbox/kpi/pull/4692/)