### PR TITLE
Adjust anon submission tooltip layout issue

### DIFF
--- a/jsapp/js/components/anonymousSubmission.component.tsx
+++ b/jsapp/js/components/anonymousSubmission.component.tsx
@@ -22,6 +22,7 @@ export default function AnonymousSubmission(props: AnonymousSubmissionProps) {
       />
       <a
         href={envStore.data.support_url + HELP_ARTICLE_ANON_SUBMISSIONS_URL}
+        className='right-tooltip wrapped-tooltip'
         target='_blank'
         data-tip={t(
           'Allow anyone to see this form and add submissions. Click the icon to learn more.'

--- a/jsapp/js/components/anonymousSubmission.module.scss
+++ b/jsapp/js/components/anonymousSubmission.module.scss
@@ -9,5 +9,5 @@
 }
 
 a {
-  padding-left: sizes.$x8;
+  margin-left: sizes.$x8;
 }

--- a/jsapp/scss/components/_kobo.tooltips.scss
+++ b/jsapp/scss/components/_kobo.tooltips.scss
@@ -96,6 +96,12 @@ Additional class names:
     transform: translate(0);
   }
 
+  .wrapped-tooltip [data-tip]::after,
+  .wrapped-tooltip[data-tip]::after {
+    width: 300px;
+    white-space: normal;
+  }
+
   // more actions in asset-row adjustment
   .asset-row .popover-menu [data-tip]::after {
     left: -60%;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes a problem where the long tooltip on the anonymous submission form caused [unwanted overflow](https://github.com/kobotoolbox/kpi/pull/4719#issuecomment-1858440469) from the containing element. I created a separate `wrapped-tooltip` class for this purpose, since the main goal at the moment is to fix this issue rather than changing existing tooltips on the site. I also switched the <a> element's padding to margin in the anonymous submission scss, as this was causing the tooltip's point to be off center.

![image](https://github.com/kobotoolbox/kpi/assets/68701146/4df37da3-4188-49ac-adaf-5575f815704f)

