### PR TITLE
Fix "Could not get data for your organization" when browsing as an anonymous user.

### DIFF
--- a/jsapp/js/account/billingContextProvider.component.tsx
+++ b/jsapp/js/account/billingContextProvider.component.tsx
@@ -5,8 +5,12 @@ import {
   OrganizationContext,
   useOrganization,
 } from 'js/account/organizations/useOrganization.hook';
+import sessionStore from 'js/stores/session';
 
 export const BillingContextProvider = (props: {children: ReactNode}) => {
+  if (!sessionStore.isLoggedIn) {
+    return <>{props.children}</>;
+  }
   const [organization, reloadOrg, orgStatus] = useOrganization();
   const usage = useUsage(organization?.id);
   const products = useProducts();


### PR DESCRIPTION
## Description

Retrieve organization data only for logged-in users to prevent error messages.

## Notes

This PR is a backport of #and supersedes it. 

## Related issues

Related to #4991

