### PR TITLE
NLP split tabs components

### DIFF
--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -29,6 +29,7 @@ import type {
 } from 'js/dataInterface';
 import type {LanguageCode} from 'js/components/languages/languagesStore';
 import type {AnyRowTypeName} from 'js/constants';
+import {destroyConfirm} from 'js/alertify';
 
 export enum SingleProcessingTabs {
   Transcript = 'trc',
@@ -751,6 +752,18 @@ class SingleProcessingStore extends Reflux.Store {
   deleteTranscriptDraft() {
     this.data.transcriptDraft = undefined;
     this.trigger(this.data);
+  }
+
+  safelyDeleteTranscriptDraft() {
+    if (this.hasUnsavedTranscriptDraftValue()) {
+      destroyConfirm(
+        this.deleteTranscriptDraft.bind(this),
+        t('Discard unsaved changes?'),
+        t('Discard')
+      );
+    } else {
+      this.deleteTranscriptDraft();
+    }
   }
 
   /**

--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -842,6 +842,18 @@ class SingleProcessingStore extends Reflux.Store {
     this.trigger(this.data);
   }
 
+  safelyDeleteTranslationDraft() {
+    if (this.hasUnsavedTranslationDraftValue()) {
+      destroyConfirm(
+        this.deleteTranslationDraft.bind(this),
+        t('Discard unsaved changes?'),
+        t('Discard')
+      );
+    } else {
+      this.deleteTranslationDraft();
+    }
+  }
+
   /**
    * Returns a list of language codes of languages that are activated within
    * advanced_features.translated

--- a/jsapp/js/components/processing/transcript/headerLanguageAndDate.component.tsx
+++ b/jsapp/js/components/processing/transcript/headerLanguageAndDate.component.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {formatTime} from 'js/utils';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+/** We have this as separate component, because we use it in two places. */
+export default function HeaderLanguageAndDate() {
+  const storeTranscript = singleProcessingStore.getTranscript();
+  const draft = singleProcessingStore.getTranscriptDraft();
+  const valueLanguageCode =
+    draft?.languageCode || storeTranscript?.languageCode;
+  if (valueLanguageCode === undefined) {
+    return null;
+  }
+
+  let dateText = '';
+  if (storeTranscript) {
+    if (storeTranscript.dateCreated !== storeTranscript?.dateModified) {
+      dateText = t('last modified ##date##').replace(
+        '##date##',
+        formatTime(storeTranscript.dateModified)
+      );
+    } else {
+      dateText = t('created ##date##').replace(
+        '##date##',
+        formatTime(storeTranscript.dateCreated)
+      );
+    }
+  }
+
+  return (
+    <React.Fragment>
+      <label className={bodyStyles.transxHeaderLanguage}>
+        <AsyncLanguageDisplayLabel code={valueLanguageCode} />
+      </label>
+
+      {dateText !== '' && (
+        <time className={bodyStyles.transxHeaderDate}>{dateText}</time>
+      )}
+    </React.Fragment>
+  );
+}

--- a/jsapp/js/components/processing/transcript/stepBegin.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepBegin.component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import cx from 'classnames';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepBegin() {
+  function begin() {
+    // Make an empty draft.
+    singleProcessingStore.setTranscriptDraft({});
+  }
+
+  const typeLabel =
+    singleProcessingStore.currentQuestionType || t('source file');
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepBegin)}>
+      <header className={bodyStyles.header}>
+        {t('This ##type## does not have a transcript yet').replace(
+          '##type##',
+          typeLabel
+        )}
+      </header>
+
+      <Button
+        type='full'
+        color='blue'
+        size='l'
+        label={t('begin')}
+        onClick={begin}
+      />
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/transcript/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfig.component.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import cx from 'classnames';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import LanguageSelector, {
+  resetAllLanguageSelectors,
+} from 'js/components/languages/languageSelector';
+import type {
+  DetailedLanguage,
+  ListLanguage,
+} from 'js/components/languages/languagesStore';
+import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
+import envStore from 'js/envStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepConfig() {
+  /** Changes the draft value, preserving the other draft properties. */
+  function setDraftValue(newVal: string | undefined) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
+    newDraft.value = newVal;
+    singleProcessingStore.setTranscriptDraft(newDraft);
+  }
+
+  /** Changes the draft language, preserving the other draft properties. */
+  function onLanguageChange(newVal: DetailedLanguage | ListLanguage | null) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
+    newDraft.languageCode = newVal?.code;
+    singleProcessingStore.setTranscriptDraft(newDraft);
+  }
+
+  function back() {
+    const draft = singleProcessingStore.getTranscriptDraft();
+    if (
+      draft !== undefined &&
+      draft?.languageCode === undefined &&
+      draft?.value === undefined
+    ) {
+      singleProcessingStore.safelyDeleteTranscriptDraft();
+    }
+
+    if (draft?.languageCode !== undefined && draft?.value === undefined) {
+      singleProcessingStore.setTranslationDraft({});
+      resetAllLanguageSelectors();
+    }
+  }
+
+  function selectModeManual() {
+    // Initialize draft value.
+    setDraftValue('');
+  }
+
+  function selectModeAuto() {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
+    // The `null` value tells us that no region was selected yet, but we are
+    // interested in regions right now - i.e. when this property exists (is
+    // defined) we show the automatic service configuration step.
+    newDraft.regionCode = null;
+    singleProcessingStore.setTranscriptDraft(newDraft);
+  }
+
+  const draft = singleProcessingStore.getTranscriptDraft();
+  const typeLabel =
+    singleProcessingStore.currentQuestionType || t('source file');
+  const languageSelectorTitle = t(
+    'Please select the original language of the ##type##'
+  ).replace('##type##', typeLabel);
+  const isAutoEnabled = envStore.data.asr_mt_features_enabled;
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
+      <LanguageSelector
+        titleOverride={languageSelectorTitle}
+        onLanguageChange={onLanguageChange}
+        suggestedLanguages={singleProcessingStore.getAssetTranscriptableLanguages()}
+      />
+
+      <footer className={bodyStyles.footer}>
+        <Button
+          type='bare'
+          color='blue'
+          size='m'
+          label={t('back')}
+          startIcon='caret-left'
+          onClick={back}
+          isDisabled={singleProcessingStore.isFetchingData}
+        />
+
+        <div className={bodyStyles.footerRightButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='m'
+            label={isAutoEnabled ? t('manual') : t('transcribe')}
+            onClick={selectModeManual}
+            isDisabled={
+              draft?.languageCode === undefined ||
+              singleProcessingStore.isFetchingData
+            }
+          />
+
+          <TransxAutomaticButton
+            onClick={selectModeAuto}
+            selectedLanguage={draft?.languageCode}
+            type='transcript'
+          />
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/transcript/stepConfigAuto.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfigAuto.component.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import cx from 'classnames';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
+import RegionSelector from 'js/components/languages/regionSelector';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepConfigAuto() {
+  /** Changes the draft region, preserving the other draft properties. */
+  function onRegionChange(newVal: LanguageCode | null | undefined) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
+    newDraft.regionCode = newVal;
+    singleProcessingStore.setTranscriptDraft(newDraft);
+  }
+
+  /** Goes back from the automatic service configuration step. */
+  function cancelAuto() {
+    onRegionChange(undefined);
+  }
+
+  function requestAutoTranscription() {
+    singleProcessingStore.requestAutoTranscription();
+  }
+
+  const draft = singleProcessingStore.getTranscriptDraft();
+
+  if (draft?.languageCode === undefined) {
+    return null;
+  }
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
+      <header className={bodyStyles.header}>
+        {t('Automatic transcription of audio file from')}
+      </header>
+
+      <RegionSelector
+        isDisabled={
+          singleProcessingStore.isFetchingData ||
+          singleProcessingStore.isPollingForTranscript
+        }
+        serviceCode='goog'
+        serviceType='transcription'
+        rootLanguage={draft.languageCode}
+        onRegionChange={onRegionChange}
+        onCancel={cancelAuto}
+      />
+
+      <h2>{t('Transcription provider')}</h2>
+
+      <p>
+        {t(
+          'Automated transcription is provided by Google Cloud Platform. By ' +
+            'using this service you agree that your audio file will be sent to ' +
+            "Google's servers for the purpose of transcribing. However, it will " +
+            "not be stored on Google's servers beyond the short period needed for " +
+            'completing the transcription, and we do not allow Google to use the ' +
+            'audio for improving its transcription service.'
+        )}
+      </p>
+
+      <footer className={bodyStyles.footer}>
+        <div className={bodyStyles.footerCenterButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='m'
+            label={t('cancel')}
+            onClick={cancelAuto}
+            isDisabled={
+              singleProcessingStore.isFetchingData ||
+              singleProcessingStore.isPollingForTranscript
+            }
+          />
+
+          <Button
+            type='full'
+            color='blue'
+            size='m'
+            label={
+              singleProcessingStore.isPollingForTranscript
+                ? t('in progress')
+                : t('create transcript')
+            }
+            onClick={requestAutoTranscription}
+            isDisabled={
+              singleProcessingStore.isFetchingData ||
+              singleProcessingStore.isPollingForTranscript
+            }
+          />
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/transcript/stepEditor.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepEditor.component.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import HeaderLanguageAndDate from './headerLanguageAndDate.component';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepEditor() {
+  function discardDraft() {
+    singleProcessingStore.safelyDeleteTranscriptDraft();
+  }
+
+  function saveDraft() {
+    const draft = singleProcessingStore.getTranscriptDraft();
+    if (draft?.languageCode !== undefined && draft?.value !== undefined) {
+      singleProcessingStore.setTranscript(draft.languageCode, draft.value);
+    }
+  }
+
+  /** Changes the draft value, preserving the other draft properties. */
+  function setDraftValue(evt: React.ChangeEvent<HTMLTextAreaElement>) {
+    const newVal = evt.target.value;
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
+    newDraft.value = newVal;
+    singleProcessingStore.setTranscriptDraft(newDraft);
+  }
+
+  const draft = singleProcessingStore.getTranscriptDraft();
+
+  // The discard button will become a back button when there are no unsaved changes.
+  let discardLabel = t('Back');
+  if (singleProcessingStore.hasUnsavedTranscriptDraftValue()) {
+    discardLabel = t('Discard');
+  }
+
+  return (
+    <div className={bodyStyles.root}>
+      <header className={bodyStyles.transxHeader}>
+        <HeaderLanguageAndDate />
+
+        <nav className={bodyStyles.transxHeaderButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='s'
+            label={discardLabel}
+            onClick={discardDraft}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='full'
+            color='blue'
+            size='s'
+            label={t('Save')}
+            onClick={saveDraft}
+            isPending={singleProcessingStore.isFetchingData}
+            isDisabled={!singleProcessingStore.hasUnsavedTranscriptDraftValue()}
+          />
+        </nav>
+      </header>
+
+      <textarea
+        className={bodyStyles.textarea}
+        value={draft?.value}
+        onChange={setDraftValue}
+        disabled={singleProcessingStore.isFetchingData}
+      />
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/transcript/stepEditor.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepEditor.component.tsx
@@ -18,8 +18,7 @@ export default function StepEditor() {
   }
 
   /** Changes the draft value, preserving the other draft properties. */
-  function setDraftValue(evt: React.ChangeEvent<HTMLTextAreaElement>) {
-    const newVal = evt.target.value;
+  function setDraftValue(newVal: string | undefined) {
     const newDraft =
       clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
     newDraft.value = newVal;
@@ -64,7 +63,9 @@ export default function StepEditor() {
       <textarea
         className={bodyStyles.textarea}
         value={draft?.value}
-        onChange={setDraftValue}
+        onChange={(evt: React.ChangeEvent<HTMLTextAreaElement>) => {
+          setDraftValue(evt.target.value);
+        }}
         disabled={singleProcessingStore.isFetchingData}
       />
     </div>

--- a/jsapp/js/components/processing/transcript/stepViewer.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepViewer.component.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import HeaderLanguageAndDate from './headerLanguageAndDate.component';
+import {destroyConfirm} from 'js/alertify';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepViewer() {
+  function openEditor() {
+    const transcript = singleProcessingStore.getTranscript();
+    if (transcript) {
+      // Make new draft using existing transcript.
+      singleProcessingStore.setTranscriptDraft(transcript);
+    }
+  }
+
+  function deleteTranscript() {
+    destroyConfirm(
+      singleProcessingStore.deleteTranscript.bind(singleProcessingStore),
+      t('Delete transcript?')
+    );
+  }
+
+  return (
+    <div className={bodyStyles.root}>
+      <header className={bodyStyles.transxHeader}>
+        <HeaderLanguageAndDate />
+
+        <nav className={bodyStyles.transxHeaderButtons}>
+          <Button
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='edit'
+            onClick={openEditor}
+            tooltip={t('Edit')}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='trash'
+            onClick={deleteTranscript}
+            tooltip={t('Delete')}
+            isPending={singleProcessingStore.isFetchingData}
+          />
+        </nav>
+      </header>
+
+      <article className={bodyStyles.text}>
+        {singleProcessingStore.getTranscript()?.value}
+      </article>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
+++ b/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
@@ -43,6 +43,8 @@ export default class TranscriptTab extends React.Component<{}> {
     }
 
     // Step 2: Config - for selecting the transcript language and mode.
+    // We display it when there is ongoing draft, but it doesn't have a language 
+    // or a value, and the region code is not selected.
     if (
       draft !== undefined &&
       (draft.languageCode === undefined || draft.value === undefined) &&
@@ -51,7 +53,10 @@ export default class TranscriptTab extends React.Component<{}> {
       return <StepConfig />;
     }
 
-    // Step 2.1: Config Automatic - for selecting region and other automatic options
+    // Step 2.1: Config Automatic - for selecting region and other automatic 
+    // options.
+    // We display it when there is ongoing draft, but it doesn't have a language 
+    // or a value, and the region code is selected.
     if (
       draft !== undefined &&
       (draft.languageCode === undefined || draft.value === undefined) &&
@@ -66,6 +71,8 @@ export default class TranscriptTab extends React.Component<{}> {
     }
 
     // Step 4: Viewer - display existing (on backend) transcript.
+    // We display it when there is transcript in the store, and there is no 
+    // ongoing draft (we only support single transcript ATM).
     if (
       singleProcessingStore.getTranscript() !== undefined &&
       draft === undefined

--- a/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
+++ b/jsapp/js/components/processing/transcript/transcriptTab.component.tsx
@@ -1,23 +1,10 @@
 import React from 'react';
-import clonedeep from 'lodash.clonedeep';
-import {formatTime} from 'js/utils';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
-import LanguageSelector, {
-  resetAllLanguageSelectors,
-} from 'js/components/languages/languageSelector';
-import RegionSelector from 'js/components/languages/regionSelector';
-import Button from 'js/components/common/button';
-import {destroyConfirm} from 'js/alertify';
-import type {
-  DetailedLanguage,
-  LanguageCode,
-  ListLanguage,
-} from 'js/components/languages/languagesStore';
-import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
-import envStore from 'js/envStore';
-import bodyStyles from 'js/components/processing/processingBody.module.scss';
-import classNames from 'classnames';
+import StepBegin from './stepBegin.component';
+import StepConfig from './stepConfig.component';
+import StepConfigAuto from './stepConfigAuto.component';
+import StepEditor from './stepEditor.component';
+import StepViewer from './stepViewer.component';
 
 export default class TranscriptTab extends React.Component<{}> {
   private unlisteners: Function[] = [];
@@ -43,388 +30,6 @@ export default class TranscriptTab extends React.Component<{}> {
     this.forceUpdate();
   }
 
-  /** Changes the draft language, preserving the other draft properties. */
-  onLanguageChange(newVal: DetailedLanguage | ListLanguage | null) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
-    newDraft.languageCode = newVal?.code;
-    singleProcessingStore.setTranscriptDraft(newDraft);
-  }
-
-  /** Changes the draft region, preserving the other draft properties. */
-  onRegionChange(newVal: LanguageCode | null | undefined) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
-    newDraft.regionCode = newVal;
-    singleProcessingStore.setTranscriptDraft(newDraft);
-  }
-
-  /** Changes the draft value, preserving the other draft properties. */
-  setDraftValue(newVal: string | undefined) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranscriptDraft()) || {};
-    newDraft.value = newVal;
-    singleProcessingStore.setTranscriptDraft(newDraft);
-  }
-
-  onDraftValueChange(evt: React.ChangeEvent<HTMLTextAreaElement>) {
-    this.setDraftValue(evt.target.value);
-  }
-
-  begin() {
-    // Make an empty draft.
-    singleProcessingStore.setTranscriptDraft({});
-  }
-
-  selectModeManual() {
-    // Initialize draft value.
-    this.setDraftValue('');
-  }
-
-  selectModeAuto() {
-    // The `null` value tells us that no region was selected yet, but we are
-    // interested in regions right now - i.e. when this property exists (is
-    // defined) we show the automatic service configuration step.
-    this.onRegionChange(null);
-  }
-
-  requestAutoTranscription() {
-    singleProcessingStore.requestAutoTranscription();
-  }
-
-  /** Goes back from the automatic service configuration step. */
-  cancelAuto() {
-    this.onRegionChange(undefined);
-  }
-
-  back() {
-    const draft = singleProcessingStore.getTranscriptDraft();
-    if (
-      draft !== undefined &&
-      draft?.languageCode === undefined &&
-      draft?.value === undefined
-    ) {
-      this.discardDraft();
-    }
-
-    if (
-      draft !== undefined &&
-      draft?.languageCode !== undefined &&
-      draft?.value === undefined
-    ) {
-      singleProcessingStore.setTranslationDraft({});
-      resetAllLanguageSelectors();
-    }
-  }
-
-  discardDraft() {
-    if (singleProcessingStore.hasUnsavedTranscriptDraftValue()) {
-      destroyConfirm(
-        singleProcessingStore.deleteTranscriptDraft.bind(singleProcessingStore),
-        t('Discard unsaved changes?'),
-        t('Discard')
-      );
-    } else {
-      singleProcessingStore.deleteTranscriptDraft();
-    }
-  }
-
-  saveDraft() {
-    const draft = singleProcessingStore.getTranscriptDraft();
-    if (draft?.languageCode !== undefined && draft?.value !== undefined) {
-      singleProcessingStore.setTranscript(draft.languageCode, draft.value);
-    }
-  }
-
-  openEditor() {
-    const transcript = singleProcessingStore.getTranscript();
-    if (transcript) {
-      // Make new draft using existing transcript.
-      singleProcessingStore.setTranscriptDraft(transcript);
-    }
-  }
-
-  deleteTranscript() {
-    destroyConfirm(
-      singleProcessingStore.deleteTranscript.bind(singleProcessingStore),
-      t('Delete transcript?')
-    );
-  }
-
-  /** Whether automatic services are available for current user. */
-  isAutoEnabled() {
-    return envStore.data.asr_mt_features_enabled;
-  }
-
-  renderLanguageAndDate() {
-    const storeTranscript = singleProcessingStore.getTranscript();
-    const draft = singleProcessingStore.getTranscriptDraft();
-    const valueLanguageCode =
-      draft?.languageCode || storeTranscript?.languageCode;
-    if (valueLanguageCode === undefined) {
-      return null;
-    }
-
-    let dateText = '';
-    if (storeTranscript) {
-      if (storeTranscript.dateCreated !== storeTranscript?.dateModified) {
-        dateText = t('last modified ##date##').replace(
-          '##date##',
-          formatTime(storeTranscript.dateModified)
-        );
-      } else {
-        dateText = t('created ##date##').replace(
-          '##date##',
-          formatTime(storeTranscript.dateCreated)
-        );
-      }
-    }
-
-    return (
-      <React.Fragment>
-        <label className={bodyStyles.transxHeaderLanguage}>
-          <AsyncLanguageDisplayLabel code={valueLanguageCode} />
-        </label>
-
-        {dateText !== '' && (
-          <time className={bodyStyles.transxHeaderDate}>{dateText}</time>
-        )}
-      </React.Fragment>
-    );
-  }
-
-  renderStepBegin() {
-    const typeLabel =
-      singleProcessingStore.currentQuestionType || t('source file');
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepBegin)}>
-        <header className={bodyStyles.header}>
-          {t('This ##type## does not have a transcript yet').replace(
-            '##type##',
-            typeLabel
-          )}
-        </header>
-
-        <Button
-          type='full'
-          color='blue'
-          size='l'
-          label={t('begin')}
-          onClick={this.begin.bind(this)}
-        />
-      </div>
-    );
-  }
-
-  renderStepConfig() {
-    const draft = singleProcessingStore.getTranscriptDraft();
-
-    const typeLabel =
-      singleProcessingStore.currentQuestionType || t('source file');
-    const languageSelectorTitle = t(
-      'Please select the original language of the ##type##'
-    ).replace('##type##', typeLabel);
-
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepConfig)}>
-        <LanguageSelector
-          titleOverride={languageSelectorTitle}
-          onLanguageChange={this.onLanguageChange.bind(this)}
-          suggestedLanguages={singleProcessingStore.getAssetTranscriptableLanguages()}
-        />
-
-        <footer className={bodyStyles.footer}>
-          <Button
-            type='bare'
-            color='blue'
-            size='m'
-            label={t('back')}
-            startIcon='caret-left'
-            onClick={this.back.bind(this)}
-            isDisabled={singleProcessingStore.isFetchingData}
-          />
-
-          <div className={bodyStyles.footerRightButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='m'
-              label={this.isAutoEnabled() ? t('manual') : t('transcribe')}
-              onClick={this.selectModeManual.bind(this)}
-              isDisabled={
-                draft?.languageCode === undefined ||
-                singleProcessingStore.isFetchingData
-              }
-            />
-
-            <TransxAutomaticButton
-              onClick={this.selectModeAuto.bind(this)}
-              selectedLanguage={draft?.languageCode}
-              type='transcript'
-            />
-          </div>
-        </footer>
-      </div>
-    );
-  }
-
-  renderStepConfigAuto() {
-    const draft = singleProcessingStore.getTranscriptDraft();
-
-    if (draft?.languageCode === undefined) {
-      return null;
-    }
-
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepConfig)}>
-        <header className={bodyStyles.header}>
-          {t('Automatic transcription of audio file from')}
-        </header>
-
-        <RegionSelector
-          isDisabled={
-            singleProcessingStore.isFetchingData ||
-            singleProcessingStore.isPollingForTranscript
-          }
-          serviceCode='goog'
-          serviceType='transcription'
-          rootLanguage={draft.languageCode}
-          onRegionChange={this.onRegionChange.bind(this)}
-          onCancel={this.cancelAuto.bind(this)}
-        />
-
-        <h2>{t('Transcription provider')}</h2>
-
-        <p>
-          {t(
-            'Automated transcription is provided by Google Cloud Platform. By ' +
-              'using this service you agree that your audio file will be sent to ' +
-              "Google's servers for the purpose of transcribing. However, it will " +
-              "not be stored on Google's servers beyond the short period needed for " +
-              'completing the transcription, and we do not allow Google to use the ' +
-              'audio for improving its transcription service.'
-          )}
-        </p>
-
-        <footer className={bodyStyles.footer}>
-          <div className={bodyStyles.footerCenterButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='m'
-              label={t('cancel')}
-              onClick={this.cancelAuto.bind(this)}
-              isDisabled={
-                singleProcessingStore.isFetchingData ||
-                singleProcessingStore.isPollingForTranscript
-              }
-            />
-
-            <Button
-              type='full'
-              color='blue'
-              size='m'
-              label={
-                singleProcessingStore.isPollingForTranscript
-                  ? t('in progress')
-                  : t('create transcript')
-              }
-              onClick={this.requestAutoTranscription.bind(this)}
-              isDisabled={
-                singleProcessingStore.isFetchingData ||
-                singleProcessingStore.isPollingForTranscript
-              }
-            />
-          </div>
-        </footer>
-      </div>
-    );
-  }
-
-  renderStepEditor() {
-    const draft = singleProcessingStore.getTranscriptDraft();
-
-    // The discard button will become a back button when there are no unsaved changes.
-    let discardLabel = t('Back');
-    if (singleProcessingStore.hasUnsavedTranscriptDraftValue()) {
-      discardLabel = t('Discard');
-    }
-
-    return (
-      <div className={bodyStyles.root}>
-        <header className={bodyStyles.transxHeader}>
-          {this.renderLanguageAndDate()}
-
-          <nav className={bodyStyles.transxHeaderButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='s'
-              label={discardLabel}
-              onClick={this.discardDraft.bind(this)}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='full'
-              color='blue'
-              size='s'
-              label={t('Save')}
-              onClick={this.saveDraft.bind(this)}
-              isPending={singleProcessingStore.isFetchingData}
-              isDisabled={
-                !singleProcessingStore.hasUnsavedTranscriptDraftValue()
-              }
-            />
-          </nav>
-        </header>
-
-        <textarea
-          className={bodyStyles.textarea}
-          value={draft?.value}
-          onChange={this.onDraftValueChange.bind(this)}
-          disabled={singleProcessingStore.isFetchingData}
-        />
-      </div>
-    );
-  }
-
-  renderStepViewer() {
-    return (
-      <div className={bodyStyles.root}>
-        <header className={bodyStyles.transxHeader}>
-          {this.renderLanguageAndDate()}
-
-          <nav className={bodyStyles.transxHeaderButtons}>
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='edit'
-              onClick={this.openEditor.bind(this)}
-              tooltip={t('Edit')}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='trash'
-              onClick={this.deleteTranscript.bind(this)}
-              tooltip={t('Delete')}
-              isPending={singleProcessingStore.isFetchingData}
-            />
-          </nav>
-        </header>
-
-        <article className={bodyStyles.text}>
-          {singleProcessingStore.getTranscript()?.value}
-        </article>
-      </div>
-    );
-  }
-
   /** Identifies what step should be displayed based on the data itself. */
   render() {
     const draft = singleProcessingStore.getTranscriptDraft();
@@ -434,7 +39,7 @@ export default class TranscriptTab extends React.Component<{}> {
       singleProcessingStore.getTranscript() === undefined &&
       draft === undefined
     ) {
-      return this.renderStepBegin();
+      return <StepBegin />;
     }
 
     // Step 2: Config - for selecting the transcript language and mode.
@@ -443,7 +48,7 @@ export default class TranscriptTab extends React.Component<{}> {
       (draft.languageCode === undefined || draft.value === undefined) &&
       draft.regionCode === undefined
     ) {
-      return this.renderStepConfig();
+      return <StepConfig />;
     }
 
     // Step 2.1: Config Automatic - for selecting region and other automatic options
@@ -452,12 +57,12 @@ export default class TranscriptTab extends React.Component<{}> {
       (draft.languageCode === undefined || draft.value === undefined) &&
       draft.regionCode !== undefined
     ) {
-      return this.renderStepConfigAuto();
+      return <StepConfigAuto />;
     }
 
     // Step 3: Editor - display editor of draft transcript.
     if (draft !== undefined) {
-      return this.renderStepEditor();
+      return <StepEditor />;
     }
 
     // Step 4: Viewer - display existing (on backend) transcript.
@@ -465,7 +70,7 @@ export default class TranscriptTab extends React.Component<{}> {
       singleProcessingStore.getTranscript() !== undefined &&
       draft === undefined
     ) {
-      return this.renderStepViewer();
+      return <StepViewer />;
     }
 
     // Should not happen, but we need to return something.

--- a/jsapp/js/components/processing/translations/headerLanguageAndDate.component.tsx
+++ b/jsapp/js/components/processing/translations/headerLanguageAndDate.component.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {formatTime} from 'js/utils';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
+import TransxSelector from 'js/components/processing/transxSelector';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+interface HeaderLanguageAndDateProps {
+  /** Uses languageCode. */
+  selectedTranslation?: LanguageCode;
+  onRequestSelectTranslation: (
+    newSelectedOption: LanguageCode | undefined
+  ) => void;
+}
+
+export default function HeaderLanguageAndDate(
+  props: HeaderLanguageAndDateProps
+) {
+  /** Renders a text or a selector of translations. */
+  function renderLanguage() {
+    const draft = singleProcessingStore.getTranslationDraft();
+
+    // When editing we want to display just a text
+    if (draft?.languageCode) {
+      return (
+        <label className={bodyStyles.transxHeaderLanguage}>
+          <AsyncLanguageDisplayLabel code={draft.languageCode} />
+        </label>
+      );
+    }
+
+    const translations = singleProcessingStore.getTranslations();
+
+    // When viewing the only translation we want to display just a text
+    if (!draft && translations.length === 1) {
+      return (
+        <label className={bodyStyles.transxHeaderLanguage}>
+          <AsyncLanguageDisplayLabel code={translations[0].languageCode} />
+        </label>
+      );
+    }
+
+    // When viewing one of translations we want to have an option to select some
+    // other translation.
+    if (!draft && translations.length >= 2) {
+      return (
+        <label className={bodyStyles.transxHeaderLanguage}>
+          <TransxSelector
+            languageCodes={translations.map(
+              (translation) => translation.languageCode
+            )}
+            selectedLanguage={props.selectedTranslation}
+            onChange={(newSelectedOption: LanguageCode | null) => {
+              props.onRequestSelectTranslation(newSelectedOption || undefined);
+            }}
+            size='s'
+            type='blue'
+          />
+        </label>
+      );
+    }
+
+    return null;
+  }
+
+  const storeTranslation = singleProcessingStore.getTranslation(
+    props.selectedTranslation
+  );
+
+  let dateText = '';
+  if (storeTranslation) {
+    if (storeTranslation.dateCreated !== storeTranslation?.dateModified) {
+      dateText = t('last modified ##date##').replace(
+        '##date##',
+        formatTime(storeTranslation.dateModified)
+      );
+    } else {
+      dateText = t('created ##date##').replace(
+        '##date##',
+        formatTime(storeTranslation.dateCreated)
+      );
+    }
+  }
+
+  return (
+    <React.Fragment>
+      {renderLanguage()}
+
+      {dateText !== '' && (
+        <time className={bodyStyles.transxHeaderDate}>{dateText}</time>
+      )}
+    </React.Fragment>
+  );
+}

--- a/jsapp/js/components/processing/translations/stepBegin.component.tsx
+++ b/jsapp/js/components/processing/translations/stepBegin.component.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import cx from 'classnames';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function Foo() {
+  function begin() {
+    // Make an empty draft.
+    singleProcessingStore.setTranslationDraft({});
+  }
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepBegin)}>
+      <header className={bodyStyles.header}>
+        {t('This transcript does not have any translations yet')}
+      </header>
+
+      <Button
+        type='full'
+        color='blue'
+        size='l'
+        label={t('begin')}
+        onClick={begin}
+        isDisabled={singleProcessingStore.getTranscript() === undefined}
+      />
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/translations/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfig.component.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import cx from 'classnames';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
+import LanguageSelector, {
+  resetAllLanguageSelectors,
+} from 'js/components/languages/languageSelector';
+import type {
+  LanguageCode,
+  DetailedLanguage,
+  ListLanguage,
+} from 'js/components/languages/languagesStore';
+import envStore from 'js/envStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepConfig() {
+  /** Changes the draft value, preserving the other draft properties. */
+  function setDraftValue(newVal: string | undefined) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
+    newDraft.value = newVal;
+    singleProcessingStore.setTranslationDraft(newDraft);
+  }
+
+  /** Changes the draft language, preserving the other draft properties. */
+  function onLanguageChange(newVal: DetailedLanguage | ListLanguage | null) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
+    newDraft.languageCode = newVal?.code;
+    singleProcessingStore.setTranslationDraft(newDraft);
+  }
+
+  /** Returns languages of all translations */
+  function getTranslationsLanguages() {
+    const translations = singleProcessingStore.getTranslations();
+    const languages: LanguageCode[] = [];
+    translations.forEach((translation) => {
+      languages.push(translation.languageCode);
+    });
+    return languages;
+  }
+
+  function back() {
+    const draft = singleProcessingStore.getTranslationDraft();
+
+    if (
+      draft !== undefined &&
+      draft?.languageCode === undefined &&
+      draft?.value === undefined
+    ) {
+      singleProcessingStore.safelyDeleteTranslationDraft();
+    }
+
+    if (draft?.languageCode !== undefined && draft?.value === undefined) {
+      singleProcessingStore.setTranslationDraft({});
+      resetAllLanguageSelectors();
+    }
+  }
+
+  function selectModeManual() {
+    // Initialize draft value.
+    setDraftValue('');
+  }
+
+  function selectModeAuto() {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
+    // The `null` value tells us that no region was selected yet, but we are
+    // interested in regions right now - i.e. when this property exists (is
+    // defined) we show the automatic service configuration step.
+    newDraft.regionCode = null;
+    singleProcessingStore.setTranslationDraft(newDraft);
+  }
+
+  const draft = singleProcessingStore.getTranslationDraft();
+  const isAutoEnabled = envStore.data.asr_mt_features_enabled;
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
+      <LanguageSelector
+        titleOverride={t('Please select the language you want to translate to')}
+        onLanguageChange={onLanguageChange}
+        hiddenLanguages={getTranslationsLanguages()}
+        suggestedLanguages={singleProcessingStore.getAssetTranslatableLanguages()}
+        isDisabled={singleProcessingStore.isFetchingData}
+      />
+
+      <footer className={bodyStyles.footer}>
+        <Button
+          type='bare'
+          color='blue'
+          size='m'
+          label={t('back')}
+          startIcon='caret-left'
+          onClick={back}
+          isDisabled={singleProcessingStore.isFetchingData}
+        />
+
+        <div className={bodyStyles.footerRightButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='m'
+            label={isAutoEnabled ? t('manual') : t('translate')}
+            onClick={selectModeManual}
+            isDisabled={
+              draft?.languageCode === undefined ||
+              singleProcessingStore.isFetchingData
+            }
+          />
+
+          <TransxAutomaticButton
+            onClick={selectModeAuto}
+            selectedLanguage={draft?.languageCode}
+            type='translation'
+          />
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/translations/stepConfigAuto.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfigAuto.component.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import cx from 'classnames';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import RegionSelector from 'js/components/languages/regionSelector';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+export default function StepConfigAuto() {
+  /** Changes the draft region, preserving the other draft properties. */
+  function onRegionChange(newVal: LanguageCode | null | undefined) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
+    newDraft.regionCode = newVal;
+    singleProcessingStore.setTranslationDraft(newDraft);
+  }
+
+  /** Goes back from the automatic service configuration step. */
+  function cancelAuto() {
+    onRegionChange(undefined);
+  }
+
+  function requestAutoTranslation() {
+    // Currently we only support automatic translation from transcript language,
+    // but we should also allow to use the source data language.
+    const toLanguageCode =
+      singleProcessingStore.getTranslationDraft()?.regionCode ||
+      singleProcessingStore.getTranslationDraft()?.languageCode;
+    if (toLanguageCode) {
+      singleProcessingStore.requestAutoTranslation(toLanguageCode);
+    }
+  }
+
+  const draft = singleProcessingStore.getTranslationDraft();
+
+  if (draft?.languageCode === undefined) {
+    return null;
+  }
+
+  return (
+    <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
+      <header className={bodyStyles.header}>
+        {t('Automatic translation of transcript to')}
+      </header>
+
+      <RegionSelector
+        isDisabled={singleProcessingStore.isFetchingData}
+        serviceCode='goog'
+        serviceType='translation'
+        rootLanguage={draft.languageCode}
+        onRegionChange={onRegionChange}
+        onCancel={cancelAuto}
+      />
+
+      <h2>{t('Translation provider')}</h2>
+
+      <p>
+        {t(
+          'Automated translation is provided by Google Cloud Platform. By using ' +
+            'this service you agree that your transcript text will be sent to ' +
+            "Google's servers for the purpose of translation. However, it will not " +
+            "be stored on Google's servers beyond the very short period needed for " +
+            'completing the translation.'
+        )}
+      </p>
+
+      <footer className={bodyStyles.footer}>
+        <div className={bodyStyles.footerCenterButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='m'
+            label={t('cancel')}
+            onClick={cancelAuto}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='full'
+            color='blue'
+            size='m'
+            label={t('create translation')}
+            onClick={requestAutoTranslation}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/translations/stepEditor.component.tsx
+++ b/jsapp/js/components/processing/translations/stepEditor.component.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import clonedeep from 'lodash.clonedeep';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import HeaderLanguageAndDate from './HeaderLanguageAndDate.component';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+interface StepEditorProps {
+  /** Uses languageCode. */
+  selectedTranslation?: LanguageCode;
+  onRequestSelectTranslation: (
+    newSelectedOption: LanguageCode | undefined
+  ) => void;
+}
+
+export default function StepEditor(props: StepEditorProps) {
+  function discardDraft() {
+    singleProcessingStore.safelyDeleteTranslationDraft();
+  }
+
+  function saveDraft() {
+    const draft = singleProcessingStore.getTranslationDraft();
+
+    if (draft?.languageCode !== undefined && draft?.value !== undefined) {
+      singleProcessingStore.setTranslation(draft.languageCode, draft.value);
+    }
+  }
+
+  /** Changes the draft value, preserving the other draft properties. */
+  function setDraftValue(newVal: string | undefined) {
+    const newDraft =
+      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
+    newDraft.value = newVal;
+    singleProcessingStore.setTranslationDraft(newDraft);
+  }
+
+  const draft = singleProcessingStore.getTranslationDraft();
+
+  // The discard button will become a back button when there are no unsaved changes.
+  let discardLabel = t('Back');
+  if (singleProcessingStore.hasUnsavedTranslationDraftValue()) {
+    discardLabel = t('Discard');
+  }
+
+  return (
+    <div className={bodyStyles.root}>
+      <header className={bodyStyles.transxHeader}>
+        <HeaderLanguageAndDate
+          selectedTranslation={props.selectedTranslation}
+          onRequestSelectTranslation={props.onRequestSelectTranslation}
+        />
+
+        <div className={bodyStyles.transxHeaderButtons}>
+          <Button
+            type='frame'
+            color='blue'
+            size='s'
+            label={discardLabel}
+            onClick={discardDraft}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='full'
+            color='blue'
+            size='s'
+            label={t('Save')}
+            onClick={saveDraft}
+            isPending={singleProcessingStore.isFetchingData}
+            isDisabled={
+              !singleProcessingStore.hasUnsavedTranslationDraftValue()
+            }
+          />
+        </div>
+      </header>
+
+      <textarea
+        className={bodyStyles.textarea}
+        value={draft?.value}
+        onChange={(evt: React.ChangeEvent<HTMLTextAreaElement>) => {
+          setDraftValue(evt.target.value);
+        }}
+        disabled={singleProcessingStore.isFetchingData}
+      />
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
+++ b/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import Button from 'js/components/common/button';
+import singleProcessingStore from 'js/components/processing/singleProcessingStore';
+import HeaderLanguageAndDate from './HeaderLanguageAndDate.component';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
+import {destroyConfirm} from 'js/alertify';
+import bodyStyles from 'js/components/processing/processingBody.module.scss';
+
+interface StepSingleViewerProps {
+  /** Uses languageCode. */
+  selectedTranslation?: LanguageCode;
+  onRequestSelectTranslation: (
+    newSelectedOption: LanguageCode | undefined
+  ) => void;
+}
+
+export default function StepSingleViewer(props: StepSingleViewerProps) {
+  function addTranslation() {
+    // Make an empty draft to make the language selector appear. Unselect
+    // the current translation.
+    singleProcessingStore.setTranslationDraft({});
+  }
+
+  function openEditor() {
+    const translation = singleProcessingStore.getTranslation(
+      props.selectedTranslation
+    );
+    if (translation) {
+      // Make new draft using existing translation.
+      singleProcessingStore.setTranslationDraft(translation);
+      props.onRequestSelectTranslation(props.selectedTranslation);
+    }
+  }
+
+  function deleteTranslation() {
+    if (props.selectedTranslation) {
+      destroyConfirm(
+        singleProcessingStore.deleteTranslation.bind(
+          singleProcessingStore,
+          props.selectedTranslation
+        ),
+        t('Delete translation?')
+      );
+    }
+  }
+
+  if (!props.selectedTranslation) {
+    return null;
+  }
+
+  return (
+    <div className={bodyStyles.root}>
+      <header className={bodyStyles.transxHeader}>
+        <HeaderLanguageAndDate
+          selectedTranslation={props.selectedTranslation}
+          onRequestSelectTranslation={props.onRequestSelectTranslation}
+        />
+
+        <div className={bodyStyles.transxHeaderButtons}>
+          <Button
+            type='frame'
+            color='storm'
+            size='s'
+            startIcon='plus'
+            label={t('new translation')}
+            onClick={addTranslation}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='edit'
+            onClick={openEditor}
+            tooltip={t('Edit')}
+            isDisabled={singleProcessingStore.isFetchingData}
+          />
+
+          <Button
+            type='bare'
+            color='storm'
+            size='s'
+            startIcon='trash'
+            onClick={deleteTranslation}
+            tooltip={t('Delete')}
+            isPending={singleProcessingStore.isFetchingData}
+          />
+        </div>
+      </header>
+
+      <article className={bodyStyles.text}>
+        {singleProcessingStore.getTranslation(props.selectedTranslation)?.value}
+      </article>
+    </div>
+  );
+}

--- a/jsapp/js/components/processing/translations/translationsTab.component.tsx
+++ b/jsapp/js/components/processing/translations/translationsTab.component.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
-import clonedeep from 'lodash.clonedeep';
-import {formatTime} from 'js/utils';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
-import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
-import LanguageSelector, {
-  resetAllLanguageSelectors,
-} from 'js/components/languages/languageSelector';
-import RegionSelector from 'js/components/languages/regionSelector';
-import Button from 'js/components/common/button';
-import {destroyConfirm} from 'js/alertify';
-import type {
-  DetailedLanguage,
-  LanguageCode,
-  ListLanguage,
-} from 'js/components/languages/languagesStore';
-import {AsyncLanguageDisplayLabel} from 'js/components/languages/languagesUtils';
-import TransxSelector from 'js/components/processing/transxSelector';
-import envStore from 'js/envStore';
-import bodyStyles from 'js/components/processing/processingBody.module.scss';
-import classNames from 'classnames';
+import StepBegin from './stepBegin.component';
+import StepConfig from './stepConfig.component';
+import StepConfigAuto from './stepConfigAuto.component';
+import StepEditor from './stepEditor.component';
+import StepSingleViewer from './stepSingleViewer.component';
+import type {LanguageCode} from 'js/components/languages/languagesStore';
 
 interface TranslationsTabState {
-  /** Uses languageCode. */
-  selectedTranslation?: string;
+  selectedTranslation?: LanguageCode;
 }
 
 export default class TranslationsTab extends React.Component<
@@ -79,22 +65,6 @@ export default class TranslationsTab extends React.Component<
     this.forceUpdate();
   }
 
-  /** Changes the draft language, preserving the other draft properties. */
-  onLanguageChange(newVal: DetailedLanguage | ListLanguage | null) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
-    newDraft.languageCode = newVal?.code;
-    singleProcessingStore.setTranslationDraft(newDraft);
-  }
-
-  /** Changes the draft region, preserving the other draft properties. */
-  onRegionChange(newVal: LanguageCode | null | undefined) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
-    newDraft.regionCode = newVal;
-    singleProcessingStore.setTranslationDraft(newDraft);
-  }
-
   getDefaultSelectedTranslation() {
     let selected;
     const storedTranslations = singleProcessingStore.getTranslations();
@@ -104,455 +74,8 @@ export default class TranslationsTab extends React.Component<
     return selected;
   }
 
-  /** Changes the draft value, preserving the other draft properties. */
-  setDraftValue(newVal: string | undefined) {
-    const newDraft =
-      clonedeep(singleProcessingStore.getTranslationDraft()) || {};
-    newDraft.value = newVal;
-    singleProcessingStore.setTranslationDraft(newDraft);
-  }
-
-  onDraftValueChange(evt: React.ChangeEvent<HTMLTextAreaElement>) {
-    this.setDraftValue(evt.target.value);
-  }
-
-  begin() {
-    // Make an empty draft.
-    singleProcessingStore.setTranslationDraft({});
-  }
-
-  selectModeManual() {
-    // Initialize draft value.
-    this.setDraftValue('');
-  }
-
-  selectModeAuto() {
-    // The `null` value tells us that no region was selected yet, but we are
-    // interested in regions right now - i.e. when this property exists (is
-    // defined) we show the automatic service configuration step.
-    this.onRegionChange(null);
-  }
-
-  requestAutoTranslation() {
-    // Currently we only support automatic translation from transcript language,
-    // but we should also allow to use the source data language.
-    const toLanguageCode =
-      singleProcessingStore.getTranslationDraft()?.regionCode ||
-      singleProcessingStore.getTranslationDraft()?.languageCode;
-    if (toLanguageCode) {
-      singleProcessingStore.requestAutoTranslation(toLanguageCode);
-    }
-  }
-
-  /** Goes back from the automatic service configuration step. */
-  cancelAuto() {
-    this.onRegionChange(undefined);
-  }
-
-  back() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    if (
-      draft !== undefined &&
-      draft?.languageCode === undefined &&
-      draft?.value === undefined
-    ) {
-      this.discardDraft();
-    }
-
-    if (
-      draft !== undefined &&
-      draft?.languageCode !== undefined &&
-      draft?.value === undefined
-    ) {
-      singleProcessingStore.setTranslationDraft({});
-      resetAllLanguageSelectors();
-    }
-  }
-
-  /** Removes the draft and preselects translations if possible. */
-  discardDraft() {
-    if (singleProcessingStore.hasUnsavedTranslationDraftValue()) {
-      destroyConfirm(
-        this.discardDraftInnerMethod.bind(this),
-        t('Discard unsaved changes?'),
-        t('Discard')
-      );
-    } else {
-      this.discardDraftInnerMethod();
-    }
-  }
-
-  discardDraftInnerMethod() {
-    singleProcessingStore.deleteTranslationDraft();
-  }
-
-  saveDraft() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    if (draft?.languageCode !== undefined && draft?.value !== undefined) {
-      singleProcessingStore.setTranslation(draft.languageCode, draft.value);
-    }
-  }
-
-  openEditor(languageCode: LanguageCode) {
-    const translation = singleProcessingStore.getTranslation(languageCode);
-
-    if (translation) {
-      // Make new draft using existing translation.
-      singleProcessingStore.setTranslationDraft(translation);
-      this.setState({
-        selectedTranslation: languageCode,
-      });
-    }
-  }
-
-  deleteTranslation(languageCode: LanguageCode) {
-    destroyConfirm(
-      singleProcessingStore.deleteTranslation.bind(
-        singleProcessingStore,
-        languageCode
-      ),
-      t('Delete translation?')
-    );
-  }
-
-  addTranslation() {
-    // Make an empty draft to make the language selector appear. Unselect the current translation.
-    singleProcessingStore.setTranslationDraft({});
-  }
-
-  selectTranslation(languageCode?: string) {
+  selectTranslation(languageCode?: LanguageCode) {
     this.setState({selectedTranslation: languageCode});
-  }
-
-  /** Returns languages of all translations */
-  getTranslationsLanguages() {
-    const translations = singleProcessingStore.getTranslations();
-    const languages: LanguageCode[] = [];
-    translations.forEach((translation) => {
-      languages.push(translation.languageCode);
-    });
-    return languages;
-  }
-
-  /** Whether automatic services are available for current user. */
-  isAutoEnabled() {
-    return envStore.data.asr_mt_features_enabled;
-  }
-
-  renderLanguageAndDate() {
-    const storeTranslation = singleProcessingStore.getTranslation(
-      this.state.selectedTranslation
-    );
-
-    let dateText = '';
-    if (storeTranslation) {
-      if (storeTranslation.dateCreated !== storeTranslation?.dateModified) {
-        dateText = t('last modified ##date##').replace(
-          '##date##',
-          formatTime(storeTranslation.dateModified)
-        );
-      } else {
-        dateText = t('created ##date##').replace(
-          '##date##',
-          formatTime(storeTranslation.dateCreated)
-        );
-      }
-    }
-
-    return (
-      <React.Fragment>
-        {this.renderLanguage()}
-
-        {dateText !== '' && (
-          <time className={bodyStyles.transxHeaderDate}>{dateText}</time>
-        )}
-      </React.Fragment>
-    );
-  }
-
-  /** Renders a text or a selector of translations. */
-  renderLanguage() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    // When editing we want to display just a text
-    if (draft?.languageCode) {
-      return (
-        <label className={bodyStyles.transxHeaderLanguage}>
-          <AsyncLanguageDisplayLabel code={draft.languageCode} />
-        </label>
-      );
-    }
-
-    const translations = singleProcessingStore.getTranslations();
-
-    // When viewing the only translation we want to display just a text
-    if (!draft && translations.length === 1) {
-      return (
-        <label className={bodyStyles.transxHeaderLanguage}>
-          <AsyncLanguageDisplayLabel code={translations[0].languageCode} />
-        </label>
-      );
-    }
-
-    // When viewing one of translations we want to have an option to select some
-    // other translation.
-    if (!draft && translations.length >= 2) {
-      return (
-        <label className={bodyStyles.transxHeaderLanguage}>
-          <TransxSelector
-            languageCodes={translations.map(
-              (translation) => translation.languageCode
-            )}
-            selectedLanguage={this.state.selectedTranslation}
-            onChange={(newSelectedOption: LanguageCode | null) => {
-              this.selectTranslation(newSelectedOption || undefined);
-            }}
-            size='s'
-            type='blue'
-          />
-        </label>
-      );
-    }
-
-    return null;
-  }
-
-  renderStepBegin() {
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepBegin)}>
-        <header className={bodyStyles.header}>
-          {t('This transcript does not have any translations yet')}
-        </header>
-
-        <Button
-          type='full'
-          color='blue'
-          size='l'
-          label={t('begin')}
-          onClick={this.begin.bind(this)}
-          isDisabled={singleProcessingStore.getTranscript() === undefined}
-        />
-      </div>
-    );
-  }
-
-  renderStepConfig() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepConfig)}>
-        <LanguageSelector
-          titleOverride={t(
-            'Please select the language you want to translate to'
-          )}
-          onLanguageChange={this.onLanguageChange.bind(this)}
-          hiddenLanguages={this.getTranslationsLanguages()}
-          suggestedLanguages={singleProcessingStore.getAssetTranslatableLanguages()}
-          isDisabled={singleProcessingStore.isFetchingData}
-        />
-
-        <footer className={bodyStyles.footer}>
-          <Button
-            type='bare'
-            color='blue'
-            size='m'
-            label={t('back')}
-            startIcon='caret-left'
-            onClick={this.back.bind(this)}
-            isDisabled={singleProcessingStore.isFetchingData}
-          />
-
-          <div className={bodyStyles.footerRightButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='m'
-              label={this.isAutoEnabled() ? t('manual') : t('translate')}
-              onClick={this.selectModeManual.bind(this)}
-              isDisabled={
-                draft?.languageCode === undefined ||
-                singleProcessingStore.isFetchingData
-              }
-            />
-
-            <TransxAutomaticButton
-              onClick={this.selectModeAuto.bind(this)}
-              selectedLanguage={draft?.languageCode}
-              type='translation'
-            />
-          </div>
-        </footer>
-      </div>
-    );
-  }
-
-  renderStepConfigAuto() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    if (draft?.languageCode === undefined) {
-      return null;
-    }
-
-    return (
-      <div className={classNames(bodyStyles.root, bodyStyles.stepConfig)}>
-        <header className={bodyStyles.header}>
-          {t('Automatic translation of transcript to')}
-        </header>
-
-        <RegionSelector
-          isDisabled={singleProcessingStore.isFetchingData}
-          serviceCode='goog'
-          serviceType='translation'
-          rootLanguage={draft.languageCode}
-          onRegionChange={this.onRegionChange.bind(this)}
-          onCancel={this.cancelAuto.bind(this)}
-        />
-
-        <h2>{t('Translation provider')}</h2>
-
-        <p>
-          {t(
-            'Automated translation is provided by Google Cloud Platform. By using ' +
-              'this service you agree that your transcript text will be sent to ' +
-              "Google's servers for the purpose of translation. However, it will not " +
-              "be stored on Google's servers beyond the very short period needed for " +
-              'completing the translation.'
-          )}
-        </p>
-
-        <footer className={bodyStyles.footer}>
-          <div className={bodyStyles.footerCenterButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='m'
-              label={t('cancel')}
-              onClick={this.cancelAuto.bind(this)}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='full'
-              color='blue'
-              size='m'
-              label={t('create translation')}
-              onClick={this.requestAutoTranslation.bind(this)}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-          </div>
-        </footer>
-      </div>
-    );
-  }
-
-  renderStepEditor() {
-    const draft = singleProcessingStore.getTranslationDraft();
-
-    // The discard button will become a back button when there are no unsaved changes.
-    let discardLabel = t('Back');
-    if (singleProcessingStore.hasUnsavedTranslationDraftValue()) {
-      discardLabel = t('Discard');
-    }
-
-    return (
-      <div className={bodyStyles.root}>
-        <header className={bodyStyles.transxHeader}>
-          {this.renderLanguageAndDate()}
-
-          <div className={bodyStyles.transxHeaderButtons}>
-            <Button
-              type='frame'
-              color='blue'
-              size='s'
-              label={discardLabel}
-              onClick={this.discardDraft.bind(this)}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='full'
-              color='blue'
-              size='s'
-              label={t('Save')}
-              onClick={this.saveDraft.bind(this)}
-              isPending={singleProcessingStore.isFetchingData}
-              isDisabled={
-                !singleProcessingStore.hasUnsavedTranslationDraftValue()
-              }
-            />
-          </div>
-        </header>
-
-        <textarea
-          className={bodyStyles.textarea}
-          value={draft?.value}
-          onChange={this.onDraftValueChange.bind(this)}
-          disabled={singleProcessingStore.isFetchingData}
-        />
-      </div>
-    );
-  }
-
-  /** Displays an existing translation. */
-  renderStepSingleViewer() {
-    if (!this.state.selectedTranslation) {
-      return null;
-    }
-
-    return (
-      <div className={bodyStyles.root}>
-        <header className={bodyStyles.transxHeader}>
-          {this.renderLanguageAndDate()}
-
-          <div className={bodyStyles.transxHeaderButtons}>
-            <Button
-              type='frame'
-              color='storm'
-              size='s'
-              startIcon='plus'
-              label={t('new translation')}
-              onClick={this.addTranslation.bind(this)}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='edit'
-              onClick={this.openEditor.bind(
-                this,
-                this.state.selectedTranslation
-              )}
-              tooltip={t('Edit')}
-              isDisabled={singleProcessingStore.isFetchingData}
-            />
-
-            <Button
-              type='bare'
-              color='storm'
-              size='s'
-              startIcon='trash'
-              onClick={this.deleteTranslation.bind(
-                this,
-                this.state.selectedTranslation
-              )}
-              tooltip={t('Delete')}
-              isPending={singleProcessingStore.isFetchingData}
-            />
-          </div>
-        </header>
-
-        <article className={bodyStyles.text}>
-          {
-            singleProcessingStore.getTranslation(this.state.selectedTranslation)
-              ?.value
-          }
-        </article>
-      </div>
-    );
   }
 
   /** Identifies what step should be displayed based on the data itself. */
@@ -564,40 +87,57 @@ export default class TranslationsTab extends React.Component<
       singleProcessingStore.getTranslations().length === 0 &&
       draft === undefined
     ) {
-      return this.renderStepBegin();
+      return <StepBegin />;
     }
 
     // Step 2: Config - for selecting the translation language and mode.
+    // We display it when there is ongoing draft, but it doesn't have a language 
+    // or a value, and the region code is not selected.
     if (
       draft !== undefined &&
       (draft.languageCode === undefined || draft.value === undefined) &&
       draft.regionCode === undefined
     ) {
-      return this.renderStepConfig();
+      return <StepConfig />;
     }
 
-    // Step 2.1: Config Automatic - for selecting region and other automatic options
+    // Step 2.1: Config Automatic - for selecting region and other automatic
+    // options.
+    // We display it when there is ongoing draft, but it doesn't have a language 
+    // or a value, and the region code is selected.
     if (
       draft !== undefined &&
       (draft.languageCode === undefined || draft.value === undefined) &&
       draft.regionCode !== undefined
     ) {
-      return this.renderStepConfigAuto();
+      return <StepConfigAuto />;
     }
 
     // Step 3: Editor - display editor of draft translation.
     if (draft !== undefined) {
-      return this.renderStepEditor();
+      return (
+        <StepEditor
+          selectedTranslation={this.state.selectedTranslation}
+          onRequestSelectTranslation={this.selectTranslation.bind(this)}
+        />
+      );
     }
 
     // Step 4: Viewer - display existing (on backend) and selected translation.
+    // We display it when there is selected translation, and there are 
+    // translations in the store, and there is no ongoing draft.
     if (
       (singleProcessingStore.getTranslation(this.state.selectedTranslation) !==
         undefined ||
         singleProcessingStore.getTranslations().length >= 1) &&
       draft === undefined
     ) {
-      return this.renderStepSingleViewer();
+      return (
+        <StepSingleViewer
+          selectedTranslation={this.state.selectedTranslation}
+          onRequestSelectTranslation={this.selectTranslation.bind(this)}
+        />
+      );
     }
 
     // Should not happen, but we need to return something.


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Internal code refactor.

## Notes

I moved around the tabs components in #4847 and now I split both of them into smaller components. It's quite possible that each step component could be made into a DRY component that would be used by both transcript and translations tabs, but I think it would be confusing. 

So the changes are:
- Added `safelyDeleteTranscriptDraft` and `safelyDeleteTranslationDraft` to `singleProcessingStore`, beacause multiple places uses it.
- I've added some more comments, but am open to pointing me to places that would still be good to describe in more detail. I feel that with the tabs component split into pieces the code is much clearer to understand. I do see that my solution of making the steps be calculated from the data is elegant and efficient, but quite confusing.
- I split `transcriptTab` into pieces, quite straightforwardly.
- I split `translationsTab` into pieces - had to introduce the `selectedTranslation` and `onRequestSelectTranslation` props into the flow, to not refactor the code too much.