### PR TITLE
Fix "Could not find file.ext" error with repeated groups

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -20,7 +20,7 @@ except ImportError:
 
 import requests
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured, SuspiciousFileOperation
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
@@ -59,6 +59,7 @@ from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.permissions import is_user_anonymous
+from kpi.utils.submission import get_attachment_filenames_and_xpaths
 from kpi.utils.xml import edit_submission_xml
 from .base_backend import BaseDeploymentBackend
 from .kc_access.shadow_models import (
@@ -67,7 +68,6 @@ from .kc_access.shadow_models import (
     ReadOnlyKobocatInstance,
     ReadOnlyKobocatDailyXFormSubmissionCounter,
 )
-from .kc_access.storage import default_kobocat_storage
 from .kc_access.utils import (
     assign_applicable_kc_permissions,
     kc_transaction_atomic,
@@ -1723,9 +1723,10 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         if not request or '_attachments' not in submission:
             return submission
 
-        submission_values = submission.values()
-        questions = list(submission)
         attachment_xpaths = self.asset.get_attachment_xpaths(deployed=True)
+        filenames_and_xpaths = get_attachment_filenames_and_xpaths(
+            submission, attachment_xpaths
+        )
 
         for attachment in submission['_attachments']:
             for size, suffix in settings.KOBOCAT_THUMBNAILS_SUFFIX_MAPPING.items():
@@ -1745,22 +1746,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
             # Retrieve XPath and add it to attachment dictionary
             basename = os.path.basename(attachment['filename'])
-            attachment['question_xpath'] = ''
-
-            for idx, value in enumerate(submission_values):
-                if not isinstance(value, str):
-                    continue
-                try:
-                    valid_name = default_kobocat_storage.get_valid_name(value)
-                except SuspiciousFileOperation:
-                    continue
-
-                if (
-                    valid_name == basename
-                    and questions[idx] in attachment_xpaths
-                ):
-                    attachment['question_xpath'] = questions[idx]
-                    break
+            attachment['question_xpath'] = filenames_and_xpaths.get(basename, '')
 
         return submission
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -545,7 +545,7 @@ class Asset(ObjectPermissionMixin,
         )
 
     @cache_for_request
-    def get_attachment_xpaths(self, deployed: bool = True) -> list:
+    def get_attachment_xpaths(self, deployed: bool = True) -> Optional[list]:
         version = (
             self.latest_deployed_version if deployed else self.latest_version
         )

--- a/kpi/utils/submission.py
+++ b/kpi/utils/submission.py
@@ -1,0 +1,38 @@
+from django.core.exceptions import SuspiciousFileOperation
+
+from kpi.deployment_backends.kc_access.storage import default_kobocat_storage
+from kpi.utils.log import logging
+
+
+def get_attachment_filenames_and_xpaths(
+    submission: dict, attachment_xpaths: list
+) -> dict:
+    """
+    Return a dictionary of all valid attachment filenames of a submission mapped
+    to their respective XPath.
+    """
+
+    return_dict = {}
+    for key, value in submission.items():
+        if isinstance(value, list):
+            for item_list in value:
+                if isinstance(item_list, dict):
+                    return_dict.update(
+                        get_attachment_filenames_and_xpaths(
+                            item_list, attachment_xpaths
+                        )
+                    )
+        elif isinstance(value, dict):
+            return_dict.update(
+                get_attachment_filenames_and_xpaths(value, attachment_xpaths)
+            )
+        else:
+            if key in attachment_xpaths:
+                try:
+                    value = default_kobocat_storage.get_valid_name(value)
+                except SuspiciousFileOperation:
+                    logging.error(f'Could not get valid name from {value}')
+                    continue
+                return_dict[value] = key
+
+    return return_dict


### PR DESCRIPTION
## Description

Fix attachments which do not load when adding media questions to repeated groups.

## Notes

I've tested it with repeated groups, nested groups and repeated nested groups. ~~I used only one level for nested group but it should world for edge cases too.~~ Tried it with 2 levels of nesting. 👍 

:warning: Because **XPaths are detected from the latest deployed version only**, if the nesting of groups changes from one version to another, the images may no longer be displayed. 