### PR TITLE
Fix error in `password_date_changed` search example

### DIFF
--- a/hub/templates/admin/password_validation_advanced_search_filter.html
+++ b/hub/templates/admin/password_validation_advanced_search_filter.html
@@ -18,7 +18,7 @@
     <pre>AND date_joined__date__lt:2023-03-01</pre>
   </li>
   <li>Same as above, but more accurate version with time:
-    <pre>extra_details__last_password_date_changed__lt:2023-03-01T12:00:00</pre>
+    <pre>extra_details__password_date_changed__lt:2023-03-01T12:00:00</pre>
     <pre>AND date_joined__date__lt:2023-03-01:2023-03-01T12:00:00</pre>
   </li>
   <li><b>Fields:</b></li>


### PR DESCRIPTION
## Description

Correct one of three examples in the admin interface for searching for users by the date they last changed their password.