### PR TITLE
Deduplicate calls to asset, permission APIs

### DIFF
--- a/jsapp/js/actions.d.ts
+++ b/jsapp/js/actions.d.ts
@@ -43,7 +43,7 @@ interface GetProcessingSubmissionsCompletedDefinition extends Function {
 }
 
 interface LoadAssetDefinition extends Function {
-  (params: {id: string}): void;
+  ({id: string}, refresh?: Boolean): void;
   completed: LoadAssetCompletedDefinition;
   failed: GenericFailedDefinition;
 }

--- a/jsapp/js/components/formLanding.js
+++ b/jsapp/js/components/formLanding.js
@@ -29,7 +29,6 @@ import permConfig from 'js/components/permissions/permConfig';
 import {PERMISSIONS_CODENAMES} from 'js/components/permissions/permConstants';
 import {HELP_ARTICLE_ANON_SUBMISSIONS_URL} from 'js/constants';
 import AnonymousSubmission from './anonymousSubmission.component';
-import styles from './anonymousSubmission.module.scss';
 import NewFeatureDialog from './newFeatureDialog.component';
 
 const DVCOUNT_LIMIT_MINIMUM = 20;
@@ -61,21 +60,28 @@ class FormLanding extends React.Component {
       actions.permissions.getAssetPermissions.completed,
       this.onAssetPermissionsUpdated
     );
+    this.listenTo(
+      actions.resources.loadAsset.completed,
+      this.onAssetPermissionsUpdated
+    );
 
-    actions.permissions.getAssetPermissions(this.props.params.uid);
+    actions.resources.loadAsset({id: this.props.params.uid});
   }
 
-  onAssetPermissionsUpdated(response) {
+  onAssetPermissionsUpdated(res) {
+    let response = res;
+    if (response.permissions) {
+      response = res.permissions;
+    }
     const publicPerms = response.filter(
       (assignment) => assignment.user === buildUserUrl(ANON_USERNAME)
     );
     const anonCanAdd = publicPerms.filter(
       (perm) => perm.permission === ANON_CAN_ADD_PERM_URL
     )[0];
-
     this.setState({
       anonymousPermissions: publicPerms,
-      anonymousSubmissions: anonCanAdd ? true : false,
+      anonymousSubmissions: Boolean(anonCanAdd),
     });
   }
   updateAssetAnonymousSubmissions() {

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -85,7 +85,6 @@ export default class SharingForm extends React.Component<
         this.onAssetPermissionsUpdated.bind(this)
       )
     );
-
     if (this.props.assetUid) {
       actions.resources.loadAsset({id: this.props.assetUid});
     }
@@ -103,8 +102,11 @@ export default class SharingForm extends React.Component<
     this.setState({allAssetsCount: Object.keys(stores.allAssets.byUid).length});
   }
 
-  onAssetPermissionsUpdated(permissionAssignments: PermissionResponse[]) {
-    const ownerUrl = this.state.asset?.owner;
+  onAssetPermissionsUpdated(
+    permissionAssignments: PermissionResponse[],
+    owner: string | null = null
+  ) {
+    const ownerUrl = owner || this.state.asset?.owner;
     if (!ownerUrl) {
       return;
     }
@@ -138,9 +140,8 @@ export default class SharingForm extends React.Component<
       assignablePerms: this.getAssignablePermsMap(asset.assignable_permissions),
     });
 
-    // we need to fetch permissions after asset has loaded, as we need to have
-    // the owner username first to parse permissions
-    actions.permissions.getAssetPermissions(this.props.assetUid);
+    // use the asset's permissions to update the form
+    this.onAssetPermissionsUpdated(asset.permissions, asset.owner);
   }
 
   getAssignablePermsMap(backendPerms: AssignablePermission[]) {

--- a/jsapp/js/router/permProtectedRoute.js
+++ b/jsapp/js/router/permProtectedRoute.js
@@ -39,7 +39,7 @@ class PermProtectedRoute extends React.Component {
       actions.resources.loadAsset.completed.listen(this.onLoadAssetCompleted),
       actions.resources.loadAsset.failed.listen(this.onLoadAssetFailed)
     );
-    actions.resources.loadAsset({id: this.props.params.uid});
+    actions.resources.loadAsset({id: this.props.params.uid}, true);
   }
 
   componentWillUnmount() {
@@ -105,9 +105,13 @@ class PermProtectedRoute extends React.Component {
 
   getUserHasRequiredPermissions(asset, requiredPermissions, all = false) {
     if (all) {
-      return requiredPermissions.every((perm) => this.getUserHasRequiredPermission(asset, perm));
+      return requiredPermissions.every((perm) =>
+        this.getUserHasRequiredPermission(asset, perm)
+      );
     } else {
-      return requiredPermissions.some((perm) => this.getUserHasRequiredPermission(asset, perm));
+      return requiredPermissions.some((perm) =>
+        this.getUserHasRequiredPermission(asset, perm)
+      );
     }
   }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Prevents some unnecessary calls to the asset and permission endpoints.

## Notes

Intended to ameliorate an issue where the database was brought down due to high traffic/db usage from queries that grab anonymous submissions (related to [kpi#4834](https://github.com/kobotoolbox/kpi/pull/4834).)

Both `AssetStore` and `allAssets` are designed to cache assets, but neither worked in current code due to the listener in `actions.es6`. This change sidesteps that by making `actions.resources.loadAsset` cache its results for the duration of the page. It gets refreshed whenever a user navigates to a `PermProtectedRoute` (which should prevent stale data when switching between tabs in the project view.)

It also prevents the Anonymous Submissions component from making some addition upfront calls to get permissions, since they're now present on the asset.

For addition context, see internal threads [1](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/2.2E024.2E04.20Release/near/335571), [2](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Deduping.20asset.2Fpermission.20API.20calls/near/336117)