### PR TITLE
Repeated group version fix

### DIFF
--- a/jsapp/js/components/submissions/submissionUtils.ts
+++ b/jsapp/js/components/submissions/submissionUtils.ts
@@ -554,7 +554,7 @@ export function getRepeatGroupAnswers(
 
     // Each level could be an array of repeat group answers or object with questions.
     if (levelKey === targetKey) {
-      if (targetKeyData !== undefined) {
+      if (targetKeyData !== undefined && typeof targetKeyData !== 'object') {
         answers.push(String(targetKeyData));
       }
     } else if (

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -426,6 +426,20 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     tableStore.setFrozenColumn(fieldId, isFrozen);
   }
 
+  // Matrix response values are flat while repeat groups are nested
+  // under a parent key, but their column keys will both contain `/'.
+  // If submission response contains the parent key, we should use that.
+  _selectNestedRow(
+    row: SubmissionResponse,
+    key: string,
+    rootParentGroup: string | undefined
+  ) {
+    if (rootParentGroup && rootParentGroup in row) {
+      return row[rootParentGroup];
+    }
+    return row[key];
+  }
+
   _getColumnWidth(columnId: AnyRowTypeName | string | undefined) {
     if (!columnId) {
       return DEFAULT_DATA_CELL_WIDTH;
@@ -745,8 +759,10 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
     allColumns.forEach((key: string, columnIndex: number) => {
       let q: SurveyRow | undefined;
+      let rootParentGroup: string | undefined;
       if (key.includes('/')) {
         const qParentG = key.split('/');
+        rootParentGroup = qParentG[0];
         q = survey?.find(
           (o) =>
             o.name === qParentG[qParentG.length - 1] ||
@@ -897,7 +913,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
           );
         },
         id: key,
-        accessor: (row) => row[key],
+        accessor: (row) => this._selectNestedRow(row, key, rootParentGroup),
         index: index,
         question: q,
         // This (and the Filter itself) will be set below (we do it separately,
@@ -916,6 +932,20 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
             this.state.showGroupName,
             this.state.translationIndex
           );
+
+          if (typeof row.value === 'object') {
+            const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);
+            if (repeatGroupAnswers) {
+              // display a list of answers from a repeat group question
+              return (
+                <span className='trimmed-text' dir='auto'>
+                  {repeatGroupAnswers.join(', ')}
+                </span>
+              );
+            } else {
+              return '';
+            }
+          }
 
           if (q && q.type && row.value) {
             if (Object.keys(TABLE_MEDIA_TYPES).includes(q.type)) {
@@ -1048,25 +1078,11 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
             );
           }
 
-          if (typeof row.value === 'object' || row.value === undefined) {
-            const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);
-            if (repeatGroupAnswers) {
-              // display a list of answers from a repeat group question
-              return (
-                <span className='trimmed-text' dir='auto'>
-                  {repeatGroupAnswers.join(', ')}
-                </span>
-              );
-            } else {
-              return '';
-            }
-          } else {
-            return (
-              <span className='trimmed-text' dir='auto'>
-                {row.value}
-              </span>
-            );
-          }
+          return (
+            <span className='trimmed-text' dir='auto'>
+              {row.value}
+            </span>
+          );
         },
       });
 

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -426,8 +426,8 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     tableStore.setFrozenColumn(fieldId, isFrozen);
   }
 
-  // Matrix response values are flat while repeat groups are nested
-  // under a parent key, but their column keys will both contain `/'.
+  // We need to distinguish between repeated groups with nested values
+  // and other question types that use a flat nested key (i.e. with '/').
   // If submission response contains the parent key, we should use that.
   _selectNestedRow(
     row: SubmissionResponse,


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

The immediate bug this PR is aiming to fix is that some nested repeated group objects were being passed as props to the TextModalCell component, resulting in an error that breaks the entire data table. This bug can be triggered by creating a form with repeated group/question `foo/bar`, making a submission, then renaming the group and question to `bar/foo`.

In the process of investigating this bug, I realized that repeated groups were broken in the data table even for responses on the current version of the form. They didn't usually throw errors, but they also didn't display because the wrong key was being used to grab them from the SurveyResponse. This PR fixes that underlying issue with repeated groups so they now render properly in the data table. It also applies a stopgap fix for the original issue by simply not attempting to render objects. 

## Notes

The solution here ultimately means repeated group answers from older versions of a form are not displayed at all on the data table, even though a column will still be displayed for the older group/question. So in the above example, there will be columns `bar/foo` (displaying any responses to the new version of the group/question) and `foo` (with no data displayed). This is an improvement over breaking the data table, but obviously not ideal. 

We *might* be able to get this data to display by recursively iterating over every submission response to generate the necessary flatpaths. But I was undecided on whether this is a good idea and, if so, whether it's something I should work on now or if we should leave it as a TODO, given that John has mentioned that we might be trying to integrate better version handling in the not-so-distant future. I would appreciate input on this question.

