### PR TITLE
Fix export sorting discrepancy

### DIFF
--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -1418,6 +1418,9 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         Retrieve submissions directly from Mongo.
         Submissions can be filtered with `params`.
         """
+        # Apply a default sort of _id to prevent unpredictable natural sort
+        if not params.get('sort'):
+            params['sort'] = {'_id': 1}
         mongo_cursor, total_count = MongoHelper.get_instances(
             self.mongo_userform_id, **params)
 


### PR DESCRIPTION
## Description

Historically, exports have shown the latest submissions at the bottom, but there was no explicit sorting set in the database query. Some MongoDB (or MongoDB-compatible) servers return results in the opposite order, causing confusion. This makes the oldest-to-newest sort order explicit and consistent.

## Notes

When mongo has no sort set, it uses a [natural](https://www.mongodb.com/docs/v3.0/reference/operator/meta/natural/) sort which is unpredictable. This addresses it on KobocatDeploymentBackend by setting a default sort of (_id, 1).  Kobo already applies a userform_id + -id index and this index is used in reverse. This results in a minor performance regression.

There is no unit test coverage for mongo usage and therefore this fix has no unit test.

## Related issues

Fixes TASK-697
