### PR TITLE
Unpin docker version in gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,11 +7,9 @@ include:
   - template: SAST.gitlab-ci.yml
 
 build:
-  # Please un-pin the version (24.0.6) once the following GitLab issue is resolved:
-  # https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283
-  image: docker:24.0.6
+  image: docker
   services:
-    - docker:24.0.6-dind
+    - docker:dind
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN registry.gitlab.com
   script:


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The issue that required us to pin the docker version for the GitLab ci pipeline [has been resolved](https://gitlab.com/gitlab-com/gl-infra/production/-/issues/17283). This PR unpins the version now that that short-term fix is no longer needed.

## Related issues

Removes short-term fix from:
https://github.com/kobotoolbox/kpi/pull/4768
