### PR TITLE
Stripe product and price interface cleanup

### DIFF
--- a/jsapp/js/account/plans/addOnList.component.tsx
+++ b/jsapp/js/account/plans/addOnList.component.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import useWhen from 'js/hooks/useWhen.hook';
 import subscriptionStore from 'js/account/subscriptionStore';
 import type {
-  BasePrice,
+  Price,
   Organization,
   Product,
   SubscriptionInfo,
@@ -26,7 +26,7 @@ const AddOnList = (props: {
   organization: Organization | null;
   isBusy: boolean;
   setIsBusy: (value: boolean) => void;
-  onClickBuy: (price: BasePrice) => void;
+  onClickBuy: (price: Price) => void;
 }) => {
   const [subscribedAddOns, setSubscribedAddOns] = useState<SubscriptionInfo[]>(
     []
@@ -70,7 +70,7 @@ const AddOnList = (props: {
   );
 
   const isSubscribedAddOnPrice = useCallback(
-    (price: BasePrice) =>
+    (price: Price) =>
       isChangeScheduled(price, activeSubscriptions) ||
       subscribedAddOns.some(
         (subscription) => subscription.items[0].price.id === price.id
@@ -82,7 +82,7 @@ const AddOnList = (props: {
     props.setIsBusy(false);
   };
 
-  const onClickManage = (price?: BasePrice) => {
+  const onClickManage = (price?: Price) => {
     if (!props.organization || props.isBusy) {
       return;
     }

--- a/jsapp/js/account/plans/confirmChangeModal.component.tsx
+++ b/jsapp/js/account/plans/confirmChangeModal.component.tsx
@@ -7,7 +7,8 @@ import KoboModalHeader from 'js/components/modals/koboModalHeader';
 import KoboModalContent from 'js/components/modals/koboModalContent';
 import KoboModalFooter from 'js/components/modals/koboModalFooter';
 import type {
-  BasePrice,
+  Price,
+  PriceWithProduct,
   Product,
   SubscriptionInfo,
 } from 'js/account/stripe.types';
@@ -23,7 +24,7 @@ import BillingButton from 'js/account/plans/billingButton.component';
 import {useDisplayPrice} from 'js/account/plans/useDisplayPrice.hook';
 
 export interface ConfirmChangeProps {
-  newPrice: BasePrice | null;
+  newPrice: Price | null;
   products: Product[] | null;
   quantity?: number;
   currentSubscription: SubscriptionInfo | null;
@@ -68,7 +69,7 @@ const ConfirmChangeModal = ({
 
   // get a translatable description of a newPrice
   const getPriceDescription = useCallback(
-    (price: BasePrice) => {
+    (price: Price) => {
       const product = getProductForPriceId(price.id);
       if (price && product) {
         if (isAddonProduct(product)) {
@@ -96,7 +97,7 @@ const ConfirmChangeModal = ({
 
   // get the product type to display as a translatable string
   const getPriceType = useCallback(
-    (price: BasePrice | null) => {
+    (price: PriceWithProduct | null) => {
       if (!price) {
         return t('plan');
       }

--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -34,7 +34,6 @@ import {
 import type {
   Price,
   Organization,
-  PriceWithProduct,
   Product,
   SubscriptionInfo,
   FilteredPriceProduct,
@@ -327,7 +326,7 @@ export default function Plan() {
   );
 
   // An array of all the products that should be displayed in the UI
-  const filterProducts = useMemo((): FilteredPriceProduct[] => {
+  const filteredPriceProducts = useMemo((): FilteredPriceProduct[] => {
     if (state.products !== null) {
       const filterAmount = state.products.map((product: Product): FilteredPriceProduct => {
         const filteredPrices = product.prices.filter((price: Price) => {
@@ -421,7 +420,7 @@ export default function Plan() {
   const hasMetaFeatures = () => {
     let expandBool = false;
     if (state.products && state.products.length > 0) {
-      filterProducts.map((price) => {
+      filteredPriceProducts.map((price) => {
         for (const featureItem in price.metadata) {
           if (
             featureItem.includes('feature_support_') ||
@@ -494,7 +493,7 @@ export default function Plan() {
               </form>
 
               <div className={styles.allPlans}>
-                {filterProducts.map((product) => (
+                {filteredPriceProducts.map((product) => (
                   <div className={styles.stripePlans} key={product.id}>
                     <PlanContainer
                       key={product.price.id}
@@ -502,7 +501,7 @@ export default function Plan() {
                       expandComparison={expandComparison}
                       isSubscribedProduct={isSubscribedProduct}
                       product={product}
-                      filterPrices={filterProducts}
+                      filteredPriceProducts={filteredPriceProducts}
                       hasManageableStatus={hasManageableStatus}
                       setIsBusy={setIsBusy}
                       isDisabled={isDisabled}

--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -36,7 +36,7 @@ import type {
   Organization,
   Product,
   SubscriptionInfo,
-  FilteredPriceProduct,
+  SinglePricedProduct,
 } from 'js/account/stripe.types';
 import type {ConfirmChangeProps} from 'js/account/plans/confirmChangeModal.component';
 import ConfirmChangeModal from 'js/account/plans/confirmChangeModal.component';
@@ -326,9 +326,9 @@ export default function Plan() {
   );
 
   // An array of all the products that should be displayed in the UI
-  const filteredPriceProducts = useMemo((): FilteredPriceProduct[] => {
+  const filteredPriceProducts = useMemo((): SinglePricedProduct[] => {
     if (state.products !== null) {
-      const filterAmount = state.products.map((product: Product): FilteredPriceProduct => {
+      const filterAmount = state.products.map((product: Product): SinglePricedProduct => {
         const filteredPrices = product.prices.filter((price: Price) => {
           const interval = price.recurring?.interval;
           return (
@@ -357,7 +357,7 @@ export default function Plan() {
   const getSubscribedProduct = useCallback(getSubscriptionsForProductId, []);
 
   const isSubscribedProduct = useCallback(
-    (product: FilteredPriceProduct, quantity = null) => {
+    (product: SinglePricedProduct, quantity = null) => {
       if (!product.price?.unit_amount && !hasActiveSubscription) {
         return true;
       }

--- a/jsapp/js/account/plans/planButton.component.tsx
+++ b/jsapp/js/account/plans/planButton.component.tsx
@@ -1,6 +1,6 @@
 import BillingButton from 'js/account/plans/billingButton.component';
 import React from 'react';
-import type {Price, Organization, PriceWithProduct, FilteredPriceProduct} from 'js/account/stripe.types';
+import type {Price, Organization, FilteredPriceProduct} from 'js/account/stripe.types';
 import {postCustomerPortal} from 'js/account/stripe.api';
 import {processCheckoutResponse} from 'js/account/stripe.utils';
 

--- a/jsapp/js/account/plans/planButton.component.tsx
+++ b/jsapp/js/account/plans/planButton.component.tsx
@@ -1,6 +1,6 @@
 import BillingButton from 'js/account/plans/billingButton.component';
 import React from 'react';
-import type {Price, Organization, FilteredPriceProduct} from 'js/account/stripe.types';
+import type {Price, Organization, SinglePricedProduct} from 'js/account/stripe.types';
 import {postCustomerPortal} from 'js/account/stripe.api';
 import {processCheckoutResponse} from 'js/account/stripe.utils';
 
@@ -11,7 +11,7 @@ interface PlanButtonProps {
   isSubscribedToPlan: boolean;
   showManage: boolean;
   organization?: Organization | null;
-  product: FilteredPriceProduct;
+  product: SinglePricedProduct;
   quantity: number;
   setIsBusy: (value: boolean) => void;
 }

--- a/jsapp/js/account/plans/planButton.component.tsx
+++ b/jsapp/js/account/plans/planButton.component.tsx
@@ -1,17 +1,17 @@
 import BillingButton from 'js/account/plans/billingButton.component';
 import React from 'react';
-import type {BasePrice, Organization, Price} from 'js/account/stripe.types';
+import type {Price, Organization, PriceWithProduct, FilteredPriceProduct} from 'js/account/stripe.types';
 import {postCustomerPortal} from 'js/account/stripe.api';
 import {processCheckoutResponse} from 'js/account/stripe.utils';
 
 interface PlanButtonProps {
-  buySubscription: (price: BasePrice, quantity?: number) => void;
+  buySubscription: (price: Price, quantity?: number) => void;
   downgrading: boolean;
   isBusy: boolean;
   isSubscribedToPlan: boolean;
   showManage: boolean;
   organization?: Organization | null;
-  price: Price;
+  product: FilteredPriceProduct;
   quantity: number;
   setIsBusy: (value: boolean) => void;
 }
@@ -21,7 +21,7 @@ interface PlanButtonProps {
  * Plans need extra logic that add-ons don't, mostly to display the correct label text.
  */
 export const PlanButton = ({
-  price,
+  product,
   organization,
   downgrading,
   isBusy,
@@ -31,11 +31,11 @@ export const PlanButton = ({
   quantity,
   isSubscribedToPlan,
 }: PlanButtonProps) => {
-  if (!price || !organization || price.prices.unit_amount === 0) {
+  if (!product || !organization || product.price.unit_amount === 0) {
     return null;
   }
 
-  const manageSubscription = (subscriptionPrice?: BasePrice) => {
+  const manageSubscription = (subscriptionPrice?: Price) => {
     setIsBusy(true);
     postCustomerPortal(organization.id, subscriptionPrice?.id, quantity)
       .then(processCheckoutResponse)
@@ -46,8 +46,8 @@ export const PlanButton = ({
     return (
       <BillingButton
         label={t('Upgrade')}
-        onClick={() => buySubscription(price.prices, quantity)}
-        aria-label={`upgrade to ${price.name}`}
+        onClick={() => buySubscription(product.price, quantity)}
+        aria-label={`upgrade to ${product.name}`}
         isDisabled={isBusy}
       />
     );
@@ -58,7 +58,7 @@ export const PlanButton = ({
       <BillingButton
         label={t('Manage')}
         onClick={manageSubscription}
-        aria-label={`manage your ${price.name} subscription`}
+        aria-label={`manage your ${product.name} subscription`}
         isDisabled={isBusy}
       />
     );
@@ -67,8 +67,8 @@ export const PlanButton = ({
   return (
     <BillingButton
       label={t('Change plan')}
-      onClick={() => buySubscription(price.prices, quantity)}
-      aria-label={`change your subscription to ${price.name}`}
+      onClick={() => buySubscription(product.price, quantity)}
+      aria-label={`change your subscription to ${product.name}`}
       isDisabled={isBusy}
     />
   );

--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -3,7 +3,7 @@ import styles from 'js/account/plans/plan.module.scss';
 import Icon from 'js/components/common/icon';
 import {PlanButton} from 'js/account/plans/planButton.component';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {FilteredPriceProduct, Price, SubscriptionInfo} from 'js/account/stripe.types';
+import {SinglePricedProduct, Price, SubscriptionInfo} from 'js/account/stripe.types';
 import {FreeTierOverride, PlanState} from 'js/account/plans/plan.component';
 import {
   getAdjustedQuantityForPrice,
@@ -15,13 +15,13 @@ import KoboSelect, {KoboSelectOption} from 'js/components/common/koboSelect';
 import {useDisplayPrice} from 'js/account/plans/useDisplayPrice.hook';
 
 interface PlanContainerProps {
-  product: FilteredPriceProduct;
+  product: SinglePricedProduct;
   isDisabled: boolean;
-  isSubscribedProduct: (product: FilteredPriceProduct, quantity: number) => boolean;
+  isSubscribedProduct: (product: SinglePricedProduct, quantity: number) => boolean;
   freeTierOverride: FreeTierOverride | null;
   expandComparison: boolean;
   state: PlanState;
-  filteredPriceProducts: FilteredPriceProduct[];
+  filteredPriceProducts: SinglePricedProduct[];
   setIsBusy: (isBusy: boolean) => void;
   hasManageableStatus: (sub: SubscriptionInfo) => boolean;
   buySubscription: (price: Price, quantity?: number) => void;
@@ -45,7 +45,7 @@ export const PlanContainer = ({
   // display price for the plan/price/quantity we're currently displaying
   const displayPrice = useDisplayPrice(product.price, submissionQuantity);
   const shouldShowManage = useCallback(
-    (product: FilteredPriceProduct) => {
+    (product: SinglePricedProduct) => {
       const subscriptions = getSubscriptionsForProductId(
         product.id,
         state.subscribedProduct
@@ -102,7 +102,7 @@ export const PlanContainer = ({
     }
   }, [isSubscribedProduct, activeSubscriptions, product]);
 
-  const getFeatureMetadata = (product: FilteredPriceProduct, featureItem: string) => {
+  const getFeatureMetadata = (product: SinglePricedProduct, featureItem: string) => {
     if (
       product.price.unit_amount === 0 &&
       freeTierOverride &&

--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -3,7 +3,7 @@ import styles from 'js/account/plans/plan.module.scss';
 import Icon from 'js/components/common/icon';
 import {PlanButton} from 'js/account/plans/planButton.component';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {BasePrice, Price, SubscriptionInfo} from 'js/account/stripe.types';
+import {FilteredPriceProduct, Price, PriceWithProduct, Product, SubscriptionInfo} from 'js/account/stripe.types';
 import {FreeTierOverride, PlanState} from 'js/account/plans/plan.component';
 import {
   getAdjustedQuantityForPrice,
@@ -15,25 +15,25 @@ import KoboSelect, {KoboSelectOption} from 'js/components/common/koboSelect';
 import {useDisplayPrice} from 'js/account/plans/useDisplayPrice.hook';
 
 interface PlanContainerProps {
-  price: Price;
+  product: FilteredPriceProduct;
   isDisabled: boolean;
-  isSubscribedProduct: (product: Price, quantity: number) => boolean;
+  isSubscribedProduct: (product: FilteredPriceProduct, quantity: number) => boolean;
   freeTierOverride: FreeTierOverride | null;
   expandComparison: boolean;
   state: PlanState;
-  filterPrices: Price[];
+  filterPrices: FilteredPriceProduct[];
   setIsBusy: (isBusy: boolean) => void;
   hasManageableStatus: (sub: SubscriptionInfo) => boolean;
-  buySubscription: (price: BasePrice, quantity?: number) => void;
+  buySubscription: (price: Price, quantity?: number) => void;
   activeSubscriptions: SubscriptionInfo[];
 }
 
 export const PlanContainer = ({
-  price,
+  product,
   state,
   freeTierOverride,
   expandComparison,
-  filterPrices,
+  filterPrices: filterProducts,
   isDisabled,
   setIsBusy,
   hasManageableStatus,
@@ -43,9 +43,9 @@ export const PlanContainer = ({
 }: PlanContainerProps) => {
   const [submissionQuantity, setSubmissionQuantity] = useState(1);
   // display price for the plan/price/quantity we're currently displaying
-  const displayPrice = useDisplayPrice(price.prices, submissionQuantity);
+  const displayPrice = useDisplayPrice(product.price, submissionQuantity);
   const shouldShowManage = useCallback(
-    (product: Price) => {
+    (product: FilteredPriceProduct) => {
       const subscriptions = getSubscriptionsForProductId(
         product.id,
         state.subscribedProduct
@@ -61,56 +61,56 @@ export const PlanContainer = ({
         return false;
       }
 
-      return isChangeScheduled(product.prices, [activeSubscription]);
+      return isChangeScheduled(product.price, [activeSubscription]);
     },
     [hasManageableStatus, state.subscribedProduct]
   );
 
   const isDowngrading = useMemo(
-    () => isDowngrade(activeSubscriptions, price.prices, submissionQuantity),
-    [activeSubscriptions, price, submissionQuantity]
+    () => isDowngrade(activeSubscriptions, product.price, submissionQuantity),
+    [activeSubscriptions, product, submissionQuantity]
   );
 
   // The adjusted quantity is the number we multiply the price by to get the total price
   const adjustedQuantity = useMemo(() => {
     return getAdjustedQuantityForPrice(
       submissionQuantity,
-      price.prices.transform_quantity
+      product.price.transform_quantity
     );
-  }, [price, submissionQuantity]);
+  }, [product, submissionQuantity]);
 
   // Populate submission dropdown with the submission quantity from the customer's plan
   // Default to this price's base submission quantity, if applicable
   useEffect(() => {
     const subscribedQuantity =
       activeSubscriptions.length && activeSubscriptions?.[0].items[0].quantity;
-    if (subscribedQuantity && isSubscribedProduct(price, subscribedQuantity)) {
+    if (subscribedQuantity && isSubscribedProduct(product, subscribedQuantity)) {
       setSubmissionQuantity(subscribedQuantity);
     } else if (
       // if there's no active subscription, check if this price has a default quantity
-      price.prices.transform_quantity &&
+      product.price.transform_quantity &&
       Boolean(
-        Number(price.metadata?.submission_limit) ||
-          Number(price.prices.metadata?.submission_limit)
+        Number(product.metadata?.submission_limit) ||
+          Number(product.price.metadata?.submission_limit)
       )
     ) {
       // prioritize the submission limit from the price over the submission limit from the product
       setSubmissionQuantity(
-        parseInt(price.prices.metadata.submission_limit) ||
-          parseInt(price.metadata.submission_limit)
+        parseInt(product.price.metadata.submission_limit) ||
+          parseInt(product.metadata.submission_limit)
       );
     }
-  }, [isSubscribedProduct, activeSubscriptions, price]);
+  }, [isSubscribedProduct, activeSubscriptions, product]);
 
-  const getFeatureMetadata = (price: Price, featureItem: string) => {
+  const getFeatureMetadata = (product: FilteredPriceProduct, featureItem: string) => {
     if (
-      price.prices.unit_amount === 0 &&
+      product.price.unit_amount === 0 &&
       freeTierOverride &&
       freeTierOverride.hasOwnProperty(featureItem)
     ) {
       return freeTierOverride[featureItem as keyof FreeTierOverride];
     }
-    return price.prices.metadata?.[featureItem] || price.metadata[featureItem];
+    return product.price.metadata?.[featureItem] || product.metadata[featureItem];
   };
 
   const renderFeaturesList = (
@@ -146,8 +146,8 @@ export const PlanContainer = ({
   // Get feature items and matching icon boolean
   const getListItem = (listType: string, plan: string) => {
     const listItems: Array<{icon: boolean; item: string}> = [];
-    filterPrices.map((price) =>
-      Object.keys(price.metadata).map((featureItem: string) => {
+    filterProducts.map((product) =>
+      Object.keys(product.metadata).map((featureItem: string) => {
         const numberItem = featureItem.lastIndexOf('_');
         const currentResult = featureItem.substring(numberItem + 1);
 
@@ -155,14 +155,14 @@ export const PlanContainer = ({
         if (
           featureItem.includes(`feature_${listType}_`) &&
           !featureItem.includes(`feature_${listType}_check`) &&
-          price.name === plan
+          product.name === plan
         ) {
           const keyName = `feature_${listType}_${currentResult}`;
           let iconBool = false;
           const itemName: string =
-            price.prices.metadata?.[keyName] || price.metadata[keyName];
-          if (price.metadata?.[currentIcon] !== undefined) {
-            iconBool = JSON.parse(price.metadata[currentIcon]);
+            product.price.metadata?.[keyName] || product.metadata[keyName];
+          if (product.metadata?.[currentIcon] !== undefined) {
+            iconBool = JSON.parse(product.metadata[currentIcon]);
             listItems.push({icon: iconBool, item: itemName});
           }
         }
@@ -191,10 +191,10 @@ export const PlanContainer = ({
   const submissionOptions = useMemo((): KoboSelectOption[] => {
     const options = [];
     const submissionsPerUnit =
-      price.prices.metadata?.submission_limit ||
-      price.metadata?.submission_limit;
+      product.price.metadata?.submission_limit ||
+      product.metadata?.submission_limit;
     const maxPlanQuantity = parseInt(
-      price.prices.metadata?.max_purchase_quantity || '1'
+      product.price.metadata?.max_purchase_quantity || '1'
     );
     if (submissionsPerUnit) {
       for (let i = 1; i <= maxPlanQuantity; i++) {
@@ -209,7 +209,7 @@ export const PlanContainer = ({
       }
     }
     return options;
-  }, [price]);
+  }, [product]);
 
   const onSubmissionsChange = (value: string | null) => {
     if (value === null) {
@@ -223,28 +223,28 @@ export const PlanContainer = ({
 
   return (
     <>
-      {isSubscribedProduct(price, submissionQuantity) ? (
+      {isSubscribedProduct(product, submissionQuantity) ? (
         <div className={styles.currentPlan}>{t('Your plan')}</div>
-      ) : isSubscribedProduct(price, submissionQuantity) ? (
+      ) : isSubscribedProduct(product, submissionQuantity) ? (
         <div className={styles.currentPlan}>{t('Your plan')}</div>
       ) : null}
       <div
         className={classnames({
           [styles.planContainerWithBadge]: isSubscribedProduct(
-            price,
+            product,
             submissionQuantity
           ),
           [styles.planContainer]: true,
         })}
       >
         <h1 className={styles.priceName}>
-          {price.prices?.unit_amount
-            ? price.name
-            : freeTierOverride?.name || price.name}
+          {product.price?.unit_amount
+            ? product.name
+            : freeTierOverride?.name || product.name}
         </h1>
         <div className={styles.priceTitle}>{displayPrice}</div>
         <ul className={styles.featureContainer}>
-          {price.prices.transform_quantity && (
+          {product.price.transform_quantity && (
             <>
               <li className={styles.selectableFeature}>
                 <Icon name='check' size='m' color='teal' />
@@ -262,7 +262,7 @@ export const PlanContainer = ({
                   <Icon
                     name='check'
                     size='m'
-                    color={price.prices.unit_amount ? 'teal' : 'storm'}
+                    color={product.price.unit_amount ? 'teal' : 'storm'}
                   />
                 </div>
                 {t('##asr_minutes## minutes of automated transcription /month')
@@ -270,16 +270,16 @@ export const PlanContainer = ({
                     '##asr_minutes##',
                     (
                       (adjustedQuantity *
-                        (parseInt(price.metadata?.nlp_seconds_limit || '0') ||
+                        (parseInt(product.metadata?.nlp_seconds_limit || '0') ||
                           parseInt(
-                            price.prices.metadata?.nlp_seconds_limit || '0'
+                            product.price.metadata?.nlp_seconds_limit || '0'
                           ))) /
                       60
                     ).toLocaleString()
                   )
                   .replace(
                     '##plan_interval##',
-                    price.prices.recurring!.interval
+                    product.price.recurring!.interval
                   )}
               </li>
               <li>
@@ -287,7 +287,7 @@ export const PlanContainer = ({
                   <Icon
                     name='check'
                     size='m'
-                    color={price.prices.unit_amount ? 'teal' : 'storm'}
+                    color={product.price.unit_amount ? 'teal' : 'storm'}
                   />
                 </div>
                 {t(
@@ -297,20 +297,20 @@ export const PlanContainer = ({
                     '##mt_characters##',
                     (
                       adjustedQuantity *
-                      (parseInt(price.metadata?.nlp_character_limit || '0') ||
+                      (parseInt(product.metadata?.nlp_character_limit || '0') ||
                         parseInt(
-                          price.prices.metadata?.nlp_character_limit || '0'
+                          product.price.metadata?.nlp_character_limit || '0'
                         ))
                     ).toLocaleString()
                   )
                   .replace(
                     '##plan_interval##',
-                    price.prices.recurring!.interval
+                    product.price.recurring!.interval
                   )}
               </li>
             </>
           )}
-          {Object.keys(price.metadata).map(
+          {Object.keys(product.metadata).map(
             (featureItem: string) =>
               featureItem.includes('feature_list_') && (
                 <li key={featureItem}>
@@ -318,10 +318,10 @@ export const PlanContainer = ({
                     <Icon
                       name='check'
                       size='m'
-                      color={price.prices.unit_amount ? 'teal' : 'storm'}
+                      color={product.price.unit_amount ? 'teal' : 'storm'}
                     />
                   </div>
-                  {getFeatureMetadata(price, featureItem)}
+                  {getFeatureMetadata(product, featureItem)}
                 </li>
               )
           )}
@@ -330,13 +330,13 @@ export const PlanContainer = ({
           <div className={styles.expandedContainer}>
             <hr />
             {state.featureTypes.map((type, index, array) => {
-              const featureItem = getListItem(type, price.name);
+              const featureItem = getListItem(type, product.name);
               return (
                 featureItem.length > 0 && [
                   returnListItem(
                     type,
-                    price.name,
-                    price.metadata[`feature_${type}_title`]
+                    product.name,
+                    product.metadata[`feature_${type}_title`]
                   ),
                   index !== array.length - 1 && <hr key={`hr-${type}`} />,
                 ]
@@ -345,12 +345,12 @@ export const PlanContainer = ({
           </div>
         )}
         <PlanButton
-          price={price}
+          product={product}
           downgrading={isDowngrading}
           quantity={submissionQuantity}
-          isSubscribedToPlan={isSubscribedProduct(price, submissionQuantity)}
+          isSubscribedToPlan={isSubscribedProduct(product, submissionQuantity)}
           buySubscription={buySubscription}
-          showManage={shouldShowManage(price)}
+          showManage={shouldShowManage(product)}
           isBusy={isDisabled}
           setIsBusy={setIsBusy}
           organization={state.organization}

--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -3,7 +3,7 @@ import styles from 'js/account/plans/plan.module.scss';
 import Icon from 'js/components/common/icon';
 import {PlanButton} from 'js/account/plans/planButton.component';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {FilteredPriceProduct, Price, PriceWithProduct, Product, SubscriptionInfo} from 'js/account/stripe.types';
+import {FilteredPriceProduct, Price, SubscriptionInfo} from 'js/account/stripe.types';
 import {FreeTierOverride, PlanState} from 'js/account/plans/plan.component';
 import {
   getAdjustedQuantityForPrice,
@@ -21,7 +21,7 @@ interface PlanContainerProps {
   freeTierOverride: FreeTierOverride | null;
   expandComparison: boolean;
   state: PlanState;
-  filterPrices: FilteredPriceProduct[];
+  filteredPriceProducts: FilteredPriceProduct[];
   setIsBusy: (isBusy: boolean) => void;
   hasManageableStatus: (sub: SubscriptionInfo) => boolean;
   buySubscription: (price: Price, quantity?: number) => void;
@@ -33,7 +33,7 @@ export const PlanContainer = ({
   state,
   freeTierOverride,
   expandComparison,
-  filterPrices: filterProducts,
+  filteredPriceProducts,
   isDisabled,
   setIsBusy,
   hasManageableStatus,
@@ -146,7 +146,7 @@ export const PlanContainer = ({
   // Get feature items and matching icon boolean
   const getListItem = (listType: string, plan: string) => {
     const listItems: Array<{icon: boolean; item: string}> = [];
-    filterProducts.map((product) =>
+    filteredPriceProducts.map((product) =>
       Object.keys(product.metadata).map((featureItem: string) => {
         const numberItem = featureItem.lastIndexOf('_');
         const currentResult = featureItem.substring(numberItem + 1);

--- a/jsapp/js/account/plans/useDisplayPrice.hook.tsx
+++ b/jsapp/js/account/plans/useDisplayPrice.hook.tsx
@@ -1,9 +1,9 @@
 import {useMemo} from 'react';
-import {BasePrice} from 'js/account/stripe.types';
+import {Price} from 'js/account/stripe.types';
 import {getAdjustedQuantityForPrice} from 'js/account/stripe.utils';
 
 export const useDisplayPrice = (
-  price?: BasePrice | null,
+  price?: Price | null,
   submissionQuantity = 1
 ) => {
   return useMemo(() => {

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -88,6 +88,7 @@ export interface Product extends BaseProduct {
   prices: Price[];
 }
 
+// This is a frontend-only interface for accessing the relevant price of a product 
 export interface FilteredPriceProduct extends BaseProduct {
   price: Price;
 }
@@ -109,6 +110,7 @@ export interface Price {
   type: string;
   unit_amount: number;
   human_readable_price: string;
+  active: boolean;
   recurring?: {
     interval: RecurringInterval;
     aggregate_usage: string;
@@ -117,7 +119,6 @@ export interface Price {
   };
   metadata: {[key: string]: string};
   product: string;
-  active: boolean;
   transform_quantity: null | TransformQuantity;
 }
 

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -1,11 +1,3 @@
-export interface BaseProduct {
-  id: string;
-  name: string;
-  description: string;
-  type: string;
-  metadata: Record<string, string>;
-}
-
 interface SubscriptionPhase {
   items: [
     {
@@ -87,13 +79,17 @@ export interface SubscriptionInfo {
 
 export interface SubscriptionItem {
   id: string;
-  price: BasePrice;
+  price: PriceWithProduct;
   quantity: number;
 }
 
 // There is probably a better way to hand the nested types
 export interface Product extends BaseProduct {
-  prices: BasePrice[];
+  prices: Price[];
+}
+
+export interface FilteredPriceProduct extends BaseProduct {
+  price: Price;
 }
 
 export interface BaseProduct {
@@ -106,14 +102,13 @@ export interface BaseProduct {
 
 export type RecurringInterval = 'year' | 'month';
 
-export interface BasePrice {
+export interface Price {
   id: string;
   nickname: string;
   currency: string;
   type: string;
   unit_amount: number;
   human_readable_price: string;
-  active: boolean;
   recurring?: {
     interval: RecurringInterval;
     aggregate_usage: string;
@@ -121,9 +116,13 @@ export interface BasePrice {
     usage_type: 'metered' | 'licensed';
   };
   metadata: {[key: string]: string};
-  product: BaseProduct;
-  billing_scheme: 'per_unit' | 'tiered' | null;
+  product: string;
+  active: boolean;
   transform_quantity: null | TransformQuantity;
+}
+
+export interface PriceWithProduct extends Omit<Price, 'product'> {
+  product: BaseProduct;
 }
 
 export type PriceMetadata = Record<
@@ -167,14 +166,6 @@ export interface AccountLimit {
   nlp_seconds_limit: LimitAmount;
   nlp_character_limit: LimitAmount;
   storage_bytes_limit: LimitAmount;
-}
-
-export interface Product extends BaseProduct {
-  prices: BasePrice[];
-}
-
-export interface Price extends BaseProduct {
-  prices: BasePrice;
 }
 
 export interface Checkout {

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -89,7 +89,7 @@ export interface Product extends BaseProduct {
 }
 
 // This is a frontend-only interface for accessing the relevant price of a product 
-export interface FilteredPriceProduct extends BaseProduct {
+export interface SinglePricedProduct extends BaseProduct {
   price: Price;
 }
 

--- a/jsapp/js/account/stripe.utils.ts
+++ b/jsapp/js/account/stripe.utils.ts
@@ -3,11 +3,10 @@ import {when} from 'mobx';
 import {ACTIVE_STRIPE_STATUSES} from 'js/constants';
 import envStore from 'js/envStore';
 import {
-  BasePrice,
+  Price,
   BaseProduct,
   ChangePlan,
   Checkout,
-  Price,
   Product,
   SubscriptionChangeType,
   SubscriptionInfo,
@@ -91,7 +90,7 @@ export async function processChangePlanResponse(data: ChangePlan) {
  * Check if any of a list of subscriptions are scheduled to change to a given price at some point.
  */
 export function isChangeScheduled(
-  price: BasePrice,
+  price: Price,
   subscriptions: SubscriptionInfo[] | null
 ) {
   return (
@@ -198,7 +197,7 @@ export const getAdjustedQuantityForPrice = (
  */
 export const isDowngrade = (
   currentSubscriptions: SubscriptionInfo[],
-  price: BasePrice,
+  price: Price,
   newQuantity: number
 ) => {
   if (!currentSubscriptions.length) {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

This PR aims to improve the accuracy and readability of our frontend interfaces related to Stripe products and prices. Previously we had two extensions of the BaseProduct interace: Product and Price, with the only difference between them being that a Product's `prices` field contained an array of price objects, while a Price's `prices` field contained only a single price (obtained by filtering on the frontend). I have renamed the latter `FilteredPriceProduct`. Not the most elegant name, but I think it gets the point across (and I'm open to other suggestions). The bulk of the changes in this PR are related to this. But I also removed some duplicate interfaces in the types file and adjusted some interfaces to match our API.


