### PR TITLE
Tolerate missing field list from custom export settings

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -627,7 +627,7 @@ export default class ProjectExportsCreator extends React.Component {
           }
 
           {(this.state.selectedExportType.value === EXPORT_TYPES.xls.value ||
-              this.state.selectedExportType.value == EXPORT_TYPES.csv.value) &&
+              this.state.selectedExportType.value === EXPORT_TYPES.csv.value) &&
             <bem.ProjectDownloads__columnRow>
               <Checkbox
                 checked={this.state.isIncludeMediaUrlEnabled}
@@ -709,7 +709,7 @@ export default class ProjectExportsCreator extends React.Component {
   }
 
   render() {
-    let formClassNames = ['project-downloads__exports-creator'];
+    const formClassNames = ['project-downloads__exports-creator'];
     if (!this.state.isComponentReady) {
       formClassNames.push('project-downloads__exports-creator--loading');
     }

--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -316,7 +316,7 @@ export default class ProjectExportsCreator extends React.Component {
     // Select custom export toggle if not all rows are selected
     // but only if at least one is selected
     const customSelectionEnabled = (
-      data.export_settings.fields.length !== 0 &&
+      data.export_settings.fields?.length &&
       this.state.selectableRowsCount !== data.export_settings.fields.length
     );
 


### PR DESCRIPTION
## Description

Avoid a crash that prevents exporting submission data in situations where custom export settings are invalid

## Notes

There are two commits: the first cleans up unrelated issues flagged by `eslint`; the second fixes the export crash

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Debugging.20why.20export.20panel.20is.20grey.20out.3F