### PR TITLE
Fix `MAXIMUM_FILENAME_LENGTH` bug

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -570,8 +570,9 @@ class ExportTaskBase(ImportExportTask):
     }
 
     TIMESTAMP_KEY = '_submission_time'
-    # Above 244 seems to cause 'Download error' in Chrome 64/Linux
-    MAXIMUM_FILENAME_LENGTH = 240
+    # Above 244 seems to cause 'Download error' in Chrome 64/Linux and above
+    # 207 causes a 'Filename too long' error in Excel
+    MAXIMUM_FILENAME_LENGTH = 207
 
     class InaccessibleData(Exception):
         def __str__(self):


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Bug fix for long filenames which throw an error and prevent the user from opening the file in Excel. 

## Notes

Updated the `MAXIMUM_FILENAME_LENGTH` variable to not exceed 207 characters which is the filename length limit for Excel.
 
To test: 
1. Checkout `beta`
2. Create a project with a very long name, create a form, deploy, and submit data
3. Export the file as an XLS, download, and open the file with Excel 
4. You will get an error: "The file name is too long. Rename the file with less than 207 characters"
5. Checkout this brach: `maximum-file-length-issue`
6. Restart your dev environment (for some reason if you don't, the application does not recognize the updated variable and you will still get the same error)
7. Log in and repeat step 3 with the same project.
8. You should be able to open the file without an error. 

## Related issues

Fixes #3732
