### PR TITLE
Billing: Fix update logic for exceeding limits hook

### DIFF
--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -87,9 +87,10 @@ export const useExceedingLimits = () => {
 
   // Check if usage is more than limit
   useEffect(() => {
-    if ((!usageStatus.error && !usageStatus.pending) || !areLimitsLoaded) {
+    if (usageStatus.error || usageStatus.pending || !areLimitsLoaded) {
       return;
     }
+    setExceedList(() => []);
     isOverLimit(subscribedStorageLimit, usage.storage, 'storage');
     isOverLimit(subscribedSubmissionLimit, usage.submissions, 'submission');
     isOverLimit(


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Some quick fixes for the over-limit notification banner:

1. Adjusts the useEffect boolean logic for when to update the list of over limit usage types. New logic is to skip updates when there are errors from the usage context, usage status is still pending, or limits have not been loaded. Prior to this fix, the banner would not display at all on the usage page (though it would display on the main projects table page).

2. Clear the exceeded limit list before setting it again. We want to start from a fresh list (empty array) whenever we updated it, instead of adding to a previously calculated list.

