### PR TITLE
Lint, test, fix mongo helper partial permissions

### DIFF
--- a/kpi/models/asset_user_partial_permission.py
+++ b/kpi/models/asset_user_partial_permission.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+from __future__ import annotations
+
 from collections import defaultdict
 
 from django.db import models
@@ -33,16 +35,17 @@ class AssetUserPartialPermission(models.Model):
     class Meta:
         unique_together = [['asset', 'user']]
 
-    asset = models.ForeignKey('Asset', related_name='asset_partial_permissions',
-                              on_delete=models.CASCADE)
-    user = models.ForeignKey('auth.User', related_name='user_partial_permissions',
-                             on_delete=models.CASCADE)
+    asset = models.ForeignKey(
+        'Asset', related_name='asset_partial_permissions', on_delete=models.CASCADE
+    )
+    user = models.ForeignKey(
+        'auth.User', related_name='user_partial_permissions', on_delete=models.CASCADE
+    )
     permissions = models.JSONField(default=dict)
     date_created = models.DateTimeField(default=timezone.now)
     date_modified = models.DateTimeField(default=timezone.now)
 
     def save(self, *args, **kwargs):
-
         if self.pk is not None:
             self.date_modified = timezone.now()
 
@@ -52,20 +55,16 @@ class AssetUserPartialPermission(models.Model):
     def update_partial_perms_to_include_implied(
         asset: 'kpi.models.Asset', partial_perms: dict
     ) -> dict:
-        new_partial_perms = defaultdict(list)
+        new_partial_perms = defaultdict(list, partial_perms)
         in_op = MongoHelper.IN_OPERATOR
 
         for partial_perm, filters in partial_perms.items():
-
-            if partial_perm not in new_partial_perms:
-                new_partial_perms[partial_perm] = filters
-
             # TODO: omit `add_submissions`? It's required at the asset
             # level for any kind of editing (e.g. partial
             # `change_submissions` requires asset-wide `add_submissions`),
             # but it doesn't make sense to restrict adding submissions
             # "only to those submissions that match some criteria"
-            implied_perms = [
+            implied_perms: list[str] = [
                 implied_perm
                 for implied_perm in asset.get_implied_perms(
                     partial_perm, for_instance=asset
@@ -74,14 +73,11 @@ class AssetUserPartialPermission(models.Model):
             ]
 
             for implied_perm in implied_perms:
-
                 if (
                     implied_perm not in new_partial_perms
                     and implied_perm in partial_perms
                 ):
-                    new_partial_perms[implied_perm] = partial_perms[
-                        implied_perm
-                    ]
+                    new_partial_perms[implied_perm] = partial_perms[implied_perm]
 
                 new_partial_perm = new_partial_perms[implied_perm]
                 # Trivial case, i.e.: permissions are built with front end.

--- a/kpi/models/asset_user_partial_permission.py
+++ b/kpi/models/asset_user_partial_permission.py
@@ -36,10 +36,14 @@ class AssetUserPartialPermission(models.Model):
         unique_together = [['asset', 'user']]
 
     asset = models.ForeignKey(
-        'Asset', related_name='asset_partial_permissions', on_delete=models.CASCADE
+        'Asset',
+        related_name='asset_partial_permissions',
+        on_delete=models.CASCADE,
     )
     user = models.ForeignKey(
-        'auth.User', related_name='user_partial_permissions', on_delete=models.CASCADE
+        'auth.User',
+        related_name='user_partial_permissions',
+        on_delete=models.CASCADE,
     )
     permissions = models.JSONField(default=dict)
     date_created = models.DateTimeField(default=timezone.now)
@@ -77,7 +81,9 @@ class AssetUserPartialPermission(models.Model):
                     implied_perm not in new_partial_perms
                     and implied_perm in partial_perms
                 ):
-                    new_partial_perms[implied_perm] = partial_perms[implied_perm]
+                    new_partial_perms[implied_perm] = partial_perms[
+                        implied_perm
+                    ]
 
                 new_partial_perm = new_partial_perms[implied_perm]
                 # Trivial case, i.e.: permissions are built with front end.

--- a/kpi/serializers/v2/asset_permission_assignment.py
+++ b/kpi/serializers/v2/asset_permission_assignment.py
@@ -64,7 +64,9 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
         user = validated_data['user']
         asset = validated_data['asset']
         if asset.owner_id == user.id:
-            raise serializers.ValidationError({'user': t(ASSIGN_OWNER_ERROR_MESSAGE)})
+            raise serializers.ValidationError(
+                {'user': t(ASSIGN_OWNER_ERROR_MESSAGE)}
+            )
         permission = validated_data['permission']
         partial_permissions = validated_data.get('partial_permissions', None)
 
@@ -82,7 +84,9 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
         except KeyError:
             return object_permission.label
         else:
-            return asset.get_label_for_permission(object_permission.permission.codename)
+            return asset.get_label_for_permission(
+                object_permission.permission.codename
+            )
 
     def get_partial_permissions(self, object_permission):
         codename = object_permission.permission.codename
@@ -103,7 +107,9 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
                 hyperlinked_partial_perms = []
                 for perm_codename, filters in partial_perms.items():
                     url = self.__get_permission_hyperlink(perm_codename)
-                    hyperlinked_partial_perms.append({'url': url, 'filters': filters})
+                    hyperlinked_partial_perms.append(
+                        {'url': url, 'filters': filters}
+                    )
                 return hyperlinked_partial_perms
         return None
 
@@ -147,7 +153,9 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
 
         if isinstance(request.data, dict):  # for a single assignment
             partial_permissions = request.data.get('partial_permissions')
-        elif self.context.get('partial_permissions'):  # injected during bulk assignment
+        elif self.context.get(
+            'partial_permissions'
+        ):  # injected during bulk assignment
             partial_permissions = self.context.get('partial_permissions')
 
         if not partial_permissions:
@@ -159,9 +167,10 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
 
         partial_permissions_attr = defaultdict(list)
 
-        for partial_permission, filters_ in self.__get_partial_permissions_generator(
-            partial_permissions
-        ):
+        for (
+            partial_permission,
+            filters_,
+        ) in self.__get_partial_permissions_generator(partial_permissions):
             try:
                 resolver_match = absolute_resolve(partial_permission.get('url'))
             except (TypeError, Resolver404):
@@ -173,7 +182,9 @@ class AssetPermissionAssignmentSerializer(serializers.ModelSerializer):
                 _invalid_partial_permissions(t('Invalid `url`'))
 
             # Permission must valid and must be assignable.
-            if not self._validate_permission(codename, SUFFIX_SUBMISSIONS_PERMS):
+            if not self._validate_permission(
+                codename, SUFFIX_SUBMISSIONS_PERMS
+            ):
                 _invalid_partial_permissions(t('Invalid `url`'))
 
             # No need to validate Mongo syntax, query will fail
@@ -314,7 +325,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
 
     @dataclass(frozen=True)
     class PermissionAssignment:
-        """A more-explicit alternative to a simple tuple"""
+        """
+        A more-explicit alternative to a simple tuple
+        """
 
         user_pk: int
         permission_codename: str
@@ -385,7 +398,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
         ):
             # Expand the stupid cache to include any users present in the
             # existing assignments but not in the incoming assignments
-            user_pk_to_obj_cache[assignment_in_db.user_id] = assignment_in_db.user
+            user_pk_to_obj_cache[
+                assignment_in_db.user_id
+            ] = assignment_in_db.user
 
             if assignment_in_db.permission.codename == PERM_PARTIAL_SUBMISSIONS:
                 partial_permissions_json = json.dumps(
@@ -421,9 +436,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
             # always require a fully-fledged `User` object? Until then, keep a
             # stupid object cache thing because `assign_perm()` and
             # `remove_perm()` REQUIRE user objects
-            user_pk_to_obj_cache[incoming_assignment['user'].pk] = incoming_assignment[
-                'user'
-            ]
+            user_pk_to_obj_cache[
+                incoming_assignment['user'].pk
+            ] = incoming_assignment['user']
 
             # Expand to include implied permissions
             for implied_codename in asset.get_implied_perms(
@@ -465,18 +480,22 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
         # …for looking up by API permission URLs by codename
         codename_to_url = dict()
 
-        assignable_permissions = self.context['asset'].get_assignable_permissions(
-            with_partial=True
-        )
+        assignable_permissions = self.context[
+            'asset'
+        ].get_assignable_permissions(with_partial=True)
 
         # Perhaps not the best error messages, but they're what DRF was already
         # returning
         INVALID_PERMISSION_ERROR = {
             'permission': t('Invalid hyperlink - Object does not exist.')
         }
-        INVALID_USER_ERROR = {'user': t('Invalid hyperlink - Object does not exist.')}
+        INVALID_USER_ERROR = {
+            'user': t('Invalid hyperlink - Object does not exist.')
+        }
         # This matches the behavior of `AssetPermissionAssignmentSerializer`
-        INVALID_PARTIAL_PERMISSION_ERROR = {'partial_permissions': t('Invalid `url`')}
+        INVALID_PARTIAL_PERMISSION_ERROR = {
+            'partial_permissions': t('Invalid `url`')
+        }
 
         # Fill in the dictionaries by parsing the incoming assignments
         for assignment in attrs['assignments']:
@@ -501,7 +520,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
                     partial_codename in assignable_permissions
                     and partial_codename.endswith(SUFFIX_SUBMISSIONS_PERMS)
                 ):
-                    raise serializers.ValidationError(INVALID_PARTIAL_PERMISSION_ERROR)
+                    raise serializers.ValidationError(
+                        INVALID_PARTIAL_PERMISSION_ERROR
+                    )
                 codename_to_url[partial_codename] = partial_assignment['url']
 
         # Create a dictionary of API user URLs to `User` objects
@@ -526,7 +547,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
         if len(url_to_permission) != len(codename_to_url):
             # This should never happen since all codenames were found within
             # `assignable_permissions`
-            raise RuntimeError('Unexpected mismatch while processing permissions')
+            raise RuntimeError(
+                'Unexpected mismatch while processing permissions'
+            )
 
         # Rewrite the incoming assignments, replacing user and permission URLs
         # with their corresponding model instance objects
@@ -540,7 +563,9 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
                 assignment_with_objects['permission'].codename
                 == PERM_PARTIAL_SUBMISSIONS
             ):
-                assignment_with_objects['partial_permissions'] = defaultdict(list)
+                assignment_with_objects['partial_permissions'] = defaultdict(
+                    list
+                )
                 for partial_assignment in assignment['partial_permissions']:
                     partial_codename = url_to_permission[
                         partial_assignment['url']

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from copy import deepcopy
 
+import pytest
 from django.contrib.auth.models import Permission, User
 from django.urls import reverse
 from rest_framework import status
@@ -43,7 +44,9 @@ class BaseApiAssetPermissionTestCase(KpiTestCase):
         """
         data = {
             'user': self.obj_to_url(User.objects.get(username=username)),
-            'permission': self.obj_to_url(Permission.objects.get(codename=codename)),
+            'permission': self.obj_to_url(
+                Permission.objects.get(codename=codename)
+            ),
         }
         response = self.client.post(
             self.get_asset_perm_assignment_list_url(self.asset),
@@ -56,7 +59,9 @@ class BaseApiAssetPermissionTestCase(KpiTestCase):
 class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
     def test_owner_can_give_permissions(self):
         # Current user is `self.admin`
-        response = self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user(
+            'someuser', PERM_VIEW_ASSET
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_viewers_cannot_give_permissions(self):
@@ -64,7 +69,9 @@ class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_VIEW_ASSET))
         self.client.login(username='someuser', password='someuser')
         # Current user is now: `self.someuser`
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user(
+            'anotheruser', PERM_VIEW_ASSET
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_editors_cannot_give_permissions(self):
@@ -72,27 +79,37 @@ class ApiAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_CHANGE_ASSET))
         self.client.login(username='someuser', password='someuser')
         # Current user is now: `self.someuser`
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user(
+            'anotheruser', PERM_VIEW_ASSET
+        )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_anonymous_cannot_give_permissions(self):
         self.client.logout()
-        response = self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user(
+            'someuser', PERM_VIEW_ASSET
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_managers_can_give_permissions(self):
         self._grant_perm_as_logged_in_user('someuser', PERM_MANAGE_ASSET)
         self.assertTrue(self.asset.has_perm(self.someuser, PERM_MANAGE_ASSET))
         self.client.login(username='someuser', password='someuser')
-        response = self._grant_perm_as_logged_in_user('anotheruser', PERM_VIEW_ASSET)
+        response = self._grant_perm_as_logged_in_user(
+            'anotheruser', PERM_VIEW_ASSET
+        )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_submission_assignments_ignored_for_non_survey_assets(self):
         self.asset.asset_type = ASSET_TYPE_TEMPLATE
         self.asset.save()
-        response = self._grant_perm_as_logged_in_user('someuser', PERM_VIEW_SUBMISSIONS)
+        response = self._grant_perm_as_logged_in_user(
+            'someuser', PERM_VIEW_SUBMISSIONS
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertFalse(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS)
+        )
 
 
 class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
@@ -116,7 +133,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         permission_list_response = self.client.get(
             self.get_asset_perm_assignment_list_url(self.asset), format='json'
         )
-        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            permission_list_response.status_code, status.HTTP_200_OK
+        )
         results = permission_list_response.data
 
         # `anotheruser` must see only permissions assigned to themselves, the
@@ -143,7 +162,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
                     object_permission.permission.codename,
                 )
             )
-        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
+        obj_perms = sorted(
+            obj_perms, key=lambda element: (element[0], element[1])
+        )
 
         self.assertEqual(expected_perms, obj_perms)
 
@@ -154,7 +175,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         self.asset.assign_perm(manager, PERM_MANAGE_ASSET)
 
         self.client.login(username='businessfish', password='manage this!')
-        response = self.client.get(self.get_asset_perm_assignment_list_url(self.asset))
+        response = self.client.get(
+            self.get_asset_perm_assignment_list_url(self.asset)
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         returned_urls = [r['url'] for r in response.data]
@@ -179,7 +202,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         permission_list_response = self.client.get(
             self.get_asset_perm_assignment_list_url(self.asset), format='json'
         )
-        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            permission_list_response.status_code, status.HTTP_200_OK
+        )
         results = permission_list_response.data
 
         # As an editor of the asset, `someuser` should see all.
@@ -209,7 +234,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
                     object_permission.permission.codename,
                 )
             )
-        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
+        obj_perms = sorted(
+            obj_perms, key=lambda element: (element[0], element[1])
+        )
 
         self.assertEqual(expected_perms, obj_perms)
 
@@ -218,7 +245,9 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         permission_list_response = self.client.get(
             self.get_asset_perm_assignment_list_url(self.asset), format='json'
         )
-        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            permission_list_response.status_code, status.HTTP_200_OK
+        )
         admin = self.admin
         admin_perms = self.asset.get_perms(admin)
         anon = get_anonymous_user()
@@ -240,10 +269,15 @@ class ApiAssetPermissionListTestCase(BaseApiAssetPermissionTestCase):
         for assignment in results:
             object_permission = self.url_to_obj(assignment.get('url'))
             obj_perms.append(
-                (object_permission.user.username, object_permission.permission.codename)
+                (
+                    object_permission.user.username,
+                    object_permission.permission.codename,
+                )
             )
 
-        obj_perms = sorted(obj_perms, key=lambda element: (element[0], element[1]))
+        obj_perms = sorted(
+            obj_perms, key=lambda element: (element[0], element[1])
+        )
         self.assertEqual(expected_perms, obj_perms)
 
 
@@ -315,12 +349,17 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         permission_list_response = self.client.get(
             self.get_asset_perm_assignment_list_url(self.asset), format='json'
         )
-        self.assertEqual(permission_list_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            permission_list_response.status_code, status.HTTP_200_OK
+        )
 
         response = self._assign_perms_as_logged_in_user(
             [
                 ('someuser', PERM_VIEW_ASSET),
-                ('someuser', PERM_VIEW_ASSET),  # Add a duplicate which should not count
+                (
+                    'someuser',
+                    PERM_VIEW_ASSET,
+                ),  # Add a duplicate which should not count
                 ('anotheruser', PERM_CHANGE_ASSET),
             ]
         )
@@ -335,7 +374,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         )
         self.assertListEqual(
             sorted(
-                assigned_obj_perms.values_list('user__username', 'permission__codename')
+                assigned_obj_perms.values_list(
+                    'user__username', 'permission__codename'
+                )
             ),
             sorted(
                 [
@@ -421,8 +462,12 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
             ]
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(self.asset.has_perm(self.anotheruser, PERM_CHANGE_ASSET))
-        self.assertTrue(self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS))
+        self.assertTrue(
+            self.asset.has_perm(self.anotheruser, PERM_CHANGE_ASSET)
+        )
+        self.assertTrue(
+            self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
+        )
 
     def test_submission_assignments_ignored_for_non_survey_assets(self):
         self.asset.asset_type = ASSET_TYPE_TEMPLATE
@@ -434,7 +479,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
             ]
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertFalse(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS)
+        )
         self.assertFalse(
             self.asset.has_perm(self.anotheruser, PERM_VALIDATE_SUBMISSIONS)
         )
@@ -469,7 +516,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         self.asset.assign_perm(
             users['zariah'],
             PERM_PARTIAL_SUBMISSIONS,
-            partial_perms={PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'zariah'}]},
+            partial_perms={
+                PERM_DELETE_SUBMISSIONS: [{'_submitted_by': 'zariah'}]
+            },
         )
         assert self.asset.asset_partial_permissions.get(
             user__username='zariah'
@@ -488,7 +537,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 'partial_permissions': [
                     {
                         'url': PERM_VIEW_SUBMISSIONS,
-                        'filters': [{'_submitted_by': {'$in': ['simone', 'zariah']}}],
+                        'filters': [
+                            {'_submitted_by': {'$in': ['simone', 'zariah']}}
+                        ],
                     },
                     {
                         'url': PERM_DELETE_SUBMISSIONS,
@@ -507,7 +558,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             },
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
             kwargs={'parent_lookup_asset': self.asset.uid},
@@ -553,7 +606,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
             kwargs={'parent_lookup_asset': self.asset.uid},
@@ -561,11 +616,15 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         # Perform bulk assignment twice to check permission-difference
         # optimization logic
         for _ in range(2):
-            response = self.client.post(bulk_endpoint, assignments, format='json')
+            response = self.client.post(
+                bulk_endpoint, assignments, format='json'
+            )
             assert response.status_code == status.HTTP_200_OK
             assert self.asset.asset_partial_permissions.get(
                 user__username='someuser'
-            ).permissions == {PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}]}
+            ).permissions == {
+                PERM_VIEW_SUBMISSIONS: [{'_submitted_by': 'someuser'}]
+            }
             # `someuser` should have received the implied `view_asset`
             # permission
             assert self.someuser.has_perm(PERM_VIEW_ASSET, self.asset)
@@ -575,8 +634,12 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         get_anonymous_user()
 
         # Ensure someuser and anotheruser do not have 'view_submissions' on `self.asset`
-        self.assertFalse(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
-        self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS)
+        )
+        self.assertFalse(
+            self.asset.has_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
+        )
 
         # Allow someuser and anotheruser to view submissions
         good_assignments = [
@@ -590,7 +653,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
             },
         ]
 
-        assignments = self.translate_usernames_and_codenames_to_urls(good_assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            good_assignments
+        )
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
             kwargs={'parent_lookup_asset': self.asset.uid},
@@ -599,12 +664,20 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
         # Everything worked as expected, someuser and anotheruser got 'view_submissions'
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS))
-        self.assertTrue(self.asset.has_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS))
+        self.assertTrue(
+            self.asset.has_perm(self.someuser, PERM_VIEW_SUBMISSIONS)
+        )
+        self.assertTrue(
+            self.asset.has_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
+        )
 
         # but do not have respectively 'delete_submissions' and 'change_submissions'
-        self.assertFalse(self.asset.has_perm(self.someuser, PERM_DELETE_SUBMISSIONS))
-        self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.someuser, PERM_DELETE_SUBMISSIONS)
+        )
+        self.assertFalse(
+            self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
+        )
 
         bad_assignments = [
             {
@@ -620,7 +693,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 'permission': PERM_CHANGE_SUBMISSIONS,
             },
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(bad_assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            bad_assignments
+        )
 
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
@@ -632,11 +707,15 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
         # Ensure that someuser and anotheruser did not get any other permissions
         # than the one they already had, i.e.: 'view_submissions'.
-        self.assertFalse(self.asset.has_perm(self.someuser, PERM_DELETE_SUBMISSIONS))
-        self.assertFalse(self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS))
+        self.assertFalse(
+            self.asset.has_perm(self.someuser, PERM_DELETE_SUBMISSIONS)
+        )
+        self.assertFalse(
+            self.asset.has_perm(self.anotheruser, PERM_CHANGE_SUBMISSIONS)
+        )
 
-    # TODO
-    def xtest_partial_permission_no_duplicate_with_simple_filter(self):
+    @pytest.mark.skip(reason="TODO")
+    def test_partial_permission_no_duplicate_with_simple_filter(self):
         assignments = [
             {
                 'user': 'someuser',
@@ -657,7 +736,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
 
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
@@ -691,8 +772,8 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
         assert expected == returned_partial_perms
 
-    # TODO
-    def xtest_partial_permission_no_duplicate_with_complex_OR_filters(self):
+    @pytest.mark.skip(reason="TODO")
+    def test_partial_permission_no_duplicate_with_complex_OR_filters(self):
         assignments = [
             {
                 'user': 'someuser',
@@ -713,7 +794,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
 
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
@@ -747,8 +830,8 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
 
         assert expected == returned_partial_perms
 
-    # TODO
-    def xtest_partial_permission_no_duplicate_with_complex_AND_filters(self):
+    @pytest.mark.skip(reason="TODO")
+    def test_partial_permission_no_duplicate_with_complex_AND_filters(self):
         assignments = [
             {
                 'user': 'someuser',
@@ -779,7 +862,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
 
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),
@@ -798,19 +883,28 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 'url': f'http://testserver/api/v2/permissions/{PERM_VIEW_SUBMISSIONS}/',
                 'filters': [
                     [{'_submitted_by': 'someuser'}],
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                    [
+                        {'my_question': 'my_response1'},
+                        {'my_question2': 'my_response2'},
+                    ],
                 ],
             },
             {
                 'url': f'http://testserver/api/v2/permissions/{PERM_DELETE_SUBMISSIONS}/',
                 'filters': [
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                    [
+                        {'my_question': 'my_response1'},
+                        {'my_question2': 'my_response2'},
+                    ],
                 ],
             },
             {
                 'url': f'http://testserver/api/v2/permissions/{PERM_VALIDATE_SUBMISSIONS}/',
                 'filters': [
-                    [{'my_question': 'my_response1'}, {'my_question2': 'my_response2'}],
+                    [
+                        {'my_question': 'my_response1'},
+                        {'my_question2': 'my_response2'},
+                    ],
                 ],
             },
         ]
@@ -832,7 +926,9 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
                 ],
             }
         ]
-        assignments = self.translate_usernames_and_codenames_to_urls(assignments)
+        assignments = self.translate_usernames_and_codenames_to_urls(
+            assignments
+        )
 
         bulk_endpoint = reverse(
             self._get_endpoint('asset-permission-assignment-bulk-assignments'),

--- a/kpi/tests/test_mongo_helper.py
+++ b/kpi/tests/test_mongo_helper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import copy
+
+from django.conf import settings
+from django.test import TestCase
+from model_bakery import baker
+
+from kpi.tests.utils import baker_generators  # noqa
+from kpi.utils.mongo_helper import MongoHelper
+
+
+class MongoHelperTestCase(TestCase):
+    def setUp(self):
+        settings.MONGO_DB.instances.drop()
+
+    def add_submissions(self, asset, submissions: list[dict]):
+        for submission in submissions:
+            submission['__version__'] = asset.latest_deployed_version.uid
+        asset.deployment.mock_submissions(copy.deepcopy(submissions), flush_db=False)
+
+    def assert_instances_count(self, instances: tuple, expected_count: int):
+        assert instances[1] == expected_count
+
+    def test_get_instances(self):
+        users = baker.make('auth.User', _quantity=2)
+        assets = []
+        for user in users:
+            asset = baker.make('kpi.Asset', owner=user)
+            asset.deploy(backend='mock', active=True)
+            assets.append(asset)
+        (asset1, asset2) = assets
+        userform_id1 = asset1.deployment.mongo_userform_id
+        userform_id2 = asset2.deployment.mongo_userform_id
+
+        # No submissions
+        self.assert_instances_count(MongoHelper.get_instances(userform_id1), 0)
+
+        submissions = [
+            {
+                'q1': 'a1',
+            },
+            {
+                'q2': 'a2',
+            },
+        ]
+        self.add_submissions(asset1, submissions)
+        self.add_submissions(asset2, submissions)
+
+        self.assert_instances_count(MongoHelper.get_instances(userform_id1), 2)
+        self.assert_instances_count(MongoHelper.get_instances(userform_id2), 2)
+        self.assert_instances_count(
+            MongoHelper.get_instances(userform_id1, query={'q1': 'a1'}), 1
+        )
+        self.assert_instances_count(
+            MongoHelper.get_instances(userform_id1, query={'expect': 'nothing'}), 0
+        )

--- a/kpi/tests/test_mongo_helper.py
+++ b/kpi/tests/test_mongo_helper.py
@@ -17,7 +17,9 @@ class MongoHelperTestCase(TestCase):
     def add_submissions(self, asset, submissions: list[dict]):
         for submission in submissions:
             submission['__version__'] = asset.latest_deployed_version.uid
-        asset.deployment.mock_submissions(copy.deepcopy(submissions), flush_db=False)
+        asset.deployment.mock_submissions(
+            copy.deepcopy(submissions), flush_db=False
+        )
 
     def assert_instances_count(self, instances: tuple, expected_count: int):
         assert instances[1] == expected_count
@@ -53,5 +55,8 @@ class MongoHelperTestCase(TestCase):
             MongoHelper.get_instances(userform_id1, query={'q1': 'a1'}), 1
         )
         self.assert_instances_count(
-            MongoHelper.get_instances(userform_id1, query={'expect': 'nothing'}), 0
+            MongoHelper.get_instances(
+                userform_id1, query={'expect': 'nothing'}
+            ),
+            0,
         )

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Union
+from typing import Optional, Union
 
 from django.conf import settings
 
@@ -17,6 +17,7 @@ def drop_mock_only(func):
     in a testing environment. It ensures that MockMongo is used and no prodction
     data is deleted
     """
+
     def _inner(*args, **kwargs):
         # Ensure we are using MockMongo before deleting data
         mongo_db_driver__repr = repr(settings.MONGO_DB)
@@ -85,7 +86,7 @@ class MongoHelper:
     def delete(cls, mongo_userform_id: str, submission_ids: list):
         query = {
             '_id': {cls.IN_OPERATOR: submission_ids},
-            cls.USERFORM_ID: mongo_userform_id
+            cls.USERFORM_ID: mongo_userform_id,
         }
         delete_counts = settings.MONGO_DB.instances.delete_many(query)
 
@@ -114,7 +115,8 @@ class MongoHelper:
             fields={'_id': 1},
             query=query,
             submission_ids=submission_ids,
-            permission_filters=permission_filters)
+            permission_filters=permission_filters,
+        )
 
         return total_count
 
@@ -124,11 +126,11 @@ class MongoHelper:
         mongo_userform_id,
         start=None,
         limit=None,
-        sort=None,
-        fields=None,
-        query=None,
-        submission_ids=None,
-        permission_filters=None,
+        sort: Optional[dict] = None,
+        fields: Optional[dict] = None,
+        query: Optional[dict] = None,
+        submission_ids: Optional[list] = None,
+        permission_filters: Optional[list] = None,
         skip_count=False,
     ):
         cursor, total_count = cls._get_cursor_and_count(
@@ -144,7 +146,7 @@ class MongoHelper:
         if limit is not None:
             cursor.limit(limit)
 
-        if len(sort) == 1:
+        if sort is not None and len(sort) == 1:
             sort = MongoHelper.to_safe_dict(sort, reading=True)
             sort_key = list(sort.keys())[0]
             sort_dir = int(sort[sort_key])  # -1 for desc, 1 for asc
@@ -184,10 +186,11 @@ class MongoHelper:
         """
 
         for key, value in list(d.items()):
-            if type(value) == list:
-                value = [cls.to_readable_dict(e)
-                         if type(e) == dict else e for e in value]
-            elif type(value) == dict:
+            if isinstance(value, list):
+                value = [
+                    cls.to_readable_dict(e) if isinstance(e, dict) else e for e in value
+                ]
+            elif isinstance(value, dict):
                 value = cls.to_readable_dict(value)
 
             if cls._is_attribute_encoded(key):
@@ -232,10 +235,12 @@ class MongoHelper:
                 }
         """
         for key, value in list(d.items()):
-            if type(value) == list:
-                value = [cls.to_safe_dict(e, reading=reading)
-                         if type(e) == dict else e for e in value]
-            elif type(value) == dict:
+            if isinstance(value, list):
+                value = [
+                    cls.to_safe_dict(e, reading=reading) if isinstance(e, dict) else e
+                    for e in value
+                ]
+            elif isinstance(value, dict):
                 value = cls.to_safe_dict(value, reading=reading)
             elif key == '_id':
                 try:
@@ -248,10 +253,10 @@ class MongoHelper:
                 # If we want to write into Mongo, we need to transform the dot delimited string into a dict
                 # Otherwise, for reading, Mongo query engine reads dot delimited string as a nested object.
                 # Drawback, if a user uses a reserved property with dots, it will be converted as well.
-                if not reading and key.count(".") > 0:
+                if not reading and key.count('.') > 0:
                     tree = {}
                     t = tree
-                    parts = key.split(".")
+                    parts = key.split('.')
                     last_index = len(parts) - 1
                     for index, part in enumerate(parts):
                         v = value if index == last_index else {}
@@ -273,34 +278,8 @@ class MongoHelper:
         return d
 
     @classmethod
-    def encode(cls, key):
-        """
-        Replace characters not allowed in Mongo keys with their base64-encoded
-        representations
-
-        :param key: string
-        :return: string
-        """
-        for pattern, repl in cls.ENCODING_SUBSTITUTIONS:
-            key = re.sub(pattern, repl, key)
-        return key
-
-    @classmethod
-    def decode(cls, key):
-        """
-        Replace base64-encoded characters not allowed in Mongo keys with their
-        original representations
-
-        :param key: string
-        :return: string
-        """
-        for pattern, repl in cls.DECODING_SUBSTITUTIONS:
-            key = re.sub(pattern, repl, key)
-        return key
-
-    @classmethod
     def get_permission_filters_query(
-        cls, query: dict, permission_filters: Union[dict, list]
+        cls, query: dict, permission_filters: Optional[Union[dict, list]]
     ) -> dict:
         if permission_filters is None:
             return query
@@ -315,39 +294,25 @@ class MongoHelper:
                         {cls.OR_OPERATOR: permission_filter}
                     )
                 else:
-                    permission_filters_query[cls.OR_OPERATOR].append(
-                        permission_filter
-                    )
+                    permission_filters_query[cls.OR_OPERATOR].append(permission_filter)
 
         return {cls.AND_OPERATOR: [query, permission_filters_query]}
-
-    @classmethod
-    def is_attribute_invalid(cls, key):
-        """
-        Checks if an attribute can't be passed to Mongo as is.
-        :param key:
-        :return:
-        """
-        return (
-            key not in cls.KEY_WHITELIST
-            and (key.startswith('$') or key.count('.') > 0)
-        )
 
     @classmethod
     def _get_cursor_and_count(
         cls,
         mongo_userform_id,
-        fields=None,
-        query=None,
-        submission_ids=None,
+        fields: Optional[dict] = None,
+        query: Optional[dict] = None,
+        submission_ids: Optional[list] = None,
         permission_filters=None,
         skip_count=False,
     ):
+        if query is None:
+            query = {}
 
-        if len(submission_ids) > 0:
-            query.update({
-                '_id': {cls.IN_OPERATOR: submission_ids}
-            })
+        if submission_ids is not None and len(submission_ids) > 0:
+            query.update({'_id': {cls.IN_OPERATOR: submission_ids}})
 
         query.update({cls.USERFORM_ID: mongo_userform_id})
 
@@ -357,13 +322,12 @@ class MongoHelper:
 
         query = cls.to_safe_dict(query, reading=True)
 
-        if len(fields) > 0:
+        if fields is not None and len(fields) > 0:
             # Retrieve only specified fields from Mongo. Remove
             # `cls.USERFORM_ID` from those fields in case users try to add it.
             if cls.USERFORM_ID in fields:
                 fields.remove(cls.USERFORM_ID)
-            fields_to_select = dict(
-                [(cls.encode(field), 1) for field in fields])
+            fields_to_select = dict([(cls.encode(field), 1) for field in fields])
         else:
             # Retrieve all fields except `cls.USERFORM_ID`
             fields_to_select = {cls.USERFORM_ID: 0}
@@ -386,8 +350,9 @@ class MongoHelper:
         :param key: string
         :return: string
         """
-        return key not in cls.KEY_WHITELIST and (key.startswith('JA==') or
-                                                 key.count('Lg==') > 0)
+        return key not in cls.KEY_WHITELIST and (
+            key.startswith('JA==') or key.count('Lg==') > 0
+        )
 
     @staticmethod
     def _is_nested_reserved_attribute(key):
@@ -398,6 +363,6 @@ class MongoHelper:
         :return: boolean
         """
         for reserved_attribute in NESTED_MONGO_RESERVED_ATTRIBUTES:
-            if key.startswith("{}.".format(reserved_attribute)):
+            if key.startswith('{}.'.format(reserved_attribute)):
                 return True
         return False

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -188,7 +188,8 @@ class MongoHelper:
         for key, value in list(d.items()):
             if isinstance(value, list):
                 value = [
-                    cls.to_readable_dict(e) if isinstance(e, dict) else e for e in value
+                    cls.to_readable_dict(e) if isinstance(e, dict) else e
+                    for e in value
                 ]
             elif isinstance(value, dict):
                 value = cls.to_readable_dict(value)
@@ -237,7 +238,9 @@ class MongoHelper:
         for key, value in list(d.items()):
             if isinstance(value, list):
                 value = [
-                    cls.to_safe_dict(e, reading=reading) if isinstance(e, dict) else e
+                    cls.to_safe_dict(e, reading=reading)
+                    if isinstance(e, dict)
+                    else e
                     for e in value
                 ]
             elif isinstance(value, dict):
@@ -294,7 +297,9 @@ class MongoHelper:
                         {cls.OR_OPERATOR: permission_filter}
                     )
                 else:
-                    permission_filters_query[cls.OR_OPERATOR].append(permission_filter)
+                    permission_filters_query[cls.OR_OPERATOR].append(
+                        permission_filter
+                    )
 
         return {cls.AND_OPERATOR: [query, permission_filters_query]}
 
@@ -327,7 +332,9 @@ class MongoHelper:
             # `cls.USERFORM_ID` from those fields in case users try to add it.
             if cls.USERFORM_ID in fields:
                 fields.remove(cls.USERFORM_ID)
-            fields_to_select = dict([(cls.encode(field), 1) for field in fields])
+            fields_to_select = dict(
+                [(cls.encode(field), 1) for field in fields]
+            )
         else:
             # Retrieve all fields except `cls.USERFORM_ID`
             fields_to_select = {cls.USERFORM_ID: 0}

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -184,13 +184,18 @@ class AssetPermissionAssignmentViewSet(
         :return: JSON
         """
         serializer = AssetBulkInsertPermissionSerializer(
-            data={'assignments': request.data}, context=self.get_serializer_context()
+            data={'assignments': request.data},
+            context=self.get_serializer_context(),
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return self.list(request, *args, **kwargs)
 
-    @action(detail=False, methods=['PATCH'], renderer_classes=[renderers.JSONRenderer])
+    @action(
+        detail=False,
+        methods=['PATCH'],
+        renderer_classes=[renderers.JSONRenderer],
+    )
     def clone(self, request, *args, **kwargs):
         source_asset_uid = self.request.data[CLONE_ARG_NAME]
         source_asset = get_object_or_404(Asset, uid=source_asset_uid)
@@ -257,7 +262,9 @@ class AssetPermissionAssignmentViewSet(
         return context_
 
     def get_queryset(self):
-        return get_user_permission_assignments_queryset(self.asset, self.request.user)
+        return get_user_permission_assignments_queryset(
+            self.asset, self.request.user
+        )
 
     def perform_create(self, serializer):
         serializer.save(asset=self.asset)

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -1,11 +1,14 @@
 # coding: utf-8
-from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as t
-from rest_framework import exceptions, viewsets, status, renderers
+from rest_framework import exceptions, renderers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin, \
-    DestroyModelMixin, ListModelMixin
+from rest_framework.mixins import (
+    CreateModelMixin,
+    DestroyModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+)
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -27,13 +30,19 @@ from kpi.utils.object_permission import (
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
 
-class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
-                                       NestedViewSetMixin,
-                                       CreateModelMixin, RetrieveModelMixin,
-                                       DestroyModelMixin, ListModelMixin,
-                                       viewsets.GenericViewSet):
+class AssetPermissionAssignmentViewSet(
+    AssetNestedObjectViewsetMixin,
+    NestedViewSetMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    DestroyModelMixin,
+    ListModelMixin,
+    viewsets.GenericViewSet,
+):
     """
     ## Permission assignments of an asset
+
+    **Important**: partial_permissions section of API is not stable and may change without notice.
 
     This endpoint shows assignments on an asset. An assignment implies:
 
@@ -154,15 +163,19 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
     """
 
     model = ObjectPermission
-    lookup_field = "uid"
+    lookup_field = 'uid'
     serializer_class = AssetPermissionAssignmentSerializer
     permission_classes = (AssetPermissionAssignmentPermission,)
     pagination_class = None
     # filter_backends = Just kidding! Look at this instead:
     #     kpi.utils.object_permission.get_user_permission_assignments_queryset
 
-    @action(detail=False, methods=['POST'], renderer_classes=[renderers.JSONRenderer],
-            url_path='bulk')
+    @action(
+        detail=False,
+        methods=['POST'],
+        renderer_classes=[renderers.JSONRenderer],
+        url_path='bulk',
+    )
     def bulk_assignments(self, request, *args, **kwargs):
         """
         Assigns all permissions at once for the same asset.
@@ -171,27 +184,29 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
         :return: JSON
         """
         serializer = AssetBulkInsertPermissionSerializer(
-            data={'assignments': request.data},
-            context=self.get_serializer_context()
+            data={'assignments': request.data}, context=self.get_serializer_context()
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return self.list(request, *args, **kwargs)
 
-    @action(detail=False, methods=['PATCH'],
-            renderer_classes=[renderers.JSONRenderer])
+    @action(detail=False, methods=['PATCH'], renderer_classes=[renderers.JSONRenderer])
     def clone(self, request, *args, **kwargs):
-
         source_asset_uid = self.request.data[CLONE_ARG_NAME]
         source_asset = get_object_or_404(Asset, uid=source_asset_uid)
         user = request.user
 
-        if user.has_perm(PERM_MANAGE_ASSET, self.asset) and \
-                user.has_perm(PERM_VIEW_ASSET, source_asset):
+        if user.has_perm(PERM_MANAGE_ASSET, self.asset) and user.has_perm(
+            PERM_VIEW_ASSET, source_asset
+        ):
             if not self.asset.copy_permissions_from(source_asset):
                 http_status = status.HTTP_400_BAD_REQUEST
-                response = {'detail': t("Source and destination objects don't "
-                                        "seem to have the same type")}
+                response = {
+                    'detail': t(
+                        "Source and destination objects don't "
+                        'seem to have the same type'
+                    )
+                }
                 return Response(response, status=http_status)
         else:
             raise exceptions.PermissionDenied()
@@ -216,9 +231,10 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
         ):
             raise exceptions.PermissionDenied()
         elif user.pk == self.asset.owner_id:
-            return Response({
-                'detail': t("Owner's permissions cannot be deleted")
-            }, status=status.HTTP_409_CONFLICT)
+            return Response(
+                {'detail': t("Owner's permissions cannot be deleted")},
+                status=status.HTTP_409_CONFLICT,
+            )
 
         codename = object_permission.permission.codename
         self.asset.remove_perm(user, codename)
@@ -232,16 +248,16 @@ class AssetPermissionAssignmentViewSet(AssetNestedObjectViewsetMixin,
         """
 
         context_ = super().get_serializer_context()
-        context_.update({
-            'asset_uid': self.asset.uid,
-            'asset': self.asset,
-        })
+        context_.update(
+            {
+                'asset_uid': self.asset.uid,
+                'asset': self.asset,
+            }
+        )
         return context_
 
     def get_queryset(self):
-        return get_user_permission_assignments_queryset(
-            self.asset, self.request.user
-        )
+        return get_user_permission_assignments_queryset(self.asset, self.request.user)
 
     def perform_create(self, serializer):
         serializer.save(asset=self.asset)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Formatters are optional, this configuration attempts to make as many
+# tools "just work" in a way compatible with kobo code standards
 [tool.black]
 # Do not enable `verbose = true` unless Black changes their behavior to respect
 # `--quiet` on the command line properly
@@ -9,11 +11,17 @@ profile = "black"
 known_first_party = "kobo"
 no_lines_before = ["LOCALFOLDER"]
 
+[tool.ruff]
+line-length = 80
 [tool.ruff.format]
-quote-style = "single"
+quote-style = "single"  # Preserve is coming soon to ruff
 [tool.ruff.lint]
+# Enable ruff isort
 extend-select = ["I"]
+[tool.ruff.lint.isort]
+known-first-party = ["kobo"]
 
+# Types are not enforced but are a good practice
 [tool.mypy]
 # Exclude virtual environment projects that cause mypy to error
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,19 @@ skip-string-normalization = true
 profile = "black"
 known_first_party = "kobo"
 no_lines_before = ["LOCALFOLDER"]
+
+[tool.ruff.format]
+quote-style = "single"
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.mypy]
+# Exclude virtual environment projects that cause mypy to error
+exclude = [
+    "src/django-digest",
+    "src/formpack",
+    "src/kobo-service-account",
+    "src/python-digest"
+]
+[tool.django-stubs]
+django_settings_module = "kobo.settings"


### PR DESCRIPTION
## Notes

This PR should contain no user facing changes. We need to rewrite a sizable portion of the affected files to support AND and OR in partial permissions. To make changes manageable, I split up the PR. This PR contains only lint, minor bug fixes, tests, and type corrections. All things that are only tangentially related to partial permissions. The partial permissions, partial rewrite is complex and functional types are key to successful implementation. Getting the linting done here will greatly simplify the job while keeping our PR diffs very readable.

-  Run linter on mongo helper and partial perm files
-  Add mypy and ruff pyproject settings
-  Refactor mongo helper default args, fix documented types
-  Add mongo helper unit test
-  Add partial perm unit tests (not all pass here, marked to not run)
-  Improve validation on asset permission assignment

While the majority of the changes are cosmetic, it contains some fixes and simplifications which could in theory introduce bugs that we don't have test coverage on.

Testing done: I created some shared partial permission in the existing UI and saw no error.

## Related issues

- Part of [TASK-402](https://www.notion.so/kobotoolbox/And-or-support-for-mongo-helper-and-partial-permissions-API-14c82b9c0d5d45c98bd3d011caa50b90)
- Partial replacement for https://github.com/kobotoolbox/kpi/pull/4757
- Replaces https://github.com/kobotoolbox/kpi/pull/4718 (close when merged)