### PR TITLE
Partial submissions bug fixes

### DIFF
--- a/kpi/models/asset_user_partial_permission.py
+++ b/kpi/models/asset_user_partial_permission.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import annotations
 from collections import defaultdict
-from typing import Literal, Union
+from typing import Dict, List, Literal, Union
 
 from django.db import models
 from django.utils import timezone
@@ -9,11 +9,11 @@ from django.utils import timezone
 from kpi.constants import SUFFIX_SUBMISSIONS_PERMS
 
 
-SimplePartialPermFilter = dict[str, str]
+SimplePartialPermFilter = Dict[str, str]
 """Basic filter such as my_question: my_response"""
 
-SubmittedByPartialPermissionFilter = dict[
-    Literal["_submitted_by"], dict[Literal["_submitted_by"], list[str]]
+SubmittedByPartialPermissionFilter = Dict[
+    Literal["_submitted_by"], Dict[Literal["_submitted_by"], List[str]]
 ]
 """
 Inner mongo filter for _submitted_by that accepts a subset of mongo operations
@@ -25,7 +25,7 @@ PartialPermissionFilter = Union[
 ]
 """Any valid type of partial permission filter"""
 
-PartialPermissions = dict[str, list[list[PartialPermissionFilter]]]
+PartialPermissions = Dict[str, List[List[PartialPermissionFilter]]]
 """
 A partial permission is a permission string and it's set of filters
 {
@@ -33,8 +33,8 @@ A partial permission is a permission string and it's set of filters
 }
 """
 
-LegacyPartialPermissions = dict[
-    str, list[Union[list[PartialPermissionFilter], SubmittedByPartialPermissionFilter]]
+LegacyPartialPermissions = Dict[
+    str, List[Union[List[PartialPermissionFilter], SubmittedByPartialPermissionFilter]]
 ]
 """Older partial permissions use format like 'some_permission': [{'_submitted_by': {'$in': ['a']}}]"""
 

--- a/kpi/models/asset_user_partial_permission.py
+++ b/kpi/models/asset_user_partial_permission.py
@@ -1,11 +1,98 @@
 # coding: utf-8
 from collections import defaultdict
+from typing import Literal, Union
 
 from django.db import models
 from django.utils import timezone
 
 from kpi.constants import SUFFIX_SUBMISSIONS_PERMS
-from kpi.utils.mongo_helper import MongoHelper
+
+
+SimplePartialPermFilter = dict[str, str]
+"""Basic filter such as my_question: my_response"""
+
+SubmittedByPartialPermissionFilter = dict[
+    Literal["_submitted_by"], dict[Literal['_submitted_by'], list[str]]
+]
+"""
+Inner mongo filter for _submitted_by that accepts a subset of mongo operations
+{'_submitted_by': {'$in': ['a']}}
+"""
+
+PartialPermissionFilter = Union[
+    SimplePartialPermFilter, SubmittedByPartialPermissionFilter
+]
+"""Any valid type of partial permission filter"""
+
+PartialPermissions = dict[str, list[list[PartialPermissionFilter]]]
+"""
+A partial permission is a permission string and it's set of filters
+{
+    'some_permission': [[{'_submitted_by': {'$in': ['a']}}]]
+}
+"""
+
+LegacyPartialPermissions = dict[
+    str, list[Union[list[PartialPermissionFilter], SubmittedByPartialPermissionFilter]]
+]
+"""Older partial permissions use format like 'some_permission': [{'_submitted_by': {'$in': ['a']}}]"""
+
+
+def normalize_permissions(permissions: LegacyPartialPermissions) -> PartialPermissions:
+    """
+    Normalize permissions to meet expectations for our UI and limited set of supported permissions
+    This may change in the future to support additional and more complex filters
+    """
+    return {
+        key: [
+            [filter_dict] if isinstance(filter_dict, dict) else filter_dict
+            for filter_dict in filter_list
+        ]
+        for key, filter_list in permissions.items()
+    }
+
+
+def add_implied_permission(
+    perms: PartialPermissions, partial_perm: str, implied_perm: str
+) -> PartialPermissions:
+    """
+    Add implied permission for any partial perm
+
+    implied_perm = "view_submissions"
+    partial_perm = "validate_submissions"
+
+    input_perm = {
+        'view_submissions': [{'_submitted_by': {'$in': ['a']}}],
+        'validate_submissions': [
+            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
+        ],
+        'delete_submissions': [
+            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+            {'_submitted_by': {'$in': ['v']}}
+        ],
+    }
+
+    returns
+
+    {
+        'view_submissions': [
+            [{'_submitted_by': 'someuser'}],
+            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+        ],
+        'validate_submissions': [
+            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
+        ],
+        'delete_submissions': [
+            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
+        ],
+    }
+    """
+    if perms_to_add := perms[partial_perm]:
+        for perm_to_add in perms_to_add:
+            if perm_to_add not in perms[implied_perm]:
+                perms[implied_perm].append(perm_to_add)
+
+    return perms
 
 
 class AssetUserPartialPermission(models.Model):
@@ -31,18 +118,19 @@ class AssetUserPartialPermission(models.Model):
     """
 
     class Meta:
-        unique_together = [['asset', 'user']]
+        unique_together = [["asset", "user"]]
 
-    asset = models.ForeignKey('Asset', related_name='asset_partial_permissions',
-                              on_delete=models.CASCADE)
-    user = models.ForeignKey('auth.User', related_name='user_partial_permissions',
-                             on_delete=models.CASCADE)
+    asset = models.ForeignKey(
+        "Asset", related_name="asset_partial_permissions", on_delete=models.CASCADE
+    )
+    user = models.ForeignKey(
+        "auth.User", related_name="user_partial_permissions", on_delete=models.CASCADE
+    )
     permissions = models.JSONField(default=dict)
     date_created = models.DateTimeField(default=timezone.now)
     date_modified = models.DateTimeField(default=timezone.now)
 
     def save(self, *args, **kwargs):
-
         if self.pk is not None:
             self.date_modified = timezone.now()
 
@@ -50,22 +138,21 @@ class AssetUserPartialPermission(models.Model):
 
     @staticmethod
     def update_partial_perms_to_include_implied(
-        asset: 'kpi.models.Asset', partial_perms: dict
-    ) -> dict:
-        new_partial_perms = defaultdict(list)
-        in_op = MongoHelper.IN_OPERATOR
+        asset: "kpi.models.Asset", partial_perms: LegacyPartialPermissions
+    ) -> PartialPermissions:
+        # Copy partial_perms dict as a defaultdict so that we can safely add
+        # arbitrary partial permissions later
+        new_partial_perms: PartialPermissions = defaultdict(
+            list, normalize_permissions(partial_perms)
+        )
 
         for partial_perm, filters in partial_perms.items():
-
-            if partial_perm not in new_partial_perms:
-                new_partial_perms[partial_perm] = filters
-
             # TODO: omit `add_submissions`? It's required at the asset
             # level for any kind of editing (e.g. partial
             # `change_submissions` requires asset-wide `add_submissions`),
             # but it doesn't make sense to restrict adding submissions
             # "only to those submissions that match some criteria"
-            implied_perms = [
+            implied_perms: list[str] = [
                 implied_perm
                 for implied_perm in asset.get_implied_perms(
                     partial_perm, for_instance=asset
@@ -74,108 +161,6 @@ class AssetUserPartialPermission(models.Model):
             ]
 
             for implied_perm in implied_perms:
-
-                if (
-                    implied_perm not in new_partial_perms
-                    and implied_perm in partial_perms
-                ):
-                    new_partial_perms[implied_perm] = partial_perms[
-                        implied_perm
-                    ]
-
-                new_partial_perm = new_partial_perms[implied_perm]
-                # Trivial case, i.e.: permissions are built with front end.
-                # All permissions have only one filter and the same filter
-                # Example:
-                # ```
-                # partial_perms = {
-                #   'view_submissions' : [
-                #       {'_submitted_by': {'$in': ['johndoe']}}
-                #   ],
-                #   'delete_submissions':  [
-                #       {'_submitted_by': {'$in': ['quidam']}}
-                #   ]
-                # }
-                # ```
-                # should give
-                # ```
-                # new_partial_perms = {
-                #   'view_submissions' : [
-                #       {'_submitted_by': {'$in': ['johndoe', 'quidam']}}
-                #   ],
-                #   'delete_submissions':  [
-                #       {'_submitted_by': {'$in': ['quidam']}}
-                #   ]
-                # }
-                if (
-                    len(filters) == 1
-                    and len(new_partial_perm) == 1
-                    and isinstance(new_partial_perm, list)
-                ):
-                    current_filters = new_partial_perms[implied_perm][0]
-                    filter_ = filters[0]
-                    # Front end only supports `_submitted_by`, but if users
-                    # use the API, it could be something else.
-                    filter_key = list(filter_)[0]
-                    try:
-                        new_value = filter_[filter_key][in_op]
-                        current_values = current_filters[filter_key][in_op]
-                    except (KeyError, TypeError):
-                        pass
-                    else:
-                        new_partial_perm[0][filter_key][in_op] = list(
-                            set(current_values + new_value)
-                        )
-                        continue
-
-                # As said earlier, front end only supports `'_submitted_by'`
-                # filter, but many different and more complex filters could
-                # be used.
-                # If we reach these lines, it means conditions cannot be
-                # merged, so we concatenate then with an `OR` operator.
-                # Example:
-                # ```
-                # partial_perms = {
-                #   'view_submissions' : [{'_submitted_by': 'johndoe'}],
-                #   'delete_submissions':  [
-                #       {'_submission_date': {'$lte': '2021-01-01'},
-                #       {'_submission_date': {'$gte': '2020-01-01'}
-                #   ]
-                # }
-                # ```
-                # should give
-                # ```
-                # new_partial_perms = {
-                #   'view_submissions' : [
-                #           [{'_submitted_by': 'johndoe'}],
-                #           [
-                #               {'_submission_date': {'$lte': '2021-01-01'},
-                #               {'_submission_date': {'$gte': '2020-01-01'}
-                #           ]
-                #   },
-                #   'delete_submissions':  [
-                #       {'_submission_date': {'$lte': '2021-01-01'},
-                #       {'_submission_date': {'$gte': '2020-01-01'}
-                #   ]
-                # }
-
-                # To avoid more complexity (and different syntax than
-                # trivial case), we delegate to MongoHelper the task to join
-                # lists with the `$or` operator.
-                try:
-                    new_partial_perm = new_partial_perms[implied_perm][0]
-                except IndexError:
-                    # If we get an IndexError, implied permission does not
-                    # belong to current assignment. Let's copy the filters
-                    #
-                    new_partial_perms[implied_perm] = filters
-                else:
-                    if not isinstance(new_partial_perm, list):
-                        new_partial_perms[implied_perm] = [
-                            filters,
-                            new_partial_perms[implied_perm],
-                        ]
-                    elif filters not in new_partial_perms[implied_perm]:
-                        new_partial_perms[implied_perm].append(filters)
+                add_implied_permission(new_partial_perms, partial_perm, implied_perm)
 
         return new_partial_perms

--- a/kpi/models/asset_user_partial_permission.py
+++ b/kpi/models/asset_user_partial_permission.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import annotations
 from collections import defaultdict
 from typing import Literal, Union
 
@@ -12,7 +13,7 @@ SimplePartialPermFilter = dict[str, str]
 """Basic filter such as my_question: my_response"""
 
 SubmittedByPartialPermissionFilter = dict[
-    Literal["_submitted_by"], dict[Literal['_submitted_by'], list[str]]
+    Literal["_submitted_by"], dict[Literal["_submitted_by"], list[str]]
 ]
 """
 Inner mongo filter for _submitted_by that accepts a subset of mongo operations

--- a/kpi/serializers/v2/asset_permission_assignment.py
+++ b/kpi/serializers/v2/asset_permission_assignment.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import Permission, User
 from django.urls import Resolver404
 from django.utils.translation import gettext as t
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
 from kpi.constants import (
@@ -503,6 +504,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
             username = self._get_arg_from_url('username', user_url)
             username_to_url[username] = user_url
             for partial_assignment in assignment.get('partial_permissions', []):
+                if "filters" not in partial_assignment:
+                    # Instead of this, we should validate using DRF 
+                    raise ValidationError("Permission assignment must contain filters")
                 partial_codename = self._get_arg_from_url(
                     'codename', partial_assignment['url']
                 )

--- a/kpi/serializers/v2/asset_permission_assignment.py
+++ b/kpi/serializers/v2/asset_permission_assignment.py
@@ -562,7 +562,7 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
                     ].codename
                     assignment_with_objects['partial_permissions'][
                         partial_codename
-                    ] = partial_assignment['filters']
+                    ] = partial_assignment.get('filters')
             assignments_with_objects.append(assignment_with_objects)
 
         attrs['assignments'] = assignments_with_objects

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -813,13 +813,13 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                     {
                         'url': PERM_VALIDATE_SUBMISSIONS,
                         'filters': [
-                            [{'my_question': 'my_response1'}, {'my_question': 'my_response2'}]
+                            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
                         ],
                     },
                     {
                         'url': PERM_DELETE_SUBMISSIONS,
                         'filters': [
-                            [{'my_question': 'my_response1'}, {'my_question': 'my_response2'}]
+                            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
                         ],
                     }
                 ],
@@ -848,19 +848,19 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
                 'filters': [
                     [{'_submitted_by': 'someuser'}],
-                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
                 ],
             },
             {
                 'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
                 'filters': [
-                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
                 ],
             },
             {
                 'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
                 'filters': [
-                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
                 ],
             },
         ]

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -23,18 +23,17 @@ from kpi.utils.object_permission import get_anonymous_user
 
 
 class BaseApiAssetPermissionTestCase(KpiTestCase):
-
     fixtures = ["test_data"]
 
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     def setUp(self):
-        self.admin = User.objects.get(username='admin')
-        self.someuser = User.objects.get(username='someuser')
-        self.anotheruser = User.objects.get(username='anotheruser')
+        self.admin = User.objects.get(username="admin")
+        self.someuser = User.objects.get(username="someuser")
+        self.anotheruser = User.objects.get(username="anotheruser")
 
-        self.client.login(username='admin', password='pass')
-        self.asset = self.create_asset('An asset to be shared')
+        self.client.login(username="admin", password="pass")
+        self.asset = self.create_asset("An asset to be shared")
 
     def _grant_perm_as_logged_in_user(self, username, codename):
         """
@@ -43,60 +42,55 @@ class BaseApiAssetPermissionTestCase(KpiTestCase):
         authentication.
         """
         data = {
-            'user': self.obj_to_url(User.objects.get(username=username)),
-            'permission': self.obj_to_url(
-                Permission.objects.get(codename=codename)
-            ),
+            "user": self.obj_to_url(User.objects.get(username=username)),
+            "permission": self.obj_to_url(Permission.objects.get(codename=codename)),
         }
         response = self.client.post(
             self.get_asset_perm_assignment_list_url(self.asset),
             data,
-            format='json',
+            format="json",
         )
         return response
 
 
 class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
-
     def test_owner_can_give_permissions(self):
         # Current user is `self.admin`
-        response = self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user("someuser", PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_viewers_cannot_give_permissions(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_ASSET)
+        self._grant_perm_as_logged_in_user("someuser", PERM_VIEW_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_VIEW_ASSET))
-        self.client.login(username='someuser', password='someuser')
+        self.client.login(username="someuser", password="someuser")
         # Current user is now: `self.someuser`
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user("anotheruser", PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_editors_cannot_give_permissions(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_CHANGE_ASSET)
+        self._grant_perm_as_logged_in_user("someuser", PERM_CHANGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_CHANGE_ASSET))
-        self.client.login(username='someuser', password='someuser')
+        self.client.login(username="someuser", password="someuser")
         # Current user is now: `self.someuser`
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user("anotheruser", PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_anonymous_cannot_give_permissions(self):
         self.client.logout()
-        response = self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user("someuser", PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_managers_can_give_permissions(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_MANAGE_ASSET)
+        self._grant_perm_as_logged_in_user("someuser", PERM_MANAGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_MANAGE_ASSET))
-        self.client.login(username='someuser', password='someuser')
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        self.client.login(username="someuser", password="someuser")
+        response = self._grant_perm_as_logged_in_user("anotheruser", PERM_VIEW_ASSET)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_submission_assignments_ignored_for_non_survey_assets(self):
         self.asset.asset_type = ASSET_TYPE_TEMPLATE
         self.asset.save()
-        response = self._grant_perm_as_logged_in_user(
-            'someuser', PERM_VIEW_SUBMISSIONS
-        )
+        response = self._grant_perm_as_logged_in_user("someuser", PERM_VIEW_SUBMISSIONS)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
 
@@ -105,6 +99,7 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
     """
     TODO Refactor tests - Redundant codes
     """
+
     fixtures = ["test_data"]
 
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
@@ -117,14 +112,11 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         self.asset.assign_perm(get_anonymous_user(), PERM_VIEW_ASSET)
 
     def test_viewers_see_only_self_anon_and_owner_assignments(self):
-
-        self.client.login(username='anotheruser', password='anotheruser')
+        self.client.login(username="anotheruser", password="anotheruser")
         permission_list_response = self.client.get(
-            self.get_asset_perm_assignment_list_url(self.asset), format='json'
+            self.get_asset_perm_assignment_list_url(self.asset), format="json"
         )
-        self.assertEqual(
-            permission_list_response.status_code, status.HTTP_200_OK
-        )
+        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         results = permission_list_response.data
 
         # `anotheruser` must see only permissions assigned to themselves, the
@@ -144,32 +136,28 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
 
         obj_perms = []
         for assignment in results:
-            object_permission = self.url_to_obj(assignment.get('url'))
+            object_permission = self.url_to_obj(assignment.get("url"))
             obj_perms.append(
                 (
                     object_permission.user.username,
                     object_permission.permission.codename,
                 )
             )
-        obj_perms = sorted(
-            obj_perms, key=lambda element: (element[0], element[1])
-        )
+        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
 
         self.assertEqual(expected_perms, obj_perms)
 
     def test_managers_see_all_assignments(self):
-        manager = User(username='businessfish')
-        manager.set_password('manage this!')
+        manager = User(username="businessfish")
+        manager.set_password("manage this!")
         manager.save()
         self.asset.assign_perm(manager, PERM_MANAGE_ASSET)
 
-        self.client.login(username='businessfish', password='manage this!')
-        response = self.client.get(
-            self.get_asset_perm_assignment_list_url(self.asset)
-        )
+        self.client.login(username="businessfish", password="manage this!")
+        response = self.client.get(self.get_asset_perm_assignment_list_url(self.asset))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        returned_urls = [r['url'] for r in response.data]
+        returned_urls = [r["url"] for r in response.data]
         all_obj_perms = self.asset.permissions.all()
         assigned_obj_perms = all_obj_perms.filter(
             permission__codename__in=self.asset.get_assignable_permissions(
@@ -187,14 +175,11 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         )
 
     def test_editors_see_only_self_anon_and_owner_assignments(self):
-
-        self.client.login(username='someuser', password='someuser')
+        self.client.login(username="someuser", password="someuser")
         permission_list_response = self.client.get(
-            self.get_asset_perm_assignment_list_url(self.asset), format='json'
+            self.get_asset_perm_assignment_list_url(self.asset), format="json"
         )
-        self.assertEqual(
-            permission_list_response.status_code, status.HTTP_200_OK
-        )
+        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         results = permission_list_response.data
 
         # As an editor of the asset, `someuser` should see all.
@@ -217,24 +202,21 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
 
         obj_perms = []
         for assignment in results:
-            object_permission = self.url_to_obj(assignment.get('url'))
+            object_permission = self.url_to_obj(assignment.get("url"))
             obj_perms.append(
                 (
                     object_permission.user.username,
                     object_permission.permission.codename,
                 )
             )
-        obj_perms = sorted(
-            obj_perms, key=lambda element: (element[0], element[1])
-        )
+        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
 
         self.assertEqual(expected_perms, obj_perms)
 
     def test_anonymous_get_only_owner_and_anonymous_assignments(self):
-
         self.client.logout()
         permission_list_response = self.client.get(
-            self.get_asset_perm_assignment_list_url(self.asset), format='json'
+            self.get_asset_perm_assignment_list_url(self.asset), format="json"
         )
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
         admin = self.admin
@@ -251,21 +233,21 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
                 if perm in assignable_perms:
                     expected_perms.append((user.username, perm))
 
-        expected_perms = sorted(expected_perms, key=lambda element: (element[0],
-                                                                     element[1]))
+        expected_perms = sorted(
+            expected_perms, key=lambda element: (element[0], element[1])
+        )
         obj_perms = []
         for assignment in results:
-            object_permission = self.url_to_obj(assignment.get('url'))
-            obj_perms.append((object_permission.user.username,
-                              object_permission.permission.codename))
+            object_permission = self.url_to_obj(assignment.get("url"))
+            obj_perms.append(
+                (object_permission.user.username, object_permission.permission.codename)
+            )
 
-        obj_perms = sorted(obj_perms, key=lambda element: (element[0],
-                                                           element[1]))
+        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
         self.assertEqual(expected_perms, obj_perms)
 
 
 class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
-
     def _assign_perms_as_logged_in_user(self, assignments):
         """
         Uses the bulk API to replace the permission assignments of `self.asset`
@@ -273,14 +255,14 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         """
         url = reverse(
             # this view name is a bit... bulky
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
 
         def get_data_template(username_, codename_):
             return {
-                'user': self.obj_to_url(User.objects.get(username=username)),
-                'permission': self.obj_to_url(
+                "user": self.obj_to_url(User.objects.get(username=username)),
+                "permission": self.obj_to_url(
                     Permission.objects.get(codename=codename_)
                 ),
             }
@@ -288,7 +270,7 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         data = []
         for username, codename in assignments:
             data.append(get_data_template(username, codename))
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
         return response
 
     def translate_usernames_and_codenames_to_urls(self, assignments: list):
@@ -308,42 +290,43 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         """
         assignments = deepcopy(assignments)
         for assignment in assignments:
-            assignment['user'] = self.obj_to_url(
-                User.objects.get(username=assignment['user'])
+            assignment["user"] = self.obj_to_url(
+                User.objects.get(username=assignment["user"])
             )
-            assignment['permission'] = self.obj_to_url(
-                Permission.objects.get(codename=assignment['permission'])
+            assignment["permission"] = self.obj_to_url(
+                Permission.objects.get(codename=assignment["permission"])
             )
-            partial_permissions = assignment.get('partial_permissions', [])
+            partial_permissions = assignment.get("partial_permissions", [])
             for partial_perm in partial_permissions:
-                partial_perm['url'] = self.obj_to_url(
-                    Permission.objects.get(codename=partial_perm['url'])
+                partial_perm["url"] = self.obj_to_url(
+                    Permission.objects.get(codename=partial_perm["url"])
                 )
         return assignments
 
     def test_cannot_assign_permissions_to_owner(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_MANAGE_ASSET)
-        self.client.login(username='someuser', password='someuser')
-        response = self._assign_perms_as_logged_in_user([
-            ('admin', PERM_VIEW_ASSET),
-            ('admin', PERM_CHANGE_ASSET)
-        ])
+        self._grant_perm_as_logged_in_user("someuser", PERM_MANAGE_ASSET)
+        self.client.login(username="someuser", password="someuser")
+        response = self._assign_perms_as_logged_in_user(
+            [("admin", PERM_VIEW_ASSET), ("admin", PERM_CHANGE_ASSET)]
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_owner_can_assign_permissions(self):
         permission_list_response = self.client.get(
-            self.get_asset_perm_assignment_list_url(self.asset), format='json'
+            self.get_asset_perm_assignment_list_url(self.asset), format="json"
         )
         self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
 
-        response = self._assign_perms_as_logged_in_user([
-            ('someuser', PERM_VIEW_ASSET),
-            ('someuser', PERM_VIEW_ASSET),  # Add a duplicate which should not count
-            ('anotheruser', PERM_CHANGE_ASSET)
-        ])
+        response = self._assign_perms_as_logged_in_user(
+            [
+                ("someuser", PERM_VIEW_ASSET),
+                ("someuser", PERM_VIEW_ASSET),  # Add a duplicate which should not count
+                ("anotheruser", PERM_CHANGE_ASSET),
+            ]
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        returned_urls = [r['url'] for r in response.data]
+        returned_urls = [r["url"] for r in response.data]
         all_obj_perms = self.asset.permissions.all()
         assigned_obj_perms = all_obj_perms.filter(
             permission__codename__in=self.asset.get_assignable_permissions(
@@ -352,23 +335,23 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         )
         self.assertListEqual(
             sorted(
-                assigned_obj_perms.values_list(
-                    'user__username', 'permission__codename'
-                )
+                assigned_obj_perms.values_list("user__username", "permission__codename")
             ),
-            sorted([
-                ('admin', PERM_VIEW_ASSET),
-                ('admin', PERM_CHANGE_ASSET),
-                ('admin', PERM_MANAGE_ASSET),
-                ('admin', PERM_ADD_SUBMISSIONS),
-                ('admin', PERM_DELETE_SUBMISSIONS),
-                ('admin', PERM_VIEW_SUBMISSIONS),
-                ('admin', PERM_CHANGE_SUBMISSIONS),
-                ('admin', PERM_VALIDATE_SUBMISSIONS),
-                ('someuser', PERM_VIEW_ASSET),
-                ('anotheruser', PERM_VIEW_ASSET),
-                ('anotheruser', PERM_CHANGE_ASSET),
-            ]),
+            sorted(
+                [
+                    ("admin", PERM_VIEW_ASSET),
+                    ("admin", PERM_CHANGE_ASSET),
+                    ("admin", PERM_MANAGE_ASSET),
+                    ("admin", PERM_ADD_SUBMISSIONS),
+                    ("admin", PERM_DELETE_SUBMISSIONS),
+                    ("admin", PERM_VIEW_SUBMISSIONS),
+                    ("admin", PERM_CHANGE_SUBMISSIONS),
+                    ("admin", PERM_VALIDATE_SUBMISSIONS),
+                    ("someuser", PERM_VIEW_ASSET),
+                    ("anotheruser", PERM_VIEW_ASSET),
+                    ("anotheruser", PERM_CHANGE_ASSET),
+                ]
+            ),
         )
         self.assertListEqual(
             sorted(returned_urls),
@@ -382,54 +365,61 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
     def test_assignment_removes_old_permissions(self):
         self.asset.assign_perm(self.someuser, PERM_CHANGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_CHANGE_ASSET))
-        response = self._assign_perms_as_logged_in_user([
-            ('someuser', PERM_VIEW_ASSET),
-            ('anotheruser', PERM_CHANGE_ASSET)
-        ])
+        response = self._assign_perms_as_logged_in_user(
+            [("someuser", PERM_VIEW_ASSET), ("anotheruser", PERM_CHANGE_ASSET)]
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(self.asset.has_perm(self.someuser, PERM_CHANGE_ASSET))
 
     def test_viewers_cannot_give_permissions(self):
         self.asset.assign_perm(self.someuser, PERM_VIEW_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_VIEW_ASSET))
-        self.client.login(username='someuser', password='someuser')
-        response = self._assign_perms_as_logged_in_user([
-            ('anotheruser', PERM_CHANGE_ASSET),
-            ('anotheruser', PERM_CHANGE_SUBMISSIONS)
-        ])
+        self.client.login(username="someuser", password="someuser")
+        response = self._assign_perms_as_logged_in_user(
+            [
+                ("anotheruser", PERM_CHANGE_ASSET),
+                ("anotheruser", PERM_CHANGE_SUBMISSIONS),
+            ]
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         # If they don't have `view_asset`, they don't have anything, and we're
         # in good shape
         self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_VIEW_ASSET))
 
     def test_editors_cannot_give_permissions(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_CHANGE_ASSET)
+        self._grant_perm_as_logged_in_user("someuser", PERM_CHANGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_CHANGE_ASSET))
-        self.client.login(username='someuser', password='someuser')
-        response = self._assign_perms_as_logged_in_user([
-            ('anotheruser', PERM_CHANGE_ASSET),
-            ('anotheruser', PERM_CHANGE_SUBMISSIONS)
-        ])
+        self.client.login(username="someuser", password="someuser")
+        response = self._assign_perms_as_logged_in_user(
+            [
+                ("anotheruser", PERM_CHANGE_ASSET),
+                ("anotheruser", PERM_CHANGE_SUBMISSIONS),
+            ]
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_VIEW_ASSET))
 
     def test_anonymous_cannot_give_permissions(self):
         self.client.logout()
-        response = self._assign_perms_as_logged_in_user([
-            ('anotheruser', PERM_CHANGE_ASSET),
-            ('anotheruser', PERM_CHANGE_SUBMISSIONS)
-        ])
+        response = self._assign_perms_as_logged_in_user(
+            [
+                ("anotheruser", PERM_CHANGE_ASSET),
+                ("anotheruser", PERM_CHANGE_SUBMISSIONS),
+            ]
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_VIEW_ASSET))
 
     def test_managers_can_give_permissions(self):
-        self._grant_perm_as_logged_in_user('someuser', PERM_MANAGE_ASSET)
+        self._grant_perm_as_logged_in_user("someuser", PERM_MANAGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_MANAGE_ASSET))
-        self.client.login(username='someuser', password='someuser')
-        response = self._assign_perms_as_logged_in_user([
-            ('anotheruser', PERM_CHANGE_ASSET),
-            ('anotheruser', PERM_CHANGE_SUBMISSIONS)
-        ])
+        self.client.login(username="someuser", password="someuser")
+        response = self._assign_perms_as_logged_in_user(
+            [
+                ("anotheruser", PERM_CHANGE_ASSET),
+                ("anotheruser", PERM_CHANGE_SUBMISSIONS),
+            ]
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(self.asset.has_perm(self.anotheruser, PERM_CHANGE_ASSET))
         self.assertTrue(self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS))
@@ -439,115 +429,110 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         self.asset.save()
         response = self._assign_perms_as_logged_in_user(
             [
-                ('someuser', PERM_VIEW_SUBMISSIONS),
-                ('anotheruser', PERM_VALIDATE_SUBMISSIONS),
+                ("someuser", PERM_VIEW_SUBMISSIONS),
+                ("anotheruser", PERM_VALIDATE_SUBMISSIONS),
             ]
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
-        self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
+        )
 
     def test_implied_partial_permissions_are_retained(self):
         users = {}
-        for username in 'simone', 'zariah':
+        for username in "simone", "zariah":
             users[username] = User.objects.create(username=username)
         # Allow Simone to view and delete their own and Zariah's submissions
         self.asset.assign_perm(
-            users['simone'],
+            users["simone"],
             PERM_PARTIAL_SUBMISSIONS,
             partial_perms={
                 PERM_DELETE_SUBMISSIONS: [
-                    {'_submitted_by': {'$in': ['simone', 'zariah']}}
+                    {"_submitted_by": {"$in": ["simone", "zariah"]}}
                 ]
             },
         )
         assert self.asset.asset_partial_permissions.get(
-            user__username='simone'
+            user__username="simone"
         ).permissions == (
             {
                 PERM_VIEW_SUBMISSIONS: [
-                    {'_submitted_by': {'$in': ['simone', 'zariah']}}
+                    [{"_submitted_by": {"$in": ["simone", "zariah"]}}]
                 ],
                 PERM_DELETE_SUBMISSIONS: [
-                    {'_submitted_by': {'$in': ['simone', 'zariah']}}
+                    [{"_submitted_by": {"$in": ["simone", "zariah"]}}]
                 ],
             }
         )
         # Allow Zariah to view and delete their own submissions
         self.asset.assign_perm(
-            users['zariah'],
+            users["zariah"],
             PERM_PARTIAL_SUBMISSIONS,
-            partial_perms={
-                PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'zariah'}]
-            },
+            partial_perms={PERM_DELETE_SUBMISSIONS: [{"_submitted_by": "zariah"}]},
         )
         assert self.asset.asset_partial_permissions.get(
-            user__username='zariah'
+            user__username="zariah"
         ).permissions == (
             {
-                PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'zariah'}],
-                PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'zariah'}],
+                PERM_VIEW_SUBMISSIONS: [[{"_submitted_by": "zariah"}]],
+                PERM_DELETE_SUBMISSIONS: [[{"_submitted_by": "zariah"}]],
             }
         )
         # Using the bulk API, Revoke Simone's permission to delete Zariah's
         # submissions
         assignments = [
             {
-                'user': 'simone',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "simone",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [
-                            {'_submitted_by': {'$in': ['simone', 'zariah']}}
-                        ],
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filters": [{"_submitted_by": {"$in": ["simone", "zariah"]}}],
                     },
                     {
-                        'url': PERM_DELETE_SUBMISSIONS,
-                        'filters': [{'_submitted_by': 'simone'}],
+                        "url": PERM_DELETE_SUBMISSIONS,
+                        "filters": [{"_submitted_by": "simone"}],
                     },
                 ],
             },
             {
-                'user': 'zariah',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "zariah",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_DELETE_SUBMISSIONS,
-                        'filters': [{'_submitted_by': 'zariah'}],
+                        "url": PERM_DELETE_SUBMISSIONS,
+                        "filters": [{"_submitted_by": "zariah"}],
                     }
                 ],
             },
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(bulk_endpoint, assignments, format='json')
+        response = self.client.post(bulk_endpoint, assignments, format="json")
         assert response.status_code == status.HTTP_200_OK
         # Simone should still have access to view Zariah's (and their own)
         # submissions
         assert self.asset.asset_partial_permissions.get(
-            user__username='simone'
+            user__username="simone"
         ).permissions == {
             PERM_VIEW_SUBMISSIONS: [
-                # TODO: Avoid this (harmless) duplication (which was already
-                # present in b30644e1c, before any optimization work)
-                [{'_submitted_by': 'simone'}],
-                [{'_submitted_by': {'$in': ['simone', 'zariah']}}],
+                # Duplication of simone is intentional, as one is from the implied perm
+                [{"_submitted_by": {"$in": ["simone", "zariah"]}}],
+                [{"_submitted_by": "simone"}],
             ],
-            PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'simone'}],
+            PERM_DELETE_SUBMISSIONS: [[{"_submitted_by": "simone"}]],
         }
         # Zariah's permissions should be unchanged
         assert self.asset.asset_partial_permissions.get(
-            user__username='zariah'
+            user__username="zariah"
         ).permissions == (
             {
-                PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'zariah'}],
-                PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'zariah'}],
+                PERM_VIEW_SUBMISSIONS: [[{"_submitted_by": "zariah"}]],
+                PERM_DELETE_SUBMISSIONS: [[{"_submitted_by": "zariah"}]],
             }
         )
 
@@ -555,41 +540,34 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         assert not self.someuser.has_perm(PERM_VIEW_ASSET, self.asset)
         assignments = [
             {
-                'user': 'someuser',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "someuser",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [{'_submitted_by': 'someuser'}],
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filters": [{"_submitted_by": "someuser"}],
                     }
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
         # Perform bulk assignment twice to check permission-difference
         # optimization logic
         for _ in range(2):
-            response = self.client.post(
-                bulk_endpoint, assignments, format='json'
-            )
+            response = self.client.post(bulk_endpoint, assignments, format="json")
             assert response.status_code == status.HTTP_200_OK
             assert self.asset.asset_partial_permissions.get(
-                user__username='someuser'
-            ).permissions == {
-                PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}]
-            }
+                user__username="someuser"
+            ).permissions == {PERM_VIEW_SUBMISSIONS: [[{"_submitted_by": "someuser"}]]}
             # `someuser` should have received the implied `view_asset`
             # permission
             assert self.someuser.has_perm(PERM_VIEW_ASSET, self.asset)
 
     def test_no_assignments_saved_on_error(self):
-
         # Call `get_anonymous_user()` to create AnonymousUser if it does not exist
         get_anonymous_user()
 
@@ -600,23 +578,21 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         # Allow someuser and anotheruser to view submissions
         good_assignments = [
             {
-                'user': 'someuser',
-                'permission': PERM_VIEW_SUBMISSIONS,
+                "user": "someuser",
+                "permission": PERM_VIEW_SUBMISSIONS,
             },
             {
-                'user': 'anotheruser',
-                'permission': PERM_VIEW_SUBMISSIONS,
-            }
+                "user": "anotheruser",
+                "permission": PERM_VIEW_SUBMISSIONS,
+            },
         ]
 
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            good_assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(good_assignments)
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(bulk_endpoint, assignments, format='json')
+        response = self.client.post(bulk_endpoint, assignments, format="json")
 
         # Everything worked as expected, someuser and anotheruser got 'view_submissions'
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -629,27 +605,25 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
         bad_assignments = [
             {
-                'user': 'AnonymousUser',
-                'permission': PERM_ADD_SUBMISSIONS,  # should return a 400
+                "user": "AnonymousUser",
+                "permission": PERM_ADD_SUBMISSIONS,  # should return a 400
             },
             {
-                'user': 'someuser',
-                'permission': PERM_DELETE_SUBMISSIONS,
+                "user": "someuser",
+                "permission": PERM_DELETE_SUBMISSIONS,
             },
             {
-                'user': 'anotheruser',
-                'permission': PERM_CHANGE_SUBMISSIONS,
-            }
+                "user": "anotheruser",
+                "permission": PERM_CHANGE_SUBMISSIONS,
+            },
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            bad_assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(bad_assignments)
 
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(bulk_endpoint, assignments, format='json')
+        response = self.client.post(bulk_endpoint, assignments, format="json")
         # Could not assign 'add_submissions' to anonymous user.
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -661,67 +635,53 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
     def test_partial_permission_no_duplicate_with_simple_filter(self):
         assignments = [
             {
-                'user': 'someuser',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "someuser",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [
-                            {'_submitted_by': 'someuser'}
-                        ],
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filters": [{"_submitted_by": "someuser"}],
                     },
                     {
-                        'url': PERM_VALIDATE_SUBMISSIONS,
-                        'filters': [
-                            {'my_question': 'my_response1'}
-                        ],
+                        "url": PERM_VALIDATE_SUBMISSIONS,
+                        "filters": [{"my_question": "my_response1"}],
                     },
                     {
-                        'url': PERM_DELETE_SUBMISSIONS,
-                        'filters': [
-                            {'my_question': 'my_response1'}
-                        ],
-                    }
+                        "url": PERM_DELETE_SUBMISSIONS,
+                        "filters": [{"my_question": "my_response1"}],
+                    },
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
 
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(
-            bulk_endpoint, assignments, format='json'
-        )
+        response = self.client.post(bulk_endpoint, assignments, format="json")
         assert response.status_code == status.HTTP_200_OK
         returned_partial_perms = []
         for perm in response.data:
-            if 'partial_permissions' in perm:
-                returned_partial_perms = perm['partial_permissions']
+            if "partial_permissions" in perm:
+                returned_partial_perms = perm["partial_permissions"]
 
         # ⚠️ Filters ordering could be different in response.
         expected = [
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
-                'filters': [
-                    [{'my_question': 'my_response1'}],
-                    [{'_submitted_by': 'someuser'}],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/",
+                "filters": [
+                    [{"_submitted_by": "someuser"}],
+                    [{"my_question": "my_response1"}],
                 ],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
-                'filters': [
-                    {'my_question': 'my_response1'}
-                ],
+                "url": f"http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/",
+                "filters": [[{"my_question": "my_response1"}]],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
-                'filters': [
-                    {'my_question': 'my_response1'}
-                ],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/",
+                "filters": [[{"my_question": "my_response1"}]],
             },
         ]
 
@@ -730,67 +690,53 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
     def test_partial_permission_no_duplicate_with_complex_OR_filters(self):
         assignments = [
             {
-                'user': 'someuser',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "someuser",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [
-                            [{'_submitted_by': 'someuser'}]
-                        ],
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filters": [[{"_submitted_by": "someuser"}]],
                     },
                     {
-                        'url': PERM_VALIDATE_SUBMISSIONS,
-                        'filters': [
-                            [{'my_question': 'my_response1'}]
-                        ],
+                        "url": PERM_VALIDATE_SUBMISSIONS,
+                        "filters": [[{"my_question": "my_response1"}]],
                     },
                     {
-                        'url': PERM_DELETE_SUBMISSIONS,
-                        'filters': [
-                            [{'my_question': 'my_response1'}]
-                        ],
-                    }
+                        "url": PERM_DELETE_SUBMISSIONS,
+                        "filters": [[{"my_question": "my_response1"}]],
+                    },
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
 
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(
-            bulk_endpoint, assignments, format='json'
-        )
+        response = self.client.post(bulk_endpoint, assignments, format="json")
         assert response.status_code == status.HTTP_200_OK
         returned_partial_perms = []
         for perm in response.data:
-            if 'partial_permissions' in perm:
-                returned_partial_perms = perm['partial_permissions']
+            if "partial_permissions" in perm:
+                returned_partial_perms = perm["partial_permissions"]
 
         # ⚠️ Filters ordering could be different in response.
         expected = [
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
-                'filters': [
-                    [{'_submitted_by': 'someuser'}],
-                    [{'my_question': 'my_response1'}],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/",
+                "filters": [
+                    [{"_submitted_by": "someuser"}],
+                    [{"my_question": "my_response1"}],
                 ],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
-                'filters': [
-                    [{'my_question': 'my_response1'}]
-                ],
+                "url": f"http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/",
+                "filters": [[{"my_question": "my_response1"}]],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
-                'filters': [
-                    [{'my_question': 'my_response1'}]
-                ],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/",
+                "filters": [[{"my_question": "my_response1"}]],
             },
         ]
 
@@ -799,66 +745,66 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
     def test_partial_permission_no_duplicate_with_complex_AND_filters(self):
         assignments = [
             {
-                'user': 'someuser',
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": "someuser",
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [
-                            [{'_submitted_by': 'someuser'}]
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filters": [[{"_submitted_by": "someuser"}]],
+                    },
+                    {
+                        "url": PERM_VALIDATE_SUBMISSIONS,
+                        "filters": [
+                            [
+                                {"my_question": "my_response1"},
+                                {"my_question2": "my_response2"},
+                            ]
                         ],
                     },
                     {
-                        'url': PERM_VALIDATE_SUBMISSIONS,
-                        'filters': [
-                            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
+                        "url": PERM_DELETE_SUBMISSIONS,
+                        "filters": [
+                            [
+                                {"my_question": "my_response1"},
+                                {"my_question2": "my_response2"},
+                            ]
                         ],
                     },
-                    {
-                        'url': PERM_DELETE_SUBMISSIONS,
-                        'filters': [
-                            [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}]
-                        ],
-                    }
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
 
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(
-            bulk_endpoint, assignments, format='json'
-        )
+        response = self.client.post(bulk_endpoint, assignments, format="json")
         assert response.status_code == status.HTTP_200_OK
         returned_partial_perms = []
         for perm in response.data:
-            if 'partial_permissions' in perm:
-                returned_partial_perms = perm['partial_permissions']
+            if "partial_permissions" in perm:
+                returned_partial_perms = perm["partial_permissions"]
 
         # ⚠️ Filters ordering could be different in response.
         expected = [
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
-                'filters': [
-                    [{'_submitted_by': 'someuser'}],
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/",
+                "filters": [
+                    [{"_submitted_by": "someuser"}],
+                    [{"my_question": "my_response1"}, {"my_question2": "my_response2"}],
                 ],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
-                'filters': [
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                "url": f"http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/",
+                "filters": [
+                    [{"my_question": "my_response1"}, {"my_question2": "my_response2"}],
                 ],
             },
             {
-                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
-                'filters': [
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                "url": f"http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/",
+                "filters": [
+                    [{"my_question": "my_response1"}, {"my_question2": "my_response2"}],
                 ],
             },
         ]
@@ -867,31 +813,24 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
     def test_partial_permission_invalid(self):
         """Poorly formatted json example"""
-        perm_user = User.objects.get(username='someuser')
+        perm_user = User.objects.get(username="someuser")
         assignments = [
             {
-                'user': perm_user.username,
-                'permission': PERM_PARTIAL_SUBMISSIONS,
-                'partial_permissions': [
+                "user": perm_user.username,
+                "permission": PERM_PARTIAL_SUBMISSIONS,
+                "partial_permissions": [
                     {
-                        'url': PERM_VIEW_SUBMISSIONS,
-                        'filteraaa': [
-                            [{'lol': perm_user.username}]
-                        ],
+                        "url": PERM_VIEW_SUBMISSIONS,
+                        "filteraaa": [[{"lol": perm_user.username}]],
                     },
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(
-            assignments
-        )
+        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
 
         bulk_endpoint = reverse(
-            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
-            kwargs={'parent_lookup_asset': self.asset.uid}
+            self._get_endpoint("asset-permission-assignment-bulk-assignments"),
+            kwargs={"parent_lookup_asset": self.asset.uid},
         )
-        response = self.client.post(
-            bulk_endpoint, assignments, format='json'
-        )
-        # It would be better to 400 here
-        assert response.status_code == status.HTTP_200_OK
+        response = self.client.post(bulk_endpoint, assignments, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -864,3 +864,34 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         ]
 
         assert expected == returned_partial_perms
+
+    def test_partial_permission_invalid(self):
+        """Poorly formatted json example"""
+        perm_user = User.objects.get(username='someuser')
+        assignments = [
+            {
+                'user': perm_user.username,
+                'permission': PERM_PARTIAL_SUBMISSIONS,
+                'partial_permissions': [
+                    {
+                        'url': PERM_VIEW_SUBMISSIONS,
+                        'filteraaa': [
+                            [{'lol': perm_user.username}]
+                        ],
+                    },
+                ],
+            }
+        ]
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
+
+        bulk_endpoint = reverse(
+            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
+            kwargs={'parent_lookup_asset': self.asset.uid}
+        )
+        response = self.client.post(
+            bulk_endpoint, assignments, format='json'
+        )
+        # It would be better to 400 here
+        assert response.status_code == status.HTTP_200_OK

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -659,3 +659,210 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         # than the one they already had, i.e.: 'view_submissions'.
         self.assertFalse(self.asset.has_perm(self.someuser, PERM_DELETE_SUBMISSIONS))
         self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS))
+
+    def test_partial_permission_no_duplicate_with_simple_filter(self):
+        assignments = [
+            {
+                'user': 'someuser',
+                'permission': PERM_PARTIAL_SUBMISSIONS,
+                'partial_permissions': [
+                    {
+                        'url': PERM_VIEW_SUBMISSIONS,
+                        'filters': [
+                            {'_submitted_by': 'someuser'}
+                        ],
+                    },
+                    {
+                        'url': PERM_VALIDATE_SUBMISSIONS,
+                        'filters': [
+                            {'my_question': 'my_response1'}
+                        ],
+                    },
+                    {
+                        'url': PERM_DELETE_SUBMISSIONS,
+                        'filters': [
+                            {'my_question': 'my_response1'}
+                        ],
+                    }
+                ],
+            }
+        ]
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
+
+        bulk_endpoint = reverse(
+            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
+            kwargs={'parent_lookup_asset': self.asset.uid}
+        )
+        response = self.client.post(
+            bulk_endpoint, assignments, format='json'
+        )
+        assert response.status_code == status.HTTP_200_OK
+        returned_partial_perms = []
+        for perm in response.data:
+            if 'partial_permissions' in perm:
+                returned_partial_perms = perm['partial_permissions']
+
+        # ⚠️ Filters ordering could be different in response.
+        expected = [
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
+                'filters': [
+                    [{'my_question': 'my_response1'}],
+                    [{'_submitted_by': 'someuser'}],
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
+                'filters': [
+                    {'my_question': 'my_response1'}
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
+                'filters': [
+                    {'my_question': 'my_response1'}
+                ],
+            },
+        ]
+
+        assert expected == returned_partial_perms
+
+    def test_partial_permission_no_duplicate_with_complex_OR_filters(self):
+        assignments = [
+            {
+                'user': 'someuser',
+                'permission': PERM_PARTIAL_SUBMISSIONS,
+                'partial_permissions': [
+                    {
+                        'url': PERM_VIEW_SUBMISSIONS,
+                        'filters': [
+                            [{'_submitted_by': 'someuser'}]
+                        ],
+                    },
+                    {
+                        'url': PERM_VALIDATE_SUBMISSIONS,
+                        'filters': [
+                            [{'my_question': 'my_response1'}]
+                        ],
+                    },
+                    {
+                        'url': PERM_DELETE_SUBMISSIONS,
+                        'filters': [
+                            [{'my_question': 'my_response1'}]
+                        ],
+                    }
+                ],
+            }
+        ]
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
+
+        bulk_endpoint = reverse(
+            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
+            kwargs={'parent_lookup_asset': self.asset.uid}
+        )
+        response = self.client.post(
+            bulk_endpoint, assignments, format='json'
+        )
+        assert response.status_code == status.HTTP_200_OK
+        returned_partial_perms = []
+        for perm in response.data:
+            if 'partial_permissions' in perm:
+                returned_partial_perms = perm['partial_permissions']
+
+        # ⚠️ Filters ordering could be different in response.
+        expected = [
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
+                'filters': [
+                    [{'_submitted_by': 'someuser'}],
+                    [{'my_question': 'my_response1'}],
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
+                'filters': [
+                    [{'my_question': 'my_response1'}]
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
+                'filters': [
+                    [{'my_question': 'my_response1'}]
+                ],
+            },
+        ]
+
+        assert expected == returned_partial_perms
+
+    def test_partial_permission_no_duplicate_with_complex_AND_filters(self):
+        assignments = [
+            {
+                'user': 'someuser',
+                'permission': PERM_PARTIAL_SUBMISSIONS,
+                'partial_permissions': [
+                    {
+                        'url': PERM_VIEW_SUBMISSIONS,
+                        'filters': [
+                            [{'_submitted_by': 'someuser'}]
+                        ],
+                    },
+                    {
+                        'url': PERM_VALIDATE_SUBMISSIONS,
+                        'filters': [
+                            [{'my_question': 'my_response1'}, {'my_question': 'my_response2'}]
+                        ],
+                    },
+                    {
+                        'url': PERM_DELETE_SUBMISSIONS,
+                        'filters': [
+                            [{'my_question': 'my_response1'}, {'my_question': 'my_response2'}]
+                        ],
+                    }
+                ],
+            }
+        ]
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
+
+        bulk_endpoint = reverse(
+            self._get_endpoint('asset-permission-assignment-bulk-assignments'),
+            kwargs={'parent_lookup_asset': self.asset.uid}
+        )
+        response = self.client.post(
+            bulk_endpoint, assignments, format='json'
+        )
+        assert response.status_code == status.HTTP_200_OK
+        returned_partial_perms = []
+        for perm in response.data:
+            if 'partial_permissions' in perm:
+                returned_partial_perms = perm['partial_permissions']
+
+        # ⚠️ Filters ordering could be different in response.
+        expected = [
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
+                'filters': [
+                    [{'_submitted_by': 'someuser'}],
+                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
+                'filters': [
+                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                ],
+            },
+            {
+                'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
+                'filters': [
+                    [{'_submitted_by': 'someuser'}, {'my_question': 'my_response1'}],
+                ],
+            },
+        ]
+
+        assert expected == returned_partial_perms

--- a/kpi/tests/test_mongo_helper.py
+++ b/kpi/tests/test_mongo_helper.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+import copy
+
+from model_bakery import baker
+from django.test import TestCase
+from django.conf import settings
+
+from kpi.tests.utils import baker_generators  # noqa
+from kpi.utils.mongo_helper import MongoHelper
+
+
+class MongoHelperTestCase(TestCase):
+    def setUp(self):
+        settings.MONGO_DB.instances.drop()
+
+    def add_submissions(self, asset, submissions: list[dict]):
+        for submission in submissions:
+            submission["__version__"] = asset.latest_deployed_version.uid
+        asset.deployment.mock_submissions(copy.deepcopy(submissions), flush_db=False)
+
+    def assert_instances_count(self, instances: tuple, expected_count: int):
+        assert instances[1] == expected_count
+
+    def test_get_instances(self):
+        users = baker.make("auth.User", _quantity=2)
+        assets = []
+        for user in users:
+            asset = baker.make("kpi.Asset", owner=user)
+            asset.deploy(backend="mock", active=True)
+            assets.append(asset)
+        (asset1, asset2) = assets
+        userform_id1 = asset1.deployment.mongo_userform_id
+        userform_id2 = asset2.deployment.mongo_userform_id
+
+        # No submissions
+        self.assert_instances_count(MongoHelper.get_instances(userform_id1), 0)
+
+        submissions = [
+            {
+                "q1": "a1",
+            },
+            {
+                "q2": "a2",
+            },
+        ]
+        self.add_submissions(asset1, submissions)
+        self.add_submissions(asset2, submissions)
+
+        self.assert_instances_count(MongoHelper.get_instances(userform_id1), 2)
+        self.assert_instances_count(MongoHelper.get_instances(userform_id2), 2)
+        self.assert_instances_count(
+            MongoHelper.get_instances(userform_id1, query={"q1": "a1"}), 1
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(userform_id1, query={"expect": "nothing"}), 0
+        )
+
+    def test_get_instances_permission_filters(self):
+        user = baker.make("auth.User")
+        asset = baker.make("kpi.Asset", owner=user)
+        asset.deploy(backend="mock", active=True)
+        userform_id = asset.deployment.mongo_userform_id
+        submissions = [
+            {
+                "q1": "a1",
+                "_submitted_by": "bob",
+            },
+            {
+                "q2": "a2",
+                "_submitted_by": "alice",
+            },
+        ]
+        self.add_submissions(asset, submissions)
+
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id, permission_filters=[[{"_submitted_by": "noone"}]]
+            ),
+            0,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id, permission_filters=[[{"_submitted_by": "bob"}]]
+            ),
+            1,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id,
+                permission_filters=[
+                    [{"_submitted_by": "bob"}, {"_submitted_by": "alice"}]
+                ],
+            ),
+            0,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id,
+                permission_filters=[
+                    [{"_submitted_by": "bob"}],
+                    [{"_submitted_by": "alice"}],
+                ],
+            ),
+            2,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id,
+                permission_filters=[
+                    [
+                        {"_submitted_by": {"$in": ["bob", "alice"]}},
+                        {"q1": {"$in": ["a1", "a2"]}},
+                    ]
+                ],
+            ),
+            1,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id,
+                permission_filters=[
+                    [{"_submitted_by": "/a/"}],
+                ],
+            ),
+            0,
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(
+                userform_id,
+                permission_filters=[
+                    [{"_submitted_by": {'$regex':'a'}}],
+                ],
+            ),
+            1,
+        )

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -273,32 +273,6 @@ class MongoHelper:
         return d
 
     @classmethod
-    def encode(cls, key):
-        """
-        Replace characters not allowed in Mongo keys with their base64-encoded
-        representations
-
-        :param key: string
-        :return: string
-        """
-        for pattern, repl in cls.ENCODING_SUBSTITUTIONS:
-            key = re.sub(pattern, repl, key)
-        return key
-
-    @classmethod
-    def decode(cls, key):
-        """
-        Replace base64-encoded characters not allowed in Mongo keys with their
-        original representations
-
-        :param key: string
-        :return: string
-        """
-        for pattern, repl in cls.DECODING_SUBSTITUTIONS:
-            key = re.sub(pattern, repl, key)
-        return key
-
-    @classmethod
     def get_permission_filters_query(
         cls, query: dict, permission_filters: Union[dict, list[Union[dict, list]]]
     ) -> dict:

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -35,6 +35,8 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
     """
     ## Permission assignments of an asset
 
+    **Important**: partial_permissions section of API is not stable and may change without notice.
+
     This endpoint shows assignments on an asset. An assignment implies:
 
     - a `Permission` object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,14 @@ skip-string-normalization = true
 profile = "black"
 known_first_party = "kobo"
 no_lines_before = ["LOCALFOLDER"]
+
+[tool.mypy]
+# Exclude virtual environment projects that cause mypy to error
+exclude = [
+    "src/django-digest",
+    "src/formpack",
+    "src/kobo-service-account",
+    "src/python-digest"
+]
+[tool.django-stubs]
+django_settings_module = "kobo.settings"


### PR DESCRIPTION
- Fix bug in MongoHelper.get_permission_filters_query where a list of filters would not be transformed correctly into an pymongo query
- Remove duplicate MongoHelper.is_attribute_invalid
- partial permissions support simple OR filters and support implied partial permissions
- Includes https://github.com/kobotoolbox/kpi/pull/4718

# DO NOT MERGE

- [ ] Sharing user interface matches this new partial permissions syntax
- [ ] Unit test for and/or logic on submissions.