### PR TITLE
Allow removing responses from qualitative analysis integer questions

### DIFF
--- a/jsapp/js/components/processing/analysis/constants.ts
+++ b/jsapp/js/components/processing/analysis/constants.ts
@@ -103,8 +103,8 @@ export interface AnalysisQuestionInternal extends AnalysisQuestionBase {
 export interface AnalysisResponse {
   type: AnalysisQuestionType;
   uuid: string;
-  /** `undefined` is for `qual_integer` */
-  val: string | string[] | number | undefined;
+  /** `null` is for `qual_integer` */
+  val: string | string[] | number | null;
 }
 
 /**

--- a/kobo/apps/subsequences/jsonschemas/qual_schema.py
+++ b/kobo/apps/subsequences/jsonschemas/qual_schema.py
@@ -52,7 +52,7 @@ DEFINITIONS['qual_integer'] = {
     'type': 'object',
     'properties': {
         'type': {'const': 'qual_integer'},
-        'val': {'type': 'integer'},
+        'val': {'type': ['integer', 'null']},
     },
 }
 DEFINITIONS['qual_select_one'] = {


### PR DESCRIPTION
## Description

Fixes a bug where it was impossible to remove a response from a qualitative analysis integer question once one was added.

## Notes

`null` is now sent to represent these empty responses instead of `undefined`. The qualitative analysis schema has been updated to accept either nulls or integers for `qual_integer` questions.