### PR TITLE
[TASK-601] Allow pasting strings with spaces to tags response form

### DIFF
--- a/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/tagsResponseForm.component.tsx
@@ -80,6 +80,8 @@ export default function TagsResponseForm(props: TagsResponseFormProps) {
           onlyUnique
           addOnBlur
           addOnPaste
+          // We override the default to not have "split by space character"
+          pasteSplit={(data) => [data.trim()]}
           disabled={!props.canEdit}
         />
       </section>


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://githxub.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Overriding the `pasteSplit` function did the trick.
