### PR TITLE
Reject 2FA activation with API when option is disabled for that account #4556

### DIFF
--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -28,21 +28,20 @@ class AccountAdapter(DefaultAccountAdapter):
 
         # If MFA is activated and allowed for the user, display the token form before letting them in
         mfa_active = (
-            get_mfa_model()
-            .objects.filter(is_active=True, user=user)
-            .exists()
+            get_mfa_model().objects.filter(is_active=True, user=user).exists()
         )
         mfa_allowed = mfa_allowed_for_user(user)
-        inactive_subscription = user_has_inactive_paid_subscription(user.username)
-        if  mfa_active and (mfa_allowed or inactive_subscription):
+        inactive_subscription = user_has_inactive_paid_subscription(
+            user.username
+        )
+        if mfa_active and (mfa_allowed or inactive_subscription):
             ephemeral_token_cache = user_token_generator.make_token(user)
             mfa_token_form = MfaTokenForm(
                 initial={'ephemeral_token': ephemeral_token_cache}
             )
 
-            next_url = (
-                kwargs.get('redirect_url')
-                or resolve_url(settings.LOGIN_REDIRECT_URL)
+            next_url = kwargs.get('redirect_url') or resolve_url(
+                settings.LOGIN_REDIRECT_URL
             )
 
             context = {
@@ -69,15 +68,15 @@ class AccountAdapter(DefaultAccountAdapter):
             extra_data = {k: form.cleaned_data[k] for k in extra_fields}
 
             # If the form contains a Terms of Service checkbox (checked)
-            if (extra_data.pop('terms_of_service', None)):
+            if extra_data.pop('terms_of_service', None):
                 # We 'pop' because we don't want to save 'terms_of_service':true
                 # in extra_details.data. Instead, save a now() date string as
                 # the last ToS acceptance time in private_data.
                 # See also: TOSView.post() in apps/accounts/tos.py, which
                 # lets the frontend accept ToS on behalf of existing users.
-                user.extra_details.private_data[
-                    'last_tos_accept_time'
-                ] = timezone.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+                user.extra_details.private_data['last_tos_accept_time'] = (
+                    timezone.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+                )
 
             user.extra_details.data.update(extra_data)
             if commit:

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -9,9 +9,9 @@ from django.template.response import TemplateResponse
 from django.utils import timezone
 from trench.utils import get_mfa_model, user_token_generator
 
-from .mfa.permissions import mfa_allowed_for_user
 from .mfa.forms import MfaTokenForm
 from .mfa.models import MfaAvailableToUser
+from .mfa.permissions import mfa_allowed_for_user
 from .mfa.views import MfaTokenView
 from .utils import user_has_paid_subscription
 

--- a/kobo/apps/accounts/mfa/permissions.py
+++ b/kobo/apps/accounts/mfa/permissions.py
@@ -1,19 +1,26 @@
 # coding: utf-8
 from constance import config
+from django.conf import settings
 from rest_framework.permissions import BasePermission
 
-from .models import MfaAvailableToUser
+from kobo.apps.accounts.utils import user_has_paid_subscription
 from kpi.utils.object_permission import get_database_user
+from .models import MfaAvailableToUser
 
 
 class IsMfaEnabled(BasePermission):
     def has_permission(self, request, view):
-        return config.MFA_ENABLED and (
-            # whitelist is enabled only if the table is not empty
+        user_with_subscription = (
+            settings.STRIPE_ENABLED
+            and user_has_paid_subscription(
+                get_database_user(request.user).username
+            )
+        )
+        mfa_allowed = (
             not MfaAvailableToUser.objects.all().exists()
-            # if it's enabled,
-            or
-            MfaAvailableToUser.objects.filter(
+            or MfaAvailableToUser.objects.filter(
                 user=get_database_user(request.user)
             ).exists()
         )
+
+        return config.MFA_ENABLED and (user_with_subscription or mfa_allowed)

--- a/kobo/apps/accounts/mfa/permissions.py
+++ b/kobo/apps/accounts/mfa/permissions.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from constance import config
 from rest_framework.permissions import BasePermission
 
 from .models import MfaAvailableToUser
@@ -7,7 +8,12 @@ from kpi.utils.object_permission import get_database_user
 
 class IsMfaEnabled(BasePermission):
     def has_permission(self, request, view):
-        mfa_available = MfaAvailableToUser.objects.filter(
-            user=get_database_user(request.user)
-        ).exists()
-        return mfa_available
+        return config.MFA_ENABLED and (
+            # whitelist is enabled only if the table is not empty
+            not MfaAvailableToUser.objects.all().exists()
+            # if it's enabled,
+            or
+            MfaAvailableToUser.objects.filter(
+                user=get_database_user(request.user)
+            ).exists()
+        )

--- a/kobo/apps/accounts/mfa/permissions.py
+++ b/kobo/apps/accounts/mfa/permissions.py
@@ -8,19 +8,20 @@ from kpi.utils.object_permission import get_database_user
 from .models import MfaAvailableToUser
 
 
+def mfa_allowed_for_user(user):
+    user_with_subscription = (
+        settings.STRIPE_ENABLED and user_has_paid_subscription(user.username)
+    )
+    mfa_allowed = (
+        not MfaAvailableToUser.objects.all().exists()
+        or MfaAvailableToUser.objects.filter(user=user).exists()
+    )
+
+    return config.MFA_ENABLED and (user_with_subscription or mfa_allowed)
+
+
 class IsMfaEnabled(BasePermission):
     def has_permission(self, request, view):
-        user_with_subscription = (
-            settings.STRIPE_ENABLED
-            and user_has_paid_subscription(
-                get_database_user(request.user).username
-            )
+        return mfa_allowed_for_user(
+            get_database_user(request.user)
         )
-        mfa_allowed = (
-            not MfaAvailableToUser.objects.all().exists()
-            or MfaAvailableToUser.objects.filter(
-                user=get_database_user(request.user)
-            ).exists()
-        )
-
-        return config.MFA_ENABLED and (user_with_subscription or mfa_allowed)

--- a/kobo/apps/accounts/mfa/permissions.py
+++ b/kobo/apps/accounts/mfa/permissions.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+from rest_framework.permissions import BasePermission
+
+from .models import MfaAvailableToUser
+from kpi.utils.object_permission import get_database_user
+
+
+class IsMfaEnabled(BasePermission):
+    def has_permission(self, request, view):
+        mfa_available = MfaAvailableToUser.objects.filter(
+            user=get_database_user(request.user)
+        ).exists()
+        return mfa_available

--- a/kobo/apps/accounts/mfa/tests/test_api.py
+++ b/kobo/apps/accounts/mfa/tests/test_api.py
@@ -78,7 +78,9 @@ class MfaApiTestCase(BaseTestCase):
     @override_config(MFA_ENABLED=True)
     def test_mfa_disabled(self):
         # Enable the MFA whitelist by adding a user
-        someuser_mfa_activation = MfaAvailableToUser.objects.create(user=self.someuser)
+        someuser_mfa_activation = MfaAvailableToUser.objects.create(
+            user=self.someuser
+        )
 
         anotheruser = User.objects.get(username='anotheruser')
         self.client.login(username='anotheruser', password='anotheruser')

--- a/kobo/apps/accounts/mfa/tests/test_api.py
+++ b/kobo/apps/accounts/mfa/tests/test_api.py
@@ -50,7 +50,6 @@ class MfaApiTestCase(BaseTestCase):
     @override_config(MFA_ENABLED=True)
     def test_mfa_activation_always_creates_new_secret(self):
         self.client.login(username='anotheruser', password='anotheruser')
-
         mfa_methods = trench_settings.MFA_METHODS.keys()
         for method in mfa_methods:
             first_response = self.client.post(
@@ -88,7 +87,6 @@ class MfaApiTestCase(BaseTestCase):
         someuser_mfa_activation = MfaAvailableToUser.objects.create(
             user=self.someuser
         )
-
 
         activate_response = self.client.post(
             reverse('mfa-activate', args=(method,))

--- a/kobo/apps/accounts/mfa/tests/test_api.py
+++ b/kobo/apps/accounts/mfa/tests/test_api.py
@@ -100,3 +100,9 @@ class MfaApiTestCase(BaseTestCase):
         # Reset MFA whitelist state
         mfa_availability.delete()
         someuser_mfa_activation.delete()
+
+        # Test when whitelist is disabled
+        activate_response = self.client.post(
+            reverse('mfa-activate', args=(method,))
+        )
+        assert activate_response.status_code == status.HTTP_200_OK

--- a/kobo/apps/accounts/mfa/tests/test_api.py
+++ b/kobo/apps/accounts/mfa/tests/test_api.py
@@ -81,11 +81,10 @@ class MfaApiTestCase(BaseTestCase):
         activate_response = self.client.post(
             reverse('mfa-activate', args=(method,))
         )
-        assert activate_response.status_code == 403
+        assert activate_response.status_code == status.HTTP_403_FORBIDDEN
 
         mfa_availability = MfaAvailableToUser.objects.create(user=anotheruser)
-        mfa_availability.save()
         activate_response = self.client.post(
             reverse('mfa-activate', args=(method,))
         )
-        assert activate_response.status_code == 200
+        assert activate_response.status_code == status.HTTP_200_OK

--- a/kobo/apps/accounts/mfa/urls.py
+++ b/kobo/apps/accounts/mfa/urls.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from django.urls import include, path
 
-from .views import MfaListUserMethodsView, MfaLoginView, MfaTokenView
+from .views import MfaListUserMethodsView, MfaLoginView, MfaTokenView, MfaMethodActivationView
 
 urlpatterns = [
     path('accounts/login/mfa/', MfaTokenView.as_view(), name='mfa_token'),
@@ -10,6 +10,11 @@ urlpatterns = [
         'api/v2/auth/mfa/user-methods/',
         MfaListUserMethodsView.as_view(),
         name='mfa_list_user_methods',
+    ),
+    path(
+        'api/v2/auth/<str:method>/activate/',
+        MfaMethodActivationView.as_view(),
+        name='mfa-activate',
     ),
     path('api/v2/auth/', include('trench.urls')),
 ]

--- a/kobo/apps/accounts/mfa/urls.py
+++ b/kobo/apps/accounts/mfa/urls.py
@@ -1,7 +1,12 @@
 # coding: utf-8
 from django.urls import include, path
 
-from .views import MfaListUserMethodsView, MfaLoginView, MfaTokenView, MfaMethodActivationView
+from .views import (
+    MfaListUserMethodsView,
+    MfaLoginView,
+    MfaTokenView,
+    MfaMethodActivationView,
+)
 
 urlpatterns = [
     path('accounts/login/mfa/', MfaTokenView.as_view(), name='mfa_token'),

--- a/kobo/apps/accounts/mfa/views.py
+++ b/kobo/apps/accounts/mfa/views.py
@@ -4,14 +4,14 @@ from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.db.models import QuerySet
 from django.urls import reverse
 from rest_framework.generics import ListAPIView
-from rest_framework.permissions import BasePermission
 from trench.utils import get_mfa_model
-from trench.views import MFAMethodActivationView as TrenchMFAMethodActivationView
+from trench.views import (
+    MFAMethodActivationView as TrenchMFAMethodActivationView,
+)
 
 from kpi.permissions import IsAuthenticated
-from kpi.utils.object_permission import get_database_user
 from .forms import MfaLoginForm, MfaTokenForm
-from .models import MfaAvailableToUser
+from .permissions import IsMfaEnabled
 from .serializers import UserMfaMethodSerializer
 
 
@@ -70,14 +70,6 @@ class MfaListUserMethodsView(ListAPIView):
     def get_queryset(self) -> QuerySet:
         mfa_model = get_mfa_model()
         return mfa_model.objects.filter(user_id=self.request.user.id)
-
-
-class IsMfaEnabled(BasePermission):
-    def has_permission(self, request, view):
-        mfa_available = MfaAvailableToUser.objects.filter(
-            user=get_database_user(request.user)
-        ).exists()
-        return mfa_available
 
 
 class MfaMethodActivationView(TrenchMFAMethodActivationView):

--- a/kobo/apps/accounts/mfa/views.py
+++ b/kobo/apps/accounts/mfa/views.py
@@ -4,10 +4,14 @@ from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.db.models import QuerySet
 from django.urls import reverse
 from rest_framework.generics import ListAPIView
+from rest_framework.permissions import BasePermission
 from trench.utils import get_mfa_model
+from trench.views import MFAMethodActivationView as TrenchMFAMethodActivationView
 
 from kpi.permissions import IsAuthenticated
+from kpi.utils.object_permission import get_database_user
 from .forms import MfaLoginForm, MfaTokenForm
+from .models import MfaAvailableToUser
 from .serializers import UserMfaMethodSerializer
 
 
@@ -66,3 +70,15 @@ class MfaListUserMethodsView(ListAPIView):
     def get_queryset(self) -> QuerySet:
         mfa_model = get_mfa_model()
         return mfa_model.objects.filter(user_id=self.request.user.id)
+
+
+class IsMfaEnabled(BasePermission):
+    def has_permission(self, request, view):
+        mfa_available = MfaAvailableToUser.objects.filter(
+            user=get_database_user(request.user)
+        ).exists()
+        return mfa_available
+
+
+class MfaMethodActivationView(TrenchMFAMethodActivationView):
+    permission_classes = (IsAuthenticated, IsMfaEnabled)

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -4,21 +4,18 @@ from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 
 def user_has_paid_subscription(username):
-    return (
-        User.objects.filter(
-            username=username,
-            organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0
-        )
-        .exists()
-    )
+    return User.objects.filter(
+        username=username,
+        organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+        organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0,
+    ).exists()
 
 
 def user_has_inactive_paid_subscription(username):
     return (
         User.objects.filter(
             username=username,
-            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0
+            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0,
         )
         .exclude(
             organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -3,14 +3,6 @@ from django.contrib.auth.models import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 
-def user_has_paid_subscription(username):
-    return User.objects.filter(
-        username=username,
-        organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-        organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0,
-    ).exists()
-
-
 def user_has_inactive_paid_subscription(username):
     return (
         User.objects.filter(
@@ -22,3 +14,11 @@ def user_has_inactive_paid_subscription(username):
         )
         .exists()
     )
+
+
+def user_has_paid_subscription(username):
+    return User.objects.filter(
+        username=username,
+        organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+        organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0,
+    ).exists()

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -6,10 +6,22 @@ from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 def user_has_paid_subscription(username):
     return (
         User.objects.filter(
+            username=username,
             organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0
+        )
+        .exists()
+    )
+
+
+def user_has_inactive_paid_subscription(username):
+    return (
+        User.objects.filter(
+            username=username,
+            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0
         )
         .exclude(
-            organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount=0
+            organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
         )
         .exists()
     )

--- a/kobo/apps/stripe/tests/test_mfa_login.py
+++ b/kobo/apps/stripe/tests/test_mfa_login.py
@@ -13,6 +13,7 @@ from rest_framework import status
 from trench.utils import get_mfa_model
 
 from kobo.apps.accounts.mfa.forms import MfaLoginForm
+from kobo.apps.accounts.mfa.models import MfaAvailableToUser
 from kobo.apps.organizations.models import Organization, OrganizationUser
 from kpi.tests.kpi_test_case import KpiTestCase
 
@@ -50,6 +51,10 @@ class TestStripeMFALogin(KpiTestCase):
             user=self.someuser,
             organization=self.organization,
         )
+
+        # Enable whitelist by setting available MFA for an user, if whitelist
+        # is empty, it is disabled, So we need at least one entry in it
+        MfaAvailableToUser.objects.create(user=self.anotheruser)
 
     def _create_subscription(self, unit_amount=0, billing_status='active'):
         self.customer = baker.make(Customer, subscriber=self.organization)

--- a/kobo/apps/stripe/tests/test_mfa_login.py
+++ b/kobo/apps/stripe/tests/test_mfa_login.py
@@ -186,7 +186,7 @@ class TestStripeMFALogin(KpiTestCase):
         Validate MFA form is displayed after login when the user
         has free subscription and whitelist is disabled
         """
-        self._reset_whitelist([])
+        self._reset_whitelist()
         self._create_subscription()
 
         data = {

--- a/kobo/apps/stripe/tests/test_mfa_login.py
+++ b/kobo/apps/stripe/tests/test_mfa_login.py
@@ -32,7 +32,7 @@ class TestStripeMFALogin(KpiTestCase):
         email_address.save()
 
         # Activate MFA for someuser
-        get_mfa_model().objects.create(
+        self.mfa_object = get_mfa_model().objects.create(
             user=self.someuser,
             secret='dummy_mfa_secret',
             name='app',
@@ -52,10 +52,6 @@ class TestStripeMFALogin(KpiTestCase):
             organization=self.organization,
         )
 
-        # Enable whitelist by setting available MFA for an user, if whitelist
-        # is empty, it is disabled, So we need at least one entry in it
-        MfaAvailableToUser.objects.create(user=self.anotheruser)
-
     def _create_subscription(self, unit_amount=0, billing_status='active'):
         self.customer = baker.make(Customer, subscriber=self.organization)
         self.price = baker.make(Price, unit_amount=unit_amount)
@@ -67,13 +63,29 @@ class TestStripeMFALogin(KpiTestCase):
             status=billing_status,
         )
 
+    def _reset_whitelist(self, whitelisted_users=[]):
+        MfaAvailableToUser.objects.all().delete()
+        for user in whitelisted_users:
+            MfaAvailableToUser.objects.create(user=user)
+
+    def _assert_mfa_login(self, response):
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, 'verification token')
+
+    def _assert_no_mfa_login(self, response):
+        self.assertEqual(len(response.redirect_chain), 1)
+        redirection, status_code = response.redirect_chain[0]
+        self.assertEqual(status_code, status.HTTP_302_FOUND)
+        self.assertEqual(resolve_url(settings.LOGIN_REDIRECT_URL), redirection)
+
     @override_config(MFA_ENABLED=True)
     def test_no_mfa_login_without_subscription(self):
         """
         Validate that multi-factor authentication form is not displayed after
         successful login if the user doesn't have a paid subscription
         """
-
+        # Enable whitelist but do not whitelist self.someuser
+        self._reset_whitelist([self.anotheruser])
         data = {
             'login': 'someuser',
             'password': 'someuser',
@@ -81,10 +93,7 @@ class TestStripeMFALogin(KpiTestCase):
         response = self.client.post(
             reverse('kobo_login'), data=data, follow=True
         )
-        self.assertEqual(len(response.redirect_chain), 1)
-        redirection, status_code = response.redirect_chain[0]
-        self.assertEqual(status_code, status.HTTP_302_FOUND)
-        self.assertEqual(resolve_url(settings.LOGIN_REDIRECT_URL), redirection)
+        self._assert_no_mfa_login(response)
 
     @override_config(MFA_ENABLED=True)
     def test_mfa_login_works_with_paid_subscription(self):
@@ -92,7 +101,8 @@ class TestStripeMFALogin(KpiTestCase):
         Validate that multi-factor authentication form is displayed after
         successful login if the user has a paid subscription
         """
-
+        # Enable whitelist but do not whitelist self.someuser
+        self._reset_whitelist([self.anotheruser])
         self._create_subscription(unit_amount=2000)
 
         data = {
@@ -100,8 +110,39 @@ class TestStripeMFALogin(KpiTestCase):
             'password': 'someuser',
         }
         response = self.client.post(reverse('kobo_login'), data=data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertContains(response, 'verification token')
+        self._assert_mfa_login(response)
+
+    @override_config(MFA_ENABLED=True)
+    def test_mfa_login_without_subscription_no_whitelist(self):
+        """
+        Validate MFA form is displayed after login when the user
+        has no subscription and whitelist is disabled
+        """
+        self._reset_whitelist()
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(
+            reverse('kobo_login'), data=data, follow=True
+        )
+        self._assert_mfa_login(response)
+
+    @override_config(MFA_ENABLED=True)
+    def test_mfa_login_without_subscription_but_whitelisted(self):
+        """
+        Validate MFA form is displayed after login when the user
+        has no subscription but is whitelisted
+        """
+        self._reset_whitelist([self.someuser])
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(
+            reverse('kobo_login'), data=data, follow=True
+        )
+        self._assert_mfa_login(response)
 
     @override_config(MFA_ENABLED=True)
     def test_no_mfa_login_with_free_subscription(self):
@@ -109,7 +150,7 @@ class TestStripeMFALogin(KpiTestCase):
         Validate that multi-factor authentication form is not displayed after
         successful login if the user has a free subscription
         """
-
+        self._reset_whitelist([self.anotheruser])
         self._create_subscription()
 
         data = {
@@ -119,19 +160,16 @@ class TestStripeMFALogin(KpiTestCase):
         response = self.client.post(
             reverse('kobo_login'), data=data, follow=True
         )
-        self.assertEqual(len(response.redirect_chain), 1)
-        redirection, status_code = response.redirect_chain[0]
-        self.assertEqual(status_code, status.HTTP_302_FOUND)
-        self.assertEqual(resolve_url(settings.LOGIN_REDIRECT_URL), redirection)
+        self._assert_no_mfa_login(response)
 
     @override_config(MFA_ENABLED=True)
-    def test_no_mfa_login_with_canceled_subscription(self):
+    def test_mfa_login_with_free_subscription_and_whitelisted(self):
         """
-        Validate that multi-factor authentication form is not displayed after
-        successful login if the user only has a cancelled subscription
+        Validate MFA form is displayed after login when the user
+        has free subscription and is whitelisted
         """
-
-        self._create_subscription(billing_status='canceled')
+        self._reset_whitelist([self.someuser])
+        self._create_subscription()
 
         data = {
             'login': 'someuser',
@@ -140,10 +178,63 @@ class TestStripeMFALogin(KpiTestCase):
         response = self.client.post(
             reverse('kobo_login'), data=data, follow=True
         )
-        self.assertEqual(len(response.redirect_chain), 1)
-        redirection, status_code = response.redirect_chain[0]
-        self.assertEqual(status_code, status.HTTP_302_FOUND)
-        self.assertEqual(resolve_url(settings.LOGIN_REDIRECT_URL), redirection)
+        self._assert_mfa_login(response)
+
+    @override_config(MFA_ENABLED=True)
+    def test_mfa_login_with_free_subscription_no_whitelist(self):
+        """
+        Validate MFA form is displayed after login when the user
+        has free subscription and whitelist is disabled
+        """
+        self._reset_whitelist([])
+        self._create_subscription()
+
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(
+            reverse('kobo_login'), data=data, follow=True
+        )
+        self._assert_mfa_login(response)
+
+    @override_config(MFA_ENABLED=True)
+    def test_mfa_login_with_canceled_subscription_but_previously_set(self):
+        """
+        Validate that multi-factor authentication form is displayed after
+        successful login if the user only has a cancelled subscription
+        but MFA was enabled before subscription was canceled.
+        """
+        self._reset_whitelist([self.anotheruser])
+        self._create_subscription(unit_amount=2000, billing_status='canceled')
+
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(
+            reverse('kobo_login'), data=data, follow=True
+        )
+        self._assert_mfa_login(response)
+
+    @override_config(MFA_ENABLED=True)
+    def test_no_mfa_login_with_canceled_subscription(self):
+        """
+        Validate that multi-factor authentication form is not displayed after
+        successful login if the user only has a cancelled subscription and
+        MFA was not enabled before.
+        """
+        self._reset_whitelist([self.anotheruser])
+        self._create_subscription(billing_status='canceled')
+        self.mfa_object.delete()
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(
+            reverse('kobo_login'), data=data, follow=True
+        )
+        self._assert_no_mfa_login(response)
 
     @override_config(MFA_ENABLED=True)
     def test_no_mfa_login_with_wrong_password(self):


### PR DESCRIPTION
## Description

When the MFA activation API endpoint is accessed, it fails with a forbidden error if the user is not in the MfaAvailableToUser table (#4556). We had to include a check for user subscription and STRIPE_ENABLED.

## Notes

Trench provides a set of views for the MFA API. The view `trench.views.MFAMethodActivationView` was extended to check, before accepting a call to the activation endpoint, whether or not the user can use MFA by checking the model `kobo.apps.accounts.mfa.models.MfaAvailableToUser`.   The module `kobo.apps.accounts.adapter` was also changed to use the more centralized function at `kobo.apps.accounts.mfa.permissions.mfa_allowed_for_user`. 

## Related issues

Fixes #4556
