### PR TITLE
Fix error when editing submissions with XML encoding declaration

### DIFF
--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -20,7 +20,7 @@ except ImportError:
     from backports.zoneinfo import ZoneInfo
 
 from deepmerge import always_merger
-from dict2xml import dict2xml
+from dict2xml import dict2xml as dict2xml_real
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import gettext as t
@@ -48,6 +48,11 @@ from kpi.utils.mongo_helper import MongoHelper, drop_mock_only
 from kpi.utils.xml import edit_submission_xml
 from .base_backend import BaseDeploymentBackend
 from ..exceptions import KobocatBulkUpdateSubmissionsClientException
+
+
+def dict2xml(*args, **kwargs):
+    """ To facilitate mocking in unit tests """
+    return dict2xml_real(*args, **kwargs)
 
 
 class MockDeploymentBackend(BaseDeploymentBackend):

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -655,6 +655,13 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         submission_xml = deployment.get_submission(
             submission_id, user, SUBMISSION_FORMAT_TYPE_XML
         )
+        if isinstance(submission_xml, str):
+            # Workaround for "Unicode strings with encoding declaration are not
+            # supported. Please use bytes input or XML fragments without
+            # declaration."
+            # TODO: handle this in a unified way instead of haphazardly. See,
+            # e.g., `kpi.utils.xml.strip_nodes()`
+            submission_xml = submission_xml.encode()
         submission_xml_root = etree.fromstring(submission_xml)
         # The JSON version is needed to detect its version
         submission_json = deployment.get_submission(


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Convert submission XML from `str` to `bytes` before attempting to parse, working around error "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

## Related issues

Fixes an unreleased problem introduced by #4774 