### PR TITLE
Optional TOS feature with /environment flag

### DIFF
--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -117,7 +117,7 @@ class EnvironmentTests(BaseTestCase):
             'custom_password_localized_help_text': markdown(
                 I18nUtils.get_custom_password_help_text()
             ),
-            'terms_of_service__sitewidemessage__exists' : SitewideMessage.objects.filter(slug='terms_of_service').exists(),
+            'terms_of_service__sitewidemessage__exists': False,
         }
 
     def _check_response_dict(self, response_dict):
@@ -307,3 +307,30 @@ class EnvironmentTests(BaseTestCase):
             with self.assertNumQueries(queries):
                 response = self.client.get(self.url, format='json')
         self.assertContains(response, app.name)
+
+    def test_tos_sitewide_message_exists(self):
+        # Create SitewideMessage object and check that it exsists
+        SitewideMessage.objects.create(
+            slug='terms_of_service',
+            body='tos agreement',
+        )
+        exists = SitewideMessage.objects.filter(
+            slug='terms_of_service'
+        ).exists()
+        self.assertTrue(exists)
+        self.assertNotEqual(
+            self.dict_checks['terms_of_service__sitewidemessage__exists'],
+            exists,
+        )
+
+    def test_tos_sitewide_message_does_not_exsist(self):
+        # Delete SitewideMessage object and check that it doesn't exsist
+        SitewideMessage.objects.filter(slug='terms_of_service').delete()
+        exists = SitewideMessage.objects.filter(
+            slug='terms_of_service'
+        ).exists()
+        self.assertFalse(exists)
+        self.assertEqual(
+            self.dict_checks['terms_of_service__sitewidemessage__exists'],
+            exists,
+        )

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -308,29 +308,17 @@ class EnvironmentTests(BaseTestCase):
                 response = self.client.get(self.url, format='json')
         self.assertContains(response, app.name)
 
-    def test_tos_sitewide_message_exists(self):
-        # Create SitewideMessage object and check that it exsists
+    def test_tos_sitewide_message(self):
+        # Check that fixtures properly stores terms of service
+        response = self.client.get(self.url, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert not response.data['terms_of_service__sitewidemessage__exists']
+
+        # Create SitewideMessage object and check that it properly updates terms of service
         SitewideMessage.objects.create(
             slug='terms_of_service',
             body='tos agreement',
         )
-        exists = SitewideMessage.objects.filter(
-            slug='terms_of_service'
-        ).exists()
-        self.assertTrue(exists)
-        self.assertNotEqual(
-            self.dict_checks['terms_of_service__sitewidemessage__exists'],
-            exists,
-        )
-
-    def test_tos_sitewide_message_does_not_exsist(self):
-        # Delete SitewideMessage object and check that it doesn't exsist
-        SitewideMessage.objects.filter(slug='terms_of_service').delete()
-        exists = SitewideMessage.objects.filter(
-            slug='terms_of_service'
-        ).exists()
-        self.assertFalse(exists)
-        self.assertEqual(
-            self.dict_checks['terms_of_service__sitewidemessage__exists'],
-            exists,
-        )
+        response = self.client.get(self.url, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['terms_of_service__sitewidemessage__exists']

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -12,6 +12,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from markdown import markdown
+from hub.models.sitewide_message import SitewideMessage
 from model_bakery import baker
 from rest_framework import status
 
@@ -116,6 +117,7 @@ class EnvironmentTests(BaseTestCase):
             'custom_password_localized_help_text': markdown(
                 I18nUtils.get_custom_password_help_text()
             ),
+            'terms_of_service__sitewidemessage__exists' : SitewideMessage.objects.filter(slug='terms_of_service').exists(),
         }
 
     def _check_response_dict(self, response_dict):

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -7,6 +7,7 @@ from allauth.socialaccount.models import SocialApp
 from django.conf import settings
 from django.utils.translation import gettext_lazy as t
 from markdown import markdown
+from hub.models.sitewide_message import SitewideMessage
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -190,6 +191,10 @@ class EnvironmentView(APIView):
             if date_joined > constance.config.FREE_TIER_CUTOFF_DATE:
                 data['free_tier_thresholds'] = FREE_TIER_NO_THRESHOLDS
                 data['free_tier_display'] = FREE_TIER_EMPTY_DISPLAY
+
+        data[
+            'terms_of_service__sitewidemessage__exists'
+        ] = SitewideMessage.objects.filter(slug='terms_of_service').exists()
 
         return data
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Added `terms_of_service__sitewidemessage__exists` flag to the `/environment` endpoint so that the frontend can display the TOS feature depending on the server. 

