### PR TITLE
Add $nin and $not to allowed query operators

### DIFF
--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -39,11 +39,15 @@ class MongoHelper:
     OR_OPERATOR = '$or'
     AND_OPERATOR = '$and'
     IN_OPERATOR = '$in'
+    NIN_OPERATOR = '$nin'
+    NOT_OPERATOR = '$not'
 
     KEY_WHITELIST = [
         OR_OPERATOR,
         AND_OPERATOR,
         IN_OPERATOR,
+        NIN_OPERATOR,
+        NOT_OPERATOR,
         '$exists',
         '$gt',
         '$gte',


### PR DESCRIPTION
## Description

Expand the allowed API query operators to include [`$nin`](https://www.mongodb.com/docs/manual/reference/operator/query/nin/) and `$not`.

## Notes

This allows, for example, to return submissions which are not included in a list of known `_id`s or `_uuid`s.

## Related issues

closes #4791 
