### PR TITLE
Add `OrganizationUser` to `OrgAdmin` in Django Admin 

### DIFF
--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -18,9 +18,14 @@ class OwnerInline(BaseOwnerInline):
     model = OrganizationOwner
 
 
+class OrgUserInline(admin.StackedInline):
+    model = OrganizationUser
+    extra = 0
+
+
 @admin.register(Organization)
 class OrgAdmin(BaseOrganizationAdmin):
-    inlines = [OwnerInline]
+    inlines = [OwnerInline, OrgUserInline]
     readonly_fields = ['id']
 
 

--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -20,6 +20,7 @@ class OwnerInline(BaseOwnerInline):
 
 class OrgUserInline(admin.StackedInline):
     model = OrganizationUser
+    raw_id_fields = ("user",)
     extra = 0
 
 

--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -21,6 +21,7 @@ class OwnerInline(BaseOwnerInline):
 class OrgUserInline(admin.StackedInline):
     model = OrganizationUser
     raw_id_fields = ("user",)
+    view_on_site = False
     extra = 0
 
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Streamlining the process of adding a user to an organization for the Enterprise plan. This allows a user to be added directly on the Organization admin page in the Django admin. 
