### PR TITLE
Fix header logo

### DIFF
--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -35,9 +35,13 @@
   }
 
   .header__logo {
+    // NOTE: this is overrideable, see `/kpi/templates/index.html`
     background-image: url("../img/kobologo_symbol.svg");
+    background-repeat: no-repeat;
+    background-position: 50% 50%;
     width: 40px;
     height: 40px;
+    // Needed for non-horizontal images
     background-size: contain;
     display: block;
   }
@@ -348,7 +352,7 @@
   }
 
   .mdl-layout__header .header__logo {
-    background: url("../img/kobologo.svg") no-repeat 50% 50%;
+    background-image: url("../img/kobologo.svg");
     width: 180px;
   }
 }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fix an issue when logo image was not being properly sized, but was displayed cropped instead.

## Notes

This happened because the general `background` (from a media query) is overriding all `background-*`, and thus was overriding `background-size: contain`. This was fixed now with using `background-image` in the media query.

## Related issues
