### PR TITLE
Fix "Make public" button

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -103,9 +103,6 @@ permissionsActions.assignAssetPermission.completed.listen((uid) => {
 permissionsActions.copyPermissionsFrom.completed.listen((sourceUid, targetUid) => {
   actions.resources.loadAsset({id: targetUid});
 });
-permissionsActions.setAssetPublic.completed.listen((uid) => {
-  actions.resources.loadAsset({id: uid});
-});
 permissionsActions.removeAssetPermission.completed.listen((uid, isNonOwner) => {
   // Avoid this call if a non-owner removed their own permissions as it will fail
   if (!isNonOwner) {

--- a/jsapp/js/components/common/button.scss
+++ b/jsapp/js/components/common/button.scss
@@ -219,6 +219,20 @@ $button-border-radius: sizes.$x6;
   justify-content: center;
 }
 
+// teal button ↓
+
+.k-button.k-button--color-teal.k-button--type-bare {
+  @include button-bare(colors.$kobo-teal, colors.$kobo-hover-teal);
+}
+
+.k-button.k-button--color-teal.k-button--type-frame {
+  @include button-frame(colors.$kobo-teal);
+}
+
+.k-button.k-button--color-teal.k-button--type-full {
+  @include button-full(colors.$kobo-teal, colors.$kobo-hover-teal);
+}
+
 // blue button ↓
 
 .k-button.k-button--color-blue.k-button--type-bare {

--- a/jsapp/js/components/common/button.tsx
+++ b/jsapp/js/components/common/button.tsx
@@ -20,6 +20,7 @@ import {useId} from 'js/hooks/useId.hook';
  */
 export type ButtonType = 'bare' | 'frame' | 'full';
 export type ButtonColor =
+  | 'teal'
   | 'blue'
   | 'light-blue'
   | 'red'


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes "Make public"/"Make private" button for collection that was being frozen in pending state indefinitely.

## Notes

Reproduction:
1. Got to "My Library"
2. Enter a collection
3. Make sure collection has all required meta fields
4. Click "Make public"
5. Notice that button is grayed out (meaning pending) forever :bug:

Things changed:
- New `teal` color for `Button` (needed for public collections)
- Updated `AssetPublicButton` component:
  - Replaced deprecated buttons with the common `Button` component
  - Now button is clearly pending when doing things (previously it looked disabled)
  - Moved `isAwaitingFreshPermissions` flow from `actions.es6` into the component
  - Added some commments

The problem was because of the asset caching, as this component relies on getting fresh asset after the public status of collections is changed. Thus `, true)` was added to `actions.resources.loadAsset` call.

## Related issues

Built atop #4961 