### PR TITLE
Use `overrides` to fix reflux peerDependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
     "webpack-dev-server": "^4.8.1",
     "webpack-extract-translation-keys-plugin": "^6.0.0"
   },
+  "overrides": {
+    "reflux": {
+      "react": "$react"
+    }
+  },
   "scripts": {
     "preinstall": "npm run hint",
     "postinstall": "patch-package && npm run copy-fonts",


### PR DESCRIPTION
## Description

Make reflux use the project-level version of React to resolve its peerDependency.

With this change, `--legacy-peer-deps` will no longer be needed when installing with npm >= 8.6.0.

## Related issues

Part of #4703

## Notes

Reflux specifies `"react": "^15.0.2"` as a `peerDependency`. We use a newer major version of React. Starting with **npm@8.6.0**, this would start to break `npm install`. More information: [npm/cli: npm ci validates package-lock.json and could fail to resolve](https://github.com/npm/cli/issues/5113)

The error you'd see when using npm >= 8.6.0 looked like:

```sh
  npm ERR! code ERESOLVE
  npm ERR! ERESOLVE could not resolve
  npm ERR!
  npm ERR! While resolving: reflux@6.4.1
  npm ERR! Found: react@16.13.1
```

Using [`overrides`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#overrides) in package.json ([added to npm](https://github.com/npm/cli/pull/4116) in npm [8.3.0](https://docs.npmjs.com/cli/v8/using-npm/changelog#v830-2021-12-09))

```json
    "overrides": {
      "reflux": { "react": "$react"}
    },
```

tells npm that Reflux should use our project-level version of React to resolve its dependency on "react" — even though our project-level React (16) falls outside of [the semver range that Reflux wants (^15.0.2)](https://github.com/reflux/refluxjs/blob/master/package.json#L63).

