### PR TITLE
Fix broken admin reports

### DIFF
--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -169,7 +169,6 @@ def generate_continued_usage_report(output_filename: str, end_date: str):
         'Submissions 12M',
     ]
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output:
         writer = csv.writer(output)
         writer.writerow(headers)
@@ -220,7 +219,6 @@ def generate_domain_report(output_filename: str, start_date: str, end_date: str)
     # create the CSV file
     columns = ['Email Domain', 'Users', 'Projects', 'Submissions']
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output:
         writer = csv.writer(output)
         writer.writerow(columns)
@@ -293,7 +291,6 @@ def generate_forms_count_by_submission_range(output_filename: str):
     headers = ['Range', 'Count']
 
     # Crate a csv with output filename
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output:
         writer = csv.writer(output)
         writer.writerow(headers)
@@ -317,7 +314,6 @@ def generate_media_storage_report(output_filename: str):
 
     headers = ['Username', 'Storage Used (Bytes)']
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output:
         writer = csv.writer(output)
         writer.writerow(headers)
@@ -354,7 +350,6 @@ def generate_user_count_by_organization(output_filename: str):
     # write data to a csv file
     columns = ['Organization', 'Count']
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output_file:
         writer = csv.writer(output_file)
         writer.writerow(columns)
@@ -439,7 +434,6 @@ def generate_user_report(output_filename: str):
         'last_login',
     ]
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output_file:
         writer = csv.writer(output_file)
         writer.writerow(columns)
@@ -560,7 +554,6 @@ def generate_user_statistics_report(
         'Google MT Seconds',
     ]
 
-    default_storage = get_storage_class()()
     with default_storage.open(output_filename, 'w') as output:
         writer = csv.writer(output)
         writer.writerow(columns)

--- a/kobo/apps/superuser_stats/views.py
+++ b/kobo/apps/superuser_stats/views.py
@@ -3,7 +3,7 @@ import re
 from datetime import datetime, date
 
 from django.contrib.auth.decorators import user_passes_test
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import default_storage
 from django.http import HttpResponse, StreamingHttpResponse, Http404
 from django.urls import reverse
 from django.utils import timezone
@@ -379,7 +379,6 @@ def retrieve_reports(request, base_filename):
     """
     filename = _base_filename_to_full_filename(
         base_filename, request.user.username)
-    default_storage = get_storage_class()()
     if not default_storage.exists(filename):
         raise Http404
     # File is intentionally left open so it can be read by the streaming

--- a/kpi/models/asset_file.py
+++ b/kpi/models/asset_file.py
@@ -3,7 +3,6 @@ import posixpath
 from mimetypes import guess_type
 from typing import Optional
 
-from django.core.files.storage import get_storage_class
 from django.db import models
 from django.utils import timezone
 from private_storage.fields import PrivateFileField


### PR DESCRIPTION
## Description

Fix error introduced in `2.024.04` where reports crash before being fully generated.

## Notes 

`get_storage_class()` [is deprecated since Django 4.2](https://docs.djangoproject.com/en/4.2/ref/files/storage/#django.core.files.storage.get_storage_class)

