### PR TITLE
Fix bug blocking qualitative analysis feature with "unhashable type dict" error

### DIFF
--- a/kobo/apps/subsequences/tests/test_submission_stream.py
+++ b/kobo/apps/subsequences/tests/test_submission_stream.py
@@ -262,7 +262,7 @@ class TestSubmissionStream(TestCase):
 
         # Process submissions with extras
         try:
-            output = list(
+            _ = list(
                 stream_with_extras(
                     self.asset.deployment.get_submissions(
                         user=self.asset.owner

--- a/kobo/apps/subsequences/tests/test_submission_stream.py
+++ b/kobo/apps/subsequences/tests/test_submission_stream.py
@@ -241,3 +241,38 @@ class TestSubmissionStream(TestCase):
         assert '_supplementalDetails' in output[0]
         assert '_supplementalDetails' in output[1]
         # test other things?
+
+    def test_stream_with_extras_handles_duplicated_submission_uuids(self):
+        # Define submission data with duplicated UUIDs
+        submissions = [
+            {
+                'What_s_your_name': 'Ed',
+                'Tell_me_a_story': 'ed-18_6_24.ogg',
+                'meta/instanceID': 'uuid:1c05898e-b43c-491d-814c-79595eb84e81',
+                '_uuid': '1c05898e-b43c-491d-814c-79595eb84e81',
+            },
+            {
+                'What_s_your_name': 'Ed',
+                'Tell_me_a_story': 'ed-18_6_44.ogg',
+                'meta/instanceID': 'uuid:1c05898e-b43c-491d-814c-79595eb84e81',
+                '_uuid': '1c05898e-b43c-491d-814c-79595eb84e81',
+            },
+        ]
+        self.asset.deployment.mock_submissions(submissions)
+
+        # Process submissions with extras
+        try:
+            output = list(
+                stream_with_extras(
+                    self.asset.deployment.get_submissions(
+                        user=self.asset.owner
+                    ),
+                    self.asset,
+                )
+            )
+        except TypeError as e:
+            self.fail(f"TypeError occurred: {e}")
+        self.assertTrue(True)
+
+        # Clear all mocked submissions to avoid duplicate submission errors
+        self.asset.deployment.mock_submissions([])

--- a/kobo/apps/subsequences/utils/__init__.py
+++ b/kobo/apps/subsequences/utils/__init__.py
@@ -150,7 +150,7 @@ def stream_with_extras(submission_stream, asset):
             uuid = submission[SUBMISSION_UUID_FIELD]
         else:
             uuid = submission['_uuid']
-        all_supplemental_details = extras.get(uuid, {})
+        all_supplemental_details = deepcopy(extras.get(uuid, {}))
         for qpath, supplemental_details in all_supplemental_details.items():
             try:
                 all_qual_responses = supplemental_details['qual']
@@ -176,8 +176,6 @@ def stream_with_extras(submission_stream, asset):
                         val = [val]
                     val_expanded = []
                     for v in val:
-                        if isinstance(v, dict):
-                            v = v['uuid']
                         try:
                             v_ex = qual_choices_per_question_by_uuid[
                                 qual_q['uuid']

--- a/kobo/apps/subsequences/utils/__init__.py
+++ b/kobo/apps/subsequences/utils/__init__.py
@@ -176,6 +176,8 @@ def stream_with_extras(submission_stream, asset):
                         val = [val]
                     val_expanded = []
                     for v in val:
+                        if isinstance(v, dict):
+                            v = v['uuid']
                         try:
                             v_ex = qual_choices_per_question_by_uuid[
                                 qual_q['uuid']


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

To test:
1. Create a new project from scratch
2. Add a single audio question to it and deploy
3. Collect one submission with an audio file using Enketo
4. In the data table, open the qualitative analysis tab
5. Add a `single choice` or `multiple choice` question and submit some data
6. Go back to the data table and get the _id
7. Open the Django shell for KoboCAT
8. Duplicate the submission with this code:
```python3
i = Instance.objects.get(pk=4979)  # replace 4979 with your submission _id
i.pk = None
i.save()
```
9. Get your newly created submission into MongoDB by running `./manage.py sync_mongo --remongo` also in the KoboCAT container
10. Try to go back to the data table—you should get: `TypeError: unhashable type: 'dict'`
11. Apply changes from this branch and the error should be gone. 
