### PR TITLE
Hide password help text on registration form

### DIFF
--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -73,6 +73,10 @@ class KoboSignupMixin(forms.Form):
         for field_name in ['username', 'email', 'password1', 'password2']:
             if field_name in self.fields:
                 self.fields[field_name].widget.attrs['placeholder'] = ''
+        if 'password1' in self.fields:
+            # Remove `help_text` on purpose since some guidance is provided by
+            # Constance setting. Moreover it is redundant with error messages.
+            self.fields['password1'].help_text = ''
         if 'password2' in self.fields:
             self.fields['password2'].label = t('Password confirmation')
 


### PR DESCRIPTION
## Description

Only rely on custom guidance text (set in Admin interface) and errors after submitting the form.

## Notes

Empty the HTML of the attribute `help_text` of `password` field in the class constructor instead of altering the `help_text` method of each password class. 
It lets us hide the help text on the registration form but still display it in Admin interface

## Related issues

Fixes #4860