### PR TITLE
Dynamic stripe redirects

### DIFF
--- a/kobo/apps/stripe/tests/test_customer_portal_api.py
+++ b/kobo/apps/stripe/tests/test_customer_portal_api.py
@@ -44,6 +44,7 @@ class TestCustomerPortalAPITestCase(BaseTestCase):
                 Subscription,
                 status='active',
                 customer=self.customer,
+                items__price=self.price
             )
 
     def _get_url_for_expected_request(self, create_subscription=True, product_type='plan'):

--- a/kobo/apps/stripe/tests/test_link_creation_api.py
+++ b/kobo/apps/stripe/tests/test_link_creation_api.py
@@ -20,7 +20,9 @@ class TestCheckoutLinkAPITestCase(BaseTestCase):
     def setUp(self):
         self.someuser = User.objects.get(username='someuser')
         self.client.force_login(self.someuser)
-        product = baker.prepare(Product, active=True)
+        product = baker.prepare(
+            Product, metadata={'product_type': 'plan'}, active=True
+        )
         product.save()
         self.price = baker.make(
             Price,

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -1,5 +1,6 @@
 from math import ceil, floor
 
+from django.conf import settings
 from djstripe.models import Price
 
 
@@ -16,3 +17,14 @@ def get_total_price_for_quantity(price: Price, quantity: int):
         else:
             total_price = floor(total_price)
     return total_price * price.unit_amount
+
+def generate_return_url(product_metadata):
+    """
+    Determine which frontend page Stripe should redirect users to
+    after they make a purchase or manage their account.
+    """
+    base_url = settings.KOBOFORM_URL + '/#/account/'
+    return_page = (
+        'addons' if product_metadata['product_type'] == 'addon' else 'plan'
+    )
+    return base_url + return_page

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -35,6 +35,14 @@ from kobo.apps.stripe.utils import get_total_price_for_quantity
 from kpi.permissions import IsAuthenticated
 
 
+def generate_return_url(product_metadata, price_id=None):
+    base_url = settings.KOBOFORM_URL + '/#/account/'
+    return_page = (
+        'addons' if product_metadata['product_type'] == 'addon' else 'plan'
+    )
+    return base_url + return_page
+
+
 # Lists the one-time purchases made by the organization that the logged-in user owns
 class OneTimeAddOnViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (IsAuthenticated,)
@@ -279,7 +287,7 @@ class CheckoutLinkView(APIView):
                 'kpi_owner_username': user.username,
             },
             mode=checkout_mode,
-            success_url=f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
+            success_url=generate_return_url(price.product.metadata) + f'?checkout={price.id}',
             **kwargs,
         )
 
@@ -303,14 +311,21 @@ class CustomerPortalView(APIView):
 
     @staticmethod
     def generate_portal_link(user, organization_id, price, quantity):
-        customer = Customer.objects.filter(
-            subscriber_id=organization_id,
-            subscriber__owner__organization_user__user_id=user,
-            subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-            livemode=settings.STRIPE_LIVE_MODE,
-        ).values(
-            'id', 'subscriptions__id', 'subscriptions__items__id',
-        ).first()
+        customer = (
+            Customer.objects.filter(
+                subscriber_id=organization_id,
+                subscriber__owner__organization_user__user_id=user,
+                subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                livemode=settings.STRIPE_LIVE_MODE,
+            )
+            .values(
+                'id',
+                'subscriptions__id',
+                'subscriptions__items__id',
+                'subscriptions__items__price__product__metadata',
+            )
+            .first()
+        )
 
         if not customer:
             return Response(
@@ -320,8 +335,16 @@ class CustomerPortalView(APIView):
 
         portal_kwargs = {}
 
+        return_url = generate_return_url(
+            customer['subscriptions__items__price__product__metadata']
+        )
+
         # if we're generating a portal link for a price change, find or generate a matching portal configuration
         if price:
+
+            metadata = price.product.metadata
+            return_url = generate_return_url(metadata)
+
             """
             Customers with subscription schedules can't upgrade from the portal
             So if the customer has any active subscription schedules, release them, keeping the subscription intact
@@ -349,7 +372,6 @@ class CustomerPortalView(APIView):
             Recurring add-ons and the Enterprise plan aren't included in the default billing configuration.
             This lets us hide them as an 'upgrade' option for paid plan users.
             """
-            metadata = price.product.metadata
             needs_custom_config = (
                 metadata.get('product_type') == 'addon'
                 or metadata.get('plan_type') == 'enterprise'
@@ -416,7 +438,7 @@ class CustomerPortalView(APIView):
                     'after_completion': {
                         'type': 'redirect',
                         'redirect': {
-                            'return_url': f'{settings.KOBOFORM_URL}/#/account/plan?checkout={price.id}',
+                            'return_url': return_url + f'?checkout={price.id}',
                         },
                     },
                 },
@@ -425,7 +447,7 @@ class CustomerPortalView(APIView):
         stripe_response = stripe.billing_portal.Session.create(
             api_key=djstripe_settings.STRIPE_SECRET_KEY,
             customer=customer['id'],
-            return_url=f'{settings.KOBOFORM_URL}/#/account/plan',
+            return_url=return_url,
             **portal_kwargs,
         )
         return Response({'url': stripe_response['url']})

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -35,7 +35,7 @@ from kobo.apps.stripe.utils import get_total_price_for_quantity
 from kpi.permissions import IsAuthenticated
 
 
-def generate_return_url(product_metadata, price_id=None):
+def generate_return_url(product_metadata):
     base_url = settings.KOBOFORM_URL + '/#/account/'
     return_page = (
         'addons' if product_metadata['product_type'] == 'addon' else 'plan'

--- a/kobo/apps/stripe/views.py
+++ b/kobo/apps/stripe/views.py
@@ -31,16 +31,11 @@ from kobo.apps.stripe.serializers import (
     ProductSerializer,
     SubscriptionSerializer,
 )
-from kobo.apps.stripe.utils import get_total_price_for_quantity
+from kobo.apps.stripe.utils import (
+    generate_return_url,
+    get_total_price_for_quantity,
+)
 from kpi.permissions import IsAuthenticated
-
-
-def generate_return_url(product_metadata):
-    base_url = settings.KOBOFORM_URL + '/#/account/'
-    return_page = (
-        'addons' if product_metadata['product_type'] == 'addon' else 'plan'
-    )
-    return base_url + return_page
 
 
 # Lists the one-time purchases made by the organization that the logged-in user owns


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Now that we have set up a separate page for addons on the frontend, we need to be able to tell the Stripe portal which page to redirect users to when sending them back to KPI. This PR makes the Stripe checkout and customer portal endpoints determine the appropriate redirect url based on the type of product (if any) selected by the user.
