### PR TITLE
[TASK-922] Fix infinite spinner happening when switching projects using sidebar

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -436,8 +436,14 @@ actions.resources.loadAsset.listen(function (params, refresh = false) {
     })
     .fail(actions.resources.loadAsset.failed);
   } else if (assetCache[params.id] !== 'pending') {
-    // we have a cache entry, use that
-    actions.resources.loadAsset.completed(assetCache[params.id]);
+    // HACK: because some old pieces of code relied on the fact that loadAsset
+    // was always async, we add this timeout to mimick that functionality.
+    // Without it we were encountering bugs, as things were happening much
+    // earlier than anticipated.
+    setTimeout(() => {
+      // we have a cache entry, use that
+      actions.resources.loadAsset.completed(assetCache[params.id]);
+    }, 0);
   }
   // the cache entry for this asset is currently loading, do nothing
 });

--- a/jsapp/js/lists/sidebarForms.es6
+++ b/jsapp/js/lists/sidebarForms.es6
@@ -12,6 +12,10 @@ import {COMMON_QUERIES, DEPLOYMENT_CATEGORIES} from 'js/constants';
 import AssetName from 'js/components/common/assetName';
 import {userCan} from 'js/components/permissions/utils';
 
+/**
+ * A list of projects grouped by status (deployed, draft, archived). It's meant
+ * to be displayed in the sidebar area.
+ */
 class SidebarFormsList extends Reflux.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

## Notes

After trying to find what was the exact cause of the bug, I decided to try hacking the asset cache that was the cause of multiple hard to understand bugs we've encounter since it was introduced.

The bug was happening in `PermProtectedRoute`. The `onLoadAssetCompleted` callback was being called quicker than the `props.params` got updated (after navigation). To remedy this (without relying on hackfix) we would have to revisit and improve multiple different places in the code.

## Related issues

Aftermath of #4835
