### PR TITLE
Url validation and required input improvements

### DIFF
--- a/jsapp/js/account/accountFieldsEditor.component.tsx
+++ b/jsapp/js/account/accountFieldsEditor.component.tsx
@@ -61,13 +61,22 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
 
   const metadata = envStore.data.getUserMetadataFieldsAsSimpleDict();
 
-  /** Get label and (required) for a given user metadata fieldname */
+  /** Get label for a given user metadata fieldname */
   function getLabel(fieldName: UserFieldName): string {
-    const label =
+    return (
       metadata[fieldName]?.label ||
-      (console.error(`No label for fieldname "${fieldName}"`), fieldName);
-    const required = metadata[fieldName]?.required || false;
-    return addRequiredToLabel(label, required);
+      (console.error(`No label for fieldname "${fieldName}"`), fieldName)
+    );
+  }
+
+  /** Is this label required? */
+  function isRequired(fieldName: UserFieldName): boolean {
+    return metadata[fieldName]?.required || false;
+  }
+
+  /** Get label and (required) for a given user metadata fieldname */
+  function getLabelWithRequired(fieldName: UserFieldName): string {
+    return addRequiredToLabel(getLabel(fieldName), isRequired(fieldName));
   }
 
   function isFieldRequired(fieldName: UserFieldName): boolean {
@@ -181,6 +190,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={cx(styles.field, styles.thirds)}>
             <TextBox
               label={getLabel('name')}
+              required={isRequired('name')}
               onChange={onAnyFieldChange.bind(onAnyFieldChange, 'name')}
               value={props.values.name}
               errors={props.errors?.name}
@@ -196,6 +206,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={styles.field}>
             <KoboSelect
               label={getLabel('gender')}
+              isRequired={isRequired('gender')}
               name='gender'
               type='outline'
               size='l'
@@ -216,6 +227,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={cx(styles.field, styles.thirds)}>
             <KoboSelect
               label={getLabel('country')}
+              isRequired={isRequired('country')}
               name='country'
               type='outline'
               size='l'
@@ -236,6 +248,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={cx(styles.field, styles.thirds)}>
             <TextBox
               label={getLabel('city')}
+              required={isRequired('city')}
               value={props.values.city}
               onChange={onAnyFieldChange.bind(onAnyFieldChange, 'city')}
               errors={props.errors?.city}
@@ -249,6 +262,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={styles.field}>
             <KoboSelect
               label={getLabel('sector')}
+              isRequired={isRequired('sector')}
               name='sector'
               type='outline'
               size='l'
@@ -289,6 +303,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
             <div className={styles.field}>
               <TextBox
                 label={getLabel('organization')}
+                required={isRequired('organization')}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
                   'organization'
@@ -308,7 +323,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
                 label={getLabel('organization_website')}
                 type='url'
                 value={props.values.organization_website}
-                required={true}
+                required={isRequired('organization_website')}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
                   'organization_website'
@@ -328,6 +343,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
             <TextBox
               type='text-multiline'
               label={getLabel('bio')}
+              required={isRequired('bio')}
               value={props.values.bio}
               onChange={onAnyFieldChange.bind(onAnyFieldChange, 'bio')}
               errors={props.errors?.bio}
@@ -349,7 +365,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
               <div className={styles.field}>
                 <TextBox
                   startIcon='logo-twitter'
-                  placeholder={getLabel('twitter')}
+                  placeholder={getLabelWithRequired('twitter')}
                   value={props.values.twitter}
                   onChange={onAnyFieldChange.bind(onAnyFieldChange, 'twitter')}
                   errors={props.errors?.twitter}
@@ -362,7 +378,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
               <div className={styles.field}>
                 <TextBox
                   startIcon='logo-linkedin'
-                  placeholder={getLabel('linkedin')}
+                  placeholder={getLabelWithRequired('linkedin')}
                   value={props.values.linkedin}
                   onChange={onAnyFieldChange.bind(onAnyFieldChange, 'linkedin')}
                   errors={props.errors?.linkedin}
@@ -375,7 +391,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
               <div className={styles.field}>
                 <TextBox
                   startIcon='logo-instagram'
-                  placeholder={getLabel('instagram')}
+                  placeholder={getLabelWithRequired('instagram')}
                   value={props.values.instagram}
                   onChange={onAnyFieldChange.bind(
                     onAnyFieldChange,

--- a/jsapp/js/account/accountFieldsEditor.component.tsx
+++ b/jsapp/js/account/accountFieldsEditor.component.tsx
@@ -283,6 +283,7 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
           <div className={cx(styles.field, styles.orgTypeDropdown)}>
             <KoboSelect
               label={getLabel('organization_type')}
+              isRequired={isRequired('organization_type')}
               name='organization_type'
               type='outline'
               size='l'

--- a/jsapp/js/account/accountFieldsEditor.component.tsx
+++ b/jsapp/js/account/accountFieldsEditor.component.tsx
@@ -82,6 +82,33 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
     props.onChange(newValues);
   }
 
+  const cleanedUrl = (value: string) => {
+    if (!value) {
+      return '';
+    }
+    value = ('' + value).trim();
+    if (!value.match(/.\../)) {
+      return value;
+    } // "dotless". don't change it
+    if (!value.match(/^https?:\/\/.*/)) {
+      value = 'https://' + value; // add missing protocol
+    }
+    return value;
+  };
+
+  function updateWebsiteAddress(input: string) {
+    onAnyFieldChange('organization_website', cleanedUrl(input));
+  }
+
+  function onWebsiteKeydown(event: string) {
+    if (event === 'Enter') {
+      onAnyFieldChange(
+        'organization_website',
+        cleanedUrl(props.values.organization_website)
+      );
+    }
+  }
+
   /**
    * Field will be displayed if it is enabled on Back end and not omitted
    * in `displayedFields`.
@@ -279,11 +306,15 @@ export default function AccountFieldsEditor(props: AccountFieldsEditorProps) {
             <div className={styles.field}>
               <TextBox
                 label={getLabel('organization_website')}
+                type='url'
                 value={props.values.organization_website}
+                required={true}
                 onChange={onAnyFieldChange.bind(
                   onAnyFieldChange,
                   'organization_website'
                 )}
+                onBlur={updateWebsiteAddress}
+                onKeyPress={onWebsiteKeydown}
                 errors={props.errors?.organization_website}
               />
             </div>

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
+import Button from 'js/components/common/button';
 import {observer} from 'mobx-react';
-import {unstable_usePrompt as usePrompt} from 'react-router-dom';
+import {Form, unstable_usePrompt as usePrompt} from 'react-router-dom';
 import bem, {makeBem} from 'js/bem';
 import sessionStore from 'js/stores/session';
 import './accountSettings.scss';
@@ -16,7 +17,7 @@ import type {
   AccountFieldsErrors,
 } from './account.constants';
 
-bem.AccountSettings = makeBem(null, 'account-settings');
+bem.AccountSettings = makeBem(null, 'account-settings', 'form');
 bem.AccountSettings__left = makeBem(bem.AccountSettings, 'left');
 bem.AccountSettings__right = makeBem(bem.AccountSettings, 'right');
 bem.AccountSettings__item = makeBem(bem.FormModal, 'item');
@@ -131,16 +132,16 @@ const AccountSettings = observer(() => {
   };
 
   return (
-    <bem.AccountSettings>
+    <bem.AccountSettings onSubmit={updateProfile}>
       <bem.AccountSettings__actions>
-        <bem.KoboButton
-          className='account-settings-save'
-          onClick={updateProfile.bind(form)}
-          m={['blue']}
-        >
-          {t('Save Changes')}
-          {!form.isPristine && ' *'}
-        </bem.KoboButton>
+        <Button
+          type={'full'}
+          classNames={['account-settings-save']}
+          color={'blue'}
+          size={'l'}
+          isSubmit
+          label={t('Save Changes') + (form.isPristine ? '' : ' *')}
+        />
       </bem.AccountSettings__actions>
 
       <bem.AccountSettings__item m={'column'}>

--- a/jsapp/js/components/common/koboDropdown.tsx
+++ b/jsapp/js/components/common/koboDropdown.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import bem, {makeBem} from 'js/bem';
-import {
-  KEY_CODES,
-  KeyNames,
-} from 'js/constants';
+import {KEY_CODES, KeyNames} from 'js/constants';
 import koboDropdownActions from './koboDropdownActions';
 import './koboDropdown.scss';
 
-export type KoboDropdownPlacement = 'down-center' | 'down-left' | 'down-right' | 'up-center' | 'up-left' | 'up-right';
+export type KoboDropdownPlacement =
+  | 'down-center'
+  | 'down-left'
+  | 'down-right'
+  | 'up-center'
+  | 'up-left'
+  | 'up-right';
 
 const DEFAULT_PLACEMENT: KoboDropdownPlacement = 'down-center';
 
 interface KoboDropdownProps {
   placement: KoboDropdownPlacement;
+  isRequired?: boolean;
   /** Disables the dropdowns trigger, thus disallowing opening dropdown. */
   isDisabled?: boolean;
   /** Hides menu whenever user clicks inside it, useful for simple menu with a list of actions. */
@@ -65,20 +69,26 @@ export default class KoboDropdown extends React.Component<
     this.state = {isMenuVisible: false};
   }
 
-  private checkOutsideClickBound: (evt: MouseEvent | TouchEvent) => void = this.checkOutsideClick.bind(this);
+  private checkOutsideClickBound: (evt: MouseEvent | TouchEvent) => void =
+    this.checkOutsideClick.bind(this);
 
-  private onAnyKeyWhileOpenBound: (evt: KeyboardEvent) => void = this.onAnyKeyWhileOpen.bind(this);
+  private onAnyKeyWhileOpenBound: (evt: KeyboardEvent) => void =
+    this.onAnyKeyWhileOpen.bind(this);
 
   private unlisteners: Function[] = [];
 
   componentDidMount() {
     this.unlisteners.push(
-      koboDropdownActions.hideAnyDropdown.requested.listen(this.hideMenu.bind(this))
+      koboDropdownActions.hideAnyDropdown.requested.listen(
+        this.hideMenu.bind(this)
+      )
     );
   }
 
   componentWillUnmount() {
-    this.unlisteners.forEach((clb) => {clb();});
+    this.unlisteners.forEach((clb) => {
+      clb();
+    });
     this.cancelEscKeyListener();
     this.cancelOutsideClickListener();
   }
@@ -171,7 +181,9 @@ export default class KoboDropdown extends React.Component<
     // assume it is not a dropdown.
     let parentsLookupLimit = 10;
     while (loopEl.parentNode !== null) {
-      if (--parentsLookupLimit === 0) {break;}
+      if (--parentsLookupLimit === 0) {
+        break;
+      }
       loopEl = loopEl.parentNode;
       if (
         loopEl &&
@@ -191,9 +203,7 @@ export default class KoboDropdown extends React.Component<
   getWrapperModifiers() {
     const wrapperMods = [];
 
-    if (
-      this.props.placement
-    ) {
+    if (this.props.placement) {
       wrapperMods.push(this.props.placement);
     } else {
       wrapperMods.push(DEFAULT_PLACEMENT);
@@ -227,7 +237,12 @@ export default class KoboDropdown extends React.Component<
     }
 
     return (
-      <bem.KoboDropdown m={this.getWrapperModifiers()} {...additionalWrapperAttributes}>
+      <bem.KoboDropdown
+        m={this.getWrapperModifiers()}
+        {...additionalWrapperAttributes}
+        aria-role='combobox'
+        aria-required={this.props.isRequired}
+      >
         <bem.KoboDropdown__trigger
           onClick={this.onTriggerClick.bind(this)}
           tabIndex='0'
@@ -236,11 +251,14 @@ export default class KoboDropdown extends React.Component<
           {this.props.triggerContent}
         </bem.KoboDropdown__trigger>
 
-        {this.state.isMenuVisible &&
-          <bem.KoboDropdown__menu onClick={this.onMenuClick.bind(this)}>
+        {this.state.isMenuVisible && (
+          <bem.KoboDropdown__menu
+            onClick={this.onMenuClick.bind(this)}
+            aria-role='listbox'
+          >
             {this.props.menuContent}
           </bem.KoboDropdown__menu>
-        }
+        )}
       </bem.KoboDropdown>
     );
   }

--- a/jsapp/js/components/common/koboSelect.scss
+++ b/jsapp/js/components/common/koboSelect.scss
@@ -319,6 +319,19 @@ $k-select-menu-padding: sizes.$x6;
   margin-bottom: textBox.$label-margin;
 }
 
+.k-select__required-mark {
+  // NOTE: copied from textBox.module.scss
+  // Smaller than the design, because there is also a single whitespace
+  // character between the label and this mark
+  margin-left: sizes.$x2;
+  color: colors.$kobo-red;
+  font-size: sizes.$x14;
+  // Magic number to align it similarly to Figma designs
+  line-height: sizes.$x16;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
 // Sets the different sizes for given size of a trigger button.
 @mixin triggerSize($height, $font, $icon) {
   min-height: $height;

--- a/jsapp/js/components/common/koboSelect.tsx
+++ b/jsapp/js/components/common/koboSelect.tsx
@@ -350,6 +350,7 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
         <KoboDropdown
           name={this.props.name}
           placement={'down-center'}
+          isRequired={this.props.isRequired}
           isDisabled={Boolean(this.props.isDisabled)}
           hideOnMenuClick
           triggerContent={this.renderTrigger()}

--- a/jsapp/js/components/common/koboSelect.tsx
+++ b/jsapp/js/components/common/koboSelect.tsx
@@ -343,7 +343,6 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
           <bem.KoboSelect__label htmlFor={this.props.name}>
             {this.props.label}{' '}
             {this.props.isRequired && <span className={'k-select__required-mark'}>*</span>}
-            {/* TODO: Make screenreader text "##label## (required)" */}
           </bem.KoboSelect__label>
         }
 

--- a/jsapp/js/components/common/koboSelect.tsx
+++ b/jsapp/js/components/common/koboSelect.tsx
@@ -62,6 +62,10 @@ interface KoboSelectProps {
   /** This option displays a text box filtering options when opened. */
   isSearchable?: boolean;
   isDisabled?: boolean;
+  /**
+   * Adds required mark ("*") to the label (if label is provided).
+   */
+  isRequired?: boolean;
   /** Changes the appearance to display spinner. */
   isPending?: boolean;
   options: KoboSelectOption[];
@@ -337,7 +341,9 @@ class KoboSelect extends React.Component<KoboSelectProps, KoboSelectState> {
       <bem.KoboSelect m={modifiers}>
         {this.props.label &&
           <bem.KoboSelect__label htmlFor={this.props.name}>
-            {this.props.label}
+            {this.props.label}{' '}
+            {this.props.isRequired && <span className={'k-select__required-mark'}>*</span>}
+            {/* TODO: Make screenreader text "##label## (required)" */}
           </bem.KoboSelect__label>
         }
 

--- a/jsapp/js/components/common/textBox.tsx
+++ b/jsapp/js/components/common/textBox.tsx
@@ -191,6 +191,7 @@ export default function TextBox(props: TextBoxProps) {
         <div className={styles.label}>
           {props.label}{' '}
           {props.required && <span className={styles.requiredMark}>*</span>}
+          {/* TODO: Make aria text "##label## (required)" */}
         </div>
       )}
 

--- a/jsapp/js/components/common/textBox.tsx
+++ b/jsapp/js/components/common/textBox.tsx
@@ -191,7 +191,6 @@ export default function TextBox(props: TextBoxProps) {
         <div className={styles.label}>
           {props.label}{' '}
           {props.required && <span className={styles.requiredMark}>*</span>}
-          {/* TODO: Make aria text "##label## (required)" */}
         </div>
       )}
 
@@ -209,6 +208,7 @@ export default function TextBox(props: TextBoxProps) {
         {props.type === 'text-multiline' && (
           <TextareaAutosize
             className={styles.input}
+            aria-required={props.required}
             ref={textareaReference}
             onChange={(evt: React.FormEvent<HTMLTextAreaElement>) => {
               onValueChange(evt.currentTarget.value);
@@ -219,6 +219,7 @@ export default function TextBox(props: TextBoxProps) {
         {props.type !== 'text-multiline' && (
           <input
             className={styles.input}
+            aria-required={props.required}
             type={type}
             ref={inputReference}
             // We use `onInput` instead of `onChange` here, because (for some

--- a/static/js/organization_type_skiplogic.js
+++ b/static/js/organization_type_skiplogic.js
@@ -43,7 +43,7 @@
       value = ('' + value).trim();
       if (!value.match(/.\../)) {return value;} // "dotless". don't change it
       if (!value.match(/^https?:\/\/.*/)) {
-        value = 'http://' + value; // add missing protocol
+        value = 'https://' + value; // add missing protocol
       }
       return value;
     };


### PR DESCRIPTION
This PR adds URL validation for the organization website field in the ToS and account settings forms. It also includes and finishes @p2edwards work on displaying red asterisks for required fields instead of adding (required) in the label. I have added `aria-required` to the relevant inputs for accessibility.