### PR TITLE
Fix timeout in project view

### DIFF
--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -16,6 +16,7 @@ from kpi.filters import (
 )
 from kpi.mixins.object_permission import ObjectPermissionViewSetMixin
 from kpi.models import Asset, ProjectViewExportTask
+from kpi.paginators import AssetPagination
 from kpi.permissions import IsAuthenticated
 from kpi.serializers.v2.asset import AssetMetadataListSerializer
 from kpi.serializers.v2.user import UserListSerializer
@@ -56,6 +57,7 @@ class ProjectViewViewSet(
     def assets(self, request, uid):
         if not user_has_view_perms(request.user, uid):
             raise Http404
+        self._paginator = AssetPagination()
         assets = Asset.objects.filter(asset_type=ASSET_TYPE_SURVEY).defer(
             'content',
             'report_styles',

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -33,7 +33,7 @@ class Paginated(LimitOffsetPagination):
 
 class AssetPagination(Paginated):
 
-    def get_paginated_response(self, data, metadata):
+    def get_paginated_response(self, data, metadata=None):
 
         response = OrderedDict([
             ('count', self.count),


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests N/A
2. [ ] If you've changed APIs, update (or create!) the documentation N/A
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes N/A

## Description

Loading the Project View table for a view with all countries selected no longer times out.

## Notes

Updates the ProjectViewViewSet to use the existing AssetPaginator class when loading the project views. This class has a special get_count method that doesn't require rerunning the whole distinct query and then recounting it. This should speed up the page considerably.

