### PR TITLE
[TASK-335] [TASK-337] [TASK-338] Disable non permitted UI

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisContentEmpty.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisContentEmpty.component.tsx
@@ -1,19 +1,12 @@
 import React from 'react';
 import styles from './analysisContentEmpty.module.scss';
-import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import assetStore from 'js/assetStore';
-import {userCan} from 'js/components/permissions/utils';
+import {hasManagePermissionsToCurrentAsset} from './utils';
 import InlineMessage from 'js/components/common/inlineMessage';
 import Icon from 'js/components/common/icon';
 
 /** To be displayed when there are no questions defined yet. */
 export default function AnalysisContentEmpty() {
-  const hasManagePermissions = (() => {
-    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('manage_asset', asset);
-  })();
-
-  if (hasManagePermissions) {
+  if (hasManagePermissionsToCurrentAsset()) {
     return (
       <div className={styles.root}>
         <InlineMessage

--- a/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisHeader.component.tsx
@@ -6,10 +6,9 @@ import KoboDropdown from 'js/components/common/koboDropdown';
 import {ANALYSIS_QUESTION_TYPES} from './constants';
 import type {AnalysisQuestionTypeDefinition} from './constants';
 import Icon from 'js/components/common/icon';
-import assetStore from 'jsapp/js/assetStore';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import {userCan} from 'js/components/permissions/utils';
 import classNames from 'classnames';
+import {hasManagePermissionsToCurrentAsset} from './utils';
 
 /**
  * This piece of UI is displaying the button/dropdown for adding new questions
@@ -27,11 +26,6 @@ export default function AnalysisHeader() {
   const automatedTypes = Object.values(ANALYSIS_QUESTION_TYPES).filter(
     (definition) => definition.isAutomated
   );
-
-  const hasManagePermissions = (() => {
-    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('manage_asset', asset);
-  })();
 
   function renderQuestionTypeButton(
     definition: AnalysisQuestionTypeDefinition
@@ -93,7 +87,7 @@ export default function AnalysisHeader() {
         // We only allow editing one question at a time, so adding new is not
         // possible until user stops editing
         isDisabled={
-          !hasManagePermissions ||
+          !hasManagePermissionsToCurrentAsset() ||
           analysisQuestions?.state.questionsBeingEdited.length !== 0
         }
       />

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -66,7 +66,7 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
   // Responding to analysis question requires `edit_submissions` permission.
   const hasEditSubmissionsPermissions = (() => {
     const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('edit_submissions', asset);
+    return userCan('change_submission', asset);
   })();
 
   const isDragDisabled =

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -24,6 +24,8 @@ import classnames from 'classnames';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
 import {handleApiFail} from 'js/api';
 import type {FailResponse} from 'js/dataInterface';
+import assetStore from 'js/assetStore';
+import {userCan} from 'js/components/permissions/utils';
 
 export interface AnalysisQuestionRowProps {
   uuid: string;
@@ -55,7 +57,14 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
     return null;
   }
 
-  const isDragDisabled = analysisQuestions.state.isPending;
+  // Reordering analysis questions requires `manage_asset` permission.
+  const hasManagePermissions = (() => {
+    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
+    return userCan('manage_asset', asset);
+  })();
+
+  const isDragDisabled =
+    analysisQuestions.state.isPending || !hasManagePermissions;
 
   const previewRef = useRef<HTMLLIElement>(null);
   const dragRef = useRef<HTMLDivElement>(null);

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -66,7 +66,7 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
   // Responding to analysis question requires `edit_submissions` permission.
   const hasEditSubmissionsPermissions = (() => {
     const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('change_submission', asset);
+    return userCan('change_submissions', asset);
   })();
 
   const isDragDisabled =

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -63,6 +63,12 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
     return userCan('manage_asset', asset);
   })();
 
+  // Responding to analysis question requires `edit_submissions` permission.
+  const hasEditSubmissionsPermissions = (() => {
+    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
+    return userCan('edit_submissions', asset);
+  })();
+
   const isDragDisabled =
     analysisQuestions.state.isPending || !hasManagePermissions;
 
@@ -197,19 +203,44 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
             return <CommonHeader uuid={item.uuid} />;
           }
           case 'qual_select_multiple': {
-            return <SelectMultipleResponseForm uuid={item.uuid} />;
+            return (
+              <SelectMultipleResponseForm
+                uuid={item.uuid}
+                canEdit={hasEditSubmissionsPermissions}
+              />
+            );
           }
           case 'qual_select_one': {
-            return <SelectOneResponseForm uuid={item.uuid} />;
+            return (
+              <SelectOneResponseForm
+                uuid={item.uuid}
+                canEdit={hasEditSubmissionsPermissions}
+              />
+            );
           }
           case 'qual_tags': {
-            return <TagsResponseForm uuid={item.uuid} />;
+            return (
+              <TagsResponseForm
+                uuid={item.uuid}
+                canEdit={hasEditSubmissionsPermissions}
+              />
+            );
           }
           case 'qual_integer': {
-            return <IntegerResponseForm uuid={item.uuid} />;
+            return (
+              <IntegerResponseForm
+                uuid={item.uuid}
+                canEdit={hasEditSubmissionsPermissions}
+              />
+            );
           }
           case 'qual_text': {
-            return <TextResponseForm uuid={item.uuid} />;
+            return (
+              <TextResponseForm
+                uuid={item.uuid}
+                canEdit={hasEditSubmissionsPermissions}
+              />
+            );
           }
           default: {
             return (

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionRow.component.tsx
@@ -19,6 +19,7 @@ import {
   findQuestion,
   getQuestionsFromSchema,
   updateSurveyQuestions,
+  hasManagePermissionsToCurrentAsset,
 } from '../utils';
 import classnames from 'classnames';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
@@ -57,20 +58,15 @@ export default function AnalysisQuestionRow(props: AnalysisQuestionRowProps) {
     return null;
   }
 
-  // Reordering analysis questions requires `manage_asset` permission.
-  const hasManagePermissions = (() => {
-    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('manage_asset', asset);
-  })();
-
   // Responding to analysis question requires `edit_submissions` permission.
   const hasEditSubmissionsPermissions = (() => {
     const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
     return userCan('change_submissions', asset);
   })();
 
+  // Reordering analysis questions requires `manage_asset` permission.
   const isDragDisabled =
-    analysisQuestions.state.isPending || !hasManagePermissions;
+    analysisQuestions.state.isPending || !hasManagePermissionsToCurrentAsset();
 
   const previewRef = useRef<HTMLLIElement>(null);
   const dragRef = useRef<HTMLDivElement>(null);

--- a/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
@@ -15,6 +15,8 @@ import type {AnalysisQuestionInternal} from '../constants';
 import singleProcessingStore from '../../singleProcessingStore';
 import type {FailResponse} from 'js/dataInterface';
 import {handleApiFail} from 'js/api';
+import assetStore from 'js/assetStore';
+import {userCan} from 'js/components/permissions/utils';
 
 interface ResponseFormHeaderProps {
   uuid: string;
@@ -41,6 +43,12 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
   if (!qaDefinition) {
     return null;
   }
+
+  // Editing and deleting question definition requires `manage_asset` permission.
+  const hasManagePermissions = (() => {
+    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
+    return userCan('manage_asset', asset);
+  })();
 
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
 
@@ -143,6 +151,7 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
         // We only allow editing one question at a time, so adding new is not
         // possible until user stops editing
         isDisabled={
+          !hasManagePermissions ||
           analysisQuestions.state.questionsBeingEdited.length !== 0 ||
           analysisQuestions.state.isPending
         }
@@ -154,7 +163,7 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
         size='s'
         startIcon='trash'
         onClick={() => setIsDeletePromptOpen(true)}
-        isDisabled={analysisQuestions.state.isPending}
+        isDisabled={!hasManagePermissions || analysisQuestions.state.isPending}
       />
     </header>
   );

--- a/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/commonHeader.component.tsx
@@ -9,14 +9,13 @@ import {
   getQuestionTypeDefinition,
   getQuestionsFromSchema,
   updateSurveyQuestions,
+  hasManagePermissionsToCurrentAsset,
 } from 'js/components/processing/analysis/utils';
 import KoboPrompt from 'js/components/modals/koboPrompt';
 import type {AnalysisQuestionInternal} from '../constants';
 import singleProcessingStore from '../../singleProcessingStore';
 import type {FailResponse} from 'js/dataInterface';
 import {handleApiFail} from 'js/api';
-import assetStore from 'js/assetStore';
-import {userCan} from 'js/components/permissions/utils';
 
 interface ResponseFormHeaderProps {
   uuid: string;
@@ -43,12 +42,6 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
   if (!qaDefinition) {
     return null;
   }
-
-  // Editing and deleting question definition requires `manage_asset` permission.
-  const hasManagePermissions = (() => {
-    const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
-    return userCan('manage_asset', asset);
-  })();
 
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false);
 
@@ -151,7 +144,7 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
         // We only allow editing one question at a time, so adding new is not
         // possible until user stops editing
         isDisabled={
-          !hasManagePermissions ||
+          !hasManagePermissionsToCurrentAsset() ||
           analysisQuestions.state.questionsBeingEdited.length !== 0 ||
           analysisQuestions.state.isPending
         }
@@ -163,7 +156,10 @@ export default function ResponseFormHeader(props: ResponseFormHeaderProps) {
         size='s'
         startIcon='trash'
         onClick={() => setIsDeletePromptOpen(true)}
-        isDisabled={!hasManagePermissions || analysisQuestions.state.isPending}
+        isDisabled={
+          !hasManagePermissionsToCurrentAsset() ||
+          analysisQuestions.state.isPending
+        }
       />
     </header>
   );

--- a/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/integerResponseForm.component.tsx
@@ -12,6 +12,7 @@ import commonStyles from './common.module.scss';
 
 interface IntegerResponseFormProps {
   uuid: string;
+  canEdit: boolean;
 }
 
 /**
@@ -80,6 +81,7 @@ export default function IntegerResponseForm(props: IntegerResponseFormProps) {
           onChange={onInputChange}
           placeholder={t('Type your answer')}
           onBlur={saveResponse}
+          disabled={!props.canEdit}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectMultipleResponseForm.component.tsx
@@ -12,6 +12,7 @@ import commonStyles from './common.module.scss';
 
 interface SelectMultipleResponseFormProps {
   uuid: string;
+  canEdit: boolean;
 }
 
 /**
@@ -101,6 +102,7 @@ export default function SelectMultipleResponseForm(
           type='bare'
           items={getCheckboxes()}
           onChange={onCheckboxesChange}
+          disabled={!props.canEdit}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/selectOneResponseForm.component.tsx
@@ -14,6 +14,7 @@ import styles from './selectOneResponseForm.module.scss';
 
 interface SelectOneResponseFormProps {
   uuid: string;
+  canEdit: boolean;
 }
 
 /**
@@ -87,6 +88,7 @@ export default function SelectOneResponseForm(
           onChange={onRadioChange}
           selected={response}
           isClearable
+          isDisabled={!props.canEdit}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
@@ -13,6 +13,7 @@ import commonStyles from './common.module.scss';
 
 interface TagsResponseFormProps {
   uuid: string;
+  canEdit: boolean;
 }
 
 /**
@@ -78,6 +79,7 @@ export default function TagsResponseForm(props: TagsResponseFormProps) {
           onlyUnique
           addOnBlur
           addOnPaste
+          disabled={!props.canEdit}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/textResponseForm.component.tsx
@@ -12,6 +12,7 @@ import commonStyles from './common.module.scss';
 
 interface TextResponseFormProps {
   uuid: string;
+  canEdit: boolean;
 }
 
 /**
@@ -80,6 +81,7 @@ export default function TextResponseForm(props: TextResponseFormProps) {
           onChange={onInputChange}
           placeholder={t('Type your answer')}
           onBlur={saveResponse}
+          disabled={!props.canEdit}
         />
       </section>
     </>

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -169,7 +169,11 @@ export async function updateSurveyQuestions(
   try {
     const response = await fetchPatch<AssetResponse>(
       endpoints.ASSET_URL.replace(':uid', assetUid),
-      {advanced_features: advancedFeatures as Json}
+      {advanced_features: advancedFeatures as Json},
+      // The `updateSurveyQuestions` function can fail for other reasons too, so
+      // we rely on the error displaying to be handled elsewhere - to avoid
+      // duplicated notifications
+      {notifyAboutError: false}
     );
 
     // TODO think of better way to handle this

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -22,6 +22,7 @@ import type {
 import type {Json} from '../../common/common.interfaces';
 import assetStore from 'js/assetStore';
 import singleProcessingStore from '../singleProcessingStore';
+import {userCan} from 'js/components/permissions/utils';
 
 /** Finds given question in state */
 export function findQuestion(uuid: string, state: AnalysisQuestionsState) {
@@ -294,4 +295,9 @@ export async function updateResponseAndReducer(
     handleApiFail(err as FailResponse);
     dispatch({type: 'updateResponseFailed'});
   }
+}
+
+export function hasManagePermissionsToCurrentAsset(): boolean {
+  const asset = assetStore.getAsset(singleProcessingStore.currentAssetUid);
+  return userCan('manage_asset', asset);
 }

--- a/jsapp/js/components/processing/analysis/utils.ts
+++ b/jsapp/js/components/processing/analysis/utils.ts
@@ -219,7 +219,9 @@ async function updateResponse(
 
     const apiResponse = await fetchPostUrl<SubmissionProcessingDataResponse>(
       processingUrl,
-      payload as Json
+      payload as Json,
+      // We handle the errors in the `updateResponseAndReducer` function.
+      {notifyAboutError: false}
     );
 
     return {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The UI for editing Analysis Questions will be disabled for users with insufficient permissions. Also fixes issue with duplicated error notifications.

## Notes

Changes here:
- Avoid displaying duplicated error notifications for editing questions definitions and for editing responses
- Disable analysis question deleting, editing and reordering if user doesn't have `manage_asset` permission
- Disable editing analysis question responses if user doesn't have `change_submissions` permission
