### PR TITLE
[TASK-627] Fix analysis questions reordering

### DIFF
--- a/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
+++ b/jsapp/js/components/processing/analysis/analysisQuestions.reducer.ts
@@ -26,7 +26,7 @@ export interface AnalysisQuestionsState {
    *
    * When user is not reordering questions, this list doesn't exist. The purpose
    * of it is to avoid unnecessary API calls during reordering - we make single
-   * call on reordering end.
+   * call on reordering end (see `applyQuestionsOrderCompleted` action).
    */
   draftQuestionsOrder?: string[];
 }

--- a/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
+++ b/jsapp/js/components/processing/analysis/list/analysisQuestionsList.component.tsx
@@ -17,11 +17,6 @@ export default function AnalysisQuestionsList() {
     return null;
   }
 
-  // We only want to display analysis questions for this survey question
-  const filteredQuestions = analysisQuestions.state.questions.filter(
-    (question) => question.qpath === singleProcessingStore.currentQuestionQpath
-  );
-
   const moveRow = useCallback(
     (uuid: string, oldIndex: number, newIndex: number) => {
       analysisQuestions.dispatch({
@@ -35,7 +30,15 @@ export default function AnalysisQuestionsList() {
   return (
     <DndProvider backend={HTML5Backend}>
       <ul className={styles.root}>
-        {filteredQuestions.map((question, index: number) => {
+        {analysisQuestions.state.questions.map((question, index: number) => {
+          // We hide analysis questions for other survey questions. We need to
+          // hide them at this point (not filtering the whole list beforehand),
+          // because we need the indexes to match the whole list. And FYI all
+          // analysis questions live on a single list :)
+          if (question.qpath !== singleProcessingStore.currentQuestionQpath) {
+            return null;
+          }
+
           // TODO: we temporarily hide Keyword Search from the UI until
           // https://github.com/kobotoolbox/kpi/issues/4594 is done
           if (question.type === 'qual_auto_keyword_count') {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes issue with analysis questions reordering not working for a project with multiple audio questions, where each have some analysis questions.

## Notes

The problem was happening because we started to filter analysis questions by project question it belongs to (it was a bug fix). The filtering happened before reordering was set up, so it was trying to work on indexes of filtered array, to reorder the indexes of non-filtered array. It worked for a project with one audio question only. We store all analysis questions of all project questions in a single list, so reordering is a bit trickier.