### PR TITLE
Handle submission XML with namespace or encoding declaration

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -12,13 +12,13 @@ from collections import defaultdict
 from datetime import date, datetime
 from typing import Generator, Optional, Union
 from urllib.parse import urlparse
-from xml.etree import ElementTree as ET
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 
 import requests
+from defusedxml import ElementTree as DET
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, SuspiciousFileOperation
 from django.core.files import File
@@ -29,7 +29,6 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from django_redis import get_redis_connection
 from kobo_service_account.utils import get_request_headers
-from lxml import etree
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -59,6 +58,7 @@ from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.permissions import is_user_anonymous
+from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
 from .base_backend import BaseDeploymentBackend
 from .kc_access.shadow_models import (
     KobocatXForm,
@@ -384,7 +384,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         )
 
         # parse XML string to ET object
-        xml_parsed = ET.fromstring(submission)
+        xml_parsed = fromstring_preserve_root_xmlns(submission)
 
         # attempt to update XML fields for duplicate submission. Note that
         # `start` and `end` are not guaranteed to be included in the XML object
@@ -399,10 +399,12 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # Rely on `meta/instanceID` being present. If it's absent, something is
         # fishy enough to warrant raising an exception instead of continuing
         # silently
-        xml_parsed.find('meta/instanceID').text = uuid_formatted
+        xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text = (
+            uuid_formatted
+        )
 
         kc_response = self.store_submission(
-            user, ET.tostring(xml_parsed), _uuid, attachments
+            user, xml_tostring(xml_parsed), _uuid, attachments
         )
         if kc_response.status_code == status.HTTP_201_CREATED:
             return next(self.get_submissions(user, query={'_uuid': _uuid}))
@@ -420,8 +422,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         """
         submission_xml = xml_submission_file.read()
         try:
-            xml_root = ET.fromstring(submission_xml)
-        except ET.ParseError:
+            xml_root = fromstring_preserve_root_xmlns(submission_xml)
+        except DET.ParseError:
             raise SubmissionIntegrityError(
                 t('Your submission XML is malformed.')
             )
@@ -551,18 +553,11 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             raise SubmissionNotFoundException
 
         if xpath:
-            submission_tree = ET.ElementTree(ET.fromstring(submission_xml))
-
-            try:
-                element = submission_tree.find(xpath)
-            except KeyError:
-                raise InvalidXPathException
-
-            try:
-                attachment_filename = element.text
-            except AttributeError:
+            submission_root = fromstring_preserve_root_xmlns(submission_xml)
+            element = submission_root.find(xpath)
+            if element is None:
                 raise XPathNotFoundException
-
+            attachment_filename = element.text
             filters = {
                 'media_file_basename': attachment_filename,
             }
@@ -1125,7 +1120,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
     def store_submission(
         self, user, xml_submission, submission_uuid, attachments=None
     ):
-        file_tuple = (submission_uuid, io.BytesIO(xml_submission))
+        file_tuple = (submission_uuid, io.StringIO(xml_submission))
         files = {'xml_submission_file': file_tuple}
         if attachments:
             files.update(attachments)
@@ -1557,14 +1552,17 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # so it needs to be parsed before extracting the text
         results = []
         for response in kc_responses:
+            message = t('Something went wrong')
             try:
-                message = (
-                    ET.fromstring(response['response'].content)
-                    .find(OPEN_ROSA_XML_MESSAGE)
-                    .text
+                xml_parsed = fromstring_preserve_root_xmlns(
+                    response['response'].content
                 )
-            except ET.ParseError:
-                message = t('Something went wrong')
+            except DET.ParseError:
+                pass
+            else:
+                message_el = xml_parsed.find(OPEN_ROSA_XML_MESSAGE)
+                if message_el is not None and message_el.text.strip():
+                    message = message_el.text
 
             results.append(
                 {
@@ -1582,6 +1580,8 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         return {
             'status': status.HTTP_200_OK
             if total_successes > 0
+            # FIXME: If KoboCAT returns something unexpected, like a 404 or a
+            # 500, then 400 is not the right response to send to the client
             else status.HTTP_400_BAD_REQUEST,
             'data': {
                 'count': total_update_attempts,

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -7,11 +7,9 @@ import uuid
 from collections import defaultdict
 from datetime import date, datetime
 from typing import Optional, Union
-from xml.etree import ElementTree as ET
 
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
-from lxml import etree
 
 try:
     from zoneinfo import ZoneInfo
@@ -22,7 +20,6 @@ from deepmerge import always_merger
 from dict2xml import dict2xml as dict2xml_real
 from django.conf import settings
 from django.urls import reverse
-from lxml import etree
 from rest_framework import status
 
 from kobo.apps.trackers.models import NLPUsageCounter
@@ -43,6 +40,7 @@ from kpi.interfaces.sync_backend_media import SyncBackendMediaInterface
 from kpi.models.asset_file import AssetFile
 from kpi.tests.utils.mock import MockAttachment
 from kpi.utils.mongo_helper import MongoHelper, drop_mock_only
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 from .base_backend import BaseDeploymentBackend
 
 
@@ -233,14 +231,18 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             sub['_id']
             for sub in self.get_submissions(self.asset.owner, fields=['_id'])
         )) + 1
-        duplicated_submission.update({
-            '_id': next_id,
-            'start': updated_time,
-            'end': updated_time,
-            'meta/instanceID': f'uuid:{uuid.uuid4()}',
-            'meta/deprecatedID': submission['meta/instanceID'],
-            '_attachments': dup_att,
-        })
+        duplicated_submission.update(
+            {
+                '_id': next_id,
+                'start': updated_time,
+                'end': updated_time,
+                self.SUBMISSION_CURRENT_UUID_XPATH: f'uuid:{uuid.uuid4()}',
+                self.SUBMISSION_DEPRECATED_UUID_XPATH: submission[
+                    self.SUBMISSION_CURRENT_UUID_XPATH
+                ],
+                '_attachments': dup_att,
+            }
+        )
 
         self.asset.deployment.mock_submissions([duplicated_submission])
         return duplicated_submission
@@ -283,11 +285,9 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         )
 
         if xpath:
-            submission_tree = ET.ElementTree(
-                ET.fromstring(submission_xml)
-            )
+            submission_root = fromstring_preserve_root_xmlns(submission_xml)
             try:
-                element = submission_tree.find(xpath)
+                element = submission_root.find(xpath)
             except KeyError:
                 raise InvalidXPathException
 
@@ -589,6 +589,7 @@ class MockDeploymentBackend(BaseDeploymentBackend):
         """
         Return a mock response without actually storing anything
         """
+
         return {
             'uuid': submission_uuid,
             'status_code': status.HTTP_201_CREATED,

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import annotations
+
 import copy
 import os
 import time
@@ -7,10 +8,6 @@ import uuid
 from collections import defaultdict
 from datetime import date, datetime
 from typing import Optional, Union
-
-from django.db.models import Sum
-from django.db.models.functions import Coalesce
-
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
@@ -19,6 +16,8 @@ except ImportError:
 from deepmerge import always_merger
 from dict2xml import dict2xml as dict2xml_real
 from django.conf import settings
+from django.db.models import Sum
+from django.db.models.functions import Coalesce
 from django.urls import reverse
 from rest_framework import status
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1605,6 +1605,36 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_201_CREATED
         self._check_duplicate(response)
 
+    def test_duplicate_submission_with_xml_encoding(self):
+        with mock.patch(
+            'kpi.deployment_backends.mock_backend.dict2xml'
+        ) as mock_dict2xml:
+            mock_dict2xml.side_effect = dict2xml_with_encoding_declaration
+            submission_xml = self.asset.deployment.get_submissions(
+                user=self.asset.owner,
+                format_type=SUBMISSION_FORMAT_TYPE_XML,
+                submission_ids=[self.submission['_id']],
+            )[0]
+            assert submission_xml.startswith(
+                '<?xml version="1.0" encoding="utf-8"?>'
+            )
+            self.test_duplicate_submission_as_owner_allowed()
+
+    def test_duplicate_submission_with_xml_namespace(self):
+        with mock.patch(
+            'kpi.deployment_backends.mock_backend.dict2xml'
+        ) as mock_dict2xml:
+            mock_dict2xml.side_effect = dict2xml_with_namespace
+            submission_xml = self.asset.deployment.get_submissions(
+                user=self.asset.owner,
+                format_type=SUBMISSION_FORMAT_TYPE_XML,
+                submission_ids=[self.submission['_id']],
+            )[0]
+            assert (
+                'xmlns="http://opendatakit.org/submissions"' in submission_xml
+            )
+            self.test_duplicate_submission_as_owner_allowed()
+
     def test_duplicate_submission_as_anotheruser_not_allowed(self):
         """
         someuser is the owner of the project.
@@ -1752,6 +1782,12 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_200_OK
         self._check_bulk_update(response)
 
+    @pytest.mark.skip(
+        reason=(
+            'Useless with the current implementation of'
+            ' MockDeploymentBackend.duplicate_submission()'
+        )
+    )
     def test_bulk_update_submissions_with_xml_encoding(self):
         with mock.patch(
             'kpi.deployment_backends.mock_backend.dict2xml'
@@ -1770,6 +1806,12 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
             )
             self.test_bulk_update_submissions_allowed_as_owner()
 
+    @pytest.mark.skip(
+        reason=(
+            'Useless with the current implementation of'
+            ' MockDeploymentBackend.duplicate_submission()'
+        )
+    )
     def test_bulk_update_submissions_with_xml_namespace(self):
         with mock.patch(
             'kpi.deployment_backends.mock_backend.dict2xml'

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -47,6 +47,19 @@ from kpi.tests.utils.mock import (
 )
 
 
+def dict2xml_with_encoding_declaration(*args, **kwargs):
+    return '<?xml version="1.0" encoding="utf-8"?>' + dict2xml(
+        *args, **kwargs
+    )
+
+
+def dict2xml_with_namespace(*args, **kwargs):
+    xml_string = dict2xml(*args, **kwargs)
+    xml_root = lxml.etree.fromstring(xml_string)
+    xml_root.set('xmlns', 'http://opendatakit.org/submissions')
+    return lxml.etree.tostring(xml_root).decode()
+
+
 class BaseSubmissionTestCase(BaseTestCase):
     """
     DataViewset uses `BrowsableAPIRenderer` as the first renderer.
@@ -1251,11 +1264,6 @@ class SubmissionEditApiTests(BaseSubmissionTestCase):
 
     @responses.activate
     def test_edit_submission_with_xml_encoding_declaration(self):
-        def dict2xml_with_encoding_declaration(*args, **kwargs):
-            return '<?xml version="1.0" encoding="utf-8"?>' + dict2xml(
-                *args, **kwargs
-            )
-
         with mock.patch(
             'kpi.deployment_backends.mock_backend.dict2xml'
         ) as mock_dict2xml:
@@ -1743,6 +1751,42 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         )
         assert response.status_code == status.HTTP_200_OK
         self._check_bulk_update(response)
+
+    def test_bulk_update_submissions_with_xml_encoding(self):
+        with mock.patch(
+            'kpi.deployment_backends.mock_backend.dict2xml'
+        ) as mock_dict2xml:
+            mock_dict2xml.side_effect = dict2xml_with_encoding_declaration
+            submission = self.submissions[
+                self.updated_submission_data['submission_ids'][-1]
+            ]
+            submission_xml = self.asset.deployment.get_submissions(
+                user=self.asset.owner,
+                format_type=SUBMISSION_FORMAT_TYPE_XML,
+                submission_ids=[submission['_id']],
+            )[0]
+            assert submission_xml.startswith(
+                '<?xml version="1.0" encoding="utf-8"?>'
+            )
+            self.test_bulk_update_submissions_allowed_as_owner()
+
+    def test_bulk_update_submissions_with_xml_namespace(self):
+        with mock.patch(
+            'kpi.deployment_backends.mock_backend.dict2xml'
+        ) as mock_dict2xml:
+            mock_dict2xml.side_effect = dict2xml_with_namespace
+            submission = self.submissions[
+                self.updated_submission_data['submission_ids'][-1]
+            ]
+            submission_xml = self.asset.deployment.get_submissions(
+                user=self.asset.owner,
+                format_type=SUBMISSION_FORMAT_TYPE_XML,
+                submission_ids=[submission['_id']],
+            )[0]
+            assert (
+                'xmlns="http://opendatakit.org/submissions"' in submission_xml
+            )
+            self.test_bulk_update_submissions_allowed_as_owner()
 
     def test_cannot_bulk_update_submissions_as_anotheruser(self):
         """

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -19,7 +19,13 @@ from kpi.utils.autoname import autovalue_choices_in_place
 from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
-from kpi.utils.xml import strip_nodes, edit_submission_xml
+from kpi.utils.xml import (
+    edit_submission_xml,
+    fromstring_preserve_root_xmlns,
+    get_or_create_element,
+    strip_nodes,
+    xml_tostring,
+)
 
 
 class UtilsTestCase(TestCase):
@@ -475,8 +481,60 @@ class XmlUtilsTestCase(TestCase):
 
         )
 
+    def test_get_or_create_element(self):
+        initial_xml_with_ns = '''
+            <hello xmlns="http://opendatakit.org/submissions">
+                <meta>
+                    <instanceID>uuid:abc-123</instanceID>
+                </meta>
+            </hello>
+        '''
+        expected_xml_with_ns_after_modification = '''
+            <hello xmlns="http://opendatakit.org/submissions">
+                <meta>
+                    <instanceID>uuid:def-456</instanceID>
+                    <deprecatedID>uuid:abc-123</deprecatedID>
+                </meta>
+            </hello>
+        '''
+
+        initial_xml_without_ns = initial_xml_with_ns.replace(
+            ' xmlns="http://opendatakit.org/submissions"', ''
+        )
+        expected_xml_without_ns_after_modification = (
+            expected_xml_with_ns_after_modification.replace(
+                ' xmlns="http://opendatakit.org/submissions"', ''
+            )
+        )
+
+        for initial, expected in (
+            (initial_xml_with_ns, expected_xml_with_ns_after_modification),
+            (
+                initial_xml_without_ns,
+                expected_xml_without_ns_after_modification,
+            ),
+        ):
+            root = fromstring_preserve_root_xmlns(initial)
+            assert root.tag == 'hello'
+
+            initial_e = get_or_create_element(root, 'meta/instanceID')
+            assert (
+                initial_e.text == 'uuid:abc-123'
+            )
+            initial_e.text = 'uuid:def-456'
+
+            new_e = get_or_create_element(root, 'meta/deprecatedID')
+            assert new_e.tag == 'deprecatedID'
+            assert new_e.text is None
+            new_e.text = 'uuid:abc-123'
+
+            self.__compare_xml(
+                xml_tostring(root),
+                expected,
+            )
+
     def test_edit_submission_xml(self):
-        xml_parsed = etree.fromstring(self.__submission)
+        xml_parsed = fromstring_preserve_root_xmlns(self.__submission)
         update_data = {
             'group1/subgroup1/question_1': 'Edit 1',
             'group1/subgroup11/question_3': 'Edit 2',
@@ -533,7 +591,7 @@ class XmlUtilsTestCase(TestCase):
                 </a>
             </root>
         '''
-        self.__compare_xml(etree.tostring(xml_parsed).decode(), xml_expected)
+        self.__compare_xml(xml_tostring(xml_parsed), xml_expected)
 
     def __compare_xml(self, source: str, target: str) -> bool:
         """ Attempts to standardize XML by removing whitespace between tags """

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -69,10 +69,10 @@ def enketo_edit_instance_response_with_uuid_validation(request):
     submission = body['instance']
     submission_xml_root = lxml.etree.fromstring(submission)
     assert submission_xml_root.find(
-        './formhub/uuid'
+        'formhub/uuid'
     ).text.strip()
     assert submission_xml_root.find(
-        './meta/instanceID'
+        'meta/instanceID'
     ).text.strip()
 
     resp_body = {

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -238,7 +238,17 @@ class OmitDefaultNamespacePrefixTreeBuilder(ET.TreeBuilder):
         if self.default_namespace_uri:
             # Remove the Clark notation prefix if it matches the default
             # namespace
-            tag = tag.removeprefix('{' + self.default_namespace_uri + '}')
+            # TODO remove try/except when Python 3.8 support is removed
+            try:
+                tag = tag.removeprefix('{' + self.default_namespace_uri + '}')
+            except AttributeError:
+                remove_prefix = (
+                    lambda text, prefix: text[len(prefix):]
+                    if text.startswith(prefix)
+                    else text
+                )
+                tag = remove_prefix(tag, '{' + self.default_namespace_uri + '}')
+
         return super().start(tag, attrs)
 
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Previously, submissions with namespaces or encoding declarations in their XML could not be bulk edited or cloned.

## Notes

Makes some progress toward standardized XML handing with defusedxml. In the future, all XML work should be done in `kpi.utils.xml`.

## Related issues

Fixes #4283