### PR TITLE
Fix hover color few button variations

### DIFF
--- a/jsapp/js/components/common/button.scss
+++ b/jsapp/js/components/common/button.scss
@@ -251,7 +251,7 @@ $button-border-radius: sizes.$x6;
 .k-button.k-button--color-light-blue.k-button--type-full {
   @include button-full(
     colors.$kobo-bg-blue,
-    color.adjust(colors.$kobo-dark-blue, $lightness: -5%),
+    color.adjust(colors.$kobo-bg-blue, $lightness: -5%),
     colors.$kobo-dark-blue
   );
 }
@@ -300,8 +300,8 @@ $button-border-radius: sizes.$x6;
 
 .k-button.k-button--color-light-storm.k-button--type-bare {
   @include button-bare(
-    colors.$kobo-light-storm,
-    color.adjust(colors.$kobo-light-storm, $lightness: -5%)
+    colors.$kobo-storm,
+    color.adjust(colors.$kobo-storm, $lightness: -5%)
   );
 }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

## Notes

Mainly fixes problem with hover styles for `light-blue` `full` button.

## Related issues

Followup to #4881 