### PR TITLE
Make 'select multiple' responses show up in the data table when displaying XML values

### DIFF
--- a/jsapp/js/components/submissions/table.es6
+++ b/jsapp/js/components/submissions/table.es6
@@ -885,7 +885,7 @@ export class DataTable extends React.Component {
                 return <span className='trimmed-text'>{row.value}</span>;
               }
             }
-            if (q.type === QUESTION_TYPES.select_multiple.id && row.value) {
+            if (q.type === QUESTION_TYPES.select_multiple.id && row.value && !tableStore.getTranslationIndex()) {
               const values = row.value.split(' ');
               const labels = [];
               values.forEach(function (v) {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix an issue where 'select multiple' responses wouldn't show up in the data table when displaying XML values.