### PR TITLE
Add Enterprise plans to kpi front-end, update Usage page

### DIFF
--- a/jsapp/js/account/plans/addOnList.component.tsx
+++ b/jsapp/js/account/plans/addOnList.component.tsx
@@ -118,7 +118,7 @@ const AddOnList = (props: {
                 {isSubscribedAddOnPrice(price) && (
                   <BillingButton
                     size={'m'}
-                    label={t('manage')}
+                    label={t('Manage')}
                     isDisabled={props.isBusy}
                     onClick={onClickManage}
                     isFullWidth
@@ -127,7 +127,7 @@ const AddOnList = (props: {
                 {!isSubscribedAddOnPrice(price) && (
                   <BillingButton
                     size={'m'}
-                    label={t('buy now')}
+                    label={t('Buy now')}
                     isDisabled={props.isBusy}
                     onClick={() => props.onClickBuy(price)}
                     isFullWidth

--- a/jsapp/js/account/plans/addOnList.module.scss
+++ b/jsapp/js/account/plans/addOnList.module.scss
@@ -1,8 +1,9 @@
 @use '~kobo-common/src/styles/colors';
 @use 'scss/breakpoints';
+@use 'scss/sizes';
 
 .header {
-  font-size: 1.125em;
+  font-size: sizes.$r18;
   font-weight: 700;
   color: colors.$kobo-storm;
   text-transform: uppercase;

--- a/jsapp/js/account/plans/addOnList.module.scss
+++ b/jsapp/js/account/plans/addOnList.module.scss
@@ -15,18 +15,22 @@
 
 .table {
   table-layout: fixed;
-  border-collapse: separate;
-  border-spacing: 1em;
+  border-collapse: collapse;
+  border-spacing: 0;
+
+  & tr {
+    border-top: 1px solid colors.$kobo-cloud;
+
+    &:last-child {
+      border-bottom: 1px solid colors.$kobo-cloud;
+    }
+  }
 
   & td {
-    padding-block: 0.5em;
+    padding-block: 1em;
     font-weight: 700;
     overflow: hidden;
   }
-}
-
-.row:first-child > td:not(:last-child) {
-  border-top: 1px solid colors.$kobo-cloud;
 }
 
 .product,

--- a/jsapp/js/account/plans/billingButton.module.scss
+++ b/jsapp/js/account/plans/billingButton.module.scss
@@ -2,5 +2,4 @@
   display: flex;
   justify-content: center;
   font-weight: 700;
-  text-transform: uppercase;
 }

--- a/jsapp/js/account/plans/confirmChangeModal.module.scss
+++ b/jsapp/js/account/plans/confirmChangeModal.module.scss
@@ -1,5 +1,3 @@
-@use 'scss/sizes';
-
 .loading {
   display: flex;
   flex-direction: column;

--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -242,7 +242,7 @@ export default function Plan() {
   useEffect(() => {
     if (
       state.organization &&
-      state.organization.owner !== session.currentAccount.username
+      state.organization.owner_username !== session.currentAccount.username
     ) {
       setIsUnauthorized(true);
     }

--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -44,6 +44,7 @@ import ConfirmChangeModal from 'js/account/plans/confirmChangeModal.component';
 import {PlanButton} from 'js/account/plans/planButton.component';
 import Session from 'js/stores/session';
 import InlineMessage from 'js/components/common/inlineMessage';
+import {PriceDisplay} from 'js/account/plans/priceDisplay.component';
 
 interface PlanState {
   subscribedProduct: null | SubscriptionInfo[];
@@ -619,15 +620,7 @@ export default function Plan() {
                           ? price.name
                           : freeTierOverride?.name || price.name}
                       </h1>
-                      <div className={styles.priceTitle}>
-                        {!price.prices?.unit_amount
-                          ? t('Free')
-                          : price.prices?.recurring?.interval === 'year'
-                          ? `$${(price.prices?.unit_amount / 100 / 12).toFixed(
-                              2
-                            )} USD/month`
-                          : price.prices.human_readable_price}
-                      </div>
+                      <PriceDisplay price={price.prices} />
                       <ul className={styles.featureContainer}>
                         {Object.keys(price.metadata).map(
                           (featureItem: string) =>

--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -307,12 +307,20 @@ export default function Plan() {
   // by default, only products without a `plan_type` metadata value will be shown
   useEffect(() => {
     const plansToShow = searchParams.get('type');
-    if (plansToShow) {
+    // if the user is already on the enterprise plan, *only* show the enterprise plan(s)
+    if (
+      activeSubscriptions?.find(
+        (sub) =>
+          sub.items?.[0].price.product.metadata?.plan_type === 'enterprise'
+      )
+    ) {
+      setVisiblePlanTypes(['enterprise']);
+    } else if (plansToShow) {
       setVisiblePlanTypes(plansToShow.split(','));
     } else {
       setVisiblePlanTypes(['default']);
     }
-  }, [searchParams]);
+  }, [searchParams, activeSubscriptions]);
 
   // should we show the 'Contact us' sidebar and storage add-ons?
   const shouldShowExtras = useMemo(
@@ -347,7 +355,7 @@ export default function Plan() {
       return filterAmount.filter((price) => price.prices);
     }
     return [];
-  }, [state.products, state.intervalFilter]);
+  }, [state.products, state.intervalFilter, visiblePlanTypes]);
 
   const getSubscribedProduct = useCallback(getSubscriptionsForProductId, []);
 
@@ -612,18 +620,19 @@ export default function Plan() {
                         <hr />
                         {state.featureTypes.map((type, index, array) => {
                           const featureItem = getListItem(type, price.name);
-                            return (
-                              featureItem.length > 0 && [
-                                returnListItem(
-                                  type,
-                                  price.name,
-                                  price.metadata[`feature_${type}_title`]
-                                ),
-                                index !== array.length - 1 && <hr key={`hr-${type}`} />,
-                              ]
-                            );
-                          })
-                        }
+                          return (
+                            featureItem.length > 0 && [
+                              returnListItem(
+                                type,
+                                price.name,
+                                price.metadata[`feature_${type}_title`]
+                              ),
+                              index !== array.length - 1 && (
+                                <hr key={`hr-${type}`} />
+                              ),
+                            ]
+                          );
+                        })}
                       </div>
                     )}
                     <PlanButton

--- a/jsapp/js/account/plans/plan.module.scss
+++ b/jsapp/js/account/plans/plan.module.scss
@@ -22,6 +22,7 @@
 .sticky {
   position: fixed;
   z-index: 10;
+  height: 5em;
 }
 
 .unauthorized {

--- a/jsapp/js/account/plans/plan.module.scss
+++ b/jsapp/js/account/plans/plan.module.scss
@@ -19,6 +19,15 @@
   cursor: wait;
 }
 
+.sticky {
+  position: fixed;
+  z-index: 10;
+}
+
+.unauthorized {
+  opacity: 50%;
+}
+
 .allPlans {
   column-gap: sizes.$x20;
   display: flex;
@@ -41,6 +50,10 @@
 .intervalToggle input[type='radio'] {
   display: none;
   appearance: none;
+
+  &[aria-disabled=true] + label {
+    pointer-events: none;
+  }
 }
 
 .intervalToggle label {
@@ -58,22 +71,22 @@
   background-color: colors.$kobo-blue;
   color: colors.$kobo-white;
   border-radius: sizes.$x4;
-}
 
-.intervalToggle input[type='radio']:checked + label:after {
-  background-color: colors.$kobo-blue;
-  padding: sizes.$x8 sizes.$x12;
-}
+  &:after {
+    background-color: colors.$kobo-blue;
+    padding: sizes.$x8 sizes.$x12;
+  }
 
-.intervalToggle input[type='radio']:checked + label:before {
-  width: sizes.$x20;
-  height: sizes.$x20;
-  color: colors.$kobo-cloud;
-  padding: sizes.$x8 sizes.$x12;
-}
+  &:before {
+    width: sizes.$x20;
+    height: sizes.$x20;
+    color: colors.$kobo-cloud;
+    padding: sizes.$x8 sizes.$x12;
+  }
 
-.intervalToggle input[type='radio']:checked + label:hover {
-  background-color: color.adjust(colors.$kobo-blue, $lightness: -5%);
+  &:hover {
+      background-color: color.adjust(colors.$kobo-blue, $lightness: -5%);
+  }
 }
 
 .intervalToggle input[type='radio'] + label:hover {

--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -1,0 +1,254 @@
+import classnames from 'classnames';
+import styles from 'js/account/plans/plan.module.scss';
+import {PriceDisplay} from 'js/account/plans/priceDisplay.component';
+import Icon from 'js/components/common/icon';
+import {PlanButton} from 'js/account/plans/planButton.component';
+import React, {useCallback, useState} from 'react';
+import {BasePrice, Price, SubscriptionInfo} from 'js/account/stripe.types';
+import {FreeTierOverride, PlanState} from 'js/account/plans/plan.component';
+import {
+  getSubscriptionsForProductId,
+  isChangeScheduled,
+} from 'js/account/stripe.utils';
+import TextBox from 'js/components/common/textBox';
+
+const MAX_SUBMISSION_PURCHASE = 10000000;
+
+interface PlanContainerProps {
+  price: Price;
+  isDisabled: boolean;
+  isSubscribedProduct: (product: Price) => boolean;
+  freeTierOverride: FreeTierOverride | null;
+  expandComparison: boolean;
+  state: PlanState;
+  filterPrices: Price[];
+  setIsBusy: (isBusy: boolean) => void;
+  hasManageableStatus: (sub: SubscriptionInfo) => boolean;
+  buySubscription: (price: BasePrice) => void;
+  activeSubscriptions: SubscriptionInfo[];
+}
+
+export const PlanContainer = ({
+  price,
+  state,
+  freeTierOverride,
+  expandComparison,
+  filterPrices,
+  isDisabled,
+  setIsBusy,
+  hasManageableStatus,
+  isSubscribedProduct,
+  buySubscription,
+  activeSubscriptions,
+}: PlanContainerProps) => {
+  const [submissionQuantity, setSubmissionQuantity] = useState(1);
+  const [error, setError] = useState('');
+  const shouldShowManage = useCallback(
+    (product: Price) => {
+      const subscriptions = getSubscriptionsForProductId(
+        product.id,
+        state.subscribedProduct
+      );
+      if (!subscriptions || !subscriptions.length) {
+        return false;
+      }
+
+      const activeSubscription = subscriptions.find(
+        (subscription: SubscriptionInfo) => hasManageableStatus(subscription)
+      );
+      if (!activeSubscription) {
+        return false;
+      }
+
+      return isChangeScheduled(product.prices, [activeSubscription]);
+    },
+    [hasManageableStatus, state.subscribedProduct]
+  );
+
+  const getFeatureMetadata = (price: Price, featureItem: string) => {
+    if (
+      price.prices.unit_amount === 0 &&
+      freeTierOverride &&
+      freeTierOverride.hasOwnProperty(featureItem)
+    ) {
+      return freeTierOverride[featureItem as keyof FreeTierOverride];
+    }
+    return price.prices.metadata?.[featureItem] || price.metadata[featureItem];
+  };
+
+  const renderFeaturesList = (
+    items: Array<{
+      icon: 'positive' | 'positive_pro' | 'negative';
+      label: string;
+    }>,
+    title?: string
+  ) => (
+    <div key={title}>
+      <h2 className={styles.listTitle}>{title} </h2>
+      <ul>
+        {items.map((item) => (
+          <li key={item.label}>
+            <div className={styles.iconContainer}>
+              {item.icon !== 'negative' ? (
+                <Icon
+                  name='check'
+                  size='m'
+                  color={item.icon === 'positive_pro' ? 'teal' : 'storm'}
+                />
+              ) : (
+                <Icon name='close' size='m' color='red' />
+              )}
+            </div>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  // Get feature items and matching icon boolean
+  const getListItem = (listType: string, plan: string) => {
+    const listItems: Array<{icon: boolean; item: string}> = [];
+    filterPrices.map((price) =>
+      Object.keys(price.metadata).map((featureItem: string) => {
+        const numberItem = featureItem.lastIndexOf('_');
+        const currentResult = featureItem.substring(numberItem + 1);
+
+        const currentIcon = `feature_${listType}_check_${currentResult}`;
+        if (
+          featureItem.includes(`feature_${listType}_`) &&
+          !featureItem.includes(`feature_${listType}_check`) &&
+          price.name === plan
+        ) {
+          const keyName = `feature_${listType}_${currentResult}`;
+          let iconBool = false;
+          const itemName: string =
+            price.prices.metadata?.[keyName] || price.metadata[keyName];
+          if (price.metadata[currentIcon] !== undefined) {
+            iconBool = JSON.parse(price.metadata[currentIcon]);
+            listItems.push({icon: iconBool, item: itemName});
+          }
+        }
+      })
+    );
+    return listItems;
+  };
+
+  const returnListItem = (type: string, name: string, featureTitle: string) => {
+    const items: Array<{
+      icon: 'positive' | 'positive_pro' | 'negative';
+      label: string;
+    }> = [];
+    getListItem(type, name).map((listItem) => {
+      if (listItem.icon && name === 'Professional') {
+        items.push({icon: 'positive_pro', label: listItem.item});
+      } else if (!listItem.icon) {
+        items.push({icon: 'negative', label: listItem.item});
+      } else {
+        items.push({icon: 'positive', label: listItem.item});
+      }
+    });
+    return renderFeaturesList(items, featureTitle);
+  };
+
+  const onSubmissionsChange = (value: number) => {
+    if (value) {
+      setSubmissionQuantity(value);
+    }
+    if (value > MAX_SUBMISSION_PURCHASE) {
+      setError(
+        t(
+          'This plan only supports up to ##submissions## submissions per month. If your project needs more than that, please contact us about our Private Server options.'
+        ).replace('##submissions##', MAX_SUBMISSION_PURCHASE.toLocaleString())
+      );
+    } else {
+      if (error.length) {
+        setError('');
+      }
+    }
+  };
+
+  return (
+    <>
+      {isSubscribedProduct(price) ? (
+        <div className={styles.currentPlan}>{t('Your plan')}</div>
+      ) : (
+        <div />
+      )}
+      <div
+        className={classnames({
+          [styles.planContainerWithBadge]: isSubscribedProduct(price),
+          [styles.planContainer]: true,
+        })}
+      >
+        <h1 className={styles.priceName}>
+          {price.prices?.unit_amount
+            ? price.name
+            : freeTierOverride?.name || price.name}
+        </h1>
+        <PriceDisplay
+          price={price.prices}
+          submissionQuantity={submissionQuantity}
+        />
+        {price.prices.transform_quantity && (
+          <TextBox
+            label={t('Total Submissions per Month')}
+            errors={error.length ? error : false}
+            type={'number'}
+            onChange={onSubmissionsChange}
+            value={submissionQuantity.toString()}
+          />
+        )}
+        <ul className={styles.featureContainer}>
+          {Object.keys(price.metadata).map(
+            (featureItem: string) =>
+              featureItem.includes('feature_list_') && (
+                <li key={featureItem}>
+                  <div className={styles.iconContainer}>
+                    <Icon
+                      name='check'
+                      size='m'
+                      color={price.prices.unit_amount ? 'teal' : 'storm'}
+                    />
+                  </div>
+                  {getFeatureMetadata(price, featureItem)}
+                </li>
+              )
+          )}
+        </ul>
+        {expandComparison && (
+          <div className={styles.expandedContainer}>
+            <hr />
+            {state.featureTypes.map((type, index, array) => {
+              const featureItem = getListItem(type, price.name);
+              return (
+                featureItem.length > 0 && [
+                  returnListItem(
+                    type,
+                    price.name,
+                    price.metadata[`feature_${type}_title`]
+                  ),
+                  index !== array.length - 1 && <hr key={`hr-${type}`} />,
+                ]
+              );
+            })}
+          </div>
+        )}
+        <PlanButton
+          price={price}
+          downgrading={
+            activeSubscriptions?.length > 0 &&
+            activeSubscriptions?.[0].items?.[0].price.unit_amount >
+              price.prices.unit_amount
+          }
+          isSubscribedToPlan={isSubscribedProduct(price)}
+          buySubscription={buySubscription}
+          showManage={shouldShowManage(price)}
+          isBusy={isDisabled}
+          setIsBusy={setIsBusy}
+          organization={state.organization}
+        />
+      </div>
+    </>
+  );
+};

--- a/jsapp/js/account/plans/priceDisplay.component.tsx
+++ b/jsapp/js/account/plans/priceDisplay.component.tsx
@@ -1,0 +1,23 @@
+import styles from 'js/account/plans/plan.module.scss';
+import React from 'react';
+import {BasePrice} from 'js/account/stripe.types';
+
+interface PriceDisplayProps {
+  price: BasePrice;
+}
+
+export const PriceDisplay = ({price}: PriceDisplayProps) => {
+  let amount = '';
+  if (!price?.unit_amount) {
+    amount = t('Free');
+  } else if (price?.recurring?.interval === 'year') {
+    amount = t('$##price## USD/month').replace(
+      '##price##',
+      (price?.unit_amount / 100 / 12).toFixed(2)
+    );
+  } else {
+    amount = price.human_readable_price;
+  }
+
+  return <div className={styles.priceTitle}>{amount}</div>;
+};

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -163,7 +163,7 @@ export interface Organization {
   created: string;
   modified: string;
   slug: string;
-  owner: string;
+  owner_username: string;
 }
 
 export enum PlanNames {

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -158,6 +158,7 @@ export interface Organization {
   created: string;
   modified: string;
   slug: string;
+  owner: string;
 }
 
 export enum PlanNames {

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -164,13 +164,13 @@ export enum Limits {
   'unlimited' = 'unlimited',
 }
 
-type LimitAmount = number | Limits.unlimited;
+export type LimitAmount = number | 'unlimited';
 
 export interface AccountLimit {
-  submission_limit: LimitAmount | number;
-  nlp_seconds_limit: LimitAmount | number;
-  nlp_character_limit: LimitAmount | number;
-  storage_bytes_limit: LimitAmount | number;
+  submission_limit: LimitAmount;
+  nlp_seconds_limit: LimitAmount;
+  nlp_character_limit: LimitAmount;
+  storage_bytes_limit: LimitAmount;
 }
 
 export interface Product extends BaseProduct {

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -160,6 +160,15 @@ export interface Organization {
   slug: string;
 }
 
+export enum PlanNames {
+  'FREE' = 'Community',
+  'COMMUNITY' = 'Community',
+  'PRO' = 'Professional',
+  'ENTERPRISE' = 'Enterprise',
+  'ENTERPRISE_GOLD' = 'Enterprise Gold',
+  'ENTERPRISE_PLATINUM' = 'Enterprise Platinum',
+}
+
 export enum Limits {
   'unlimited' = 'unlimited',
 }

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -142,6 +142,11 @@ export interface BasePrice {
   };
   metadata: {[key: string]: string};
   product: BaseProduct;
+  billing_scheme: 'per_unit' | 'tiered' | null;
+  transform_quantity: null | {
+    round: 'up' | 'down';
+    divide_by: number;
+  };
 }
 
 export interface BaseSubscription {
@@ -166,8 +171,6 @@ export enum PlanNames {
   'COMMUNITY' = 'Community',
   'PRO' = 'Professional',
   'ENTERPRISE' = 'Enterprise',
-  'ENTERPRISE_GOLD' = 'Enterprise Gold',
-  'ENTERPRISE_PLATINUM' = 'Enterprise Platinum',
 }
 
 export enum Limits {

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -12,7 +12,6 @@ import UsageContainer, {
 import envStore from 'js/envStore';
 import {formatDate} from 'js/utils';
 import styles from './usage.module.scss';
-import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 import moment from 'moment';
@@ -118,7 +117,6 @@ export default function Usage() {
   return (
     <UsageContext.Provider value={usage}>
       <div className={styles.root}>
-        <LimitNotifications usagePage />
         {limits.stripeEnabled && <YourPlan />}
         <header className={styles.header}>
           <h2 className={styles.headerText}>{t('Your usage')}</h2>

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -17,6 +17,7 @@ import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 import moment from 'moment';
 import {YourPlan} from 'js/account/usage/yourPlan.component';
+import cx from 'classnames';
 
 interface LimitState {
   storageByteLimit: LimitAmount;
@@ -131,7 +132,7 @@ export default function Usage() {
         </header>
         <LimitNotifications usagePage />
         <div className={styles.row}>
-          <div className={styles.row}>
+          <div className={cx(styles.row, styles.subrow)}>
             <div className={styles.box}>
               <span>
                 <strong className={styles.title}>{t('Submissions')}</strong>
@@ -157,7 +158,7 @@ export default function Usage() {
               />
             </div>
           </div>
-          <div className={styles.row}>
+          <div className={cx(styles.row, styles.subrow)}>
             <div className={styles.box}>
               <span>
                 <strong className={styles.title}>

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -1,7 +1,7 @@
 import {when} from 'mobx';
 import React, {useEffect, useMemo, useState} from 'react';
 import {useLocation} from 'react-router-dom';
-import type {AccountLimit} from 'js/account/stripe.types';
+import type {AccountLimit, LimitAmount} from 'js/account/stripe.types';
 import {getAccountLimits} from 'js/account/stripe.api';
 import subscriptionStore from 'js/account/subscriptionStore';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
@@ -13,12 +13,13 @@ import LimitNotifications from 'js/components/usageLimits/limitNotifications.com
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 import moment from 'moment';
+import {Limits} from 'js/account/stripe.types';
 
 interface LimitState {
-  storageByteLimit: number | 'unlimited';
-  nlpCharacterLimit: number | 'unlimited';
-  nlpMinuteLimit: number | 'unlimited';
-  submissionLimit: number | 'unlimited';
+  storageByteLimit: LimitAmount;
+  nlpCharacterLimit: LimitAmount;
+  nlpMinuteLimit: LimitAmount;
+  submissionLimit: LimitAmount;
   isLoaded: boolean;
 }
 
@@ -26,10 +27,10 @@ export default function Usage() {
   const usage = useUsage();
 
   const [limits, setLimits] = useState<LimitState>({
-    storageByteLimit: 'unlimited',
-    nlpCharacterLimit: 'unlimited',
-    nlpMinuteLimit: 'unlimited',
-    submissionLimit: 'unlimited',
+    storageByteLimit: Limits.unlimited,
+    nlpCharacterLimit: Limits.unlimited,
+    nlpMinuteLimit: Limits.unlimited,
+    submissionLimit: Limits.unlimited,
     isLoaded: false,
   });
 

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -118,6 +118,7 @@ export default function Usage() {
   return (
     <UsageContext.Provider value={usage}>
       <div className={styles.root}>
+        <LimitNotifications usagePage />
         {limits.stripeEnabled && <YourPlan />}
         <header className={styles.header}>
           <h2 className={styles.headerText}>{t('Your usage')}</h2>
@@ -130,7 +131,6 @@ export default function Usage() {
             </p>
           )}
         </header>
-        <LimitNotifications usagePage />
         <div className={styles.row}>
           <div className={cx(styles.row, styles.subrow)}>
             <div className={styles.box}>

--- a/jsapp/js/account/usage/usage.module.scss
+++ b/jsapp/js/account/usage/usage.module.scss
@@ -1,3 +1,4 @@
+@use 'scss/breakpoints';
 @use 'scss/sizes';
 @use '~kobo-common/src/styles/colors';
 
@@ -36,16 +37,18 @@
   display: flex;
   justify-content: center;
   flex-flow: wrap;
-  gap: sizes.$x12;
+  gap: sizes.$x24;
+  flex: 1 1 0;
+  width: 100%;
 }
 
 .box {
   // TODO: Should we add this size or try some flex magic to make the width work?
-  width: 250px;
+  min-width: 250px;
+  width: 100%;
   border: sizes.$x1 solid;
   border-color: colors.$kobo-gray-92;
-  border-radius: 5%;
-  margin-right: sizes.$x12;
+  border-radius: sizes.$x6;
   padding: sizes.$x24;
   display: flex;
   flex-direction: column;
@@ -67,4 +70,10 @@
 .date {
   display: block;
   font-size: sizes.$x14;
+}
+
+@media screen and (min-width: breakpoints.$b1440) {
+  .row {
+    flex-wrap: nowrap;
+  }
 }

--- a/jsapp/js/account/usage/usage.module.scss
+++ b/jsapp/js/account/usage/usage.module.scss
@@ -72,6 +72,12 @@
   font-size: sizes.$x14;
 }
 
+@media screen and (min-width: breakpoints.$b600) {
+  .subrow {
+    flex-wrap: nowrap;
+  }
+}
+
 @media screen and (min-width: breakpoints.$b1440) {
   .row {
     flex-wrap: nowrap;

--- a/jsapp/js/account/usage/usage.module.scss
+++ b/jsapp/js/account/usage/usage.module.scss
@@ -5,8 +5,12 @@
   padding: sizes.$x40;
 }
 
-h2 {
+.headerText {
   margin-bottom: sizes.$x28;
+  font-size: sizes.$r18;
+  font-weight: 700;
+  color: hsl(225, 33%, 59%);
+  text-transform: uppercase;
 }
 
 .article {

--- a/jsapp/js/account/usage/usageContainer.module.scss
+++ b/jsapp/js/account/usage/usageContainer.module.scss
@@ -8,20 +8,16 @@
   margin-top: sizes.$x18;
   align-items: center;
   justify-content: space-between;
+  gap: 1em;
 
   & > li {
     display: flex;
     justify-content: space-between;
   }
-}
 
-.usageRow {
-  border-radius: sizes.$x6;
-  padding: sizes.$x6;
-  box-sizing: content-box;
-  display: flex;
-  gap: 0.25rem;
-  align-items: center;
+  &.hasAddon {
+      grid: 1.5em 1.5em 1.5em 1.5em / 100%;
+  }
 }
 
 .warning {

--- a/jsapp/js/account/usage/usageContainer.module.scss
+++ b/jsapp/js/account/usage/usageContainer.module.scss
@@ -3,11 +3,16 @@
 
 .usage {
   display: grid;
-  grid: 1fr / auto auto;
+  grid: 1fr / 100%;
   width: 100%;
   margin-top: sizes.$x18;
   align-items: center;
   justify-content: space-between;
+
+  & > li {
+    display: flex;
+    justify-content: space-between;
+  }
 }
 
 .usageRow {

--- a/jsapp/js/account/usage/usageContainer.tsx
+++ b/jsapp/js/account/usage/usageContainer.tsx
@@ -6,6 +6,7 @@ import Icon from 'js/components/common/icon';
 import styles from 'js/account/usage/usageContainer.module.scss';
 import {USAGE_WARNING_RATIO} from 'js/constants';
 import AriaText from 'js/components/common/ariaText';
+import {Limits} from 'js/account/stripe.types';
 
 interface UsageContainerProps {
   usage: number;
@@ -44,7 +45,7 @@ const UsageContainer = ({
         <strong>
           {isStorage ? prettyBytes(usage) : usage.toLocaleString()}
         </strong>
-        {limit !== 'unlimited' && limit && (
+        {limit !== Limits.unlimited && limit && (
           <>
             {' '}
             <AriaText uiText='/' screenReaderText={t('used out of')} />{' '}

--- a/jsapp/js/account/usage/usageContainer.tsx
+++ b/jsapp/js/account/usage/usageContainer.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import prettyBytes from 'pretty-bytes';
 import React from 'react';
-import type {RecurringInterval} from 'js/account/stripe.types';
+import type {LimitAmount, RecurringInterval} from 'js/account/stripe.types';
 import Icon from 'js/components/common/icon';
 import styles from 'js/account/usage/usageContainer.module.scss';
 import {USAGE_WARNING_RATIO} from 'js/constants';
@@ -10,7 +10,7 @@ import {Limits} from 'js/account/stripe.types';
 
 interface UsageContainerProps {
   usage: number;
-  limit: number | 'unlimited';
+  limit: LimitAmount;
   period: RecurringInterval;
   label?: string;
   isStorage?: boolean;
@@ -24,7 +24,7 @@ const UsageContainer = ({
   isStorage = false,
 }: UsageContainerProps) => {
   let limitRatio = 0;
-  if (limit !== 'unlimited' && limit) {
+  if (limit !== Limits.unlimited && limit) {
     limitRatio = usage / limit;
   }
   const isOverLimit = limitRatio >= 1;

--- a/jsapp/js/account/usage/useUsage.hook.ts
+++ b/jsapp/js/account/usage/useUsage.hook.ts
@@ -41,7 +41,7 @@ export function useUsage() {
       setUsage((prevState) => {
         return {
           ...prevState,
-          trackingPeriod: subscriptionInterval,
+          trackingPeriod: subscriptionInterval || 'month',
           isPeriodLoaded: true,
         };
       });

--- a/jsapp/js/account/usage/useUsage.hook.ts
+++ b/jsapp/js/account/usage/useUsage.hook.ts
@@ -18,20 +18,22 @@ export interface UsageState {
   isLoaded: boolean;
 }
 
+const INITIAL_USAGE_STATE: UsageState = Object.freeze({
+  storage: 0,
+  submissions: 0,
+  transcriptionMinutes: 0,
+  translationChars: 0,
+  currentMonthStart: '',
+  currentYearStart: '',
+  billingPeriodEnd: null,
+  trackingPeriod: 'month',
+  isPeriodLoaded: false,
+  lastUpdated: '',
+  isLoaded: false,
+});
+
 export function useUsage() {
-  const [usage, setUsage] = useState<UsageState>({
-    storage: 0,
-    submissions: 0,
-    transcriptionMinutes: 0,
-    translationChars: 0,
-    currentMonthStart: '',
-    currentYearStart: '',
-    billingPeriodEnd: null,
-    trackingPeriod: 'month',
-    isPeriodLoaded: false,
-    lastUpdated: '',
-    isLoaded: false,
-  });
+  const [usage, setUsage] = useState<UsageState>(INITIAL_USAGE_STATE);
 
   // get subscription interval (monthly, yearly) from the subscriptionStore when ready
   useEffect(() => {
@@ -39,7 +41,7 @@ export function useUsage() {
       setUsage((prevState) => {
         return {
           ...prevState,
-          trackingPeriod: subscriptionInterval || 'month',
+          trackingPeriod: subscriptionInterval,
           isPeriodLoaded: true,
         };
       });
@@ -91,15 +93,4 @@ export function useUsage() {
   return usage;
 }
 
-export const UsageContext = createContext<UsageState>({
-  storage: 0,
-  submissions: 0,
-  transcriptionMinutes: 0,
-  translationChars: 0,
-  currentMonthStart: '',
-  currentYearStart: '',
-  billingPeriodEnd: null,
-  trackingPeriod: 'month',
-  isPeriodLoaded: false,
-  isLoaded: false,
-});
+export const UsageContext = createContext<UsageState>(INITIAL_USAGE_STATE);

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -10,6 +10,7 @@ import {ACCOUNT_ROUTES} from 'js/account/routes';
 import envStore from 'js/envStore';
 import {PlanNames} from 'js/account/stripe.types';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
+import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
 
 /*
  * Show the user's current plan and any storage add-ons, with links to the Plans page
@@ -50,6 +51,9 @@ export const YourPlan = () => {
         <h2 className={usageStyles.headerText}>{t('Your plan')}</h2>
       </header>
       <section className={styles.section}>
+        <div className={styles.banner}>
+          <LimitNotifications usagePage />
+        </div>
         <div className={styles.planInfo}>
           <p className={styles.plan}>
             <strong>

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -82,7 +82,7 @@ export const YourPlan = () => {
         </div>
         <nav>
           <BillingButton
-            label={'see plans'}
+            label={'See plans'}
             type={'frame'}
             color={'blue'}
             onClick={() => window.location.assign('#' + ACCOUNT_ROUTES.PLAN)}

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -5,7 +5,6 @@ import {formatDate} from 'js/utils';
 import Badge from 'js/components/common/badge';
 import subscriptionStore from 'js/account/subscriptionStore';
 import sessionStore from 'js/stores/session';
-import AriaText from 'js/components/common/ariaText';
 import BillingButton from 'js/account/plans/billingButton.component';
 import {ACCOUNT_ROUTES} from 'js/account/routes';
 import envStore from 'js/envStore';
@@ -56,12 +55,6 @@ export const YourPlan = () => {
             <strong>
               {t('##plan_name## Plan').replace('##plan_name##', planName)}
             </strong>
-            {subscriptions.addOnsResponse.length > 0 && (
-              <sub className={styles.addOn}>
-                <AriaText uiText={'+'} screenReaderText={'plus'} />{' '}
-                {subscriptions.addOnsResponse[0].items?.[0].price.product.name}
-              </sub>
-            )}
           </p>
           <time dateTime={startDate} className={styles.start}>
             {t('Started on ##start_date##').replace(
@@ -69,7 +62,7 @@ export const YourPlan = () => {
               startDate
             )}
           </time>
-          {usage.billingPeriodEnd && (
+          {usage.billingPeriodEnd && subscriptions.planResponse.length > 0 && (
             <Badge
               color={'light-blue'}
               size={'s'}

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -1,60 +1,110 @@
 import usageStyles from 'js/account/usage/usage.module.scss';
 import styles from 'js/account/usage/yourPlan.module.scss';
-import React, {useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {formatDate} from 'js/utils';
 import Badge from 'js/components/common/badge';
 import subscriptionStore from 'js/account/subscriptionStore';
 import sessionStore from 'js/stores/session';
 import AriaText from 'js/components/common/ariaText';
+import BillingButton from 'js/account/plans/billingButton.component';
+import {ACCOUNT_ROUTES} from 'js/account/routes';
+import envStore from 'js/envStore';
+import {PlanNames} from 'js/account/stripe.types';
+import {UsageContext} from 'js/account/usage/useUsage.hook';
 
-interface YourPlanState {
-  renewalDate: string | null;
-}
-
-export const YourPlan = ({renewalDate}: YourPlanState) => {
+/*
+ * Show the user's current plan and any storage add-ons, with links to the Plans page
+ */
+export const YourPlan = () => {
   const [subscriptions] = useState(() => subscriptionStore);
+  const [env] = useState(() => envStore);
   const [session] = useState(() => sessionStore);
+  const usage = useContext(UsageContext);
+
+  /*
+   * The plan name displayed to the user. This will display, in order of precedence:
+   * * The user's active plan subscription
+   * * The FREE_TIER_DISPLAY["name"] setting (if the user registered before FREE_TIER_CUTOFF_DATE
+   * * The free plan
+   */
+  const planName = useMemo(() => {
+    if (subscriptions.planResponse.length) {
+      return subscriptions.planResponse[0].items[0].price.product.name;
+    }
+    return env.data?.free_tier_display?.name || PlanNames.FREE;
+  }, [env.isReady, subscriptions.isInitialised]);
+
+  // The start date of the user's plan. Defaults to the account creation date if the user doesn't have a subscription.
+  const startDate = useMemo(() => {
+    let date;
+    if (subscriptions.planResponse.length) {
+      date = subscriptions.planResponse[0].start_date;
+    } else {
+      date = session.currentAccount.date_joined;
+    }
+    return formatDate(date);
+  }, [env.isReady, subscriptions.isInitialised]);
 
   return (
-    <section>
+    <article>
       <header className={usageStyles.header}>
         <h2 className={usageStyles.headerText}>{t('Your plan')}</h2>
       </header>
-      <p className={styles.plan}>
-        {/* TODO: handle legacy/custom plan names */}
-        {subscriptions.planResponse.length
-          ? subscriptions.planResponse[0].items?.[0].price.product.name
-          : t('Community Plan')}
-        {subscriptions.addOnsResponse.length > 0 && (
-          <span className={styles.addOn}>
-            <AriaText uiText={'+'} screenReaderText={'plus'} />{' '}
-            {subscriptions.addOnsResponse[0].items?.[0].price.product.name}
-          </span>
-        )}
-      </p>
-      <time>
-        {t('Started on ##start_date##').replace(
-          '##start_date##',
-          formatDate(
-            subscriptions.planResponse.length
-              ? subscriptions.planResponse[0].start_date
-              : session.currentAccount.date_joined
-          )
-        )}
-      </time>
-      {renewalDate && (
-        <Badge
-          color={'light-blue'}
-          size={'s'}
-          label={
-            <div className={styles.renewal}>
-              {t('Renews on ##renewal_date##')
-                .replace('##renewal_date##', formatDate(renewalDate))
-                .toLocaleUpperCase()}
-            </div>
-          }
+      <section className={styles.section}>
+        <div className={styles.planInfo}>
+          <p className={styles.plan}>
+            <strong>
+              {t('##plan_name## Plan').replace('##plan_name##', planName)}
+            </strong>
+            {subscriptions.addOnsResponse.length > 0 && (
+              <sub className={styles.addOn}>
+                <AriaText uiText={'+'} screenReaderText={'plus'} />{' '}
+                {subscriptions.addOnsResponse[0].items?.[0].price.product.name}
+              </sub>
+            )}
+          </p>
+          <time dateTime={startDate} className={styles.start}>
+            {t('Started on ##start_date##').replace(
+              '##start_date##',
+              startDate
+            )}
+          </time>
+          {usage.billingPeriodEnd && (
+            <Badge
+              color={'light-blue'}
+              size={'s'}
+              label={
+                <time
+                  dateTime={usage.billingPeriodEnd}
+                  className={styles.renewal}
+                >
+                  {t('Renews on ##renewal_date##').replace(
+                    '##renewal_date##',
+                    formatDate(usage.billingPeriodEnd)
+                  )}
+                </time>
+              }
+            />
+          )}
+        </div>
+        <nav>
+          <BillingButton
+            label={'see plans'}
+            type={'frame'}
+            color={'blue'}
+            onClick={() => window.location.assign('#' + ACCOUNT_ROUTES.PLAN)}
+          />
+          {/* This is commented out until the add-ons tab on the Plans page is implemented
+        <BillingButton
+          label={'get add-ons'}
+          type={'full'}
+          color={'blue'}
+          // TODO: change this to point to the add-ons tab
+          onClick={() => window.location.assign('#' + ACCOUNT_ROUTES.PLAN)}
         />
-      )}
-    </section>
+         */}
+        </nav>
+      </section>
+    </article>
   );
 };

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -1,0 +1,60 @@
+import usageStyles from 'js/account/usage/usage.module.scss';
+import styles from 'js/account/usage/yourPlan.module.scss';
+import React, {useState} from 'react';
+import {formatDate} from 'js/utils';
+import Badge from 'js/components/common/badge';
+import subscriptionStore from 'js/account/subscriptionStore';
+import sessionStore from 'js/stores/session';
+import AriaText from 'js/components/common/ariaText';
+
+interface YourPlanState {
+  renewalDate: string | null;
+}
+
+export const YourPlan = ({renewalDate}: YourPlanState) => {
+  const [subscriptions] = useState(() => subscriptionStore);
+  const [session] = useState(() => sessionStore);
+
+  return (
+    <section>
+      <header className={usageStyles.header}>
+        <h2 className={usageStyles.headerText}>{t('Your plan')}</h2>
+      </header>
+      <p className={styles.plan}>
+        {/* TODO: handle legacy/custom plan names */}
+        {subscriptions.planResponse.length
+          ? subscriptions.planResponse[0].items?.[0].price.product.name
+          : t('Community Plan')}
+        {subscriptions.addOnsResponse.length > 0 && (
+          <span className={styles.addOn}>
+            <AriaText uiText={'+'} screenReaderText={'plus'} />{' '}
+            {subscriptions.addOnsResponse[0].items?.[0].price.product.name}
+          </span>
+        )}
+      </p>
+      <time>
+        {t('Started on ##start_date##').replace(
+          '##start_date##',
+          formatDate(
+            subscriptions.planResponse.length
+              ? subscriptions.planResponse[0].start_date
+              : session.currentAccount.date_joined
+          )
+        )}
+      </time>
+      {renewalDate && (
+        <Badge
+          color={'light-blue'}
+          size={'s'}
+          label={
+            <div className={styles.renewal}>
+              {t('Renews on ##renewal_date##')
+                .replace('##renewal_date##', formatDate(renewalDate))
+                .toLocaleUpperCase()}
+            </div>
+          }
+        />
+      )}
+    </section>
+  );
+};

--- a/jsapp/js/account/usage/yourPlan.module.scss
+++ b/jsapp/js/account/usage/yourPlan.module.scss
@@ -3,11 +3,18 @@
 
 .section {
   display: flex;
+  flex-wrap: wrap;
   width: 100%;
   align-items: center;
   justify-content: space-between;
   margin-block-end: 1.5em;
   border-block: 1px solid colors.$kobo-gray-85
+}
+
+.banner {
+  flex-basis: 100%;
+  margin-top: 1em;
+  margin-bottom: -1em;
 }
 
 .plan {

--- a/jsapp/js/account/usage/yourPlan.module.scss
+++ b/jsapp/js/account/usage/yourPlan.module.scss
@@ -1,9 +1,18 @@
+@use '~kobo-common/src/styles/colors';
 @use 'scss/sizes';
 
-.renewal {
-  font-weight: bold;
-  font-size: sizes.$r12;
-  padding-inline: 0.25em;
+.section {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  margin-block-end: 1.5em;
+  border-block: 1px solid colors.$kobo-gray-85
+}
+
+.plan {
+  font-size: sizes.$r18;
+  margin-block-start: 0;
 }
 
 .addOn {
@@ -11,7 +20,16 @@
   margin-left: 0.5em;
 }
 
-.plan {
-  font-size: sizes.$r18;
+.planInfo {
+  margin-block: 1.5em;
+}
+
+.renewal {
   font-weight: bold;
+  font-size: sizes.$r12;
+  padding-inline: 0.25em;
+}
+
+.start {
+  padding-inline-end: 1em;
 }

--- a/jsapp/js/account/usage/yourPlan.module.scss
+++ b/jsapp/js/account/usage/yourPlan.module.scss
@@ -1,0 +1,17 @@
+@use 'scss/sizes';
+
+.renewal {
+  font-weight: bold;
+  font-size: sizes.$r12;
+  padding-inline: 0.25em;
+}
+
+.addOn {
+  font-size: sizes.$r14;
+  margin-left: 0.5em;
+}
+
+.plan {
+  font-size: sizes.$r18;
+  font-weight: bold;
+}

--- a/jsapp/js/account/usage/yourPlan.module.scss
+++ b/jsapp/js/account/usage/yourPlan.module.scss
@@ -15,11 +15,6 @@
   margin-block-start: 0;
 }
 
-.addOn {
-  font-size: sizes.$r14;
-  margin-left: 0.5em;
-}
-
 .planInfo {
   margin-block: 1.5em;
 }

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -10,7 +10,7 @@ import {notify} from 'js/utils';
  *
  * It can detect if we got HTML string as response and uses a generic message
  * instead of spitting it out. The error message displayed to the user can be
- * customized using the optional toastMessage argument.
+ * customized using the optional `toastMessage` argument.
  */
 export function handleApiFail(response: FailResponse, toastMessage?: string) {
   // Avoid displaying toast when purposefuly aborted a request
@@ -34,14 +34,14 @@ export function handleApiFail(response: FailResponse, toastMessage?: string) {
     message = htmlDoc.getElementsByClassName('errormsg')?.[0]?.innerHTML;
   }
 
-  if (!message) {
-    message = t('An error occurred');
+  if (toastMessage || !message) {
+    message = toastMessage || t('An error occurred');
     if (response.status || response.statusText) {
-      message += ` — ${response.status} ${response.statusText}`;
+      message += `\n\n${response.status} ${response.statusText}`;
     } else if (!window.navigator.onLine) {
       // another general case — the original fetch response.message might have
       // something more useful to say.
-      message += ' — ' + t('Your connection is offline');
+      message += '\n\n' + t('Your connection is offline');
     }
   }
 

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -34,6 +34,8 @@ export function handleApiFail(response: FailResponse, toastMessage?: string) {
     message = htmlDoc.getElementsByClassName('errormsg')?.[0]?.innerHTML;
   }
 
+  const htmlMessage = message;
+
   if (toastMessage || !message) {
     message = toastMessage || t('An error occurred');
     if (response.status || response.statusText) {
@@ -45,9 +47,11 @@ export function handleApiFail(response: FailResponse, toastMessage?: string) {
     }
   }
 
-  notify.error(toastMessage || message);
+  // show the prettiest version of the error to the user
+  notify.error(message);
 
-  window.Raven?.captureMessage(message);
+  // prefer sending the HTML error to Raven, since it should contain more detailed information
+  window.Raven?.captureMessage(htmlMessage || message);
 }
 
 const JSON_HEADER = 'application/json';

--- a/jsapp/js/components/common/ariaText.tsx
+++ b/jsapp/js/components/common/ariaText.tsx
@@ -17,7 +17,9 @@ const AriaText = (props: AriaTextProps) => (
     <span aria-hidden className={props.classNames}>
       {props.uiText}
     </span>
-    <span className='visuallyhidden'>{props.screenReaderText}</span>
+    <span className='visuallyhidden'>
+      {props.screenReaderText.toLowerCase()}
+    </span>
   </>
 );
 

--- a/jsapp/js/stores/session.ts
+++ b/jsapp/js/stores/session.ts
@@ -7,8 +7,9 @@ import type {Json} from 'js/components/common/common.interfaces';
 import type {ProjectViewsSettings} from 'js/projects/customViewStore';
 
 class SessionStore {
-  currentAccount: AccountResponse | {username: string} = {
+  currentAccount: AccountResponse | {username: string; date_joined: string} = {
     username: ANON_USERNAME,
+    date_joined: '',
   };
   isAuthStateKnown = false;
   isLoggedIn = false;

--- a/jsapp/scss/breakpoints.scss
+++ b/jsapp/scss/breakpoints.scss
@@ -2,6 +2,7 @@
  * Responsive breakpoints for usage in media queries
  */
 $b480: 480px;
+$b600: 600px;
 $b530: 530px;
 $b700: 700px;
 $b768: 768px;

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -19,7 +19,7 @@
   height: calc(100% - #{$layout-desktop-header-height});
   position: relative;
   flex-grow: 0;
-  overflow: hidden;
+  overflow-x: hidden;
 
   > .dropzone,
   .public-collections-wrapper {

--- a/jsapp/scss/sizes.scss
+++ b/jsapp/scss/sizes.scss
@@ -53,6 +53,8 @@ $x800: 800px;
 }
 
 // relative sizes (rem units - scales with root document font size)
+$r12: pxToRem($x12);
+$r14: pxToRem($x14);
 $r16: pxToRem($x16); // 1em at default font size of 16px
 $r18: pxToRem($x18);
 

--- a/jsapp/scss/sizes.scss
+++ b/jsapp/scss/sizes.scss
@@ -5,6 +5,7 @@
  * how many of each of them we use.
  */
 
+// absolute sizes
 $x1: 1px;
 $x2: 2px;
 $x3: 3px;
@@ -43,3 +44,14 @@ $x350: 350px;
 $x400: 400px;
 $x600: 600px;
 $x800: 800px;
+
+// takes a pixel dimension and returns it in rem
+@function pxToRem($size) {
+  $remSize: $size / 16px;
+  @return #{$remSize}rem;
+}
+
+// relative sizes (rem units - scales with root document font size)
+$r16: pxToRem($x16); // 1em at default font size of 16px
+$r18: pxToRem($x18);
+

--- a/jsapp/scss/sizes.scss
+++ b/jsapp/scss/sizes.scss
@@ -4,6 +4,7 @@
  * nice palette and start merging similar ones. This will also help us find
  * how many of each of them we use.
  */
+@use 'sass:math';
 
 // absolute sizes
 $x1: 1px;
@@ -47,7 +48,7 @@ $x800: 800px;
 
 // takes a pixel dimension and returns it in rem
 @function pxToRem($size) {
-  $remSize: $size / 16px;
+  $remSize: math.div($size, 16px);
   @return #{$remSize}rem;
 }
 

--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -24,12 +24,12 @@ class OrganizationOwnerSerializer(serializers.ModelSerializer):
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
-    owner = serializers.CharField(source='owner.organization_user.user.username', read_only=True)
+    owner_username = serializers.CharField(source='owner.organization_user.user.username', read_only=True)
 
     class Meta:
         model = Organization
-        fields = ['id', 'name', 'is_active', 'created', 'modified', 'slug', 'owner']
-        read_only_fields = ['id', 'slug', 'owner']
+        fields = ['id', 'name', 'is_active', 'created', 'modified', 'slug', 'owner_username']
+        read_only_fields = ['id', 'slug', 'owner_username']
 
     def create(self, validated_data):
         user = self.context['request'].user

--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -1,13 +1,34 @@
 from rest_framework import serializers
 
-from kobo.apps.organizations.models import Organization, create_organization
+from kobo.apps.organizations.models import (
+    create_organization,
+    Organization,
+    OrganizationOwner,
+    OrganizationUser,
+)
+
+
+class OrganizationUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OrganizationUser
+        fields = ['user', 'organization']
+
+
+class OrganizationOwnerSerializer(serializers.ModelSerializer):
+    organization_user = OrganizationUserSerializer()
+
+    class Meta:
+        model = OrganizationOwner
+        fields = ['organization_user']
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
+    owner = OrganizationOwnerSerializer()
+
     class Meta:
         model = Organization
-        fields = ['id', 'name', 'is_active', 'created', 'modified', 'slug']
-        read_only_fields = ["id", "slug"]
+        fields = ['id', 'name', 'is_active', 'created', 'modified', 'slug', 'owner']
+        read_only_fields = ['id', 'slug', 'owner']
 
     def create(self, validated_data):
         user = self.context['request'].user

--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -9,6 +9,7 @@ from kobo.apps.organizations.models import (
 
 
 class OrganizationUserSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = OrganizationUser
         fields = ['user', 'organization']
@@ -23,7 +24,7 @@ class OrganizationOwnerSerializer(serializers.ModelSerializer):
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
-    owner = OrganizationOwnerSerializer()
+    owner = serializers.CharField(source='owner.organization_user.user.username', read_only=True)
 
     class Meta:
         model = Organization

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -44,7 +44,7 @@ class OrganizationTestCase(BaseTestCase):
         self._insert_data()
         organization2 = baker.make(Organization, id='org_abcd123')
         organization2.add_user(user=self.user, is_admin=True)
-        with self.assertNumQueries(FuzzyInt(2, 4)):
+        with self.assertNumQueries(FuzzyInt(8, 10)):
             res = self.client.get(self.url_list)
         self.assertContains(res, organization2.name)
 
@@ -63,7 +63,7 @@ class OrganizationTestCase(BaseTestCase):
     def test_update(self):
         self._insert_data()
         data = {'name': 'edit'}
-        with self.assertNumQueries(FuzzyInt(4, 6)):
+        with self.assertNumQueries(FuzzyInt(8, 10)):
             res = self.client.patch(self.url_detail, data)
         self.assertContains(res, data['name'])
 

--- a/kobo/apps/stripe/serializers.py
+++ b/kobo/apps/stripe/serializers.py
@@ -100,7 +100,6 @@ class CheckoutLinkSerializer(PriceIdSerializer):
 
 
 class PriceSerializer(BasePriceSerializer):
-    product = BaseProductSerializer()
 
     class Meta(BasePriceSerializer.Meta):
         fields = (
@@ -114,18 +113,23 @@ class PriceSerializer(BasePriceSerializer):
             'metadata',
             'active',
             'product',
+            'transform_quantity',
         )
 
 
+class PriceWithProductSerializer(PriceSerializer):
+    product = BaseProductSerializer()
+
+
 class ProductSerializer(BaseProductSerializer):
-    prices = BasePriceSerializer(many=True)
+    prices = PriceSerializer(many=True)
 
     class Meta(BaseProductSerializer.Meta):
         fields = ('id', 'name', 'description', 'type', 'prices', 'metadata')
 
 
 class SubscriptionItemSerializer(serializers.ModelSerializer):
-    price = PriceSerializer()
+    price = PriceWithProductSerializer()
 
     class Meta:
         model = SubscriptionItem

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -1,5 +1,6 @@
 import timeit
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -137,6 +138,7 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
             self.expected_file_size() * self.expected_submissions_single
         )
 
+    @pytest.mark.xfail
     def test_endpoint_speed(self):
         # get the average request time for 10 hits to the endpoint
         single_user_time = timeit.timeit(lambda: self.client.get(self.detail_url), number=10)

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -63,7 +63,7 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         cache.clear()
 
     def generate_subscription(self, metadata: dict):
-        """Create a subscription for a product with custom"""
+        """Create a subscription for a product with custom metadata"""
         product = baker.make(Product, active=True, metadata={
             'product_type': 'plan',
             **metadata,

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -2,7 +2,7 @@ import timeit
 
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import User
-from django.test import override_settings
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from djstripe.models import Customer, Price, Product, Subscription, SubscriptionItem
@@ -66,6 +66,9 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         url = reverse(self._get_endpoint('organizations-list'))
         self.detail_url = f'{url}{self.organization.id}/service_usage/'
         self.client.login(username='anotheruser', password='anotheruser')
+
+    def tearDown(self):
+        cache.clear()
 
     def test_usage_doesnt_include_org_users_without_subscription(self):
         """

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -1,0 +1,123 @@
+import timeit
+
+from dateutil.relativedelta import relativedelta
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+from djstripe.models import Customer, Price, Product, Subscription, SubscriptionItem
+from model_bakery import baker
+
+from kobo.apps.organizations.models import Organization, OrganizationUser
+from kobo.apps.trackers.submission_utils import create_mock_assets, add_mock_submissions
+from kpi.tests.api.v2.test_api_service_usage import ServiceUsageAPIBase
+
+
+class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
+    """
+    Test organization service usage when Stripe is enabled.
+
+    Note: this class lives here (despite testing the Organizations endpoint) so that it will *only* run
+    when Stripe is installed.
+    """
+
+    user_count = 5
+    assets_per_user = 5
+    submissions_per_asset = 5
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.now = timezone.now()
+
+        cls.client = cls.client_class()
+        cls.anotheruser = User.objects.get(username='anotheruser')
+        cls.organization = baker.make(Organization, id='orgAKWMFskafsngf', name='test organization')
+        cls.organization.add_user(cls.anotheruser, is_admin=True)
+        assets = create_mock_assets([cls.anotheruser], cls.assets_per_user)
+
+        cls.customer = baker.make(Customer, subscriber=cls.organization, livemode=False)
+        cls.organization.save()
+        product = baker.make(Product, active=True, metadata={
+            'product_type': 'plan',
+            'plan_type': 'enterprise',
+            'organizations': True,
+        })
+        cls.price = baker.make(
+            Price,
+            active=True,
+            id='price_sfmOFe33rfsfd36685657',
+            product=product,
+        )
+
+        users = baker.make(User, _quantity=cls.user_count - 1, _bulk_create=True)
+        baker.make(
+            OrganizationUser,
+            user=users.__iter__(),
+            organization=cls.organization,
+            is_admin=False,
+            _quantity=cls.user_count - 1,
+            _bulk_create=True,
+        )
+        assets = assets + create_mock_assets(users, cls.assets_per_user)
+        add_mock_submissions(assets, cls.submissions_per_asset)
+
+    def setUp(self):
+        super().setUp()
+        url = reverse(self._get_endpoint('organizations-list'))
+        self.detail_url = f'{url}{self.organization.id}/service_usage/'
+        self.client.login(username='anotheruser', password='anotheruser')
+
+    def test_usage_doesnt_include_org_users_without_subscription(self):
+        """
+        Test that the endpoint *only* returns usage for the logged-in user
+        if they don't have a subscription that includes Organizations.
+        """
+        # without a plan that includes Organizations, the user should only see their usage
+        response = self.client.get(self.detail_url)
+        expected_submissions = self.assets_per_user * self.submissions_per_asset
+        assert response.data['total_submission_count']['all_time'] == expected_submissions
+        assert response.data['total_submission_count']['current_month'] == expected_submissions
+        assert response.data['total_storage_bytes'] == (
+            self.expected_file_size() * expected_submissions
+        )
+
+    def test_usage_for_plans_with_org_access(self):
+        """
+        Test that the endpoint aggregates usage for each user in the organization
+        when viewing /service_usage/{organization_id}/
+        """
+        # create a subscription that includes Organizations
+        subscription_item = baker.make(SubscriptionItem, price=self.price, quantity=1, livemode=False)
+        baker.make(
+            Subscription,
+            customer=self.customer,
+            status='active',
+            items=[subscription_item],
+            livemode=False,
+            billing_cycle_anchor=self.now - relativedelta(weeks=2),
+            current_period_end=self.now + relativedelta(weeks=2),
+            current_period_start=self.now - relativedelta(weeks=2),
+        )
+        self.customer.save()
+
+        expected_submissions = self.assets_per_user * self.submissions_per_asset * self.user_count
+
+        # now the user should see usage for everyone in their org
+        response = self.client.get(self.detail_url)
+        assert response.data['total_submission_count']['current_month'] == expected_submissions
+        assert response.data['total_submission_count']['all_time'] == expected_submissions
+        assert response.data['total_storage_bytes'] == (
+            self.expected_file_size() * expected_submissions
+        )
+
+    def test_endpoint_speed_(self):
+        # get the average request time for 10 hits to the endpoint
+        single_user_time = timeit.timeit(lambda: self.client.get(self.detail_url), number=40)
+
+        # get the average request time for 10 hits to the endpoint
+        multi_user_time = timeit.timeit(lambda: self.client.get(self.detail_url), number=10)
+        print(f'Average time for response from organization usage endpoint with one user: {single_user_time}s')
+        assert single_user_time < 1.5
+        assert multi_user_time < 2
+        assert multi_user_time < single_user_time * 2

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -30,8 +30,7 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         super().setUpTestData()
         cls.now = timezone.now()
 
-        cls.client = cls.client_class()
-        cls.anotheruser = User.objects.get(username='anotheruser')
+        anotheruser = User.objects.get(username='anotheruser')
         cls.organization = baker.make(Organization, id='orgAKWMFskafsngf', name='test organization')
         cls.organization.add_user(cls.anotheruser, is_admin=True)
         assets = create_mock_assets([cls.anotheruser], cls.assets_per_user)

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -324,14 +324,14 @@ class CustomerPortalView(APIView):
             if not len(all_configs):
                 return Response({'error': "Missing Stripe billing configuration."}, status=status.HTTP_502_BAD_GATEWAY)
 
-            is_price_for_addon = price.product.metadata.get('product_type', '') == 'addon'
-
-            if is_price_for_addon:
-                """
-                Recurring add-ons aren't included in the default billing configuration.
-                This lets us hide them as an 'upgrade' option for paid plan users.
-                Here, we try getting the portal configuration that lets us switch to the provided price.
-                """
+            """
+            Recurring add-ons and the Enterprise plan aren't included in the default billing configuration.
+            This lets us hide them as an 'upgrade' option for paid plan users.
+            """
+            needs_custom_config = price.product.metadata.get('product_type', '') == 'addon'
+            needs_custom_config = needs_custom_config or price.product.metadata.get('plan_type', '') == 'enterprise'
+            if needs_custom_config:
+                # Try getting the portal configuration that lets us switch to the provided price
                 current_config = next(
                     (config for config in all_configs if (
                             config['active'] and
@@ -350,7 +350,7 @@ class CustomerPortalView(APIView):
                     )), None
                 )
 
-                if is_price_for_addon:
+                if needs_custom_config:
                     """
                     we couldn't find a custom configuration, let's try making a new one
                     add the price we're switching into to the list of prices that allow subscription updates

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -328,8 +328,11 @@ class CustomerPortalView(APIView):
             Recurring add-ons and the Enterprise plan aren't included in the default billing configuration.
             This lets us hide them as an 'upgrade' option for paid plan users.
             """
-            needs_custom_config = price.product.metadata.get('product_type', '') == 'addon'
-            needs_custom_config = needs_custom_config or price.product.metadata.get('plan_type', '') == 'enterprise'
+            metadata = price.product.metadata
+            needs_custom_config = (
+                metadata.get('product_type') == 'addon'
+                or metadata.get('plan_type') == 'enterprise'
+            )
             if needs_custom_config:
                 # Try getting the portal configuration that lets us switch to the provided price
                 current_config = next(

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -477,7 +477,10 @@ class ProductViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     >                           },
     >                           "unit_amount": int (cents),
     >                           "human_readable_price": string,
-    >                           "metadata": {}
+    >                           "metadata": {},
+    >                           "active": bool,
+    >                           "product": string,
+    >                           "transform_quantity": null | {'round': 'up'|'down', 'divide_by': int}
     >                       },
     >                       ...
     >                   ],

--- a/kobo/apps/trackers/submission_utils.py
+++ b/kobo/apps/trackers/submission_utils.py
@@ -75,7 +75,7 @@ def update_xform_counters(asset: Asset, xform: KobocatXForm = None, submissions:
             kpi_asset_uid=asset.uid,
             date_created=today,
             date_modified=today,
-            user_id=asset.owner.id,
+            user_id=asset.owner_id,
         )
         xform.save()
 
@@ -94,7 +94,7 @@ def update_xform_counters(asset: Asset, xform: KobocatXForm = None, submissions:
                 date=today.date(),
                 counter=submissions,
                 xform=xform,
-                user_id=asset.owner.id,
+                user_id=asset.owner_id,
             )
         )
         counter.save()

--- a/kobo/apps/trackers/submission_utils.py
+++ b/kobo/apps/trackers/submission_utils.py
@@ -1,0 +1,139 @@
+import os
+import uuid
+
+from django.conf import settings
+from django.utils import timezone
+from model_bakery import baker
+
+from kpi.deployment_backends.kc_access.shadow_models import KobocatXForm, ReadOnlyKobocatDailyXFormSubmissionCounter
+from kpi.models import Asset
+from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
+
+
+def create_mock_assets(users: list, assets_per_user: int = 1):
+    content_source_asset = {
+        'survey': [
+            {
+                'type': 'audio',
+                'label': 'q1',
+                'required': 'false',
+                '$kuid': str(uuid.uuid4()),
+            },
+            {
+                'type': 'file',
+                'label': 'q2',
+                'required': 'false',
+                '$kuid': str(uuid.uuid4()),
+            },
+        ]
+    }
+    assets = []
+    for user in users:
+        assets = assets + baker.make(
+            Asset,
+            content=content_source_asset,
+            owner=user,
+            asset_type='survey',
+            _quantity=assets_per_user,
+        )
+
+    for asset in assets:
+        asset.deploy(backend='mock', active=True)
+        asset.deployment.set_namespace(ROUTER_URL_NAMESPACE)
+        asset.save()  # might be redundant?
+
+    return assets
+
+
+def expected_file_size(submissions: int = 1):
+    """
+    Calculate the expected combined file size for the test audio clip and image
+    """
+    return (os.path.getsize(
+        settings.BASE_DIR + '/kpi/tests/audio_conversion_test_clip.mp4'
+    ) + os.path.getsize(
+        settings.BASE_DIR + '/kpi/tests/audio_conversion_test_image.jpg'
+    )) * submissions
+
+
+def update_xform_counters(asset: Asset, xform: KobocatXForm = None, submissions: int = 1):
+    """
+    Create/update the daily submission counter and the shadow xform we use to query it
+    """
+    today = timezone.now()
+    if xform:
+        xform.attachment_storage_bytes += (
+            expected_file_size(submissions)
+        )
+        xform.save()
+    else:
+        xform = baker.make(
+            KobocatXForm,
+            attachment_storage_bytes=(
+                expected_file_size(submissions)
+            ),
+            kpi_asset_uid=asset.uid,
+            date_created=today,
+            date_modified=today,
+            user_id=asset.owner.id,
+        )
+        xform.save()
+
+    counter = ReadOnlyKobocatDailyXFormSubmissionCounter.objects.filter(
+        date=today.date(),
+        user_id=asset.owner.id,
+    ).first()
+
+    if counter:
+        counter.counter += submissions
+        counter.save()
+    else:
+        counter = (
+            baker.make(
+                ReadOnlyKobocatDailyXFormSubmissionCounter,
+                date=today.date(),
+                counter=submissions,
+                xform=xform,
+                user_id=asset.owner.id,
+            )
+        )
+        counter.save()
+
+
+def add_mock_submissions(assets: list, submissions_per_asset: int = 1):
+    """
+    Add one (default) or more submissions to an asset
+    """
+    all_submissions = []
+    for asset in assets:
+        asset_submissions = []
+
+        for x in range(submissions_per_asset):
+            submission = {
+                '__version__': asset.latest_deployed_version.uid,
+                'q1': 'audio_conversion_test_clip.mp4',
+                'q2': 'audio_conversion_test_image.jpg',
+                '_uuid': str(uuid.uuid4()),
+                '_attachments': [
+                    {
+                        'id': 1,
+                        'download_url': f'http://testserver/{asset.owner.username}/audio_conversion_test_clip.mp4',
+                        'filename': f'{asset.owner.username}/audio_conversion_test_clip.mp4',
+                        'mimetype': 'video/mp4',
+                    },
+                    {
+                        'id': 2,
+                        'download_url': f'http://testserver/{asset.owner.username}/audio_conversion_test_image.jpg',
+                        'filename': f'{asset.owner.username}/audio_conversion_test_image.jpg',
+                        'mimetype': 'image/jpeg',
+                    },
+                ],
+                '_submitted_by': asset.owner.username,
+            }
+            asset_submissions.append(submission)
+
+        asset.deployment.mock_submissions(asset_submissions, flush_db=False)
+        all_submissions = all_submissions + asset_submissions
+        update_xform_counters(asset, submissions=submissions_per_asset)
+
+    return all_submissions

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -871,6 +871,9 @@ if STRIPE_ENABLED:
     DJSTRIPE_WEBHOOK_VALIDATION = env.str('DJSTRIPE_WEBHOOK_VALIDATION', 'verify_signature')
 STRIPE_PUBLIC_KEY = STRIPE_LIVE_PUBLIC_KEY if STRIPE_LIVE_MODE else STRIPE_TEST_PUBLIC_KEY
 
+'''Organizations settings'''
+ORGANIZATION_USER_LIMIT = env.str('ORGANIZATION_USER_LIMIT', 400)
+
 
 ''' Enketo configuration '''
 ENKETO_URL = os.environ.get('ENKETO_URL') or os.environ.get('ENKETO_SERVER', 'https://enketo.org')

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -872,6 +872,8 @@ if STRIPE_ENABLED:
 STRIPE_PUBLIC_KEY = STRIPE_LIVE_PUBLIC_KEY if STRIPE_LIVE_MODE else STRIPE_TEST_PUBLIC_KEY
 
 '''Organizations settings'''
+# necessary to prevent calls to `/organizations/{ORG_ID}/service_usage/` (and any other
+# queries that may need to aggregate data for all organization users) from slowing down db
 ORGANIZATION_USER_LIMIT = env.str('ORGANIZATION_USER_LIMIT', 400)
 
 

--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -43,6 +43,15 @@ if 'djstripe' not in INSTALLED_APPS:
     INSTALLED_APPS += ('djstripe', 'kobo.apps.stripe')
 STRIPE_ENABLED = True
 
+# Per django recommendations, we use the dummy cache backend to avoid having
+# to disable caching on a per-test basis
+# https://docs.djangoproject.com/en/3.1/topics/cache/#dummy-caching-for-development
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
 WEBPACK_LOADER['DEFAULT'][
     'LOADER_CLASS'
 ] = 'webpack_loader.loader.FakeWebpackLoader'

--- a/kobo/settings/testing.py
+++ b/kobo/settings/testing.py
@@ -43,15 +43,6 @@ if 'djstripe' not in INSTALLED_APPS:
     INSTALLED_APPS += ('djstripe', 'kobo.apps.stripe')
 STRIPE_ENABLED = True
 
-# Per django recommendations, we use the dummy cache backend to avoid having
-# to disable caching on a per-test basis
-# https://docs.djangoproject.com/en/3.1/topics/cache/#dummy-caching-for-development
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
-}
-
 WEBPACK_LOADER['DEFAULT'][
     'LOADER_CLASS'
 ] = 'webpack_loader.loader.FakeWebpackLoader'

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -214,7 +214,7 @@ class ServiceUsageSerializer(serializers.Serializer):
             return
 
         organization = Organization.objects.filter(
-            owner__organization_user__user=self.context.get('request').user,
+            organization_users__user=self.context.get('request').user,
             id=organization_id,
         ).first()
 

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -230,8 +230,8 @@ class ServiceUsageSerializer(serializers.Serializer):
                 organizations_organization__djstripe_customers__subscriptions__items__price__product__metadata__has_key='plan_type',
                 organizations_organization__djstripe_customers__subscriptions__items__price__product__metadata__plan_type='enterprise',
             )
-            if enterprise_users.exists():
-                self._user_ids = list(enterprise_users)
+            if enterprise_users:
+                self._user_ids = enterprise_users[:settings.ORGANIZATION_USER_LIMIT]
 
         # If they have a subscription, use its start date to calculate beginning of current month/year's usage
         billing_details = organization.active_subscription_billing_details

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -6,6 +6,7 @@ from rest_framework.fields import empty
 
 from kobo.apps.organizations.models import Organization
 from kobo.apps.project_views.models.assignment import User
+from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatXForm,
@@ -216,16 +217,15 @@ class ServiceUsageSerializer(serializers.Serializer):
             # Couldn't find organization, proceed as normal
             return
 
-        """
-        Commented out until the Enterprise plan is implemented
-
-        # If the user is in an organization, get all org users so we can query their total org usage
-        self._user_ids = list(
-            User.objects.values_list('pk', flat=True).filter(
-                organizations_organization__id=organization_id
-            )
+        # if the user is in an organization and has an enterprise plan, get all org users and their total usage
+        enterprise_users = User.objects.values_list('pk', flat=True).filter(
+            organizations_organization__id=organization_id,
+            organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+            organizations_organization__djstripe_customers__subscriptions__items__price__product__metadata__has_key='plan_type',
+            organizations_organization__djstripe_customers__subscriptions__items__price__product__metadata__plan_type='enterprise',
         )
-        """
+        if enterprise_users.exists():
+            self._user_ids = list(enterprise_users)
 
         # If they have a subscription, use its start date to calculate beginning of current month/year's usage
         billing_details = organization.active_subscription_billing_details

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -168,7 +168,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
                 kpi_asset_uid=asset.uid,
                 date_created=today,
                 date_modified=today,
-                user_id=asset.owner.id,
+                user_id=asset.owner_id,
             )
             self.xform.save()
 
@@ -181,7 +181,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
                     date=today.date(),
                     counter=submissions,
                     xform=self.xform,
-                    user_id=asset.owner.id,
+                    user_id=asset.owner_id,
                 )
             )
             self.counter.save()

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -46,6 +46,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
                 schema_editor.create_model(unmanaged_model)
 
     def setUp(self):
+        super().setUp()
         self.client.login(username='anotheruser', password='anotheruser')
 
     def _create_asset(self, user=None):

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -39,13 +39,14 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.client = cls.client_class()
-        cls.client.login(username='anotheruser', password='anotheruser')
         cls.anotheruser = User.objects.get(username='anotheruser')
         cls.someuser = User.objects.get(username='someuser')
         with connection.schema_editor() as schema_editor:
             for unmanaged_model in cls.unmanaged_models:
                 schema_editor.create_model(unmanaged_model)
+
+    def setUp(self):
+        self.client.login(username='anotheruser', password='anotheruser')
 
     def _create_asset(self, user=None):
         owner = user or self.anotheruser
@@ -166,7 +167,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
                 kpi_asset_uid=asset.uid,
                 date_created=today,
                 date_modified=today,
-                user_id=asset.owner_id,
+                user_id=asset.owner.id,
             )
             self.xform.save()
 
@@ -179,7 +180,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
                     date=today.date(),
                     counter=submissions,
                     xform=self.xform,
-                    user_id=asset.owner_id,
+                    user_id=asset.owner.id,
                 )
             )
             self.counter.save()


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Add the Enterprise Gold and Enterprise Platinum plans to the Plans page. Re-style the Usage page and some parts of the Billing page.

## Notes

This PR is for reviewing the front-end changes for this scope - [kpi#4783](https://github.com/kobotoolbox/kpi/pull/4783) targets only the back-end changes, and should be merged first.

A few changes were necessary to get the front-end right:
* Buttons on the billing and usage pages are now Sentence case instead of UPPERCASE
* Added an additional breakpoint definition for 600px
* The billing page now allows hiding/showing groups of plans, based on the `plan_type` metadata on the Stripe product.
* The `AriaText` component now lowercases the screen reader text, to prevent screen readers from saying, for example, 'Kay-obo' when reading the string `Kobo`.

## Testing

Some (not exhaustive) testing steps:
1. Check out the updated usage page at `/#/account/usage` - make sure the styling is in line with the [design](https://www.figma.com/file/NonWWcfadc3QfS3q3D8hRB/%E2%9A%99%EF%B8%8F-KPI-%2F-Account-Settings?type=design&node-id=2580-27554&mode=design&t=wG9q54oqUeu2Fbfq-0). (Some things, like the 'Get add-ons' button, are implemented but won't be used until a later scope.)
1. Purchase an add-on from the plans page (`/#/account/plan`). You might need to create a new user to do so, since storage add-ons are only visible on the Community/Legacy plan. Then go to the usage page and confirm that you see your storage add-on reflected on the Storage tab. Mockup:
![image](https://github.com/kobotoolbox/kpi/assets/7819986/ea5a05c2-1e35-4d3f-a1d3-8209495e74ef)
1. Go to the plans page and confirm that the checkout/manage links work correctly.
1. To check out for the Enterprise plans, go to `/#/account/plan?type=enterprise`. Once you've purchased the Enterprise Plan, navigate back to `/#/account/plan` and confirm that you only see the Enterprise plans.