### PR TITLE
Restore API call when switching between PermProtectedRoutes

### DIFF
--- a/jsapp/js/router/permProtectedRoute.js
+++ b/jsapp/js/router/permProtectedRoute.js
@@ -51,7 +51,7 @@ class PermProtectedRoute extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.params.uid !== nextProps.params.uid) {
       this.setState(this.getInitialState());
-      actions.resources.loadAsset({id: nextProps.params.uid});
+      actions.resources.loadAsset({id: nextProps.params.uid}, true);
     } else if (
       this.props.requiredPermissions !== nextProps.requiredPermissions ||
       this.props.requireAll !== nextProps.requireAll ||


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Prevents infinite loading spinner when switching to a project that's already been loaded in the Project pane.

## Notes

Technically, this shouldn't be 100% necessary, but there's a race between `actions.resources.loadAsset` and the `props` of `PermProtectedRoute` getting updated. (You can see this if you put a timeout on `actions.resources.loadAsset.completed`.) The best way to fix that would be to refactor `PermProtectedRoute` to be functional and not rely on the quite deprecated `componentWillReceiveProps()`, but it relies on a Reflux store, so that's a no-go for now.

Still, this should provide a better experience (switching between projects is a logical and consistent time to revalidate data for end-users) and is in-line with how the code worked before [kpi#4835](https://github.com/kobotoolbox/kpi/pull/4835). And only one call to the asset endpoint is made per route, which retains the performance benefits.

## Related issues

Related to [kpi#4835](https://github.com/kobotoolbox/kpi/pull/4835)
