### PR TITLE
Prevent bulk edit if the project is archived

### DIFF
--- a/jsapp/js/components/submissions/tableBulkOptions.es6
+++ b/jsapp/js/components/submissions/tableBulkOptions.es6
@@ -201,7 +201,7 @@ class TableBulkOptions extends React.Component {
           </PopoverMenu>
         }
 
-        {Object.keys(this.props.selectedRows).length > 0 && (userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) || userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)) &&
+        {Object.keys(this.props.selectedRows).length > 0 && this.props.asset.deployment__active && (userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) || userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)) &&
           <bem.KoboLightButton
             m='blue'
             onClick={this.onEdit}


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixed bug which removes the bulk edit button for submissions of an archived project. 

## Notes

Added a check for the condition to render the bulk edit button which uses the boolean `deployment__active`
## Related issues

Fixes #4218
