### PR TITLE
Consolidate common deployment backend code

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -4,6 +4,7 @@ import abc
 import copy
 import datetime
 import json
+import uuid
 from datetime import date
 from typing import Union, Iterator, Optional
 
@@ -12,6 +13,7 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from django.core.exceptions import PermissionDenied
+from lxml import etree
 from rest_framework import serializers
 from rest_framework.pagination import _positive_int as positive_int
 from shortuuid import ShortUUID
@@ -19,12 +21,15 @@ from shortuuid import ShortUUID
 from kpi.constants import (
     SUBMISSION_FORMAT_TYPE_XML,
     SUBMISSION_FORMAT_TYPE_JSON,
+    PERM_CHANGE_SUBMISSIONS,
     PERM_PARTIAL_SUBMISSIONS,
     PERM_VIEW_SUBMISSIONS,
 )
+from kpi.exceptions import BulkUpdateSubmissionsClientException
 from kpi.models.asset_file import AssetFile
 from kpi.models.paired_data import PairedData
 from kpi.utils.django_orm_helper import UpdateJSONFieldAttributes
+from kpi.utils.xml import edit_submission_xml
 
 
 class BaseDeploymentBackend(abc.ABC):
@@ -70,11 +75,106 @@ class BaseDeploymentBackend(abc.ABC):
     def bulk_assign_mapped_perms(self):
         pass
 
-    @abc.abstractmethod
     def bulk_update_submissions(
         self, data: dict, user: 'auth.User'
     ) -> dict:
-        pass
+        """
+        Allows for bulk updating (bulk editing) of submissions. A
+        `deprecatedID` for each submission is given the previous value of
+        `instanceID` and `instanceID` receives an updated uuid. For each key
+        and value within `request_data`, either a new element is created on the
+        submission's XML tree, or the existing value is replaced by the updated
+        value.
+
+        Args:
+            data (dict): must contain a list of `submission_ids` and at
+                least one other key:value field for updating the submissions
+            user (User)
+
+        Returns:
+            dict: formatted dict to be passed to a Response object
+        """
+        submission_ids = self.validate_access_with_partial_perms(
+            user=user,
+            perm=PERM_CHANGE_SUBMISSIONS,
+            submission_ids=data['submission_ids'],
+            query=data['query'],
+        )
+
+        # If `submission_ids` is not empty, user has partial permissions.
+        # Otherwise, they have full access.
+        if submission_ids:
+            # Reset query, because all the submission ids have been already
+            # retrieve
+            data['query'] = {}
+        else:
+            submission_ids = data['submission_ids']
+
+        submissions = self.get_submissions(
+            user=user,
+            format_type=SUBMISSION_FORMAT_TYPE_XML,
+            submission_ids=submission_ids,
+            query=data['query'],
+        )
+
+        if not self.current_submission_count:
+            raise BulkUpdateSubmissionsClientException(
+                detail=t('No submissions match the given `submission_ids`')
+            )
+
+        # Remove potentially destructive keys from the payload
+        update_data = copy.deepcopy(data['data'])
+        update_data = {
+            k: v
+            for k, v in update_data.items()
+            if not (
+                k in self.PROTECTED_XML_FIELDS
+                or '/' in k
+                and k.split('/')[0] in self.PROTECTED_XML_FIELDS
+            )
+        }
+
+        kc_responses = []
+        for submission in submissions:
+            xml_parsed = etree.fromstring(submission)
+
+            _uuid, uuid_formatted = self.generate_new_instance_id()
+
+            # Updating xml fields for submission. In order to update an existing
+            # submission, the current `instanceID` must be moved to the value
+            # for `deprecatedID`.
+            instance_id = xml_parsed.find('meta/instanceID')
+            # If the submission has been edited before, it will already contain
+            # a deprecatedID element - otherwise create a new element
+            deprecated_id = xml_parsed.find('meta/deprecatedID')
+            deprecated_id_or_new = (
+                deprecated_id
+                if deprecated_id is not None
+                else etree.SubElement(xml_parsed.find('meta'), 'deprecatedID')
+            )
+            deprecated_id_or_new.text = instance_id.text
+            instance_id.text = uuid_formatted
+
+            # If the form has been updated with new fields and earlier
+            # submissions have been selected as part of the bulk update,
+            # a new element has to be created before a value can be set.
+            # However, with this new power, arbitrary fields can be added
+            # to the XML tree through the API.
+            for path, value in update_data.items():
+                edit_submission_xml(xml_parsed, path, value)
+
+            kc_response = self.store_submission(
+                user, etree.tostring(xml_parsed), _uuid
+            )
+            kc_responses.append(
+                {
+                    'uuid': _uuid,
+                    'response': kc_response,
+                }
+            )
+
+        return self.prepare_bulk_update_response(kc_responses)
+
 
     @abc.abstractmethod
     def calculated_submission_count(self, user: 'auth.User', **kwargs):
@@ -120,6 +220,16 @@ class BaseDeploymentBackend(abc.ABC):
     @abc.abstractmethod
     def enketo_id(self):
         pass
+
+    @staticmethod
+    def generate_new_instance_id() -> (str, str):
+        """
+        Returns:
+            - Generated uuid
+            - Formatted uuid for OpenRosa xml
+        """
+        _uuid = str(uuid.uuid4())
+        return _uuid, f'uuid:{_uuid}'
 
     @abc.abstractmethod
     def get_attachment(
@@ -352,6 +462,13 @@ class BaseDeploymentBackend(abc.ABC):
     @property
     def stored_data_key(self):
         return self.__stored_data_key
+
+    @property
+    @abc.abstractmethod
+    def store_submission(
+        self, user, xml_submission, submission_uuid, attachments=None
+    ):
+        pass
 
     @property
     @abc.abstractmethod

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -59,7 +59,6 @@ from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.permissions import is_user_anonymous
-from kpi.utils.xml import edit_submission_xml
 from .base_backend import BaseDeploymentBackend
 from .kc_access.shadow_models import (
     KobocatXForm,
@@ -75,7 +74,6 @@ from .kc_access.utils import (
 )
 from ..exceptions import (
     BadFormatException,
-    KobocatBulkUpdateSubmissionsClientException,
     KobocatDeploymentException,
     KobocatDuplicateSubmissionException,
 )
@@ -120,106 +118,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
                 if user.id == self.asset.owner_id:
                     continue
                 assign_applicable_kc_permissions(self.asset, user, perms)
-
-    def bulk_update_submissions(
-        self, data: dict, user: 'auth.User'
-    ) -> dict:
-        """
-        Allows for bulk updating of submissions proxied through KoBoCAT. A
-        `deprecatedID` for each submission is given the previous value of
-        `instanceID` and `instanceID` receives an updated uuid. For each key
-        and value within `request_data`, either a new element is created on the
-        submission's XML tree, or the existing value is replaced by the updated
-        value.
-
-        Args:
-            data (dict): must contain a list of `submission_ids` and at
-                least one other key:value field for updating the submissions
-            user (User)
-
-        Returns:
-            dict: formatted dict to be passed to a Response object
-        """
-        submission_ids = self.validate_access_with_partial_perms(
-            user=user,
-            perm=PERM_CHANGE_SUBMISSIONS,
-            submission_ids=data['submission_ids'],
-            query=data['query'],
-        )
-
-        # If `submission_ids` is not empty, user has partial permissions.
-        # Otherwise, they have full access.
-        if submission_ids:
-            # Reset query, because all the submission ids have been already
-            # retrieve
-            data['query'] = {}
-        else:
-            submission_ids = data['submission_ids']
-
-        submissions = self.get_submissions(
-            user=user,
-            format_type=SUBMISSION_FORMAT_TYPE_XML,
-            submission_ids=submission_ids,
-            query=data['query'],
-        )
-
-        if not self.current_submission_count:
-            raise KobocatBulkUpdateSubmissionsClientException(
-                detail=t('No submissions match the given `submission_ids`')
-            )
-
-        update_data = self.__prepare_bulk_update_data(data['data'])
-        kc_responses = []
-        for submission in submissions:
-            xml_parsed = etree.fromstring(submission)
-
-            _uuid, uuid_formatted = self.generate_new_instance_id()
-
-            # Updating xml fields for submission. In order to update an existing
-            # submission, the current `instanceID` must be moved to the value
-            # for `deprecatedID`.
-            instance_id = xml_parsed.find('meta/instanceID')
-            # If the submission has been edited before, it will already contain
-            # a deprecatedID element - otherwise create a new element
-            deprecated_id = xml_parsed.find('meta/deprecatedID')
-            deprecated_id_or_new = (
-                deprecated_id
-                if deprecated_id is not None
-                else etree.SubElement(xml_parsed.find('meta'), 'deprecatedID')
-            )
-            deprecated_id_or_new.text = instance_id.text
-            instance_id.text = uuid_formatted
-
-            # If the form has been updated with new fields and earlier
-            # submissions have been selected as part of the bulk update,
-            # a new element has to be created before a value can be set.
-            # However, with this new power, arbitrary fields can be added
-            # to the XML tree through the API.
-            for path, value in update_data.items():
-                edit_submission_xml(xml_parsed, path, value)
-
-            # TODO: Might be worth refactoring this as it is also used when
-            # duplicating a submission
-            file_tuple = (_uuid, io.BytesIO(etree.tostring(xml_parsed)))
-            files = {'xml_submission_file': file_tuple}
-            # `POST` is required by OpenRosa spec https://docs.getodk.org/openrosa-form-submission
-            kc_request = requests.Request(
-                method='POST',
-                url=self.submission_url,
-                files=files,
-            )
-            kc_response = self.__kobocat_proxy_request(
-                kc_request, user=user
-            )
-
-            kc_responses.append(
-                {
-                    'uuid': _uuid,
-                    'response': kc_response,
-                }
-            )
-
-        return self.__prepare_bulk_update_response(kc_responses)
 
     def calculated_submission_count(self, user: 'auth.User', **kwargs) -> int:
         params = self.validate_submission_list_params(
@@ -503,20 +401,9 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # silently
         xml_parsed.find('meta/instanceID').text = uuid_formatted
 
-        file_tuple = (_uuid, io.BytesIO(ET.tostring(xml_parsed)))
-        files = {'xml_submission_file': file_tuple}
-
-        # Combine all files altogether
-        if attachments:
-            files.update(attachments)
-
-        kc_request = requests.Request(
-            method='POST', url=self.submission_url, files=files
+        kc_response = self.store_submission(
+            user, ET.tostring(xml_parsed), _uuid, attachments
         )
-        kc_response = self.__kobocat_proxy_request(
-            kc_request, user=user
-        )
-
         if kc_response.status_code == status.HTTP_201_CREATED:
             return next(self.get_submissions(user, query={'_uuid': _uuid}))
         else:
@@ -611,16 +498,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             repl=settings.KOBOCAT_INTERNAL_URL,
             string=url
         )
-
-    @staticmethod
-    def generate_new_instance_id() -> (str, str):
-        """
-        Returns:
-            - Generated uuid
-            - Formatted uuid for OpenRosa xml
-        """
-        _uuid = str(uuid.uuid4())
-        return _uuid, f'uuid:{_uuid}'
 
     def get_attachment(
         self,
@@ -1245,6 +1122,19 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         kc_response = self.__kobocat_proxy_request(kc_request, user)
         return self.__prepare_as_drf_response_signature(kc_response)
 
+    def store_submission(
+        self, user, xml_submission, submission_uuid, attachments=None
+    ):
+        file_tuple = (submission_uuid, io.BytesIO(xml_submission))
+        files = {'xml_submission_file': file_tuple}
+        if attachments:
+            files.update(attachments)
+        kc_request = requests.Request(
+            method='POST', url=self.submission_url, files=files
+        )
+        kc_response = self.__kobocat_proxy_request(kc_request, user=user)
+        return kc_response
+
     @property
     def submission_count(self):
         try:
@@ -1645,24 +1535,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
         return prepared_drf_response
 
-    @classmethod
-    def __prepare_bulk_update_data(cls, updates: dict) -> dict:
-        """
-        Preparing the request payload for bulk updating of submissions
-        """
-        # Sanitizing the payload of potentially destructive keys
-        sanitized_updates = copy.deepcopy(updates)
-        for key in updates:
-            if (
-                key in cls.PROTECTED_XML_FIELDS
-                or '/' in key and key.split('/')[0] in cls.PROTECTED_XML_FIELDS
-            ):
-                sanitized_updates.pop(key)
-
-        return sanitized_updates
-
     @staticmethod
-    def __prepare_bulk_update_response(kc_responses: list) -> dict:
+    def prepare_bulk_update_response(kc_responses: list) -> dict:
         """
         Formatting the response to allow for partial successes to be seen
         more explicitly.

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 import copy
 import os
-import re
 import time
 import uuid
 from collections import defaultdict
@@ -12,7 +11,7 @@ from xml.etree import ElementTree as ET
 
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
-from django.utils import timezone
+from lxml import etree
 
 try:
     from zoneinfo import ZoneInfo
@@ -23,7 +22,6 @@ from deepmerge import always_merger
 from dict2xml import dict2xml as dict2xml_real
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import gettext as t
 from lxml import etree
 from rest_framework import status
 
@@ -45,9 +43,7 @@ from kpi.interfaces.sync_backend_media import SyncBackendMediaInterface
 from kpi.models.asset_file import AssetFile
 from kpi.tests.utils.mock import MockAttachment
 from kpi.utils.mongo_helper import MongoHelper, drop_mock_only
-from kpi.utils.xml import edit_submission_xml
 from .base_backend import BaseDeploymentBackend
-from ..exceptions import KobocatBulkUpdateSubmissionsClientException
 
 
 def dict2xml(*args, **kwargs):
@@ -71,66 +67,6 @@ class MockDeploymentBackend(BaseDeploymentBackend):
 
     def bulk_assign_mapped_perms(self):
         pass
-
-    def bulk_update_submissions(
-        self, data: dict, user: 'auth.User'
-    ) -> dict:
-        submission_ids = self.validate_access_with_partial_perms(
-            user=user,
-            perm=PERM_CHANGE_SUBMISSIONS,
-            submission_ids=data['submission_ids'],
-            query=data['query'],
-        )
-
-        if submission_ids:
-            data['query'] = {}
-        else:
-            submission_ids = data['submission_ids']
-
-        submissions = self.get_submissions(
-            user=user,
-            format_type=SUBMISSION_FORMAT_TYPE_XML,
-            submission_ids=submission_ids,
-            query=data['query'],
-        )
-
-        if not self.current_submission_count:
-            raise KobocatBulkUpdateSubmissionsClientException(
-                detail=t('No submissions match the given `submission_ids`')
-            )
-
-        update_data = self.__prepare_bulk_update_data(data['data'])
-        kc_responses = []
-        for submission in submissions:
-            # Remove XML declaration from submission
-            submission = re.sub(r'(<\?.*\?>)', '', submission)
-            xml_parsed = etree.fromstring(submission)
-
-            _uuid, uuid_formatted = self.generate_new_instance_id()
-
-            instance_id = xml_parsed.find('meta/instanceID')
-            deprecated_id = xml_parsed.find('meta/deprecatedID')
-            deprecated_id_or_new = (
-                deprecated_id
-                if deprecated_id is not None
-                else etree.SubElement(xml_parsed.find('meta'), 'deprecatedID')
-            )
-            deprecated_id_or_new.text = instance_id.text
-            instance_id.text = uuid_formatted
-
-            for path, value in update_data.items():
-                edit_submission_xml(xml_parsed, path, value)
-
-            kc_responses.append(
-                {
-                    'uuid': _uuid,
-                    'status_code': status.HTTP_201_CREATED,
-                    'message': 'Successful submission',
-                    'updated_submission': etree.tostring(xml_parsed)  # only for testing
-                }
-            )
-
-        return self.__prepare_bulk_update_response(kc_responses)
 
     def calculated_submission_count(self, user: 'auth.User', **kwargs) -> int:
         params = self.validate_submission_list_params(user,
@@ -647,15 +583,18 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             }
         }
 
-    @staticmethod
-    def generate_new_instance_id() -> (str, str):
+    def store_submission(
+        self, user, xml_submission, submission_uuid, attachments=None
+    ):
         """
-        Returns:
-            - Generated uuid
-            - Formatted uuid for OpenRosa xml
+        Return a mock response without actually storing anything
         """
-        _uuid = str(uuid.uuid4())
-        return _uuid, f'uuid:{_uuid}'
+        return {
+            'uuid': submission_uuid,
+            'status_code': status.HTTP_201_CREATED,
+            'message': 'Successful submission',
+            'updated_submission': xml_submission,
+        }
 
     @property
     def submission_count(self):
@@ -711,7 +650,7 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         return sanitized_updates
 
     @staticmethod
-    def __prepare_bulk_update_response(kc_responses: list) -> dict:
+    def prepare_bulk_update_response(kc_responses: list) -> dict:
         total_update_attempts = len(kc_responses)
         total_successes = total_update_attempts  # all will be successful
         return {

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -44,6 +44,12 @@ class BadPermissionsException(Exception):
     pass
 
 
+class BulkUpdateSubmissionsClientException(exceptions.ValidationError):
+    # This is message should be overridden with something more specific
+    default_detail = t('Invalid payload for bulk updating of submissions')
+    default_code = 'bulk_update_submissions_client_error'
+
+
 class DeploymentDataException(Exception):
 
     def __init__(self, *args, **kwargs):
@@ -98,12 +104,6 @@ class KobocatCommunicationError(Exception):
         self, message='Could not communicate with KoBoCAT', *args, **kwargs
     ):
         super().__init__(message, *args, **kwargs)
-
-
-class KobocatBulkUpdateSubmissionsClientException(exceptions.ValidationError):
-    # This is message should be overridden with something more specific
-    default_detail = t('Invalid payload for bulk updating of submissions')
-    default_code = 'bulk_update_submissions_client_error'
 
 
 class KobocatBulkUpdateSubmissionsException(exceptions.APIException):

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -106,13 +106,6 @@ class KobocatCommunicationError(Exception):
         super().__init__(message, *args, **kwargs)
 
 
-class KobocatBulkUpdateSubmissionsException(exceptions.APIException):
-    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    default_detail = t(
-        'An error occurred trying to bulk update the submissions.')
-    default_code = 'bulk_update_submissions_error'
-
-
 class KobocatDeploymentException(exceptions.APIException):
     def __init__(self, *args, **kwargs):
         if 'response' in kwargs:


### PR DESCRIPTION
## Description

Move duplicated logic from  from `KobocatDeploymentBackend` and `MockDeploymentBackend` into 
`BaseDeploymentBackend`. Remove unused `KobocatBulkUpdateSubmissionsClientException` class.

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Related issues

Most of the affected code is related to bulk editing (aka bulk updating), added in #2920. However, that code was then modified in various subsequent PRs.

Partially addresses #3784.