### PR TITLE
Add sorting to table columns on usage project breakdown page

### DIFF
--- a/jsapp/js/account/usage/usage.api.ts
+++ b/jsapp/js/account/usage/usage.api.ts
@@ -1,5 +1,9 @@
 import {fetchGet} from 'jsapp/js/api';
 import {getOrganization} from 'js/account/stripe.api';
+import {PROJECT_FIELDS} from 'jsapp/js/projects/projectViews/constants';
+import type {ProjectsTableOrder} from 'jsapp/js/projects/projectsTable/projectsTable';
+import type {ProjectFieldName} from 'jsapp/js/projects/projectViews/constants';
+
 
 export interface AssetUsage {
   count: string;
@@ -90,7 +94,7 @@ export async function getAssetUsage(url?: string) {
   });
 }
 
-export async function getAssetUsageForOrganization(pageNumber: number) {
+export async function getAssetUsageForOrganization(pageNumber: number, order?: ProjectsTableOrder) {
   let organizations;
   try {
     organizations = await getOrganization();
@@ -98,10 +102,16 @@ export async function getAssetUsageForOrganization(pageNumber: number) {
     return await getAssetUsage(ASSET_USAGE_URL);
   }
 
-  const apiUrl = ORGANIZATION_ASSET_USAGE_URL.replace(
+  let apiUrl = ORGANIZATION_ASSET_USAGE_URL.replace(
     '##ORGANIZATION_ID##',
     organizations.results?.[0].id || ''
   ).replace('##PAGE_NUM##', pageNumber.toString());
+
+  if (order?.fieldName && order.direction && (order.direction === 'ascending' || order.direction === 'descending')) {
+    const orderingPrefix = order.direction === 'ascending' ? '' : '-';
+    const fieldDefinition = PROJECT_FIELDS[order.fieldName as ProjectFieldName];
+    apiUrl += `&ordering=${orderingPrefix}${fieldDefinition.apiOrderingName}`;
+  }
 
   return await getAssetUsage(apiUrl);
 }

--- a/jsapp/js/account/usage/usageProjectBreakdown.module.scss
+++ b/jsapp/js/account/usage/usageProjectBreakdown.module.scss
@@ -22,7 +22,6 @@ table th {
 .projects {
   padding-right: 15%;
   padding-left: sizes.$x8;
-  white-space: nowrap;
 }
 
 .wrap {
@@ -30,8 +29,8 @@ table th {
 }
 
 th {
-  font-weight: 700;
-  font-size: sizes.$x14;
+  font-weight: 800;
+  font-size: sizes.$x13;
   color: colors.$kobo-gray-40;
   text-align: left;
   padding-block: 1.5%;
@@ -96,5 +95,5 @@ button {
 }
 
 .badge {
-  width: sizes.$x120;
+  width: sizes.$x150;
 }

--- a/jsapp/js/projects/projectViews/constants.ts
+++ b/jsapp/js/projects/projectViews/constants.ts
@@ -121,7 +121,7 @@ export interface ProjectFieldDefinition {
   availableConditions: FilterConditionName[];
 }
 
-type ProjectFields = {[P in ProjectFieldName]: ProjectFieldDefinition};
+export type ProjectFields = {[P in ProjectFieldName]: ProjectFieldDefinition};
 /**
  * A full list of available fields for projects. Order is important here, as it
  * influences the order these will be displayed in UI.

--- a/jsapp/js/projects/projectsTable/projectsTableHeader.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableHeader.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import {PROJECT_FIELDS} from 'js/projects/projectViews/constants';
 import type {
   ProjectFieldDefinition,
@@ -7,12 +7,9 @@ import type {
 import type {ProjectsTableOrder} from './projectsTable';
 import tableStyles from './projectsTable.module.scss';
 import rowStyles from './projectsTableRow.module.scss';
-import styles from './projectsTableHeader.module.scss';
 import classNames from 'classnames';
-import Icon from 'js/components/common/icon';
-import KoboDropdown from 'js/components/common/koboDropdown';
-import Button from 'jsapp/js/components/common/button';
 import ColumnResizer from './columnResizer';
+import SortableColumnHeader from './sortableColumnHeader';
 
 interface ProjectsTableHeaderProps {
   highlightedFields: ProjectFieldName[];
@@ -24,8 +21,6 @@ interface ProjectsTableHeaderProps {
 }
 
 export default function ProjectsTableHeader(props: ProjectsTableHeaderProps) {
-  // We track the menu visibility for the trigger icon.
-  const [visibleMenuNames, setVisibleMenuNames] = useState<string[]>([]);
 
   const renderColumn = (field: ProjectFieldDefinition) => {
     // Hide not visible fields.
@@ -33,121 +28,20 @@ export default function ProjectsTableHeader(props: ProjectsTableHeaderProps) {
       return null;
     }
 
-    const isMenuVisible = visibleMenuNames.includes(field.name);
+    // Generate a unique key for each rendered column
+    const key = `${field.name}_${Date.now()}`;
 
     return (
-      <div
-        title={field.label}
-        className={classNames({
-          [styles.columnRoot]: true,
-          [styles.isMenuVisible]: isMenuVisible,
-          [rowStyles.cell]: true,
-          [rowStyles.cellHighlighted]: props.highlightedFields.includes(
-            field.name
-          ),
-        })}
-        // This attribute is being used for styling and for ColumnResizer
-        data-field={field.name}
-        key={field.name}
-      >
-        <KoboDropdown
-          name={field.name}
-          placement={'down-left'}
-          hideOnMenuClick
-          onMenuVisibilityChange={(isVisible: boolean) => {
-            let newVisibleMenuNames = Array.from(visibleMenuNames);
-            if (isVisible) {
-              newVisibleMenuNames.push(field.name);
-            } else {
-              newVisibleMenuNames = newVisibleMenuNames.filter(
-                (item) => item !== field.name
-              );
-            }
-            setVisibleMenuNames(newVisibleMenuNames);
-          }}
-          triggerContent={
-            <div className={styles.trigger}>
-              <Icon
-                size='xxs'
-                name={isMenuVisible ? 'caret-up' : 'caret-down'}
-              />
-
-              <label className={rowStyles.headerLabel}>{field.label}</label>
-
-              {props.order.fieldName === field.name && (
-                <Icon
-                  name={
-                    props.order.direction === 'descending'
-                      ? 'sort-descending'
-                      : 'sort-ascending'
-                  }
-                  size='s'
-                />
-              )}
-            </div>
-          }
-          menuContent={
-            <div className={styles.dropdownContent}>
-              {props.orderableFields.includes(field.name) && (
-                <Button
-                  type='bare'
-                  color='storm'
-                  size='m'
-                  label={t('Default sort')}
-                  startIcon='sort-default'
-                  onClick={() => {
-                    props.onChangeOrderRequested({});
-                  }}
-                />
-              )}
-              {props.orderableFields.includes(field.name) && (
-                <Button
-                  type='bare'
-                  color='storm'
-                  size='m'
-                  label={t('Sort A→Z')}
-                  startIcon='sort-ascending'
-                  onClick={() => {
-                    props.onChangeOrderRequested({
-                      fieldName: field.name,
-                      direction: 'ascending',
-                    });
-                  }}
-                />
-              )}
-              {props.orderableFields.includes(field.name) && (
-                <Button
-                  type='bare'
-                  color='storm'
-                  size='m'
-                  label={t('Sort Z→A')}
-                  startIcon='sort-descending'
-                  onClick={() => {
-                    props.onChangeOrderRequested({
-                      fieldName: field.name,
-                      direction: 'descending',
-                    });
-                  }}
-                />
-              )}
-              {/* The `name` field is always visible, no need for the button */}
-              {field.name !== 'name' && (
-                <Button
-                  type='bare'
-                  color='storm'
-                  size='m'
-                  label={t('Hide field')}
-                  startIcon='hide'
-                  onClick={() => {
-                    props.onHideFieldRequested(field.name);
-                  }}
-                />
-              )}
-            </div>
-          }
-        />
-        <div className={styles.resizer} data-resize-fieldname={field.name} />
-      </div>
+      <SortableColumnHeader
+        key={key}
+        styling
+        field={field}
+        highlightedFields={props.highlightedFields}
+        orderableFields={props.orderableFields}
+        order={props.order}
+        onChangeOrderRequested={props.onChangeOrderRequested}
+        onHideFieldRequested={props.onHideFieldRequested}
+      />
     );
   };
 

--- a/jsapp/js/projects/projectsTable/sortableColumnHeader.tsx
+++ b/jsapp/js/projects/projectsTable/sortableColumnHeader.tsx
@@ -1,0 +1,133 @@
+import React, {useState} from 'react';
+import classNames from 'classnames';
+import Icon from 'js/components/common/icon';
+import Button from 'jsapp/js/components/common/button';
+import type {ProjectsTableOrder} from './projectsTable';
+import {type ProjectFieldDefinition, type ProjectFieldName} from '../projectViews/constants';
+import styles from './projectsTableHeader.module.scss';
+import rowStyles from './projectsTableRow.module.scss';
+import KoboDropdown from 'jsapp/js/components/common/koboDropdown';
+
+interface SortableColumnHeaderProps {
+  styling: boolean;
+  field: ProjectFieldDefinition;
+  highlightedFields?: ProjectFieldName[];
+  orderableFields: ProjectFieldName[];
+  order: ProjectsTableOrder;
+  onChangeOrderRequested: (order: ProjectsTableOrder) => void;
+  onHideFieldRequested?: (fieldName: ProjectFieldName) => void;
+}
+
+
+export default function SortableColumnHeader(props: SortableColumnHeaderProps) {
+  const [visibleMenuNames, setVisibleMenuNames] = useState<string[]>([]);
+  const isMenuVisible = visibleMenuNames.includes(props.field.name);
+
+  return (
+      <div
+        title={props.field.label}
+        className={classNames({
+          [styles.columnRoot]: props.styling,
+          [styles.isMenuVisible]: isMenuVisible,
+          [rowStyles.cell]: props.styling,
+          [rowStyles.cellHighlighted]: props.highlightedFields?.includes(
+            props.field.name
+          ),
+        })}
+        // This attribute is being used for styling and for ColumnResizer
+        data-field={props.field.name}
+        key={props.field.name}
+      >
+          <KoboDropdown
+            name={props.field.name}
+            placement={'down-left'}
+            hideOnMenuClick
+            onMenuVisibilityChange={(isVisible: boolean) => {
+              let newVisibleMenuNames = Array.from(visibleMenuNames);
+              if (isVisible) {
+                newVisibleMenuNames.push(props.field.name);
+              } else {
+                newVisibleMenuNames = newVisibleMenuNames.filter((item) => item !== props.field.name);
+              }
+              setVisibleMenuNames(newVisibleMenuNames);
+            }}
+            triggerContent={
+              <div className={styles.trigger}>
+                <Icon size='xxs' name={visibleMenuNames.includes(props.field.name) ? 'caret-up' : 'caret-down'} />
+                <label className={rowStyles.headerLabel}>{props.field.label}</label>
+                {props.order.fieldName === props.field.name && (
+                  <Icon
+                    name={
+                      props.order.direction === 'descending' ? 'sort-descending' : 'sort-ascending'
+                    }
+                    size='s'
+                  />
+                )}
+              </div>
+            }
+            menuContent={
+              <div className={styles.dropdownContent}>
+                {props.orderableFields.includes(props.field.name) && (
+                  <Button
+                    type='bare'
+                    color='storm'
+                    size='m'
+                    label={t('Default sort')}
+                    startIcon='sort-default'
+                    onClick={() => {
+                      props.onChangeOrderRequested({});
+                    }}
+                  />
+                )}
+                {props.orderableFields.includes(props.field.name) && (
+                  <Button
+                    type='bare'
+                    color='storm'
+                    size='m'
+                    label={t('Sort A→Z')}
+                    startIcon='sort-ascending'
+                    onClick={() => {
+                      props.onChangeOrderRequested({
+                        fieldName: props.field.name,
+                        direction: 'ascending',
+                      });
+                    }}
+                  />
+                )}
+                {props.orderableFields.includes(props.field.name) && (
+                  <Button
+                    type='bare'
+                    color='storm'
+                    size='m'
+                    label={t('Sort Z→A')}
+                    startIcon='sort-descending'
+                    onClick={() => {
+                      props.onChangeOrderRequested({
+                        fieldName: props.field.name,
+                        direction: 'descending',
+                      });
+                    }}
+                  />
+                )}
+                {/* The `name` field is always visible, no need for the button */}
+                {props.field.name !== 'name' && (
+                  <Button
+                    type='bare'
+                    color='storm'
+                    size='m'
+                    label={t('Hide field')}
+                    startIcon='hide'
+                    onClick={() => {
+                      if (props.onHideFieldRequested) {
+                        props.onHideFieldRequested(props.field.name);
+                      }
+                    }}
+                  />
+                )}
+              </div>
+            }
+          />
+        <div className={styles.resizer} data-resize-fieldname={props.field.name} />
+      </div>
+    );
+}

--- a/jsapp/js/projects/projectsTable/sortableColumnHeader.tsx
+++ b/jsapp/js/projects/projectsTable/sortableColumnHeader.tsx
@@ -20,6 +20,7 @@ interface SortableColumnHeaderProps {
 
 
 export default function SortableColumnHeader(props: SortableColumnHeaderProps) {
+  // We track the menu visibility for the trigger icon.
   const [visibleMenuNames, setVisibleMenuNames] = useState<string[]>([]);
   const isMenuVisible = visibleMenuNames.includes(props.field.name);
 

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -3,6 +3,7 @@ from django.db.models import QuerySet
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_dont_vary_on.decorators import only_vary_on
+from kpi import filters
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -176,7 +177,13 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             **self.get_serializer_context(),
         }
 
-        page = self.paginate_queryset(assets)
+        filtered_assets = (
+            filters.AssetOrganizationUsageFilter().filter_queryset(
+                request, assets, self
+            )
+        )
+
+        page = self.paginate_queryset(filtered_assets)
 
         if page is not None:
             serializer = CustomAssetUsageSerializer(
@@ -185,6 +192,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             return self.get_paginated_response(serializer.data)
 
         serializer = CustomAssetUsageSerializer(
-            assets, many=True, context=context
+            filtered_assets, many=True, context=context
         )
         return Response(serializer.data)

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -15,6 +15,7 @@ from django.db.models.query import QuerySet
 from django.utils.datastructures import MultiValueDictKeyError
 from rest_framework import filters
 from rest_framework.request import Request
+import logging
 
 from kpi.constants import (
     ASSET_SEARCH_DEFAULT_FIELD_LOOKUPS,
@@ -54,6 +55,28 @@ class AssetOwnerFilterBackend(filters.BaseFilterBackend):
         fields = {"asset__owner": request.user}
         return queryset.filter(**fields)
 
+
+class AssetOrganizationUsageFilter(filters.OrderingFilter):
+
+    DEFAULT_USAGE_ORDERING_FIELDS = [
+        'asset__name',
+        'nlp_usage_current_month',
+        'nlp_usage_all_time',
+        'storage_bytes',
+        'submission_count_current_month',
+        'submission_count_all_time',
+        '_deployment_status',
+    ]
+
+    ordering_fields = DEFAULT_USAGE_ORDERING_FIELDS
+
+    def filter_queryset(self, request, queryset, view):
+        ordering = self.get_ordering(request, queryset, view)
+
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+
+        return queryset
 
 class AssetOrderingFilter(filters.OrderingFilter):
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

Allow users to sort projects by `project name` and `deployment status`. Implemented this by extracting `sortableColumnHeader` from the `projectsTableHeader` to allow sorting on desired columns. 
