### PR TITLE
Update webpack-dev-middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,7 @@
         "webpack": "^5.76.1",
         "webpack-bundle-tracker": "^1.5.0",
         "webpack-cli": "^4.9.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "webpack-dev-server": "^4.8.1",
         "webpack-extract-translation-keys-plugin": "^6.0.0"
       },
@@ -18060,9 +18060,10 @@
       }
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Unlicense"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -20992,11 +20993,12 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.4.1",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
       "dev": true,
-      "license": "Unlicense",
       "dependencies": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.4"
       },
       "engines": {
         "node": ">= 4.0.0"
@@ -27883,12 +27885,13 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.1",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.10",
-        "memfs": "^3.4.1",
+        "memfs": "^3.4.3",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
@@ -41279,7 +41282,9 @@
       }
     },
     "fs-monkey": {
-      "version": "1.0.3",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==",
       "dev": true
     },
     "fs.realpath": {
@@ -43293,10 +43298,12 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.1",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
+      "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
       "dev": true,
       "requires": {
-        "fs-monkey": "1.0.3"
+        "fs-monkey": "^1.0.4"
       }
     },
     "memoize-one": {
@@ -48134,11 +48141,13 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.1",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.10",
-        "memfs": "^3.4.1",
+        "memfs": "^3.4.3",
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "webpack": "^5.76.1",
     "webpack-bundle-tracker": "^1.5.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-middleware": "^5.3.1",
+    "webpack-dev-middleware": "^5.3.4",
     "webpack-dev-server": "^4.8.1",
     "webpack-extract-translation-keys-plugin": "^6.0.0"
   },


### PR DESCRIPTION
## Description

Update webpack-dev-middleware to a newer version.

## Notes

The  [path traversal vulnerability](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6) patched by this update does not seem to affect us directly:

- We don't use the `writeToDisk` option mentioned in the CVE
- We don't expose webpack-dev-server to public traffic nor use it in production

That said, it's good to update anyway. Someone self-hosting or developing might be running things a little differently.