### PR TITLE
Move and rename all nlp tabs main components in consistent way

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisTab.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisTab.component.tsx
@@ -27,7 +27,7 @@ import type {FailResponse} from 'js/dataInterface';
  * Displays content of the "Analysis" tab. This component is handling all of
  * the Qualitative Analysis functionality.
  */
-export default function Analysis() {
+export default function AnalysisTab() {
   const [isInitialised, setIsInitialised] = useState(false);
   const [isErrored, setIsErrored] = useState(false);
 

--- a/jsapp/js/components/processing/analysis/analysisTab.component.tsx
+++ b/jsapp/js/components/processing/analysis/analysisTab.component.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo, useReducer, useState, useEffect} from 'react';
-import bodyStyles from '../processingBody.module.scss';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
 import AnalysisContent from './analysisContent.component';
 import {
   initialState,
@@ -16,7 +16,7 @@ import {
   applyUpdateResponseToInternalQuestions,
   getQuestionsFromSchema,
 } from './utils';
-import singleProcessingStore from '../singleProcessingStore';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
 import {fetchGetUrl, handleApiFail} from 'js/api';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import InlineMessage from 'js/components/common/inlineMessage';

--- a/jsapp/js/components/processing/singleProcessingContent.tsx
+++ b/jsapp/js/components/processing/singleProcessingContent.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import singleProcessingStore, {
   SingleProcessingTabs,
 } from 'js/components/processing/singleProcessingStore';
-import Analysis from 'js/components/processing/analysis/analysis.component';
-import TranscriptTabContent from 'js/components/processing/transcriptTabContent';
-import TranslationsTabContent from 'js/components/processing/translationsTabContent';
+import AnalysisTab from 'js/components/processing/analysis/analysisTab.component';
+import TranscriptTab from 'js/components/processing/transcript/transcriptTab.component';
+import TranslationsTab from 'js/components/processing/translations/translationsTab.component';
 import protectorHelpers from 'js/protector/protectorHelpers';
 import styles from './singleProcessingContent.module.scss';
 import classNames from 'classnames';
@@ -52,11 +52,11 @@ export default class SingleProcessingContent extends React.Component<{}> {
   renderTabContent() {
     switch (singleProcessingStore.getActiveTab()) {
       case SingleProcessingTabs.Transcript:
-        return <TranscriptTabContent />;
+        return <TranscriptTab />;
       case SingleProcessingTabs.Translations:
-        return <TranslationsTabContent />;
+        return <TranslationsTab />;
       case SingleProcessingTabs.Analysis:
-        return <Analysis />;
+        return <AnalysisTab />;
       default:
         return null;
     }

--- a/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
+++ b/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import clonedeep from 'lodash.clonedeep';
 import {formatTime} from 'js/utils';
-import singleProcessingStore from '../singleProcessingStore';
-import TransxAutomaticButton from '../transxAutomaticButton';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
 import LanguageSelector, {
   resetAllLanguageSelectors,
 } from 'js/components/languages/languageSelector';
@@ -16,7 +16,7 @@ import type {
 } from 'js/components/languages/languagesStore';
 import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
 import envStore from 'js/envStore';
-import bodyStyles from '../processingBody.module.scss';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
 import classNames from 'classnames';
 
 export default class TranscriptTab extends React.Component<{}> {
@@ -187,9 +187,7 @@ export default class TranscriptTab extends React.Component<{}> {
         </label>
 
         {dateText !== '' && (
-          <time className={bodyStyles.transxHeaderDate}>
-            {dateText}
-          </time>
+          <time className={bodyStyles.transxHeaderDate}>{dateText}</time>
         )}
       </React.Fragment>
     );

--- a/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
+++ b/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import clonedeep from 'lodash.clonedeep';
 import {formatTime} from 'js/utils';
-import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
+import singleProcessingStore from '../singleProcessingStore';
+import TransxAutomaticButton from '../transxAutomaticButton';
 import LanguageSelector, {
   resetAllLanguageSelectors,
 } from 'js/components/languages/languageSelector';
@@ -16,10 +16,10 @@ import type {
 } from 'js/components/languages/languagesStore';
 import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
 import envStore from 'js/envStore';
-import bodyStyles from './processingBody.module.scss';
+import bodyStyles from '../processingBody.module.scss';
 import classNames from 'classnames';
 
-export default class TranscriptTabContent extends React.Component<{}> {
+export default class TranscriptTab extends React.Component<{}> {
   private unlisteners: Function[] = [];
 
   componentDidMount() {

--- a/jsapp/js/components/processing/translations/translationsTab.component.tsx
+++ b/jsapp/js/components/processing/translations/translationsTab.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import clonedeep from 'lodash.clonedeep';
 import {formatTime} from 'js/utils';
-import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
+import singleProcessingStore from '../singleProcessingStore';
+import TransxAutomaticButton from '../transxAutomaticButton';
 import LanguageSelector, {
   resetAllLanguageSelectors,
 } from 'js/components/languages/languageSelector';
@@ -15,19 +15,19 @@ import type {
   ListLanguage,
 } from 'js/components/languages/languagesStore';
 import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
-import TransxSelector from './transxSelector';
+import TransxSelector from '../transxSelector';
 import envStore from 'js/envStore';
-import bodyStyles from './processingBody.module.scss';
+import bodyStyles from '../processingBody.module.scss';
 import classNames from 'classnames';
 
-interface TranslationsTabContentState {
+interface TranslationsTabState {
   /** Uses languageCode. */
   selectedTranslation?: string;
 }
 
-export default class TranslationsTabContent extends React.Component<
+export default class TranslationsTab extends React.Component<
   {},
-  TranslationsTabContentState
+  TranslationsTabState
 > {
   constructor(props: {}) {
     super(props);

--- a/jsapp/js/components/processing/translations/translationsTab.component.tsx
+++ b/jsapp/js/components/processing/translations/translationsTab.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import clonedeep from 'lodash.clonedeep';
 import {formatTime} from 'js/utils';
-import singleProcessingStore from '../singleProcessingStore';
-import TransxAutomaticButton from '../transxAutomaticButton';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
 import LanguageSelector, {
   resetAllLanguageSelectors,
 } from 'js/components/languages/languageSelector';
@@ -15,9 +15,9 @@ import type {
   ListLanguage,
 } from 'js/components/languages/languagesStore';
 import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
-import TransxSelector from '../transxSelector';
+import TransxSelector from 'js/components/processing/transxSelector';
 import envStore from 'js/envStore';
-import bodyStyles from '../processingBody.module.scss';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
 import classNames from 'classnames';
 
 interface TranslationsTabState {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

## Notes

All three NLP tabs components are now in their respective directories. I've renamed all of them to follow same pattern. I need this, because it's more orderly, and because I will most probably refactor the code a bit (split most of `renderStepX` into separate components)