### PR TITLE
Handle edits of submissions lacking UUIDs in XML

### DIFF
--- a/kobo/apps/subsequences/models.py
+++ b/kobo/apps/subsequences/models.py
@@ -19,6 +19,7 @@ class SubmissionExtras(models.Model):
 
     date_created = models.DateTimeField(auto_now_add=True)
     date_modified = models.DateTimeField(auto_now=True)
+    # FIXME: uuid on the KoboCAT logger.Instance model has max_length 249
     submission_uuid = models.CharField(max_length=40)
     content = models.JSONField(default=dict)
     asset = models.ForeignKey(

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -32,6 +32,16 @@ class BaseDeploymentBackend(abc.ABC):
     Defines the interface for a deployment backend.
     """
 
+    PROTECTED_XML_FIELDS = [
+        '__version__',
+        'formhub',
+        'meta',
+    ]
+
+    # XPaths are relative to the root node
+    SUBMISSION_UUID_XPATH = './meta/deprecatedID'
+    FORM_UUID_XPATH = './formhub/uuid'
+
     def __init__(self, asset):
         self.asset = asset
         # Python-only attribute used by `kpi.views.v2.data.DataViewSet.list()`

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -101,10 +101,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         AssetFile.PAIRED_DATA: 'paired_data',
     }
 
-    SUBMISSION_UUID_PATTERN = re.compile(
-        r'[a-z\d]{8}-([a-z\d]{4}-){3}[a-z\d]{12}'
-    )
-
     @property
     def attachment_storage_bytes(self):
         try:
@@ -641,10 +637,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         except ValueError:
             submission_uuid = submission_id_or_uuid
         if submission_uuid:
-            if not re.match(self.SUBMISSION_UUID_PATTERN, submission_uuid):
-                # not sure how necessary such a sanitization step is,
-                # but it's not hurting anything
-                raise SubmissionNotFoundException
             # `_uuid` is the legacy identifier that changes (per OpenRosa spec)
             # after every edit; `meta/rootUuid` remains consistent across
             # edits. prefer the latter when fetching by UUID.

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -90,12 +90,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     `self.asset._deployment_data` models.JSONField (referred as "deployment data")
     """
 
-    PROTECTED_XML_FIELDS = [
-        '__version__',
-        'formhub',
-        'meta',
-    ]
-
     SYNCED_DATA_FILE_TYPES = {
         AssetFile.FORM_MEDIA: 'media',
         AssetFile.PAIRED_DATA: 'paired_data',
@@ -545,8 +539,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 t('Your submission XML is malformed.')
             )
         try:
-            deprecated_uuid = xml_root.find('.//meta/deprecatedID').text
-            xform_uuid = xml_root.find('.//formhub/uuid').text
+            deprecated_uuid = xml_root.find(self.SUBMISSION_UUID_XPATH).text
+            xform_uuid = xml_root.find(self.FORM_UUID_XPATH).text
         except AttributeError:
             raise SubmissionIntegrityError(
                 t('Your submission XML is missing critical elements.')

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -55,12 +55,6 @@ class MockDeploymentBackend(BaseDeploymentBackend):
     Only used for unit testing and interface testing.
     """
 
-    PROTECTED_XML_FIELDS = [
-        '__version__',
-        'formhub',
-        'meta',
-    ]
-
     @property
     def attachment_storage_bytes(self):
         submissions = self.get_submissions(self.asset.owner)
@@ -140,6 +134,10 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         return MongoHelper.get_count(self.mongo_userform_id, **params)
 
     def connect(self, active=False):
+        def generate_uuid_for_form():
+            # From KoboCAT's onadata.libs.utils.model_tools
+            return uuid.uuid4().hex
+
         self.store_data({
             'backend': 'mock',
             'identifier': 'mock://%s' % self.asset.uid,
@@ -147,7 +145,8 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             'backend_response': {
                 'downloadable': active,
                 'has_kpi_hook': self.asset.has_active_hooks,
-                'kpi_asset_uid': self.asset.uid
+                'kpi_asset_uid': self.asset.uid,
+                'uuid': generate_uuid_for_form(),
             },
             'version': self.asset.version_id,
         })

--- a/kpi/models/asset_snapshot.py
+++ b/kpi/models/asset_snapshot.py
@@ -67,6 +67,7 @@ class AssetSnapshot(
     owner = models.ForeignKey('auth.User', related_name='asset_snapshots',
                               null=True, on_delete=models.CASCADE)
     asset = models.ForeignKey('Asset', null=True, on_delete=models.CASCADE)
+    # FIXME: uuid on the KoboCAT logger.Instance model has max_length 249
     submission_uuid = models.CharField(null=True, max_length=41)
     _reversion_version_id = models.IntegerField(null=True)
     asset_version = models.ForeignKey(

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1,5 +1,7 @@
 # coding: utf-8
+import copy
 import json
+import lxml
 import random
 import string
 import time
@@ -38,6 +40,7 @@ from kpi.utils.object_permission import get_anonymous_user
 from kpi.tests.utils.mock import (
     enketo_edit_instance_response,
     enketo_edit_instance_response_with_root_name_validation,
+    enketo_edit_instance_response_with_uuid_validation,
     enketo_view_instance_response,
 )
 
@@ -1243,6 +1246,53 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
             submission_uuid=f"uuid:{self.submission['_uuid']}"
         )
         assert new_snapshot.pk != snapshot.pk
+
+    @responses.activate
+    def test_edit_submission_with_xml_missing_uuids(self):
+        # Make a new submission without UUIDs
+        submission = copy.deepcopy(self.submissions[-1])
+        submission['_id'] += 1
+        del submission['meta/instanceID']
+        submission['find_this'] = 'hello!'
+        # The form UUID is already omitted by these tests, but fail if that
+        # changes in the future
+        assert 'formhub/uuid' not in submission.keys()
+        self.asset.deployment.mock_submissions([submission])
+
+        # Find and verify the new submission
+        submission_xml = self.asset.deployment.get_submissions(
+            user=self.asset.owner,
+            format_type=SUBMISSION_FORMAT_TYPE_XML,
+            find_this='hello!',
+        )[0]
+        submission_xml_root = lxml.etree.fromstring(submission_xml)
+        submission_id = int(submission_xml_root.find('./_id').text)
+        assert submission_id == submission['_id']
+        assert submission_xml_root.find('./find_this').text == 'hello!'
+        assert submission_xml_root.find('./meta/instanceID') is None
+        assert submission_xml_root.find('./formhub/uuid') is None
+
+        # Get edit endpoint
+        edit_url = reverse(
+            self._get_endpoint('submission-enketo-edit'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': submission_id,
+            },
+        )
+
+        # Set up a mock Enketo response and attempt the edit request
+        ee_url = (
+            f'{settings.ENKETO_URL}/{settings.ENKETO_EDIT_INSTANCE_ENDPOINT}'
+        )
+        responses.add_callback(
+            responses.POST,
+            ee_url,
+            callback=enketo_edit_instance_response_with_uuid_validation,
+            content_type='application/json',
+        )
+        response = self.client.get(edit_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
 
     @responses.activate
     def test_get_edit_link_submission_with_latest_asset_deployment(self):

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import json
+import lxml
 import os
 from mimetypes import guess_type
 from tempfile import NamedTemporaryFile
@@ -10,6 +11,7 @@ from django.conf import settings
 from django.core.files import File
 from rest_framework import status
 
+from kpi.deployment_backends.base_backend import BaseDeploymentBackend
 from kpi.mixins.audio_transcoding import AudioTranscodingMixin
 from kpi.models.asset_snapshot import AssetSnapshot
 from kpi.tests.utils.xml import get_form_and_submission_tag_names
@@ -47,6 +49,32 @@ def enketo_edit_instance_response_with_root_name_validation(request):
     ) = get_form_and_submission_tag_names(snapshot.xml, submission)
 
     assert form_root_name == submission_root_name
+
+    resp_body = {
+        'edit_url': (
+            f"{settings.ENKETO_URL}/edit/{body['instance_id']}"
+        )
+    }
+    headers = {}
+    return status.HTTP_201_CREATED, headers, json.dumps(resp_body)
+
+
+def enketo_edit_instance_response_with_uuid_validation(request):
+    """
+    Simulate Enketo response and validate that formhub/uuid and meta/instanceID
+    are present and non-empty
+    """
+    # Decode `x-www-form-urlencoded` data
+    body = {k: v[0] for k, v in parse_qs(unquote(request.body)).items()}
+
+    submission = body['instance']
+    submission_xml_root = lxml.etree.fromstring(submission)
+    assert submission_xml_root.find(
+        BaseDeploymentBackend.FORM_UUID_XPATH
+    ).text.strip()
+    assert submission_xml_root.find(
+        BaseDeploymentBackend.SUBMISSION_UUID_XPATH
+    ).text.strip()
 
     resp_body = {
         'edit_url': (

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -2,7 +2,7 @@
 import copy
 import json
 import re
-from xml.etree import ElementTree as ET
+from lxml import etree  # for compatibility with edit_submission_xml()
 
 import requests
 from django.conf import settings
@@ -48,6 +48,7 @@ from kpi.renderers import (
 )
 from kpi.utils.log import logging
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
+from kpi.utils.xml import edit_submission_xml
 from kpi.serializers.v2.data import DataBulkActionsValidator
 
 
@@ -654,16 +655,48 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         submission_xml = deployment.get_submission(
             submission_id, user, SUBMISSION_FORMAT_TYPE_XML
         )
+        submission_xml_root = etree.fromstring(submission_xml)
         # The JSON version is needed to detect its version
         submission_json = deployment.get_submission(
             submission_id, user, request=request
         )
         if 'meta/rootUuid' in submission_json:
             # this submission has been edited at least one time
-            submission_uuid = submission_json['meta/rootUuid']
+            original_submission_uuid = submission_json['meta/rootUuid']
         else:
             # never been edited
-            submission_uuid = submission_json['meta/instanceID']
+
+            # Note: KoboCAT will accept a submission whose XML lacks
+            # `<meta><instanceID>`, even though that violates the OpenRosa
+            # spec. KoboCAT then automatically generates a UUID for the
+            # submission, but that UUID is added neither to the XML nor to
+            # `meta/instanceID` in the JSON representation
+            original_submission_uuid = 'uuid:' + submission_json['_uuid']
+
+        # Add mandatory XML elements if they are missing from the original
+        # submission. They could be overwritten unconditionally, but be
+        # conservative for now and don't modify anything unless they're missing
+        # entirely
+        if (
+            not (e := submission_xml_root.find(deployment.FORM_UUID_XPATH))
+            or not e.text.strip()
+        ):
+            form_uuid = deployment.backend_response['uuid']
+            edit_submission_xml(
+                submission_xml_root, deployment.FORM_UUID_XPATH, form_uuid
+            )
+        if (
+            not (
+                e := submission_xml_root.find(deployment.SUBMISSION_UUID_XPATH)
+            )
+            or not e.text.strip()
+        ):
+            edit_submission_xml(
+                submission_xml_root,
+                deployment.SUBMISSION_UUID_XPATH,
+                'uuid:' + submission_json['_uuid']
+            )
+
         # Do not use version_uid from the submission until UI gives users the
         # possibility to choose which version they want to use
 
@@ -683,7 +716,7 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         # root node name specified in the form XML (i.e. the first child of
         # `<instance>`) must match the root node name of the submission XML,
         # otherwise Enketo will refuse to open the submission.
-        xml_root_node_name = ET.fromstring(submission_xml).tag
+        xml_root_node_name = submission_xml_root.tag
 
         # This will raise `AssetVersion.DoesNotExist` if the inferred version
         # of the submission disappears between the call to `build_formpack()`
@@ -693,7 +726,7 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
             regenerate=True,
             root_node_name=xml_root_node_name,
             version_uid=version_uid,
-            submission_uuid=submission_uuid,
+            submission_uuid=original_submission_uuid,
         )
 
         data = {
@@ -702,7 +735,7 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
                 kwargs={'uid': snapshot.uid},
                 request=request,
             ),
-            'instance': submission_xml,
+            'instance': etree.tostring(submission_xml_root),
             'instance_id': submission_json['_uuid'],
             'form_id': snapshot.uid,
             'return_url': 'false'  # String to be parsed by EE as a boolean


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

These submissions violate the [OpenRosa specification](https://docs.getodk.org/openrosa-metadata/#fields), which requires the `instanceID` element, but they are accepted by KoboCAT and exist in our databases. These changes allow them to be edited.