### PR TITLE
Fix 500 error when loading table view

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -558,20 +558,21 @@ class Asset(ObjectPermissionMixin,
         survey = content['survey']
 
         def _get_xpaths(survey_: dict) -> Optional[list]:
-            try:
-                return [
-                    question['$xpath']
-                    for question in survey_
-                    if question['type'] in ATTACHMENT_QUESTION_TYPES
-                ]
-            except KeyError as e:
-                # If KeyError is anything else than '$xpath', we raise the error.
-                # Otherwise, we pass (and return None) because '$xpath'
-                # and '$qpath' should be injected before next try
-                if str(e).strip("'") != '$xpath':
-                    raise e
-
-            return None
+            """
+            Returns an empty list if no questions that take attachments are
+            present. Returns `None` if XPath are missing from the survey
+            content
+            """
+            xpaths = []
+            for question in survey_:
+                if question['type'] not in ATTACHMENT_QUESTION_TYPES:
+                    continue
+                try:
+                    xpath = question['$xpath']
+                except KeyError:
+                    return None
+                xpaths.append(xpath)
+            return xpaths
 
         if xpaths := _get_xpaths(survey):
             return xpaths

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -549,12 +549,35 @@ class Asset(ObjectPermissionMixin,
         version = (
             self.latest_deployed_version if deployed else self.latest_version
         )
-        survey = version.to_formpack_schema()['content']['survey']
-        return [
-            q['$xpath']
-            for q in survey
-            if q['type'] in ATTACHMENT_QUESTION_TYPES
-        ]
+
+        if version:
+            content = version.to_formpack_schema()['content']
+        else:
+            content = self.content
+
+        survey = content['survey']
+
+        def _get_xpaths(survey_: dict) -> Optional[list]:
+            try:
+                return [
+                    question['$xpath']
+                    for question in survey_
+                    if question['type'] in ATTACHMENT_QUESTION_TYPES
+                ]
+            except KeyError as e:
+                # If KeyError is anything else than '$xpath', we raise the error.
+                # Otherwise, we pass (and return None) because '$xpath'
+                # and '$qpath' should be injected before next try
+                if str(e).strip("'") != '$xpath':
+                    raise e
+
+            return None
+
+        if xpaths := _get_xpaths(survey):
+            return xpaths
+
+        self._insert_qpath(content)
+        return _get_xpaths(survey)
 
     def get_filters_for_partial_perm(
         self, user_id: int, perm: str = PERM_VIEW_SUBMISSIONS

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -856,3 +856,22 @@ def test_populates_qpath_xpath_correctly():
     rs = asset.content['survey'][0:4]
     assert [rr['$qpath'] for rr in rs] == ['g1', 'g1-r1', 'g1-g2', 'g1-g2-r2']
     assert [rr['$xpath'] for rr in rs] == ['g1', 'g1/r1', 'g1/g2', 'g1/g2/r2']
+
+
+def test_return_xpaths_and_qpath_even_if_missing():
+    asset = Asset(content={
+        'survey': [
+            {'type': 'begin_group', 'name': 'g1'},
+            {'type': 'audio', 'name': 'r1', '$kuid': 'k1'},
+            {'type': 'begin_group', 'name': 'g2'},
+            {'type': 'image', 'name': 'r2', '$kuid': 'k2'},
+            {'type': 'end_group'},
+            {'type': 'end_group'},
+        ],
+    })
+    expected = ['g1/r1', 'g1/g2/r2']
+    # 'qpath' and 'xpath' are not injected until an Asset object is saved with `adjust_content=True`
+    # or `adjust_content_on_save()` is called directly.
+    # No matter what, `get_attachment_xpaths()` should be able to return
+    # attachment xpaths.
+    assert asset.get_attachment_xpaths(deployed=False) == expected


### PR DESCRIPTION
## Description

Fix an error when - under certain circumstances - the table view does not load and display Server Error(500)

## Notes
#4811 expected every Asset to have `$xpath` injected in its content. It may be not the case for old projects which have not been edited at least once since version `2.022.44a`. Therefore #4811 bug fix crashes on KeyError `$xpath`.

