### PR TITLE
Make coveralls CI action success not required for CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -59,8 +59,6 @@ jobs:
       # Explicitly name the directories where coverage should be measured;
       # specifying just `--cov=.` includes `src`, which contains third-party packages
       run: pytest --cov=hub --cov=kobo --cov=kpi -ra
-    - name: Run coveralls for back-end code
-      uses: AndreMiras/coveralls-python-action@develop
-      # Coveralls action will intermittently give 422 errors
-      # only run this action on `main` or `beta`, since the issue only seems to affect PRs
-      if: ${{ github.event_name != 'pull_request' }}
+    # Coveralls action will intermittently give 422 errors - until that issue is resolved this step is commented out.
+    #- name: Run coveralls for back-end code
+    #  uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,4 +63,4 @@ jobs:
       uses: AndreMiras/coveralls-python-action@develop
       # Coveralls action will intermittently give 422 errors
       # only run this action on `main` or `beta`, since the issue only seems to affect PRs
-      if: ${{ github.event_name != "pull_request" }}
+      if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,4 +63,4 @@ jobs:
       uses: AndreMiras/coveralls-python-action@develop
       # Coveralls action will intermittently give 422 errors
       # only run this action on `main` or `beta`, since the issue only seems to affect PRs
-      if: github.event_name != 'pull_request'
+      if: ${{ github.event_name != "pull_request" }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,3 +61,6 @@ jobs:
       run: pytest --cov=hub --cov=kobo --cov=kpi -ra
     - name: Run coveralls for back-end code
       uses: AndreMiras/coveralls-python-action@develop
+      # Coveralls action will intermittently give 422 errors
+      # only run this action on `main` or `beta`, since the issue only seems to affect PRs
+      if: github.event_name != 'pull_request'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -59,6 +59,7 @@ jobs:
       # Explicitly name the directories where coverage should be measured;
       # specifying just `--cov=.` includes `src`, which contains third-party packages
       run: pytest --cov=hub --cov=kobo --cov=kpi -ra
-    # Coveralls action will intermittently give 422 errors - until that issue is resolved this step is commented out.
-    #- name: Run coveralls for back-end code
-    #  uses: AndreMiras/coveralls-python-action@develop
+    - name: Run coveralls for back-end code
+      uses: AndreMiras/coveralls-python-action@develop
+      # Coveralls action will intermittently give 422 errors - until that issue is resolved this step allowed to error.
+      continue-on-error: true


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Resolves an issue that caused python CI to fail.

## Notes

This PR is used to fix an issue where the `Run coveralls for back-end code` step would consistently fail on some branches, causing CI to fail.

[Internal thread cross-reference](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/GitHub.20CI.20Python.20broken/near/294990)

Unlike #4717, this PR temporarily resolves the issue by adding `continue-on-error` to the step, since a failure generating the coverage report is unrelated to whether the code passes tests, builds, lints, etc. The coverage % badge will still be updated, since the 422 issue appears to be sporadic and hasn't affected `beta` or `main` yet - the main difference will be that some PRs don't submit a coverage report.