### PR TITLE
fix button styles in certain modals

### DIFF
--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -461,13 +461,6 @@ iframe {
     &:not(.inline) {
       display: block;
     }
-
-    &.next-to-checkbox {
-      display: inline-block !important;
-      margin-left: 10px;
-      max-width: 90%;
-      vertical-align: top;
-    }
   }
 
   input[type='text'],

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -87,7 +87,7 @@
 
 .text-small {
   font-size: 0.85em;
-  opacity: .75;
+  opacity: 0.75;
 }
 
 // Popover menu
@@ -410,13 +410,14 @@ iframe {
   border: none;
 }
 
-
-
 // Flexbox helps us maintain a layout when some fields may be customized
 // or removed.
 // Place sector and country side-by-side, when both fields exist and we're
 // not in the narrow form builder sidebar. Similar to registration screen.
-.form-modal__form.project-settings--project-details:not(.project-settings--narrow) > .form-modal__item--wrapper {
+.form-modal__form.project-settings--project-details:not(
+    .project-settings--narrow
+  )
+  > .form-modal__item--wrapper {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
@@ -446,7 +447,7 @@ iframe {
     }
   }
 
-  label {
+  label:not(.k-button__label) {
     font-weight: normal;
     font-size: 12px;
     color: colors.$kobo-gray-40;

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -447,7 +447,7 @@ iframe {
     }
   }
 
-  label:not(.k-button__label) {
+  & > label {
     font-weight: normal;
     font-size: 12px;
     color: colors.$kobo-gray-40;
@@ -457,17 +457,17 @@ iframe {
       margin-bottom: 10px;
       font-size: variables.$base-font-size;
     }
-  }
 
-  label:not(.inline) {
-    display: block;
-  }
+    &:not(.inline) {
+      display: block;
+    }
 
-  label.next-to-checkbox {
-    display: inline-block !important;
-    margin-left: 10px;
-    max-width: 90%;
-    vertical-align: top;
+    &.next-to-checkbox {
+      display: inline-block !important;
+      margin-left: 10px;
+      max-width: 90%;
+      vertical-align: top;
+    }
   }
 
   input[type='text'],


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [X] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes incorrect button styles in form modals.

## Notes

Any label inside of a form modal was getting extra styling applied due to changing the `<Button/>` label from a `<span>` to a `<label>`. I chose to fix it in the most low-impact way I could see available, to avoid any other styling mishaps.

## Related issues

Related to #4855
