### PR TITLE
[TASK-806] Duplicating submissions doesn’t copy extra submission details

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -219,6 +219,19 @@ class BaseDeploymentBackend(abc.ABC):
     ) -> dict:
         pass
 
+    def copy_submission_extras(self, origin_uuid: str, dest_uuid: str):
+        """
+        Copy the submission extras from a origin submission uuid
+        to a destination uuid
+        """
+        original_extras = self.asset.submission_extras.filter(
+            submission_uuid=origin_uuid
+        ).first()
+        if original_extras is not None:
+            duplicated_extras = copy.deepcopy(original_extras.content)
+            duplicated_extras['submission'] = dest_uuid
+            self.asset.update_submission_extra(duplicated_extras)
+
     @property
     @abc.abstractmethod
     def enketo_id(self):

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -384,7 +384,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # Rely on `meta/instanceID` being present. If it's absent, something is
         # fishy enough to warrant raising an exception instead of continuing
         # silently
-        original_uuid_formatted = xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text
         xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text = (
             uuid_formatted
         )
@@ -392,11 +391,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             user, xml_tostring(xml_parsed), _uuid, attachments
         )
         if kc_response.status_code == status.HTTP_201_CREATED:
-            original_uuid = original_uuid_formatted.split(":")[-1]
-            original_extras = self.asset.submission_extras.filter(submission_uuid=original_uuid).first()
-            duplicated_extras = deepcopy(original_extras.content)
-            duplicated_extras['submission'] = _uuid
-            self.asset.update_submission_extra(duplicated_extras)
             return next(self.get_submissions(user, query={'_uuid': _uuid}))
         else:
             raise KobocatDuplicateSubmissionException

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -5,6 +5,7 @@ import json
 import re
 from collections import defaultdict
 from contextlib import contextmanager
+from copy import deepcopy
 from datetime import date, datetime
 from typing import Generator, Optional, Union
 from urllib.parse import urlparse
@@ -367,7 +368,6 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             if attachment_objects
             else None
         )
-
         # parse XML string to ET object
         xml_parsed = fromstring_preserve_root_xmlns(submission)
 
@@ -384,14 +384,19 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         # Rely on `meta/instanceID` being present. If it's absent, something is
         # fishy enough to warrant raising an exception instead of continuing
         # silently
+        original_uuid_formatted = xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text
         xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text = (
             uuid_formatted
         )
-
         kc_response = self.store_submission(
             user, xml_tostring(xml_parsed), _uuid, attachments
         )
         if kc_response.status_code == status.HTTP_201_CREATED:
+            original_uuid = original_uuid_formatted.split(":")[-1]
+            original_extras = self.asset.submission_extras.filter(submission_uuid=original_uuid).first()
+            duplicated_extras = deepcopy(original_extras.content)
+            duplicated_extras['submission'] = _uuid
+            self.asset.update_submission_extra(duplicated_extras)
             return next(self.get_submissions(user, query={'_uuid': _uuid}))
         else:
             raise KobocatDuplicateSubmissionException

--- a/kpi/deployment_backends/kobocat_backend.py
+++ b/kpi/deployment_backends/kobocat_backend.py
@@ -5,7 +5,6 @@ import json
 import re
 from collections import defaultdict
 from contextlib import contextmanager
-from copy import deepcopy
 from datetime import date, datetime
 from typing import Generator, Optional, Union
 from urllib.parse import urlparse
@@ -368,6 +367,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
             if attachment_objects
             else None
         )
+
         # parse XML string to ET object
         xml_parsed = fromstring_preserve_root_xmlns(submission)
 
@@ -387,6 +387,7 @@ class KobocatDeploymentBackend(BaseDeploymentBackend):
         xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text = (
             uuid_formatted
         )
+
         kc_response = self.store_submission(
             user, xml_tostring(xml_parsed), _uuid, attachments
         )

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1924,10 +1924,14 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         duplicated_extra = self.asset.submission_extras.filter(
             submission_uuid=duplicated_submission['_uuid']
         ).first()
-        assert duplicated_extra.content['q1']['translation']['tx1']['value'] == \
-            dummy_extra['q1']['translation']['tx1']['value']
-        assert duplicated_extra.content['q1']['transcript']['value'] == \
-            dummy_extra['q1']['transcript']['value']
+        assert (
+            duplicated_extra.content['q1']['translation']['tx1']['value']
+            == dummy_extra['q1']['translation']['tx1']['value']
+        )
+        assert (
+            duplicated_extra.content['q1']['transcript']['value']
+            == dummy_extra['q1']['transcript']['value']
+        )
 
 
 class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1711,6 +1711,15 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
 
     def setUp(self):
         super().setUp()
+        self.asset.advanced_features = {
+            'translation': {
+                'values': ['q1'],
+                'languages': ['tx1', 'tx2'],
+            },
+            'transcript': {
+                'values': ['q1'],
+            }
+        }
         current_time = datetime.now(tz=ZoneInfo('UTC')).isoformat('T', 'milliseconds')
         # TODO: also test a submission that's missing `start` or `end`; see
         # #3054. Right now that would be useless, though, because the
@@ -1892,6 +1901,33 @@ class SubmissionDuplicateApiTests(BaseSubmissionTestCase):
         response = self.client.post(url, {'format': 'json'})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self._check_duplicate(response, submission)
+
+    def test_duplicate_submission_with_extras(self):
+        dummy_extra = {
+            'q1': {
+                'transcript': {
+                    'value': 'dummy transcription',
+                    'languageCode': 'en',
+                },
+                'translation': {
+                    'tx1': {
+                        'value': 'dummy translation',
+                        'languageCode': 'xx',
+                    }
+                },
+            },
+            'submission': self.submission['_uuid']
+        }
+        self.asset.update_submission_extra(dummy_extra)
+        response = self.client.post(self.submission_url, {'format': 'json'})
+        duplicated_submission = response.data
+        duplicated_extra = self.asset.submission_extras.filter(
+            submission_uuid=duplicated_submission['_uuid']
+        ).first()
+        assert duplicated_extra.content['q1']['translation']['tx1']['value'] == \
+            dummy_extra['q1']['translation']['tx1']['value']
+        assert duplicated_extra.content['q1']['transcript']['value'] == \
+            dummy_extra['q1']['transcript']['value']
 
 
 class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -546,9 +546,12 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         submission = submissions[0]
         return Response(submission)
 
-    @action(detail=True, methods=['POST'],
-            renderer_classes=[renderers.JSONRenderer],
-            permission_classes=[DuplicateSubmissionPermission])
+    @action(
+        detail=True,
+        methods=['POST'],
+        renderer_classes=[renderers.JSONRenderer],
+        permission_classes=[DuplicateSubmissionPermission],
+    )
     def duplicate(self, request, pk, *args, **kwargs):
         """
         Creates a duplicate of the submission with a given `pk`
@@ -556,11 +559,15 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         deployment = self._get_deployment()
         # Coerce to int because back end only finds matches with same type
         submission_id = positive_int(pk)
-        original_submission = deployment.get_submission(submission_id, request.user)
+        original_submission = deployment.get_submission(
+            submission_id, request.user, fields=['_uuid']
+        )
         duplicate_response = deployment.duplicate_submission(
             submission_id=submission_id, user=request.user
         )
-        deployment.copy_submission_extras(original_submission['_uuid'], duplicate_response['_uuid'])
+        deployment.copy_submission_extras(
+            original_submission['_uuid'], duplicate_response['_uuid']
+        )
         return Response(duplicate_response, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['GET', 'PATCH', 'DELETE'],

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -556,9 +556,11 @@ class DataViewSet(AssetNestedObjectViewsetMixin, NestedViewSetMixin,
         deployment = self._get_deployment()
         # Coerce to int because back end only finds matches with same type
         submission_id = positive_int(pk)
+        original_submission = deployment.get_submission(submission_id, request.user)
         duplicate_response = deployment.duplicate_submission(
             submission_id=submission_id, user=request.user
         )
+        deployment.copy_submission_extras(original_submission['_uuid'], duplicate_response['_uuid'])
         return Response(duplicate_response, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['GET', 'PATCH', 'DELETE'],


### PR DESCRIPTION
## Description

This PR solves the issue when data is duplicated and the submission extras are not copied to the new instance.

## Notes

The code on the kobocat deployment class was changed to duplicate the submission extras after the submission is duplicated.

## Related issues

Task 806 on Notion.