### PR TITLE
Add django-import-export for organization users

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -184,6 +184,8 @@ django-extensions==3.2.3
     #   django-organizations
 django-filter==24.1
     # via -r dependencies/pip/requirements.in
+django-import-export==4.1.0
+    # via -r dependencies/pip/requirements.in
 django-loginas==0.3.11
     # via -r dependencies/pip/requirements.in
 django-markdownx==4.0.7

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -39,6 +39,7 @@ django-csp
 django-debug-toolbar
 django-environ
 django-filter
+django-import-export
 django-extensions
 django-oauth-toolkit
 django-organizations

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -161,6 +161,8 @@ django-extensions==3.2.3
     #   django-organizations
 django-filter==24.1
     # via -r dependencies/pip/requirements.in
+django-import-export==4.1.0
+    # via -r dependencies/pip/requirements.in
 django-loginas==0.3.11
     # via -r dependencies/pip/requirements.in
 django-markdownx==4.0.7

--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -1,4 +1,9 @@
 from django.contrib import admin
+from django.contrib.auth import get_user_model
+from import_export import resources
+from import_export.admin import ImportExportModelAdmin
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
 from organizations.base_admin import (
     BaseOrganizationAdmin,
     BaseOrganizationOwnerAdmin,
@@ -12,6 +17,8 @@ from .models import (
     OrganizationOwner,
     OrganizationUser,
 )
+
+User = get_user_model()
 
 
 class OwnerInline(BaseOwnerInline):
@@ -31,9 +38,15 @@ class OrgAdmin(BaseOrganizationAdmin):
     readonly_fields = ['id']
 
 
+class OrgUserResource(resources.ModelResource):
+    user = Field(attribute='user', column_name='user', widget=ForeignKeyWidget(User, field="username"))
+    class Meta:
+        model = OrganizationUser
+
+
 @admin.register(OrganizationUser)
-class OrgUserAdmin(BaseOrganizationUserAdmin):
-    pass
+class OrgUserAdmin(ImportExportModelAdmin, BaseOrganizationUserAdmin):
+    resource_classes = [OrgUserResource]
 
 
 @admin.register(OrganizationOwner)

--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -27,7 +27,7 @@ class OwnerInline(BaseOwnerInline):
 
 class OrgUserInline(admin.StackedInline):
     model = OrganizationUser
-    raw_id_fields = ("user",)
+    raw_id_fields = ('user',)
     view_on_site = False
     extra = 0
 
@@ -39,7 +39,12 @@ class OrgAdmin(BaseOrganizationAdmin):
 
 
 class OrgUserResource(resources.ModelResource):
-    user = Field(attribute='user', column_name='user', widget=ForeignKeyWidget(User, field="username"))
+    user = Field(
+        attribute='user',
+        column_name='user',
+        widget=ForeignKeyWidget(User, field='username'),
+    )
+
     class Meta:
         model = OrganizationUser
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.microsoft',
     'allauth.socialaccount.providers.openid_connect',
     'hub.HubAppConfig',
+    'import_export',
     'loginas',
     'webpack_loader',
     'django_extensions',


### PR DESCRIPTION
## Description

Django admin can now import and export organization users to and from formats including csv.

## Notes

It's a common need to import and export users. Django-import-export provides a customizable way to do so with minimal code. It's IMO a well maintained package but does occasionally include minor breaking changes, such as the 4.x release.

This change took about 45 minutes and was tested with importing Organization Users.