### PR TITLE
Fix XLSX bulk library import, broken by #3765

### DIFF
--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -767,7 +767,7 @@ class AssetImportTaskTest(BaseTestCase):
         assert expected_content_settings == created_asset.content['settings']
         assert not created_asset.content['kobo--locking-profiles']
 
-    def test_import_library_bulk_xls(self):
+    def _test_import_library_bulk(self, filetype='xlsx'):
         library_sheet_content = [
             ['block', 'name', 'type', 'label', 'tag:subject:fungus', 'tag:subject:useless'],
             ['mushroom', 'cap', 'text', 'Describe the cap', '1', None],
@@ -785,14 +785,19 @@ class AssetImportTaskTest(BaseTestCase):
             ['seasons', 'fall', 'Fall'],
             ['seasons', 'winter', 'Winter'],
         ]
-
         content = (
             ('library', library_sheet_content),
             ('choices', choices_sheet_content),
         )
-        task_data = self._construct_xls_for_import(
-            content, name='Collection created from bulk library import'
-        )
+        name='Collection created from bulk library import'
+
+        if filetype ==  'xls':
+            task_data = self._construct_xls_for_import(content, name=name)
+        elif filetype == 'xlsx':
+            task_data = self._construct_xlsx_for_import(content, name=name)
+        else:
+            raise NotImplementedError(f'{filetype} must be either xls or xlsx')
+
         post_url = reverse('api_v2:importtask-list')
         response = self.client.post(post_url, task_data)
         assert response.status_code == status.HTTP_201_CREATED
@@ -887,6 +892,12 @@ class AssetImportTaskTest(BaseTestCase):
         self._assert_assets_contents_equal(
             tagged_as_useless[1], non_block_assets[1]
         )
+
+    def test_import_library_bulk_xls(self):
+        self._test_import_library_bulk('xls')
+
+    def test_import_library_bulk_xlsx(self):
+        self._test_import_library_bulk('xlsx')
 
     def test_import_asset_xls(self):
         xlsx_io = self.asset.to_xlsx_io()

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -48,6 +48,6 @@ def rename_xlsx_sheet(
         raise NoFromSheetError(from_sheet)
     book[from_sheet].title = to_sheet
     stream = BytesIO()
-    writable.save(stream)
+    book.save(stream)
     stream.seek(0)
     return stream

--- a/kpi/utils/rename_xls_sheet.py
+++ b/kpi/utils/rename_xls_sheet.py
@@ -1,9 +1,8 @@
 from io import BytesIO
 
 import openpyxl
-from xlutils.copy import copy
-from xlrd import open_workbook
-
+import xlrd
+import xlutils.copy
 
 class NoFromSheetError(Exception):
     pass
@@ -22,17 +21,17 @@ def rename_xls_sheet(
     sheet names in pyxform inputs;
     see https://github.com/XLSForm/pyxform/issues/229.
     """
-    readable = open_workbook(file_contents=xls_stream.read())
-    writable = copy(readable)
-    sheet_names = readable.sheet_names()
+    read_only_book = xlrd.open_workbook(file_contents=xls_stream.read())
+    book = xlutils.copy.copy(read_only_book)
+    sheet_names = read_only_book.sheet_names()
     if from_sheet in sheet_names and to_sheet in sheet_names:
         raise ConflictSheetError()
     if from_sheet not in sheet_names:
         raise NoFromSheetError(from_sheet)
     index = sheet_names.index(from_sheet)
-    writable.get_sheet(index).name = to_sheet
+    book.get_sheet(index).name = to_sheet
     stream = BytesIO()
-    writable.save(stream)
+    book.save(stream)
     stream.seek(0)
     return stream
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Corrects the `name 'writable' is not defined` error when attempting to upload bulk library items with an XLSX (Excel 2007+) file

## Notes

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/7-Kobo-UX.2FUI.2FProduct/topic/Library.20bulk.20imports/near/315222