### PR TITLE
Remove the Note qualitative analysis question type from exports 

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -502,6 +502,9 @@ class Asset(ObjectPermissionMixin,
                 settings='??',
                 path=[qpath, qual_question['uuid']],
             )
+            if field['type'] == 'qual_note':
+                # don't include note question type in exports
+                continue
             try:
                 field['choices'] = qual_question['choices']
             except KeyError:

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -471,7 +471,10 @@ class Asset(ObjectPermissionMixin,
             # Remove newlines and tabs (they are stripped in front end anyway)
             self.name = re.sub(r'[\n\t]+', '', _title)
 
-    def analysis_form_json(self):
+    def analysis_form_json(self, omit_question_types=None):
+        if omit_question_types is None:
+            omit_question_types = []
+
         additional_fields = list(self._get_additional_fields())
         engines = dict(self._get_engines())
         output = {'engines': engines, 'additional_fields': additional_fields}
@@ -502,8 +505,7 @@ class Asset(ObjectPermissionMixin,
                 settings='??',
                 path=[qpath, qual_question['uuid']],
             )
-            if field['type'] == 'qual_note':
-                # don't include note question type in exports
+            if field['type'] in omit_question_types:
                 continue
             try:
                 field['choices'] = qual_question['choices']

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -859,7 +859,9 @@ class ExportTaskBase(ImportExportTask):
         )
 
         if source.has_advanced_features:
-            pack.extend_survey(source.analysis_form_json())
+            pack.extend_survey(
+                source.analysis_form_json(omit_question_types=['qual_note'])
+            )
 
         # Wrap the submission stream in a generator that records the most
         # recent timestamp


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

To test: 

- Checkout `beta` and create a project with an audio question 
- Submit a response and add a note in the analysis view 
- Make an export and you can see an extra column created for the note
- Checkout this branch and restart your development environment 
- Make another export of the project and confirm that note doesn't generate an extra column 
