### PR TITLE
[TASK-328] Filter analysis questions by current survey question

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisContent.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisContent.component.tsx
@@ -3,6 +3,7 @@ import AnalysisQuestionsContext from './analysisQuestions.context';
 import AnalysisContentEmpty from './analysisContentEmpty.component';
 import AnalysisQuestionsList from './list/analysisQuestionsList.component';
 import styles from './analysisContent.module.scss';
+import singleProcessingStore from '../singleProcessingStore';
 
 /** Displays either a special message for no content, or the list of questions. */
 export default function AnalysisContent() {
@@ -11,15 +12,16 @@ export default function AnalysisContent() {
     return null;
   }
 
+  // We only want to display analysis questions for this survey question
+  const filteredQuestions = analysisQuestions.state.questions.filter(
+    (question) => question.qpath === singleProcessingStore.currentQuestionQpath
+  );
+
   return (
     <section className={styles.root}>
-      {analysisQuestions.state.questions.length === 0 && (
-        <AnalysisContentEmpty />
-      )}
+      {filteredQuestions.length === 0 && <AnalysisContentEmpty />}
 
-      {analysisQuestions.state.questions.length > 0 && (
-        <AnalysisQuestionsList />
-      )}
+      {filteredQuestions.length > 0 && <AnalysisQuestionsList />}
     </section>
   );
 }

--- a/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
@@ -51,7 +51,10 @@ export default function AnalysisHeader() {
         onClick={() => {
           analysisQuestions?.dispatch({
             type: 'addQuestion',
-            payload: {type: definition.type},
+            payload: {
+              qpath: singleProcessingStore.currentQuestionQpath,
+              type: definition.type,
+            },
           });
         }}
         tabIndex={0}

--- a/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
@@ -8,7 +8,7 @@ export type AnalysisQuestionsAction =
   // Sets all the quetsion with new ones (useful for initialising)
   | {type: 'setQuestions'; payload: {questions: AnalysisQuestionInternal[]}}
   // Creates a draft question of given type with new uid assigned
-  | {type: 'addQuestion'; payload: {type: AnalysisQuestionType}}
+  | {type: 'addQuestion'; payload: {qpath: string; type: AnalysisQuestionType}}
   // Opens question for editing, i.e. causes the editor to be opened for given
   // question
   | {type: 'startEditingQuestion'; payload: {uuid: string}}

--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -70,6 +70,7 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
       }
 
       const newQuestion: AnalysisQuestionInternal = {
+        qpath: action.payload.qpath,
         type: action.payload.type,
         labels: {_default: ''},
         uuid: newUuid,

--- a/jsapp/js/components/processing/analysis/constants.ts
+++ b/jsapp/js/components/processing/analysis/constants.ts
@@ -71,13 +71,14 @@ export interface AnalysisQuestionBase {
   labels: AnalysisLabels;
   uuid: string;
   options?: AnalysisQuestionOptions;
+  /** The survey question that this analysis questions is for. */
+  qpath: string;
 }
 
 /** Analysis question definition from the asset's schema (i.e. from Back end) */
 export interface AnalysisQuestionSchema extends AnalysisQuestionBase {
   // 'by_question#survey'
   scope: string;
-  qpath: string;
   choices?: AnalysisQuestionChoice[];
 }
 

--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -131,7 +131,6 @@ export default function AnalysisQuestionEditor(
       try {
         const response = await updateSurveyQuestions(
           singleProcessingStore.currentAssetUid,
-          singleProcessingStore.currentQuestionQpath,
           updatedQuestions
         );
 

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -150,7 +150,6 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
         try {
           const response = await updateSurveyQuestions(
             singleProcessingStore.currentAssetUid,
-            singleProcessingStore.currentQuestionQpath,
             analysisQuestions.state.questions
           );
 

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
@@ -4,6 +4,7 @@ import styles from './analysisQuestionsList.module.scss';
 import AnalysisQuestionRow from './analysisQuestionRow.component';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
+import singleProcessingStore from '../../singleProcessingStore';
 
 /**
  * Renders a list of questions (`AnalysisQuestionRow`s to be precise).
@@ -15,6 +16,11 @@ export default function AnalysisQuestionsList() {
   if (!analysisQuestions) {
     return null;
   }
+
+  // We only want to display analysis questions for this survey question
+  const filteredQuestions = analysisQuestions.state.questions.filter(
+    (question) => question.qpath === singleProcessingStore.currentQuestionQpath
+  );
 
   const moveRow = useCallback(
     (uuid: string, oldIndex: number, newIndex: number) => {
@@ -29,7 +35,7 @@ export default function AnalysisQuestionsList() {
   return (
     <DndProvider backend={HTML5Backend}>
       <ul className={styles.root}>
-        {analysisQuestions.state.questions.map((question, index: number) => {
+        {filteredQuestions.map((question, index: number) => {
           // TODO: we temporarily hide Keyword Search from the UI until
           // https://github.com/kobotoolbox/kpi/issues/4594 is done
           if (question.type === 'qual_auto_keyword_count') {

--- a/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
@@ -81,7 +81,6 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
       // Step 3: update asset endpoint with new questions
       const response = await updateSurveyQuestions(
         singleProcessingStore.currentAssetUid,
-        singleProcessingStore.currentQuestionQpath,
         newQuestions
       );
 

--- a/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
@@ -51,6 +51,7 @@ export default function IntegerResponseForm(props: IntegerResponseFormProps) {
 
     updateResponseAndReducer(
       analysisQuestions.dispatch,
+      question.qpath,
       props.uuid,
       question.type,
       response

--- a/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
@@ -62,6 +62,7 @@ export default function SelectMultipleResponseForm(
     // Update endpoint and reducer
     updateResponseAndReducer(
       analysisQuestions.dispatch,
+      question.qpath,
       props.uuid,
       question.type,
       newResponse

--- a/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
@@ -56,6 +56,7 @@ export default function SelectOneResponseForm(
     // Update endpoint and reducer
     updateResponseAndReducer(
       analysisQuestions.dispatch,
+      question.qpath,
       props.uuid,
       question.type,
       newResponse

--- a/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
@@ -54,6 +54,7 @@ export default function TagsResponseForm(props: TagsResponseFormProps) {
     // Update endpoint and reducer
     updateResponseAndReducer(
       analysisQuestions.dispatch,
+      question.qpath,
       props.uuid,
       question.type,
       newTags

--- a/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
@@ -51,6 +51,7 @@ export default function TextResponseForm(props: TextResponseFormProps) {
 
     updateResponseAndReducer(
       analysisQuestions.dispatch,
+      question.qpath,
       props.uuid,
       question.type,
       response

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -57,8 +57,6 @@ export function getQuestionTypeDefinition(type: AnalysisQuestionType) {
  * questions definitions on endpoint.
  */
 export function convertQuestionsFromInternalToSchema(
-  /** The qpath of the asset question to which the analysis questions will refer */
-  qpath: string,
   questions: AnalysisQuestionInternal[]
 ): AnalysisQuestionSchema[] {
   return questions.map((question) => {
@@ -69,7 +67,7 @@ export function convertQuestionsFromInternalToSchema(
       options: question.options,
       choices: question.additionalFields?.choices,
       scope: 'by_question#survey',
-      qpath: qpath,
+      qpath: question.qpath,
     };
   });
 }
@@ -84,6 +82,7 @@ export function convertQuestionsFromSchemaToInternal(
 ): AnalysisQuestionInternal[] {
   return questions.map((question) => {
     const output: AnalysisQuestionInternal = {
+      qpath: question.qpath,
       uuid: question.uuid,
       type: question.type,
       labels: question.labels,
@@ -143,7 +142,6 @@ export function getQuestionsFromSchema(
  */
 export async function updateSurveyQuestions(
   assetUid: string,
-  qpath: string,
   questions: AnalysisQuestionInternal[]
 ) {
   // Step 1: Make sure not to mutate existing object
@@ -161,7 +159,6 @@ export async function updateSurveyQuestions(
 
   // Step 3: prepare the data for the endpoint
   advancedFeatures.qual.qual_survey = convertQuestionsFromInternalToSchema(
-    qpath,
     questions
   );
 
@@ -244,6 +241,7 @@ async function updateResponse(
  */
 export async function updateResponseAndReducer(
   dispatch: React.Dispatch<AnalysisQuestionsAction>,
+  surveyQuestionQpath: string,
   analysisQuestionUUid: string,
   analysisQuestionType: AnalysisQuestionType,
   response: string | string[]
@@ -272,7 +270,7 @@ export async function updateResponseAndReducer(
     const result = await updateResponse(
       processingUrl,
       singleProcessingStore.currentSubmissionEditId,
-      singleProcessingStore.currentQuestionQpath,
+      surveyQuestionQpath,
       analysisQuestionUUid,
       analysisQuestionType,
       actualResponse


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes a bug with analysis questions appearing for all survey questions.

## Notes

This is a piece of functionality that was missing, rather than a bug. We use `qpath` of analysis questions to filter out the ones defined for other survey questions. Previous code had a bug that caused qpath to be overwritten - now it is fixed.
