### PR TITLE
Require "edit submissions", not "add submissions", for working with transcripts and translations

### DIFF
--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError as SchemaValidationError
@@ -48,8 +49,17 @@ def _check_asr_mt_access_if_applicable(user, posted_data):
                     raise PermissionDenied('ASR/MT features are not available')
 
 
+class AdvancedSubmissionPermission(SubmissionPermission):
+    """
+    Regular `SubmissionPermission` maps POST to `add_submissions`, but
+    `change_submissions` should be required here
+    """
+    perms_map = deepcopy(SubmissionPermission.perms_map)
+    perms_map['POST'] = ['%(app_label)s.change_%(model_name)s']
+
+
 class AdvancedSubmissionView(APIView):
-    permission_classes = [SubmissionPermission]
+    permission_classes = [AdvancedSubmissionPermission]
     queryset = Asset.objects.all()
     asset = None
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Doing any kind of work with transcripts or translations—whether adding a new one or editing an existing one—now always requires the "edit submissions" permission.