### PR TITLE
Fix bug to allow collection managers to add library items 

### DIFF
--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -22,8 +22,8 @@ import {
   getRouteAssetUid,
   isAnyFormRoute,
 } from 'js/router/routerUtils';
-import managedCollectionsStore from 'jsapp/js/components/library/managedCollectionsStore';
-import type {ManagedCollectionsStoreData} from 'jsapp/js/components/library/managedCollectionsStore';
+import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
+import type {OwnedCollectionsStoreData} from 'js/components/library/ownedCollectionsStore';
 import './assetActionButtons.scss';
 import {withRouter} from 'jsapp/js/router/legacy';
 import type {WithRouterProps} from 'jsapp/js/router/legacy';
@@ -57,7 +57,7 @@ interface AssetActionButtonsProps extends WithRouterProps {
 }
 
 interface AssetActionButtonsState {
-  managedCollections: AssetResponse[];
+  ownedCollections: AssetResponse[];
   shouldHidePopover: boolean;
   isPopoverVisible: boolean;
   isSubscribePending: boolean;
@@ -77,7 +77,7 @@ class AssetActionButtons extends React.Component<
   constructor(props: AssetActionButtonsProps) {
     super(props);
     this.state = {
-      managedCollections: managedCollectionsStore.data.collections,
+      ownedCollections: ownedCollectionsStore.data.collections,
       shouldHidePopover: false,
       isPopoverVisible: false,
       isSubscribePending: false,
@@ -86,8 +86,8 @@ class AssetActionButtons extends React.Component<
   }
 
   componentDidMount() {
-    managedCollectionsStore.listen(
-      this.onManagedCollectionsStoreChanged.bind(this),
+    ownedCollectionsStore.listen(
+      this.onOwnedCollectionsStoreChanged.bind(this),
       this
     );
     this.unlisteners.push(
@@ -110,8 +110,8 @@ class AssetActionButtons extends React.Component<
     this.setState({isSubscribePending: false});
   }
 
-  onManagedCollectionsStoreChanged(storeData: ManagedCollectionsStoreData) {
-    this.setState({managedCollections: storeData.collections});
+  onOwnedCollectionsStoreChanged(storeData: OwnedCollectionsStoreData) {
+    this.setState({ownedCollections: storeData.collections});
   }
 
   // methods for inner workings of component
@@ -331,12 +331,12 @@ class AssetActionButtons extends React.Component<
         {userCanEdit &&
           assetType !== ASSET_TYPES.survey.id &&
           assetType !== ASSET_TYPES.collection.id &&
-          this.state.managedCollections.length > 0 && [
+          this.state.ownedCollections.length > 0 && [
             <bem.PopoverMenu__heading key='heading'>
               {t('Move to')}
             </bem.PopoverMenu__heading>,
             <bem.PopoverMenu__moveTo key='list'>
-              {this.state.managedCollections.map((collection) => {
+              {this.state.ownedCollections.map((collection) => {
                 const modifiers = ['move-coll-item'];
                 const isAssetParent =
                   collection.url === this.props.asset.parent;

--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -22,8 +22,8 @@ import {
   getRouteAssetUid,
   isAnyFormRoute,
 } from 'js/router/routerUtils';
-import managedCollectionsStore from 'jsapp/js/components/library/managedCollectionsStore';
-import type {ManagedCollectionsStoreData} from 'jsapp/js/components/library/managedCollectionsStore';
+import managedCollectionsStore from 'js/components/library/managedCollectionsStore';
+import type {ManagedCollectionsStoreData} from 'js/components/library/managedCollectionsStore';
 import './assetActionButtons.scss';
 import {withRouter} from 'jsapp/js/router/legacy';
 import type {WithRouterProps} from 'jsapp/js/router/legacy';

--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -22,8 +22,8 @@ import {
   getRouteAssetUid,
   isAnyFormRoute,
 } from 'js/router/routerUtils';
-import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
-import type {OwnedCollectionsStoreData} from 'js/components/library/ownedCollectionsStore';
+import managedCollectionsStore from 'jsapp/js/components/library/managedCollectionsStore';
+import type {ManagedCollectionsStoreData} from 'jsapp/js/components/library/managedCollectionsStore';
 import './assetActionButtons.scss';
 import {withRouter} from 'jsapp/js/router/legacy';
 import type {WithRouterProps} from 'jsapp/js/router/legacy';
@@ -57,7 +57,7 @@ interface AssetActionButtonsProps extends WithRouterProps {
 }
 
 interface AssetActionButtonsState {
-  ownedCollections: AssetResponse[];
+  managedCollections: AssetResponse[];
   shouldHidePopover: boolean;
   isPopoverVisible: boolean;
   isSubscribePending: boolean;
@@ -77,7 +77,7 @@ class AssetActionButtons extends React.Component<
   constructor(props: AssetActionButtonsProps) {
     super(props);
     this.state = {
-      ownedCollections: ownedCollectionsStore.data.collections,
+      managedCollections: managedCollectionsStore.data.collections,
       shouldHidePopover: false,
       isPopoverVisible: false,
       isSubscribePending: false,
@@ -86,8 +86,8 @@ class AssetActionButtons extends React.Component<
   }
 
   componentDidMount() {
-    ownedCollectionsStore.listen(
-      this.onOwnedCollectionsStoreChanged.bind(this),
+    managedCollectionsStore.listen(
+      this.onManagedCollectionsStoreChanged.bind(this),
       this
     );
     this.unlisteners.push(
@@ -110,8 +110,8 @@ class AssetActionButtons extends React.Component<
     this.setState({isSubscribePending: false});
   }
 
-  onOwnedCollectionsStoreChanged(storeData: OwnedCollectionsStoreData) {
-    this.setState({ownedCollections: storeData.collections});
+  onManagedCollectionsStoreChanged(storeData: ManagedCollectionsStoreData) {
+    this.setState({managedCollections: storeData.collections});
   }
 
   // methods for inner workings of component
@@ -331,12 +331,12 @@ class AssetActionButtons extends React.Component<
         {userCanEdit &&
           assetType !== ASSET_TYPES.survey.id &&
           assetType !== ASSET_TYPES.collection.id &&
-          this.state.ownedCollections.length > 0 && [
+          this.state.managedCollections.length > 0 && [
             <bem.PopoverMenu__heading key='heading'>
               {t('Move to')}
             </bem.PopoverMenu__heading>,
             <bem.PopoverMenu__moveTo key='list'>
-              {this.state.ownedCollections.map((collection) => {
+              {this.state.managedCollections.map((collection) => {
                 const modifiers = ['move-coll-item'];
                 const isAssetParent =
                   collection.url === this.props.asset.parent;

--- a/jsapp/js/components/library/managedCollectionsStore.ts
+++ b/jsapp/js/components/library/managedCollectionsStore.ts
@@ -133,7 +133,7 @@ class ManagedCollectionsStore extends Reflux.Store {
   }
 }
 
-/** This store keeps an up to date list of owned collections. */
+/** This store keeps an up to date list of managed collections. */
 const managedCollectionsStore = new ManagedCollectionsStore();
 managedCollectionsStore.init();
 

--- a/jsapp/js/components/library/managedCollectionsStore.ts
+++ b/jsapp/js/components/library/managedCollectionsStore.ts
@@ -12,15 +12,15 @@ import type {
 } from 'js/dataInterface';
 import {router} from 'js/router/legacy';
 
-export interface OwnedCollectionsStoreData {
+export interface ManagedCollectionsStoreData {
   isFetchingData: boolean;
   collections: AssetResponse[];
 }
 
-class OwnedCollectionsStore extends Reflux.Store {
+class ManagedCollectionsStore extends Reflux.Store {
   isInitialised = false;
 
-  data: OwnedCollectionsStoreData = {
+  data: ManagedCollectionsStoreData = {
     isFetchingData: false,
     collections: [],
   };
@@ -128,7 +128,7 @@ class OwnedCollectionsStore extends Reflux.Store {
 }
 
 /** This store keeps an up to date list of owned collections. */
-const ownedCollectionsStore = new OwnedCollectionsStore();
-ownedCollectionsStore.init();
+const managedCollectionsStore = new ManagedCollectionsStore();
+managedCollectionsStore.init();
 
-export default ownedCollectionsStore;
+export default managedCollectionsStore;

--- a/jsapp/js/components/library/ownedCollectionsStore.ts
+++ b/jsapp/js/components/library/ownedCollectionsStore.ts
@@ -12,15 +12,15 @@ import type {
 } from 'js/dataInterface';
 import {router} from 'js/router/legacy';
 
-export interface ManagedCollectionsStoreData {
+export interface OwnedCollectionsStoreData {
   isFetchingData: boolean;
   collections: AssetResponse[];
 }
 
-class ManagedCollectionsStore extends Reflux.Store {
+class OwnedCollectionsStore extends Reflux.Store {
   isInitialised = false;
 
-  data: ManagedCollectionsStoreData = {
+  data: OwnedCollectionsStoreData = {
     isFetchingData: false,
     collections: [],
   };
@@ -128,7 +128,7 @@ class ManagedCollectionsStore extends Reflux.Store {
 }
 
 /** This store keeps an up to date list of owned collections. */
-const managedCollectionsStore = new ManagedCollectionsStore();
-managedCollectionsStore.init();
+const ownedCollectionsStore = new OwnedCollectionsStore();
+ownedCollectionsStore.init();
 
-export default managedCollectionsStore;
+export default ownedCollectionsStore;

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -18,7 +18,7 @@ import assetUtils from 'js/assetUtils';
 import {renderBackButton} from './modalHelpers';
 import {ASSET_TYPES} from 'js/constants';
 import mixins from 'js/mixins';
-import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
+import managedCollectionsStore from 'js/components/library/managedCollectionsStore';
 import envStore from 'js/envStore';
 import {withRouter} from 'js/router/legacy';
 
@@ -152,7 +152,7 @@ export class LibraryAssetFormComponent extends React.Component {
         this.isLibrarySingle() &&
         params.asset_type !== ASSET_TYPES.collection.id
       ) {
-        const found = ownedCollectionsStore.find(this.currentAssetID());
+        const found = managedCollectionsStore.find(this.currentAssetID());
         if (found && found.asset_type === ASSET_TYPES.collection.id) {
           // when creating from within a collection page, make the new asset
           // a child of this collection

--- a/jsapp/js/components/modalForms/libraryAssetForm.es6
+++ b/jsapp/js/components/modalForms/libraryAssetForm.es6
@@ -18,7 +18,7 @@ import assetUtils from 'js/assetUtils';
 import {renderBackButton} from './modalHelpers';
 import {ASSET_TYPES} from 'js/constants';
 import mixins from 'js/mixins';
-import managedCollectionsStore from 'js/components/library/managedCollectionsStore';
+import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
 import envStore from 'js/envStore';
 import {withRouter} from 'js/router/legacy';
 
@@ -152,7 +152,7 @@ export class LibraryAssetFormComponent extends React.Component {
         this.isLibrarySingle() &&
         params.asset_type !== ASSET_TYPES.collection.id
       ) {
-        const found = managedCollectionsStore.find(this.currentAssetID());
+        const found = ownedCollectionsStore.find(this.currentAssetID());
         if (found && found.asset_type === ASSET_TYPES.collection.id) {
           // when creating from within a collection page, make the new asset
           // a child of this collection

--- a/jsapp/js/components/modalForms/libraryNewItemForm.es6
+++ b/jsapp/js/components/modalForms/libraryNewItemForm.es6
@@ -13,7 +13,7 @@ import {
 } from 'js/constants';
 import {ROUTES} from 'js/router/routerConstants';
 import mixins from 'js/mixins';
-import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
+import managedCollectionsStore from 'js/components/library/managedCollectionsStore';
 import {withRouter} from 'js/router/legacy';
 import {when} from 'mobx';
 
@@ -38,7 +38,7 @@ class LibraryNewItemForm extends React.Component {
 
     let targetPath = ROUTES.NEW_LIBRARY_ITEM;
     if (this.isLibrarySingle()) {
-      const found = ownedCollectionsStore.find(this.currentAssetID());
+      const found = managedCollectionsStore.find(this.currentAssetID());
       if (found && found.asset_type === ASSET_TYPES.collection.id) {
         // when creating from within a collection page, make the new asset
         // a child of this collection

--- a/jsapp/js/components/modalForms/libraryNewItemForm.es6
+++ b/jsapp/js/components/modalForms/libraryNewItemForm.es6
@@ -13,7 +13,7 @@ import {
 } from 'js/constants';
 import {ROUTES} from 'js/router/routerConstants';
 import mixins from 'js/mixins';
-import managedCollectionsStore from 'js/components/library/managedCollectionsStore';
+import ownedCollectionsStore from 'js/components/library/ownedCollectionsStore';
 import {withRouter} from 'js/router/legacy';
 import {when} from 'mobx';
 
@@ -38,7 +38,7 @@ class LibraryNewItemForm extends React.Component {
 
     let targetPath = ROUTES.NEW_LIBRARY_ITEM;
     if (this.isLibrarySingle()) {
-      const found = managedCollectionsStore.find(this.currentAssetID());
+      const found = ownedCollectionsStore.find(this.currentAssetID());
       if (found && found.asset_type === ASSET_TYPES.collection.id) {
         // when creating from within a collection page, make the new asset
         // a child of this collection


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes


## Notes

Renamed the `OwnedCollectionsStore` store to `ManageCollectionsStore` based on this [internal discussion]( https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/'move.20to'.20menu.20in.20library.20only.20shows.202.20collections/near/315471
)
## Related issues

Fixes #4778
