### PR TITLE
Show labels, not XML, for select one/multiple questions with multiple translations when viewing a report

### DIFF
--- a/jsapp/js/components/reports/reportContents.es6
+++ b/jsapp/js/components/reports/reportContents.es6
@@ -83,7 +83,7 @@ export default class ReportContents extends React.Component {
               return (
                 question &&
                 o.list_name === question.select_from_list_name &&
-                (o.label === resps[j])
+                (o.name === resps[j])
               );
             });
             if (choice && choice.label && choice.label[tnslIndex]) {
@@ -96,6 +96,7 @@ export default class ReportContents extends React.Component {
           const vals = reportData[i].data.values;
           if (vals && vals[0] && vals[0][1] && vals[0][1].responses) {
             var respValues = vals[0][1].responses;
+
             reportData[i].data.responseLabels = [];
             let qGB = asset.content.survey.find((z) => {
               return z.name === groupBy || z.$autoname === groupBy;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

To reproduce, create a form with a select one and a select multiple question. Add two or more languages to the form, then add translations for each of the questions. Submit a few responses, then go to Data -> Reports.

Figuring this out was kind of tough, but the fix is pretty succinct. The label was being compared to the XML value, so it would never use the correct translated label unless the two values were the same. That check has been fixed.

Note that you still need to define a translation for your question choices to see the labels - otherwise, it will default to showing the XML value (as it was originally written.)

## Media

With this PR:
![image](https://github.com/kobotoolbox/kpi/assets/7819986/25584c78-caac-46c6-bd51-6e77d8247996)

On `beta`:
![image](https://github.com/kobotoolbox/kpi/assets/7819986/f5c0b551-83df-4ea8-9378-5f4390ea3f68)
