### PR TITLE
[TASK-771] Fix Single Submission modal crash bug

### DIFF
--- a/jsapp/js/components/processing/transcript/transcript.utils.ts
+++ b/jsapp/js/components/processing/transcript/transcript.utils.ts
@@ -28,8 +28,8 @@ export function getAttachmentForProcessing(
     assetContent.survey,
     submissionData
   );
-  // We need row data to go further.
-  if (!rowData) {
+  // We need row data to go further. And we are expecting a string (filename).
+  if (!rowData || typeof rowData !== 'string') {
     return errorMessage;
   }
 

--- a/jsapp/js/components/submissions/submissionDataTable.scss
+++ b/jsapp/js/components/submissions/submissionDataTable.scss
@@ -62,31 +62,8 @@ $submission-data-table-space: sizes.$x12;
     }
   }
 
-  &.submission-data-table__row--response,
-  &.submission-data-table__row--point {
+  &.submission-data-table__row--response {
     background-color: colors.$kobo-white;
-  }
-
-  &.submission-data-table__row--point {
-    & + & {
-      border-top: sizes.$x1 dotted colors.$kobo-gray-92;
-    }
-
-    &:first-child .submission-data-table__column {
-      padding-top: 0;
-    }
-
-    &:last-child .submission-data-table__column {
-      padding-bottom: 0;
-    }
-
-    .submission-data-table__column:first-child {
-      padding-left: 0;
-    }
-
-    .submission-data-table__column:last-child {
-      padding-right: 0;
-    }
   }
 }
 

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -132,7 +132,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
           }
         </bem.SubmissionDataTable__column>
 
-        <bem.SubmissionDataTable__column m='data'>
+        <bem.SubmissionDataTable__column m={['data', `type-${item.type}`]}>
           {this.renderResponseData(item)}
         </bem.SubmissionDataTable__column>
       </bem.SubmissionDataTable__row>
@@ -202,17 +202,15 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
             {formatTimeDate(item.data)}
           </bem.SubmissionDataTable__value>
         );
-      case QUESTION_TYPES.geopoint.id:
-        return this.renderPointData(item.data);
       case QUESTION_TYPES.image.id:
       case QUESTION_TYPES.audio.id:
       case QUESTION_TYPES.video.id:
       case QUESTION_TYPES.file.id:
         return this.renderAttachment(item.type, item.data, item.name, item.xpath);
+      case QUESTION_TYPES.geopoint.id:
       case QUESTION_TYPES.geotrace.id:
-        return this.renderMultiplePointsData(item.data);
       case QUESTION_TYPES.geoshape.id:
-        return this.renderMultiplePointsData(item.data);
+        return this.renderPointsData(item.data);
       default:
         // all types not specified above just returns raw data
         return (
@@ -229,41 +227,54 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     );
   }
 
-  renderPointData(data: string) {
-    const parts = data.split(' ');
-    return (
-      <ul>
-        <li>
-          {t('latitude (x.y °):') + ' '}
-          <bem.SubmissionDataTable__value>{parts[0]}</bem.SubmissionDataTable__value>
-        </li>
-        <li>
-          {t('longitude (x.y °):') + ' '}
-          <bem.SubmissionDataTable__value>{parts[1]}</bem.SubmissionDataTable__value>
-        </li>
-        <li>
-          {t('altitude (m):') + ' '}
-          <bem.SubmissionDataTable__value>{parts[2]}</bem.SubmissionDataTable__value>
-        </li>
-        <li>
-          {t('accuracy (m):') + ' '}
-          <bem.SubmissionDataTable__value>{parts[3]}</bem.SubmissionDataTable__value>
-        </li>
-      </ul>
-    );
-  }
+  renderPointsData(data: string) {
+    const pointsArray: string[][] = data.split(';').map((pointString) => pointString.split(' '));
 
-  renderMultiplePointsData(data: string) {
-    return (data.split(';').map((pointData, pointIndex) =>
-      <bem.SubmissionDataTable__row m={['columns', 'point']} key={pointIndex}>
-        <bem.SubmissionDataTable__column>
-          P<sub>{pointIndex + 1}</sub>
-        </bem.SubmissionDataTable__column>
-        <bem.SubmissionDataTable__column>
-          {this.renderPointData(pointData)}
-        </bem.SubmissionDataTable__column>
-      </bem.SubmissionDataTable__row>
-    ));
+    return(
+      <bem.SimpleTable>
+        <bem.SimpleTable__header>
+          <bem.SimpleTable__row>
+            <bem.SimpleTable__cell>
+              {t('Point')}
+            </bem.SimpleTable__cell>
+            <bem.SimpleTable__cell>
+              {t('latitude (x.y °):')}
+            </bem.SimpleTable__cell>
+            <bem.SimpleTable__cell>
+              {t('longitude (x.y °):')}
+            </bem.SimpleTable__cell>
+            <bem.SimpleTable__cell>
+              {t('altitude (m):')}
+            </bem.SimpleTable__cell>
+            <bem.SimpleTable__cell>
+              {t('accuracy (m):')}
+            </bem.SimpleTable__cell>
+          </bem.SimpleTable__row>
+        </bem.SimpleTable__header>
+
+        <bem.SimpleTable__body>
+          {pointsArray.map((pointArray, pointIndex) => (
+            <bem.SimpleTable__row>
+              <bem.SimpleTable__cell>
+                P<sub>{pointIndex + 1}</sub>
+              </bem.SimpleTable__cell>
+              <bem.SimpleTable__cell>
+                {pointArray[0]}
+              </bem.SimpleTable__cell>
+              <bem.SimpleTable__cell>
+                {pointArray[1]}
+              </bem.SimpleTable__cell>
+              <bem.SimpleTable__cell>
+                {pointArray[2]}
+              </bem.SimpleTable__cell>
+              <bem.SimpleTable__cell>
+                {pointArray[3]}
+              </bem.SimpleTable__cell>
+            </bem.SimpleTable__row>
+          ))}
+        </bem.SimpleTable__body>
+      </bem.SimpleTable>
+    );
   }
 
   renderAttachment(type: string, filename: string, name: string, xpath: string) {

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -139,14 +139,16 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     );
   }
 
-  renderResponseData(
-    item: DisplayResponse
-    // type: AnyRowTypeName | null,
-    // data: string | null,
-    // listName?: string
-  ) {
-    if (item.data === null) {
+  renderResponseData(item: DisplayResponse) {
+    if (item.data === null || item.data === undefined) {
       return null;
+    }
+
+    if (typeof item.data !== 'string') {
+      // We are only expecting strings at this point in the code, if we get
+      // anything else, we fall back to displaying raw data as a string (better
+      // than displaying nothing)
+      return String(item.data);
     }
 
     let choice;

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -167,13 +167,26 @@ interface SubmissionSupplementalDetails {
   };
 }
 
+export type SubmissionResponseValue =
+  | string
+  | string[]
+  | number
+  | number[]
+  | null
+  | object
+  | SubmissionAttachment[]
+  | SubmissionSupplementalDetails
+  // This happens with responses to questions inside repeat groups
+  | Array<{[questionName: string]: SubmissionResponseValue}>
+  | undefined;
+
 export interface SubmissionResponse {
-  [questionName: string]: any;
+  [questionName: string]: SubmissionResponseValue;
   __version__: string;
   _attachments: SubmissionAttachment[];
-  _geolocation: any[];
+  _geolocation: number[] | null[];
   _id: number;
-  _notes: any[];
+  _notes: string[];
   _status: string;
   _submission_time: string;
   _submitted_by: string | null;

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -184,7 +184,7 @@ export type SubmissionResponseValue =
   | Array<{[questionName: string]: SubmissionResponseValue}>
   | undefined;
 
-export interface SubmissionResponse extends SubmissionResponseGeneric {
+export interface SubmissionResponse {
   // `SubmissionResponseValue` covers all possible values (responses to form
   // questions and other submission properties)
   [propName: string]: SubmissionResponseValue;

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -167,6 +167,10 @@ interface SubmissionSupplementalDetails {
   };
 }
 
+/**
+ * Value of a property found in `SubmissionResponse`, it can be either a built
+ * in submission property (e.g. `_geolocation`) or a response to a form question
+ */
 export type SubmissionResponseValue =
   | string
   | string[]
@@ -180,8 +184,11 @@ export type SubmissionResponseValue =
   | Array<{[questionName: string]: SubmissionResponseValue}>
   | undefined;
 
-export interface SubmissionResponse {
-  [questionName: string]: SubmissionResponseValue;
+export interface SubmissionResponse extends SubmissionResponseGeneric {
+  // `SubmissionResponseValue` covers all possible values (responses to form
+  // questions and other submission properties)
+  [propName: string]: SubmissionResponseValue;
+  // Below are all known properties of submission response:
   __version__: string;
   _attachments: SubmissionAttachment[];
   _geolocation: number[] | null[];


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes app crash in Single Submission modal for a particular mix of repeat groups, [XLSForm pulldata function](https://xlsform.org/en/#how-to-pull-data-from-csv) and matrix type question. Also now point data (for types `geopoint`, `geotrace`, and `geoshape`) will be displayed as compact table in Single Submission modal.

## Notes

I wasn't able to find a reproduction for this unfortunately. There are some details in Notion task that can help understand this more. The crash was happening, because the code was expecting an object, and was accessing a prop (`obj[prop]`), but was getting a `null` instead. The code in which the bug happens is already in TypeScript, but unfortunately we had `any` in three places in `SubmissionResponse`, and thus the bug could happen.

I thought I've introduced a bug in rendering point data, but it turned out the UI was already broken for any response with more than 3 points. I've improved it by rendering point data as table :)

<details><summary>Point data before (screenshot)</summary>
<p>
<img width="544" alt="Screenshot 2024-05-28 at 21 09 54" src="https://github.com/kobotoolbox/kpi/assets/2521888/e1dd92ec-f960-4560-a640-dd745bf0c564">
</p>
</details> 

<details><summary>Point data after (screenshot)</summary>
<p>
<img width="538" alt="Screenshot 2024-05-28 at 21 09 58" src="https://github.com/kobotoolbox/kpi/assets/2521888/55dd1f5e-ca92-4529-98ef-3f2e7ef1bef7">
</p>
</details> 

## Related issues

Related to #4942 as it touches the same area
