### PR TITLE
[TASK-628] Fix questions deleting

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -96,6 +96,7 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
       return {
         ...state,
         isPending: true,
+        hasUnsavedWork: true,
         // Here we immediately mark the question as `deleted` and wait for
         // a successful API call that will return new questions list (to ensure
         // the deletion went as expected).
@@ -180,6 +181,7 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
       return {
         ...state,
         isPending: true,
+        hasUnsavedWork: true,
       };
     }
     case 'updateResponseCompleted': {
@@ -216,12 +218,14 @@ export const analysisQuestionsReducer: AnalysisQuestionReducerType = (
       return {
         ...state,
         isPending: true,
+        hasUnsavedWork: true,
       };
     }
     case 'applyQuestionsOrderCompleted': {
       return {
         ...state,
         isPending: false,
+        hasUnsavedWork: false,
         questions: action.payload.questions,
       };
     }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Ensure that after deleting qualitative analysis questions, the UI is not displaying obsolete cached questions.

## Notes

The problem was due to recently introduced asset cache. I've made sure that marking `singleProcessingStore` as not pristine happens with all different data changing actions. Marking it not pristine causes the fresh asset data to be fetched upon closing NLP View.