### PR TITLE
Make image attachments resizing work again

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/create_image_thumbnails.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/create_image_thumbnails.py
@@ -10,7 +10,7 @@ from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
 from kobo.apps.openrosa.libs.utils.image_tools import resize
 from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator
-from kobo.apps.openrosa.libs.utils.viewer_tools import get_path
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_optimized_image_path
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
@@ -60,12 +60,10 @@ class Command(BaseCommand):
 
         for att in queryset_iterator(attachments_qs):
             filename = att.media_file.name
-            full_path = get_path(
-                filename, settings.THUMB_CONF['small']['suffix']
-            )
+            full_path = get_optimized_image_path(filename, 'small')
             if kwargs.get('force') is not None:
-                for s in settings.THUMB_CONF.keys():
-                    fp = get_path(filename, settings.THUMB_CONF[s]['suffix'])
+                for suffix in settings.THUMB_CONF.keys():
+                    fp = get_optimized_image_path(filename, suffix)
                     if default_storage.exists(fp):
                         default_storage.delete(fp)
 
@@ -73,10 +71,7 @@ class Command(BaseCommand):
                 try:
                     resize(filename)
                     if default_storage.exists(
-                        get_path(
-                            filename,
-                            '%s' % settings.THUMB_CONF['small']['suffix'],
-                        )
+                        get_optimized_image_path(filename, 'small')
                     ):
                         print(
                             'Thumbnails created for %(file)s'

--- a/kobo/apps/openrosa/apps/logger/models/attachment.py
+++ b/kobo/apps/openrosa/apps/logger/models/attachment.py
@@ -90,18 +90,18 @@ class Attachment(models.Model):
     def filename(self):
         return os.path.basename(self.media_file.name)
 
-    def secure_url(self, suffix="original"):
+    def secure_url(self, suffix: str = 'original'):
         """
-        Returns image URL through kobocat redirector.
+        Returns image URL through KoboCAT redirector.
         :param suffix: str. original|large|medium|small
         :return: str
         """
-        if suffix != "original" and suffix not in settings.THUMB_CONF.keys():
-            raise Exception("Invalid image thumbnail")
+        if suffix != 'original' and suffix not in settings.THUMB_CONF.keys():
+            raise Exception('Invalid image thumbnail')
 
-        return "{kobocat_url}{media_url}{suffix}?{media_file}".format(
+        return '{kobocat_url}{media_url}{suffix}?{media_file}'.format(
             kobocat_url=settings.KOBOCAT_URL,
             media_url=settings.MEDIA_URL,
             suffix=suffix,
-            media_file=urlencode({"media_file": self.media_file.name})
+            media_file=urlencode({'media_file': self.media_file.name})
         )

--- a/kobo/apps/openrosa/apps/logger/signals.py
+++ b/kobo/apps/openrosa/apps/logger/signals.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import logging
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import F
 from django.db.models.signals import (
@@ -12,6 +13,7 @@ from django.dispatch import receiver
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
+from kobo.apps.openrosa.libs.utils.image_tools import get_optimized_image_path
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
@@ -60,6 +62,10 @@ def pre_delete_attachment(instance, **kwargs):
         # `attachment.save()` behind the scene which would call again the `post_save`
         # signal below. Bonus: it avoids an extra query 😎.
         default_storage.delete(media_file_name)
+        for suffix in settings.THUMB_CONF:
+            default_storage.delete(
+                get_optimized_image_path(media_file_name, suffix)
+            )
     except Exception as e:
         logging.error('Failed to delete attachment: ' + str(e), exc_info=True)
 

--- a/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
+++ b/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
@@ -12,7 +12,6 @@ from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
 
-
 class TestAttachment(TestBase):
 
     def setUp(self):
@@ -20,12 +19,18 @@ class TestAttachment(TestBase):
         self._publish_transportation_form_and_submit_instance()
         self.media_file = "1335783522563.jpg"
         media_file = os.path.join(
-            self.this_directory, 'fixtures',
-            'transportation', 'instances', self.surveys[0], self.media_file)
+            self.this_directory,
+            'fixtures',
+            'transportation',
+            'instances',
+            self.surveys[0],
+            self.media_file,
+        )
         self.instance = Instance.objects.all()[0]
         self.attachment = Attachment.objects.create(
             instance=self.instance,
-            media_file=File(open(media_file, 'rb'), media_file))
+            media_file=File(open(media_file, 'rb'), media_file),
+        )
 
     def test_mimetype(self):
         self.assertEqual(self.attachment.mimetype, 'image/jpeg')
@@ -35,13 +40,16 @@ class TestAttachment(TestBase):
             url = image_url(attachment, 'small')
             filename = attachment.media_file.name.replace('.jpg', '')
             thumbnail = '%s-small.jpg' % filename
-            self.assertNotEqual(
-                url.find(thumbnail), -1)
+            self.assertNotEqual(url.find(thumbnail), -1)
             for size in ['small', 'medium', 'large']:
                 thumbnail = f'{filename}-{size}.jpg'
-                self.assertTrue(
-                    default_storage.exists(thumbnail))
-                default_storage.delete(thumbnail)
+                self.assertTrue(default_storage.exists(thumbnail))
+
+            # Ensure clean-up is ok
+            attachment.delete()
+            for size in ['small', 'medium', 'large']:
+                thumbnail = f'{filename}-{size}.jpg'
+                self.assertFalse(default_storage.exists(thumbnail))
 
     def test_create_thumbnails_command(self):
         call_command("create_image_thumbnails")
@@ -50,17 +58,19 @@ class TestAttachment(TestBase):
             filename = attachment.media_file.name.replace('.jpg', '')
             for size in settings.THUMB_CONF.keys():
                 thumbnail = '%s-%s.jpg' % (filename, size)
-                self.assertTrue(
-                    default_storage.exists(thumbnail))
-                created_times[size] = default_storage.get_modified_time(thumbnail)
+                self.assertTrue(default_storage.exists(thumbnail))
+                created_times[size] = default_storage.get_modified_time(
+                    thumbnail
+                )
         # replace or regenerate thumbnails if they exist
         call_command("create_image_thumbnails", force=True)
         for attachment in Attachment.objects.filter(instance=self.instance):
             filename = attachment.media_file.name.replace('.jpg', '')
             for size in settings.THUMB_CONF.keys():
                 thumbnail = f'{filename}-{size}.jpg'
+                self.assertTrue(default_storage.exists(thumbnail))
                 self.assertTrue(
-                    default_storage.exists(thumbnail))
-                self.assertTrue(
-                    default_storage.get_modified_time(thumbnail) > created_times[size])
+                    default_storage.get_modified_time(thumbnail)
+                    > created_times[size]
+                )
                 default_storage.delete(thumbnail)

--- a/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
+++ b/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
@@ -177,8 +177,7 @@ class DataDictionary(XForm):
                 self._survey = \
                     builder.create_survey_element_from_json(self.json)
             except ValueError:
-                xml = bytes(bytearray(self.xml, encoding='utf-8'))
-                self._survey = create_survey_element_from_xml(xml)
+                self._survey = create_survey_element_from_xml(self.xml)
         return self._survey
 
     survey = property(get_survey)

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -35,9 +35,9 @@ def format_date_for_mongo(x):
     )
 
 
-def get_path(path, suffix):
-    fileName, fileExtension = os.path.splitext(path)
-    return fileName + suffix + fileExtension
+def get_optimized_image_path(path: str, suffix: str) -> str:
+    file_name, ext = os.path.splitext(path)
+    return f'{file_name}-{suffix}{ext}'
 
 
 def image_urls_dict(instance):
@@ -51,10 +51,8 @@ def image_urls_dict(instance):
     :return: dict
     """
     urls = dict()
-    # Remove leading dash from suffix
-    suffix = settings.THUMB_CONF['medium']['suffix'][1:]
     for a in instance.attachments.all():
-        urls[a.filename] = a.secure_url(suffix=suffix)
+        urls[a.filename] = a.secure_url(suffix='medium')
     return urls
 
 

--- a/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
+++ b/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
@@ -429,10 +429,10 @@ class GoogleTranscriptionSubmissionTest(APITestCase):
             'submission': submission_id,
             'q1': {GOOGLETS: {'status': 'requested', 'languageCode': ''}}
         }
-        with self.assertNumQueries(FuzzyInt(51, 55)):
+        with self.assertNumQueries(FuzzyInt(51, 57)):
             res = self.client.post(url, data, format='json')
         self.assertContains(res, 'complete')
-        with self.assertNumQueries(FuzzyInt(20, 24)):
+        with self.assertNumQueries(FuzzyInt(20, 26)):
             self.client.post(url, data, format='json')
 
     @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1583,12 +1583,6 @@ add_type('application/wkt', '.wkt')
 add_type('application/geo+json', '.geojson')
 
 KOBOCAT_MEDIA_URL = f'{KOBOCAT_URL}/media/'
-KOBOCAT_THUMBNAILS_SUFFIX_MAPPING = {
-    'original': '',
-    'large': '_large',
-    'medium': '_medium',
-    'small': '_small',
-}
 
 TRENCH_AUTH = {
     'USER_MFA_MODEL': 'mfa.MfaMethod',
@@ -1734,12 +1728,10 @@ DEFAULT_VALIDATION_STATUSES = [
 ]
 
 THUMB_CONF = {
-    'large': {'size': 1280, 'suffix': '-large'},
-    'medium': {'size': 640, 'suffix': '-medium'},
-    'small': {'size': 240, 'suffix': '-small'},
+    'large': 1280,
+    'medium': 640,
+    'small': 240,
 }
-# order of thumbnails from largest to smallest
-THUMB_ORDER = ['large', 'medium', 'small']
 
 SUPPORTED_MEDIA_UPLOAD_TYPES = [
     'image/jpeg',

--- a/kpi/deployment_backends/kc_access/shadow_models.py
+++ b/kpi/deployment_backends/kc_access/shadow_models.py
@@ -171,20 +171,19 @@ class KobocatAttachment(ShadowModel, AudioTranscodingMixin):
         return f'{self.storage_path}.mp3'
 
     def protected_path(
-        self, format_: Optional[str] = None, size: Optional[str] = None
+        self, format_: Optional[str] = None, suffix: Optional[str] = None
     ) -> str:
         """
         Return path to be served as protected file served by NGINX
         """
-
         if format_ == 'mp3':
             attachment_file_path = self.absolute_mp3_path
         else:
             attachment_file_path = self.absolute_path
 
-        if size and self.mimetype.startswith('image/'):
+        if suffix and self.mimetype.startswith('image/'):
             optimized_image_path = get_optimized_image_path(
-                self.media_file.name, size
+                self.media_file.name, suffix
             )
             if not default_kobocat_storage.exists(optimized_image_path):
                 resize(self.media_file.name)

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -792,9 +792,9 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         """
 
         mongo_query_params['submission_ids'] = submission_ids
-        params = self.validate_submission_list_params(user,
-                                                      format_type=format_type,
-                                                      **mongo_query_params)
+        params = self.validate_submission_list_params(
+            user, format_type=format_type, **mongo_query_params
+        )
 
         if format_type == SUBMISSION_FORMAT_TYPE_JSON:
             submissions = self.__get_submissions_in_json(request, **params)

--- a/kpi/tests/api/v2/test_api_attachments.py
+++ b/kpi/tests/api/v2/test_api_attachments.py
@@ -1,10 +1,19 @@
 import uuid
 
+from django.conf import settings
+from django.core.files.base import File
 from django.http import QueryDict
 from django.urls import reverse
 from rest_framework import status
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.main.models import UserProfile
+from kobo.apps.openrosa.apps.logger.models import XForm, Instance, Attachment
+from kobo.apps.openrosa.apps.logger.models.attachment import upload_to
+from kobo.apps.openrosa.apps.viewer.models import ParsedInstance
+from kpi.deployment_backends.kc_access.storage import (
+    default_kobocat_storage as default_storage,
+)
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseAssetTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
@@ -261,3 +270,104 @@ class AttachmentApiTests(BaseAssetTestCase):
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response['Content-Type'] == 'video/3gpp'
+
+    def test_thumbnail_creation_on_demand(self):
+        media_file = settings.BASE_DIR + '/kpi/tests/audio_conversion_test_image.jpg'
+
+        xform_xml = f"""<?xml version="1.0" encoding="utf-8"?>
+            <h:html xmlns="http://www.w3.org/2002/xforms"
+                xmlns:ev="http://www.w3.org/2001/xml-events"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                xmlns:jr="http://openrosa.org/javarosa"
+                xmlns:odk="http://www.opendatakit.org/xforms"
+                xmlns:orx="http://openrosa.org/xforms"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+              <h:head>
+                <h:title>Project with attachments</h:title>
+                <model odk:xforms-version="1.0.0">
+                  <instance>
+                    <{self.asset.uid} id="{self.asset.uid}">
+                      <formhub>
+                        <uuid/>
+                      </formhub>
+                      <attachments/>
+                      <__version__/>
+                      <meta>
+                        <instanceID/>
+                      </meta>
+                    </{self.asset.uid}>
+                  </instance>
+                  <bind nodeset="/{self.asset.uid}/attachments" required="false()" type="binary"/>
+                  <bind calculate="vd3dpf3fL2C8abWG4EPJWC" nodeset="/{self.asset.uid}/__version__" type="string"/>
+                  <bind jr:preload="uid" nodeset="/{self.asset.uid}/meta/instanceID" readonly="true()" type="string"/>
+                  <bind nodeset="/{self.asset.uid}/formhub/uuid" type="string" calculate="027e8acb31b24acebb7f6b2a74ac1ff3"/>
+                </model>
+              </h:head>
+              <h:body>
+                <upload mediatype="image/*" ref="/{self.asset.uid}/attachments">
+                  <label>attachments</label>
+                </upload>
+              </h:body>
+            </h:html>
+        """
+
+        instance_xml = f"""
+            <{self.asset.uid} xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="{self.asset.uid}">
+            <formhub>
+                <uuid>027e8acb31b24acebb7f6b2a74ac1ff3</uuid>
+            </formhub>
+            <attachments>audio_conversion_test_image.jpg</attachments>
+            <__version__>vd3dpf3fL2C8abWG4EPJWC</__version__>
+            <meta>
+                <instanceID>uuid:ba82fbca-9a05-45c7-afb6-295c90f838e5</instanceID>
+            </meta>
+            </{self.asset.uid}>
+        """
+
+        UserProfile.objects.get_or_create(user=self.someuser)
+        xform = XForm.objects.create(
+            user=self.someuser,
+            xml=xform_xml,
+            id_string=self.asset.uid,
+            kpi_asset_uid=self.asset.uid
+        )
+        instance = Instance.objects.create(xform=xform, xml=instance_xml)
+        attachment = Attachment.objects.create(instance=instance)
+        attachment.media_file = File(
+            open(media_file, 'rb'), upload_to(attachment, media_file)
+        )
+        attachment.save()
+
+        pi = ParsedInstance.objects.create(instance=instance)
+        self.asset.deployment.mock_submissions(
+            [pi.to_dict_for_mongo()]
+        )
+        detail_url = reverse(
+            self._get_endpoint('attachment-detail'),
+            args=(
+                self.asset.uid,
+                instance.pk,
+                attachment.pk
+            ),
+        )
+        self.client.get(detail_url)
+        filename = attachment.media_file.name.replace('.jpg', '')
+        thumbnail = f'{filename}-small.jpg'
+        # Thumbs should not exist yet
+        self.assertFalse(default_storage.exists(thumbnail))
+
+        thumb_url = reverse(
+            self._get_endpoint('attachment-thumb'),
+            args=(
+                self.asset.uid,
+                instance.pk,
+                attachment.pk,
+                'small'
+            ),
+        )
+        self.client.get(thumb_url)
+        # Thumbs should exist
+        self.assertTrue(default_storage.exists(thumbnail))
+
+        # Clean-up
+        attachment.delete()

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -134,11 +134,13 @@ class MockAttachment(AudioTranscodingMixin):
     def absolute_path(self):
         return self.media_file.path
 
-    def protected_path(self, format_: Optional[str] = None):
+    def protected_path(
+        self, format_: Optional[str] = None, size: Optional[str] = None
+    ) -> str:
         if format_ == 'mp3':
-            suffix = f'.mp3'
+            suffix = '.mp3'
             with NamedTemporaryFile(suffix=suffix) as f:
-                self.content = self.get_transcoded_audio('mp3')
+                self.content = self.get_transcoded_audio(format_)
             return f.name
         else:
             return self.absolute_path

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -9,8 +9,13 @@ from urllib.parse import parse_qs, unquote
 
 from django.conf import settings
 from django.core.files import File
+from django.core.files.storage import default_storage
 from rest_framework import status
 
+from kobo.apps.openrosa.libs.utils.image_tools import (
+    get_optimized_image_path,
+    resize,
+)
 from kpi.mixins.audio_transcoding import AudioTranscodingMixin
 from kpi.models.asset_snapshot import AssetSnapshot
 from kpi.tests.utils.xml import get_form_and_submission_tag_names
@@ -104,24 +109,40 @@ class MockAttachment(AudioTranscodingMixin):
     """
     Mock object to simulate KobocatAttachment.
     Relationship with ReadOnlyKobocatInstance is ignored but could be implemented
+
+    TODO Remove this class and use `Attachment` model everywhere in tests
     """
     def __init__(self, pk: int, filename: str, mimetype: str = None, **kwargs):
 
         self.id = pk  # To mimic Django model instances
         self.pk = pk
-        basename = os.path.basename(filename)
-        file_ = os.path.join(
-            settings.BASE_DIR,
-            'kpi',
-            'tests',
-            basename
-        )
 
-        self.media_file = File(open(file_, 'rb'), basename)
-        self.media_file.path = file_
-        self.media_file_size = os.path.getsize(file_)
+        # Unit test `test_thumbnail_creation_on_demand()` is using real `Attachment`
+        # objects while other tests are using `MockAttachment` objects.
+        # If an Attachment object exists, let's assume unit test is using real
+        # Attachment objects. Otherwise, use MockAttachment.
+        from kobo.apps.openrosa.apps.logger.models import Attachment  # Avoid circular import
+
+        attachment_object = Attachment.objects.filter(pk=pk).first()
+        if attachment_object:
+            self.media_file = attachment_object.media_file
+            self.media_file_size = attachment_object.media_file_size
+            self.media_file_basename = attachment_object.media_file_basename
+        else:
+            basename = os.path.basename(filename)
+            file_ = os.path.join(
+                settings.BASE_DIR,
+                'kpi',
+                'tests',
+                basename
+            )
+            self.media_file = File(open(file_, 'rb'), basename)
+            self.media_file.path = file_
+            self.media_file_size = os.path.getsize(file_)
+            self.media_file_basename = basename
+
         self.content = self.media_file.read()
-        self.media_file_basename = basename
+
         if not mimetype:
             self.mimetype, _ = guess_type(file_)
         else:
@@ -135,12 +156,20 @@ class MockAttachment(AudioTranscodingMixin):
         return self.media_file.path
 
     def protected_path(
-        self, format_: Optional[str] = None, size: Optional[str] = None
+        self, format_: Optional[str] = None, suffix: Optional[str] = None
     ) -> str:
         if format_ == 'mp3':
-            suffix = '.mp3'
-            with NamedTemporaryFile(suffix=suffix) as f:
+            extension = '.mp3'
+            with NamedTemporaryFile(suffix=extension) as f:
                 self.content = self.get_transcoded_audio(format_)
             return f.name
         else:
-            return self.absolute_path
+            if suffix and self.mimetype.startswith('image/'):
+                optimized_image_path = get_optimized_image_path(
+                    self.media_file.name, suffix
+                )
+                if not default_storage.exists(optimized_image_path):
+                    resize(self.media_file.name)
+                return default_storage.path(optimized_image_path)
+            else:
+                return self.absolute_path

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -71,17 +71,17 @@ class AttachmentViewSet(
             request,
             submission_id_or_uuid,
             attachment_id=pk,
-            size=kwargs.get('size'),
+            suffix=kwargs.get('suffix'),
         )
 
     @action(
         detail=True,
         methods=['GET'],
-        url_path=f'(?P<size>({thumbnail_suffixes_pattern}))'
+        url_path=f'(?P<suffix>({thumbnail_suffixes_pattern}))'
     )
-    def thumb(self, request, pk, size, *args, **kwargs):
-        if size != 'original':
-            kwargs['size'] = size
+    def thumb(self, request, pk, suffix, *args, **kwargs):
+        if suffix != 'original':
+            kwargs['suffix'] = suffix
         return self.retrieve(request, pk, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
@@ -101,7 +101,7 @@ class AttachmentViewSet(
         submission_id_or_uuid: Union[str, int],
         attachment_id: Optional[int] = None,
         xpath: Optional[str] = None,
-        size: Optional[str] = None,
+        suffix: Optional[str] = None,
     ) -> Response:
 
         try:
@@ -122,7 +122,7 @@ class AttachmentViewSet(
         try:
             protected_path = attachment.protected_path(
                 format_=request.accepted_renderer.format,
-                size=size,
+                suffix=suffix,
             )
         except FFMpegException:
             raise serializers.ValidationError({

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.shortcuts import Http404
 from django.utils.translation import gettext as t
 from rest_framework import viewsets, serializers
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -19,6 +20,10 @@ from kpi.exceptions import (
 from kpi.permissions import SubmissionPermission
 from kpi.renderers import MediaFileRenderer, MP3ConversionRenderer
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
+
+thumbnail_suffixes_pattern = 'original|' + '|'.join(
+    [suffix for suffix in settings.THUMB_CONF]
+)
 
 
 class AttachmentViewSet(
@@ -62,7 +67,22 @@ class AttachmentViewSet(
         # Since endpoint is needed for KobocatDeploymentBackend to overwrite
         # Mongo attachments URL with their primary keys (instead of their XPath)
         submission_id_or_uuid = kwargs['parent_lookup_data']
-        return self._get_response(request, submission_id_or_uuid, attachment_id=pk)
+        return self._get_response(
+            request,
+            submission_id_or_uuid,
+            attachment_id=pk,
+            size=kwargs.get('size'),
+        )
+
+    @action(
+        detail=True,
+        methods=['GET'],
+        url_path=f'(?P<size>({thumbnail_suffixes_pattern}))'
+    )
+    def thumb(self, request, pk, size, *args, **kwargs):
+        if size != 'original':
+            kwargs['size'] = size
+        return self.retrieve(request, pk, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
         submission_id_or_uuid = kwargs['parent_lookup_data']
@@ -81,6 +101,7 @@ class AttachmentViewSet(
         submission_id_or_uuid: Union[str, int],
         attachment_id: Optional[int] = None,
         xpath: Optional[str] = None,
+        size: Optional[str] = None,
     ) -> Response:
 
         try:
@@ -100,7 +121,8 @@ class AttachmentViewSet(
 
         try:
             protected_path = attachment.protected_path(
-                request.accepted_renderer.format
+                format_=request.accepted_renderer.format,
+                size=size,
             )
         except FFMpegException:
             raise serializers.ValidationError({


### PR DESCRIPTION
## Description

The API `v2` exposes `large`, `medium`, `small` versions of image attachments. 

## Notes

All the links were pointing to the same file without any resizing while using API `v2` since the code was sitting in Kobocat repo. Having the code available in the same repo now let us call the code that resize the images on the fly, 


