### PR TITLE
Make some read-only shadow models writable

### DIFF
--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -25,7 +25,7 @@ from kobo.apps.trash_bin.exceptions import TrashIntegrityError
 from kobo.apps.trash_bin.models.account import AccountTrash
 from kobo.apps.trash_bin.utils import move_to_trash
 from kpi.deployment_backends.kc_access.shadow_models import (
-    ReadOnlyKobocatMonthlyXFormSubmissionCounter,
+    KobocatMonthlyXFormSubmissionCounter,
 )
 from kpi.models.asset import AssetDeploymentStatus
 from .filters import UserAdvancedSearchFilter
@@ -241,7 +241,7 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
         displayed in the Django admin user changelist page
         """
         today = timezone.now().date()
-        instances = ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.filter(
+        instances = KobocatMonthlyXFormSubmissionCounter.objects.filter(
             user_id=obj.id,
             year=today.year,
             month=today.month,

--- a/kobo/apps/superuser_stats/models.py
+++ b/kobo/apps/superuser_stats/models.py
@@ -1,9 +1,9 @@
 from kpi.deployment_backends.kc_access.shadow_models import (
-    ReadOnlyKobocatMonthlyXFormSubmissionCounter,
+    KobocatMonthlyXFormSubmissionCounter,
 )
 
 
-class SuperuserStatsModel(ReadOnlyKobocatMonthlyXFormSubmissionCounter):
+class SuperuserStatsModel(KobocatMonthlyXFormSubmissionCounter):
     """
     Spoiler: Kludgy!
 
@@ -11,7 +11,7 @@ class SuperuserStatsModel(ReadOnlyKobocatMonthlyXFormSubmissionCounter):
     the superuser section in Django Admin.
     Django needs a model to register an admin model, so it extends a shadow
     model (as a proxy) to avoid creating new migrations.
-    It extends `ReadOnlyKobocatMonthlyXFormSubmissionCounter` but it could have
+    It extends `KobocatMonthlyXFormSubmissionCounter` but it could have
     been anyone of the (shadow) models since we do not add/update/delete objects
     from the admin interface. The HTML template only lists the available reports.
     """

--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -32,11 +32,11 @@ from kobo.apps.trackers.models import NLPUsageCounter
 from kobo.static_lists import COUNTRIES
 from kpi.constants import ASSET_TYPE_SURVEY
 from kpi.deployment_backends.kc_access.shadow_models import (
+    KobocatMonthlyXFormSubmissionCounter,
     KobocatXForm,
     KobocatUser,
     KobocatUserProfile,
     ReadOnlyKobocatInstance,
-    ReadOnlyKobocatMonthlyXFormSubmissionCounter,
 )
 from kpi.models.asset import Asset, AssetDeploymentStatus
 
@@ -111,7 +111,7 @@ def generate_continued_usage_report(output_filename: str, end_date: str):
             date_created__date__range=(twelve_months_time, end_date),
         )
         submissions_count = (
-            ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.annotate(
+            KobocatMonthlyXFormSubmissionCounter.objects.annotate(
                 date=Cast(
                     Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
                     DateField(),
@@ -201,7 +201,7 @@ def generate_domain_report(output_filename: str, start_date: str, end_date: str)
 
     # get a count of the submissions
     domain_submissions = {
-        domain: ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.annotate(
+        domain: KobocatMonthlyXFormSubmissionCounter.objects.annotate(
             date=Cast(
                 Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
                 DateField(),
@@ -478,7 +478,7 @@ def generate_user_statistics_report(
 
     # Get records from SubmissionCounter
     records = (
-        ReadOnlyKobocatMonthlyXFormSubmissionCounter.objects.annotate(
+        KobocatMonthlyXFormSubmissionCounter.objects.annotate(
             date=Cast(
                 Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
                 DateField(),

--- a/kobo/apps/trackers/submission_utils.py
+++ b/kobo/apps/trackers/submission_utils.py
@@ -5,7 +5,10 @@ from django.conf import settings
 from django.utils import timezone
 from model_bakery import baker
 
-from kpi.deployment_backends.kc_access.shadow_models import KobocatXForm, ReadOnlyKobocatDailyXFormSubmissionCounter
+from kpi.deployment_backends.kc_access.shadow_models import (
+    KobocatDailyXFormSubmissionCounter,
+    KobocatXForm,
+)
 from kpi.models import Asset
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
@@ -79,7 +82,7 @@ def update_xform_counters(asset: Asset, xform: KobocatXForm = None, submissions:
         )
         xform.save()
 
-    counter = ReadOnlyKobocatDailyXFormSubmissionCounter.objects.filter(
+    counter = KobocatDailyXFormSubmissionCounter.objects.filter(
         date=today.date(),
         user_id=asset.owner.id,
     ).first()
@@ -90,7 +93,7 @@ def update_xform_counters(asset: Asset, xform: KobocatXForm = None, submissions:
     else:
         counter = (
             baker.make(
-                ReadOnlyKobocatDailyXFormSubmissionCounter,
+                KobocatDailyXFormSubmissionCounter,
                 date=today.date(),
                 counter=submissions,
                 xform=xform,

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -93,6 +93,104 @@ class ShadowModel(models.Model):
             app_label=app_label, model=model_name)
 
 
+class KobocatAttachmentManager(models.Manager):
+
+    def get_queryset(self):
+        return super().get_queryset().exclude(deleted_at__isnull=False)
+
+
+class KobocatAttachment(ShadowModel, AudioTranscodingMixin):
+
+    class Meta(ShadowModel.Meta):
+        db_table = 'logger_attachment'
+
+    instance = models.ForeignKey(
+        'superuser_stats.ReadOnlyKobocatInstance',
+        related_name='attachments',
+        on_delete=models.CASCADE,
+    )
+    media_file = models.FileField(storage=get_kobocat_storage(), max_length=380,
+                                  db_index=True)
+    media_file_basename = models.CharField(
+        max_length=260, null=True, blank=True, db_index=True)
+    # `PositiveIntegerField` will only accommodate 2 GiB, so we should consider
+    # `PositiveBigIntegerField` after upgrading to Django 3.1+
+    media_file_size = models.PositiveIntegerField(blank=True, null=True)
+    mimetype = models.CharField(
+        max_length=100, null=False, blank=True, default=''
+    )
+    deleted_at = models.DateTimeField(blank=True, null=True, db_index=True)
+    objects = KobocatAttachmentManager()
+    all_objects = models.Manager()
+
+    @property
+    def absolute_mp3_path(self):
+        """
+        Return the absolute path on local file system of the converted version of
+        attachment. Otherwise, return the AWS url (e.g. https://...)
+        """
+
+        kobocat_storage = get_kobocat_storage()
+
+        if not kobocat_storage.exists(self.mp3_storage_path):
+            content = self.get_transcoded_audio('mp3')
+            kobocat_storage.save(self.mp3_storage_path, ContentFile(content))
+
+        if isinstance(kobocat_storage, KobocatFileSystemStorage):
+            return f'{self.media_file.path}.mp3'
+
+        return kobocat_storage.url(self.mp3_storage_path)
+
+    @property
+    def absolute_path(self):
+        """
+        Return the absolute path on local file system of the attachment.
+        Otherwise, return the AWS url (e.g. https://...)
+        """
+        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
+            return self.media_file.path
+
+        return self.media_file.url
+
+    @property
+    def mp3_storage_path(self):
+        """
+        Return the path of file after conversion. It is the exact same name, plus
+        the conversion audio format extension concatenated.
+        E.g: file.mp4 and file.mp4.mp3
+        """
+        return f'{self.storage_path}.mp3'
+
+    def protected_path(self, format_: Optional[str] = None):
+        """
+        Return path to be served as protected file served by NGINX
+        """
+
+        if format_ == 'mp3':
+            attachment_file_path = self.absolute_mp3_path
+        else:
+            attachment_file_path = self.absolute_path
+
+        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
+            # Django normally sanitizes accented characters in file names during
+            # save on disk but some languages have extra letters
+            # (out of ASCII character set) and must be encoded to let NGINX serve
+            # them
+            protected_url = urlquote(attachment_file_path.replace(
+                settings.KOBOCAT_MEDIA_PATH, '/protected')
+            )
+        else:
+            # Double-encode the S3 URL to take advantage of NGINX's
+            # otherwise troublesome automatic decoding
+            protected_url = f'/protected-s3/{urlquote(attachment_file_path)}'
+
+        return protected_url
+
+    @property
+    def storage_path(self):
+        return str(self.media_file)
+
+
 class KobocatContentType(ShadowModel):
     """
     Minimal representation of Django 1.8's
@@ -110,6 +208,25 @@ class KobocatContentType(ShadowModel):
         # complete with whitespace. That requires access to the Python model
         # class, though
         return self.model
+
+
+class KobocatDailyXFormSubmissionCounter(ShadowModel):
+
+    date = models.DateField()
+    user = models.ForeignKey(
+        'shadow_model.KobocatUser', null=True, on_delete=models.CASCADE
+    )
+    xform = models.ForeignKey(
+        'shadow_model.KobocatXForm',
+        related_name='daily_counts',
+        null=True,
+        on_delete=models.CASCADE,
+    )
+    counter = models.IntegerField(default=0)
+
+    class Meta(ShadowModel.Meta):
+        db_table = 'logger_dailyxformsubmissioncounter'
+        unique_together = [['date', 'xform', 'user'], ['date', 'user']]
 
 
 class KobocatDigestPartial(ShadowModel):
@@ -250,6 +367,27 @@ class KobocatGenericForeignKey(GenericForeignKey):
                 ]
             else:
                 return []
+
+
+class KobocatMonthlyXFormSubmissionCounter(ShadowModel):
+    year = models.IntegerField()
+    month = models.IntegerField()
+    user = models.ForeignKey(
+        'shadow_model.KobocatUser',
+        on_delete=models.CASCADE,
+    )
+    xform = models.ForeignKey(
+        'shadow_model.KobocatXForm',
+        related_name='monthly_counts',
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    counter = models.IntegerField(default=0)
+
+    class Meta(ShadowModel.Meta):
+        app_label = 'superuser_stats'
+        db_table = 'logger_monthlyxformsubmissioncounter'
+        verbose_name_plural = 'User Statistics'
 
 
 class KobocatPermission(ShadowModel):
@@ -516,117 +654,6 @@ class ReadOnlyModel(ShadowModel):
         abstract = True
 
 
-class ReadOnlyKobocatAttachmentManager(models.Manager):
-
-    def get_queryset(self):
-        return super().get_queryset().exclude(deleted_at__isnull=False)
-
-
-class ReadOnlyKobocatAttachment(ReadOnlyModel, AudioTranscodingMixin):
-
-    class Meta(ReadOnlyModel.Meta):
-        db_table = 'logger_attachment'
-
-    instance = models.ForeignKey(
-        'superuser_stats.ReadOnlyKobocatInstance',
-        related_name='attachments',
-        on_delete=models.CASCADE,
-    )
-    media_file = models.FileField(storage=get_kobocat_storage(), max_length=380,
-                                  db_index=True)
-    media_file_basename = models.CharField(
-        max_length=260, null=True, blank=True, db_index=True)
-    # `PositiveIntegerField` will only accommodate 2 GiB, so we should consider
-    # `PositiveBigIntegerField` after upgrading to Django 3.1+
-    media_file_size = models.PositiveIntegerField(blank=True, null=True)
-    mimetype = models.CharField(
-        max_length=100, null=False, blank=True, default=''
-    )
-    deleted_at = models.DateTimeField(blank=True, null=True, db_index=True)
-    objects = ReadOnlyKobocatAttachmentManager()
-
-    @property
-    def absolute_mp3_path(self):
-        """
-        Return the absolute path on local file system of the converted version of
-        attachment. Otherwise, return the AWS url (e.g. https://...)
-        """
-
-        kobocat_storage = get_kobocat_storage()
-
-        if not kobocat_storage.exists(self.mp3_storage_path):
-            content = self.get_transcoded_audio('mp3')
-            kobocat_storage.save(self.mp3_storage_path, ContentFile(content))
-
-        if isinstance(kobocat_storage, KobocatFileSystemStorage):
-            return f'{self.media_file.path}.mp3'
-
-        return kobocat_storage.url(self.mp3_storage_path)
-
-    @property
-    def absolute_path(self):
-        """
-        Return the absolute path on local file system of the attachment.
-        Otherwise, return the AWS url (e.g. https://...)
-        """
-        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
-            return self.media_file.path
-
-        return self.media_file.url
-
-    @property
-    def mp3_storage_path(self):
-        """
-        Return the path of file after conversion. It is the exact same name, plus
-        the conversion audio format extension concatenated.
-        E.g: file.mp4 and file.mp4.mp3
-        """
-        return f'{self.storage_path}.mp3'
-
-    def protected_path(self, format_: Optional[str] = None):
-        """
-        Return path to be served as protected file served by NGINX
-        """
-
-        if format_ == 'mp3':
-            attachment_file_path = self.absolute_mp3_path
-        else:
-            attachment_file_path = self.absolute_path
-
-        if isinstance(get_kobocat_storage(), KobocatFileSystemStorage):
-            # Django normally sanitizes accented characters in file names during
-            # save on disk but some languages have extra letters
-            # (out of ASCII character set) and must be encoded to let NGINX serve
-            # them
-            protected_url = urlquote(attachment_file_path.replace(
-                settings.KOBOCAT_MEDIA_PATH, '/protected')
-            )
-        else:
-            # Double-encode the S3 URL to take advantage of NGINX's
-            # otherwise troublesome automatic decoding
-            protected_url = f'/protected-s3/{urlquote(attachment_file_path)}'
-
-        return protected_url
-
-    @property
-    def storage_path(self):
-        return str(self.media_file)
-
-
-class ReadOnlyKobocatDailyXFormSubmissionCounter(ReadOnlyModel):
-
-    date = models.DateField()
-    user = models.ForeignKey(KobocatUser, null=True, on_delete=models.CASCADE)
-    xform = models.ForeignKey(
-        KobocatXForm, related_name='daily_counts', null=True, on_delete=models.CASCADE
-    )
-    counter = models.IntegerField(default=0)
-
-    class Meta(ReadOnlyModel.Meta):
-        db_table = 'logger_dailyxformsubmissioncounter'
-        unique_together = [['date', 'xform', 'user'], ['date', 'user']]
-
-
 class ReadOnlyKobocatInstance(ReadOnlyModel):
 
     class Meta(ReadOnlyModel.Meta):
@@ -645,27 +672,6 @@ class ReadOnlyKobocatInstance(ReadOnlyModel):
     status = models.CharField(max_length=20,
                               default='submitted_via_web')
     uuid = models.CharField(max_length=249, default='')
-
-
-class ReadOnlyKobocatMonthlyXFormSubmissionCounter(ReadOnlyModel):
-    year = models.IntegerField()
-    month = models.IntegerField()
-    user = models.ForeignKey(
-        'shadow_model.KobocatUser',
-        on_delete=models.CASCADE,
-    )
-    xform = models.ForeignKey(
-        'shadow_model.KobocatXForm',
-        related_name='monthly_counts',
-        null=True,
-        on_delete=models.SET_NULL,
-    )
-    counter = models.IntegerField(default=0)
-
-    class Meta:
-        app_label = 'superuser_stats'
-        db_table = 'logger_monthlyxformsubmissioncounter'
-        verbose_name_plural = 'User Statistics'
 
 
 def safe_kc_read(func):

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -11,7 +11,7 @@ from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatXForm,
-    ReadOnlyKobocatDailyXFormSubmissionCounter,
+    KobocatDailyXFormSubmissionCounter,
 )
 from kpi.deployment_backends.kobocat_backend import KobocatDeploymentBackend
 from kpi.models.asset import Asset
@@ -288,7 +288,7 @@ class ServiceUsageSerializer(serializers.Serializer):
 
         Users are represented by their ids with `self._user_ids`
         """
-        submission_count = ReadOnlyKobocatDailyXFormSubmissionCounter.objects.only(
+        submission_count = KobocatDailyXFormSubmissionCounter.objects.only(
             'counter', 'user_id'
         ).filter(self._user_id_query).aggregate(
             all_time=Coalesce(Sum('counter'), 0),

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -13,7 +13,7 @@ from rest_framework import status
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatXForm,
-    ReadOnlyKobocatDailyXFormSubmissionCounter,
+    KobocatDailyXFormSubmissionCounter,
 )
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseAssetTestCase
@@ -29,7 +29,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     unmanaged_models = [
-        ReadOnlyKobocatDailyXFormSubmissionCounter,
+        KobocatDailyXFormSubmissionCounter,
         KobocatXForm,
     ]
     xform = None
@@ -177,7 +177,7 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
             self.counter.save()
         else:
             self.counter = (
-                ReadOnlyKobocatDailyXFormSubmissionCounter.objects.create(
+                KobocatDailyXFormSubmissionCounter.objects.create(
                     date=today.date(),
                     counter=submissions,
                     xform=self.xform,

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -102,7 +102,7 @@ def enketo_view_instance_response(request):
 
 class MockAttachment(AudioTranscodingMixin):
     """
-    Mock object to simulate ReadOnlyKobocatAttachment.
+    Mock object to simulate KobocatAttachment.
     Relationship with ReadOnlyKobocatInstance is ignored but could be implemented
     """
     def __init__(self, pk: int, filename: str, mimetype: str = None, **kwargs):


### PR DESCRIPTION
## Notes

Transferring a project implies to update counters and attachments. KPI needs to get write access to some read-only KC (shadow) models.

This PR removes `Readonly` prefix from shadow models:
- `ReadonlyKobocatMonthlyXFormSubmissionCounter`
- `ReadonlyKobocatDailyXFormSubmissionCounter`
- `ReadonlyKobocatAttachment`

## Related issues

Part of #4743 
