### PR TITLE
feat: add geojson support on media of a form

### DIFF
--- a/kpi/models/asset_file.py
+++ b/kpi/models/asset_file.py
@@ -78,6 +78,8 @@ class AssetFile(models.Model, AbstractFormMedia):
             'text/csv',
             'application/xml',
             'application/zip',
+            'application/geo+json',
+            'application/json',
         ),
         PAIRED_DATA: ('application/xml',),
         MAP_LAYER: (


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #5014) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Added support for `.geojson` MIME type to allow uploading geojson files in media files when using the `select_one_from_file {filename}.geojson` field type in KoboToolbox forms. This resolves the validation issue that prevented the geojson file from being uploaded.

## Notes

The KPI backend validation was updated to include the `.geojson` MIME type, which allows users to upload geojson files as media files in the Kobo form builder. This enhancement ensures that forms using the `select_one_from_file {filename}.geojson` field type can now properly utilize geojson files.

## Related issues

Fixes #5014
