### PR TITLE
Drop deprecated Moment.js package in favor of Day.js

### DIFF
--- a/jsapp/js/account/useUsage.hook.ts
+++ b/jsapp/js/account/useUsage.hook.ts
@@ -3,7 +3,6 @@ import type {RecurringInterval} from 'js/account/stripe.api';
 import {getSubscriptionInterval} from 'js/account/stripe.api';
 import {formatRelativeTime, truncateNumber} from 'js/utils';
 import {getUsageForOrganization} from 'js/account/usage.api';
-import moment from 'moment';
 
 export interface UsageState {
   storage: number;

--- a/jsapp/js/locales.ts
+++ b/jsapp/js/locales.ts
@@ -1,0 +1,29 @@
+/*
+  List of locales to load for time/date formatting functions.
+  This should stay even with the list of displayed languages in kpi.
+  Note: some languages available by default in kpi are not listed here,
+  which is consistent with the Moment library that DayJS replaces.
+*/
+import 'dayjs/locale/am';
+import 'dayjs/locale/ar';
+import 'dayjs/locale/bn';
+import 'dayjs/locale/cs';
+import 'dayjs/locale/de';
+// 'en' is already loaded
+import 'dayjs/locale/es';
+import 'dayjs/locale/fa';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/hi';
+import 'dayjs/locale/hu';
+import 'dayjs/locale/id';
+import 'dayjs/locale/ja';
+import 'dayjs/locale/ku';
+import 'dayjs/locale/my';
+import 'dayjs/locale/ne';
+import 'dayjs/locale/pl';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/th';
+import 'dayjs/locale/tr';
+import 'dayjs/locale/uk';
+import 'dayjs/locale/vi';
+import 'dayjs/locale/zh';

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -5,6 +5,8 @@
 
 require('jquery-ui/ui/widgets/sortable');
 import dayjs from 'dayjs';
+// import specific locales for dayjs
+import 'js/locales';
 import AllRoutes from 'js/router/allRoutes';
 import RegistrationPasswordApp from './registrationPasswordApp';
 import {AppContainer} from 'react-hot-loader';

--- a/jsapp/js/main.es6
+++ b/jsapp/js/main.es6
@@ -4,7 +4,7 @@
  */
 
 require('jquery-ui/ui/widgets/sortable');
-import moment from 'moment';
+import dayjs from 'dayjs';
 import AllRoutes from 'js/router/allRoutes';
 import RegistrationPasswordApp from './registrationPasswordApp';
 import {AppContainer} from 'react-hot-loader';
@@ -15,8 +15,8 @@ import {csrfSafeMethod, currentLang} from 'utils';
 require('../scss/main.scss');
 import Modal from 'react-modal';
 
-// Tell moment library what is the app language
-moment.locale(currentLang());
+// Tell dayjs library which language the app is using
+dayjs.locale(currentLang());
 
 // Setup Google Analytics
 const gaTokenEl = document.head.querySelector('meta[name=google-analytics-token]');

--- a/jsapp/js/project/submissionsCountGraph.component.tsx
+++ b/jsapp/js/project/submissionsCountGraph.component.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect, useCallback, useRef} from 'react';
 import classNames from 'classnames';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import Chart from 'chart.js/auto';
 import type {ChartConfiguration} from 'chart.js/auto';
 import type {FailResponse} from 'js/dataInterface';
@@ -64,7 +64,7 @@ export default function SubmissionsCountGraph(
     const daysAmount = StatsPeriods[currentPeriod] - 1;
 
     const daysFromLabel = formatDate(
-      moment().subtract(daysAmount, 'days').format()
+      dayjs().subtract(daysAmount, 'days').format()
     );
     const daysToLabel = t('Today');
 
@@ -99,7 +99,7 @@ export default function SubmissionsCountGraph(
       total: number
     ) => {
       const output: GraphData = new Map<string, number>();
-      const today = moment();
+      const today = dayjs();
       // Get the furthest day in the past that we need. We subtract one day,
       // because we already start from today.
       let day = today
@@ -129,7 +129,7 @@ export default function SubmissionsCountGraph(
       total: number
     ) => {
       const output: GraphData = new Map();
-      const today = moment();
+      const today = dayjs();
       // Get the furthest month in the past that we need. We subtract one month,
       // because we already start from today.
       let month = today

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -23,9 +23,6 @@ import calendar from 'dayjs/plugin/calendar';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 
-// import specific locales for dayjs
-import 'js/locales';
-
 export const LANGUAGE_COOKIE_NAME = 'django_language';
 
 const cookies = new Cookies();
@@ -165,9 +162,6 @@ dayjs.extend(utc);
 dayjs.extend(calendar);
 dayjs.extend(relativeTime);
 dayjs.extend(localizedFormat);
-
-// localize dates using the current language setting
-dayjs.locale(currentLang());
 
 /**
  * Returns something like "Today at 4:06 PM", "Yesterday at 5:46 PM", "Last Saturday at 5:46 PM" or "February 11, 2021"

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -22,13 +22,11 @@ import type Raven from 'raven';
 
 export const LANGUAGE_COOKIE_NAME = 'django_language';
 
-// extend dayjs with the plugins we need
-dayjs.extend(utc);
-dayjs.extend(calendar);
-dayjs.extend(relativeTime);
-dayjs.extend(localizedFormat);
-
 const cookies = new Cookies();
+
+export function currentLang(): string {
+  return cookies.get(LANGUAGE_COOKIE_NAME) || 'en';
+}
 
 /**
  * Pop up a notification with react-hot-toast
@@ -156,12 +154,21 @@ export function join(arr: any[], separator: any): any[] {
   return result;
 }
 
+// extend dayjs with the plugins we need
+dayjs.extend(utc);
+dayjs.extend(calendar);
+dayjs.extend(relativeTime);
+dayjs.extend(localizedFormat);
+
+// localize dates using the current language setting
+dayjs.locale(currentLang());
+
 /**
  * Returns something like "Today at 4:06 PM", "Yesterday at 5:46 PM", "Last Saturday at 5:46 PM" or "February 11, 2021"
  */
 export function formatTime(timeStr: string): string {
-  const myMoment = dayjs.utc(timeStr).local();
-  return myMoment.calendar(null, {sameElse: 'LL'});
+  const time = dayjs.utc(timeStr).local();
+  return time.calendar(null, {sameElse: 'LL'});
 }
 
 /**
@@ -172,11 +179,11 @@ export function formatDate(
   localize = true,
   format = 'll'
 ): string {
-  let myMoment = dayjs.utc(timeStr);
+  let date = dayjs.utc(timeStr);
   if (localize) {
-    myMoment = myMoment.local();
+    date = date.local();
   }
-  return myMoment.format(format);
+  return date.format(format);
 }
 
 /**
@@ -212,11 +219,11 @@ export function formatSeconds(seconds: number) {
 }
 
 export function formatRelativeTime(timeStr: string, localize = true): string {
-  let myMoment = dayjs.utc(timeStr);
+  let relativeTime = dayjs.utc(timeStr);
   if (localize) {
-    myMoment = myMoment.local();
+    relativeTime = relativeTime.local();
   }
-  return myMoment.fromNow();
+  return relativeTime.fromNow();
 }
 
 // works universally for v1 and v2 urls
@@ -288,10 +295,6 @@ export function replaceBracketsWithLink(str: string, url?: string): string {
   }
   const linkHtml = `<a href="${url}" target="_blank">$1</a>`;
   return str.replace(bracketRegex, linkHtml);
-}
-
-export function currentLang(): string {
-  return cookies.get(LANGUAGE_COOKIE_NAME) || 'en';
 }
 
 interface LangObject {

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -7,11 +7,6 @@
  * NOTE: We have other utils files related to asset, submissions, etc.
  */
 
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import calendar from 'dayjs/plugin/calendar';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
 import type {Toast, ToastOptions} from 'react-hot-toast';
 import {toast} from 'react-hot-toast';
 import {Cookies} from 'react-cookie';
@@ -19,6 +14,17 @@ import {Cookies} from 'react-cookie';
 import constants from 'js/constants';
 import type {FailResponse} from './dataInterface';
 import type Raven from 'raven';
+
+import dayjs from 'dayjs';
+
+// import dayjs plugins
+import utc from 'dayjs/plugin/utc';
+import calendar from 'dayjs/plugin/calendar';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+
+// import specific locales for dayjs
+import 'js/locales';
 
 export const LANGUAGE_COOKIE_NAME = 'django_language';
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -7,7 +7,11 @@
  * NOTE: We have other utils files related to asset, submissions, etc.
  */
 
-import moment from 'moment';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import calendar from 'dayjs/plugin/calendar';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
 import type {Toast, ToastOptions} from 'react-hot-toast';
 import {toast} from 'react-hot-toast';
 import {Cookies} from 'react-cookie';
@@ -17,6 +21,12 @@ import type {FailResponse} from './dataInterface';
 import type Raven from 'raven';
 
 export const LANGUAGE_COOKIE_NAME = 'django_language';
+
+// extend dayjs with the plugins we need
+dayjs.extend(utc);
+dayjs.extend(calendar);
+dayjs.extend(relativeTime);
+dayjs.extend(localizedFormat);
 
 const cookies = new Cookies();
 
@@ -150,7 +160,7 @@ export function join(arr: any[], separator: any): any[] {
  * Returns something like "Today at 4:06 PM", "Yesterday at 5:46 PM", "Last Saturday at 5:46 PM" or "February 11, 2021"
  */
 export function formatTime(timeStr: string): string {
-  const myMoment = moment.utc(timeStr).local();
+  const myMoment = dayjs.utc(timeStr).local();
   return myMoment.calendar(null, {sameElse: 'LL'});
 }
 
@@ -162,7 +172,7 @@ export function formatDate(
   localize = true,
   format = 'll'
 ): string {
-  let myMoment = moment.utc(timeStr);
+  let myMoment = dayjs.utc(timeStr);
   if (localize) {
     myMoment = myMoment.local();
   }
@@ -202,7 +212,7 @@ export function formatSeconds(seconds: number) {
 }
 
 export function formatRelativeTime(timeStr: string, localize = true): string {
-  let myMoment = moment.utc(timeStr);
+  let myMoment = dayjs.utc(timeStr);
   if (localize) {
     myMoment = myMoment.local();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "backbone": "^1.4.0",
         "backbone-validation": "^0.11.5",
         "classnames": "^2.3.1",
+        "dayjs": "^1.11.10",
         "fuse.js": "^6.4.3",
         "immutable": "^3.8.2",
         "jquery": "^3.5.1",
@@ -15674,6 +15675,11 @@
     "node_modules/d3-queue": {
       "version": "2.0.3",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -39385,6 +39391,11 @@
     },
     "d3-queue": {
       "version": "2.0.3"
+    },
+    "dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,6 @@
         "fork-ts-checker-webpack-plugin": "^8.0.0",
         "mocha": "^7.1.2",
         "mocha-chrome": "^2.2.0",
-        "moment": "^2.25.3",
         "patch-package": "^6.5.1",
         "postcss": "^7.0.30",
         "postcss-loader": "^4.2.0",
@@ -21362,14 +21361,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.27.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mri": {
@@ -43364,10 +43355,6 @@
         "meow": "^5.0.0",
         "nanobus": "^4.2.0"
       }
-    },
-    "moment": {
-      "version": "2.27.0",
-      "dev": true
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "backbone": "^1.4.0",
     "backbone-validation": "^0.11.5",
     "classnames": "^2.3.1",
+    "dayjs": "^1.11.10",
     "fuse.js": "^6.4.3",
     "immutable": "^3.8.2",
     "jquery": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "mocha": "^7.1.2",
     "mocha-chrome": "^2.2.0",
-    "moment": "^2.25.3",
     "patch-package": "^6.5.1",
     "postcss": "^7.0.30",
     "postcss-loader": "^4.2.0",


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Moment.js has been in maintenance mode for a while, and its last update was in 2022. We've needed to replace it for a bit now - [Day.js](https://github.com/iamkun/dayjs) is a drop-in replacement that's actively maintained. It gives us better tree-shaking options (import plugins individually instead of using everything in `'moment'`) so we can reduce bundle size a bit, and it relies on immutable datatypes, unlike Moment.js.

This PR replaces the few places where we were using Moment.js with Day.js. In my testing, all functionality remains the same.