### PR TITLE
Fix styling for frozen columns in data table

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -990,7 +990,9 @@ export class DataTable extends React.Component {
         col.className = col.className
           ? `is-frozen is-last-frozen ${col.className}`
           : 'is-frozen is-last-frozen';
-        col.headerClassName = 'is-frozen is-last-frozen';
+        col.headerClassName = col.headerClassName
+          ? `is-frozen is-last-frozen ${col.headerClassName}`
+          : 'is-frozen is-last-frozen';
       }
     });
 

--- a/jsapp/js/components/submissions/table.scss
+++ b/jsapp/js/components/submissions/table.scss
@@ -1,6 +1,7 @@
 @use '~kobo-common/src/styles/colors';
 @use 'scss/z-indexes';
 @use 'js/components/common/checkbox';
+@use 'sass:color';
 
 // These are custom styles for Table View table.
 
@@ -471,7 +472,11 @@ $s-data-table-font: 13px;
   }
 
   .rt-th.is-sorted {
-    background-color: rgba(colors.$kobo-light-teal, 0.5);
+    background-color: color.adjust(colors.$kobo-light-teal, $lightness: 4%);
+  }
+
+  .rt-td.is-sorted {
+    background-color: color.adjust(colors.$kobo-light-teal, $lightness: 8%);
   }
 
   // NOTE: submissions actions column is always frozen as first column

--- a/jsapp/js/components/submissions/table.scss
+++ b/jsapp/js/components/submissions/table.scss
@@ -474,10 +474,6 @@ $s-data-table-font: 13px;
     background-color: rgba(colors.$kobo-light-teal, 0.5);
   }
 
-  .rt-td.is-sorted {
-    background-color: rgba(colors.$kobo-light-teal, 0.2);
-  }
-
   // NOTE: submissions actions column is always frozen as first column
   .rt-th.rt-sub-actions,
   .rt-td.rt-sub-actions {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Removed the css code in `table.scss` that was causing a transparent teal background to be applied to a sorted column. Also fixed the bug which was not applying styling to frozen and sorted columns. 

## Related issues

Fixes #4764
