### PR TITLE
Double errors when logged out while changing password

### DIFF
--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -77,7 +77,7 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
         await fetchPatch(endpoints.ME_URL, {
           current_password: currentPassword,
           new_password: newPassword,
-        });
+        }, {notifyAboutError: false});
         setIsPending(false);
         setCurrentPassword('');
         setNewPassword('');

--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -105,10 +105,7 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
         }
 
         setIsPending(false);
-        // Accounting for double error edge case when error status is 403
-        if (errorObj.status !== 403){
-          notify(t('failed to change password'), 'error');
-        }
+        notify(t('failed to change password'), 'error');
       }
     }
   }

--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -72,6 +72,7 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
 
     if (!hasErrors) {
       setIsPending(true);
+
       try {
         await fetchPatch(endpoints.ME_URL, {
           current_password: currentPassword,

--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -72,7 +72,6 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
 
     if (!hasErrors) {
       setIsPending(true);
-
       try {
         await fetchPatch(endpoints.ME_URL, {
           current_password: currentPassword,
@@ -105,7 +104,10 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
         }
 
         setIsPending(false);
-        notify(t('failed to change password'), 'error');
+        // Accounting for double error edge case when error status is 403
+        if (errorObj.status !== 403){
+          notify(t('failed to change password'), 'error');
+        }
       }
     }
   }

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -163,7 +163,10 @@ export const fetchPatch = async <T>(
   path: string,
   data: Json,
   options?: FetchDataOptions
-) => fetchData<T>(path, 'PATCH', data, options);
+) => {
+  options = Object.assign({}, options, {notifyAboutError: false});
+  return fetchData<T>(path, 'PATCH', data, options);
+};
 
 /** PUT (replace) data to Kobo API at path */
 export const fetchPut = async <T>(

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -163,10 +163,7 @@ export const fetchPatch = async <T>(
   path: string,
   data: Json,
   options?: FetchDataOptions
-) => {
-  options = Object.assign({}, options, {notifyAboutError: false});
-  return fetchData<T>(path, 'PATCH', data, options);
-};
+) => fetchData<T>(path, 'PATCH', data, options);
 
 /** PUT (replace) data to Kobo API at path */
 export const fetchPut = async <T>(


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description



## Notes

Checks if the error is a 403 before sending a notification about the failed password change. 

## Related issues

Fixes #4614
