### PR TITLE
Uncreated Question Block Bug in Form Builder 

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -543,7 +543,10 @@ export default Object.assign({
     if (this.state.backRoute === ROUTES.FORMS) {
       targetRoute = ROUTES.FORM.replace(':uid', this.state.asset_uid);
     } else if (this.state.backRoute === ROUTES.LIBRARY) {
-      targetRoute = ROUTES.LIBRARY_ITEM.replace(':uid', this.state.asset_uid);
+      // Check if the the uid is undefined to prevent getting an Access Denied screen
+      if (this.state.asset_uid !== undefined) {
+        targetRoute = ROUTES.LIBRARY_ITEM.replace(':uid', this.state.asset_uid);
+      }
     }
     this.safeNavigateToRoute(targetRoute);
   },


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

When the user cancels the creation of Question Block, they see an Access Denied screen which is confusing. 
Fixed this behavior so that the user is taken back to "My Library".  

## Notes

Added a check for if the `uid` is `undefined` before appending the `uid` to the route url. The Access Denied resulted from making a call like this: `/#/library/asset/undefined` so we want to prevent this behavior. 

## Related issues

Fixes #4534
