### PR TITLE
Fix exports button being disabled after selecting zero fields and disabling custom selection

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -797,7 +797,7 @@ export default class ProjectExportsCreator extends React.Component {
                 type='submit'
                 onClick={this.onSubmit}
                 disabled={
-                  this.state.selectedRows.size === 0 ||
+                  (this.state.isCustomSelectionEnabled && this.state.selectedRows.size === 0) ||
                   this.state.isPending
                 }
               >


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Steps to reproduce this tiny bug:
1. Go to `#/forms/<uid>/data/downloads`
2. Open "Advanced options" and toggle on "Select questions to be exported"
3. Use "Deselect all" button
4. Notice that the (main blue) "Export" button is disabled - this is correct, because we selected zero fields
5. Toggle off "Select questions to be exported"
6. Notice that the (main blue) "Export" button is still disabled - this is incorrect, because with custom selection disabled, we are choosing all fields