### PR TITLE
Reject 2FA activation with API when option is disabled for that account #4556 - B

### DIFF
--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -1,9 +1,13 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 
 def user_has_inactive_paid_subscription(username):
+    if not settings.STRIPE_ENABLED:
+        return False
+
     return (
         User.objects.filter(
             username=username,
@@ -17,6 +21,9 @@ def user_has_inactive_paid_subscription(username):
 
 
 def user_has_paid_subscription(username):
+    if not settings.STRIPE_ENABLED:
+        return False
+
     return User.objects.filter(
         username=username,
         organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,


### PR DESCRIPTION
## Description

This PR includes a fix for the stripe module that made login fail when Stripe is not enabled in the settings

## Related issues

Fixes #4556