### PR TITLE
File cleanup and grouped maintenance task

### DIFF
--- a/kobo/apps/markdownx_uploader/tasks.py
+++ b/kobo/apps/markdownx_uploader/tasks.py
@@ -17,4 +17,4 @@ def remove_unused_markdown_files():
     for file in files:
         default_storage.delete(file)
 
-    queryset.delete()
+    queryset._raw_delete(queryset.db)

--- a/kobo/apps/markdownx_uploader/tasks.py
+++ b/kobo/apps/markdownx_uploader/tasks.py
@@ -1,10 +1,8 @@
 from django.core.files.storage import default_storage
 
-from kobo.celery import celery_app
 from .models import MarkdownxUploaderFile, MarkdownxUploaderFileReference
 
 
-@celery_app.task
 def remove_unused_markdown_files():
     """
     Clean-up unused files uploaded via markdown editor

--- a/kobo/apps/markdownx_uploader/tasks.py
+++ b/kobo/apps/markdownx_uploader/tasks.py
@@ -1,17 +1,13 @@
 from django.core.files.storage import default_storage
 
-from .models import MarkdownxUploaderFile, MarkdownxUploaderFileReference
+from .models import MarkdownxUploaderFile
 
 
 def remove_unused_markdown_files():
     """
     Clean-up unused files uploaded via markdown editor
     """
-    queryset = MarkdownxUploaderFile.objects.exclude(
-        pk__in=MarkdownxUploaderFileReference.objects.values_list(
-            'file_id', flat=True
-        )
-    )
+    queryset = MarkdownxUploaderFile.objects.filter(markdown_fields=None)
 
     files = list(queryset.values_list('content', flat=True))
     for file in files:

--- a/kobo/apps/markdownx_uploader/tests/test_tasks.py
+++ b/kobo/apps/markdownx_uploader/tests/test_tasks.py
@@ -1,0 +1,35 @@
+from model_bakery import baker
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from kobo.apps.markdownx_uploader.models import (
+    MarkdownxUploaderFile,
+    MarkdownxUploaderFileReference,
+)
+from kobo.apps.markdownx_uploader.tasks import remove_unused_markdown_files
+from kpi.tests.kpi_test_case import BaseTestCase
+
+
+class MarkdownXUploaderTasksTestCase(BaseTestCase):
+    def test_remove_unused_markdown_files(self):
+        used_file_content = SimpleUploadedFile('used_file.txt', b'file content')
+        unused_file_content = SimpleUploadedFile(
+            'file_not_used.txt', b'file content'
+        )
+        used_file = baker.make(
+            MarkdownxUploaderFile,
+            content=used_file_content,
+        )
+        baker.make(MarkdownxUploaderFileReference, file=used_file)
+        baker.make(
+            MarkdownxUploaderFile,
+            content=unused_file_content,
+            _quantity=9,
+        )
+        assert MarkdownxUploaderFile.objects.count() == 10
+
+        with self.assertNumQueries(2):
+            remove_unused_markdown_files()
+
+        assert MarkdownxUploaderFile.objects.count() == 1
+        assert 'used_file' in MarkdownxUploaderFile.objects.first().content.name

--- a/kobo/apps/markdownx_uploader/tests/test_tasks.py
+++ b/kobo/apps/markdownx_uploader/tests/test_tasks.py
@@ -23,9 +23,15 @@ class MarkdownXUploaderTasksTestCase(BaseTestCase):
         baker.make(
             MarkdownxUploaderFile,
             content=unused_file_content,
-            _quantity=9,
+            _quantity=4,
         )
-        assert MarkdownxUploaderFile.objects.count() == 10
+        assert MarkdownxUploaderFile.objects.count() == 5
+        unused_file_names = [
+            file.content.name
+            for file in MarkdownxUploaderFile.objects.filter(
+                markdown_fields=None
+            )
+        ]
 
         with self.assertNumQueries(2):
             remove_unused_markdown_files()
@@ -33,5 +39,6 @@ class MarkdownXUploaderTasksTestCase(BaseTestCase):
         assert MarkdownxUploaderFile.objects.count() == 1
         assert 'used_file' in MarkdownxUploaderFile.objects.first().content.name
 
-        # TODO: Find way to set up test media storage so this isn't necessary
-        MarkdownxUploaderFile.objects.first().delete()
+        for name in unused_file_names:
+            if MarkdownxUploaderFile.content.field.storage.exists(name):
+                raise self.failureException(f'file {name} was not deleted')

--- a/kobo/apps/markdownx_uploader/tests/test_tasks.py
+++ b/kobo/apps/markdownx_uploader/tests/test_tasks.py
@@ -1,6 +1,5 @@
-from model_bakery import baker
-
 from django.core.files.uploadedfile import SimpleUploadedFile
+from model_bakery import baker
 
 from kobo.apps.markdownx_uploader.models import (
     MarkdownxUploaderFile,
@@ -33,3 +32,6 @@ class MarkdownXUploaderTasksTestCase(BaseTestCase):
 
         assert MarkdownxUploaderFile.objects.count() == 1
         assert 'used_file' in MarkdownxUploaderFile.objects.first().content.name
+
+        # TODO: Find way to set up test media storage so this isn't necessary
+        MarkdownxUploaderFile.objects.first().delete()

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -966,19 +966,19 @@ CELERY_BEAT_SCHEDULE = {
     'send-hooks-failures-reports': {
         'task': 'kobo.apps.hook.tasks.failures_reports',
         'schedule': crontab(hour=0, minute=0),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_low_priority_queue'},
     },
     # Schedule every 30 minutes
     'trash-bin-garbage-collector': {
         'task': 'kobo.apps.trash_bin.tasks.garbage_collector',
         'schedule': crontab(minute=30),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_low_priority_queue'},
     },
-    # Schedule every monday at 00:30
-    'markdown-images-garbage-collector': {
-        'task': 'kobo.apps.markdownx_upload.tasks.remove_unused_markdown_files',
-        'schedule': crontab(hour=0, minute=30, day_of_week=0),
-        'options': {'queue': 'kpi_low_priority_queue'}
+    # Run maintenance every day at 20:00 UTC
+    'perform-maintenance': {
+        'task': 'kobo.tasks.perform_maintenance',
+        'schedule': crontab(hour=20, minute=0),
+        'options': {'queue': 'kpi_low_priority_queue'},
     },
 }
 

--- a/kobo/tasks.py
+++ b/kobo/tasks.py
@@ -1,0 +1,11 @@
+from celery import shared_task
+
+from kobo.apps.markdownx_uploader.tasks import remove_unused_markdown_files
+
+
+@shared_task
+def perform_maintenance():
+    """
+    Run daily maintenance tasks
+    """
+    remove_unused_markdown_files()


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

This PR creates a new perform_maintenance task that will include maintenance tasks that need to be run daily. Instead of scheduling each task separately, we can run each of them one at a time as part of `perform_maintenance`.  The only task included at the moment is the existing `remove_unused_markdown_files`. I have added a unit test for this task and made some slight optimizations to the task itself. The updated task uses `_raw_delete` to remove orphaned markdown files. Using the class delete method results in an unnecessary db call to delete upload_reference files that we already know don't exist.

## Notes

I tried using the new (as of Django 4.2) `InMemoryStorage` class in the interest of optimizing testing and removing the need to store media files in testing, but it broke a number of other tests and not in a way that seemed easily resolved. 