### PR TITLE
[TASK-543] Ensure latest columns are displayed in Data Table after closing NLP screen

### DIFF
--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -2,7 +2,6 @@ import React, {Suspense} from 'react';
 import PropTypes from 'prop-types';
 import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
-import Reflux from 'reflux';
 import {actions} from '../actions';
 import bem from 'js/bem';
 import assetStore from 'js/assetStore';
@@ -42,7 +41,6 @@ export class FormSubScreens extends React.Component {
     autoBind(this);
   }
   componentDidMount() {
-    this.listenTo(assetStore, this.dmixAssetStoreChange);
     var uid =
       this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
@@ -165,7 +163,6 @@ export class FormSubScreens extends React.Component {
   }
 }
 
-reactMixin(FormSubScreens.prototype, Reflux.ListenerMixin);
 reactMixin(FormSubScreens.prototype, mixins.dmix);
 reactMixin(FormSubScreens.prototype, mixins.contextRouter);
 

--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -41,10 +41,12 @@ export class FormSubScreens extends React.Component {
     autoBind(this);
   }
   componentDidMount() {
-    var uid =
-      this.props.params.assetid || this.props.uid || this.props.params.uid;
+    const uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
-      actions.resources.loadAsset({id: uid});
+      // We need to refresh the asset, because when user leaves Single
+      // Processing View, there might be some new Data Table columns to be 
+      // displayed
+      actions.resources.loadAsset({id: uid}, true);
     }
   }
   render() {

--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -42,14 +42,7 @@ export class FormSubScreens extends React.Component {
   componentDidMount() {
     const uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
-      // TODO: remove the refresh flag, when Back-end fix for inconsistent
-      // `analysis_form_json.additional_fields` response after PATCHing is in
-      // place
-      //
-      // We need to refresh the asset, because when user leaves Single
-      // Processing View, there might be some new Data Table columns to be
-      // displayed
-      actions.resources.loadAsset({id: uid}, true);
+      actions.resources.loadAsset({id: uid});
     }
   }
   render() {

--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -4,7 +4,6 @@ import reactMixin from 'react-mixin';
 import autoBind from 'react-autobind';
 import {actions} from '../actions';
 import bem from 'js/bem';
-import assetStore from 'js/assetStore';
 import mixins from '../mixins';
 import DocumentTitle from 'react-document-title';
 import SharingForm from './permissions/sharingForm.component';
@@ -44,7 +43,7 @@ export class FormSubScreens extends React.Component {
     const uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
       // We need to refresh the asset, because when user leaves Single
-      // Processing View, there might be some new Data Table columns to be 
+      // Processing View, there might be some new Data Table columns to be
       // displayed
       actions.resources.loadAsset({id: uid}, true);
     }

--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -42,6 +42,10 @@ export class FormSubScreens extends React.Component {
   componentDidMount() {
     const uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
+      // TODO: remove the refresh flag, when Back-end fix for inconsistent
+      // `analysis_form_json.additional_fields` response after PATCHing is in
+      // place
+      //
       // We need to refresh the asset, because when user leaves Single
       // Processing View, there might be some new Data Table columns to be
       // displayed

--- a/jsapp/js/components/processing/singleProcessingHeader.tsx
+++ b/jsapp/js/components/processing/singleProcessingHeader.tsx
@@ -14,8 +14,9 @@ import KoboSelect from 'js/components/common/koboSelect';
 import type {KoboSelectOption} from 'js/components/common/koboSelect';
 import styles from './singleProcessingHeader.module.scss';
 import {openProcessing} from './processingUtils';
-import {withRouter} from 'jsapp/js/router/legacy';
-import type {WithRouterProps} from 'jsapp/js/router/legacy';
+import {withRouter} from 'js/router/legacy';
+import type {WithRouterProps} from 'js/router/legacy';
+import {actions} from 'js/actions';
 import classNames from 'classnames';
 
 interface SingleProcessingHeaderProps extends WithRouterProps {
@@ -24,12 +25,19 @@ interface SingleProcessingHeaderProps extends WithRouterProps {
   assetContent: AssetContent;
 }
 
+interface SingleProcessingHeaderState {
+  isDoneButtonPending: boolean;
+}
+
 /**
  * Component with the current question label and the UI for switching between
  * submissions and questions. It also has means of leaving Single Processing
  * via "DONE" button.
  */
-class SingleProcessingHeader extends React.Component<SingleProcessingHeaderProps> {
+class SingleProcessingHeader extends React.Component<
+  SingleProcessingHeaderProps,
+  SingleProcessingHeaderState
+> {
   private unlisteners: Function[] = [];
 
   componentDidMount() {
@@ -116,20 +124,36 @@ class SingleProcessingHeader extends React.Component<SingleProcessingHeaderProps
 
   /** Goes back to Data Table route for given project. */
   onDone() {
-    // If there are any changes to the data, we need to ensure that the latest
-    // asset is available in the Data Table, when it will rebuild itself, so
-    // that all the columns are rendered. This is needed for the case when user
-    // added/deleted transcript or translation, as editing the text value for it
-    // is already handled properly by Data Table code.
+    // HACK: If there are any changes to the data, we need to ensure that
+    // the latest asset is available in the Data Table, when it will rebuild
+    // itself, so that all the columns are rendered. This is needed for the case
+    // when user added/deleted transcript or translation (editing the text
+    // value for it is already handled properly by Data Table code).
     if (!singleProcessingStore.isPristine) {
-      // Here we delete the cached asset object from the cache, so that when
+      // Mark button as pending to let user know we wait for stuff.
+      this.setState({isDoneButtonPending: true});
+
+      // We don't need to add these listeners prior to this moment, and we don't
+      // need to cancel them, as regardless of outcome, we will navigate out of
+      // current view.
+      actions.resources.loadAsset.completed.listen(
+        this.navigateToDataTable.bind(this)
+      );
+
+      // For failed load we still navigate to Data Table, as this is not
+      // something that would cause a massive disruption or data loss
+      actions.resources.loadAsset.failed.listen(
+        this.navigateToDataTable.bind(this)
+      );
+
+      // We force load asset to overwrite the cache, so that when
       // `FormSubScreens` (a parent of Data Table) starts loading in a moment,
-      // it would fetch latest asset and make Data Table use it.
-
-      // JESSICA TODO: here add a line that removes the asset
+      // it would fetch latest asset and make Data Table use it. To avoid
+      // race conditions we wait until it loads to leave.
+      actions.resources.loadAsset({id: this.props.assetUid}, true);
+    } else {
+      this.navigateToDataTable();
     }
-
-    this.navigateToDataTable();
   }
 
   navigateToDataTable() {
@@ -311,6 +335,7 @@ class SingleProcessingHeader extends React.Component<SingleProcessingHeaderProps
             size='l'
             color='blue'
             label={t('DONE')}
+            isPending={this.state?.isDoneButtonPending}
             onClick={this.onDone.bind(this)}
           />
         </section>

--- a/jsapp/js/components/processing/singleProcessingHeader.tsx
+++ b/jsapp/js/components/processing/singleProcessingHeader.tsx
@@ -116,6 +116,23 @@ class SingleProcessingHeader extends React.Component<SingleProcessingHeaderProps
 
   /** Goes back to Data Table route for given project. */
   onDone() {
+    // If there are any changes to the data, we need to ensure that the latest
+    // asset is available in the Data Table, when it will rebuild itself, so
+    // that all the columns are rendered. This is needed for the case when user
+    // added/deleted transcript or translation, as editing the text value for it
+    // is already handled properly by Data Table code.
+    if (!singleProcessingStore.isPristine) {
+      // Here we delete the cached asset object from the cache, so that when
+      // `FormSubScreens` (a parent of Data Table) starts loading in a moment,
+      // it would fetch latest asset and make Data Table use it.
+
+      // JESSICA TODO: here add a line that removes the asset
+    }
+
+    this.navigateToDataTable();
+  }
+
+  navigateToDataTable() {
     const newRoute = ROUTES.FORM_TABLE.replace(':uid', this.props.assetUid);
     this.props.router.navigate(newRoute);
   }

--- a/jsapp/js/components/processing/singleProcessingHeader.tsx
+++ b/jsapp/js/components/processing/singleProcessingHeader.tsx
@@ -136,14 +136,18 @@ class SingleProcessingHeader extends React.Component<
       // We don't need to add these listeners prior to this moment, and we don't
       // need to cancel them, as regardless of outcome, we will navigate out of
       // current view.
-      actions.resources.loadAsset.completed.listen(
-        this.navigateToDataTable.bind(this)
+      this.unlisteners.push(
+        actions.resources.loadAsset.completed.listen(
+          this.navigateToDataTable.bind(this)
+        )
       );
 
       // For failed load we still navigate to Data Table, as this is not
       // something that would cause a massive disruption or data loss
-      actions.resources.loadAsset.failed.listen(
-        this.navigateToDataTable.bind(this)
+      this.unlisteners.push(
+        actions.resources.loadAsset.failed.listen(
+          this.navigateToDataTable.bind(this)
+        )
       );
 
       // We force load asset to overwrite the cache, so that when

--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -145,6 +145,7 @@ class SingleProcessingStore extends Reflux.Store {
   public isFetchingData = false;
   public isPollingForTranscript = false;
 
+  /** Clears all data - useful before making initialisation call */
   private resetProcessingData() {
     this.isProcessingDataLoaded = false;
     this.isPollingForTranscript = false;
@@ -272,7 +273,7 @@ class SingleProcessingStore extends Reflux.Store {
   }
 
   /** This is making sure the asset processing features are activated. */
-  onAssetLoad(asset: AssetResponse) {
+  private onAssetLoad(asset: AssetResponse) {
     if (
       isFormSingleProcessingRoute(
         this.currentAssetUid,
@@ -289,11 +290,11 @@ class SingleProcessingStore extends Reflux.Store {
     }
   }
 
-  onActivateAssetCompleted() {
+  private onActivateAssetCompleted() {
     this.fetchAllInitialDataForAsset();
   }
 
-  activateAsset() {
+  private activateAsset() {
     processingActions.activateAsset(this.currentAssetUid, true, []);
   }
 

--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -150,6 +150,7 @@ export class DataTable extends React.Component {
       )
     );
 
+    // TODO: why this line is needed? Why not use `assetStore`?
     stores.allAssets.whenLoaded(this.props.asset.uid, this.whenLoaded);
   }
 
@@ -193,7 +194,7 @@ export class DataTable extends React.Component {
       // the props asset is not yet updated
       this._prepColumns(this.state.submissions);
     } else if (!isEqual(prevAdditionalFields, newAdditionalFields)) {
-      // If additional fields have changed, it means that user has added 
+      // If additional fields have changed, it means that user has added
       // transcript or translations, thus we need to display more columns.
       this._prepColumns(this.state.submissions);
     }

--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -1,6 +1,7 @@
 import React from 'react';
 import autoBind from 'react-autobind';
 import clonedeep from 'lodash.clonedeep';
+import isEqual from 'lodash.isequal';
 import enketoHandler from 'js/enketoHandler';
 import Checkbox from 'js/components/common/checkbox';
 import {actions} from 'js/actions';
@@ -176,6 +177,9 @@ export class DataTable extends React.Component {
       newSettings = {};
     }
 
+    const prevAdditionalFields = prevProps.asset?.analysis_form_json?.additional_fields;
+    const newAdditionalFields = this.props.asset?.analysis_form_json?.additional_fields;
+
     // If sort setting changed, we definitely need to get new submissions (which
     // will rebuild columns)
     if (
@@ -183,10 +187,14 @@ export class DataTable extends React.Component {
       JSON.stringify(prevSettings[DATA_TABLE_SETTINGS.SORT_BY])
     ) {
       this.refreshSubmissions();
+    } else if (JSON.stringify(newSettings) !== JSON.stringify(prevSettings)) {
       // If some other table settings changed, we need to fix columns using
       // existing data, as after `actions.table.updateSettings` resolves,
       // the props asset is not yet updated
-    } else if (JSON.stringify(newSettings) !== JSON.stringify(prevSettings)) {
+      this._prepColumns(this.state.submissions);
+    } else if (!isEqual(prevAdditionalFields, newAdditionalFields)) {
+      // If additional fields have changed, it means that user has added 
+      // transcript or translations, thus we need to display more columns.
       this._prepColumns(this.state.submissions);
     }
   }

--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -19,6 +19,7 @@ import {ROUTES} from 'js/router/routerConstants';
 import {dataInterface} from 'js/dataInterface';
 import {stores} from './stores';
 import assetStore from 'js/assetStore';
+import type {AssetStoreData} from 'js/assetStore';
 import {actions} from './actions';
 import {log, notify, escapeHtml, join} from 'js/utils';
 import type {
@@ -264,7 +265,9 @@ const mixins: MixinsObject = {
     },
 
     componentDidMount() {
-      assetStore.listen(this.dmixAssetStoreChange, this);
+      this.dmixAssetStoreCancelListener = assetStore.listen((data: AssetStoreData) => {
+        this.dmixAssetStoreChange(data);
+      }, this);
 
       // TODO 2/2
       // HACK FIX: for when we use `PermProtectedRoute`, we don't need to make the
@@ -275,6 +278,12 @@ const mixins: MixinsObject = {
         this.setState(Object.assign({}, assetStore.data[uid]));
       } else if (uid) {
         actions.resources.loadAsset({id: uid});
+      }
+    },
+
+    componentWillUnmount() {
+      if (typeof this.dmixAssetStoreCancelListener === 'function') {
+        this.dmixAssetStoreCancelListener();
       }
     },
 

--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -235,7 +235,7 @@ const mixins: MixinsObject = {
       const uid = this._getAssetUid();
       const asset = data[uid];
       if (asset) {
-        this.setState(Object.assign({}, data[uid]));
+        this.setState(Object.assign({}, asset));
       }
     },
     _getAssetUid() {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

After closing NLP screen, Data Table will now correctly display all the columns for the newly added transcript or translations.

## Notes

This turned out to be quite hard to crack. Few attempts were made and finally I understand what is happening. Some of the changes in the PR are unneeded improvements I developed while trying different approaches - not sure if we should leave them :shrug:

Changes here:
- Removed `assetStore` listener from `FormSubScreens`, as it already uses `dmix` mixin, which has it built in
- Added `isPristine` flag to `singleProcessingStore`
- Added (unfinished) code to "Done" button that will prune the asset cache before leaving the NLP screen
- `DataTable` now ensures that if new `props.asset` is received that includes some new columns, the columns will be rebuilt (not sure if this case will ever happen though, i.e. if while `DataTable` is mounted, there will be any incoming changes for the NLP stuff).
- Added listener cancelling code to `dmix` (also not sure if needed)

## Related issues

Partially related to #4835