### PR TITLE
Fix custom exports of grouped NLP questions

### DIFF
--- a/kobo/apps/subsequences/tests/test_known_cols_utils.py
+++ b/kobo/apps/subsequences/tests/test_known_cols_utils.py
@@ -42,10 +42,10 @@ def test_known_cols_transc_uniqs():
         'qpath2 - transcript',
     ]
     assert rs['qpath'] == [
-        'qpath1-transcript-en',
-        'qpath1-transcript-fr',
-        'qpath2-transcript-en',
-        'qpath2-transcript-fr',
+        'col-qpath1-transcript-en',
+        'col-qpath1-transcript-fr',
+        'col-qpath2-transcript-en',
+        'col-qpath2-transcript-fr',
     ]
 
 
@@ -61,10 +61,10 @@ def test_known_cols_transl_uniqs():
     labls = [r['label'] for r in results]
     qpths = [r['qpath'] for r in results]
     assert qpths == [
-        'qpath1-translation-en',
-        'qpath1-translation-fr',
-        'qpath2-translation-en',
-        'qpath2-translation-fr',
+        'col-qpath1-translation-en',
+        'col-qpath1-translation-fr',
+        'col-qpath2-translation-en',
+        'col-qpath2-translation-fr',
     ]
 
 
@@ -78,3 +78,28 @@ def test_known_cols_combos():
     langs = [r['language'] for r in results]
     assert langs == ['en', 'fr', 'en', 'fr']
     assert len(results) == 4
+
+
+def test_known_cols_grouped_source():
+    # TODO: refer to commit d013bfe0f5 and `extend_col_deets()` to figure out
+    # how this should behave
+    results = parse_known_cols([
+        # `group` is the group name
+        # `question` is the (source) question name
+        'group-question:transcript:en',
+        'group-question:translation:es',
+    ])
+    sources = [r['source'] for r in results]
+    qpaths = [r['qpath'] for r in results]
+    names = [r['name'] for r in results]
+    assert set(sources) == set(('group-question',))
+    assert qpaths == [
+        'group-question-transcript-en',
+        'group-question-translation-es',
+    ]
+    assert names == [
+        # This can't be right (why a mixture of dash and slash delimiters?) but
+        # it is at least what the front end expects
+        'group-question/transcript_en',
+        'group-question/translation_es',
+    ]

--- a/kobo/apps/subsequences/utils/parse_known_cols.py
+++ b/kobo/apps/subsequences/utils/parse_known_cols.py
@@ -15,15 +15,17 @@ from collections import defaultdict
 
 
 def extend_col_deets(lang, coltype, label, q_path):
+    # NB: refer to commit d013bfe0f5 when trying to figure out the original
+    # intent here
     name = q_path.split('-')[-1]
-    out = {'label': name, 'name': name}
+    out = {'label': name}
     out['dtpath'] = f'{q_path}/{coltype}_{lang}'
     out['type'] = coltype
     out['language'] = lang
     out['label'] = f'{label} - {coltype}'
-    out['name'] = f'{name}/{coltype}_{lang}'
+    out['name'] = f'{q_path}/{coltype}_{lang}'
     out['source'] = q_path
-    out['qpath'] = f'{name}-{coltype}-{lang}'
+    out['qpath'] = f'{q_path}-{coltype}-{lang}'
     out['settings'] = {'mode': 'manual', 'engine': f'engines/{coltype}_manual'}
     out['path'] = [q_path, coltype]
     return out

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -480,27 +480,27 @@ class Asset(ObjectPermissionMixin,
         except KeyError:
             return output
         for qual_question in qual_survey:
-            qname = qual_question['qpath'].split('-')[-1]
             # Surely some of this stuff is not actually used…
             # (added to match extend_col_deets() from
             # kobo/apps/subsequences/utils/parse_known_cols)
             #
             # See also injectSupplementalRowsIntoListOfRows() in
             # assetUtils.ts
+            qpath = qual_question['qpath']
             field = dict(
                 label=qual_question['labels']['_default'],
-                name=f"{qname}/{qual_question['uuid']}",
-                dtpath=f"{qual_question['qpath']}/{qual_question['uuid']}",
+                name=f"{qpath}/{qual_question['uuid']}",
+                dtpath=f"{qpath}/{qual_question['uuid']}",
                 type=qual_question['type'],
                 # could say '_default' or the language of the transcript,
                 # but really that would be meaningless and misleading
                 language='??',
-                source=qual_question['qpath'],
-                qpath=f"{qual_question['qpath']}-{qual_question['uuid']}",
+                source=qpath,
+                qpath=f"{qpath}-{qual_question['uuid']}",
                 # seems not applicable given the transx questions describe
                 # manual vs. auto here and which engine was used
                 settings='??',
-                path=[qual_question['qpath'], qual_question['uuid']],
+                path=[qpath, qual_question['uuid']],
             )
             try:
                 field['choices'] = qual_question['choices']


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Solves the problem of transcripts and translations for grouped source questions not appearing when custom exports include only a subset of fields.

## Notes

Many questions remain about the original intent of the code, but given the comment in the original commit, d013bfe0f5, it's likely there's just extraneous stuff here that needs to be removed (after understanding that it's safe to do so):

    this should be pared down to just the atts that are used
    in the frontend and formpack