### PR TITLE
Stop making unnecessary calls in Project Summary page

### DIFF
--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -11,6 +11,7 @@ import type {
   SubmissionResponse,
 } from 'js/dataInterface';
 import {dataInterface} from 'js/dataInterface';
+import {handleApiFail} from 'js/api';
 import {formatTime} from 'js/utils';
 import AssetStatusBadge from './common/assetStatusBadge';
 import Avatar from './common/avatar';
@@ -29,6 +30,12 @@ export default function FormSummaryProjectInfo(
   >();
 
   useEffect(() => {
+    // The call below will fail with 400 if asset doesn't have submissions,
+    // plus there is no point trying to get last submission data in such case
+    if (!props.asset?.deployment__submission_count) {
+      return;
+    }
+
     // Fetches one last submission, and only two fields for it.
     dataInterface
       .getSubmissions(
@@ -42,7 +49,8 @@ export default function FormSummaryProjectInfo(
         if (response.count) {
           setLatestSubmissionDate(response.results[0]['end']);
         }
-      });
+      })
+      .fail(handleApiFail);
   }, []);
 
   const lastDeployedDate =

--- a/jsapp/js/project/submissionsCountGraph.component.tsx
+++ b/jsapp/js/project/submissionsCountGraph.component.tsx
@@ -167,7 +167,7 @@ export default function SubmissionsCountGraph(
         let path = ASSET_COUNTS_ENDPOINT.replace('<uid>', props.assetUid);
         const days = StatsPeriods[currentPeriod];
         path += `?days=${days}`;
-        const response = await fetchGet<AssetCountsResponse>(path);
+        const response = await fetchGet<AssetCountsResponse>(path, {notifyAboutError: false});
         setCounts(response);
       } catch (error) {
         const errorObj = error as FailResponse;

--- a/jsapp/js/project/submissionsCountGraph.component.tsx
+++ b/jsapp/js/project/submissionsCountGraph.component.tsx
@@ -167,7 +167,9 @@ export default function SubmissionsCountGraph(
         let path = ASSET_COUNTS_ENDPOINT.replace('<uid>', props.assetUid);
         const days = StatsPeriods[currentPeriod];
         path += `?days=${days}`;
-        const response = await fetchGet<AssetCountsResponse>(path, {notifyAboutError: false});
+        const response = await fetchGet<AssetCountsResponse>(path, {
+          notifyAboutError: false,
+        });
         setCounts(response);
       } catch (error) {
         const errorObj = error as FailResponse;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Avoid making unnecessary calls for project with no submissions. Also don't show a "Not found" error for expected 404 response from API for the graph.

## Notes

Things changed here:
- `SubmissionsCountGraph` component is making a call to counts API, a `404` will be returned when there are no counts for given period. We were unnecessarily displaying error notification for this
- Similarly `FormSummaryProjectInfo` is making a call to submissions API to display information about latest submission. We were unnecessarily making call knowing there are no submissions