### PR TITLE
Fix styles for anonymous submissions toggle

### DIFF
--- a/jsapp/js/components/anonymousSubmission.module.scss
+++ b/jsapp/js/components/anonymousSubmission.module.scss
@@ -3,11 +3,12 @@
 
 .root {
   display: flex;
+  align-items: flex-start;
   padding-bottom: sizes.$x12;
   padding-top: sizes.$x8;
   border-bottom: 1px solid colors.$kobo-gray-96;
 }
 
-a {
-  margin-left: sizes.$x8;
+.root > *:not(:last-child) {
+  margin-right: sizes.$x8;
 }


### PR DESCRIPTION
## Description

Removes the global `a` styles that caused many issues throughout the app. Also improves tooltip placement for the help link.

## Related issues

Aftermath of #4719