### PR TITLE
Refactor redirect for plans page to not require a react-router version upgrade

### DIFF
--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
 import {ROUTES} from 'js/router/routerConstants';
-import {authLoader} from '../router/routerUtils';
 
 const ChangePasswordRoute = React.lazy(
   () => import(/* webpackPrefetch: true */ './changePasswordRoute.component')
@@ -50,7 +49,6 @@ export default function routes() {
             <PlanRoute />
           </RequireAuth>
         }
-        loader={authLoader}
       />
       <Route
         path={ACCOUNT_ROUTES.USAGE}

--- a/jsapp/js/components/drawer.es6
+++ b/jsapp/js/components/drawer.es6
@@ -13,11 +13,10 @@ import mixins from '../mixins';
 import LibrarySidebar from 'js/components/library/librarySidebar';
 import HelpBubble from 'js/components/support/helpBubble';
 import {COMMON_QUERIES, MODAL_TYPES} from '../constants';
-import {ROUTES} from 'js/router/routerConstants';
+import {ROUTES, PROJECTS_ROUTES} from 'js/router/routerConstants';
 import SidebarFormsList from '../lists/sidebarForms';
 import envStore from 'js/envStore';
 import {router, routerIsActive, withRouter} from '../router/legacy';
-import {PROJECTS_ROUTES} from 'js/projects/routes';
 
 const AccountSidebar = lazy(() => import('js/account/accountSidebar'));
 

--- a/jsapp/js/projects/projectViews/viewSwitcher.tsx
+++ b/jsapp/js/projects/projectViews/viewSwitcher.tsx
@@ -4,7 +4,7 @@ import {observer} from 'mobx-react-lite';
 import classNames from 'classnames';
 import Icon from 'js/components/common/icon';
 import KoboDropdown from 'js/components/common/koboDropdown';
-import {PROJECTS_ROUTES} from 'js/projects/routes';
+import {PROJECTS_ROUTES} from 'jsapp/js/router/routerConstants';
 import projectViewsStore from './projectViewsStore';
 import styles from './viewSwitcher.module.scss';
 import {HOME_VIEW} from './constants';

--- a/jsapp/js/projects/routes.tsx
+++ b/jsapp/js/projects/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
-import {ROUTES} from 'js/router/routerConstants';
+import {ROUTES, PROJECTS_ROUTES} from 'js/router/routerConstants';
 
 const MyProjectsRoute = React.lazy(
   () => import(/* webpackPrefetch: true */ './myProjectsRoute')
@@ -9,11 +9,6 @@ const MyProjectsRoute = React.lazy(
 const CustomViewRoute = React.lazy(
   () => import(/* webpackPrefetch: true */ './customViewRoute')
 );
-
-export const PROJECTS_ROUTES: {readonly [key: string]: string} = {
-  MY_PROJECTS: ROUTES.PROJECTS_ROOT + '/home',
-  CUSTOM_VIEW: ROUTES.PROJECTS_ROOT + '/:viewUid',
-};
 
 export default function routes() {
   return (

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -2,24 +2,11 @@ import React, {ReactElement, Suspense, useEffect, useState} from 'react';
 import {RouteObject} from 'react-router-dom';
 import sessionStore from 'js/stores/session';
 import LoadingSpinner from '../components/common/loadingSpinner';
-import {PATHS} from './routerConstants';
+import {redirectToLogin} from './routerUtils';
 
 interface Props {
   children: RouteObject[] | undefined | ReactElement;
   redirect?: boolean;
-}
-
-export function getRedirectedLogin() {
-  let loginUrl = PATHS.LOGIN;
-  const loc = location.hash.split('#');
-  const currentLoc = loc.length > 1 ? loc[1] : '';
-
-  if (currentLoc) {
-    const nextUrl = encodeURIComponent(`/#${currentLoc}`);
-    loginUrl += `?next=${nextUrl}`;
-  }
-
-  window.location.href = loginUrl;
 }
 
 export default function RequireAuth({children, redirect = true}: Props) {
@@ -27,7 +14,7 @@ export default function RequireAuth({children, redirect = true}: Props) {
 
   useEffect(() => {
     if (redirect && !session.isLoggedIn) {
-      getRedirectedLogin();
+      redirectToLogin();
     }
   }, [session.isLoggedIn, redirect]);
 

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -1,18 +1,39 @@
-import React, {ReactElement, Suspense, useState} from 'react';
+import React, {ReactElement, Suspense, useEffect, useState} from 'react';
 import {RouteObject} from 'react-router-dom';
 import sessionStore from 'js/stores/session';
-import AccessDenied from './accessDenied';
+import LoadingSpinner from '../components/common/loadingSpinner';
+import {PATHS} from './routerConstants';
 
 interface Props {
   children: RouteObject[] | undefined | ReactElement;
+  redirect?: boolean;
 }
 
-/** https://gist.github.com/mjackson/d54b40a094277b7afdd6b81f51a0393f */
-export default function RequireAuth({children}: Props) {
+export function getRedirectedLogin() {
+  let loginUrl = PATHS.LOGIN;
+  const loc = location.hash.split('#');
+  const currentLoc = loc.length > 1 ? loc[1] : '';
+
+  if (currentLoc) {
+    const nextUrl = encodeURIComponent(`/#${currentLoc}`);
+    loginUrl += `?next=${nextUrl}`;
+  }
+
+  window.location.href = loginUrl;
+}
+
+export default function RequireAuth({children, redirect = true}: Props) {
   const [session] = useState(() => sessionStore);
-  return session.isLoggedIn ? (
+
+  useEffect(() => {
+    if (redirect && !session.isLoggedIn) {
+      getRedirectedLogin();
+    }
+  }, [session.isLoggedIn, redirect]);
+
+  return redirect && session.isLoggedIn ? (
     <Suspense fallback={null}>{children}</Suspense>
   ) : (
-    <AccessDenied />
+    <LoadingSpinner />
   );
-};
+}

--- a/jsapp/js/router/router.tsx
+++ b/jsapp/js/router/router.tsx
@@ -6,9 +6,9 @@ import {
   createRoutesFromElements,
 } from 'react-router-dom';
 import App from 'js/app';
-import {ROUTES} from './routerConstants';
+import {ROUTES, PROJECTS_ROUTES} from './routerConstants';
 import accountRoutes from 'js/account/routes';
-import projectsRoutes, {PROJECTS_ROUTES} from 'js/projects/routes';
+import projectsRoutes from 'js/projects/routes';
 import RequireAuth from './requireAuth';
 import {FormPage, LibraryAssetEditor} from 'js/components/formEditors';
 import MyLibraryRoute from 'js/components/library/myLibraryRoute';

--- a/jsapp/js/router/routerConstants.ts
+++ b/jsapp/js/router/routerConstants.ts
@@ -47,3 +47,8 @@ export const ROUTES = Object.freeze({
   FORM_REST_HOOK: '/forms/:uid/settings/rest/:hookUid',
   FORM_RESET: '/forms/:uid/reset',
 });
+
+export const PROJECTS_ROUTES: {readonly [key: string]: string} = {
+  MY_PROJECTS: ROUTES.PROJECTS_ROOT + '/home',
+  CUSTOM_VIEW: ROUTES.PROJECTS_ROOT + '/:viewUid',
+};

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -10,7 +10,7 @@
 
 import {ROUTES, PATHS, PROJECTS_ROUTES} from 'js/router/routerConstants';
 import session from '../stores/session';
-import {redirectDocument} from 'react-router';
+// import {redirectDocument} from 'react-router';
 import {when} from 'mobx';
 
 /**
@@ -41,13 +41,16 @@ export function getCurrentPath(): string {
  * Redirects to `getLoginUrl()` if a page that requires authentication
  * is naviagated to
  */
-export const authLoader = async () => {
-  await when(() => session.isAuthStateKnown);
-  if (!session.isLoggedIn) {
-    return redirectDocument(getLoginUrl());
-  }
-  return null;
-};
+// This function uses `redirectDocument` which requires a react-router version
+// of 6.19.1 or greater but upgrading is causing a AwaitRenderStatus error when
+// we run `npm run build`
+// export const authLoader = async () => {
+//   await when(() => session.isAuthStateKnown);
+//   if (!session.isLoggedIn) {
+//     return redirectDocument(getLoginUrl());
+//   }
+//   return null;
+// };
 
 /*
  * A list of functions that match routes defined in constants

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -8,11 +8,7 @@
  * of defined ROUTES.
  */
 
-import {
-  ROUTES,
-  PATHS,
-} from 'js/router/routerConstants';
-import {PROJECTS_ROUTES} from 'js/projects/routes';
+import {ROUTES, PATHS, PROJECTS_ROUTES} from 'js/router/routerConstants';
 
 /**
  * Returns login url with a `next` parameter - after logging in, the  app will

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-infinite-scroller": "^1.2.6",
         "react-mixin": "^5.0.0",
         "react-modal": "^3.15.1",
-        "react-router-dom": "~6.21",
+        "react-router-dom": "~6.14.2",
         "react-select": "^5.3.0",
         "react-table": "^6.8.1",
         "react-tagsinput": "^3.19.0",
@@ -3589,11 +3589,11 @@
       "dev": true
     },
     "node_modules/@remix-run/router": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
-      "integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -23558,29 +23558,29 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
-      "integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "dependencies": {
-        "@remix-run/router": "1.14.0"
+        "@remix-run/router": "1.7.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
-      "integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "dependencies": {
-        "@remix-run/router": "1.14.0",
-        "react-router": "6.21.0"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -30781,9 +30781,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.0.tgz",
-      "integrity": "sha512-WOHih+ClN7N8oHk9N4JUiMxQJmRVaOxcg8w7F/oHUXzJt920ekASLI/7cYX8XkntDWRhLZtsk6LbGrkgOAvi5A=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
+      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -44936,20 +44936,20 @@
       }
     },
     "react-router": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.0.tgz",
-      "integrity": "sha512-hGZ0HXbwz3zw52pLZV3j3+ec+m/PQ9cTpBvqjFQmy2XVUWGn5MD+31oXHb6dVTxYzmAeaiUBYjkoNz66n3RGCg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
+      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
       "requires": {
-        "@remix-run/router": "1.14.0"
+        "@remix-run/router": "1.7.2"
       }
     },
     "react-router-dom": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.0.tgz",
-      "integrity": "sha512-1dUdVj3cwc1npzJaf23gulB562ESNvxf7E4x8upNJycqyUm5BRRZ6dd3LrlzhtLaMrwOCO8R0zoiYxdaJx4LlQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
+      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
       "requires": {
-        "@remix-run/router": "1.14.0",
-        "react-router": "6.21.0"
+        "@remix-run/router": "1.7.2",
+        "react-router": "6.14.2"
       }
     },
     "react-select": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-infinite-scroller": "^1.2.6",
     "react-mixin": "^5.0.0",
     "react-modal": "^3.15.1",
-    "react-router-dom": "~6.21",
+    "react-router-dom": "~6.14.2",
     "react-select": "^5.3.0",
     "react-table": "^6.8.1",
     "react-tagsinput": "^3.19.0",


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Original [redirect pr](https://github.com/kobotoolbox/kpi/pull/4767/files) required a react-router version upgrade which was throwing an `AwaitRenderStatus` reference error, see internal discussion: [https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/2.2E023.2E52.20release/near/318048](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/2.2E023.2E52.20release/near/318048)

## Notes

Reverting react-router version back to `6.14.2` and commenting out the `authLoader` function which was dependent on the upgrade. Moved `PROJECTS_ROUTES` to `jsapp/js/projects/routes.tsx` to prevent circular dependency errors and updated the `requireAuth` component to redirect appropriately based on the user's login status. 
