### PR TITLE
Always display require auth checkbox

### DIFF
--- a/jsapp/js/account/accountFieldsEditor.component.tsx
+++ b/jsapp/js/account/accountFieldsEditor.component.tsx
@@ -34,6 +34,11 @@ interface AccountFieldsEditorProps {
    */
   values: AccountFieldsValues;
   onChange: (fields: AccountFieldsValues) => void;
+  /**
+   * Handles the require authentication checkbox. If not provided, the checkbox
+   * will be displayed.
+   */
+  isRequireAuthDisplayed?: boolean;
 }
 
 /**
@@ -84,7 +89,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
     <div>
       <div className={styles.row}>
         {/* Privacy */}
-        {isFieldToBeDisplayed('require_auth') && (
+        {props.isRequireAuthDisplayed !== false && (
           <div className={styles.field}>
             <label>{t('Privacy')}</label>
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix the code responsible for displaying "Require authentication to see forms and submit data" checkbox.

## Notes

New optional prop is handling the checkbox displaying. Not providing it is the same as `true`. I will use this in the #4699.
