### PR TITLE
Fix KC url on in Android instructions, remove references to deployment__identifier

### DIFF
--- a/jsapp/js/components/formLanding.js
+++ b/jsapp/js/components/formLanding.js
@@ -362,14 +362,8 @@ class FormLanding extends React.Component {
     const chosenMethodLink = this.state.deployment__links[chosenMethod] || null;
 
     var kc_server = document.createElement('a');
-    kc_server.href = this.state.deployment__identifier;
+    kc_server.href = envStore.data.open_rosa_server;
     var kobocollect_url = kc_server.origin;
-
-    /* TODO
-     `deployment__identifier` has been removed from API response.
-     Stop reading `kc_server` from `deployment__identifier` and use `open_rosa_server`
-     property provided in `/environment` endpoint
-    */
 
     return (
       <bem.FormView__row>

--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -42,7 +42,8 @@ export class FormSubScreens extends React.Component {
     autoBind(this);
   }
   componentDidMount() {
-    const uid = this.props.params.assetid || this.props.uid || this.props.params.uid;
+    const uid =
+      this.props.params.assetid || this.props.uid || this.props.params.uid;
     if (uid) {
       actions.resources.loadAsset({id: uid});
     }
@@ -53,12 +54,8 @@ export class FormSubScreens extends React.Component {
     }
 
     var iframeUrl = '';
-    var deployment__identifier = '';
 
     if (this.state.uid != undefined) {
-      if (this.state.deployment__identifier != undefined) {
-        deployment__identifier = this.state.deployment__identifier;
-      }
       switch (this.props.router.location.pathname) {
         case ROUTES.FORM_TABLE.replace(':uid', this.state.uid):
           return (

--- a/jsapp/js/components/submissions/submissionUtils.mocks.es6
+++ b/jsapp/js/components/submissions/submissionUtils.mocks.es6
@@ -1829,7 +1829,6 @@ export const assetWithSupplementalDetails = {
       },
     ],
   },
-  'deployment__identifier': 'http://kc.kobo.local/kobo/forms/aDDywpeYGnvuDLTeiveyxZ',
   'deployment__links': {
     'url': 'http://ee.kobo.local/6PTli7y9',
     'single_url': 'http://ee.kobo.local/single/6PTli7y9',

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -218,7 +218,9 @@ interface AssignablePermissionPartial {
   label: AssignablePermissionPartialLabel;
 }
 
-export type AssignablePermission = AssignablePermissionRegular | AssignablePermissionPartial;
+export type AssignablePermission =
+  | AssignablePermissionRegular
+  | AssignablePermissionPartial;
 
 export interface LabelValuePair {
   /** Note: the labels are always localized in the current UI language */
@@ -584,7 +586,6 @@ export interface AssetResponse extends AssetRequestObject {
       date_modified: string;
     }>;
   };
-  deployment__identifier: string | null;
   deployment__links?: {
     url?: string;
     single_url?: string;

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -42,6 +42,7 @@ interface EnvironmentResponse {
    * if we should display TOS Screen to user :)
    */
   terms_of_service__sitewidemessage__exists: boolean;
+  open_rosa_server: string;
 }
 
 /*
@@ -128,6 +129,7 @@ export class EnvStoreData {
   public custom_password_localized_help_text = '';
   public enable_password_entropy_meter = false;
   public terms_of_service__sitewidemessage__exists = false;
+  public open_rosa_server = '';
 
   getProjectMetadataField(
     fieldName: ProjectMetadataFieldKey
@@ -219,6 +221,7 @@ class EnvStore {
     this.data.social_apps = response.social_apps;
     this.data.free_tier_thresholds = response.free_tier_thresholds;
     this.data.free_tier_display = response.free_tier_display;
+    this.data.open_rosa_server = response.open_rosa_server;
 
     if (response.sector_choices) {
       this.data.sector_choices = response.sector_choices.map(


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Change the URL in the Android instructions, which was incorrectly showing the current URL's origin instead of the correct KoboCat URL.

## Notes

`deployment__identifier` has been deprecated and removed due to pointing to a non-existent URL - we use the `open_rosa_server` from `/environment` to get the correct URL instead.