### PR TITLE
[TASK-892] Fix Submission Modal pagination

### DIFF
--- a/jsapp/js/components/bigModal/bigModal.es6
+++ b/jsapp/js/components/bigModal/bigModal.es6
@@ -380,7 +380,6 @@ class BigModal extends React.Component {
                 ids={this.props.params.ids}
                 isDuplicated={this.props.params.isDuplicated}
                 duplicatedSubmission={this.props.params.duplicatedSubmission}
-                backgroundAudioUrl={this.props.params.backgroundAudioUrl}
                 tableInfo={this.props.params.tableInfo || false}
               />
             }

--- a/jsapp/js/components/common/koboDropdown.tsx
+++ b/jsapp/js/components/common/koboDropdown.tsx
@@ -27,8 +27,8 @@ interface KoboDropdownProps {
   /** The content of dropdown, anything's allowed. */
   menuContent: React.ReactNode;
   /**
-   * Optional name value useful for styling and `menuVisibilityChange` action,
-   * ends up in `data-name` attribut.e
+   * Name useful for styling and `menuVisibilityChange` action, it ends up in
+   * the `data-name` attribute.
    */
   name: string;
   'data-cy'?: string;
@@ -41,7 +41,7 @@ interface KoboDropdownState {
 }
 
 interface AdditionalWrapperAttributes {
-  'data-name'?: string;
+  'data-name': string;
   'data-cy'?: string;
 }
 
@@ -229,12 +229,10 @@ export default class KoboDropdown extends React.Component<
   }
 
   render() {
-    const additionalWrapperAttributes: AdditionalWrapperAttributes = {};
-
-    if (this.props.name) {
+    const additionalWrapperAttributes: AdditionalWrapperAttributes = {
       // We use `data-name` attribute to allow any character in the name.
-      additionalWrapperAttributes['data-name'] = this.props.name;
-    }
+      ['data-name']: this.props.name,
+    };
 
     if (this.props['data-cy']) {
       additionalWrapperAttributes['data-cy'] = this.props['data-cy'];

--- a/jsapp/js/components/common/koboSelect.scss
+++ b/jsapp/js/components/common/koboSelect.scss
@@ -89,9 +89,23 @@ $k-select-menu-padding: sizes.$x6;
 
 .k-select__option {
   @include mixins.buttonReset;
+  font-weight: 400;
+  position: relative;
+
+  &:hover,
+  &.k-select__option--selected {
+    color: colors.$kobo-gray-24;
+    background-color: colors.$kobo-gray-96;
+  }
+
+  &:focus-visible {
+    @include mixins.default-ui-focus;
+    // Needed so that option--selected never appears above focus styles
+    z-index: 1;
+  }
 
   .k-icon {
-    color: colors.$kobo-gray-85;
+    color: inherit;
   }
 }
 
@@ -132,23 +146,6 @@ $k-select-menu-padding: sizes.$x6;
     .k-select__trigger {
       background-color: colors.$kobo-light-red;
     }
-  }
-}
-
-.k-select__option {
-  font-weight: 500;
-  position: relative;
-
-  &:hover,
-  &.k-select__option--selected {
-    color: colors.$kobo-gray-24;
-    background-color: colors.$kobo-gray-96;
-  }
-
-  &:focus-visible {
-    @include mixins.default-ui-focus;
-    // Needed so that option--selected never appears above focus styles
-    z-index: 1;
   }
 }
 

--- a/jsapp/js/components/modals/koboModal.tsx
+++ b/jsapp/js/components/modals/koboModal.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import Modal from 'react-modal';
+import cx from 'classnames';
 import bem, {makeBem} from 'js/bem';
 import './koboModal.scss';
 
 bem.KoboModal = makeBem(null, 'kobo-modal');
 
 type KoboModalSize = 'large' | 'medium';
+
+const DEFAULT_SIZE: KoboModalSize = 'medium';
 
 interface KoboModalProps {
   /** For displaying the modal. */
@@ -23,16 +26,14 @@ interface KoboModalProps {
 }
 
 export default function KoboModal(props: KoboModalProps) {
-  const modalSize: KoboModalSize = props.size || 'medium';
-
-  const modalClassNames = ['kobo-modal', `kobo-modal--size-${modalSize}`];
+  const modalSize: KoboModalSize = props.size || DEFAULT_SIZE;
 
   return (
     <Modal
       ariaHideApp
       isOpen={props.isOpen}
       onRequestClose={props.onRequestClose}
-      className={modalClassNames.join(' ')}
+      className={cx('kobo-modal', `kobo-modal--size-${modalSize}`)}
       overlayClassName='kobo-modal-overlay'
       shouldCloseOnOverlayClick={props.isDismissableByDefaultMeans}
       shouldCloseOnEsc={props.isDismissableByDefaultMeans}

--- a/jsapp/js/components/submissions/submissionDataTable.scss
+++ b/jsapp/js/components/submissions/submissionDataTable.scss
@@ -86,19 +86,31 @@ $submission-data-table-space: sizes.$x12;
 
 .submission-data-table__row--response .submission-data-table__column.submission-data-table__column--data {
   @include mixins.centerRowFlex;
+  gap: 10px;
 
   flex: 1;
 
   .audio-player:first-child {
-    padding-right: sizes.$x30;
-  }
-
-  > *:first-child {
+    margin-right: 30px;
     flex: 1;
   }
 
-  > *:not(:last-child) {
-    margin-right: sizes.$x20;
+  video {
+    max-width: 100%;
+    object-fit: contain;
+  }
+}
+
+.submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-audio,
+.submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-image,
+.submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-video {
+  justify-content: flex-end;
+
+  img {
+    // We don't want the image to take too much space, as it's making the UI
+    // harder to follow. There are other ways to see full image, and
+    // `SubmissionDataTable` is more about the full picture.
+    max-height: 250px;
   }
 }
 

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -3,7 +3,6 @@ import autoBind from 'react-autobind';
 import bem, {makeBem} from 'js/bem';
 import Button from 'js/components/common/button';
 import {
-  downloadUrl,
   formatTimeDate,
   formatDate,
 } from 'js/utils';
@@ -21,7 +20,7 @@ import {
   SCORE_ROW_TYPE,
   RANK_LEVEL_TYPE,
 } from 'js/constants';
-import type {MetaQuestionTypeName} from 'js/constants';
+import type {MetaQuestionTypeName, AnyRowTypeName} from 'js/constants';
 import './submissionDataTable.scss';
 import type {
   AssetResponse,
@@ -277,42 +276,46 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     );
   }
 
-  renderAttachment(type: string, filename: string, name: string, xpath: string) {
+  renderAttachment(type: AnyRowTypeName, filename: string, name: string, xpath: string) {
     const attachment = getMediaAttachment(this.props.submissionData, filename, xpath);
     if (attachment && attachment instanceof Object) {
-      if (type === QUESTION_TYPES.audio.id) {
-        return (
-          <React.Fragment>
-            <AudioPlayer mediaURL={attachment.download_url} />
+      return (
+        <>
+          {type === QUESTION_TYPES.audio.id &&
+            <>
+              <AudioPlayer mediaURL={attachment.download_url} />
 
-            <Button
-              type='full'
-              size='s'
-              color='blue'
-              endIcon='arrow-up-right'
-              label={t('Open')}
-              onClick={this.openProcessing.bind(this, name)}
-            />
+              <Button
+                type='full'
+                size='s'
+                color='blue'
+                endIcon='arrow-up-right'
+                label={t('Open')}
+                onClick={this.openProcessing.bind(this, name)}
+              />
+            </>
+          }
 
-            <Button
-              type='frame'
-              size='s'
-              color='blue'
-              endIcon='download'
-              label={t('Download')}
-              onClick={downloadUrl.bind(this, attachment.download_url)}
+          {type === QUESTION_TYPES.image.id &&
+            <a href={attachment.download_url} target='_blank'>
+              <img src={attachment.download_medium_url}/>
+            </a>
+          }
+
+          {type === QUESTION_TYPES.video.id &&
+            <video
+              src={attachment.download_url}
+              controls
             />
-          </React.Fragment>
-        );
-      } else if (type === QUESTION_TYPES.image.id) {
-        return (
-          <a href={attachment.download_url} target='_blank'>
-            <img src={attachment.download_medium_url}/>
-          </a>
-        );
-      } else {
-        return (<a href={attachment.download_url} target='_blank'>{filename}</a>);
-      }
+          }
+
+          {type === QUESTION_TYPES.file.id &&
+            <a href={attachment.download_url} target='_blank'>
+              {filename}
+            </a>
+          }
+        </>
+      );
     // In the case that an attachment is missing, don't crash the page
     } else {
       return attachment;

--- a/jsapp/js/components/submissions/submissionModal.scss
+++ b/jsapp/js/components/submissions/submissionModal.scss
@@ -7,22 +7,37 @@
   }
 }
 
-.submission-modal-section {
+.submission-modal-buttons {
   display: flex;
   justify-content: space-between;
   gap: 20px;
   margin-bottom: 20px;
+
+  .checkbox {
+    margin-right: 40px;
+
+    .checkbox__label {
+      white-space: nowrap;
+    }
+  }
 }
 
-.submission-modal-warning {
+.submission-modal-buttons-group {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.submission-modal-message-box {
   margin-bottom: 20px;
   padding: 20px;
   background: colors.$kobo-gray-96;
   text-align: center;
-  line-height: 1em;
+  border-radius: 6px;
 
-  p {
-    margin: 0 0 20px 0;
+  p:not(:last-child) {
+    margin: 0 auto 20px auto;
   }
 }
 
@@ -34,73 +49,42 @@
   display: flex;
   gap: 20px;
   justify-content: space-between;
+  margin-bottom: 20px;
 
-  .switch--label-language,
-  .switch--validation-status {
-    .k-select {
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 8px;
+  .k-select {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    width: auto;
 
-      .k-select__label {
-        white-space: nowrap;
-        margin: 0;
-      }
-
-      .kobo-dropdown {
-        min-width: 140px;
-      }
-    }
-  }
-}
-
-.submission-modal-actions {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
-
-  .checkbox {
-    margin-right: 40px;
-
-    .checkbox__label {
+    .k-select__label {
       white-space: nowrap;
+      margin: 0;
+    }
+
+    .kobo-dropdown {
+      min-width: 140px;
     }
   }
 }
 
-.submission-pager {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
-}
+.duplicated-submission-subheader {
+  .submission-modal-buttons-group {
+    justify-content: center;
+  }
 
-.submission-modal-duplicate-actions {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  margin-bottom: 20px;
-}
+  .submission-duplicate__text {
+    max-width: 640px;
+    text-align: center;
+    margin: auto;
+    margin-bottom: 20px;
+  }
 
-.submission-duplicate__button {
-  margin-left: 12px;
-}
-
-.submission-duplicate__text {
-  max-width: 60%;
-  text-align: center;
-  margin: auto;
-  margin-bottom: 20px;
-}
-
-.submission-duplicate__header {
-  max-width: 60%;
-  text-align: center;
-  margin: auto;
-  margin-bottom: 12px;
-  color: colors.$kobo-blue;
+  .submission-duplicate__header {
+    text-align: center;
+    margin: auto;
+    margin-bottom: 12px;
+    color: colors.$kobo-blue;
+  }
 }

--- a/jsapp/js/components/submissions/submissionModal.tsx
+++ b/jsapp/js/components/submissions/submissionModal.tsx
@@ -29,6 +29,9 @@ import type {
   SubmissionResponse,
   ValidationStatusResponse,
 } from 'js/dataInterface';
+import AudioPlayer from 'js/components/common/audioPlayer';
+import {getBackgroundAudioQuestionName} from 'js/components/submissions/tableUtils';
+import {getMediaAttachment} from 'js/components/submissions/submissionUtils';
 import './submissionModal.scss';
 
 const DETAIL_NOT_FOUND = '{\"detail\":\"Not found.\"}';
@@ -39,7 +42,6 @@ interface SubmissionModalProps {
   ids: number[];
   isDuplicated: boolean;
   duplicatedSubmission: SubmissionResponse | null;
-  backgroundAudioUrl: string;
   tableInfo:
     | {
         resultsTotal: number;
@@ -387,10 +389,43 @@ class SubmissionModal extends React.Component<
     });
   }
 
-  hasBackgroundAudio() {
+  /**
+   * Whether the form has background audio enabled. This means that there is
+   * a possibility that the submission could have a background audio recording.
+   * If you need to know if recording exist, please use `getBackgroundAudioUrl`.
+   */
+  hasBackgroundAudioEnabled() {
     return this.props.asset?.content?.survey?.some(
       (question) => question.type === META_QUESTION_TYPES['background-audio']
     );
+  }
+
+  getBackgroundAudioUrl() {
+    const backgroundAudioName = getBackgroundAudioQuestionName(
+      this.props.asset
+    );
+
+    if (
+      backgroundAudioName &&
+      this.state.submission &&
+      Object.keys(this.state.submission).includes(backgroundAudioName)
+    ) {
+      const response = this.state.submission[backgroundAudioName];
+      if (typeof response === 'string') {
+        const mediaAttachment = getMediaAttachment(
+          this.state.submission,
+          response,
+          META_QUESTION_TYPES['background-audio']
+        );
+        if (typeof mediaAttachment === 'string') {
+          return mediaAttachment;
+        } else {
+          return mediaAttachment.download_medium_url;
+        }
+      }
+    }
+
+    return undefined;
   }
 
   renderDropdowns() {
@@ -465,7 +500,7 @@ class SubmissionModal extends React.Component<
       return <CenteredMessage message={t('Unknown error')} />;
     }
 
-    const s = this.state.submission;
+    const bgAudioUrl = this.getBackgroundAudioUrl();
 
     // Use this modal if we just duplicated a submission, but not if we are
     // editing it
@@ -558,19 +593,6 @@ class SubmissionModal extends React.Component<
           )}
 
           <section className='submission-modal-section'>
-            {this.hasBackgroundAudio() && (
-              <bem.BackgroundAudioPlayer>
-                <bem.BackgroundAudioPlayer__label>
-                  {t('Background audio recording')}
-                </bem.BackgroundAudioPlayer__label>
-
-                <bem.BackgroundAudioPlayer__audio
-                  controls
-                  src={this.props?.backgroundAudioUrl}
-                />
-              </bem.BackgroundAudioPlayer>
-            )}
-
             {this.renderDropdowns()}
           </section>
 
@@ -717,6 +739,30 @@ class SubmissionModal extends React.Component<
               )}
             </div>
           </section>
+
+          {this.hasBackgroundAudioEnabled() && (
+            <bem.SubmissionDataTable>
+              <bem.SubmissionDataTable__row m={['columns', 'column-names']}>
+                <bem.SubmissionDataTable__column>
+                  {t('Background audio recording')}
+                </bem.SubmissionDataTable__column>
+              </bem.SubmissionDataTable__row>
+
+              <bem.SubmissionDataTable__row m={['columns', 'response', 'type-audio']}>
+                {bgAudioUrl &&
+                  <bem.SubmissionDataTable__column m={['data', 'type-audio']}>
+                    <AudioPlayer mediaURL={bgAudioUrl} />
+                  </bem.SubmissionDataTable__column>
+                }
+
+                {!bgAudioUrl &&
+                  <bem.SubmissionDataTable__column m='data'>
+                    {t('N/A')}
+                  </bem.SubmissionDataTable__column>
+                }
+              </bem.SubmissionDataTable__row>
+            </bem.SubmissionDataTable>
+          )}
 
           {this.state.submission && (
             <SubmissionDataTable

--- a/jsapp/js/components/submissions/submissionModal.tsx
+++ b/jsapp/js/components/submissions/submissionModal.tsx
@@ -323,12 +323,8 @@ export default class SubmissionModal extends React.Component<
     enketoHandler
       .openSubmission(this.props.asset.uid, this.state.sid, EnketoActions.edit)
       .then(
-        () => {
-          this.setState({isEnketoEditLoading: false});
-        },
-        () => {
-          this.setState({isEnketoEditLoading: false});
-        }
+        () => {this.setState({isEnketoEditLoading: false});},
+        () => {this.setState({isEnketoEditLoading: false});}
       );
   }
 
@@ -336,14 +332,13 @@ export default class SubmissionModal extends React.Component<
    * Opens current submission as view-only in Enketo (in new browser tab).
    */
   launchViewSubmission() {
-    this.setState({
-      isEnketoViewLoading: true,
-    });
+    this.setState({isEnketoViewLoading: true});
     enketoHandler
       .openSubmission(this.props.asset.uid, this.state.sid, EnketoActions.view)
-      .then(() => {
-        this.setState({isEnketoViewLoading: false});
-      });
+      .then(
+        () => {this.setState({isEnketoViewLoading: false});},
+        () => {this.setState({isEnketoViewLoading: false});}
+      );
   }
 
   duplicateSubmission() {
@@ -363,9 +358,7 @@ export default class SubmissionModal extends React.Component<
    */
   triggerRefresh() {
     this.getSubmission(this.props.asset.uid, this.props.sid);
-    this.setState({
-      isRefreshNeeded: false,
-    });
+    this.setState({isRefreshNeeded: false});
     // Prompt table to refresh submission list
     actions.resources.refreshTableSubmissions();
   }
@@ -558,11 +551,10 @@ export default class SubmissionModal extends React.Component<
         </h1>
 
         <p className='submission-duplicate__text'>
-          {t(
-            'A duplicate of the submission record was successfully created. You can view the new instance below and make changes using the action buttons below.'
-          )}
-          <br />
-          <br />
+          {t('A duplicate of the submission record was successfully created. You can view the new instance below and make changes using the action buttons below.')}
+        </p>
+
+        <p className='submission-duplicate__text'>
           {t('Source submission uuid:' + ' ')}
           <code>{this.state.duplicatedSubmission?._uuid}</code>
         </p>

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -586,7 +586,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
               tooltip={t('Open')}
               tooltipPosition='left'
               onClick={() => {
-                this.launchSubmissionModal(row, row.original._id);
+                this.launchSubmissionModal(row.original._id);
               }}
             />
 
@@ -1254,39 +1254,8 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
    * Opens submission modal
    * @param {object} row
    */
-  launchSubmissionModal(row: CellInfo, sid: string) {
-    if (row && row.original) {
-      const backgroundAudioName = getBackgroundAudioQuestionName(
-        this.props.asset
-      );
-      if (
-        backgroundAudioName &&
-        Object.keys(row.original).includes(backgroundAudioName)
-      ) {
-        const mediaAttachment = getMediaAttachment(
-          row.original,
-          row.original[backgroundAudioName],
-          META_QUESTION_TYPES['background-audio']
-        );
-
-        let backgroundAudioUrl;
-        if (typeof mediaAttachment === 'string') {
-          backgroundAudioUrl = mediaAttachment;
-        } else {
-          backgroundAudioUrl = mediaAttachment.download_medium_url;
-        }
-
-        this.submissionModalProcessing(
-          sid,
-          this.state.submissions,
-          false,
-          null,
-          backgroundAudioUrl
-        );
-      } else {
-        this.submissionModalProcessing(sid, this.state.submissions);
-      }
-    }
+  launchSubmissionModal(sid: string) {
+    this.submissionModalProcessing(sid, this.state.submissions);
   }
 
   /**
@@ -1297,7 +1266,6 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     submissions: SubmissionResponse[],
     isDuplicated: boolean = false,
     duplicatedSubmission: SubmissionResponse | null = null,
-    backgroundAudioUrl: string | null = null
   ) {
     const ids = submissions.map((item) => item._id);
 
@@ -1308,7 +1276,6 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
       ids: ids,
       isDuplicated: isDuplicated,
       duplicatedSubmission: duplicatedSubmission,
-      backgroundAudioUrl: backgroundAudioUrl,
       tableInfo: {
         currentPage: this.state.currentPage,
         pageSize: this.state.pageSize,

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -93,6 +93,7 @@ import type {
   SurveyRow,
 } from 'js/dataInterface';
 import type {
+  SubmissionPageName,
   TableColumn,
   ReactTableState,
   ReactTableInstance,
@@ -123,7 +124,7 @@ interface DataTableState {
   /** A list of rows that are selected. */
   selectedRows: DataTableSelectedRows;
   selectAll: boolean;
-  submissionPager: boolean | 'next' | 'prev';
+  submissionPager?: SubmissionPageName;
   /** state of react-table table */
   fetchState?: ReactTableState;
   /** instance data of react-table table */
@@ -165,7 +166,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
       resultsTotal: 0,
       selectedRows: {},
       selectAll: false,
-      submissionPager: false,
+      submissionPager: undefined,
       lastChecked: null,
       shiftSelection: {},
     };
@@ -326,7 +327,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
         selectedRows: {},
         selectAll: false,
         submissions: results,
-        submissionPager: false,
+        submissionPager: undefined,
         resultsTotal: response.count,
       }, () => {
         this._prepColumns(results);
@@ -1190,9 +1191,11 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     sid: string,
     duplicatedSubmission: SubmissionResponse
   ) {
+    // Load fresh table of submissions
     if (this.state.fetchInstance) {
       this.fetchSubmissions(this.state.fetchInstance);
     }
+    // Open submission modal
     this.submissionModalProcessing(
       sid,
       this.state.submissions,
@@ -1298,19 +1301,29 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
   onPageStateUpdated(pageState: PageStateStoreState) {
     // This function serves purpose only for Submission Modal and only when
     // user reaches the end of currently loaded submissions in the table with
-    // the "next" button.
+    // the "next" button (and similarly with "prev" button).
     if (
       pageState.modal &&
       pageState.modal.type === MODAL_TYPES.SUBMISSION &&
       !pageState.modal.sid
     ) {
+      // HACK: this is our way of forcing `react-table` to switch page. There is
+      // a way to manually control pagination, but it would require some
+      // refactoring to happen. This hack (i.e. using internal `setState` of
+      // `react-table` component) will most definitely not work when we upgrade
+      // `react-table` to v7, but since that major version is a huge overhaul,
+      // we would be refactoring everything regardless.
+      let page = 0;
+      if (pageState.modal.page === 'next') {
+        page = this.state.currentPage + 1;
+      } else if (pageState.modal.page === 'prev') {
+        page = this.state.currentPage - 1;
+      }
       const fetchInstance = this.state.fetchInstance;
+      fetchInstance?.setState({page: page});
 
       this.setState(
-        {
-          fetchInstance: fetchInstance,
-          submissionPager: pageState.modal.page,
-        },
+        {submissionPager: pageState.modal.page},
         this.fetchDataForCurrentInstance.bind(this)
       );
     }

--- a/jsapp/js/components/submissions/table.types.ts
+++ b/jsapp/js/components/submissions/table.types.ts
@@ -4,6 +4,8 @@ import type {
   SubmissionResponse,
 } from 'js/dataInterface';
 
+export type SubmissionPageName = 'next' | 'prev';
+
 // TODO: there might be some more properties here
 export interface TableColumn extends Column<SubmissionResponse> {
   id: string;
@@ -203,4 +205,6 @@ export interface ReactTableInstance {
   sortData: Function;
   state: ReactTableState;
   updater: any;
+  /** Internal function. You can pass any of `ReactTableState` properties. */
+  setState: (params: any) => void;
 }

--- a/jsapp/js/components/submissions/table.types.ts
+++ b/jsapp/js/components/submissions/table.types.ts
@@ -1,10 +1,5 @@
 import type {Column} from 'react-table';
 import type {
-  QuestionTypeName,
-  MetaQuestionTypeName,
-  MiscRowTypeName,
-} from 'js/constants';
-import type {
   SurveyRow,
   SubmissionResponse,
 } from 'js/dataInterface';

--- a/jsapp/js/pageState.store.ts
+++ b/jsapp/js/pageState.store.ts
@@ -2,6 +2,10 @@ import Reflux from 'reflux';
 
 interface PageStateModalParams {
   type: string; // one of MODAL_TYPES
+  // TODO: this is dangerous, as we are not checking what we are passing around,
+  // but since there are multiple completely different modals that use these
+  // params, and we are planning to not use this modal component, refactoring
+  // might be too much work.
   [name: string]: any;
 }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes switching between submissions in Submission Modal in cases when previous/next submission was coming from previous/next page of Data Table results. Includes some internal code cleanup.

## Notes

Things changed here:
- Small fix in `KoboDropdown` to use the nonoptional `name` prop without unnecessary checks
- Fixed color of icon in `KoboSelect` component (previous was lighter, now follows Figma designs to use darker color)
- `KoboModal` uses `classnames` utility and the default size is more obvious
- `SubmissionDataTable` component (the table being displayed in Submission Modal) has couple of changes:
  - `video` questions now display a video player (simplest possible) instead of a link
  - `image` questions now have a limit how big the displayed image is
  - Some paddings and margins cleanup
  - Prepares code for adding new feature (attachment deleting)
- `SubmissionModal` component has couple of changes too:
  - Moved `backgroundAudioUrl` handling to be completely handled here and changed how background audio is being displayed to make it appear more like a piece of submission data than element of modal UI
  - Some style cleanups (paddings and margins)
  - Cleaned up duplicated submission info rendering - generally introduced few `renderX` functions for pieces of modal to make it a bit clearer to read and understand
  - Renamed few props to less confusing names
  - Added pending states to few components that have such option available
- **Fixed a bug in `SubmissionModal` that made changing prev/next submission impossible if it was on other page of results**
- Added bunch of (hopefully) useful comments

## Related issues

Bug introduced by #4942 (i.e. by me)
Needed for #4995
