### PR TITLE
[TASK-329] Use new qual labels on Front end

### DIFF
--- a/jsapp/js/components/processing/analysis/constants.ts
+++ b/jsapp/js/components/processing/analysis/constants.ts
@@ -105,10 +105,54 @@ export interface AnalysisRequest {
   val: string | string[] | number;
 }
 
-/** This is basically `AnalysisRequest` but with few more properties. */
-export interface AnalysisResponse
-  extends AnalysisRequest,
-    AnalysisQuestionBase {}
+/**
+ * This is a response object for `qual_select_one` and `qual_select_multiple`.
+ * Besides `uuid` of a choice, it also has `labels`. It makes it easier to
+ * display these responses in the UI.
+ */
+interface AnalysisResponseSelectXValue {
+  labels: AnalysisLabels;
+  /** The `uuid` of selected `AnalysisQuestionChoice`. */
+  val: string;
+}
+
+/**
+ * A lot of options, because:
+ * - `qual_tags` returns `string[]`
+ * - `qual_text` returns `string`
+ * - `qual_integer` returns `number`
+ * - `qual_select_one` returns `AnalysisResponseSelectXValue`
+ * - `qual_select_multiple` returns `AnalysisResponseSelectXValue[]`
+ */
+type AnalysisResponseValue =
+  | string
+  | string[]
+  | number
+  | AnalysisResponseSelectXValue
+  | AnalysisResponseSelectXValue[];
+
+/**
+ * This is the object that is returned from interacting with the processing
+ * endpoint (`asset.advanced_submission_schema.url`). It's similar to
+ * the `SubmissionAnalysisResponse`, but with less detailed `val` - for both
+ * `qual_select_one` and `qual_select_multiple` it will return a `string` (an
+ * `uuid` of choice) and `string[]` (list of `uuid` of selected choices)
+ * respectively.
+ */
+export interface AnalysisResponse extends AnalysisQuestionBase {
+  val: string | string[] | number;
+}
+
+/**
+ * This is the object that is returned from interacting with the data endpoint
+ * (`/api/v2/assets/:uid/data`), it will be inside the `_supplementalDetails`
+ * object for each appropiate submission. It's similar to `AnalysisResponse`,
+ * but with more detailed `val` for `qual_select_one` and `qual_select_multiple`
+ * - containing both `uuid` and a `labels` object.
+ */
+export interface SubmissionAnalysisResponse extends AnalysisQuestionBase {
+  val: AnalysisResponseValue;
+}
 
 /**
  * This is the payload of a request made to update a question response.

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -28,26 +28,6 @@ export function findQuestion(uuid: string, state: AnalysisQuestionsState) {
   return state.questions.find((question) => question.uuid === uuid);
 }
 
-/** Finds given question in schema object */
-export function findQuestionInSchema(
-  questionUuid: string,
-  advancedFeatures: AssetAdvancedFeatures | undefined
-) {
-  return advancedFeatures?.qual?.qual_survey?.find(
-    (item) => item.uuid === questionUuid
-  );
-}
-
-/** Find a choice of a given question (if applicable) in schema object */
-export function findQuestionChoiceInSchema(
-  questionUuid: string,
-  choiceUuid: string,
-  advancedFeatures: AssetAdvancedFeatures | undefined
-) {
-  const question = findQuestionInSchema(questionUuid, advancedFeatures);
-  return question?.choices?.find((item) => item.uuid === choiceUuid);
-}
-
 export function getQuestionTypeDefinition(type: AnalysisQuestionType) {
   return ANALYSIS_QUESTION_TYPES.find((definition) => definition.type === type);
 }

--- a/jsapp/js/components/submissions/submissionUtils.mocks.es6
+++ b/jsapp/js/components/submissions/submissionUtils.mocks.es6
@@ -2587,8 +2587,18 @@ export const submissionWithSupplementalDetails = {
         },
         {
           'val': [
-            'b180037c-930b-4025-ba21-1d59ee07485d',
-            'fa63c403-2a26-426c-97d6-9b8cfc277545',
+            {
+              labels: {
+                _default: 'First',
+              },
+              val: 'b180037c-930b-4025-ba21-1d59ee07485d',
+            },
+            {
+              labels: {
+                _default: 'Third',
+              },
+              val: 'fa63c403-2a26-426c-97d6-9b8cfc277545',
+            },
           ],
           'type': 'qual_select_multiple',
           'uuid': '1a89e0da-3344-4b5d-b919-ab8b072e0918',
@@ -2604,7 +2614,12 @@ export const submissionWithSupplementalDetails = {
           'uuid': '056c8f57-0733-4669-a84e-aa9726ffbf6b',
         },
         {
-          'val': '33f4e83d-4bd7-4dbc-b80b-94cac72944fb',
+          'val': {
+            labels: {
+              _default: 'Yes',
+            },
+            val: '33f4e83d-4bd7-4dbc-b80b-94cac72944fb',
+          },
           'type': 'qual_select_one',
           'uuid': '6f230992-b0c4-4cf4-a4a3-a5bd5b50ab4d',
         },

--- a/jsapp/js/components/submissions/submissionUtils.tests.es6
+++ b/jsapp/js/components/submissions/submissionUtils.tests.es6
@@ -28,7 +28,6 @@ import {
   matrixRepeatSurveySubmission,
   matrixRepeatSurveyDisplayData,
   submissionWithAttachmentsWithUnicode,
-  assetWithSupplementalDetails,
   submissionWithSupplementalDetails,
 } from './submissionUtils.mocks';
 import {
@@ -188,8 +187,7 @@ describe('getSupplementalDetailsContent', () => {
   it('should return analysis question value properly for qual_select_multiple', () => {
     const test = getSupplementalDetailsContent(
       submissionWithSupplementalDetails,
-      '_supplementalDetails/Secret_password_as_an_audio_file/1a89e0da-3344-4b5d-b919-ab8b072e0918',
-      assetWithSupplementalDetails.advanced_features
+      '_supplementalDetails/Secret_password_as_an_audio_file/1a89e0da-3344-4b5d-b919-ab8b072e0918'
     );
     expect(test).to.equal('First, Third');
   });
@@ -197,8 +195,7 @@ describe('getSupplementalDetailsContent', () => {
   it('should return analysis question value properly for qual_tags', () => {
     const test = getSupplementalDetailsContent(
       submissionWithSupplementalDetails,
-      '_supplementalDetails/Secret_password_as_an_audio_file/b05f29f7-8b58-4dd7-8695-c29cb04f3f7a',
-      assetWithSupplementalDetails.advanced_features
+      '_supplementalDetails/Secret_password_as_an_audio_file/b05f29f7-8b58-4dd7-8695-c29cb04f3f7a'
     );
     expect(test).to.equal('best, things, ever recorder by human, 3');
   });
@@ -206,8 +203,7 @@ describe('getSupplementalDetailsContent', () => {
   it('should return analysis question value properly for qual_integer', () => {
     const test = getSupplementalDetailsContent(
       submissionWithSupplementalDetails,
-      '_supplementalDetails/Secret_password_as_an_audio_file/97fd5387-ac2b-4108-b5b4-37fa91ae0e22',
-      assetWithSupplementalDetails.advanced_features
+      '_supplementalDetails/Secret_password_as_an_audio_file/97fd5387-ac2b-4108-b5b4-37fa91ae0e22'
     );
     expect(test).to.equal('12345');
   });

--- a/jsapp/js/components/submissions/submissionUtils.ts
+++ b/jsapp/js/components/submissions/submissionUtils.ts
@@ -289,8 +289,8 @@ export function getSubmissionDisplayData(
         // score and rank don't have list name on them and they need to use
         // the one of their parent
         if (row.type === SCORE_ROW_TYPE || row.type === RANK_LEVEL_TYPE) {
-          const parentGroupRow = survey.find((rowItem) =>
-            getRowName(rowItem) === parentGroup.name
+          const parentGroupRow = survey.find(
+            (rowItem) => getRowName(rowItem) === parentGroup.name
           );
           rowListName = getRowListName(parentGroupRow);
         }
@@ -312,7 +312,11 @@ export function getSubmissionDisplayData(
               getColumnLabel(asset, sdKey, false),
               sdKey,
               undefined,
-              getSupplementalDetailsContent(submissionData, sdKey, asset.advanced_features),
+              getSupplementalDetailsContent(
+                submissionData,
+                sdKey,
+                asset.advanced_features
+              )
             )
           );
         });
@@ -595,7 +599,7 @@ export function getSupplementalDetailsContent(
    * This is not an optional parameter, but it's possible it's not defined in
    * the AssetResponse object.
    */
-  advancedFeatures: AssetAdvancedFeatures | undefined,
+  advancedFeatures: AssetAdvancedFeatures | undefined
 ): string {
   let pathArray;
   const pathParts = getSupplementalPathParts(path);
@@ -639,7 +643,9 @@ export function getSupplementalDetailsContent(
     pathArray.pop();
     pathArray.push('qual');
     const qualResponses: AnalysisResponse[] = get(submission, pathArray, []);
-    const foundResponse = qualResponses.find((item: AnalysisResponse) => item.uuid === pathParts.analysisQuestionUuid);
+    const foundResponse = qualResponses.find(
+      (item: AnalysisResponse) => item.uuid === pathParts.analysisQuestionUuid
+    );
     if (foundResponse) {
       if (foundResponse.type === 'qual_select_one') {
         // We need to pass on a string, and we know that `qual_select_one` will
@@ -683,7 +689,10 @@ export function getSupplementalDetailsContent(
       // property, so we handle it here by the `val` type
       if (Array.isArray(foundResponse.val) && foundResponse.val.length > 0) {
         return foundResponse.val.join(', ');
-      } else if (typeof foundResponse.val === 'string' && foundResponse.val !== '') {
+      } else if (
+        typeof foundResponse.val === 'string' &&
+        foundResponse.val !== ''
+      ) {
         return foundResponse.val;
       } else if (typeof foundResponse.val === 'number') {
         return String(foundResponse.val);

--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -905,8 +905,7 @@ export class DataTable extends React.Component {
           ) {
             const supplementalDetailsContent = getSupplementalDetailsContent(
               row.original,
-              key,
-              this.props.asset.advanced_features
+              key
             );
 
             return (

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -18,7 +18,7 @@ import type {Json} from './components/common/common.interfaces';
 import type {ProjectViewsSettings} from './projects/customViewStore';
 import type {
   AnalysisQuestionSchema,
-  AnalysisResponse
+  SubmissionAnalysisResponse,
 } from './components/processing/analysis/constants';
 import type {TransxObject} from './components/processing/processingActions';
 import type {UserResponse} from 'js/users/userExistence.store';
@@ -161,7 +161,7 @@ interface SubmissionSupplementalDetails {
     translation?: {
       [languageCode: LanguageCode]: TransxObject;
     };
-    qual?: AnalysisResponse[];
+    qual?: SubmissionAnalysisResponse[];
   };
 }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Use new, simpler way of displaying labels of selected responses for Analysis Questions.

## Notes

This targets [feature-analysis__4627-return-qual-labels-in-api](https://github.com/kobotoolbox/kpi/tree/feature-analysis__4627-return-qual-labels-in-api) because it relies on new Back end code in that branch.

Changes here:
- Improved types for responses, distinguishing between different vals returned
- Updated tests
- Simplified `getSupplementalDetailsContent` function to use new labels instead of getting them through schema

## Related issues

Closes #4652 