### PR TITLE
Don't prevent users from saving an existing social application due to provider ID validation

### DIFF
--- a/kobo/apps/django_allauth/admin.py
+++ b/kobo/apps/django_allauth/admin.py
@@ -32,7 +32,7 @@ class RequireProviderIdSocialAppForm(SocialAppForm):
         if SocialApp.objects.filter(
             Q(provider_id=provider_id) |
             Q(provider=provider_id)
-        ).exists():
+        ).exclude(pk=self.instance.pk).exists():
             raise ValidationError(
                 """The Provider ID value must be unique and cannot match an existing Provider name.
                 Please use a different value."""


### PR DESCRIPTION
… provider ID validation

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixed a bug that prevent updating Social Applications in the admin.

## Notes

This problem was introduced by the recent django-allauth changes ([kpi#4715](https://github.com/kobotoolbox/kpi/pull/4715)); the check to see if the `provider` and `provider_id` fields were unique didn't account for social applications that were being edited, just new ones. So adding a Social Application would work fine, but editing an existing Social Application and clicking 'Save' would fail with a validation error.