### PR TITLE
Require authentication to initiate batch job for user detail report

### DIFF
--- a/kobo/apps/superuser_stats/views.py
+++ b/kobo/apps/superuser_stats/views.py
@@ -330,6 +330,7 @@ def user_statistics_report(request):
     return HttpResponse(template_ish)
 
 
+@user_passes_test(lambda u: u.is_superuser)
 def user_details_report(request):
 
     # Get the date filters from the query and set defaults


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Anonymous requests could previously kick off background generation of a report, which could improperly consume server resources. Initiating these reports is now restricted to superusers. This change has no bearing on accessing report data, which has always been restricted to superusers.
