### PR TITLE
Use organization/subscription info for Asset Usage endpoint

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from django.db.models import F
+from django_request_cache import cache_for_request
+
 if settings.STRIPE_ENABLED:
    from djstripe.models import Customer, Subscription
 from functools import partial
@@ -27,7 +29,7 @@ class Organization(AbstractOrganization):
         """
         return self.owner.organization_user.user.email
 
-    @property
+    @cache_for_request
     def active_subscription_billing_details(self):
         """
         Retrieve the billing dates and interval for the organization's newest active subscription

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -1,0 +1,46 @@
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+
+from kobo.apps.organizations.models import Organization
+
+
+def organization_month_start(organization: Organization | None):
+    now = timezone.now()
+    first_of_this_month = now.date().replace(day=1)
+    # If no organization/subscription, just use the first day of current month
+    if not organization:
+        return first_of_this_month
+    if not (billing_details := organization.active_subscription_billing_details()):
+        return first_of_this_month
+    if not billing_details.get('billing_cycle_anchor'):
+        return first_of_this_month
+
+    # Subscription is billed monthly, use the current billing period start date
+    if billing_details.get('recurring_interval') == 'month':
+        return billing_details.get('current_period_start')
+
+    # Subscription is billed yearly - count backwards from the end of the current billing year
+    month_start = billing_details.get('current_period_end')
+    while month_start > now:
+        month_start -= relativedelta(months=1)
+    return month_start
+
+
+def organization_year_start(organization: Organization | None):
+    now = timezone.now()
+    first_of_this_year = now.date().replace(month=1, day=1)
+    if not organization:
+        return first_of_this_year
+    if not (billing_details := organization.active_subscription_billing_details()):
+        return first_of_this_year
+    if not (anchor_date := billing_details.get('billing_cycle_anchor')):
+        return first_of_this_year
+
+    # Subscription is billed yearly, use the provided anchor date as start date
+    if billing_details.get('subscription_interval') == 'year':
+        return billing_details.get('period_start')
+
+    # Subscription is monthly, calculate this year's start based on anchor date
+    while anchor_date + relativedelta(years=1) < now:
+        anchor_date += relativedelta(years=1)
+    return anchor_date

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -1,10 +1,12 @@
+from typing import Union
+
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from kobo.apps.organizations.models import Organization
 
 
-def organization_month_start(organization: Organization | None):
+def organization_month_start(organization: Union[Organization, None]):
     now = timezone.now()
     first_of_this_month = now.date().replace(day=1)
     # If no organization/subscription, just use the first day of current month
@@ -26,7 +28,7 @@ def organization_month_start(organization: Organization | None):
     return month_start
 
 
-def organization_year_start(organization: Organization | None):
+def organization_year_start(organization: Union[Organization, None]):
     now = timezone.now()
     first_of_this_year = now.date().replace(month=1, day=1)
     if not organization:

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -40,7 +40,7 @@ def organization_year_start(organization: Union[Organization, None]):
 
     # Subscription is billed yearly, use the provided anchor date as start date
     if billing_details.get('subscription_interval') == 'year':
-        return billing_details.get('period_start')
+        return billing_details.get('current_period_start')
 
     # Subscription is monthly, calculate this year's start based on anchor date
     while anchor_date + relativedelta(years=1) < now:

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -171,7 +171,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         )
 
         context = {
-            'organization_id': kwargs.get('id', None),
+            'organization': organization,
             **self.get_serializer_context(),
         }
 

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -1,21 +1,23 @@
+import pytest
 import timeit
 
-import pytest
-from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from djstripe.models import Customer, Price, Product, Subscription, SubscriptionItem
+from djstripe.models import Customer
 from model_bakery import baker
 
 from kobo.apps.organizations.models import Organization, OrganizationUser
+from kobo.apps.stripe.tests.utils import generate_enterprise_subscription, generate_plan_subscription
 from kobo.apps.trackers.submission_utils import create_mock_assets, add_mock_submissions
 from kpi.models.asset import Asset
 from kpi.tests.api.v2.test_api_service_usage import ServiceUsageAPIBase
 from kpi.tests.api.v2.test_api_asset_usage import AssetUsageAPITestCase
 from rest_framework import status
+
 
 
 class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
@@ -36,19 +38,15 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
         super().setUpTestData()
         cls.now = timezone.now()
 
-        anotheruser = User.objects.get(username='anotheruser')
-        organization = baker.make(Organization, id=cls.org_id, name='test organization')
-        organization.add_user(cls.anotheruser, is_admin=True)
+        cls.organization = baker.make(Organization, id=cls.org_id, name='test organization')
+        cls.organization.add_user(cls.anotheruser, is_admin=True)
         assets = create_mock_assets([cls.anotheruser], cls.assets_per_user)
-
-        cls.customer = baker.make(Customer, subscriber=organization, livemode=False)
-        organization.save()
 
         users = baker.make(User, _quantity=cls.user_count - 1, _bulk_create=True)
         baker.make(
             OrganizationUser,
             user=users.__iter__(),
-            organization=organization,
+            organization=cls.organization,
             is_admin=False,
             _quantity=cls.user_count - 1,
             _bulk_create=True,
@@ -65,31 +63,6 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
 
     def tearDown(self):
         cache.clear()
-
-    def generate_subscription(self, metadata: dict):
-        """Create a subscription for a product with custom metadata"""
-        product = baker.make(Product, active=True, metadata={
-            'product_type': 'plan',
-            **metadata,
-        })
-        price = baker.make(
-            Price,
-            active=True,
-            id='price_sfmOFe33rfsfd36685657',
-            product=product,
-        )
-
-        subscription_item = baker.make(SubscriptionItem, price=price, quantity=1, livemode=False)
-        baker.make(
-            Subscription,
-            customer=self.customer,
-            status='active',
-            items=[subscription_item],
-            livemode=False,
-            billing_cycle_anchor=self.now - relativedelta(weeks=2),
-            current_period_end=self.now + relativedelta(weeks=2),
-            current_period_start=self.now - relativedelta(weeks=2),
-        )
 
     def test_usage_doesnt_include_org_users_without_subscription(self):
         """
@@ -110,12 +83,7 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
         when viewing /service_usage/{organization_id}/
         """
 
-        self.generate_subscription(
-            {
-                'plan_type': 'enterprise',
-                'organizations': True,
-            }
-        )
+        generate_enterprise_subscription(self.organization)
 
         # the user should see usage for everyone in their org
         response = self.client.get(self.detail_url)
@@ -131,7 +99,7 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
         when subscribed to a product that doesn't include org access
         """
 
-        self.generate_subscription({})
+        generate_plan_subscription(self.organization)
 
         response = self.client.get(self.detail_url)
         # without the proper subscription, the user should only see their usage
@@ -146,12 +114,7 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
         # get the average request time for 10 hits to the endpoint
         single_user_time = timeit.timeit(lambda: self.client.get(self.detail_url), number=10)
 
-        self.generate_subscription(
-            {
-                'plan_type': 'enterprise',
-                'organizations': True,
-            }
-        )
+        generate_enterprise_subscription(self.organization)
 
         # get the average request time for 10 hits to the endpoint
         multi_user_time = timeit.timeit(lambda: self.client.get(self.detail_url), number=10)
@@ -164,12 +127,7 @@ class OrganizationServiceUsageAPITestCase(ServiceUsageAPIBase):
         """
         Test that multiple hits to the endpoint from the same origin are properly cached
         """
-        self.generate_subscription(
-            {
-                'plan_type': 'enterprise',
-                'organizations': True,
-            }
-        )
+        generate_enterprise_subscription(self.organization)
 
         response = self.client.get(self.detail_url)
         assert response.data['total_submission_count']['current_month'] == self.expected_submissions_multi
@@ -204,8 +162,11 @@ class OrganizationAssetUsageAPITestCase(AssetUsageAPITestCase):
             Organization, id=self.org_id, name='test organization'
         )
 
+        self.someuser = User.objects.get(username='someuser')
         self.anotheruser = User.objects.get(username='anotheruser')
-        self.organization.users.add(self.anotheruser)
+        self.newuser = baker.make(User, username='newuser')
+        self.organization.add_user(self.anotheruser, is_admin=True)
+        baker.make(Customer, subscriber=self.organization)
         self.client.force_login(self.anotheruser)
 
     def test_unauthorized_user(self):
@@ -218,38 +179,35 @@ class OrganizationAssetUsageAPITestCase(AssetUsageAPITestCase):
         non_org_id = 'lkdjalkfewkl'
         url_with_non_org_id = f'{self.url}{non_org_id}/asset_usage/'
         response = self.client.get(url_with_non_org_id)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_user_not_member_of_organization(self):
-        non_member_user = User.objects.create(username='non_member_user')
-        self.client.force_login(non_member_user)
+        self.client.force_login(self.someuser)
         response = self.client.get(self.detail_url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_successful_retrieval(self):
-        Asset.objects.create(
-            content={
-                'survey': [
-                    {
-                        'type': 'file',
-                        'label': 'upload1',
-                        'required': 'true',
-                        '$kuid': 'kdem',
-                    },
-                    {
-                        'type': 'file',
-                        'label': 'upload2',
-                        'required': 'true',
-                        '$kuid': 'emfs',
-                    },
-                ]
-            },
-            owner=self.anotheruser,
-            asset_type='survey',
-            name='test',
-        )
+        generate_enterprise_subscription(self.organization)
+        create_mock_assets([self.anotheruser])
         response = self.client.get(self.detail_url)
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['asset__name'] == 'test'
-        assert response.data['results'][0]['deployment_status'] == 'draft'
+        assert response.data['results'][0]['deployment_status'] == 'deployed'
+
+    def test_aggregates_usage_for_enterprise_org(self):
+        generate_enterprise_subscription(self.organization)
+        self.organization.add_user(self.newuser)
+        # create 2 additional assets, one per user
+        create_mock_assets([self.anotheruser, self.newuser])
+        response = self.client.get(self.detail_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+
+    def test_users_without_enterprise_see_only_their_usage(self):
+        generate_plan_subscription(self.organization)
+        self.organization.add_user(self.newuser)
+        create_mock_assets([self.anotheruser, self.newuser])
+        response = self.client.get(self.detail_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1

--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -1,0 +1,46 @@
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+from djstripe.models import Customer, Product, SubscriptionItem, Subscription, Price
+from model_bakery import baker
+
+from kobo.apps.organizations.models import Organization
+
+
+def generate_plan_subscription(
+    organization: Organization, metadata: dict = None, customer: Customer = None
+) -> Subscription:
+    """Create a subscription for a product with custom metadata"""
+    now = timezone.now()
+
+    if not customer:
+        customer = baker.make(Customer, subscriber=organization, livemode=False)
+        organization.save()
+
+    product_metadata = {
+        'product_type': 'plan',
+    }
+    if metadata:
+        product_metadata = {**product_metadata, **metadata}
+    product = baker.make(Product, active=True, metadata=product_metadata)
+    price = baker.make(
+        Price,
+        active=True,
+        id='price_sfmOFe33rfsfd36685657',
+        product=product,
+    )
+
+    subscription_item = baker.make(SubscriptionItem, price=price, quantity=1, livemode=False)
+    return baker.make(
+        Subscription,
+        customer=customer,
+        status='active',
+        items=[subscription_item],
+        livemode=False,
+        billing_cycle_anchor=now - relativedelta(weeks=2),
+        current_period_end=now + relativedelta(weeks=2),
+        current_period_start=now - relativedelta(weeks=2),
+    )
+
+
+def generate_enterprise_subscription(organization: Organization, customer: Customer = None):
+    return generate_plan_subscription(organization, {'plan_type': 'enterprise'}, customer)

--- a/kobo/apps/trackers/submission_utils.py
+++ b/kobo/apps/trackers/submission_utils.py
@@ -37,6 +37,7 @@ def create_mock_assets(users: list, assets_per_user: int = 1):
             content=content_source_asset,
             owner=user,
             asset_type='survey',
+            name='test',
             _quantity=assets_per_user,
         )
 

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -18,7 +18,6 @@ from kpi.deployment_backends.kobocat_backend import KobocatDeploymentBackend
 from kpi.models.asset import Asset
 
 
-
 class AssetUsageSerializer(serializers.HyperlinkedModelSerializer):
     asset = serializers.HyperlinkedIdentityField(
         lookup_field='uid',

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -1,13 +1,13 @@
-from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import User
 from django.conf import settings
-from django.db.models import Sum, Q, OuterRef, Subquery, QuerySet
+from django.db.models import Sum, Q
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.fields import empty
 
 from kobo.apps.organizations.models import Organization
+from kobo.apps.organizations.utils import organization_month_start, organization_year_start
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.deployment_backends.kc_access.shadow_models import (
@@ -16,6 +16,7 @@ from kpi.deployment_backends.kc_access.shadow_models import (
 )
 from kpi.deployment_backends.kobocat_backend import KobocatDeploymentBackend
 from kpi.models.asset import Asset
+
 
 
 class AssetUsageSerializer(serializers.HyperlinkedModelSerializer):
@@ -49,16 +50,15 @@ class AssetUsageSerializer(serializers.HyperlinkedModelSerializer):
 
     def __init__(self, instance=None, data=empty, **kwargs):
         super().__init__(instance=instance, data=data, **kwargs)
-
-        self._now = timezone.now().date()
+        organization = self.context.get('organization')
+        self._month_start = organization_month_start(organization)
+        self._year_start = organization_year_start(organization)
 
     def get_nlp_usage_current_month(self, asset):
-        start_date = self._now.replace(day=1)
-        return self._get_nlp_tracking_data(asset, start_date)
+        return self._get_nlp_tracking_data(asset, self._month_start)
 
     def get_nlp_usage_current_year(self, asset):
-        start_date = self._now.replace(day=1, month=1)
-        return self._get_nlp_tracking_data(asset, start_date)
+        return self._get_nlp_tracking_data(asset, self._year_start)
 
     def get_nlp_usage_all_time(self, asset):
         return self._get_nlp_tracking_data(asset)
@@ -66,14 +66,12 @@ class AssetUsageSerializer(serializers.HyperlinkedModelSerializer):
     def get_submission_count_current_month(self, asset):
         if not asset.has_deployment:
             return 0
-        start_date = self._now.replace(day=1)
-        return asset.deployment.submission_count_since_date(start_date)
+        return asset.deployment.submission_count_since_date(self._month_start)
 
     def get_submission_count_current_year(self, asset):
         if not asset.has_deployment:
             return 0
-        start_date = self._now.replace(day=1, month=1)
-        return asset.deployment.submission_count_since_date(start_date)
+        return asset.deployment.submission_count_since_date(self._year_start)
 
     def get_submission_count_all_time(self, asset):
         if not asset.has_deployment:
@@ -125,10 +123,8 @@ class ServiceUsageSerializer(serializers.Serializer):
         self._total_submission_count = {}
         self._current_month_start = None
         self._current_year_start = None
-        self._anchor_date = None
-        self._period_start = None
+        self._organization = None
         self._period_end = None
-        self._subscription_interval = None
         self._now = timezone.now().date()
         self._get_per_asset_usage(instance)
 
@@ -149,35 +145,6 @@ class ServiceUsageSerializer(serializers.Serializer):
 
     def get_billing_period_end(self, user):
         return self._period_end
-
-    def _get_current_month_start_date(self):
-        # No subscription info, just use the first day of current month
-        if not self._anchor_date:
-            return self._now.replace(day=1)
-
-        # Subscription is billed monthly, use the current billing period start date
-        if self._subscription_interval == 'month':
-            return self._period_start
-
-        month_start = self._period_end
-        while month_start > self._now:
-            month_start -= relativedelta(months=1)
-        return month_start
-
-    def _get_current_year_start_date(self):
-        # No subscription info, just use the first day of current year
-        if not self._anchor_date:
-            return self._now.replace(day=1, month=1)
-
-        # Subscription is billed yearly, use the provided anchor date as start date
-        if self._subscription_interval == 'year':
-            return self._period_start
-
-        # Subscription is monthly, calculate this year's start based on anchor date
-        year_start = self._anchor_date
-        while year_start + relativedelta(years=1) < self._now:
-            year_start += relativedelta(years=1)
-        return year_start
 
     def _filter_by_user(self, user_ids: list) -> Q:
         """
@@ -217,21 +184,14 @@ class ServiceUsageSerializer(serializers.Serializer):
         if not organization_id:
             return
 
-        organization = Organization.objects.filter(
+        self._organization = Organization.objects.filter(
             organization_users__user_id=user_id,
             id=organization_id,
         ).first()
 
-        if not organization:
+        if not self._organization:
             # Couldn't find organization, proceed as normal
             return
-
-        # If they have a subscription, use its start date to calculate beginning of current month/year's usage
-        if billing_details := organization.active_subscription_billing_details:
-            self._anchor_date = billing_details['billing_cycle_anchor'].date()
-            self._period_start = billing_details['current_period_start'].date()
-            self._period_end = billing_details['current_period_end'].date()
-            self._subscription_interval = billing_details['recurring_interval']
 
         if settings.STRIPE_ENABLED:
             # if the user is in an organization and has an enterprise plan, get all org users
@@ -257,8 +217,8 @@ class ServiceUsageSerializer(serializers.Serializer):
 
         self._get_storage_usage()
 
-        self._current_month_start = self._get_current_month_start_date()
-        self._current_year_start = self._get_current_year_start_date()
+        self._current_month_start = organization_month_start(self._organization)
+        self._current_year_start = organization_year_start(self._organization)
 
         current_month_filter = Q(
             date__range=[self._current_month_start, self._now]

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -160,7 +160,7 @@ class ServiceUsageSerializer(serializers.Serializer):
             return self._period_start
 
         month_start = self._period_end
-        while month_start > self._now():
+        while month_start > self._now:
             month_start -= relativedelta(months=1)
         return month_start
 


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Update the organization asset usage endpoint (`api/v2/organizations/{ORG ID}/asset_usage/`) to get all assets for users in the organization and use any start/end date from their subscription plan.

## Notes
There are some places in `views.py` where logic gets refactored to [reduce the number of queries being made](https://docs.djangoproject.com/en/4.2/topics/db/optimization/#retrieve-everything-at-once-if-you-know-you-will-need-it) - for instance, checking if the user is the org owner in initial query on the `Organization`.

The error handling for unauthorized requests has been tweaked a little bit too - now, whenever the organization can't be found, a 400 is always returned. This is to prevent users from being able to find out if an organization with a given ID exists by trying different URLS and seeing which ones return a 404 and which ones return a 403 (aka [enumeration](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account)).