### PR TITLE
Remove `KPI_` prefix from broker and storage settings

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import logging
+import warnings
 import os
 import string
 import subprocess
@@ -1207,7 +1208,15 @@ if 'KOBOCAT_URL' in os.environ:
     SYNC_KOBOCAT_PERMISSIONS = (
         os.environ.get('SYNC_KOBOCAT_PERMISSIONS', 'True') == 'True')
 
-CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'redis://localhost:6379/1')
+CELERY_BROKER_URL = os.environ.get(
+    'CELERY_BROKER_URL',
+    os.environ.get('KPI_BROKER_URL', 'redis://localhost:6379/1')
+)
+if 'KPI_BROKER_URL' in os.environ:
+    warnings.warn(
+        "KPI_BROKER_URL is renamed CELERY_BROKER_URL, update the environment variable.",
+        DeprecationWarning,
+    )
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
 # Increase limits for long-running tasks
@@ -1297,12 +1306,17 @@ if env.str('AWS_ACCESS_KEY_ID', False):
 # Storage configuration
 STORAGES = global_settings.STORAGES
 
+default_file_storage = env.str('DEFAULT_FILE_STORAGE', env.str('KPI_DEFAULT_FILE_STORAGE', None))
 if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
+    warnings.warn(
+        "KPI_DEFAULT_FILE_STORAGE is renamed DEFAULT_FILE_STORAGE, update the environment variable.",
+        DeprecationWarning,
+    )
+
+if default_file_storage:
 
     global_default_file_storage = STORAGES['default']['BACKEND']
-    default_file_storage = STORAGES['default']['BACKEND'] = env.str(
-        'KPI_DEFAULT_FILE_STORAGE'
-    )
+    default_file_storage = STORAGES['default']['BACKEND'] = default_file_storage
     if default_file_storage != global_default_file_storage:
         if default_file_storage.endswith('S3Boto3Storage'):
             # To use S3 storage, set this to `kobo.apps.storage_backends.s3boto3.S3Boto3Storage`
@@ -1323,8 +1337,9 @@ if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
                 'AZURE_URL_EXPIRATION_SECS', None
             )
 
-    if 'KPI_AWS_STORAGE_BUCKET_NAME' in os.environ:
-        AWS_STORAGE_BUCKET_NAME = os.environ.get('KPI_AWS_STORAGE_BUCKET_NAME')
+    aws_storage_bucket_name = env.str('AWS_STORAGE_BUCKET_NAME', env.str('KPI_AWS_STORAGE_BUCKET_NAME', None))
+    if aws_storage_bucket_name:
+        AWS_STORAGE_BUCKET_NAME = aws_storage_bucket_name
         AWS_DEFAULT_ACL = 'private'
         # django-private-storage needs its own S3 configuration
         PRIVATE_STORAGE_CLASS = \

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1309,7 +1309,7 @@ STORAGES = global_settings.STORAGES
 default_file_storage = env.str('DEFAULT_FILE_STORAGE', env.str('KPI_DEFAULT_FILE_STORAGE', None))
 if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
     warnings.warn(
-        "KPI_DEFAULT_FILE_STORAGE is renamed DEFAULT_FILE_STORAGE, update the environment variable.",
+        'KPI_DEFAULT_FILE_STORAGE is renamed DEFAULT_FILE_STORAGE, update the environment variable.',
         DeprecationWarning,
     )
 


### PR DESCRIPTION
## Description

Remove the KPI_ prefix from some environment variable settings

KPI_BROKER_URL > CELERY_BROKER_URL
KPI_DEFAULT_FILE_STORAGE > DEFAULT_FILE_STORAGE
KPI_AWS_STORAGE_BUCKET_NAME > AWS_STORAGE_BUCKET_NAME

## Notes

I added fallbacks and deprecation warnings to KPI_BROKER_URL and KPI_DEFAULT_FILE_STORAGE

## Related issues

Part of https://github.com/kobotoolbox/kpi/pull/4888
