### PR TITLE
Pin `check-dependencies` to version 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ WORKDIR ${KPI_SRC_DIR}/
 
 RUN rm -rf ${KPI_NODE_PATH} && \
     npm install -g npm@8.5.5 && \
-    npm install -g check-dependencies && \
+    npm install -g check-dependencies@1 && \
     rm -rf "${KPI_SRC_DIR}/jsapp/fonts" && \
     rm -rf "${KPI_SRC_DIR}/jsapp/compiled" && \
     npm install --quiet && \


### PR DESCRIPTION
`check-dependencies` [2.0.0, released last week](https://github.com/mgol/check-dependencies/releases#tag-select-menu-e66f2eb0-8947-11ee-8423-7a603ea96d49), dropped support for Node <18.3. Node 18.3 added `utils.parseArgs`

credit: @p2edwards 

## Description
Fix `TypeError: util.parseArgs is not a function` during the build process