### PR TITLE
Remove redundant filter in Project View table

### DIFF
--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -41,7 +41,8 @@ function CustomViewRoute() {
     customView.setUp(
       viewUid,
       `${ROOT_URL}/api/v2/project-views/${viewUid}/assets/`,
-      DEFAULT_VISIBLE_FIELDS
+      DEFAULT_VISIBLE_FIELDS,
+      false
     );
   }, [viewUid]);
 

--- a/jsapp/js/projects/customViewStore.tests.ts
+++ b/jsapp/js/projects/customViewStore.tests.ts
@@ -1,0 +1,31 @@
+import chai from 'chai';
+import customViewStore from './customViewStore';
+import { HOME_DEFAULT_VISIBLE_FIELDS } from './projectViews/constants';
+
+describe('customViewStore', () => {
+  describe('constructFullQueryParams', () => {
+    it('includes asset_type filter by default', () => {
+      const store = customViewStore.setUp(
+        '',
+        '',
+        HOME_DEFAULT_VISIBLE_FIELDS,
+      )
+      const url = new URL('http://www.example.com');
+      const params = customViewStore.constructFullQueryParams(url);
+      const paramsObject = Object.fromEntries(params)
+      chai.expect(paramsObject).to.deep.equal({q: '(asset_type:survey)', limit: '50'});
+    });
+    it('removes asset_type if includeTypeFilter is false', () => {
+      const store = customViewStore.setUp(
+        '',
+        '',
+        HOME_DEFAULT_VISIBLE_FIELDS,
+        false,
+      )
+      const url = new URL('http://www.example.com');
+      const params = customViewStore.constructFullQueryParams(url);
+      const paramsObject = Object.fromEntries(params)
+      chai.expect(paramsObject).to.deep.equal({'limit': '50'});
+    });
+  });
+});

--- a/jsapp/js/projects/customViewStore.ts
+++ b/jsapp/js/projects/customViewStore.ts
@@ -178,17 +178,17 @@ class CustomViewStore {
     const url = new URL(this.baseUrl);
     const params = new URLSearchParams(url.search);
 
-    // Step 3: Build queries for Back end (for `q=`)
+    // Step 3: Build queries for Back end (for `q=`). The backend will take care of filtering down to only surveys
     const queries = buildQueriesFromFilters(this.filters);
-    // We are only interested in surveys
-    queries.push(COMMON_QUERIES.s);
     // Add search query
     const searchPhrase = (searchBoxStore.data.searchPhrase ?? '').trim();
     if (searchPhrase !== '') {
       queries.push(searchPhrase);
     }
-    const queriesString = '(' + queries.join(') AND (') + ')';
-    params.set('q', queriesString);
+    if (queries.length > 0) {
+      const queriesString = '(' + queries.join(') AND (') + ')';
+      params.set('q', queriesString);
+    }
 
     // Step 4: Build ordering string
     const orderingString = this.getOrderQuery();

--- a/jsapp/js/projects/customViewStore.ts
+++ b/jsapp/js/projects/customViewStore.ts
@@ -164,6 +164,44 @@ class CustomViewStore {
   }
 
   /**
+   * Constructs all the parameters needed for the API call to fetch assets.
+   * Left public for easier testing.
+   */
+
+  public constructFullQueryParams(url: URL) {
+    const params = new URLSearchParams(url.search);
+
+    // Step 1: Build queries for Back end (for `q=`).
+    const queries = buildQueriesFromFilters(this.filters);
+
+    // We are only interested in surveys, but some URLs will automatically add that query on the backend, so let the
+    // caller decide if we need to add it explicitly
+    if (this.includeTypeFilter) {
+      queries.push(COMMON_QUERIES.s);
+    }
+
+    // Step 2: Add search query
+    const searchPhrase = (searchBoxStore.data.searchPhrase ?? '').trim();
+    if (searchPhrase !== '') {
+      queries.push(searchPhrase);
+    }
+    if (queries.length > 0) {
+      const queriesString = '(' + queries.join(') AND (') + ')';
+      params.set('q', queriesString);
+    }
+
+    // Step 3: Build ordering string
+    const orderingString = this.getOrderQuery();
+    if (orderingString) {
+      params.set('ordering', orderingString);
+    }
+
+    params.set('limit', String(PAGE_SIZE));
+
+    return params;
+  }
+
+  /**
    * Gets the first page of results. It will replace whatever assets are loaded
    * already.
    */
@@ -179,42 +217,14 @@ class CustomViewStore {
 
     // Step 2: Prepare url
     const url = new URL(this.baseUrl);
-    const params = new URLSearchParams(url.search);
+    const params = this.constructFullQueryParams(url)
 
-    // Step 3: Build queries for Back end (for `q=`).
-    const queries = buildQueriesFromFilters(this.filters);
-
-    // We are only interested in surveys, but some URLs will automatically add that query on the backend, so let the
-    // caller decide if we need to add it explicitly
-    if (this.includeTypeFilter) {
-      queries.push(COMMON_QUERIES.s);
-    }
-
-    // Add search query
-    const searchPhrase = (searchBoxStore.data.searchPhrase ?? '').trim();
-    if (searchPhrase !== '') {
-      queries.push(searchPhrase);
-    }
-    if (queries.length > 0) {
-      const queriesString = '(' + queries.join(') AND (') + ')';
-      params.set('q', queriesString);
-    }
-
-    // Step 4: Build ordering string
-    const orderingString = this.getOrderQuery();
-    if (orderingString) {
-      params.set('ordering', orderingString);
-    }
-
-    // Step 5: Stop any ongoing call (as it is no longer needed)
+    // Step 3: Stop any ongoing call (as it is no longer needed)
     if (this.ongoingFetch) {
       this.ongoingFetch.abort();
     }
 
-    // Step 6: Set limit
-    params.set('limit', String(PAGE_SIZE));
-
-    // Step 7: Make API call :)
+    // Step 4: Make API call :)
     this.ongoingFetch = $.ajax({
       dataType: 'json',
       method: 'GET',

--- a/jsapp/js/projects/customViewStore.ts
+++ b/jsapp/js/projects/customViewStore.ts
@@ -167,7 +167,6 @@ class CustomViewStore {
    * Constructs all the parameters needed for the API call to fetch assets.
    * Left public for easier testing.
    */
-
   public constructFullQueryParams(url: URL) {
     const params = new URLSearchParams(url.search);
 

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -60,7 +60,7 @@ function MyProjectsRoute() {
     customView.setUp(
       HOME_VIEW.uid,
       `${ROOT_URL}/api/v2/assets/`,
-      HOME_DEFAULT_VISIBLE_FIELDS,
+      HOME_DEFAULT_VISIBLE_FIELDS
     );
 
     const inviteParams = searchParams.get('invite');

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -60,7 +60,7 @@ function MyProjectsRoute() {
     customView.setUp(
       HOME_VIEW.uid,
       `${ROOT_URL}/api/v2/assets/`,
-      HOME_DEFAULT_VISIBLE_FIELDS
+      HOME_DEFAULT_VISIBLE_FIELDS,
     );
 
     const inviteParams = searchParams.get('invite');

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ require('../jsapp/js/components/formBuilder/formBuilderUtils.tests');
 require('../jsapp/js/assetUtils.tests');
 require('../jsapp/js/components/locking/lockingUtils.tests');
 require('../jsapp/js/components/submissions/submissionUtils.tests');
+require('../jsapp/js/projects/customViewStore.tests')
 require('../jsapp/js/projects/projectViews/utils.tests');
 require('../jsapp/js/components/processing/processingUtils.tests');
 require('../jsapp/js/components/processing/routes.utils.tests');


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation N/A
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE) N/A
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes N/A

## Description
Ensure the Project View table doesn't spend extra time running the same filter twice. 

## Notes
The project_view/<ID>/assets endpoint in the backend always filters the assets to only surveys, so including this filter in the front-end query of a Project View URL is redundant.

Update customViewStore.setUp() to take an additional parameter, includeTypeFilter. The parameter defaults to true. If the parameter is set, the viewStore will continue the previous behavior of adding asset_type:survey to the querystring. Otherwise, it will leave it out. The parameter is set to false in the customViewRoute because it hits the project_view endpoint.

Also does a little refactoring and adds a few tests around the new logic.

