### PR TITLE
[TASK-599] Transcript and translation UI properly respects permissions on the frontend

### DIFF
--- a/jsapp/js/components/processing/transcript/stepBegin.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepBegin.component.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import Button from 'js/components/common/button';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import {hasManagePermissionsToCurrentAsset} from '../analysis/utils';
 
 export default function StepBegin() {
   function begin() {
@@ -28,6 +29,7 @@ export default function StepBegin() {
         size='l'
         label={t('begin')}
         onClick={begin}
+        isDisabled={!hasManagePermissionsToCurrentAsset()}
       />
     </div>
   );

--- a/jsapp/js/components/processing/transcript/stepEditor.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepEditor.component.tsx
@@ -4,6 +4,7 @@ import Button from 'js/components/common/button';
 import singleProcessingStore from 'js/components/processing/singleProcessingStore';
 import HeaderLanguageAndDate from './headerLanguageAndDate.component';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import {hasManagePermissionsToCurrentAsset} from '../analysis/utils';
 
 export default function StepEditor() {
   function discardDraft() {
@@ -45,7 +46,10 @@ export default function StepEditor() {
             size='s'
             label={discardLabel}
             onClick={discardDraft}
-            isDisabled={singleProcessingStore.data.isFetchingData}
+            isDisabled={
+              singleProcessingStore.data.isFetchingData ||
+              !hasManagePermissionsToCurrentAsset()
+            }
           />
 
           <Button
@@ -55,7 +59,10 @@ export default function StepEditor() {
             label={t('Save')}
             onClick={saveDraft}
             isPending={singleProcessingStore.data.isFetchingData}
-            isDisabled={!singleProcessingStore.hasUnsavedTranscriptDraftValue()}
+            isDisabled={
+              !singleProcessingStore.hasUnsavedTranscriptDraftValue() ||
+              !hasManagePermissionsToCurrentAsset
+            }
           />
         </nav>
       </header>

--- a/jsapp/js/components/processing/transcript/stepEditor.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepEditor.component.tsx
@@ -61,7 +61,7 @@ export default function StepEditor() {
             isPending={singleProcessingStore.data.isFetchingData}
             isDisabled={
               !singleProcessingStore.hasUnsavedTranscriptDraftValue() ||
-              !hasManagePermissionsToCurrentAsset
+              !hasManagePermissionsToCurrentAsset()
             }
           />
         </nav>

--- a/jsapp/js/components/processing/transcript/stepViewer.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepViewer.component.tsx
@@ -4,6 +4,7 @@ import singleProcessingStore from 'js/components/processing/singleProcessingStor
 import HeaderLanguageAndDate from './headerLanguageAndDate.component';
 import {destroyConfirm} from 'js/alertify';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import {hasManagePermissionsToCurrentAsset} from '../analysis/utils';
 
 export default function StepViewer() {
   function openEditor() {
@@ -34,7 +35,10 @@ export default function StepViewer() {
             startIcon='edit'
             onClick={openEditor}
             tooltip={t('Edit')}
-            isDisabled={singleProcessingStore.data.isFetchingData}
+            isDisabled={
+              singleProcessingStore.data.isFetchingData ||
+              !hasManagePermissionsToCurrentAsset()
+            }
           />
 
           <Button
@@ -45,6 +49,7 @@ export default function StepViewer() {
             onClick={deleteTranscript}
             tooltip={t('Delete')}
             isPending={singleProcessingStore.data.isFetchingData}
+            isDisabled={!hasManagePermissionsToCurrentAsset()}
           />
         </nav>
       </header>

--- a/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
+++ b/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
@@ -5,6 +5,7 @@ import HeaderLanguageAndDate from './headerLanguageAndDate.component';
 import type {LanguageCode} from 'js/components/languages/languagesStore';
 import {destroyConfirm} from 'js/alertify';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import {hasManagePermissionsToCurrentAsset} from '../analysis/utils';
 
 interface StepSingleViewerProps {
   /** Uses languageCode. */
@@ -64,7 +65,10 @@ export default function StepSingleViewer(props: StepSingleViewerProps) {
             startIcon='plus'
             label={t('new translation')}
             onClick={addTranslation}
-            isDisabled={singleProcessingStore.data.isFetchingData}
+            isDisabled={
+              singleProcessingStore.data.isFetchingData ||
+              !hasManagePermissionsToCurrentAsset()
+            }
           />
 
           <Button
@@ -74,7 +78,10 @@ export default function StepSingleViewer(props: StepSingleViewerProps) {
             startIcon='edit'
             onClick={openEditor}
             tooltip={t('Edit')}
-            isDisabled={singleProcessingStore.data.isFetchingData}
+            isDisabled={
+              !hasManagePermissionsToCurrentAsset() ||
+              singleProcessingStore.data.isFetchingData
+            }
           />
 
           <Button
@@ -84,7 +91,12 @@ export default function StepSingleViewer(props: StepSingleViewerProps) {
             startIcon='trash'
             onClick={deleteTranslation}
             tooltip={t('Delete')}
-            isPending={singleProcessingStore.data.isFetchingData}
+            isPending={
+              singleProcessingStore.data.isFetchingData
+            }
+            isDisabled={
+              !hasManagePermissionsToCurrentAsset()
+            }
           />
         </div>
       </header>

--- a/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
+++ b/jsapp/js/components/processing/translations/stepSingleViewer.component.tsx
@@ -79,8 +79,8 @@ export default function StepSingleViewer(props: StepSingleViewerProps) {
             onClick={openEditor}
             tooltip={t('Edit')}
             isDisabled={
-              !hasManagePermissionsToCurrentAsset() ||
-              singleProcessingStore.data.isFetchingData
+              singleProcessingStore.data.isFetchingData ||
+              !hasManagePermissionsToCurrentAsset()
             }
           />
 
@@ -91,12 +91,8 @@ export default function StepSingleViewer(props: StepSingleViewerProps) {
             startIcon='trash'
             onClick={deleteTranslation}
             tooltip={t('Delete')}
-            isPending={
-              singleProcessingStore.data.isFetchingData
-            }
-            isDisabled={
-              !hasManagePermissionsToCurrentAsset()
-            }
+            isPending={singleProcessingStore.data.isFetchingData}
+            isDisabled={!hasManagePermissionsToCurrentAsset()}
           />
         </div>
       </header>


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The edit and delete buttons as well as the 'begin'` button on the transcirpt/translation pages now are greyed out if the user does not have the sufficient permissions.
## Notes

Made the permissions match the ones needed to edit the analysis questions: `manage_asset` as that was already used in the analysis questions tab. The notion page says to use `change_submissions`.
