### PR TITLE
Allow to set sentry environment via env var SENTRY_ENVIRONMENT

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1193,6 +1193,7 @@ if sentry_dsn:
             sentry_logging
         ],
         traces_sample_rate=env.float('SENTRY_TRACES_SAMPLE_RATE', 0.01),
+        environment=env.str('SENTRY_ENVIRONMENT', 'production'),
         send_default_pii=True
     )
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Updated Sentry initialization to dynamically set the `environment` parameter using an environment variable `SENTRY_ENVIRONMENT`. This aids in filtering and analyzing errors by deployment stage.

## Notes

Added this line to `sentry_sdk.init` call's params:

```
environment=env.str('SENTRY_ENVIRONMENT', 'production'),
```

It's set by default to `production` for backwards compatibility purposes. This is what's [set by default](https://docs.sentry.io/platforms/python/configuration/environments/).
