### PR TITLE
Fix npm front-end build error when starting container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,13 +115,13 @@ COPY --from=build-python "$VIRTUAL_ENV" "$VIRTUAL_ENV"
 WORKDIR ${KPI_SRC_DIR}/
 
 RUN rm -rf ${KPI_NODE_PATH} && \
+    mkdir -p "${TMP_DIR}/.npm" && \
+    npm config set cache "${TMP_DIR}/.npm" --global && \
     npm install -g npm@8.5.5 && \
     npm install -g check-dependencies@1 && \
     rm -rf "${KPI_SRC_DIR}/jsapp/fonts" && \
     rm -rf "${KPI_SRC_DIR}/jsapp/compiled" && \
     npm install --quiet && \
-    mkdir -p "${TMP_DIR}/.npm" && \
-    npm config set cache "${TMP_DIR}/.npm" --global && \
     npm cache clean --force
 
 ENV PATH $PATH:${KPI_NODE_PATH}/.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,8 @@ RUN rm -rf ${KPI_NODE_PATH} && \
     rm -rf "${KPI_SRC_DIR}/jsapp/fonts" && \
     rm -rf "${KPI_SRC_DIR}/jsapp/compiled" && \
     npm install --quiet && \
+    mkdir -p "${TMP_DIR}/.npm" && \
+    npm config set cache "${TMP_DIR}/.npm" --global && \
     npm cache clean --force
 
 ENV PATH $PATH:${KPI_NODE_PATH}/.bin


### PR DESCRIPTION
## Description
Fix  `npm ERR! code EACCES` because of a lack of permissions of the user `kobo` when calling `npm`. 

## Notes

` npm` is run as `root` when building the image, thus its cache is saved at `/root/.npm`.  
This PR moves the cache folder to a location that both `root` and `kobo` are able to write to.

⚠️ Image has to be rebuild to see the patch in action.