### PR TITLE
[TASK-935] Fix automatic transcription flow styles and sharing form bug

### DIFF
--- a/jsapp/js/components/permissions/userAssetPermsEditor.component.tsx
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.component.tsx
@@ -228,13 +228,15 @@ export default class UserAssetPermsEditor extends React.Component<
   }
 
   onBulkSetAssetPermissionCompleted() {
-    this.setState({isSubmitPending: false});
-    this.notifyParentAboutSubmitEnd(true);
+    this.setState({isSubmitPending: false}, () => {
+      this.notifyParentAboutSubmitEnd(true);
+    });
   }
 
   onBulkSetAssetPermissionFailed() {
-    this.setState({isSubmitPending: false});
-    this.notifyParentAboutSubmitEnd(false);
+    this.setState({isSubmitPending: false}, () => {
+      this.notifyParentAboutSubmitEnd(false);
+    });
   }
 
   notifyParentAboutSubmitEnd(isSuccess: boolean) {

--- a/jsapp/js/components/processing/processingBody.module.scss
+++ b/jsapp/js/components/processing/processingBody.module.scss
@@ -29,6 +29,10 @@
   margin: 0 auto;
 }
 
+.root.stepConfig :global .loadingSpinner {
+  height: auto;
+}
+
 .root.stepBegin {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes UI elements spacing for automatic transcription flow. And fixes sharing form bug - after submitting user permissions, the editor was not closing.

## Notes

One problem was related to `LoadingSpinner` styles, and the other was caused by race condition of `setState`.

## Related issues
