### PR TITLE
Migrate Social Providers from environment variables to database

### DIFF
--- a/kobo/apps/django_allauth/migrations/0001_initial.py
+++ b/kobo/apps/django_allauth/migrations/0001_initial.py
@@ -2,44 +2,51 @@ import os
 import re
 from django.db import migrations
 
-
+"""
+Add any OIDC providers from the environment variables to the database. The upgrade to
+django-allauth@0.57.0 removed code from /settings/base.py that parsed OIDC settings from
+environment variables, so this migration is needed to avoid manually setting up OIDC
+providers from the admin. Adapted from:
+https://gitlab.com/glitchtip/glitchtip-backend/-/blob/master/users/migrations/0010_allauth_oidc_from_env_var.py?ref_type=heads
+"""
 def add_OIDC_settings_from_env(apps, schema_editor):
     SocialApp = apps.get_model('socialaccount', 'SocialApp')
 
-    oidc_prefix = "SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_"
-    oidc_pattern = re.compile(r'{prefix}\w+'.format(prefix=oidc_prefix))
-    oidc_apps = {}
+    prefix = 'SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_'
+    pattern = re.compile(r'{prefix}\w+'.format(prefix=prefix))
+    social_apps = {}
+
     for key, value in {
-        key.replace(oidc_prefix, ''): val
+        key.replace(prefix, ''): val
         for key, val in os.environ.items()
-        if oidc_pattern.match(key)
+        if pattern.match(key)
     }.items():
         number, setting = key.split('_', 1)
-        if number in oidc_apps:
-            oidc_apps[number][setting] = value
+        if number in social_apps:
+            social_apps[number][setting] = value
         else:
-            oidc_apps[number] = {setting: value}
-    oidc_apps = [x for x in oidc_apps.values()]
+            social_apps[number] = {setting: value}
+    social_apps = [x for x in social_apps.values()]
 
-    for index, app in enumerate(oidc_apps):
+    for index, app in enumerate(social_apps):
         app_id = app.get('id')
+        # the app needs a name to be editable in the admin - give it a default name if necessary
         app_name = app.get('name', f'OIDC {index}')
         app_settings = {'server_url': app.get('server_url', None)}
-        if app_tenant := app.get('TENANT', None):
+        # parse the tenant variable for microsoft OIDC providers - check for uppercase (old way) and lowercase (new way)
+        if app_tenant := app.get('TENANT', app.get('tenant', None)):
             app_settings['tenant'] = app_tenant
-        if app_id and app_settings['server_url']:
-            db_social_app, created = SocialApp.objects.get_or_create(provider=app_id)
-            if created or not db_social_app.settings:
-                db_social_app.provider = 'openid_connect'
-                db_social_app.provider_id = app_id
-                db_social_app.name = app_name
-                db_social_app.client_id = app.get('APP_client_id', '')
-                db_social_app.secret = app.get('APP_secret', '')
-                db_social_app.key = app.get('APP_key', '')
-                db_social_app.settings = app_settings
-                db_social_app.save()
-            if not db_social_app:
-                pass
+        if app_id and app_settings['server_url'] and not (
+            SocialApp.objects.filter(provider_id=app_id).exists()
+        ):
+            db_social_app, _ = SocialApp.objects.get_or_create(provider_id=app_id)
+            db_social_app.provider = 'openid_connect'
+            db_social_app.name = app_name
+            db_social_app.client_id = app.get('APP_client_id', '')
+            db_social_app.secret = app.get('APP_secret', '')
+            db_social_app.key = app.get('APP_key', '')
+            db_social_app.settings = app_settings
+            db_social_app.save()
 
 
 class Migration(migrations.Migration):

--- a/kobo/apps/django_allauth/migrations/0001_initial.py
+++ b/kobo/apps/django_allauth/migrations/0001_initial.py
@@ -1,0 +1,54 @@
+import os
+import re
+from django.db import migrations
+
+
+def add_OIDC_settings_from_env(apps, schema_editor):
+    SocialApp = apps.get_model('socialaccount', 'SocialApp')
+
+    oidc_prefix = "SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_"
+    oidc_pattern = re.compile(r'{prefix}\w+'.format(prefix=oidc_prefix))
+    oidc_apps = {}
+    for key, value in {
+        key.replace(oidc_prefix, ''): val
+        for key, val in os.environ.items()
+        if oidc_pattern.match(key)
+    }.items():
+        number, setting = key.split('_', 1)
+        if number in oidc_apps:
+            oidc_apps[number][setting] = value
+        else:
+            oidc_apps[number] = {setting: value}
+    oidc_apps = [x for x in oidc_apps.values()]
+
+    for index, app in enumerate(oidc_apps):
+        app_id = app.get('id')
+        app_name = app.get('name', f'OIDC {index}')
+        app_settings = {'server_url': app.get('server_url', None)}
+        if app_tenant := app.get('TENANT', None):
+            app_settings['tenant'] = app_tenant
+        if app_id and app_settings['server_url']:
+            db_social_app, created = SocialApp.objects.get_or_create(provider=app_id)
+            if created or not db_social_app.settings:
+                db_social_app.provider = 'openid_connect'
+                db_social_app.provider_id = app_id
+                db_social_app.name = app_name
+                db_social_app.client_id = app.get('APP_client_id', '')
+                db_social_app.secret = app.get('APP_secret', '')
+                db_social_app.key = app.get('APP_key', '')
+                db_social_app.settings = app_settings
+                db_social_app.save()
+            if not db_social_app:
+                pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('socialaccount', '0005_socialtoken_nullable_app'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=add_OIDC_settings_from_env, reverse_code=migrations.RunPython.noop
+        )
+    ]


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

After running `django_allauth.0001_initial`, any previously-configured `SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_*` environment variables will now be editable from Social Accounts > Social Applications in the Django admin. You can safely remove the variables from your environment once you've confirmed that the imported social applications are working correctly. If you want the app's login button to be visible at `/accounts/login/`, make sure to remove any entries for that app from Account Extras > Social app custom datas.

## Notes
The django-allauth@0.57.0 upgrade removed some code that added OIDC providers set in env vars to the django settings. Since this would mean an extra manual migration step. Migration logic has been adapted from [this similar migration](https://gitlab.com/glitchtip/glitchtip-backend/-/blob/master/users/migrations/0010_allauth_oidc_from_env_var.py?ref_type=heads#L10), with permission.

**Additional changes:**

- Since OIDC apps configured in env vars were not shown on the login page, the migration adds SocialAppCustomData entries for each app created by the migration.
- The code to parse the `SOCIALACCOUNT_PROVIDERS_microsoft_TENANT` env var was also removed; the migration pastes that value into any Social Applications with a `microsoft` provider, if they don't already have a `tenant` key in their `settings`.

## Testing
Add the following env vars to kpi (and restart the server):
```yaml
  SOCIALACCOUNT_PROVIDERS_microsoft_TENANT: "microsoft oauth tenant"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_id: "google"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_server_url: "server url 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_provider: "provider 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_name: "social app 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_APP_client_id: "client id 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_APP_secret: "secret 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_0_APP_key: "key 0"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_1_id: "microsoft"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_1_name: "name 1"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_1_server_url: "server_url 1"
  SOCIALACCOUNT_PROVIDERS_openid_connect_SERVERS_1_TENANT: "tenant 1"
```

Create a new Social Application in the admin using dummy values and the Microsoft Graph provider. Then run the migration. Confirm that the social application settings match the environment variables.