### PR TITLE
KoboSelect style fixes

### DIFF
--- a/jsapp/js/components/common/koboSelect.scss
+++ b/jsapp/js/components/common/koboSelect.scss
@@ -20,6 +20,10 @@ $k-select-menu-padding: sizes.$x6;
 .k-select .kobo-dropdown__trigger:focus-visible .k-select__trigger {
   @include mixins.default-ui-focus;
 }
+// And we need to remove the default styles from the de facto trigger
+.k-select .kobo-dropdown__trigger:focus-visible {
+  outline: none;
+}
 
 .k-select__trigger {
   @include mixins.centerRowFlex;

--- a/jsapp/js/components/common/koboSelect.scss
+++ b/jsapp/js/components/common/koboSelect.scss
@@ -282,6 +282,7 @@ $k-select-menu-padding: sizes.$x6;
 .k-select.k-select--type-outline {
   .k-select__trigger {
     border-color: colors.$kobo-gray-92;
+    background-color: colors.$kobo-white;
   }
 
   &:not(.k-select--is-menu-visible) .k-select__trigger:hover,


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes small visual glitch in KoboSelect component and adds missing background color.

## Notes

`KoboSelect` uses its own focus styles (nested element has focus). Its base component `KoboDropdown` already has some default focus styles that appear underneath causing this visual glitch of a darker pixel near the rounded corners. This PR fixes that problem.

I've also added white background to "outline" type, as this matches the designs and is improving readability everywher we are using `KoboSelect` on non-white background.

## Related issues

Discovered while working on #4733 
