### PR TITLE
Add AND/OR functionality to mongo helper permissions filters

### DIFF
--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 import re
-from typing import Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from django.conf import settings
 
 from kobo.celery import celery_app
 from kpi.constants import NESTED_MONGO_RESERVED_ATTRIBUTES
 from kpi.utils.strings import base64_encodestring
+
+PermissionFilter = Dict[str, Any]
 
 
 def drop_mock_only(func):
@@ -282,26 +284,49 @@ class MongoHelper:
 
     @classmethod
     def get_permission_filters_query(
-        cls, query: dict, permission_filters: Optional[Union[dict, list]]
-    ) -> dict:
+        cls,
+        query: dict,
+        permission_filters: Optional[
+            Union[PermissionFilter, list[PermissionFilter]]
+        ],
+    ) -> dict[str, list[dict]]:
         if permission_filters is None:
             return query
 
-        if len(permission_filters) == 1:
-            permission_filters_query = permission_filters[0]
-        else:
-            permission_filters_query = {cls.OR_OPERATOR: []}
-            for permission_filter in permission_filters:
-                if isinstance(permission_filter, list):
-                    permission_filters_query[cls.OR_OPERATOR].append(
-                        {cls.OR_OPERATOR: permission_filter}
-                    )
-                else:
-                    permission_filters_query[cls.OR_OPERATOR].append(
-                        permission_filter
-                    )
+        permission_filters_query = cls._convert_permissions(permission_filters)
 
         return {cls.AND_OPERATOR: [query, permission_filters_query]}
+
+    @classmethod
+    def _convert_permissions(
+        cls, input_data: Union[PermissionFilter, list[PermissionFilter]]
+    ) -> PermissionFilter:
+        """
+        Convert permissions to mongo readable perms
+
+        - list implies OR
+        - dict implies AND
+
+        Additional MongoHelper.KEY_WHITELIST data is accepted.
+
+        While this function is recursive, it is not tested nor intended to support
+        infinite nesting. Values inside of a dict are passed as is.
+        This will not work {"a": {"ba": "ca", "bb": "cb"}, {"c": "ca"}} inner dict
+        will not receive AND
+        """
+        if isinstance(input_data, list):
+            operator = (
+                cls.OR_OPERATOR if len(input_data) > 1 else cls.AND_OPERATOR
+            )
+            return {
+                operator: [
+                    cls._convert_permissions(item) for item in input_data
+                ]
+            }
+        elif isinstance(input_data, dict) and len(input_data) > 1:
+            return {cls.AND_OPERATOR: [{k: v} for k, v in input_data.items()]}
+        else:
+            return input_data
 
     @classmethod
     def _get_cursor_and_count(


### PR DESCRIPTION
## Notes

Changes the unstable partial permissions section of the asset permissions assignment API.

Rewrite and test MongoHelper.get_permission_filters_query to support both AND and OR. Prior behavior supported only OR. This should be a backwards compatible change.

## Related issues

Part of TASK-402
