### PR TITLE
Update Usage page and modal/banner calculations to account for add-ons

### DIFF
--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -4,6 +4,10 @@ import RequireAuth from 'js/router/requireAuth';
 import {ROUTES} from 'js/router/routerConstants';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 import {ProductsContext, useProducts} from './useProducts.hook';
+import {
+  OneTimeAddOnsContext,
+  useOneTimeAddOns,
+} from './useOneTimeAddonList.hook';
 
 const ChangePasswordRoute = React.lazy(
   () => import(/* webpackPrefetch: true */ './changePasswordRoute.component')
@@ -36,11 +40,14 @@ export const ACCOUNT_ROUTES: {readonly [key: string]: string} = {
 const BillingOutlet = () => {
   const usage = useUsage();
   const products = useProducts();
+  const oneTimeAddOns = useOneTimeAddOns();
   return (
     <RequireAuth>
       <UsageContext.Provider value={usage}>
         <ProductsContext.Provider value={products}>
-          <Outlet />
+          <OneTimeAddOnsContext.Provider value={oneTimeAddOns}>
+            <Outlet />
+          </OneTimeAddOnsContext.Provider>
         </ProductsContext.Provider>
       </UsageContext.Provider>
     </RequireAuth>

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -206,28 +206,30 @@ const addOneTimeAddOnLimits = (
   limits: AccountLimit,
   oneTimeAddOns: OneTimeAddOn[]
 ) => {
-  oneTimeAddOns.forEach((addon) => {
-    if (
-      addon.limits_remaining.submission_limit &&
-      limits.submission_limit !== Limits.unlimited
-    ) {
-      limits.submission_limit += addon.limits_remaining.submission_limit;
-    }
-    if (
-      addon.limits_remaining.asr_seconds_limit &&
-      limits.nlp_seconds_limit !== Limits.unlimited
-    ) {
-      limits.nlp_seconds_limit += addon.limits_remaining.asr_seconds_limit;
-    }
-    if (
-      addon.limits_remaining.mt_characters_limit &&
-      limits.nlp_character_limit !== Limits.unlimited
-    ) {
-      limits.nlp_character_limit +=
-        addon.limits_remaining.mt_characters_limit;
-    }
-  });
-  return limits
+  oneTimeAddOns
+    .filter((addon) => addon.is_available)
+    .forEach((addon) => {
+      if (
+        addon.limits_remaining.submission_limit &&
+        limits.submission_limit !== Limits.unlimited
+      ) {
+        limits.submission_limit += addon.limits_remaining.submission_limit;
+      }
+      if (
+        addon.limits_remaining.asr_seconds_limit &&
+        limits.nlp_seconds_limit !== Limits.unlimited
+      ) {
+        limits.nlp_seconds_limit += addon.limits_remaining.asr_seconds_limit;
+      }
+      if (
+        addon.limits_remaining.mt_characters_limit &&
+        limits.nlp_character_limit !== Limits.unlimited
+      ) {
+        limits.nlp_character_limit +=
+          addon.limits_remaining.mt_characters_limit;
+      }
+    });
+  return limits;
 };
 
 /**
@@ -302,7 +304,7 @@ export async function getAccountLimits(
 
   // finally, add one-time addon limits to the limits calculated so far
   if (oneTimeAddOns.length) {
-    limits = addOneTimeAddOnLimits(limits, oneTimeAddOns)
+    limits = addOneTimeAddOnLimits(limits, oneTimeAddOns);
   }
   return limits;
 }

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -208,23 +208,23 @@ const addOneTimeAddOnLimits = (
 ) => {
   oneTimeAddOns.forEach((addon) => {
     if (
-      addon.total_usage_limits.submission_limit &&
+      addon.limits_remaining.submission_limit &&
       limits.submission_limit !== Limits.unlimited
     ) {
-      limits.submission_limit += addon.total_usage_limits.submission_limit;
+      limits.submission_limit += addon.limits_remaining.submission_limit;
     }
     if (
-      addon.total_usage_limits.asr_seconds_limit &&
+      addon.limits_remaining.asr_seconds_limit &&
       limits.nlp_seconds_limit !== Limits.unlimited
     ) {
-      limits.nlp_seconds_limit += addon.total_usage_limits.asr_seconds_limit;
+      limits.nlp_seconds_limit += addon.limits_remaining.asr_seconds_limit;
     }
     if (
-      addon.total_usage_limits.mt_characters_limit &&
+      addon.limits_remaining.mt_characters_limit &&
       limits.nlp_character_limit !== Limits.unlimited
     ) {
       limits.nlp_character_limit +=
-        addon.total_usage_limits.mt_characters_limit;
+        addon.limits_remaining.mt_characters_limit;
     }
   });
   return limits
@@ -296,9 +296,11 @@ export async function getAccountLimits(
     // if the user is on the free tier, overwrite their limits with whatever free tier limits exist
     limits = await getFreeTierLimits(limits);
 
-    // if the user has active recurring add-ons, use those as the final say on their limits
+    // if the user has active recurring add-ons, use those as their limits
     limits = getRecurringAddOnLimits(limits);
   }
+
+  // finally, add one-time addon limits to the limits calculated so far
   if (oneTimeAddOns.length) {
     limits = addOneTimeAddOnLimits(limits, oneTimeAddOns)
   }

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -208,7 +208,7 @@ export interface OneTimeAddOn {
   is_available: boolean;
   usage_limits: Partial<OneTimeUsageLimits>;
   total_usage_limits: Partial<OneTimeUsageLimits>;
-  usage_limits_remaining: Partial<OneTimeUsageLimits>;
+  limits_remaining: Partial<OneTimeUsageLimits>;
   organization: string;
   product: string;
 }

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -15,6 +15,7 @@ import styles from './usage.module.scss';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {ProductsContext} from '../useProducts.hook';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
+import {OneTimeAddOnsContext} from '../useOneTimeAddonList.hook';
 import moment from 'moment';
 import {YourPlan} from 'js/account/usage/yourPlan.component';
 import cx from 'classnames';
@@ -32,6 +33,7 @@ interface LimitState {
 export default function Usage() {
   const productsContext = useContext(ProductsContext);
   const usage = useContext(UsageContext);
+  const oneTimeAddOnsContext = useContext(OneTimeAddOnsContext);
 
   const [limits, setLimits] = useState<LimitState>({
     storageByteLimit: Limits.unlimited,
@@ -86,7 +88,10 @@ export default function Usage() {
       await when(() => envStore.isReady);
       let limits: AccountLimit;
       if (envStore.data.stripe_public_key) {
-        limits = await getAccountLimits(productsContext.products);
+        limits = await getAccountLimits(
+          productsContext.products,
+          oneTimeAddOnsContext.addons
+        );
       } else {
         setLimits((prevState) => {
           return {
@@ -114,7 +119,7 @@ export default function Usage() {
     };
 
     getLimits();
-  }, [productsContext.isLoaded]);
+  }, [productsContext.isLoaded, oneTimeAddOnsContext.isLoaded]);
 
   // if stripe is enabled, load fresh subscription info whenever we navigate to this route
   useWhenStripeIsEnabled(() => {

--- a/jsapp/js/account/useOneTimeAddonList.hook.ts
+++ b/jsapp/js/account/useOneTimeAddonList.hook.ts
@@ -31,5 +31,5 @@ export function useOneTimeAddOns() {
   return addons;
 }
 
-export const AddOnsContext =
+export const OneTimeAddOnsContext =
   createContext<OneTimeAddOnState>(INITIAL_ADDONS_STATE);

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -53,8 +53,8 @@ export const useExceedingLimits = () => {
       ).then((limits) => {
         setSubscribedSubmissionLimit(limits.submission_limit);
         setSubscribedStorageLimit(limits.storage_bytes_limit);
-        setTranscriptionMinutes(Number(limits.nlp_seconds_limit));
-        setTranslationChars(Number(limits.nlp_character_limit));
+        setTranscriptionMinutes(limits.nlp_seconds_limit);
+        setTranslationChars(limits.nlp_character_limit);
         setAreLimitsLoaded(true);
       });
     }

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -7,7 +7,7 @@ import {when} from 'mobx';
 import subscriptionStore from 'js/account/subscriptionStore';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
 import {ProductsContext} from 'jsapp/js/account/useProducts.hook';
-import { OneTimeAddOnsContext } from 'jsapp/js/account/useOneTimeAddonList.hook';
+import {OneTimeAddOnsContext} from 'jsapp/js/account/useOneTimeAddonList.hook';
 
 interface SubscribedState {
   subscribedProduct: null | SubscriptionInfo;
@@ -58,7 +58,12 @@ export const useExceedingLimits = () => {
         setAreLimitsLoaded(true);
       });
     }
-  }, [productsContext, oneTimeAddOnsContext]);
+  }, [
+    productsContext.isLoaded,
+    productsContext.products,
+    oneTimeAddOnsContext.isLoaded,
+    oneTimeAddOnsContext.addons,
+  ]);
 
   // Get subscription data
   useWhenStripeIsEnabled(

--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -26,6 +26,7 @@ import ProjectQuickActions from './projectsTable/projectQuickActions';
 import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
 import ProjectBulkActions from './projectsTable/projectBulkActions';
 import {ProductsContext, useProducts} from 'js/account/useProducts.hook';
+import {OneTimeAddOnsContext, useOneTimeAddOns} from '../account/useOneTimeAddonList.hook';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 
 function CustomViewRoute() {
@@ -38,6 +39,7 @@ function CustomViewRoute() {
   const [projectViews] = useState(projectViewsStore);
   const [customView] = useState(customViewStore);
   const [selectedRows, setSelectedRows] = useState<string[]>([]);
+  const oneTimeAddOns = useOneTimeAddOns();
   const products = useProducts();
   const usage = useUsage();
 
@@ -127,7 +129,9 @@ function CustomViewRoute() {
       </header>
       <UsageContext.Provider value={usage}>
         <ProductsContext.Provider value={products}>
-          <LimitNotifications useModal />
+          <OneTimeAddOnsContext.Provider value={oneTimeAddOns}>
+            <LimitNotifications useModal />
+          </OneTimeAddOnsContext.Provider>
         </ProductsContext.Provider>
       </UsageContext.Provider>
       <ProjectsTable

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -27,6 +27,7 @@ import {validFileTypes} from 'js/utils';
 import Icon from 'js/components/common/icon';
 import {dropImportXLSForms} from 'js/dropzone.utils';
 import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
+import { OneTimeAddOnsContext, useOneTimeAddOns } from '../account/useOneTimeAddonList.hook';
 import {ProductsContext, useProducts} from 'js/account/useProducts.hook';
 import {UsageContext, useUsage} from 'js/account/usage/useUsage.hook';
 
@@ -35,6 +36,7 @@ function MyProjectsRoute() {
   const [selectedRows, setSelectedRows] = useState<string[]>([]);
   const products = useProducts();
   const usage = useUsage();
+  const oneTimeAddons = useOneTimeAddOns();
 
   useEffect(() => {
     customView.setUp(
@@ -83,7 +85,9 @@ function MyProjectsRoute() {
 
       <UsageContext.Provider value={usage}>
         <ProductsContext.Provider value={products}>
-          <LimitNotifications useModal />
+          <OneTimeAddOnsContext.Provider value={oneTimeAddons}>
+            <LimitNotifications useModal />
+          </OneTimeAddOnsContext.Provider>
         </ProductsContext.Provider>
       </UsageContext.Provider>
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Adds one-time addon limits to total usage limits for usage page and limit notification modal/banner.

### Notes

The context nesting is starting to look unwieldy, but I know that's being addressed separately so considered it out of scope for this particular task.
