### PR TITLE
Allow service account to fetch external xml for connected projects

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,11 +13,12 @@ build:
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:
-    - docker pull $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} || true
-    - docker build --cache-from $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-} .
+    - CI_COMMIT_REF_NAME_SANITIZED=${CI_COMMIT_REF_NAME/\#/-}
+    - CI_COMMIT_REF_NAME_SANITIZED=${CI_COMMIT_REF_NAME_SANITIZED//\//-}
+    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED || true
+    - docker build --cache-from $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
-    - docker push $CI_REGISTRY_IMAGE:${CI_COMMIT_REF_NAME//\//-}
-
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED
 deploy-beta:
   stage: deploy
   image:

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -769,6 +769,7 @@ REST_FRAMEWORK = {
         'kpi.authentication.BasicAuthentication',
         'kpi.authentication.TokenAuthentication',
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+        'kobo_service_account.authentication.ServiceAccountAuthentication',
     ],
     'DEFAULT_RENDERER_CLASSES': [
        'rest_framework.renderers.JSONRenderer',


### PR DESCRIPTION
## Description

Expect service account to make requests on behalf of the owner of the child connected project project.

## Notes
For self-hosters who do not use kobo-install, domain restrictions should enforce by add `SERVICE_ACCOUNT_WHITELISTED_HOSTS` environment variable to KPI container. It should contain KPI internal domain , e.g. : `<kpi_subdomain>.<domain>.internal` 


## Related issues

Related to kobotoolbox/kobocat#909 
