### PR TITLE
Prevent stale content when repeatedly navigating to Form Builder

### DIFF
--- a/jsapp/js/mixins.tsx
+++ b/jsapp/js/mixins.tsx
@@ -265,9 +265,12 @@ const mixins: MixinsObject = {
     },
 
     componentDidMount() {
-      this.dmixAssetStoreCancelListener = assetStore.listen((data: AssetStoreData) => {
-        this.dmixAssetStoreChange(data);
-      }, this);
+      this.dmixAssetStoreCancelListener = assetStore.listen(
+        (data: AssetStoreData) => {
+          this.dmixAssetStoreChange(data);
+        },
+        this
+      );
 
       // TODO 2/2
       // HACK FIX: for when we use `PermProtectedRoute`, we don't need to make the
@@ -277,7 +280,7 @@ const mixins: MixinsObject = {
       if (uid && this.props.initialAssetLoadNotNeeded) {
         this.setState(Object.assign({}, assetStore.data[uid]));
       } else if (uid) {
-        actions.resources.loadAsset({id: uid});
+        actions.resources.loadAsset({id: uid}, true);
       }
     },
 
@@ -400,11 +403,14 @@ const mixins: MixinsObject = {
                       )
                     );
                     if (params.assetUid) {
-                      router!.navigate(ROUTES.FORM.replace(':uid', params.assetUid));
+                      router!.navigate(
+                        ROUTES.FORM.replace(':uid', params.assetUid)
+                      );
                     }
                   } else {
                     if (
-                      this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE &&
+                      this.props.context ===
+                        PROJECT_SETTINGS_CONTEXTS.REPLACE &&
                       routerIsActive(ROUTES.FORMS)
                     ) {
                       actions.resources.loadAsset({id: assetUid});

--- a/jsapp/js/router/permProtectedRoute.tsx
+++ b/jsapp/js/router/permProtectedRoute.tsx
@@ -26,6 +26,7 @@ interface PermProtectedRouteState {
   userHasRequiredPermissions: boolean | null;
   errorMessage?: string;
   asset: AssetResponse | null;
+  initialAssetLoadNotNeeded: boolean;
 }
 
 /**
@@ -50,6 +51,7 @@ class PermProtectedRoute extends React.Component<
       userHasRequiredPermissions: null,
       errorMessage: undefined,
       asset: null,
+      initialAssetLoadNotNeeded: true,
     };
   }
 
@@ -67,9 +69,14 @@ class PermProtectedRoute extends React.Component<
       // in the UI (from this component; see `render()` below).
       this.onLoadAssetCompleted(assetFromStore);
     } else {
+      this.setState({initialAssetLoadNotNeeded: true});
       this.unlisteners.push(
-        actions.resources.loadAsset.completed.listen(this.onLoadAssetCompleted.bind(this)),
-        actions.resources.loadAsset.failed.listen(this.onLoadAssetFailed.bind(this))
+        actions.resources.loadAsset.completed.listen(
+          this.onLoadAssetCompleted.bind(this)
+        ),
+        actions.resources.loadAsset.failed.listen(
+          this.onLoadAssetFailed.bind(this)
+        )
       );
       actions.resources.loadAsset({id: this.props.params.uid}, true);
     }
@@ -165,7 +172,7 @@ class PermProtectedRoute extends React.Component<
         <Suspense fallback={<LoadingSpinner />}>
           <this.props.protectedComponent
             {...this.props}
-            initialAssetLoadNotNeeded
+            initialAssetLoadNotNeeded={this.state.initialAssetLoadNotNeeded}
           />
         </Suspense>
       );

--- a/jsapp/js/router/permProtectedRoute.tsx
+++ b/jsapp/js/router/permProtectedRoute.tsx
@@ -51,7 +51,7 @@ class PermProtectedRoute extends React.Component<
       userHasRequiredPermissions: null,
       errorMessage: undefined,
       asset: null,
-      initialAssetLoadNotNeeded: true,
+      initialAssetLoadNotNeeded: false,
     };
   }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Prevent stale form content when saving a change in Form Builder, exiting, and then re-entering Form Builder.

## Notes

### Steps to reproduce ([internal xref](https://www.notion.so/kobotoolbox/Stale-asset-content-after-saving-in-form-builder-e983b948d33849eca6a290da1ed4d70b))

1. Load the app for the first time in a browser session
2. Create a new project from scratch
3. Add some stuff in the form builder
4. Hit save; see a valid PATCH sent to the back end
5. Exit the form builder
6. Re-enter the form builder
7. See a blank survey
8. Refresh
9. See the content you created