### PR TITLE
Tolerate submissions that lack `<formhub><uuid>`

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -193,6 +193,11 @@ class BaseDeploymentBackend(abc.ABC):
     def connect(self, active=False):
         pass
 
+    @property
+    @abc.abstractmethod
+    def form_uuid(self):
+        pass
+
     @abc.abstractmethod
     def nlp_tracking_data(self, start_date: Optional[datetime.date] = None):
         pass
@@ -793,7 +798,8 @@ class BaseDeploymentBackend(abc.ABC):
             attachment['filename'] = os.path.join(
                 self.asset.owner.username,
                 'attachments',
-                submission['formhub/uuid'],
+                # KoboCAT accepts submissions even when they lack `formhub/uuid`
+                self.form_uuid or submission['formhub/uuid'],
                 submission['_uuid'],
                 os.path.basename(filename)
             )

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -173,6 +173,16 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             }
         )
 
+    @property
+    def form_uuid(self):
+        try:
+            return self.backend_response['uuid']
+        except KeyError:
+            logging.warning(
+                'KoboCAT backend response has no `uuid`', exc_info=True
+            )
+            return None
+
     @staticmethod
     def nlp_tracking_data(asset_ids, start_date=None):
         """

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -95,6 +95,10 @@ class MockDeploymentBackend(BaseDeploymentBackend):
             'version': self.asset.version_id,
         })
 
+    @property
+    def form_uuid(self):
+        return 'formhub-uuid'  # to match existing tests
+
     def nlp_tracking_data(self, start_date=None):
         """
         Get the NLP tracking data since a specified date


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes a 500 error when trying to access submission data in projects where one or more submissions has non-standard XML.

## Notes

These are accepted by KoboCAT but were breaking the submission API because the logic to rewrite attachment URLs required `formhub/uuid` to be present in the JSON submission representation.

This change tries first to read the form UUID from the KoboCAT API response stored at the asset level (`deployment.backend_response`) and, if that's somehow missing, only then does it attempt to read the UUID from the submission.