### PR TITLE
Fix GitLab 'build' job error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,9 +7,11 @@ include:
   - template: SAST.gitlab-ci.yml
 
 build:
-  image: docker
+  # Please un-pin the version (24.0.6) once the following GitLab issue is resolved:
+  # https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283
+  image: docker:24.0.6
   services:
-    - docker:dind
+    - docker:24.0.6-dind
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes an issue with Docker images that cause GitLab CI to fail on the 'build' step.

## Notes

The `build` step was failing while trying to authorize through Docker, consistently spitting out something like:

```bash
ERROR: error during connect: Get "http://docker:2375/_ping": dial tcp: lookup docker on 169.254.169.254:53: no such host
```

After some research, it was determined that [this GitLab incident](https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283) (ongoing at the time of this PR) was the root cause. This PR applies the suggested fix of pinning docker and docker:dind to `24.0.6`. Once the incident is resolved, we should be able to safely un-pin that version.