### PR TITLE
Organization_type skip logic in signup form and back-end validation

### DIFF
--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -131,14 +131,27 @@ class KoboSignupMixin(forms.Form):
 
             field = self.fields[field_name]
             # Part of 'skip logic' for organization fields
+            #     The 'Organization Type' dropdown hides 'Organization' and
+            # 'Organization Website' inputs if the user has selected
+            # 'I am not associated with an organization'. In that case the
+            # back end accepts omitted or blank values for organization and
+            # organization_website, even if they're 'required'.
+            #     Adding errors is easier than removing errors we don't want.
+            # So make these fields 'not required', remember we did, and add
+            # 'required' errors in the clean() function.
             if (
                 desired_metadata_fields.get('organization_type')
+                and desired_field.get('required')
                 and field_name in ['organization', 'organization_website']
-                and desired_field.get('required', False)
             ):
+                # Potentially 'skippable' organization-related field
                 field.required = False
+                # Add a [data-required] attribute, used by
+                #   1. JS to replicate the 'required' appearance, and
+                #   2. clean() to remember these are conditionally required
                 field.widget.attrs.update({'data-required': True})
             else:
+                # Any other field, require based on metadata
                 field.required = desired_field.get('required', False)
             self.fields[field_name].label = desired_field['label']
 

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -226,7 +226,12 @@ class SignupForm(KoboSignupMixin, BaseSignupForm):
         organization_type = self.cleaned_data.get('organization_type')
         # if organization_type is enabled and the user is affiliated with an organization,
         # require both organization and organization_website
-        if organization_type and organization_type != 'none':
+        if (
+            self.fields['organization_type'].required
+            and self.fields['organization'].required
+            and self.fields['organization_website'].required
+            and organization_type != 'none'
+        ):
             self.fields['organization_website'].required = True
             self.fields['organization'].required = True
 

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -101,6 +101,7 @@ class KoboSignupMixin(forms.Form):
         if 'email' in self.fields:
             self.fields['email'].widget.attrs['placeholder'] = t('name@organization.org')
 
+
         # Intentional t() call on dynamic string because the default choices
         # are translated (see static_lists.py)
         # Strip "\r" for legacy data created prior to django-constance 2.7.

--- a/kobo/apps/accounts/templates/account/signup.html
+++ b/kobo/apps/accounts/templates/account/signup.html
@@ -37,6 +37,8 @@
         {% endif %}
       {% endfor %}
 
+      <script src="{% static 'js/organization_type_skiplogic.js' %}"></script>
+
       <button
         type="submit"
         name="Create Account"

--- a/kobo/apps/accounts/tests/test_current_user.py
+++ b/kobo/apps/accounts/tests/test_current_user.py
@@ -142,3 +142,68 @@ class CurrentUserAPITestCase(APITestCase):
         # Ensure accepted_tos is now True after accepting ToS
         response = self.client.get(self.url)
         assert response.data['accepted_tos'] == True
+
+    def test_validate_extra_detail_organization_type(self):
+        constance.config.USER_METADATA_FIELDS = json.dumps(
+            [
+                {'name': 'organization', 'required': True},
+                {'name': 'organization_type', 'required': True},
+                {'name': 'organization_website', 'required': True},
+            ]
+        )
+
+        # Validate that a user can submit empty strings for `organization`
+        # and `organization_website` if `organization_type` is none
+        patch_data = {
+            'extra_details': {
+                'organization': '',
+                'organization_type': 'none',
+                'organization_website': '',
+            }
+        }
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        response_extra_details = response.json()['extra_details']
+        assert response_extra_details['organization'] == ''
+        assert response_extra_details['organization_type'] == 'none'
+        assert response_extra_details['organization_website'] == ''
+
+        # Validate that a user cannot submit empty strings for `organization`
+        # and `organization_website` if `organization_type` is not none
+        patch_data = {
+            'extra_details': {
+                'organization': '',
+                'organization_type': 'government',
+                'organization_website': '',
+            }
+        }
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'extra_details': {
+                'organization': 'This field may not be blank.',
+                'organization_website': 'This field may not be blank.',
+            }
+        }
+
+    def test_validate_extra_detail_no_organization_type(self):
+        constance.config.USER_METADATA_FIELDS = json.dumps(
+            [
+                {'name': 'organization', 'required': True},
+                {'name': 'organization_website', 'required': True},
+            ]
+        )
+
+        # Ensure `organization` and `organization_website` fields behave normally
+        # if `organization_type` is not enabled
+        patch_data = {
+            'extra_details': {
+                'organization': 'sample',
+                'organization_website': 'sample.org',
+            }
+        }
+        response = self.client.patch(self.url, data=patch_data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        response_extra_details = response.json()['extra_details']
+        assert response_extra_details['organization'] == 'sample'
+        assert response_extra_details['organization_website'] == 'sample.org'

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -250,6 +250,44 @@ class AccountFormsTestCase(TestCase):
             form = SignupForm(data)
             assert form.is_valid()
 
+        with override_config(
+            USER_METADATA_FIELDS=LazyJSONSerializable(
+                [
+                    {'name': 'organization', 'required': True},
+                    {'name': 'organization_website', 'required': True},
+                ]
+            )
+        ):
+            # Support excluding 'organization_type' from metadata fields
+            form = SignupForm(basic_data)
+            data = basic_data.copy()
+            data['organization'] = 'ministry of love'
+            data['organization_type'] = 'none'
+            # If organization_type is not in the metadata, setting
+            # organization_type to 'none' shouldn't bypass a required field
+            assert not form.is_valid()
+            data['organization_website'] = 'https://minilove.test'
+            form = SignupForm(data)
+            assert form.is_valid()
+
+        with override_config(
+            USER_METADATA_FIELDS=LazyJSONSerializable(
+                [
+                    {'name': 'organization_type', 'required': True},
+                ]
+            )
+        ):
+            # Support 'organization_type' by itself
+            form = SignupForm(basic_data)
+            data = basic_data.copy()
+            assert not form.is_valid()
+            data['organization_type'] = 'government'
+            form = SignupForm(data)
+            assert form.is_valid()
+            data['organization_type'] = 'none'
+            form = SignupForm(data)
+            assert form.is_valid()
+
     def test_organization_type_valid_field(self):
         with override_config(
             USER_METADATA_FIELDS=LazyJSONSerializable(

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -4,7 +4,7 @@ from django.utils import translation
 from model_bakery import baker
 from pyquery import PyQuery
 
-from kobo.apps.accounts.forms import SocialSignupForm
+from kobo.apps.accounts.forms import SignupForm, SocialSignupForm
 from kpi.utils.json import LazyJSONSerializable
 
 
@@ -201,9 +201,10 @@ class AccountFormsTestCase(TestCase):
 
             data = basic_data.copy()
             data['organization_type'] = 'government'
-            form = SignupForm(basic_data)
-            # No other organization fields should be required
-            assert form.is_valid()
+            form = SignupForm(data)
+            # Since the `organization_type` is not `none`, the other fields will
+            # become required
+            assert not form.is_valid()
 
         with override_config(
             USER_METADATA_FIELDS=LazyJSONSerializable(
@@ -220,9 +221,10 @@ class AccountFormsTestCase(TestCase):
 
             data = basic_data.copy()
             data['organization_type'] = 'government'
-            form = SignupForm(basic_data)
-            # No other organization fields should be required
-            assert form.is_valid()
+            form = SignupForm(data)
+            # Since the `organization_type` is not `none`, the other fields will
+            # become required
+            assert not form.is_valid()
 
         with override_config(
             USER_METADATA_FIELDS=LazyJSONSerializable(
@@ -240,14 +242,14 @@ class AccountFormsTestCase(TestCase):
             data['organization_type'] = 'government'
             data['organization'] = 'ministry of love'
             data['organization_website'] = 'https://minilove.test'
-            form = SignupForm(basic_data)
+            form = SignupForm(data)
             assert form.is_valid()
 
             data = basic_data.copy()
             data['organization_type'] = 'none'
             # The special string 'none' should cause the required-ness of other
             # organization fields to be ignored
-            form = SignupForm(basic_data)
+            form = SignupForm(data)
             assert form.is_valid()
 
     def test_organization_type_valid_field(self):

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -202,9 +202,8 @@ class AccountFormsTestCase(TestCase):
             data = basic_data.copy()
             data['organization_type'] = 'government'
             form = SignupForm(data)
-            # Since the `organization_type` is not `none`, the other fields will
-            # become required
-            assert not form.is_valid()
+            # No other organization fields should be required
+            assert form.is_valid()
 
         with override_config(
             USER_METADATA_FIELDS=LazyJSONSerializable(
@@ -222,9 +221,8 @@ class AccountFormsTestCase(TestCase):
             data = basic_data.copy()
             data['organization_type'] = 'government'
             form = SignupForm(data)
-            # Since the `organization_type` is not `none`, the other fields will
-            # become required
-            assert not form.is_valid()
+            # No other organization fields should be required
+            assert form.is_valid()
 
         with override_config(
             USER_METADATA_FIELDS=LazyJSONSerializable(

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -201,21 +201,18 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             constance.config.USER_METADATA_FIELDS
         )
 
-        # If the user has selected that they are not associated with an organization,
-        # change the required-ness of `organization` and `organization_website` fields to false
+        # If the organization type is the special string 'none', then ignore
+        # the required-ness of other organization-related fields
+        desired_metadata_dict = {r['name']: r for r in desired_metadata_fields}
         if (
-            any(
-                field.get('name') == 'organization_type'
-                for field in desired_metadata_fields
-            )
+            'organization_type' in desired_metadata_dict
             and value.get('organization_type') == 'none'
         ):
-            for field in desired_metadata_fields:
-                if field['name'] in [
-                    'organization',
-                    'organization_website',
-                ]:
-                    field['required'] = False
+            for field in 'organization', 'organization_website':
+                metadata_field = desired_metadata_dict.get(field)
+                if not metadata_field:
+                    continue
+                metadata_field['required'] = False
 
         errors = {}
         for field in desired_metadata_fields:

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -201,6 +201,22 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             constance.config.USER_METADATA_FIELDS
         )
 
+        # If the user has selected that they are not associated with an organization,
+        # change the required-ness of `organization` and `organization_website` fields to false
+        if (
+            any(
+                field.get('name') == 'organization_type'
+                for field in desired_metadata_fields
+            )
+            and value.get('organization_type') == 'none'
+        ):
+            for field in desired_metadata_fields:
+                if field['name'] in [
+                    'organization',
+                    'organization_website',
+                ]:
+                    field['required'] = False
+
         errors = {}
         for field in desired_metadata_fields:
             if not field['required']:

--- a/static/js/organization_type_skiplogic.js
+++ b/static/js/organization_type_skiplogic.js
@@ -1,0 +1,54 @@
+/*
+  Location: /accounts/signup (and SSO equivalent)
+  DOM location: After signup fields (organization type, name, ...)
+
+  - Show/hide organization and organization_website based on organization_type
+  - Apply 'required' appearance if needed.
+*/
+(function() {
+  const organization_type    = document.querySelector('form.registration  select[name=organization_type]')
+  const organization         = document.querySelector('form.registration   input[name=organization]')
+  const organization_website = document.querySelector('form.registration   input[name=organization_website]')
+
+  if (!organization_type?.required) {return}
+
+  document.querySelectorAll('[data-required]').forEach(function(field) {
+    // On the frontend, treat these fields like regular required fields.
+    const redAsterisk = document.createElement('span')
+    redAsterisk.classList.add('required')
+    redAsterisk.textContent = '*'
+    field.before(redAsterisk) // label, *, field
+    field.required = true
+  })
+
+  const organization_parent = organization?.parentElement
+  const organization_website_parent = organization_website?.parentElement
+  const organization_placeholder = document.createElement('div')
+  const organization_website_placeholder = document.createElement('div')
+
+  const applySkipLogic = function() {
+    // Swap fields with placeholders, removing or re-adding them to the form
+    if (organization_type.value === 'none' || organization_type.value === '') {
+      if (organization_parent) {
+        organization_parent.before(organization_placeholder)
+        organization_parent.remove()
+      }
+      if (organization_website_parent) {
+        organization_website_parent.before(organization_website_placeholder)
+        organization_website_parent.remove()
+      }
+    } else {
+      if (organization_parent) {
+        organization_placeholder.before(organization_parent)
+        organization_placeholder.remove()
+      }
+      if (organization_website_parent) {
+        organization_website_placeholder?.before(organization_website_parent)
+        organization_website_placeholder?.remove()
+      }
+    }
+  }
+
+  organization_type.addEventListener('change', applySkipLogic)
+  applySkipLogic()
+})()


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Added skip logic and tests based on if the superuser has enabled and/or required the `organization_type` field.

In forms.py:
- If the organization type is enabled, initialize the signup form with the `organization_type` required and other organization fields to not be required
- When the user submits the form, we check if the `organization_type` is none and if it is not, we require the `organization` and `organization_website` fields. 

In current_user.py:
- When validating the extra_details, if the `organization_type` field is enabled and the value is none, change the required values of `organization` and `organization_website` to `false`. 
