### PR TITLE
Restrict anonymous submission migration to surveys

### DIFF
--- a/kpi/migrations/0055_set_require_auth_per_project.py
+++ b/kpi/migrations/0055_set_require_auth_per_project.py
@@ -4,7 +4,11 @@ from itertools import islice
 from django.conf import settings
 from django.db import migrations
 
-from kpi.constants import PERM_ADD_SUBMISSIONS, SKIP_HEAVY_MIGRATIONS_GUIDANCE
+from kpi.constants import (
+    ASSET_TYPE_SURVEY,
+    PERM_ADD_SUBMISSIONS,
+    SKIP_HEAVY_MIGRATIONS_GUIDANCE,
+)
 from kpi.deployment_backends.kc_access.shadow_models import KobocatUserProfile
 
 CHUNK_SIZE = 2000
@@ -41,6 +45,7 @@ def assign_add_submissions_to_anonymous_users(apps, schema_editor):
                     inherited=False,
                 )
                 for asset_id in Asset.objects.filter(
+                    asset_type=ASSET_TYPE_SURVEY,
                     owner_id__in=owner_ids
                 ).values_list('pk', flat=True)
             ],


### PR DESCRIPTION
## Notes

Asset types other than `survey` should not be assigned `add_submissions`; we thought it was benign, but it can cause problems when:
1. The back end includes this in the list of permissions assignments served to the front end for some non-`survey` library item
2. The front end sends the (possibly modified) assignments back in bulk, including the extraneous `add_submission` assignment
3. The back end rejects the front end's request because `add_submission` is not a valid assignment for the asset type

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/can't.20share.20collections.20in.20library/near/337874

## Description

Avoids future "Failed to update permissions" errors when trying to change sharing settings for library items

## Related issues

Related to #4719