### PR TITLE
Fix incorrect calls to `routerIsActive()`

### DIFF
--- a/jsapp/js/assetQuickActions.tsx
+++ b/jsapp/js/assetQuickActions.tsx
@@ -32,7 +32,7 @@ import {userCan} from './components/permissions/utils';
 import {renderJSXMessage} from './alertify';
 
 export function openInFormBuilder(uid: string) {
-  if (routerIsActive('library')) {
+  if (routerIsActive(ROUTES.LIBRARY)) {
     router!.navigate(ROUTES.EDIT_LIBRARY_ITEM.replace(':uid', uid));
   } else {
     router!.navigate(ROUTES.FORM_EDIT.replace(':uid', uid));

--- a/jsapp/js/components/library/librarySidebar.es6
+++ b/jsapp/js/components/library/librarySidebar.es6
@@ -9,6 +9,7 @@ import bem from 'js/bem';
 import {MODAL_TYPES} from 'js/constants';
 import myLibraryStore from './myLibraryStore';
 import { routerIsActive } from '../../router/legacy';
+import {ROUTES} from '../../router/routerConstants';
 import {NavLink} from 'react-router-dom';
 
 class LibrarySidebar extends Reflux.Component {
@@ -44,11 +45,11 @@ class LibrarySidebar extends Reflux.Component {
   }
 
   isMyLibrarySelected() {
-    return routerIsActive('library/my-library');
+    return routerIsActive(ROUTES.MY_LIBRARY);
   }
 
   isPublicCollectionsSelected() {
-    return routerIsActive('library/public-collections');
+    return routerIsActive(ROUTES.PUBLIC_COLLECTIONS);
   }
 
   render() {

--- a/jsapp/js/dropzone.utils.tsx
+++ b/jsapp/js/dropzone.utils.tsx
@@ -22,7 +22,7 @@ function onImportSingleXLSFormFile(
   name: string,
   base64Encoded: string | ArrayBuffer | null
 ) {
-  const isLibrary = routerIsActive('library');
+  const isLibrary = routerIsActive(ROUTES.LIBRARY);
 
   const importPromise = new Promise<ImportResponse>((resolve, reject) => {
     if (!base64Encoded) {
@@ -149,7 +149,7 @@ function onImportOneAmongMany(
   fileIndex: number,
   totalFilesInBatch: number
 ) {
-  const isLibrary = routerIsActive('library');
+  const isLibrary = routerIsActive(ROUTES.LIBRARY);
   const isLastFileInBatch = fileIndex + 1 === totalFilesInBatch;
 
   // We open the modal that displays the message with total files count.

--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -147,7 +147,7 @@ const mixins: MixinsObject = {
             {
               onComplete: (asset: AssetResponse) => {
                 dialog.destroy();
-                router!.navigate(`/forms/${asset.uid}`);
+                router!.navigate(ROUTES.FORM.replace(':uid', asset.uid));
               },
             }
           );
@@ -340,7 +340,7 @@ const mixins: MixinsObject = {
     _forEachDroppedFile(params: CreateImportRequest = {}) {
       const totalFiles = params.totalFiles || 1;
 
-      const isLibrary = routerIsActive('library');
+      const isLibrary = routerIsActive(ROUTES.LIBRARY);
       const multipleFiles = params.totalFiles && totalFiles > 1 ? true : false;
       params = Object.assign({library: isLibrary}, params);
 
@@ -391,16 +391,16 @@ const mixins: MixinsObject = {
                       )
                     );
                     if (params.assetUid) {
-                      router!.navigate(`/forms/${params.assetUid}`);
+                      router!.navigate(ROUTES.FORM.replace(':uid', params.assetUid));
                     }
                   } else {
                     if (
                       this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE &&
-                      routerIsActive('forms')
+                      routerIsActive(ROUTES.FORMS)
                     ) {
                       actions.resources.loadAsset({id: assetUid});
                     } else if (!isLibrary) {
-                      router!.navigate(`/forms/${assetUid}`);
+                      router!.navigate(ROUTES.FORM.replace(':uid', assetUid));
                     }
                     notify(t('XLS Import completed'));
                   }


### PR DESCRIPTION
…that did not use leading slashes, meaning that `routerIsActive()` would always return false.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/React.20Router/near/315484

## Description

Fixes "a library cannot be imported into the form list" error when bulk-importing library items in Excel 2003 (XLS) format. Excel 2007 (XLSX) bulk imports will need a separate fix in the back end.

## Notes

There are some related improvements to `navigate()` calls in a file I was already editing, but there are **many more** calls elsewhere that still do not use the standard `ROUTES` constants.

## Related issues

Continues work from the React Router 6 upgrade, #4102