### PR TITLE
Use `env.bool` instead of brittle string matching for the `SKIP_CELERY` environment variable

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1060,9 +1060,8 @@ CSP_REPORT_ONLY = env.bool("CSP_REPORT_ONLY", False)
 
 CELERY_TIMEZONE = "UTC"
 
-if os.environ.get('SKIP_CELERY', 'False') == 'True':
-    # helpful for certain debugging
-    CELERY_TASK_ALWAYS_EAGER = True
+# helpful for certain debugging
+CELERY_TASK_ALWAYS_EAGER = env.bool('SKIP_CELERY', False)
 
 # Replace a worker after it completes 7 tasks by default. This allows the OS to
 # reclaim memory allocated during large tasks


### PR DESCRIPTION
Audience: developers only.

KoboCAT [already](https://github.com/kobotoolbox/kobocat/blob/2dd751f6ea33f4830c574537faaeab44d79e73f2/onadata/settings/base.py#L675) has this improvement, which is great, until you get confused because `SKIP_CELERY=1` works in there but not here (because KPI is using a string comparison to `True`). This fixes that.

Internal "discussion": https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/REST.20Service.20issue.20with.20domain.20transfer.20.28EU.20Server.29/near/266974