### PR TITLE
Fix error `This field is required` while saving in-app messages in Admin interface

### DIFF
--- a/kobo/apps/help/admin.py
+++ b/kobo/apps/help/admin.py
@@ -2,11 +2,13 @@
 from django.contrib import admin
 
 from kobo.apps.markdownx_uploader.admin import MarkdownxModelAdminBase
-from .models import InAppMessage, InAppMessageFile
+from .models import InAppMessage
+from .forms import InAppMessageForm
 
 
 class InAppMessageAdmin(MarkdownxModelAdminBase):
 
+    form = InAppMessageForm
     model = InAppMessage
 
     new_message_warning = (
@@ -15,6 +17,10 @@ class InAppMessageAdmin(MarkdownxModelAdminBase):
         'here will not cause it to reappear.'
     )
     readonly_fields = ['uid', 'last_editor']
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.filter(generic_related_objects={})
 
     def get_fieldsets(self, request, obj=None):
         """

--- a/kobo/apps/help/forms.py
+++ b/kobo/apps/help/forms.py
@@ -1,10 +1,18 @@
 # coding: utf-8
 import os
 
+from django.forms import ModelForm, ValidationError
 from django.urls import reverse
 from markdownx.forms import ImageForm
 
-from .models import InAppMessageFile
+from .models import InAppMessage, InAppMessageFile
+
+
+class InAppMessageForm(ModelForm):
+
+    class Meta:
+        model = InAppMessage
+        exclude = ['generic_related_objects']
 
 
 class InAppMessageImageForm(ImageForm):


### PR DESCRIPTION
## Description

`generic_related_objects` is not required anymore

## Notes

The in-app messages related to transfer ownership are also hidden

## Related issues

Fixes #4908 