### PR TITLE
Display submission counts only for users who have unrestricted access to view submissions

### DIFF
--- a/jsapp/js/components/header/mainHeader.component.tsx
+++ b/jsapp/js/components/header/mainHeader.component.tsx
@@ -144,7 +144,7 @@ const MainHeader = class MainHeader extends React.Component<MainHeaderProps> {
 
             <HeaderTitleEditor asset={asset} isEditable={userCanEditAsset} />
 
-            {asset.has_deployment && (
+            {asset.has_deployment && asset.deployment__submission_count !== null && (
               <bem.MainHeader__counter>
                 {asset.deployment__submission_count} {t('submissions')}
               </bem.MainHeader__counter>

--- a/jsapp/js/project/projectTopTabs.component.tsx
+++ b/jsapp/js/project/projectTopTabs.component.tsx
@@ -34,7 +34,8 @@ export default function ProjectTopTabs() {
   const isDataTabEnabled =
     asset?.deployment__identifier != undefined &&
     asset?.has_deployment &&
-    asset?.deployment__submission_count > 0 &&
+    (asset?.deployment__submission_count === null ||
+      asset?.deployment__submission_count > 0) &&
     (userCan('view_submissions', asset) ||
       userCanPartially('view_submissions', asset));
 

--- a/jsapp/js/projects/projectsTable/projectsTableRow.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableRow.tsx
@@ -85,6 +85,9 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
       case 'languages':
         return assetUtils.getLanguagesDisplayString(props.asset);
       case 'submissions':
+        if (props.asset.deployment__submission_count === null) {
+          return null;
+        }
         return (
           <Badge
             color='cloud'

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -587,21 +587,19 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         try:
             request = self.context['request']
-            user = request.user
-            if obj.owner_id == user.id:
-                return obj.deployment.submission_count
-
-            # `has_perm` benefits from internal calls which use
-            # `django_cache_request`. It won't hit DB multiple times
-            if obj.has_perm(user, PERM_VIEW_SUBMISSIONS):
-                return obj.deployment.submission_count
-
-            if obj.has_perm(user, PERM_PARTIAL_SUBMISSIONS):
-                return obj.deployment.calculated_submission_count(user=user)
         except KeyError:
-            pass
+            return None
 
-        return 0
+        user = request.user
+        if obj.owner_id == user.id:
+            return obj.deployment.submission_count
+
+        # `has_perm` benefits from internal calls which use
+        # `django_cache_request`. It won't hit DB multiple times
+        if obj.has_perm(user, PERM_VIEW_SUBMISSIONS):
+            return obj.deployment.submission_count
+
+        return None
 
     def get_assignable_permissions(self, asset):
         return [

--- a/kpi/serializers/v2/asset_counts.py
+++ b/kpi/serializers/v2/asset_counts.py
@@ -28,6 +28,9 @@ class AssetCountsSerializer(serializers.Serializer):
         return daily_counts
 
     def get_total_submission_count(self, asset):
+        # TODO: de-duplicate this logic with
+        # AssetSerializer.get_deployment__submission_count()
+
         request = self.context['request']
         user = get_database_user(request.user)
 
@@ -39,7 +42,10 @@ class AssetCountsSerializer(serializers.Serializer):
         if asset.has_perm(user, PERM_VIEW_SUBMISSIONS):
             return asset.deployment.submission_count
 
-        if asset.has_perm(user, PERM_PARTIAL_SUBMISSIONS):
-            return asset.deployment.calculated_submission_count(user=user)
+        if (
+            asset.has_perm(user, PERM_PARTIAL_SUBMISSIONS)
+            and asset.deployment.submission_count == 0
+        ):
+            return 0
 
-        return 0
+        return None

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1043,7 +1043,9 @@ class AssetDetailApiTests(BaseAssetDetailTestCase):
         self.client.logout()
         self.client.login(username='anotheruser', password='anotheruser')
         response = self.client.get(self.asset_url, format='json')
-        self.assertEqual(response.data['deployment__submission_count'], 1)
+        # No submission count is provided any longer to users with only
+        # row-level permissions
+        self.assertEqual(response.data['deployment__submission_count'], None)
 
     def test_assignable_permissions(self):
         self.assertEqual(self.asset.asset_type, 'survey')


### PR DESCRIPTION
Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/User's.20page.20not.20loading!/near/301064

## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Those who have [row-level "partial" permissions](https://support.kobotoolbox.org/row_level_permissions.html) no longer have access to submission counts. This avoids 504 errors when the database cannot count the number of submissions that match the row-level filters fast enough.