### PR TITLE
Fix settings for repeating groups in form builder

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -474,6 +474,8 @@ module.exports = do ->
         image: ['signature', 'draw', 'annotate']
         date: ['month-year', 'year']
         group: ['select', ['field-list', 'Show all questions in this group on the same screen'], ['other', 'Advanced']]
+      # `repeat` is a repeating group with the same appearance options
+      types.repeat = types.group
 
       types[@model._parent.getValue('type').split(' ')[0]]
     html: ->


### PR DESCRIPTION
With @p2edwards

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Make the settings gear icon work properly again for repeating groups

## Related issues

Related to #4403