### PR TITLE
Fix "There was an error loading Enketo" when attempting to edit submissions

### DIFF
--- a/kpi/models/asset_snapshot.py
+++ b/kpi/models/asset_snapshot.py
@@ -214,12 +214,6 @@ class AssetSnapshot(
         warnings = []
         details = {}
 
-        for row in source_copy['survey']:
-            if row.get('type') in ['select_one_from_file', 'select_multiple_from_file']:
-                ff = row.pop('file')
-                _type = row.pop('type')
-                row['type'] = f'{_type} {ff}'
-
         try:
             xml = FormPack({'content': source_copy},
                             root_node_name=root_node_name,


### PR DESCRIPTION


## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Properly handle surveys that were created with `select_one_from_file` or `select_multiple_from_file` questions prior to release 2.024.09.

## Notes

Remove brittle and now unnecessary flattening of `file` columns in `select_one_from_file` and `select_multiple_from_file` rows. This was causing a `KeyError` when the asset content predated #4403 and kobotoolbox/formpack#314.

Flattening of `{"type": "select_one_from_file", "file": "choices.csv"}` (and equivalent `select_multiple_from_file` structures) to the XLSForm-standard `{"type": "select_one_from_file choices.csv"}` is handled by kobotoolbox/formpack#318 and kobotoolbox/formpack#319.

## Related issues

Fixes a problem in #4403 and kobotoolbox/formpack#314
Related to kobotoolbox/formpack#318 and kobotoolbox/formpack#319