### PR TITLE
Load ESRI World Imagery tiles over HTTPS

### DIFF
--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -50,7 +50,7 @@ const baseLayers = {
       'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
   }),
   'ESRI World Imagery': L.tileLayer(
-    'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
     {
       attribution:
         'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',


### PR DESCRIPTION
## Description

Fixes a CSP error when attempting to load these map tiles in Firefox, since the CSP dictates HTTPS