### PR TITLE
Make the DATA tab clickable at all times (with permissions)

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -289,7 +289,18 @@ export class DataTable extends React.Component {
 
   onGetSubmissionsFailed(error) {
     if (error?.responseText) {
-      this.setState({error: error.responseText, loading: false});
+      let displayedError;
+      try {
+        displayedError = JSON.parse(error.responseText);
+      } catch {
+        displayedError = error.responseText;
+      }
+
+      if (displayedError.detail) {
+        this.setState({error: displayedError.detail, loading: false});
+      } else {
+        this.setState({error: displayedError, loading: false});
+      }
     } else if (error?.statusText) {
       this.setState({error: error.statusText, loading: false});
     } else {
@@ -810,7 +821,11 @@ export class DataTable extends React.Component {
               let mediaAttachment = null;
 
               if (q.type !== QUESTION_TYPES.text.id) {
-                mediaAttachment = getMediaAttachment(row.original, row.value, q.$xpath);
+                mediaAttachment = getMediaAttachment(
+                  row.original,
+                  row.value,
+                  q.$xpath
+                );
               }
 
               if (

--- a/jsapp/js/project/projectTopTabs.component.tsx
+++ b/jsapp/js/project/projectTopTabs.component.tsx
@@ -31,14 +31,6 @@ export default function ProjectTopTabs() {
     assetStore.whenLoaded(assetUid, setAsset);
   }, []);
 
-  const isDataTabEnabled =
-    asset?.deployment__identifier != undefined &&
-    asset?.has_deployment &&
-    (asset?.deployment__submission_count === null ||
-      asset?.deployment__submission_count > 0) &&
-    (userCan('view_submissions', asset) ||
-      userCanPartially('view_submissions', asset));
-
   const isSettingsTabEnabled =
     sessionStore.isLoggedIn &&
     (userCan('change_asset', asset) || userCan('change_metadata_asset', asset));
@@ -77,7 +69,6 @@ export default function ProjectTopTabs() {
           onClick={() => navigate(ROUTES.FORM_DATA.replace(':uid', assetUid))}
           className={classnames({
             [styles.tab]: true,
-            [styles.disabled]: !isDataTabEnabled,
             [styles.active]: isAnyFormDataRoute(assetUid),
           })}
         >

--- a/jsapp/js/project/projectTopTabs.component.tsx
+++ b/jsapp/js/project/projectTopTabs.component.tsx
@@ -31,6 +31,10 @@ export default function ProjectTopTabs() {
     assetStore.whenLoaded(assetUid, setAsset);
   }, []);
 
+  const isDataTabEnabled =
+    (userCan('view_submissions', asset) ||
+      userCanPartially('view_submissions', asset));
+
   const isSettingsTabEnabled =
     sessionStore.isLoggedIn &&
     (userCan('change_asset', asset) || userCan('change_metadata_asset', asset));
@@ -69,6 +73,7 @@ export default function ProjectTopTabs() {
           onClick={() => navigate(ROUTES.FORM_DATA.replace(':uid', assetUid))}
           className={classnames({
             [styles.tab]: true,
+            [styles.disabled]: !isDataTabEnabled,
             [styles.active]: isAnyFormDataRoute(assetUid),
           })}
         >


### PR DESCRIPTION
## Description

Enables the "DATA" tab at all times assuming user has proper permissions. Before, we disabled the tab until a submission is added. Now it's clickable at all times, so there is no need to reload the page after submitting data to be able to navigate to the data table.

## Notes
Removed the checks on disabling the DATA tab. Cleaned up response JSON error to display a bit cleaner when clicking the tab on a undeployed project.
