### PR TITLE
Add maintenance function to remove old import tasks

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -363,6 +363,11 @@ CONSTANCE_CONFIG = {
         'Number of days to keep asset snapshots',
         'positive_int'
     ),
+    'IMPORT_TASK_DAYS_RETENTION': (
+        90,
+        'Number of days to keep import tasks',
+        'positive_int',
+    ),
     'FREE_TIER_THRESHOLDS': (
         LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS),
         'Free tier thresholds: storage in kilobytes, '
@@ -661,9 +666,12 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES',
     ),
     'Trash bin': (
-        'ASSET_SNAPSHOT_DAYS_RETENTION',
         'ACCOUNT_TRASH_GRACE_PERIOD',
         'PROJECT_TRASH_GRACE_PERIOD',
+    ),
+    'Regular maintenance settings': (
+        'ASSET_SNAPSHOT_DAYS_RETENTION',
+        'IMPORT_TASK_DAYS_RETENTION',
     ),
     'Tier settings': (
         'FREE_TIER_THRESHOLDS',

--- a/kpi/maintenance_tasks.py
+++ b/kpi/maintenance_tasks.py
@@ -25,8 +25,10 @@ def remove_old_asset_snapshots():
 
 
 def remove_old_import_tasks():
+    days = constance.config.IMPORT_TASK_DAYS_RETENTION
+
     delete_queryset = ImportTask.objects.filter(
-        date_created__lt=timezone.now() - timedelta(days=90),
+        date_created__lt=timezone.now() - timedelta(days=days),
     )
 
     chunked_delete(delete_queryset)

--- a/kpi/maintenance_tasks.py
+++ b/kpi/maintenance_tasks.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
-from kpi.models import AssetSnapshot
+from kpi.models import AssetSnapshot, ImportTask
 
 
 def remove_old_asset_snapshots():
@@ -19,6 +19,19 @@ def remove_old_asset_snapshots():
     delete_queryset = AssetSnapshot.objects.filter(
         date_created__lt=timezone.now() - timedelta(days=days),
     ).filter(Exists(newer_snapshot_for_asset) | Q(asset_version=None))
+
+    while True:
+        count, _ = delete_queryset.filter(
+            pk__in=delete_queryset[:1000]
+        ).delete()
+        if not count:
+            break
+
+
+def remove_old_import_tasks():
+    delete_queryset = ImportTask.objects.filter(
+        date_created__lt=timezone.now() - timedelta(days=90),
+    )
 
     while True:
         count, _ = delete_queryset.filter(

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -9,7 +9,7 @@ from django.core.management import call_command
 from kobo.apps.markdownx_uploader.tasks import remove_unused_markdown_files
 from kobo.celery import celery_app
 from kpi.constants import LIMIT_HOURS_23
-from kpi.maintenance_tasks import remove_old_asset_snapshots
+from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_tasks
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import (
     ExportTask,
@@ -102,4 +102,5 @@ def perform_maintenance():
     Run daily maintenance tasks
     """
     remove_unused_markdown_files()
+    remove_old_import_tasks()
     remove_old_asset_snapshots()

--- a/kpi/tests/test_import_tasks.py
+++ b/kpi/tests/test_import_tasks.py
@@ -19,7 +19,6 @@ class AssetImportTaskHousekeepingTest(BaseTestCase):
         old_task = ImportTask.objects.create(
             user=self.user,
             data='{}',
-            date_created=timezone.now() - timedelta(days=92),
         )
 
         old_task.date_created = timezone.now() - timedelta(days=95)

--- a/kpi/tests/test_import_tasks.py
+++ b/kpi/tests/test_import_tasks.py
@@ -20,7 +20,7 @@ class AssetImportTaskHousekeepingTest(BaseTestCase):
             user=self.user,
             data='{}',
         )
-
+        # Because of `auto_date_now`, we cannot specify created_date on creation
         old_task.date_created = timezone.now() - timedelta(days=95)
         old_task.save(update_fields=['date_created'])
 

--- a/kpi/tests/test_import_tasks.py
+++ b/kpi/tests/test_import_tasks.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from kpi.maintenance_tasks import remove_old_import_tasks
+from kpi.models import ImportTask
+from kpi.tests.base_test_case import BaseTestCase
+
+
+class AssetImportTaskHousekeepingTest(BaseTestCase):
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.user = User.objects.get(username='someuser')
+
+    def test_remove_old_import_tasks(self):
+        old_task = ImportTask.objects.create(
+            user=self.user,
+            data='{}',
+            date_created=timezone.now() - timedelta(days=92),
+        )
+
+        old_task.date_created = timezone.now() - timedelta(days=95)
+        old_task.save(update_fields=['date_created'])
+
+        new_task = ImportTask.objects.create(user=self.user, data='{}')
+
+        remove_old_import_tasks()
+
+        assert ImportTask.objects.filter(id=new_task.id).exists()
+        assert not ImportTask.objects.filter(id=old_task.id).exists()

--- a/kpi/tests/test_import_tasks.py
+++ b/kpi/tests/test_import_tasks.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from datetime import timedelta
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from kpi.maintenance_tasks import remove_old_import_tasks
@@ -13,6 +13,7 @@ class AssetImportTaskHousekeepingTest(BaseTestCase):
     fixtures = ['test_data']
 
     def setUp(self):
+        User = get_user_model()
         self.user = User.objects.get(username='someuser')
 
     def test_remove_old_import_tasks(self):

--- a/kpi/utils/chunked_delete.py
+++ b/kpi/utils/chunked_delete.py
@@ -1,0 +1,8 @@
+from django.db.models import QuerySet
+
+
+def chunked_delete(queryset: QuerySet):
+    while True:
+        count, _ = queryset.filter(pk__in=queryset[:1000]).delete()
+        if not count:
+            break


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Adds maintenance task for cleaning up old import tasks. 

## Notes

I created a new test file for this. All other import task related tests are run in API test files and this didn't seem relevant to API testing. 

## Related issues

implements work from #2434 