### PR TITLE
Fix form style bug in form builder

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -96,7 +96,7 @@ export default Object.assign({
         window.setTimeout(() => {
           this.launchAppForSurveyContent(asset.content, {
             name: asset.name,
-            settings__style: asset.settings__style,
+            settings__style: asset.content.settings.style,
             asset_uid: asset.uid,
             asset_type: asset.asset_type,
             asset: asset,


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description 

Allow form style setting to be retained when the user enters and leaves the form builder.

## Notes

Changed the location of where we are accessing the `settings__style` variable when we open the form editor. The bug was that we were looking in the `asset.settings_style` which is undefined. The correct location is in the `asset.content.settings.style`. 

## Related issues

Fixes #3887
