### PR TITLE
[TASK-461] Add modal(s) to NLP page when user is over limits

### DIFF
--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -157,6 +157,13 @@ export enum PlanNames {
   'ENTERPRISE' = 'Enterprise',
 }
 
+export enum UsageLimitTypes {
+  'STORAGE' = 'storage',
+  'SUBMISSION' = 'submission',
+  'TRANSCRIPTION' = 'automated transcription',
+  'TRANSLATION' = 'machine translation',
+}
+
 export enum Limits {
   'unlimited' = 'unlimited',
 }

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -10,7 +10,7 @@ import UsageContainer, {
   USAGE_CONTAINER_TYPE,
 } from 'js/account/usage/usageContainer';
 import envStore from 'js/envStore';
-import {formatDate} from 'js/utils';
+import {convertSecondsToMinutes, formatDate} from 'js/utils';
 import styles from './usage.module.scss';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {ProductsContext} from '../useProducts.hook';
@@ -104,7 +104,7 @@ export default function Usage() {
           nlpCharacterLimit: limits.nlp_character_limit,
           nlpMinuteLimit:
             typeof limits.nlp_seconds_limit === 'number'
-              ? limits.nlp_seconds_limit / 60
+              ? convertSecondsToMinutes(limits.nlp_seconds_limit)
               : limits.nlp_seconds_limit,
           submissionLimit: limits.submission_limit,
           isLoaded: true,

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -11,8 +11,8 @@ import {USAGE_ASSETS_PER_PAGE} from 'jsapp/js/constants';
 import SortableProjectColumnHeader from 'jsapp/js/projects/projectsTable/sortableProjectColumnHeader';
 import type {ProjectFieldDefinition} from 'jsapp/js/projects/projectViews/constants';
 import type {ProjectsTableOrder} from 'jsapp/js/projects/projectsTable/projectsTable';
-import {truncateNumber} from 'jsapp/js/utils';
-import {UsageContext, useUsage} from './useUsage.hook';
+import {convertSecondsToMinutes} from 'jsapp/js/utils';
+import {UsageContext} from './useUsage.hook';
 import Button from 'js/components/common/button';
 import Icon from 'js/components/common/icon';
 import {OrganizationContext} from 'js/account/organizations/useOrganization.hook';
@@ -132,10 +132,8 @@ const ProjectBreakdown = () => {
         `submission_count_current_${usage.trackingPeriod}`
       ].toLocaleString();
 
-    const periodASRSeconds = truncateNumber(
-      project[`nlp_usage_current_${usage.trackingPeriod}`]
-        .total_nlp_asr_seconds / 60,
-      1
+    const periodASRSeconds = convertSecondsToMinutes(
+      project[`nlp_usage_current_${usage.trackingPeriod}`].total_nlp_asr_seconds
     ).toLocaleString();
 
     const periodMTCharacters =
@@ -154,9 +152,7 @@ const ProjectBreakdown = () => {
           </Link>
         </td>
         <td>{project.submission_count_all_time.toLocaleString()}</td>
-        <td className={styles.currentMonth}>
-          {periodSubmissions}
-        </td>
+        <td className={styles.currentMonth}>{periodSubmissions}</td>
         <td>{prettyBytes(project.storage_bytes)}</td>
         <td>{periodASRSeconds}</td>
         <td>{periodMTCharacters}</td>

--- a/jsapp/js/account/usage/useUsage.hook.ts
+++ b/jsapp/js/account/usage/useUsage.hook.ts
@@ -1,7 +1,7 @@
 import {createContext, useCallback} from 'react';
 import type {Organization, RecurringInterval} from 'js/account/stripe.types';
 import {getSubscriptionInterval} from 'js/account/stripe.api';
-import {formatRelativeTime, truncateNumber} from 'js/utils';
+import {convertSecondsToMinutes, formatRelativeTime} from 'js/utils';
 import {getUsage} from 'js/account/usage/usage.api';
 import {useApiFetcher, withApiFetcher} from 'js/hooks/useApiFetcher.hook';
 
@@ -50,11 +50,9 @@ const loadUsage = async (
   return {
     storage: usage.total_storage_bytes,
     submissions: usage.total_submission_count[`current_${trackingPeriod}`],
-    transcriptionMinutes: Math.floor(
-      truncateNumber(
-        usage.total_nlp_usage[`asr_seconds_current_${trackingPeriod}`] / 60
-      )
-    ), // seconds to minutes
+    transcriptionMinutes: convertSecondsToMinutes(
+      usage.total_nlp_usage[`asr_seconds_current_${trackingPeriod}`]
+    ),
     translationChars:
       usage.total_nlp_usage[`mt_characters_current_${trackingPeriod}`],
     currentMonthStart: usage.current_month_start,

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
@@ -65,7 +65,6 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
             size='l'
             onClick={handleClose}
             label={t('Go back')}
-            className={cx([styles.button, styles.frame])}
           />
 
           <Button
@@ -74,7 +73,6 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
             size='l'
             onClick={() => navigate(ACCOUNT_ROUTES.PLAN)}
             label={t('Upgrade now')}
-            className={cx([styles.button, styles.full])}
           />
         </KoboModalFooter>
       </KoboModal>

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
@@ -5,6 +5,7 @@ import KoboModalHeader from 'js/components/modals/koboModalHeader';
 import KoboModalContent from 'js/components/modals/koboModalContent';
 import KoboModalFooter from 'js/components/modals/koboModalFooter';
 import Button from 'js/components/common/button';
+import Icon from 'js/components/common/icon';
 import {useNavigate} from 'react-router-dom';
 import styles from './nlpUsageLimitBlockModal.module.scss';
 import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
@@ -30,11 +31,11 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
         onRequestClose={handleClose}
         size='medium'
       >
-        <KoboModalHeader>
+        <KoboModalHeader onRequestCloseByX={handleClose} headerColor='white'>
           {t('Upgrade to continue using this feature')}
         </KoboModalHeader>
 
-        <KoboModalContent>
+        <section className={styles.modalBody}>
           <div>
             <div>
               {t('You have reached the ##LIMIT## limit for this ##PERIOD##.')
@@ -44,9 +45,18 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
                 'Please consider our plans or add-ons to continue using this feature'
               )}
             </div>
-            <div>Put a blue box here</div>
+            <div className={styles.note}>
+              <Icon
+                name='information'
+                size='s'
+                color='blue'
+                className={styles.noteIcon}
+              />
+              {t('You can monitor your usage')}&nbsp;
+              <a href={'/#/account/usage'}>{t('here')}</a>.
+            </div>
           </div>
-        </KoboModalContent>
+        </section>
 
         <KoboModalFooter alignment='end'>
           <Button

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
@@ -1,0 +1,75 @@
+import cx from 'classnames';
+import React, {useEffect, useState} from 'react';
+import KoboModal from '../../modals/koboModal';
+import KoboModalHeader from 'js/components/modals/koboModalHeader';
+import KoboModalContent from 'js/components/modals/koboModalContent';
+import KoboModalFooter from 'js/components/modals/koboModalFooter';
+import Button from 'js/components/common/button';
+import {useNavigate} from 'react-router-dom';
+import styles from './nlpUsageLimitBlockModal.module.scss';
+import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
+
+interface NlpUsageLimitBlockModalProps {
+  isModalOpen: boolean;
+  dismissed: () => void;
+  limit: string;
+  interval: 'month' | 'year';
+}
+
+function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
+  const navigate = useNavigate();
+
+  const handleClose = () => {
+    props.dismissed();
+  };
+
+  return (
+    <div>
+      <KoboModal
+        isOpen={props.isModalOpen}
+        onRequestClose={handleClose}
+        size='medium'
+      >
+        <KoboModalHeader>
+          {t('Upgrade to continue using this feature')}
+        </KoboModalHeader>
+
+        <KoboModalContent>
+          <div>
+            <div>
+              {t('You have reached the ##LIMIT## limit for this ##PERIOD##.')
+                .replace('##LIMIT##', props.limit)
+                .replace('##PERIOD##', props.interval)}{' '}
+              {t(
+                'Please consider our plans or add-ons to continue using this feature'
+              )}
+            </div>
+            <div>Put a blue box here</div>
+          </div>
+        </KoboModalContent>
+
+        <KoboModalFooter alignment='end'>
+          <Button
+            type='frame'
+            color='dark-blue'
+            size='l'
+            onClick={handleClose}
+            label={t('Go back')}
+            className={cx([styles.button, styles.frame])}
+          />
+
+          <Button
+            type='full'
+            color='blue'
+            size='l'
+            onClick={() => navigate(ACCOUNT_ROUTES.PLAN)}
+            label={t('Upgrade now')}
+            className={cx([styles.button, styles.full])}
+          />
+        </KoboModalFooter>
+      </KoboModal>
+    </div>
+  );
+}
+
+export default NlpUsageLimitBlockModal;

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
@@ -1,8 +1,7 @@
 import cx from 'classnames';
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import KoboModal from '../../modals/koboModal';
 import KoboModalHeader from 'js/components/modals/koboModalHeader';
-import KoboModalContent from 'js/components/modals/koboModalContent';
 import KoboModalFooter from 'js/components/modals/koboModalFooter';
 import Button from 'js/components/common/button';
 import Icon from 'js/components/common/icon';
@@ -42,7 +41,7 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
                 .replace('##LIMIT##', props.limit)
                 .replace('##PERIOD##', props.interval)}{' '}
               {t(
-                'Please consider our plans or add-ons to continue using this feature'
+                'Please consider our plans or add-ons to continue using this feature.'
               )}
             </div>
             <div className={styles.note}>

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component.tsx
@@ -8,12 +8,13 @@ import Icon from 'js/components/common/icon';
 import {useNavigate} from 'react-router-dom';
 import styles from './nlpUsageLimitBlockModal.module.scss';
 import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
+import { RecurringInterval, UsageLimitTypes } from 'jsapp/js/account/stripe.types';
 
 interface NlpUsageLimitBlockModalProps {
   isModalOpen: boolean;
   dismissed: () => void;
-  limit: string;
-  interval: 'month' | 'year';
+  usageType: UsageLimitTypes.TRANSLATION | UsageLimitTypes.TRANSCRIPTION;
+  interval: RecurringInterval;
 }
 
 function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
@@ -38,7 +39,7 @@ function NlpUsageLimitBlockModal(props: NlpUsageLimitBlockModalProps) {
           <div>
             <div>
               {t('You have reached the ##LIMIT## limit for this ##PERIOD##.')
-                .replace('##LIMIT##', props.limit)
+                .replace('##LIMIT##', props.usageType)
                 .replace('##PERIOD##', props.interval)}{' '}
               {t(
                 'Please consider our plans or add-ons to continue using this feature.'

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
@@ -22,25 +22,3 @@
 .noteIcon {
   margin-right: sizes.$x8;
 }
-
-.button {
-  text-transform: uppercase;
-  gap: 1rem;
-  justify-content: center;
-
-  & span {
-    flex-shrink: 0;
-  }
-}
-
-.frame {
-  background-color: colors.$kobo-white;
-}
-
-// TODO: Abstract styling for paired buttons
-// See also overLimitModal and NLP stepConfig
-:global(.k-button) {
-  &.button.full:hover {
-    background-color: colors.$kobo-dark-blue;
-  }
-}

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
@@ -11,11 +11,6 @@
   }
 }
 
-.link {
-  color: colors.$kobo-dark-blue;
-  text-decoration: underline;
-}
-
 .note {
   display: flex;
   padding: sizes.$x12;
@@ -42,6 +37,8 @@
   background-color: colors.$kobo-white;
 }
 
+// TODO: Abstract styling for paired buttons
+// See also overLimitModal and NLP stepConfig
 :global(.k-button) {
   &.button.full:hover {
     background-color: colors.$kobo-dark-blue;

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
@@ -1,0 +1,42 @@
+@use 'scss/colors';
+
+.link {
+  color: colors.$kobo-dark-blue;
+  text-decoration: underline;
+}
+
+.messageGreeting {
+  margin-bottom: 20px;
+}
+
+.button {
+  text-transform: uppercase;
+  gap: 1rem;
+  justify-content: center;
+
+  & span {
+    flex-shrink: 0;
+  }
+}
+
+.frame {
+  background-color: colors.$kobo-white;
+}
+
+:global(.k-button) {
+  &.button.full:hover {
+    background-color: colors.$kobo-dark-blue;
+  }
+}
+
+.consequences {
+  background-color: colors.$kobo-light-red;
+  box-sizing: border-box;
+  margin: 1em 0;
+  padding: 1em 1em;
+  gap: 1em;
+}
+
+.warningIcon {
+  align-self: flex-start;
+}

--- a/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
+++ b/jsapp/js/components/processing/nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.module.scss
@@ -1,12 +1,31 @@
 @use 'scss/colors';
+@use 'scss/sizes';
+
+
+.modalBody {
+  line-height: sizes.$x24;
+  padding: 0 sizes.$x30;
+
+  p:first-of-type {
+    margin-top: 0;
+  }
+}
 
 .link {
   color: colors.$kobo-dark-blue;
   text-decoration: underline;
 }
 
-.messageGreeting {
-  margin-bottom: 20px;
+.note {
+  display: flex;
+  padding: sizes.$x12;
+  margin: sizes.$x24 0 0 0;
+  background-color: colors.$kobo-bg-blue;
+  border-radius: sizes.$x5;
+}
+
+.noteIcon {
+  margin-right: sizes.$x8;
 }
 
 .button {
@@ -27,16 +46,4 @@
   &.button.full:hover {
     background-color: colors.$kobo-dark-blue;
   }
-}
-
-.consequences {
-  background-color: colors.$kobo-light-red;
-  box-sizing: border-box;
-  margin: 1em 0;
-  padding: 1em 1em;
-  gap: 1em;
-}
-
-.warningIcon {
-  align-self: flex-start;
 }

--- a/jsapp/js/components/processing/transcript/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfig.component.tsx
@@ -14,6 +14,7 @@ import TransxAutomaticButton from 'js/components/processing/transxAutomaticButto
 import envStore from 'js/envStore';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
 import NlpUsageLimitBlockModal from '../nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component';
+import {UsageLimitTypes} from 'js/account/stripe.types';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
 import {useExceedingLimits} from 'js/components/usageLimits/useExceedingLimits.hook';
 
@@ -23,7 +24,7 @@ export default function StepConfig() {
   const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
     useState<boolean>(false);
   const isOverLimit = useMemo(() => {
-    return limits.exceedList.includes('automated transcription');
+    return limits.exceedList.includes(UsageLimitTypes.TRANSCRIPTION);
   }, [limits.exceedList]);
 
   function dismissLimitBlockModal() {
@@ -131,7 +132,7 @@ export default function StepConfig() {
           />
           <NlpUsageLimitBlockModal
             isModalOpen={isLimitBlockModalOpen}
-            limit='automated transcription'
+            usageType={UsageLimitTypes.TRANSCRIPTION}
             dismissed={dismissLimitBlockModal}
             interval={usage.trackingPeriod}
           />

--- a/jsapp/js/components/processing/transcript/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfig.component.tsx
@@ -23,7 +23,6 @@ export default function StepConfig() {
   const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
     useState<boolean>(false);
   const isOverLimit = useMemo(() => {
-    console.log(limits.exceedList);
     return limits.exceedList.includes('automated transcription');
   }, [limits.exceedList]);
 

--- a/jsapp/js/components/processing/transcript/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfig.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import cx from 'classnames';
 import clonedeep from 'lodash.clonedeep';
 import Button from 'js/components/common/button';
@@ -13,8 +13,23 @@ import type {
 import TransxAutomaticButton from 'js/components/processing/transxAutomaticButton';
 import envStore from 'js/envStore';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import NlpUsageLimitBlockModal from '../nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component';
+import {UsageContext} from 'js/account/usage/useUsage.hook';
+import {useExceedingLimits} from 'js/components/usageLimits/useExceedingLimits.hook';
 
 export default function StepConfig() {
+  const [usage] = useContext(UsageContext);
+  const limits = useExceedingLimits();
+  const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
+    useState<boolean>(false);
+  const isOverLimit = useMemo(() => {
+    console.log(limits.exceedList);
+    return limits.exceedList.includes('automated transcription');
+  }, [limits.exceedList]);
+
+  function dismissLimitBlockModal() {
+    setIsLimitBlockModalOpen(false);
+  }
   /** Changes the draft value, preserving the other draft properties. */
   function setDraftValue(newVal: string | undefined) {
     const newDraft =
@@ -62,6 +77,14 @@ export default function StepConfig() {
     singleProcessingStore.setTranscriptDraft(newDraft);
   }
 
+  function onAutomaticButtonClick() {
+    if (isOverLimit) {
+      setIsLimitBlockModalOpen(true);
+    } else {
+      selectModeAuto();
+    }
+  }
+
   const draft = singleProcessingStore.getTranscriptDraft();
   const typeLabel =
     singleProcessingStore.currentQuestionType || t('source file');
@@ -103,9 +126,15 @@ export default function StepConfig() {
           />
 
           <TransxAutomaticButton
-            onClick={selectModeAuto}
+            onClick={onAutomaticButtonClick}
             selectedLanguage={draft?.languageCode}
             type='transcript'
+          />
+          <NlpUsageLimitBlockModal
+            isModalOpen={isLimitBlockModalOpen}
+            limit='automated transcription'
+            dismissed={dismissLimitBlockModal}
+            interval={usage.trackingPeriod}
           />
         </div>
       </footer>

--- a/jsapp/js/components/processing/transcript/transcript.utils.ts
+++ b/jsapp/js/components/processing/transcript/transcript.utils.ts
@@ -5,6 +5,7 @@ import {
   getRowData,
   getMediaAttachment,
 } from 'js/components/submissions/submissionUtils';
+import { convertSecondsToMinutes } from 'jsapp/js/utils';
 
 /**
  * Returns an error string or the attachment. It's basically a wrapper function
@@ -54,7 +55,7 @@ export function secondsToTranscriptionEstimate(sourceSeconds: number): string {
   } else if (durationSeconds >= 75 && durationSeconds < 150) {
     return t('about 2 minutes');
   } else {
-    const durationMinutes = Math.round(durationSeconds / 60);
+    const durationMinutes = convertSecondsToMinutes(durationSeconds);
     return t('about ##number## minutes').replace('##number##', String(durationMinutes));
   }
 }

--- a/jsapp/js/components/processing/translations/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfig.component.tsx
@@ -15,6 +15,7 @@ import type {
 import envStore from 'js/envStore';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
 import NlpUsageLimitBlockModal from '../nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component';
+import {UsageLimitTypes} from 'js/account/stripe.types';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
 import {useExceedingLimits} from 'js/components/usageLimits/useExceedingLimits.hook';
 
@@ -24,7 +25,7 @@ export default function StepConfig() {
   const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
     useState<boolean>(false);
   const isOverLimit = useMemo(() => {
-    return limits.exceedList.includes('machine translation');
+    return limits.exceedList.includes(UsageLimitTypes.TRANSLATION);
   }, [limits.exceedList]);
 
   function dismissLimitBlockModal() {
@@ -140,7 +141,7 @@ export default function StepConfig() {
           />
           <NlpUsageLimitBlockModal
             isModalOpen={isLimitBlockModalOpen}
-            limit='machine translation'
+            usageType={UsageLimitTypes.TRANSLATION}
             dismissed={dismissLimitBlockModal}
             interval={usage.trackingPeriod}
           />

--- a/jsapp/js/components/processing/translations/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfig.component.tsx
@@ -24,7 +24,6 @@ export default function StepConfig() {
   const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
     useState<boolean>(false);
   const isOverLimit = useMemo(() => {
-    console.log(limits.exceedList);
     return limits.exceedList.includes('machine translation');
   }, [limits.exceedList]);
 

--- a/jsapp/js/components/processing/translations/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfig.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import cx from 'classnames';
 import clonedeep from 'lodash.clonedeep';
 import Button from 'js/components/common/button';
@@ -14,8 +14,23 @@ import type {
 } from 'js/components/languages/languagesStore';
 import envStore from 'js/envStore';
 import bodyStyles from 'js/components/processing/processingBody.module.scss';
+import NlpUsageLimitBlockModal from '../nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component';
+import {UsageContext} from 'js/account/usage/useUsage.hook';
+import {useExceedingLimits} from 'js/components/usageLimits/useExceedingLimits.hook';
 
 export default function StepConfig() {
+  const [usage] = useContext(UsageContext);
+  const limits = useExceedingLimits();
+  const [isLimitBlockModalOpen, setIsLimitBlockModalOpen] =
+    useState<boolean>(false);
+  const isOverLimit = useMemo(() => {
+    console.log(limits.exceedList);
+    return limits.exceedList.includes('machine translation');
+  }, [limits.exceedList]);
+
+  function dismissLimitBlockModal() {
+    setIsLimitBlockModalOpen(false);
+  }
   /** Changes the draft value, preserving the other draft properties. */
   function setDraftValue(newVal: string | undefined) {
     const newDraft =
@@ -74,6 +89,14 @@ export default function StepConfig() {
     singleProcessingStore.setTranslationDraft(newDraft);
   }
 
+  function onAutomaticButtonClick() {
+    if (isOverLimit) {
+      setIsLimitBlockModalOpen(true);
+    } else {
+      selectModeAuto();
+    }
+  }
+
   const draft = singleProcessingStore.getTranslationDraft();
   const isAutoEnabled = envStore.data.asr_mt_features_enabled;
 
@@ -112,9 +135,15 @@ export default function StepConfig() {
           />
 
           <TransxAutomaticButton
-            onClick={selectModeAuto}
+            onClick={onAutomaticButtonClick}
             selectedLanguage={draft?.languageCode}
             type='translation'
+          />
+          <NlpUsageLimitBlockModal
+            isModalOpen={isLimitBlockModalOpen}
+            limit='machine translation'
+            dismissed={dismissLimitBlockModal}
+            interval={usage.trackingPeriod}
           />
         </div>
       </footer>

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -2,6 +2,7 @@ import {useState, useReducer, useContext, useEffect} from 'react';
 import type {SubscriptionInfo} from 'js/account/stripe.types';
 import {getAccountLimits} from 'js/account/stripe.api';
 import {USAGE_WARNING_RATIO} from 'js/constants';
+import {convertSecondsToMinutes} from 'jsapp/js/utils';
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {when} from 'mobx';
 import subscriptionStore from 'js/account/subscriptionStore';
@@ -47,7 +48,9 @@ export const useExceedingLimits = () => {
     getAccountLimits(productsContext.products).then((limits) => {
       setSubscribedSubmissionLimit(limits.submission_limit);
       setSubscribedStorageLimit(limits.storage_bytes_limit);
-      setTranscriptionMinutes(Number(limits.nlp_seconds_limit));
+      setTranscriptionMinutes(
+        convertSecondsToMinutes(Number(limits.nlp_seconds_limit))
+      );
       setTranslationChars(Number(limits.nlp_character_limit));
       setAreLimitsLoaded(true);
     });

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -1,5 +1,5 @@
 import {useState, useReducer, useContext, useEffect} from 'react';
-import type {SubscriptionInfo} from 'js/account/stripe.types';
+import {SubscriptionInfo, UsageLimitTypes} from 'js/account/stripe.types';
 import {getAccountLimits} from 'js/account/stripe.api';
 import {USAGE_WARNING_RATIO} from 'js/constants';
 import {convertSecondsToMinutes} from 'jsapp/js/utils';
@@ -94,17 +94,21 @@ export const useExceedingLimits = () => {
       return;
     }
     setExceedList(() => []);
-    isOverLimit(subscribedStorageLimit, usage.storage, 'storage');
-    isOverLimit(subscribedSubmissionLimit, usage.submissions, 'submission');
+    isOverLimit(subscribedStorageLimit, usage.storage, UsageLimitTypes.STORAGE);
+    isOverLimit(
+      subscribedSubmissionLimit,
+      usage.submissions,
+      UsageLimitTypes.SUBMISSION
+    );
     isOverLimit(
       subscribedTranscriptionMinutes,
       usage.transcriptionMinutes,
-      'automated transcription'
+      UsageLimitTypes.TRANSCRIPTION
     );
     isOverLimit(
       subscribedTranslationChars,
       usage.translationChars,
-      'machine translation'
+      UsageLimitTypes.TRANSLATION
     );
   }, [usageStatus, areLimitsLoaded]);
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -417,6 +417,12 @@ export const truncateNumber = (decimal: number, decimalPlaces = 2) =>
   parseFloat(decimal.toFixed(decimalPlaces));
 
 /**
+ * Standard method for converting seconds to minutes for billing purposes
+ */
+ export const convertSecondsToMinutes = (seconds: number) =>
+  Math.floor(truncateNumber(seconds/60, 1))
+
+/**
  * Generates a simple lowercase, underscored version of a string. Useful for
  * quick filename generation
  *


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

This PR adds a frontend block to NLP usage when a user has met or exceeded their quota of ASR or MT usage for the billing period. When they click the button for automatic translation or transcription, a modal is shown directing them to upgrade their plan.

## Notes
Includes some work cleaning up handling of seconds-to-minutes conversion for ASR across the app and adds an enum for the usage limit types that show up in text form in the UI.
