### PR TITLE
Make fullscreen components appear over drawer

### DIFF
--- a/jsapp/scss/z-indexes.scss
+++ b/jsapp/scss/z-indexes.scss
@@ -6,7 +6,8 @@ $z-help-bubble-popup: 2000;
 
 $z-account-menu: 1101;
 
-$z-form-builder-wrapper: 1051;
+$z-form-builder-wrapper: 1052;
+$z-fullscreen: 1051;
 $z-kobo-drawer: 1050; // must be over leaflet
 
 $z-map-overlay: 1001; // leaflet interface elements
@@ -17,7 +18,6 @@ $z-map-settings-3: 701;
 
 $z-dropzone: 200;
 $z-form-builder-add-row: 101;
-$z-fullscreen: 101;
 $z-dropdown: 100;
 
 $z-processing-top: 80;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes a problem introduced recently that made the Drawer appearing over fullscreen components.

## Notes

Fixes this:
<img width="937" alt="Screenshot 2024-06-04 at 18 10 44" src="https://github.com/kobotoolbox/kpi/assets/2521888/25a2304d-953d-47b5-ad14-aa94e66c201c">

I've changed the order of `z-indexes` bringing the fullscreen one above drawer. We have multiple places that were broken:
- My Library
- Public Collections
- Single Collection
- Data Map
- Data Reports
- Data Table
- Data Gallery

Each of these has a "Toggle fulscreen" button (either with label or just an icon: https://github.com/kobotoolbox/kpi/blob/main/jsapp/svg-icons/expand.svg)

## Related issues
