### PR TITLE
Track addon usage over time

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -11,7 +11,7 @@ from kobo.apps.organizations.types import UsageType
 if settings.STRIPE_ENABLED:
    from djstripe.models import Customer, Subscription
    from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, ORGANIZATION_USAGE_MAX_CACHE_AGE, \
-    USAGE_LIMIT_MAP_STRIPE, USAGE_LIMIT_MAP
+     USAGE_LIMIT_MAP
 from functools import partial
 
 from organizations.abstract import (
@@ -85,7 +85,7 @@ class Organization(AbstractOrganization):
             # TODO: re-fetch service usage data if stale
             pass
         cached_usage = self.serializable_value(f'{USAGE_LIMIT_MAP[limit_type]}_limit')
-        stripe_key = f'{USAGE_LIMIT_MAP_STRIPE[limit_type]}_limit'
+        stripe_key = f'{USAGE_LIMIT_MAP[limit_type]}_limit'
         current_limit = Organization.objects.filter(
             id=self.id,
             djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -9,9 +9,13 @@ from django_request_cache import cache_for_request
 from kobo.apps.organizations.types import UsageType
 
 if settings.STRIPE_ENABLED:
-   from djstripe.models import Customer, Subscription
-   from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, ORGANIZATION_USAGE_MAX_CACHE_AGE, \
-     USAGE_LIMIT_MAP
+    from djstripe.models import Customer, Subscription
+    from kobo.apps.stripe.constants import (
+        ACTIVE_STRIPE_STATUSES,
+        ORGANIZATION_USAGE_MAX_CACHE_AGE,
+        USAGE_LIMIT_MAP_STRIPE,
+        USAGE_LIMIT_MAP,
+    )
 from functools import partial
 
 from organizations.abstract import (
@@ -85,7 +89,7 @@ class Organization(AbstractOrganization):
             # TODO: re-fetch service usage data if stale
             pass
         cached_usage = self.serializable_value(f'{USAGE_LIMIT_MAP[limit_type]}_limit')
-        stripe_key = f'{USAGE_LIMIT_MAP[limit_type]}_limit'
+        stripe_key = f'{USAGE_LIMIT_MAP_STRIPE[limit_type]}_limit'
         current_limit = Organization.objects.filter(
             id=self.id,
             djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -78,9 +78,11 @@ class Organization(AbstractOrganization):
         return self.save()
 
     @cache_for_request
-    def is_organization_over_plan_limit(self, limit_type: UsageType) -> Union[bool, None]:
+    def check_usage_exceeds_plan_limit(self, limit_type: UsageType, new_usage = 0) -> Union[bool, None]:
         """
-        Check if an organization is over their plan's limit for a given usage type
+        Check if an organization is at or over their plan's limit for a given usage type or,
+        if 'new_usage' kwarg is supplied, whether new usage will put them over their limit
+        Returns True if limit is/will be exceeded, false if not.
         Returns None if Stripe isn't enabled or the limit status couldn't be determined
         """
         if not settings.STRIPE_ENABLED:
@@ -103,7 +105,7 @@ class Organization(AbstractOrganization):
         else:
             # TODO: get the limits from the community plan, overrides
             relevant_limit = 2000
-        return int(relevant_limit) and cached_usage > int(relevant_limit)
+        return int(relevant_limit) and cached_usage + new_usage >= int(relevant_limit)
 
 
 class OrganizationUser(AbstractOrganizationUser):

--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -27,10 +27,3 @@ USAGE_LIMIT_MAP = {
     'storage': 'storage_bytes',
     'submission': 'submission',
 }
-
-USAGE_LIMIT_MAP_STRIPE = {
-    'character': 'nlp_character',
-    'seconds': 'nlp_seconds',
-    'storage': 'storage_bytes',
-    'submission': 'submission',
-}

--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -27,3 +27,10 @@ USAGE_LIMIT_MAP = {
     'storage': 'storage_bytes',
     'submission': 'submission',
 }
+
+USAGE_LIMIT_MAP_STRIPE = {
+    'character': 'nlp_character',
+    'seconds': 'nlp_seconds',
+    'storage': 'storage_bytes',
+    'submission': 'submission',
+}

--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -180,7 +180,9 @@ class PlanAddOn(models.Model):
         ).order_by(metadata_key)
         remaining = amount
         for add_on in add_ons.iterator():
-            if not add_on.organization.is_organization_over_plan_limit(add_on_type):
+            if not add_on.organization.check_usage_exceeds_plan_limit(
+                add_on_type, remaining
+            ):
                 return remaining
             if add_on.is_available():
                 remaining -= add_on.increment(limit_type=limit_key, amount_used=remaining)

--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -183,7 +183,7 @@ class PlanAddOn(models.Model):
             if not add_on.organization.is_organization_over_plan_limit(add_on_type):
                 return remaining
             if add_on.is_available():
-                remaining -= add_on.increment(limit_type=usage_type, amount_used=remaining)
+                remaining -= add_on.increment(limit_type=limit_key, amount_used=remaining)
         return remaining
 
 

--- a/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
@@ -135,6 +135,7 @@ class OneTimeAddonTrackingTestCase(BaseTestCase):
         self.charge.save()
 
     def test_increment_addon_usage(self):
+        # TODO: Remove once cache issues have been resolved
         # update_nlp_counter will error out if cache isn't updated first
         # Also note that the used asr_seconds_current_month has to be > subscription limit,
         # otherwise the addon will not be incremented (and neither will the counter, therefore)
@@ -178,6 +179,7 @@ class OneTimeAddonTrackingTestCase(BaseTestCase):
         )
 
     def test_increment_addon_usage_over_limit(self):
+        # TODO: Remove once cache issues have been resolved
         self.organization.update_usage_cache(
             {
                 'total_nlp_usage': {

--- a/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
@@ -71,7 +71,7 @@ class OneTimeAddonTrackingTestCase(ServiceUsageAPIBase):
                 'product_type': 'plan',
                 'plan_type': 'enterprise',
                 'organizations': True,
-                'asr_seconds_limit': self.subscription_limit,
+                'nlp_seconds_limit': self.subscription_limit,
             },
         )
         price = baker.make(

--- a/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
@@ -1,0 +1,196 @@
+from dateutil.relativedelta import relativedelta
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.urls import reverse
+from django.utils import timezone
+from djstripe.models import (
+    Charge,
+    Customer,
+    PaymentIntent,
+    Price,
+    Product,
+    Subscription,
+    SubscriptionItem,
+)
+from model_bakery import baker
+
+from kobo.apps.organizations.models import Organization, OrganizationUser
+from kobo.apps.trackers.models import NLPUsageCounter
+from kobo.apps.trackers.submission_utils import (
+    create_mock_assets,
+)
+from kobo.apps.stripe.models import PlanAddOn
+from kobo.apps.trackers.utils import update_nlp_counter
+from kpi.tests.api.v2.test_api_service_usage import ServiceUsageAPIBase
+
+
+class OneTimeAddonTrackingTestCase(ServiceUsageAPIBase):
+    """
+    Test OT addon tracking when Stripe is enabled.
+    """
+
+    org_id = 'orgAKWMFskafsngf'
+    subscription_limit = 1000
+    addon_limit = 2000
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.now = timezone.now()
+
+        anotheruser = User.objects.get(username='anotheruser')
+        cls.organization = baker.make(
+            Organization, id=cls.org_id, name='test organization'
+        )
+        cls.organization.add_user(cls.anotheruser, is_admin=True)
+        assets = create_mock_assets([cls.anotheruser], 1)
+        cls.asset = assets[0]
+
+        cls.customer = baker.make(
+            Customer, subscriber=cls.organization, livemode=False
+        )
+        cls.organization.save()
+
+    def setUp(self):
+        super().setUp()
+        url = reverse(self._get_endpoint('organizations-list'))
+        self.detail_url = f'{url}{self.org_id}/service_usage/'
+        self._generate_subscription()
+        self._create_payment()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _generate_subscription(
+        self,
+    ):
+        product = baker.make(
+            Product,
+            active=True,
+            metadata={
+                'product_type': 'plan',
+                'plan_type': 'enterprise',
+                'organizations': True,
+                'asr_seconds_limit': self.subscription_limit,
+            },
+        )
+        price = baker.make(
+            Price,
+            active=True,
+            id='price_sfmOFe33rfsfd36685657',
+            recurring={'interval': 'month'},
+            product=product,
+        )
+
+        subscription = baker.make(
+            Subscription,
+            customer=self.customer,
+            status='active',
+            livemode=False,
+            billing_cycle_anchor=self.now - relativedelta(weeks=2),
+            current_period_end=self.now + relativedelta(weeks=2),
+            current_period_start=self.now - relativedelta(weeks=2),
+        )
+        baker.make(
+            SubscriptionItem,
+            subscription=subscription,
+            price=price,
+            quantity=1,
+            livemode=False,
+        )
+
+    def _create_payment(
+        self, payment_status='succeeded', refunded=False, quantity=1
+    ):
+        metadata = {
+            'product_type': 'addon_onetime',
+            'asr_seconds_limit': self.addon_limit,
+            'valid_tags': 'all',
+        }
+        product = baker.make(
+            Product,
+            active=True,
+            metadata=metadata,
+        )
+        price = baker.make(Price, active=True, product=product, type='one_time')
+        product.save()
+        payment_total = quantity * 2000
+        payment_intent = baker.make(
+            PaymentIntent,
+            customer=self.customer,
+            status=payment_status,
+            payment_method_types=['card'],
+            livemode=False,
+            amount=payment_total,
+            amount_capturable=payment_total,
+            amount_received=payment_total,
+        )
+        self.charge = baker.prepare(
+            Charge,
+            customer=self.customer,
+            refunded=refunded,
+            created=timezone.now(),
+            payment_intent=payment_intent,
+            paid=True,
+            status=payment_status,
+            livemode=False,
+            amount_refunded=0 if refunded else payment_total,
+            amount=payment_total,
+        )
+        self.charge.metadata = {
+            'price_id': price.id,
+            'organization_id': self.organization.id,
+            'quantity': quantity,
+            **(product.metadata),
+        }
+        self.charge.save()
+
+    def test_increment_addon_usage(self):
+        # update_nlp_counter will error out if cache isn't updated first
+        # Also note that the used asr_seconds_current_month has to be > subscription limit,
+        # otherwise the addon will not be incremented (and neither will the counter, therefore)
+        self.organization.update_usage_cache(
+            {
+                'total_nlp_usage': {
+                    'asr_seconds_current_month': self.subscription_limit + 1,
+                    'mt_characters_current_month': 0,
+                }
+            }
+        )
+
+        seconds_used = 1500
+
+        update_nlp_counter(
+            'mock_asr_seconds', seconds_used, self.anotheruser.id, self.asset.id
+        )
+
+        counter = NLPUsageCounter.objects.first()
+        addon = PlanAddOn.objects.first()
+
+        assert counter.counters['addon_used_asr_seconds'] == seconds_used
+        assert (
+            addon.limits_remaining['asr_seconds_limit']
+            == self.addon_limit - seconds_used
+        )
+
+    def test_increment_addon_usage_over_limit(self):
+        self.organization.update_usage_cache(
+            {
+                'total_nlp_usage': {
+                    'asr_seconds_current_month': self.subscription_limit + 1,
+                    'mt_characters_current_month': 0,
+                }
+            }
+        )
+
+        seconds_used = 3000
+
+        update_nlp_counter(
+            'mock_asr_seconds', seconds_used, self.anotheruser.id, self.asset.id
+        )
+
+        counter = NLPUsageCounter.objects.first()
+        addon = PlanAddOn.objects.first()
+
+        assert counter.counters['addon_used_asr_seconds'] == self.addon_limit
+        assert addon.limits_remaining['asr_seconds_limit'] == 0

--- a/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_tracking.py
@@ -152,13 +152,13 @@ class OneTimeAddonTrackingTestCase(ServiceUsageAPIBase):
         self.organization.update_usage_cache(
             {
                 'total_nlp_usage': {
-                    'asr_seconds_current_month': self.subscription_limit + 1,
+                    'asr_seconds_current_month': self.subscription_limit,
                     'mt_characters_current_month': 0,
                 }
             }
         )
 
-        seconds_used = 1500
+        seconds_used = 1000
 
         update_nlp_counter(
             'mock_asr_seconds', seconds_used, self.anotheruser.id, self.asset.id
@@ -173,11 +173,26 @@ class OneTimeAddonTrackingTestCase(ServiceUsageAPIBase):
             == self.addon_limit - seconds_used
         )
 
+        more_seconds_used = 500
+
+        update_nlp_counter(
+            'mock_asr_seconds', more_seconds_used, self.anotheruser.id, self.asset.id
+        )
+
+        counter = NLPUsageCounter.objects.first()
+        addon = PlanAddOn.objects.first()
+
+        assert counter.counters['addon_used_asr_seconds'] == seconds_used + more_seconds_used
+        assert (
+            addon.limits_remaining['asr_seconds_limit']
+            == self.addon_limit - (seconds_used + more_seconds_used)
+        )
+
     def test_increment_addon_usage_over_limit(self):
         self.organization.update_usage_cache(
             {
                 'total_nlp_usage': {
-                    'asr_seconds_current_month': self.subscription_limit + 1,
+                    'asr_seconds_current_month': self.subscription_limit,
                     'mt_characters_current_month': 0,
                 }
             }

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -7,11 +7,21 @@ from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from djstripe.models import Customer, Price, Product, Subscription, SubscriptionItem
+from djstripe.models import (
+    Customer,
+    Price,
+    Product,
+    Subscription,
+    SubscriptionItem,
+)
 from model_bakery import baker
 
 from kobo.apps.organizations.models import Organization, OrganizationUser
-from kobo.apps.trackers.submission_utils import create_mock_assets, add_mock_submissions
+from kobo.apps.trackers.models import NLPUsageCounter
+from kobo.apps.trackers.submission_utils import (
+    create_mock_assets,
+    add_mock_submissions,
+)
 from kpi.tests.api.v2.test_api_service_usage import ServiceUsageAPIBase
 
 
@@ -37,20 +47,23 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         organization = baker.make(Organization, id=cls.org_id, name='test organization')
         organization.add_user(cls.anotheruser, is_admin=True)
         assets = create_mock_assets([cls.anotheruser], cls.assets_per_user)
+        cls.asset = assets[0]
 
-        cls.customer = baker.make(Customer, subscriber=organization, livemode=False)
+        cls.customer = baker.make(
+            Customer, subscriber=organization, livemode=False
+        )
         organization.save()
 
-        users = baker.make(User, _quantity=cls.user_count - 1, _bulk_create=True)
+        cls.users = baker.make(User, _quantity=cls.user_count - 1, _bulk_create=True)
         baker.make(
             OrganizationUser,
-            user=users.__iter__(),
+            user=cls.users.__iter__(),
             organization=organization,
             is_admin=False,
             _quantity=cls.user_count - 1,
             _bulk_create=True,
         )
-        assets = assets + create_mock_assets(users, cls.assets_per_user)
+        assets = assets + create_mock_assets(cls.users, cls.assets_per_user)
         add_mock_submissions(assets, cls.submissions_per_asset)
 
     def setUp(self):
@@ -63,42 +76,95 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
     def tearDown(self):
         cache.clear()
 
-    def generate_subscription(self, metadata: dict):
+    def generate_subscription(self, metadata: dict, monthly_interval: bool = True):
         """Create a subscription for a product with custom metadata"""
-        product = baker.make(Product, active=True, metadata={
-            'product_type': 'plan',
-            **metadata,
-        })
+        interval = 'month' if monthly_interval else 'year'
+
+        product = baker.make(
+            Product,
+            active=True,
+            metadata={
+                'product_type': 'plan',
+                **metadata,
+            },
+        )
         price = baker.make(
             Price,
             active=True,
             id='price_sfmOFe33rfsfd36685657',
+            recurring={'interval': interval},
             product=product,
         )
 
-        subscription_item = baker.make(SubscriptionItem, price=price, quantity=1, livemode=False)
+        period_offset = relativedelta(weeks=2)
+
+        if interval == 'year':
+            period_offset = relativedelta(months=6)
+
+        subscription_item = baker.make(
+            SubscriptionItem, price=price, quantity=1, livemode=False
+        )
         baker.make(
             Subscription,
             customer=self.customer,
             status='active',
             items=[subscription_item],
             livemode=False,
-            billing_cycle_anchor=self.now - relativedelta(weeks=2),
-            current_period_end=self.now + relativedelta(weeks=2),
-            current_period_start=self.now - relativedelta(weeks=2),
+            billing_cycle_anchor=self.now - period_offset,
+            current_period_end=self.now + period_offset,
+            current_period_start=self.now - period_offset,
         )
+
+    def add_nlp_trackers_for_org(self, time, num_units=1):
+        """
+        Add specified usage per user for specified period
+        """
+        # this month
+        counter = {
+            'google_asr_seconds': num_units,
+            'google_mt_characters': num_units,
+            'addon_used_asr_seconds': num_units,
+            'addon_used_mt_characters': num_units,
+        }
+  
+        NLPUsageCounter.objects.create(
+            user_id=self.anotheruser.id,
+            asset_id=self.asset.id,
+            date=time,
+            counters=counter,
+            total_asr_seconds=counter['google_asr_seconds'],
+            total_mt_characters=counter['google_mt_characters'],
+        )
+
+        for user in self.users:
+            NLPUsageCounter.objects.create(
+                user_id=user.id,
+                asset_id=self.asset.id,
+                date=time,
+                counters=counter,
+                total_asr_seconds=counter['google_asr_seconds'],
+                total_mt_characters=counter['google_mt_characters'],
+            )
+
 
     def test_usage_doesnt_include_org_users_without_subscription(self):
         """
         Test that the endpoint *only* returns usage for the logged-in user
         if they don't have a subscription that includes Organizations.
         """
+        self.add_nlp_trackers_for_org(self.now)
         response = self.client.get(self.detail_url)
         # without a plan, the user should only see their usage
         assert response.data['total_submission_count']['all_time'] == self.expected_submissions_single
         assert response.data['total_submission_count']['current_month'] == self.expected_submissions_single
         assert response.data['total_storage_bytes'] == (
             self.expected_file_size() * self.expected_submissions_single
+        )
+        assert (
+            response.data['addon_usage']['asr_seconds_current_period'] == 1
+        )
+        assert (
+            response.data['addon_usage']['mt_characters_current_period'] == 1
         )
 
     def test_usage_for_plans_with_org_access(self):
@@ -111,15 +177,53 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
             {
                 'plan_type': 'enterprise',
                 'organizations': True,
-            }
+            },
         )
 
+        self.add_nlp_trackers_for_org(self.now)
         # the user should see usage for everyone in their org
         response = self.client.get(self.detail_url)
         assert response.data['total_submission_count']['current_month'] == self.expected_submissions_multi
         assert response.data['total_submission_count']['all_time'] == self.expected_submissions_multi
         assert response.data['total_storage_bytes'] == (
             self.expected_file_size() * self.expected_submissions_multi
+        )
+        assert response.data['addon_usage']['asr_seconds_current_period'] == self.user_count
+        assert (
+            response.data['addon_usage']['mt_characters_current_period']
+            == self.user_count
+        )
+
+    def test_annual_addon_usage_aggregation(self):
+        """
+        Test that the endpoint aggregates usage data for yearly plans correctly
+        """
+
+        self.generate_subscription(
+            {
+                'plan_type': 'enterprise',
+                'organizations': True,
+            },
+            monthly_interval=False,
+        )
+        self.add_nlp_trackers_for_org(self.now)
+
+        last_month = self.now - relativedelta(months=1)
+        self.add_nlp_trackers_for_org(last_month)
+
+        # Adding these to make sure they aren't included in aggregation
+        last_year = self.now - relativedelta(months=12)
+        self.add_nlp_trackers_for_org(last_year, 50)
+
+        response = self.client.get(self.detail_url)
+
+        assert (
+            response.data['addon_usage']['asr_seconds_current_period']
+            == self.user_count * 2
+        )
+        assert (
+            response.data['addon_usage']['mt_characters_current_period']
+            == self.user_count * 2
         )
 
     def test_doesnt_include_org_users_with_invalid_plan(self):
@@ -129,6 +233,7 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         """
 
         self.generate_subscription({})
+        self.add_nlp_trackers_for_org(self.now)
 
         response = self.client.get(self.detail_url)
         # without the proper subscription, the user should only see their usage
@@ -136,6 +241,12 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         assert response.data['total_submission_count']['all_time'] == self.expected_submissions_single
         assert response.data['total_storage_bytes'] == (
             self.expected_file_size() * self.expected_submissions_single
+        )
+        assert (
+            response.data['addon_usage']['asr_seconds_current_period'] == 1
+        )
+        assert (
+            response.data['addon_usage']['mt_characters_current_period'] == 1
         )
 
     @pytest.mark.performance

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -101,18 +101,17 @@ class OrganizationUsageAPITestCase(ServiceUsageAPIBase):
         if interval == 'year':
             period_offset = relativedelta(months=6)
 
-        subscription_item = baker.make(
-            SubscriptionItem, price=price, quantity=1, livemode=False
-        )
-        baker.make(
+        subscription = baker.make(
             Subscription,
             customer=self.customer,
             status='active',
-            items=[subscription_item],
             livemode=False,
             billing_cycle_anchor=self.now - period_offset,
             current_period_end=self.now + period_offset,
             current_period_start=self.now - period_offset,
+        )
+        baker.make(
+            SubscriptionItem, subscription=subscription, price=price, quantity=1, livemode=False
         )
 
     def add_nlp_trackers_for_org(self, time, num_units=1):

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -59,7 +59,6 @@ def update_nlp_counter(
             keys_to_update.append(addon_used_key_prefix + 'asr_seconds')
             values_to_update.append(amount - remaining)
 
-
     if service.endswith('mt_characters'):
         kwargs['total_mt_characters'] = F('total_mt_characters') + amount
         if asset_id is not None:
@@ -71,8 +70,7 @@ def update_nlp_counter(
 
     NLPUsageCounter.objects.filter(pk=counter_id).update(
         counters=IncrementValues(
-            'counters',
-            keynames=keys_to_update,
-            increments=values_to_update
-        )
+            'counters', keynames=keys_to_update, increments=values_to_update
+        ),
+        **kwargs,
     )

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -47,11 +47,16 @@ def update_nlp_counter(
         kwargs['total_asr_seconds'] = F('total_asr_seconds') + amount
         if asset_id is not None:
             # If we're not updating the catch-all counter, increment any NLP add-ons the user may have
-            PlanAddOn.increment_add_ons_for_user(user_id, 'seconds', amount)
+            remaining = PlanAddOn.increment_add_ons_for_user(user_id, 'seconds', amount)
+            if addon_amount_used := amount - remaining:
+                kwargs['addon_used_asr_seconds'] = addon_amount_used
+
     if service.endswith('mt_characters'):
         kwargs['total_mt_characters'] = F('total_mt_characters') + amount
         if asset_id is not None:
-            PlanAddOn.increment_add_ons_for_user(user_id, 'character', amount)
+            remaining = PlanAddOn.increment_add_ons_for_user(user_id, 'character', amount)
+            if addon_amount_used := amount - remaining:
+                kwargs['addon_used_mt_seconds'] = addon_amount_used
 
     NLPUsageCounter.objects.filter(pk=counter_id).update(
         counters=IncrementValue('counters', keyname=service, increment=amount),

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -48,14 +48,16 @@ def update_nlp_counter(
         if asset_id is not None:
             # If we're not updating the catch-all counter, increment any NLP add-ons the user may have
             remaining = PlanAddOn.increment_add_ons_for_user(user_id, 'seconds', amount)
-            if addon_amount_used := amount - remaining:
+            addon_amount_used = amount - remaining
+            if addon_amount_used > 0:
                 kwargs['addon_used_asr_seconds'] = addon_amount_used
 
     if service.endswith('mt_characters'):
         kwargs['total_mt_characters'] = F('total_mt_characters') + amount
         if asset_id is not None:
             remaining = PlanAddOn.increment_add_ons_for_user(user_id, 'character', amount)
-            if addon_amount_used := amount - remaining:
+            addon_amount_used = amount - remaining
+            if addon_amount_used > 0:
                 kwargs['addon_used_mt_seconds'] = addon_amount_used
 
     NLPUsageCounter.objects.filter(pk=counter_id).update(

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -1286,9 +1286,19 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
 
     def transfer_counters_ownership(self, new_owner: 'auth.User'):
 
+        # Addon usage is not relevant to new owner, so we zero it
         NLPUsageCounter.objects.filter(
             asset=self.asset, user=self.asset.owner
-        ).update(user=new_owner)
+        ).update(
+            user=new_owner,
+            counters=UpdateJSONFieldAttributes(
+                'counters',
+                updates={
+                    'addon_used_asr_seconds': 0,
+                    'addon_used_mt_characters': 0,
+                },
+            ),
+        )
         KobocatDailyXFormSubmissionCounter.objects.filter(
             xform=self.xform, user_id=self.asset.owner.pk
         ).update(user=new_owner)

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -39,6 +39,7 @@ from kpi.exceptions import (
 from kpi.interfaces.sync_backend_media import SyncBackendMediaInterface
 from kpi.models.asset_file import AssetFile
 from kpi.tests.utils.mock import MockAttachment
+from kpi.utils.django_orm_helper import UpdateJSONFieldAttributes
 from kpi.utils.mongo_helper import MongoHelper, drop_mock_only
 from kpi.utils.xml import fromstring_preserve_root_xmlns
 from .base_backend import BaseDeploymentBackend
@@ -649,7 +650,16 @@ class MockDeploymentBackend(BaseDeploymentBackend):
     def transfer_counters_ownership(self, new_owner: 'auth.User'):
         NLPUsageCounter.objects.filter(
             asset=self.asset, user=self.asset.owner
-        ).update(user=new_owner)
+        ).update(
+            user=new_owner,
+            counters=UpdateJSONFieldAttributes(
+                'counters',
+                updates={
+                    'addon_used_asr_seconds': 0,
+                    'addon_used_mt_characters': 0,
+                },
+            ),
+        )
 
         # Kobocat models are not implemented, but mocked in unit tests.
 

--- a/kpi/tests/api/v2/test_api_service_usage.py
+++ b/kpi/tests/api/v2/test_api_service_usage.py
@@ -89,6 +89,8 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
         counter_1 = {
             'google_asr_seconds': 4586,
             'google_mt_characters': 5473,
+            'addon_used_asr_seconds': 100,
+            'addon_used_mt_characters': 500,
         }
         NLPUsageCounter.objects.create(
             user_id=self.anotheruser.id,
@@ -104,6 +106,8 @@ class ServiceUsageAPIBase(BaseAssetTestCase):
         counter_2 = {
             'google_asr_seconds': 142,
             'google_mt_characters': 1253,
+            'addon_used_asr_seconds': 100,
+            'addon_used_mt_characters': 500,
         }
         NLPUsageCounter.objects.create(
             user_id=self.anotheruser.id,
@@ -234,6 +238,8 @@ class ServiceUsageAPITestCase(ServiceUsageAPIBase):
         assert (
             response.data['total_nlp_usage']['mt_characters_all_time'] == 6726
         )
+        assert response.data['addon_usage']['asr_seconds_current_period'] == 100
+        assert response.data['addon_usage']['mt_characters_current_period'] == 500
         assert (
             response.data['total_storage_bytes'] == self.expected_file_size()
         )


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The basic goal here is to enable the frontend to display how many units of addon consumption were used in the current billing period. For that, we need to track addon usage as it happens. This PR aims to do that by adding new addon usage keys to the NLPUsageCounter jsonfield dict whenever an addon's usage is incremented.  The aggregated data is served to the frontend via the service_usage/organization service_usage endpoints.

Related changes:
- Overhauled `is_organization_over_plan_limit` method to check not just whether an org is over its limit, but whether it will go over its limit with a specified usage amount.

- Updated project ownership transfer code to remove addon usage counts from transferred NLPUsageCounters, as these counts will not be relevant to a new owner.

Unrelated changes:
- Fixed tests that were already broken by earlier changes in `test_one_time_addons_api.py`

## Notes

There are still some deeper issues with how we handle usage caching that will need to be resolved before this project is completed. But I think the work I have done so far could be merged into the project branch so the PR for that cache work will be more manageable.

Credit to @noliveleger for the new `IncrementValues` ORM helper.