### PR TITLE
[TASK-383] [TASK-330] Preserve response when updating Analysis Question definition

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.actions.ts
@@ -31,7 +31,7 @@ export type AnalysisQuestionsAction =
   // fresh data from Back-end.
   | {
       type: 'updateQuestionCompleted';
-      payload: {questions: AnalysisQuestionInternal[]};
+      payload: {question: AnalysisQuestionInternal};
     }
   // Unlocks UI after failed API call
   | {type: 'udpateQuestionFailed'}

--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -1,7 +1,10 @@
 import {generateUuid, moveArrayElementToIndex} from 'jsapp/js/utils';
 import type {AnalysisQuestionInternal} from './constants';
 import type {AnalysisQuestionsAction} from './analysisQuestions.actions';
-import {applyUpdateResponseToInternalQuestions} from './utils';
+import {
+  applyUpdateResponseToInternalQuestions,
+  updateSingleQuestionPreservingResponse,
+} from './utils';
 
 export interface AnalysisQuestionsState {
   /** Whether any async action is being done right now. */
@@ -157,7 +160,10 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
         ...state,
         isPending: false,
         hasUnsavedWork: false,
-        questions: action.payload.questions,
+        questions: updateSingleQuestionPreservingResponse(
+          action.payload.question,
+          state.questions
+        ),
         // After question definition was updated, we no longer modify it (this
         // closes the editor)
         // Note: this assumes we are only allowing one question editor at a time

--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -134,13 +134,22 @@ export default function AnalysisQuestionEditor(
           updatedQuestions
         );
 
-        // Step 4: update reducer's state with new list after the call finishes
-        analysisQuestions?.dispatch({
-          type: 'updateQuestionCompleted',
-          payload: {
-            questions: getQuestionsFromSchema(response?.advanced_features),
-          },
-        });
+        // We get all questions in the response, but we only need the one we've
+        // just updated
+        const newQuestions = getQuestionsFromSchema(response?.advanced_features);
+        const currentNewQuestion = newQuestions.find((item) => item.uuid === props.uuid);
+
+        if (currentNewQuestion) {
+          // Step 4: update reducer's state with new list after the call finishes
+          analysisQuestions?.dispatch({
+            type: 'updateQuestionCompleted',
+            payload: {question: currentNewQuestion},
+          });
+        } else {
+          // This should never happen :) I.e. the list of questions from
+          // `response` will include the question, it's just the `.find`
+          // that has a possibility to return `undefined` :shrug:
+        }
       } catch (err) {
         handleApiFail(err as FailResponse);
         analysisQuestions?.dispatch({type: 'udpateQuestionFailed'});

--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -149,6 +149,7 @@ export default function AnalysisQuestionEditor(
           // This should never happen :) I.e. the list of questions from
           // `response` will include the question, it's just the `.find`
           // that has a possibility to return `undefined` :shrug:
+          throw new Error('Question not found in the list of questions');
         }
       } catch (err) {
         handleApiFail(err as FailResponse);

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -128,6 +128,21 @@ export function applyUpdateResponseToInternalQuestions(
   return newQuestions;
 }
 
+/** Update a question in a list of questions preserving existing response. */
+export function updateSingleQuestionPreservingResponse(
+  questionToUpdate: AnalysisQuestionInternal,
+  questions: AnalysisQuestionInternal[]
+): AnalysisQuestionInternal[] {
+  return clonedeep(questions).map((question) => {
+    if (question.uuid === questionToUpdate.uuid) {
+      // Preserve exsiting response, but update everything else
+      return {...questionToUpdate, response: question.response};
+    } else {
+      return question;
+    }
+  });
+}
+
 export function getQuestionsFromSchema(
   advancedFeatures: AssetAdvancedFeatures | undefined
 ): AnalysisQuestionInternal[] {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

## Notes

When we get the updated question object from API endpoint, it doesn't have the response in it (as it comes from other endpoint). Thus we need to update everything in the stored question, but the response.

This is built atop the #4750 PR.