### PR TITLE
Fix Cypress tests sufficiently for a proof of concept

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -2,8 +2,8 @@
 
 To run tests, you need to do 2 things:
 
-1. Start the **test server.** This is like a kpi server, but in a special cypress_testserver mode. (You will also need to restart it between Cypress test runs.)
-2. Use the **Cypress test runner.** You can run this in command-line mode, or open an interactive browser window.
+1. [Start the **test server.**](#how-to-start-the-test-server) This is like a kpi server, but in a special cypress_testserver mode. (You will also need to restart it between Cypress test runs.)
+2. [Use the **Cypress test runner.**](#how-to-run-cypress-tests) You can run this in command-line mode, or open an interactive browser window.
 
 ## How to start the test server
 
@@ -16,13 +16,26 @@ kpi$ DJANGO_SETTINGS_MODULE=kobo.settings.cypress  \
        --noinput
 ```
 
-If you're using kobo-docker / kobo-install, the process will look like this:
+If you're using [kobo-install](https//github.com/kobotoolbox/kobo-install):
 
 ```console
+# Enter a bash session in the kpi container
 kobo-install$  ./run.py -cf exec kpi bash
-root@kpi:/srv/src/kpi#  sv stop uwsgi
-ok: down: uwsgi: 0s, normally up
-root@kpi:/srv/src/kpi# DJANGO_SETTINGS_MODULE=kobo.settings.cypress ./manage.py cypress_testserver --addrport 0.0.0.0:8000 --noinput
+
+# Stop the server that is already running
+root@kpi:/srv/src/kpi#   sv stop uwsgi
+  ok: down: uwsgi: 0s, normally up
+
+# Start the test server
+root@kpi:/srv/src/kpi#   DJANGO_SETTINGS_MODULE=kobo.settings.cypress ./manage.py cypress_testserver --addrport 0.0.0.0:8000 --noinput
+```
+
+Note: If you get a ModuleNotFoundError, you may need to install
+the dev dependencies. In your container:
+
+```console
+# Install dev dependencies (so you can run tests)
+pip install -r dependencies/pip/dev_requirements.txt
 ```
 
 <details><summary>About cypress_testserver</summary>
@@ -61,7 +74,7 @@ Between subsequent Cypress test runs, you'll need to restart the test server to 
 Cypress will likely ask you to install [some OS dependencies](https://on.cypress.io/required-dependencies) (about .5 GB) when you try to run a test.
 </details>
 
-(Make sure `$KOBOFORM_URL` or `$CYPRESS_BASE_URL` points to your test server.)
+Make sure `$KOBOFORM_URL` or `$CYPRESS_BASE_URL` points to your test server.
 
 ### Command line only tests
 
@@ -94,8 +107,7 @@ Alternatively, you could set the environment variables `CYPRESS_VIDEO` and `CYPR
 
 We have configured Cypress to read its baseUrl from `KOBOFORM_URL` because it's likely you'll already have that set from kpi or kobo-install.
 
-You can override this with `CYPRESS_BASE_URL`, or any other method of configuration.
-
+You can override this with `CYPRESS_BASE_URL`, or the config option equivalent, `baseUrl`.
 
 # Writing tests
 

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -10,7 +10,7 @@ To run tests, you need to do 2 things:
 If you normally run kpi with `./manage.py runserver 0.0.0.0:8000`, you can use:
 
 ```
-kpi$ DJANGO_SETTINGS_MODULE=kobo.settings.testing  \
+kpi$ DJANGO_SETTINGS_MODULE=kobo.settings.cypress  \
      ./manage.py cypress_testserver                \
        --addrport 0.0.0.0:8000                     \
        --noinput
@@ -22,7 +22,7 @@ If you're using kobo-docker / kobo-install, the process will look like this:
 kobo-install$  ./run.py -cf exec kpi bash
 root@kpi:/srv/src/kpi#  sv stop uwsgi
 ok: down: uwsgi: 0s, normally up
-root@kpi:/srv/src/kpi# DJANGO_SETTINGS_MODULE=kobo.settings.testing ./manage.py cypress_testserver --addrport 0.0.0.0:8000 --noinput                                     
+root@kpi:/srv/src/kpi# DJANGO_SETTINGS_MODULE=kobo.settings.cypress ./manage.py cypress_testserver --addrport 0.0.0.0:8000 --noinput
 ```
 
 <details><summary>About cypress_testserver</summary>
@@ -32,13 +32,13 @@ root@kpi:/srv/src/kpi# DJANGO_SETTINGS_MODULE=kobo.settings.testing ./manage.py 
 The **cypress_testserver** provides fixtures for the Cypress tests.
 
 ```
-DJANGO_SETTINGS_MODULE=kobo.settings.testing (1) Use test server settings
+DJANGO_SETTINGS_MODULE=kobo.settings.cypress (1) Use test server settings
               ./manage.py cypress_testserver (2) Run the test server
                      --addrport 0.0.0.0:8000 (3) Bind :8000 (check this)
                      --noinput               (4) Skip 'delete database' prompt
 ```
 
-1. `DJANGO_SETTINGS_MODULE=kobo.settings.testing` switches the server away from using your default kpi database. Source: [kpi/kobo/settings/testing.py](../kobo/settings/testing.py) 
+1. `DJANGO_SETTINGS_MODULE=kobo.settings.cypress` switches the server away from using your default kpi database. Source: [kpi/kobo/settings/cypress.py](../kobo/settings/cypress.py)
 2. `./manage.py cypress_testserver`  is a custom management command. Starts a test server with fixtures created in Python specifically for Cypress tests.
     - [kpi/management/commands/cypress_testserver.py](../kpi/management/commands/cypress_testserver.py) - Add or change fixtures here.
     - [django-admin/#testserver](https://docs.djangoproject.com/en/4.0/ref/django-admin/#testserver) - Django's built-in `testserver`, which this is based on.
@@ -55,8 +55,8 @@ Between subsequent Cypress test runs, you'll need to restart the test server to 
 
 ### Installing Cypress
 
-1. Navigate to the `cypress` folder. 
-2. Install cypress with `npm install`. 
+1. Navigate to the `cypress` folder.
+2. Install cypress with `npm install`.
 
 Cypress will likely ask you to install [some OS dependencies](https://on.cypress.io/required-dependencies) (about .5 GB) when you try to run a test.
 </details>
@@ -86,7 +86,7 @@ If you're on a computer with limited resources, you may wish to use these:
   screenshotOnRunFailure=false    Disable screenshots of Cypress tests
 ```
 
-For example, to run the command-line only tests with the above options, use `npx cypress run --config video=false,screenshotOnRunFailure=false`. 
+For example, to run the command-line only tests with the above options, use `npx cypress run --config video=false,screenshotOnRunFailure=false`.
 
 Alternatively, you could set the environment variables `CYPRESS_VIDEO` and `CYPRESS_SCREENSHOT_ON_RUN_FAILURE`.
 

--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -3,5 +3,7 @@
     "project.spec.js",
     "question.spec.js",
     "delete.spec.js"
-  ]
+  ],
+  "viewportWidth": 1440,
+  "viewportHeight": 900
 }

--- a/cypress/cypress/support/commands.js
+++ b/cypress/cypress/support/commands.js
@@ -4,8 +4,8 @@ Cypress.Commands.add('setupDatabase', () => {
 
 Cypress.Commands.add('login', (account, name) => {
   cy.visit('/accounts/login/')
-  cy.get('input[name="username"]').type(name)
-  cy.get('input[name="password"]').type(account.password)
+  cy.get('#id_login').type(name)
+  cy.get('#id_password').type(account.password)
   cy.contains('Login').click()
 })
 

--- a/kobo/settings/cypress.py
+++ b/kobo/settings/cypress.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+from copy import deepcopy
+
+from .base import WEBPACK_LOADER
+REAL_WEBPACK_LOADER = deepcopy(WEBPACK_LOADER)
+
+from .testing import *
+
+# `testing.py` uses `FakeWebpackLoader`, but Cypress actually needs the
+# front-end application to be operable. Restore the base `WEBPACK_LOADER`
+# configuration
+WEBPACK_LOADER = REAL_WEBPACK_LOADER
+assert 'Fake' not in WEBPACK_LOADER['DEFAULT'].get('LOADER_CLASS', '')

--- a/kpi/management/commands/cypress_testserver.py
+++ b/kpi/management/commands/cypress_testserver.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -113,9 +114,13 @@ class Command(BaseCommand):
             'submission_retryer',
         ]
         for user in users:
-            user_obj = User(username=user)
+            email = f'{user}@fake.kbtdev.org'
+            user_obj = User(username=user, email=email)
             user_obj.set_password(user)
             user_obj.save()
+            EmailAddress.objects.create(
+                user=user_obj, email=email, verified=True, primary=True
+            )
 
         # Create an "empty" survey with no questions other than the defaults
         # added by the form builder

--- a/kpi/management/commands/cypress_testserver.py
+++ b/kpi/management/commands/cypress_testserver.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
     help = 'Runs a development server with data to facilitate Cypress testing.'
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
## Description

Update Cypress tests so that the first test, which logs in and creates a new project, works again.

## Notes

The tests were broken by Django upgrades, the switch to django-allauth, removal of valid webpack configuration from the testing environment (#4517), and UI layout changes.

`project.spec.js` now works, but `question.spec.js` and `delete.spec.js` are still broken due to UI changes.

NB: the `/api/v2/organizations/…/service_usage/` endpoint currently cannot be served by `./manage.py cypress_testserver`; it will log this failure:
```
django.db.utils.ProgrammingError: relation "logger_xform" does not exist
LINE 1: ...ttachment_storage_bytes"), 0) AS "bytes_sum" FROM "logger_xf...
```
There's a corresponding error message in the UI, but this is not the cause of any Cypress tests failing.