### PR TITLE
[TASK-604] Fix infinite spinner with speechless audio file

### DIFF
--- a/kobo/apps/subsequences/exceptions.py
+++ b/kobo/apps/subsequences/exceptions.py
@@ -1,6 +1,12 @@
+class AudioTooLongError(Exception):
+    """Audio file is too long for specified speech service"""
+
+
 class SubsequenceTimeoutError(Exception):
     pass
 
 
-class AudioTooLongError(Exception):
-    """Audio file is too long for specified speech service"""
+class TranscriptionResultsNotFound(Exception):
+    """
+    No results returned by specified transcription service
+    """


### PR DESCRIPTION
## Description

Return an empty transcription

## Notes

Track a newly created exception and return an empty string when it is raised. Instead of returning an empty dictionary from the transcription engine process. 

(IMO) It is better if a different behaviour is needed (in the future) when engine does not return an `results` property in its response.
