### PR TITLE
Fix styling for the tooltip of grouping options

### DIFF
--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -673,7 +673,7 @@ export default Object.assign({
               m={['group', {groupable: groupable}]}
               onClick={this.groupQuestions}
               disabled={!groupable}
-              className={this.isAddingGroupsRestricted() ? LOCKING_UI_CLASSNAMES.DISABLED : ''}
+              className={'left-tooltip ' + (this.isAddingGroupsRestricted() ? LOCKING_UI_CLASSNAMES.DISABLED : '')}
               data-tip={groupable ? t('Create group with selected questions') : t('Grouping disabled. Please select at least one question.')}
             >
               <i className='k-icon k-icon-group' />

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -655,19 +655,20 @@ export default Object.assign({
               onClick={this.previewForm}
               disabled={previewDisabled}
               data-tip={t('Preview form')}
+              className='left-tooltip'
             >
               <i className='k-icon k-icon-view' />
             </bem.FormBuilderHeader__button>
 
-            { showAllAvailable &&
-              <bem.FormBuilderHeader__button m={['show-all', {
-                    open: showAllOpen,
-                  }]}
-                  onClick={this.showAll}
-                  data-tip={t('Expand / collapse questions')}>
-                <i className='k-icon k-icon-view-all' />
-              </bem.FormBuilderHeader__button>
-            }
+            <bem.FormBuilderHeader__button m={['show-all', {
+                  open: showAllOpen,
+            }]}
+              onClick={this.showAll}
+              disabled={!showAllAvailable}
+              className = 'left-tooltip'
+              data-tip={t('Expand / collapse questions')}>
+              <i className='k-icon k-icon-view-all' />
+            </bem.FormBuilderHeader__button>
 
             <bem.FormBuilderHeader__button
               m={['group', {groupable: groupable}]}
@@ -684,7 +685,7 @@ export default Object.assign({
                 m={['cascading']}
                 onClick={this.toggleCascade}
                 data-tip={t('Insert cascading select')}
-                className={this.isAddingQuestionsRestricted() ? LOCKING_UI_CLASSNAMES.DISABLED : ''}
+                className={'left-tooltip ' + (this.isAddingQuestionsRestricted() ? LOCKING_UI_CLASSNAMES.DISABLED : '')}
               >
                 <i className='k-icon k-icon-cascading' />
               </bem.FormBuilderHeader__button>

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -216,10 +216,6 @@ $s-form-builder-content-width: 1024px;
         overflow: visible;
         padding: 0;
 
-        &[data-tip]::after {
-          margin-left: 30px;
-        }
-
         &:hover,
         &:focus,
         &:focus:not(:active) {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Added left alignment styling to tooltip for grouping options button in form builder so that it is clearly visible.

## Related issues

Fixes #3830 #4106 (duplicate issues for this problem)
