### PR TITLE
Fix session authentication bug which blocks media and legacy exports

### DIFF
--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -2,7 +2,7 @@ from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.forms import SignupForm
 from constance import config
 from django.conf import settings
-from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.db import transaction
 from django.shortcuts import resolve_url
 from django.template.response import TemplateResponse
@@ -85,3 +85,9 @@ class AccountAdapter(DefaultAccountAdapter):
             )
             user.set_password(password)
             user.save()
+
+    def login(self, request, user):
+        # Override django-allauth login method to use specified authentication backend
+        super().login(request, user)
+        user.backend = settings.AUTHENTICATION_BACKENDS[0]
+        login(request, user, backend=user.backend)

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -17,6 +17,15 @@ from .utils import user_has_paid_subscription
 
 class AccountAdapter(DefaultAccountAdapter):
 
+    def is_open_for_signup(self, request):
+        return config.REGISTRATION_OPEN
+
+    def login(self, request, user):
+        # Override django-allauth login method to use specified authentication backend
+        super().login(request, user)
+        user.backend = settings.AUTHENTICATION_BACKENDS[0]
+        login(request, user, backend=user.backend)
+
     def pre_login(self, request, user, **kwargs):
 
         if parent_response := super().pre_login(request, user, **kwargs):
@@ -61,9 +70,6 @@ class AccountAdapter(DefaultAccountAdapter):
                 context=context,
             )
 
-    def is_open_for_signup(self, request):
-        return config.REGISTRATION_OPEN
-
     def save_user(self, request, user, form, commit=True):
         # Compare allauth SignupForm with our custom field
         standard_fields = set(SignupForm().fields.keys())
@@ -85,9 +91,3 @@ class AccountAdapter(DefaultAccountAdapter):
             )
             user.set_password(password)
             user.save()
-
-    def login(self, request, user):
-        # Override django-allauth login method to use specified authentication backend
-        super().login(request, user)
-        user.backend = settings.AUTHENTICATION_BACKENDS[0]
-        login(request, user, backend=user.backend)

--- a/kobo/apps/accounts/tests/constants.py
+++ b/kobo/apps/accounts/tests/constants.py
@@ -1,0 +1,15 @@
+SOCIALACCOUNT_PROVIDERS = {
+    'openid_connect': {
+        'SERVERS': [
+            {
+                'id': 'test-app',
+                'name': 'Test App',
+                'server_url': 'http://testserver/oauth',
+                'APP': {
+                    'client_id': 'test.service.id',
+                    'secret': 'test.service.secret',
+                },
+            }
+        ]
+    }
+}

--- a/kobo/apps/accounts/tests/test_backend.py
+++ b/kobo/apps/accounts/tests/test_backend.py
@@ -16,25 +16,7 @@ User = get_user_model()
 
 # from kobo.apps.openrosa.apps.main.models import UserProfile
 # from kobo.apps.kobo_auth.shortcuts import User
-
-# TODO refactor this and use `SOCIALACCOUNT_PROVIDERS` at only one place
-#   see test_templatetags.py
-
-SOCIALACCOUNT_PROVIDERS = {
-    'openid_connect': {
-        'SERVERS': [
-            {
-                'id': 'test-app',
-                'name': 'Test App',
-                'server_url': 'http://testserver/oauth',
-                'APP': {
-                    'client_id': 'test.service.id',
-                    'secret': 'test.service.secret',
-                },
-            }
-        ]
-    }
-}
+from .constants import SOCIALACCOUNT_PROVIDERS
 
 
 class SSOLoginTest(TestCase):

--- a/kobo/apps/accounts/tests/test_backend.py
+++ b/kobo/apps/accounts/tests/test_backend.py
@@ -1,0 +1,124 @@
+import json
+from mock import patch
+
+import responses
+from allauth.socialaccount.models import SocialAccount, SocialApp
+from django.conf import settings
+from django.test.utils import override_settings
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+# TODO Replace this two lines with the two commented out below when merge with
+#   release 2.024.25
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
+# from kobo.apps.openrosa.apps.main.models import UserProfile
+# from kobo.apps.kobo_auth.shortcuts import User
+
+# TODO refactor this and use `SOCIALACCOUNT_PROVIDERS` at only one place
+#   see test_templatetags.py
+
+SOCIALACCOUNT_PROVIDERS = {
+    "openid_connect": {
+        "SERVERS": [
+            {
+                "id": "test-app",
+                "name": "Test App",
+                "server_url": "http://testserver/oauth",
+                "APP": {
+                    "client_id": "test.service.id",
+                    "secret": "test.service.secret",
+                },
+            }
+        ]
+    }
+}
+
+
+class SSOLoginTest(TestCase):
+
+    def setUp(self):
+        # Create a user for the test
+        testuser = User.objects.create_user(
+            username='testuser',
+            email='testuser@testserver',
+            password='password',
+        )
+
+        # Will be needed when merged in release/2.024.25
+        # UserProfile.objects.create(user=testuser)
+
+        # Delete any social app that could be added by migration
+        # `0007_add_providers_from_environment_to_db`
+        SocialApp.objects.all().delete()
+
+        self.extra_data = {
+            'username': 'testuser',
+            'sub': 'testuser',
+            'preferred_username': 'testuser',
+            'email': 'testuser@testserver',
+        }
+
+        # Create a social account for user
+        self.social_account = SocialAccount.objects.create(
+            user=testuser,
+            provider='test-app',
+            uid='testuser',
+            extra_data=self.extra_data,
+        )
+
+    @override_settings(SOCIALACCOUNT_PROVIDERS=SOCIALACCOUNT_PROVIDERS)
+    @responses.activate
+    @patch('allauth.socialaccount.models.SocialLogin.verify_and_unstash_state')
+    def test_keep_django_auth_backend_with_sso(self, mock_verify_and_unstash_state):
+        mock_verify_and_unstash_state.return_value = {'process': 'login'}
+
+        # Mock `requests` responses to fool django-allauth
+        responses.add(
+            responses.GET,
+            'http://testserver/oauth/.well-known/openid-configuration',
+            status=status.HTTP_200_OK,
+            content_type='application/json',
+            body=json.dumps({
+                'token_endpoint': 'http://testserver/oauth/token',
+                'authorization_endpoint': 'http://testserver/oauth/authorize',
+                'userinfo_endpoint': 'http://testserver/oauth/userinfo',
+            }),
+        )
+
+        responses.add(
+            responses.POST,
+            'http://testserver/oauth/token',
+            status=status.HTTP_200_OK,
+            content_type='application/json',
+            body=json.dumps({
+                'access_token': 'mock_access_token',
+                'refresh_token': 'mock_refresh_token'
+            }),
+        )
+
+        responses.add(
+            responses.GET,
+            'http://testserver/oauth/userinfo',
+            status=status.HTTP_200_OK,
+            content_type='application/json',
+            body=json.dumps(self.extra_data),
+        )
+
+        # Get SSO provider callback URL
+        sso_login_url = reverse(
+            'openid_connect_callback', args=('openid_connect',)
+        )
+
+        # Simulate GET request to SSO provider
+        mock_sso_response = {'code': 'foobar'}
+        response = self.client.get(sso_login_url, data=mock_sso_response)
+
+        # Ensure user is logged in
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertRedirects(response, reverse(settings.LOGIN_REDIRECT_URL))
+
+        self.assertTrue(response.wsgi_request.user.is_authenticated)
+        assert response.wsgi_request.user.backend == settings.AUTHENTICATION_BACKENDS[0]

--- a/kobo/apps/accounts/tests/test_templatetags.py
+++ b/kobo/apps/accounts/tests/test_templatetags.py
@@ -1,24 +1,9 @@
-from django.test import TestCase, override_settings
 from allauth.socialaccount.models import SocialApp
+from django.test import TestCase, override_settings
+
 from kobo.apps.accounts.models import SocialAppCustomData
 from kobo.apps.accounts.templatetags.get_provider_appname import get_social_apps
-
-# example app setup for testing
-SOCIALACCOUNT_PROVIDERS = {
-    "openid_connect": {
-        "SERVERS": [
-            {
-                "id": "test-app",
-                "name": "Test App",
-                "server_url": "https://example.org/oauth",
-                "APP": {
-                    "client_id": "test.service.id",
-                    "secret": "test.service.secret",
-                },
-            }
-        ]
-    }
-}
+from .constants import SOCIALACCOUNT_PROVIDERS
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS=SOCIALACCOUNT_PROVIDERS)


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Allow users who are logging in with SSO or for the first time to export projects as any type of legacy export and media attachments (ZIP). 

## Notes

Note: must be using [kobo-install with HTTPs](https://www.notion.so/kobotoolbox/kobo-install-with-HTTPS-for-devs-a13fc536192c4a93b2c5e9aba46bb8a8?pvs=4) for testing

To test:

1. Create a new user, login, make a new project, and add submissions
2. Navigate to the Project > Data > Downloads > **Select Export Type** dropdown
3. Choose **Media Attachments (ZIP)** and observe "Not Shared" message 
4. Enable SSO on your account, logout, and then login using SSO
5. Navigate to the zip export again and observe the "Not Shared" message 
Note: SSO and first login for any account will have this issue
6. Apply my changes and repeat steps, all media attachments should be available
