### PR TITLE
[TASK-814] [TASK-815] [TASK-816] Make sharing modal accessible from project view list

### DIFF
--- a/jsapp/js/components/anonymousSubmission.component.tsx
+++ b/jsapp/js/components/anonymousSubmission.component.tsx
@@ -7,6 +7,7 @@ import styles from './anonymousSubmission.module.scss';
 
 interface AnonymousSubmissionProps {
   checked: boolean;
+  disabled: boolean;
   onChange: (isChecked: boolean) => void;
 }
 
@@ -15,6 +16,7 @@ export default function AnonymousSubmission(props: AnonymousSubmissionProps) {
     <div className={styles.root}>
       <ToggleSwitch
         checked={props.checked}
+        disabled={props.disabled}
         onChange={props.onChange}
         label={t(
           'Allow submissions to this form without a username and password'

--- a/jsapp/js/components/common/toggleSwitch.scss
+++ b/jsapp/js/components/common/toggleSwitch.scss
@@ -10,7 +10,7 @@
     cursor: pointer;
   }
 
-  .toggle-switch__wrapper.toggle-switch__wrapper--is-disabled {
+  &.toggle-switch--is-disabled .toggle-switch__wrapper {
     cursor: default;
   }
 

--- a/jsapp/js/components/common/toggleSwitch.scss
+++ b/jsapp/js/components/common/toggleSwitch.scss
@@ -1,5 +1,5 @@
 @use '~kobo-common/src/styles/colors';
-@use "scss/_variables";
+@use 'scss/_variables';
 
 .toggle-switch {
   position: relative;
@@ -8,6 +8,10 @@
 
   .toggle-switch__wrapper {
     cursor: pointer;
+  }
+
+  .toggle-switch__wrapper.toggle-switch__wrapper--is-disabled {
+    cursor: default;
   }
 
   input {
@@ -31,7 +35,7 @@
 
     &::before {
       position: absolute;
-      content: "";
+      content: '';
       height: 16px;
       width: 16px;
       left: 2px;

--- a/jsapp/js/components/common/toggleSwitch.tsx
+++ b/jsapp/js/components/common/toggleSwitch.tsx
@@ -21,11 +21,6 @@ class ToggleSwitch extends React.Component<ToggleSwitchProps, {}> {
   }
 
   render() {
-    const modifiers = [];
-    if (this.props.disabled) {
-      modifiers.push('is-disabled');
-    }
-
     return (
       <bem.ToggleSwitch>
         <bem.ToggleSwitch__wrapper m={this.props.disabled ? 'is-disabled' : ''}>

--- a/jsapp/js/components/common/toggleSwitch.tsx
+++ b/jsapp/js/components/common/toggleSwitch.tsx
@@ -21,9 +21,14 @@ class ToggleSwitch extends React.Component<ToggleSwitchProps, {}> {
   }
 
   render() {
+    const modifiers = [];
+    if (this.props.disabled) {
+      modifiers.push('is-disabled');
+    }
+
     return (
       <bem.ToggleSwitch>
-        <bem.ToggleSwitch__wrapper>
+        <bem.ToggleSwitch__wrapper m={this.props.disabled ? 'is-disabled' : ''}>
           <bem.ToggleSwitch__input
             type='checkbox'
             name={this.props.name}
@@ -33,15 +38,13 @@ class ToggleSwitch extends React.Component<ToggleSwitchProps, {}> {
             disabled={this.props.disabled}
             data-cy={this.props['data-cy']}
           />
-          <bem.ToggleSwitch__slider
-            disabled={this.props.disabled}
-          />
+          <bem.ToggleSwitch__slider disabled={this.props.disabled} />
 
-          {this.props.label &&
+          {this.props.label && (
             <bem.ToggleSwitch__label htmlFor={this.props.id}>
               {this.props.label}
             </bem.ToggleSwitch__label>
-          }
+          )}
         </bem.ToggleSwitch__wrapper>
       </bem.ToggleSwitch>
     );

--- a/jsapp/js/components/common/toggleSwitch.tsx
+++ b/jsapp/js/components/common/toggleSwitch.tsx
@@ -22,8 +22,8 @@ class ToggleSwitch extends React.Component<ToggleSwitchProps, {}> {
 
   render() {
     return (
-      <bem.ToggleSwitch>
-        <bem.ToggleSwitch__wrapper m={this.props.disabled ? 'is-disabled' : ''}>
+      <bem.ToggleSwitch m={this.props.disabled ? 'is-disabled' : ''}>
+        <bem.ToggleSwitch__wrapper>
           <bem.ToggleSwitch__input
             type='checkbox'
             name={this.props.name}

--- a/jsapp/js/components/permissions/publicShareSettings.component.tsx
+++ b/jsapp/js/components/permissions/publicShareSettings.component.tsx
@@ -22,6 +22,7 @@ interface PublicShareSettingsProps {
   publicPerms: PermissionResponse[];
   assetUid: string;
   deploymentActive: boolean;
+  disableControls: boolean;
 }
 
 class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
@@ -87,6 +88,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
           >
             <AnonymousSubmission
               checked={anonCanAddData}
+              disabled={this.props.disableControls}
               onChange={this.togglePerms.bind(this, 'add_submissions')}
             />
           </NewFeatureDialog>
@@ -99,6 +101,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
         <bem.FormModal__item>
           <Checkbox
             checked={anonCanView}
+            disabled={this.props.disableControls}
             onChange={this.togglePerms.bind(this, 'view_asset')}
             label={t('Anyone can view this form')}
           />
@@ -108,6 +111,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
           <bem.FormModal__item>
             <Checkbox
               checked={anonCanViewData}
+              disabled={this.props.disableControls}
               onChange={this.togglePerms.bind(this, 'view_submissions')}
               label={t('Anyone can view submissions made to this form')}
             />

--- a/jsapp/js/components/permissions/publicShareSettings.component.tsx
+++ b/jsapp/js/components/permissions/publicShareSettings.component.tsx
@@ -9,11 +9,7 @@ import {ROOT_URL} from 'js/constants';
 import type {PermissionCodename} from './permConstants';
 import type {PermissionResponse} from 'jsapp/js/dataInterface';
 import envStore from 'js/envStore';
-import Icon from 'js/components/common/icon';
-import ToggleSwitch from 'js/components/common/toggleSwitch';
 import AnonymousSubmission from '../anonymousSubmission.component';
-import styles from 'js/components/anonymousSubmission.module.scss';
-import {stores} from 'js/stores';
 import NewFeatureDialog from 'js/components/newFeatureDialog.component';
 
 const HELP_ARTICLE_ANON_SUBMISSIONS_URL = 'managing_permissions.html';
@@ -22,7 +18,7 @@ interface PublicShareSettingsProps {
   publicPerms: PermissionResponse[];
   assetUid: string;
   deploymentActive: boolean;
-  disableControls: boolean;
+  userCanShare: boolean;
 }
 
 class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
@@ -88,7 +84,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
           >
             <AnonymousSubmission
               checked={anonCanAddData}
-              disabled={this.props.disableControls}
+              disabled={!this.props.userCanShare}
               onChange={this.togglePerms.bind(this, 'add_submissions')}
             />
           </NewFeatureDialog>
@@ -101,7 +97,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
         <bem.FormModal__item>
           <Checkbox
             checked={anonCanView}
-            disabled={this.props.disableControls}
+            disabled={!this.props.userCanShare}
             onChange={this.togglePerms.bind(this, 'view_asset')}
             label={t('Anyone can view this form')}
           />
@@ -111,7 +107,7 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
           <bem.FormModal__item>
             <Checkbox
               checked={anonCanViewData}
-              disabled={this.props.disableControls}
+              disabled={!this.props.userCanShare}
               onChange={this.togglePerms.bind(this, 'view_submissions')}
               label={t('Anyone can view submissions made to this form')}
             />

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -174,7 +174,7 @@ export default class SharingForm extends React.Component<
   }
 
   /** Display pending owner if not already included in list of user permissions */
-  renderPendingOwner(displayControls: boolean) {
+  renderPendingOwner(userCanEditPerms: boolean) {
     if (
       this.state.asset?.project_ownership?.status ===
         TransferStatuses.Pending &&
@@ -186,7 +186,7 @@ export default class SharingForm extends React.Component<
       return (
         <UserPermissionRow
           assetUid={this.props.assetUid}
-          displayControls={displayControls}
+          userCanEditPerms={userCanEditPerms}
           nonOwnerPerms={this.state.nonOwnerPerms}
           assignablePerms={this.state.assignablePerms}
           permissions={[]}
@@ -252,7 +252,7 @@ export default class SharingForm extends React.Component<
               <UserPermissionRow
                 key={`perm.${this.props.assetUid}.${perm.user.name}`}
                 assetUid={this.props.assetUid}
-                displayControls={isManagingPossible}
+                userCanEditPerms={isManagingPossible}
                 nonOwnerPerms={this.state.nonOwnerPerms}
                 assignablePerms={this.state.assignablePerms}
                 permissions={perm.permissions}
@@ -303,7 +303,7 @@ export default class SharingForm extends React.Component<
                 publicPerms={this.state.publicPerms}
                 assetUid={this.props.assetUid}
                 deploymentActive={this.state.asset.deployment__active}
-                disableControls={!isManagingPossible}
+                userCanShare={isManagingPossible}
               />
             </bem.FormModal__item>
           </>

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -8,6 +8,7 @@ import bem from 'js/bem';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import Button from 'js/components/common/button';
 import InlineMessage from 'js/components/common/inlineMessage';
+import {userCan} from 'js/components/permissions/utils';
 import {replaceBracketsWithLink} from 'js/textUtils';
 import {ANON_USERNAME, ANON_USERNAME_URL} from 'js/users/utils';
 import {ASSET_TYPES} from 'js/constants';
@@ -173,7 +174,7 @@ export default class SharingForm extends React.Component<
   }
 
   /** Display pending owner if not already included in list of user permissions */
-  renderPendingOwner() {
+  renderPendingOwner(displayControls: boolean) {
     if (
       this.state.asset?.project_ownership?.status ===
         TransferStatuses.Pending &&
@@ -185,6 +186,7 @@ export default class SharingForm extends React.Component<
       return (
         <UserPermissionRow
           assetUid={this.props.assetUid}
+          displayControls={displayControls}
           nonOwnerPerms={this.state.nonOwnerPerms}
           assignablePerms={this.state.assignablePerms}
           permissions={[]}
@@ -204,6 +206,7 @@ export default class SharingForm extends React.Component<
     }
 
     const assetType = this.state.asset.asset_type;
+    const isManagingPossible = userCan('manage_asset', this.state.asset);
 
     const isRequireAuthWarningVisible =
       'extra_details' in sessionStore.currentAccount &&
@@ -249,6 +252,7 @@ export default class SharingForm extends React.Component<
               <UserPermissionRow
                 key={`perm.${this.props.assetUid}.${perm.user.name}`}
                 assetUid={this.props.assetUid}
+                displayControls={isManagingPossible}
                 nonOwnerPerms={this.state.nonOwnerPerms}
                 assignablePerms={this.state.assignablePerms}
                 permissions={perm.permissions}
@@ -258,11 +262,12 @@ export default class SharingForm extends React.Component<
               />
             );
           })}
-          {this.renderPendingOwner()}
+          {this.renderPendingOwner(isManagingPossible)}
 
           {!this.state.isAddUserEditorVisible && (
             <Button
               color='blue'
+              isDisabled={!isManagingPossible}
               type='full'
               size='l'
               onClick={this.toggleAddUserEditor.bind(this)}
@@ -298,26 +303,31 @@ export default class SharingForm extends React.Component<
                 publicPerms={this.state.publicPerms}
                 assetUid={this.props.assetUid}
                 deploymentActive={this.state.asset.deployment__active}
+                disableControls={!isManagingPossible}
               />
             </bem.FormModal__item>
           </>
         )}
 
         {/* copying permissions from other assets */}
-        {assetType !== ASSET_TYPES.collection.id &&
-          this.state.allAssetsCount === 0 && (
-            <>
-              <bem.Modal__hr />
-              {t('Waiting for all projects to load…')}
-            </>
-          )}
-        {assetType !== ASSET_TYPES.collection.id &&
-          this.state.allAssetsCount >= 2 && (
-            <>
-              <bem.Modal__hr />
-              <CopyTeamPermissions assetUid={this.props.assetUid} />
-            </>
-          )}
+        {isManagingPossible && (
+          <>
+            {assetType !== ASSET_TYPES.collection.id &&
+              this.state.allAssetsCount === 0 && (
+                <>
+                  <bem.Modal__hr />
+                  {t('Waiting for all projects to load…')}
+                </>
+              )}
+            {assetType !== ASSET_TYPES.collection.id &&
+              this.state.allAssetsCount >= 2 && (
+                <>
+                  <bem.Modal__hr />
+                  <CopyTeamPermissions assetUid={this.props.assetUid} />
+                </>
+              )}
+          </>
+        )}
       </bem.FormModal>
     );
   }

--- a/jsapp/js/components/permissions/userPermissionRow.component.tsx
+++ b/jsapp/js/components/permissions/userPermissionRow.component.tsx
@@ -12,6 +12,7 @@ import {getPermLabel, getFriendlyPermName} from './utils';
 
 interface UserPermissionRowProps {
   assetUid: string;
+  displayControls: boolean;
   nonOwnerPerms: PermissionBase[];
   assignablePerms: AssignablePermsMap;
   permissions: PermissionResponse[];
@@ -163,27 +164,29 @@ export default class UserPermissionRow extends React.Component<
             <bem.UserRow__perms>{t('Pending owner')}</bem.UserRow__perms>
           )}
 
-          {!this.props.isUserOwner && !this.props.isPendingOwner && (
-            <React.Fragment>
-              {this.renderPermissions(this.props.permissions)}
+          {this.props.displayControls &&
+            !this.props.isUserOwner &&
+            !this.props.isPendingOwner && (
+              <React.Fragment>
+                {this.renderPermissions(this.props.permissions)}
 
-              <bem.Button m='icon' onClick={this.toggleEditForm.bind(this)}>
-                {this.state.isEditFormVisible && (
-                  <i className='k-icon k-icon-close' />
-                )}
-                {!this.state.isEditFormVisible && (
-                  <i className='k-icon k-icon-edit' />
-                )}
-              </bem.Button>
+                <bem.Button m='icon' onClick={this.toggleEditForm.bind(this)}>
+                  {this.state.isEditFormVisible && (
+                    <i className='k-icon k-icon-close' />
+                  )}
+                  {!this.state.isEditFormVisible && (
+                    <i className='k-icon k-icon-edit' />
+                  )}
+                </bem.Button>
 
-              <bem.Button
-                m='icon'
-                onClick={this.showRemovePermissionsPrompt.bind(this)}
-              >
-                <i className='k-icon k-icon-trash' />
-              </bem.Button>
-            </React.Fragment>
-          )}
+                <bem.Button
+                  m='icon'
+                  onClick={this.showRemovePermissionsPrompt.bind(this)}
+                >
+                  <i className='k-icon k-icon-trash' />
+                </bem.Button>
+              </React.Fragment>
+            )}
         </bem.UserRow__info>
 
         {this.state.isEditFormVisible && (

--- a/jsapp/js/components/permissions/userPermissionRow.component.tsx
+++ b/jsapp/js/components/permissions/userPermissionRow.component.tsx
@@ -12,7 +12,7 @@ import {getPermLabel, getFriendlyPermName} from './utils';
 
 interface UserPermissionRowProps {
   assetUid: string;
-  displayControls: boolean;
+  userCanEditPerms: boolean;
   nonOwnerPerms: PermissionBase[];
   assignablePerms: AssignablePermsMap;
   permissions: PermissionResponse[];
@@ -164,29 +164,30 @@ export default class UserPermissionRow extends React.Component<
             <bem.UserRow__perms>{t('Pending owner')}</bem.UserRow__perms>
           )}
 
-          {this.props.displayControls &&
-            !this.props.isUserOwner &&
-            !this.props.isPendingOwner && (
-              <React.Fragment>
-                {this.renderPermissions(this.props.permissions)}
+          {!this.props.isUserOwner && !this.props.isPendingOwner && (
+            <React.Fragment>
+              {this.renderPermissions(this.props.permissions)}
+              {this.props.userCanEditPerms && (
+                <>
+                  <bem.Button m='icon' onClick={this.toggleEditForm.bind(this)}>
+                    {this.state.isEditFormVisible && (
+                      <i className='k-icon k-icon-close' />
+                    )}
+                    {!this.state.isEditFormVisible && (
+                      <i className='k-icon k-icon-edit' />
+                    )}
+                  </bem.Button>
 
-                <bem.Button m='icon' onClick={this.toggleEditForm.bind(this)}>
-                  {this.state.isEditFormVisible && (
-                    <i className='k-icon k-icon-close' />
-                  )}
-                  {!this.state.isEditFormVisible && (
-                    <i className='k-icon k-icon-edit' />
-                  )}
-                </bem.Button>
-
-                <bem.Button
-                  m='icon'
-                  onClick={this.showRemovePermissionsPrompt.bind(this)}
-                >
-                  <i className='k-icon k-icon-trash' />
-                </bem.Button>
-              </React.Fragment>
-            )}
+                  <bem.Button
+                    m='icon'
+                    onClick={this.showRemovePermissionsPrompt.bind(this)}
+                  >
+                    <i className='k-icon k-icon-trash' />
+                  </bem.Button>
+                </>
+              )}
+            </React.Fragment>
+          )}
         </bem.UserRow__info>
 
         {this.state.isEditFormVisible && (

--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -111,7 +111,10 @@ function CustomViewRoute() {
 
         {selectedAssets.length === 1 && (
           <div className={styles.actions}>
-            <ProjectQuickActions asset={selectedAssets[0]} />
+            <ProjectQuickActions
+              asset={selectedAssets[0]}
+              isProjectView={true}
+            />
           </div>
         )}
 

--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -113,7 +113,6 @@ function CustomViewRoute() {
           <div className={styles.actions}>
             <ProjectQuickActions
               asset={selectedAssets[0]}
-              isProjectView={true}
             />
           </div>
         )}

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -193,10 +193,7 @@ function MyProjectsRoute() {
 
           {selectedAssets.length === 1 && (
             <div className={styles.actions}>
-              <ProjectQuickActions
-                asset={selectedAssets[0]}
-                isProjectView={false}
-              />
+              <ProjectQuickActions asset={selectedAssets[0]} />
             </div>
           )}
 

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -193,7 +193,10 @@ function MyProjectsRoute() {
 
           {selectedAssets.length === 1 && (
             <div className={styles.actions}>
-              <ProjectQuickActions asset={selectedAssets[0]} />
+              <ProjectQuickActions
+                asset={selectedAssets[0]}
+                isProjectView={false}
+              />
             </div>
           )}
 

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -19,20 +19,20 @@ import customViewStore from 'js/projects/customViewStore';
 
 interface ProjectQuickActionsProps {
   asset: AssetResponse | ProjectViewAsset;
-  isProjectView?: boolean;
 }
 
 /**
  * Quick Actions (Archive, Share, Delete) buttons. Use these when a single
  * project is selected in the Project Table.
  */
-const ProjectQuickActions = ({asset, isProjectView = false}: ProjectQuickActionsProps) => {
+const ProjectQuickActions = ({asset}: ProjectQuickActionsProps) => {
   // The `userCan` method requires `permissions` property to be present in the
   // `asset` object. For performance reasons `ProjectViewAsset` doesn't have
   // that property, and it is fine, as we don't expect Project View to have
   // a lot of options available.
   const isChangingPossible = userCan('change_asset', asset);
   const isManagingPossible = userCan('manage_asset', asset);
+  const isProjectViewAsset = !("permissions" in asset);
 
   return (
     <div className={styles.root}>
@@ -94,7 +94,7 @@ const ProjectQuickActions = ({asset, isProjectView = false}: ProjectQuickActions
 
       {/* Share */}
       <Button
-        isDisabled={!isManagingPossible && !isProjectView}
+        isDisabled={!isManagingPossible && !isProjectViewAsset}
         type='bare'
         color='storm'
         size='s'

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -19,6 +19,7 @@ import customViewStore from 'js/projects/customViewStore';
 
 interface ProjectQuickActionsProps {
   asset: AssetResponse | ProjectViewAsset;
+  isProjectView: boolean;
 }
 
 /**
@@ -93,7 +94,7 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
 
       {/* Share */}
       <Button
-        isDisabled={!isManagingPossible}
+        isDisabled={!isManagingPossible && !props.isProjectView}
         type='bare'
         color='storm'
         size='s'

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -19,38 +19,38 @@ import customViewStore from 'js/projects/customViewStore';
 
 interface ProjectQuickActionsProps {
   asset: AssetResponse | ProjectViewAsset;
-  isProjectView: boolean;
+  isProjectView?: boolean;
 }
 
 /**
  * Quick Actions (Archive, Share, Delete) buttons. Use these when a single
  * project is selected in the Project Table.
  */
-export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
+const ProjectQuickActions = ({asset, isProjectView = false}: ProjectQuickActionsProps) => {
   // The `userCan` method requires `permissions` property to be present in the
   // `asset` object. For performance reasons `ProjectViewAsset` doesn't have
   // that property, and it is fine, as we don't expect Project View to have
   // a lot of options available.
-  const isChangingPossible = userCan('change_asset', props.asset);
-  const isManagingPossible = userCan('manage_asset', props.asset);
+  const isChangingPossible = userCan('change_asset', asset);
+  const isManagingPossible = userCan('manage_asset', asset);
 
   return (
     <div className={styles.root}>
       {/* Archive / Unarchive */}
       {/* Archive a deployed project */}
-      {props.asset.deployment_status === 'deployed' && (
+      {asset.deployment_status === 'deployed' && (
         <Button
           isDisabled={
             !isChangingPossible ||
-            props.asset.asset_type !== ASSET_TYPES.survey.id ||
-            !props.asset.has_deployment
+            asset.asset_type !== ASSET_TYPES.survey.id ||
+            !asset.has_deployment
           }
           type='bare'
           color='storm'
           size='s'
           startIcon='archived'
           onClick={() =>
-            archiveAsset(props.asset, (response: DeploymentResponse) => {
+            archiveAsset(asset, (response: DeploymentResponse) => {
               customViewStore.handleAssetChanged(response.asset);
             })
           }
@@ -59,19 +59,19 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         />
       )}
       {/* Un-archive a deployed project */}
-      {props.asset.deployment_status === 'archived' && (
+      {asset.deployment_status === 'archived' && (
         <Button
           isDisabled={
             !isChangingPossible ||
-            props.asset.asset_type !== ASSET_TYPES.survey.id ||
-            !props.asset.has_deployment
+            asset.asset_type !== ASSET_TYPES.survey.id ||
+            !asset.has_deployment
           }
           type='bare'
           color='storm'
           size='s'
           startIcon='archived'
           onClick={() =>
-            unarchiveAsset(props.asset, (response: DeploymentResponse) => {
+            unarchiveAsset(asset, (response: DeploymentResponse) => {
               customViewStore.handleAssetChanged(response.asset);
             })
           }
@@ -80,7 +80,7 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         />
       )}
       {/* Show tooltip, since drafts can't be archived/unarchived */}
-      {props.asset.deployment_status === 'draft' && (
+      {asset.deployment_status === 'draft' && (
         <Button
           isDisabled
           type='bare'
@@ -94,12 +94,12 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
 
       {/* Share */}
       <Button
-        isDisabled={!isManagingPossible && !props.isProjectView}
+        isDisabled={!isManagingPossible && !isProjectView}
         type='bare'
         color='storm'
         size='s'
         startIcon='user-share'
-        onClick={() => manageAssetSharing(props.asset.uid)}
+        onClick={() => manageAssetSharing(asset.uid)}
         tooltip={t('Share project')}
         tooltipPosition='right'
       />
@@ -113,8 +113,8 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
         startIcon='trash'
         onClick={() =>
           deleteAsset(
-            props.asset,
-            getAssetDisplayName(props.asset).final,
+            asset,
+            getAssetDisplayName(asset).final,
             (deletedAssetUid: string) => {
               customViewStore.handleAssetsDeleted([deletedAssetUid]);
             }
@@ -128,3 +128,5 @@ export default function ProjectQuickActions(props: ProjectQuickActionsProps) {
     </div>
   );
 }
+
+export default ProjectQuickActions

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -15,9 +15,10 @@ from kobo.apps.project_views.models.project_view import ProjectView
 from kpi.constants import (
     PERM_CHANGE_ASSET,
     PERM_CHANGE_METADATA_ASSET,
+    PERM_MANAGE_ASSET,
+    PERM_PARTIAL_SUBMISSIONS,
     PERM_VIEW_ASSET,
     PERM_VIEW_SUBMISSIONS,
-    PERM_PARTIAL_SUBMISSIONS,
 )
 from kpi.models import Asset, AssetFile, AssetVersion
 from kpi.models.asset import AssetDeploymentStatus
@@ -505,6 +506,42 @@ class AssetProjectViewListApiTests(BaseAssetTestCase):
         # ensure that anotheruser can still see asset detail since has
         # `view_asset` perm assigned to view
         assert asset_res.status_code == status.HTTP_200_OK
+
+    def test_project_views_for_anotheruser_can_view_all_asset_permission_assignments(
+        self,
+    ):
+        # get the first asset from the first project view
+        self._login_as_anotheruser()
+        anotheruser = User.objects.get(username='anotheruser')
+        proj_view_list = self.client.get(self.region_views_url).data['results']
+        first_proj_view = proj_view_list[0]
+        asset_list = self.client.get(first_proj_view['assets']).data['results']
+        first_asset_entry = asset_list[0]
+        asset_obj = Asset.objects.get(uid=first_asset_entry['uid'])
+
+        # make sure any access that would allow listing permission assignments
+        # is coming exclusively from the project view
+        assert asset_obj.owner != anotheruser
+        assert not asset_obj.has_perm(anotheruser, PERM_MANAGE_ASSET)
+
+        # add a non-owner, non-anon, non-`anotheruser` perm assignment
+        new_user = User.objects.create(username='a_whole_new_user')
+        asset_obj.assign_perm(new_user, PERM_VIEW_ASSET)
+
+        # get the permission assignments from the asset detail endpoint while
+        # authenticated as `anotheruser`
+        proj_view_asset_perms = self.client.get(first_asset_entry['url']).data[
+            'permissions'
+        ]
+
+        # compare those assignments to the complete list of permission
+        # assignments seen by the asset owner
+        self.client.force_login(asset_obj.owner)
+        all_asset_perms = self.client.get(first_asset_entry['url']).data[
+            'permissions'
+        ]
+        assert proj_view_asset_perms == all_asset_perms
+
 
     def test_project_views_for_anotheruser_can_preview_form(self):
         someuser = User.objects.get(username='someuser')

--- a/kpi/utils/object_permission.py
+++ b/kpi/utils/object_permission.py
@@ -12,7 +12,7 @@ from django.shortcuts import _get_queryset
 from django_request_cache import cache_for_request
 from rest_framework import serializers
 
-from kpi.constants import PERM_MANAGE_ASSET, PERM_FROM_KC_ONLY
+from kpi.constants import PERM_VIEW_ASSET, PERM_MANAGE_ASSET, PERM_FROM_KC_ONLY
 from kpi.utils.permissions import is_user_anonymous
 
 
@@ -238,6 +238,11 @@ def get_user_permission_assignments_queryset(affected_object, user):
 
     """
 
+    # Import here to avoid circular import of `get_database_user()`, which
+    # could be moved elsewhere like `kpi.utils.permissions`, eventually. Avoid
+    # such refactoring now while large work like #4888 remains in progress.
+    from kpi.utils.project_views import user_has_project_view_asset_perm
+
     # `affected_object.permissions` is a `GenericRelation(ObjectPermission)`
     # Don't Prefetch `content_object`.
     # See `AssetPermissionAssignmentSerializer.to_representation()`
@@ -256,9 +261,14 @@ def get_user_permission_assignments_queryset(affected_object, user):
                 settings.ANONYMOUS_USER_ID,
             ]
         )
-    elif not affected_object.has_perm(user, PERM_MANAGE_ASSET):
-        # Display only users' permissions if they are not allowed to modify
-        # others' permissions
+    # Users granted the `view_asset` permission via the Project Views feature
+    # may list all permission assignments, but other users may only view a
+    # subset of non-sensitive assignments
+    elif not affected_object.has_perm(
+        user, PERM_MANAGE_ASSET
+    ) and not user_has_project_view_asset_perm(
+        affected_object, user, PERM_VIEW_ASSET
+    ):
         queryset = queryset.filter(user_id__in=[user.pk,
                                                 affected_object.owner_id,
                                                 settings.ANONYMOUS_USER_ID])


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The primary goal of this PR is to enable users to access asset sharing details for assets they can only see via a Project View. This is done without respect to asset permissions. If a user is viewing a list of projects through the Project View, they will be able to use the quick links at the top of the table to see sharing details for any project in that view. This will be the only way for them to access these sharing details for the time being (that is, they will not be able to access the sharing details from within the form detail view). 

Secondarily, this PR disables/hides controls in the sharing form based on the user's permissions for that asset. This impacts both Project View users and other users on shared projects without `manage_asset` permissions, and should be a UI improvement for the latter since we were previously allowing them to click the controls and get rejected by the backend.