### PR TITLE
Filter the '_id' column as a number, not a string

### DIFF
--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -6,10 +6,7 @@ import {
   SUPPLEMENTAL_DETAILS_PROP,
   VALIDATION_STATUSES,
 } from 'js/constants';
-import type {
-  QuestionTypeName,
-  MetaQuestionTypeName,
-} from 'js/constants';
+import type {QuestionTypeName, MetaQuestionTypeName} from 'js/constants';
 import {
   EXCLUDED_COLUMNS,
   SUBMISSION_ACTIONS_ID,
@@ -291,7 +288,7 @@ export interface TableFilterQuery {
     [key: string]:
       | string
       | null
-      | {$in: string[]}
+      | {$in: number[]}
       | {$regex: string; $options: string};
   };
 }
@@ -316,7 +313,7 @@ export function buildFilterQuery(
   filters.forEach((filter) => {
     switch (filter.id) {
       case '_id': {
-        output.queryObj[filter.id] = {$in: [filter.value]};
+        output.queryObj[filter.id] = {$in: [parseInt(filter.value)]};
         break;
       }
       case VALIDATION_STATUS_ID_PROP: {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix an error that caused filtering by the '_id' field on the submission data table to always return no results.

## Notes

Because of the vagaries of `parseInt()`, this will parse some strings with mixed alphanumeric content, removing all but the first number sequence:
![image](https://github.com/kobotoolbox/kpi/assets/7819986/d6913a43-dc7b-4ede-a23f-af82c05a570d)

I considered doing a loose equality check first - like `string == parseInt(string)` - but in the interest of accepting a greater range values (since all of them will be coerced to a `number` or `NaN`), I didn't add that check. Completely non-numeric values will filter by `query={"_id":{"$in":[null]}}`.
[
internal xref](https://chat.kobotoolbox.org/#narrow/stream/5-Kobo-SysAdmin/topic/IOM.20can't.20search.20by.20_id/near/385224)