### PR TITLE
Get source from requests

### DIFF
--- a/dependencies/pip/dev_requirements.in
+++ b/dependencies/pip/dev_requirements.in
@@ -3,6 +3,7 @@
 Fabric
 coverage
 coveralls
+ddt
 ipython==8.12.3 # Max supported version by Python 3.8
 mock
 model-bakery

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -114,6 +114,8 @@ cryptography==42.0.5
     #   pyopenssl
 cssselect==1.2.0
     # via pyquery
+ddt==1.7.2
+    # via -r dependencies/pip/dev_requirements.in
 decorator==5.1.1
     # via
     #   fabric

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -608,6 +608,8 @@ tzdata==2024.1
     #   celery
     #   django-celery-beat
     #   pandas
+ua-parser==0.18.0
+    # via -r dependencies/pip/requirements.in
 uritemplate==4.1.1
     # via google-api-python-client
 urllib3==1.26.18

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -83,6 +83,7 @@ shortuuid
 sqlparse
 static3
 tabulate
+ua-parser
 uWSGI
 Werkzeug
 xlrd

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -504,6 +504,8 @@ tzdata==2024.1
     #   celery
     #   django-celery-beat
     #   pandas
+ua-parser==0.18.0
+    # via -r dependencies/pip/requirements.in
 uritemplate==4.1.1
     # via google-api-python-client
 urllib3==1.26.18

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -14,6 +14,7 @@ class AuditAction(models.TextChoices):
     PUT_BACK = 'put-back', 'PUT BACK'
     REMOVE = 'remove', 'REMOVE'
     UPDATE = 'update', 'UPDATE'
+    AUTH = 'auth', 'AUTH'
 
 
 class AuditLog(models.Model):
@@ -57,3 +58,7 @@ class AuditLog(models.Model):
             using=using,
             update_fields=update_fields,
         )
+
+    @staticmethod
+    def create_from_request(request, user=None, auth_type=None):
+        pass

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -14,7 +14,6 @@ class AuditAction(models.TextChoices):
     PUT_BACK = 'put-back', 'PUT BACK'
     REMOVE = 'remove', 'REMOVE'
     UPDATE = 'update', 'UPDATE'
-    AUTH = 'auth', 'AUTH'
 
 
 class AuditLog(models.Model):

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -58,7 +58,3 @@ class AuditLog(models.Model):
             using=using,
             update_fields=update_fields,
         )
-
-    @staticmethod
-    def create_from_request(request, user=None, auth_type=None):
-        pass

--- a/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
@@ -1,11 +1,12 @@
 # coding: utf-8
 from django.test.client import RequestFactory
+from ddt import ddt, data, unpack
 
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.libs.utils.viewer_tools import export_def_from_filename,\
-    get_client_ip
+    get_client_ip, get_human_readable_client_user_agent
 
-
+@ddt
 class TestViewerTools(TestBase):
     def test_export_def_from_filename(self):
         filename = "path/filename.xlsx"
@@ -19,3 +20,30 @@ class TestViewerTools(TestBase):
         self.assertIsNotNone(client_ip)
         # will this always be 127.0.0.1
         self.assertEqual(client_ip, "127.0.0.1")
+
+    @data(
+        # chrome on android phone
+        ("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36"
+         " (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36", "Chrome Mobile (Android)"),
+        # chrome on Windows
+        ("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
+         " Chrome/47.0.2526.111 Safari/537.36", "Chrome (Windows)"),
+        # firefox on linux
+        ("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1", "Firefox (Ubuntu)"),
+        # curl
+        ("curl/7.88.1", "curl (Other)"),
+        # system browser on iPhone
+        ("Mozilla/5.0 (Apple-iPhone7C2/1202.466; U; CPU like Mac OS X; en) AppleWebKit/420+"
+         " (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3", "Mobile Safari (iOS)"),
+        # nonsense
+        ("Lizards!", "Other (Other)"),
+        # empty
+        ("", "Other (Other)"),
+    )
+    @unpack
+    def test_client_user_agent(self, ua_string, expected_result):
+        factory = RequestFactory()
+        header = {"HTTP_USER_AGENT": ua_string}
+        request = factory.get("/", **header)
+        result = get_human_readable_client_user_agent(request)
+        self.assertEqual(result, expected_result)

--- a/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
@@ -1,51 +1,67 @@
 # coding: utf-8
+from ddt import data, ddt, unpack
 from django.test.client import RequestFactory
-from ddt import ddt, data, unpack
 
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
-from kobo.apps.openrosa.libs.utils.viewer_tools import export_def_from_filename,\
-    get_client_ip, get_human_readable_client_user_agent
+from kobo.apps.openrosa.libs.utils.viewer_tools import (
+    export_def_from_filename,
+    get_client_ip,
+    get_human_readable_client_user_agent,
+)
+
 
 @ddt
 class TestViewerTools(TestBase):
     def test_export_def_from_filename(self):
-        filename = "path/filename.xlsx"
+        filename = 'path/filename.xlsx'
         ext, mime_type = export_def_from_filename(filename)
         self.assertEqual(ext, 'xlsx')
         self.assertEqual(mime_type, 'vnd.openxmlformats')
 
     def test_get_client_ip(self):
-        request = RequestFactory().get("/")
+        request = RequestFactory().get('/')
         client_ip = get_client_ip(request)
         self.assertIsNotNone(client_ip)
         # will this always be 127.0.0.1
-        self.assertEqual(client_ip, "127.0.0.1")
+        self.assertEqual(client_ip, '127.0.0.1')
 
     @data(
         # chrome on android phone
-        ("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36"
-         " (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36", "Chrome Mobile (Android)"),
+        (
+            'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36'
+            ' (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36',
+            'Chrome Mobile (Android)',
+        ),
         # chrome on Windows
-        ("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)"
-         " Chrome/47.0.2526.111 Safari/537.36", "Chrome (Windows)"),
+        (
+            'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko)'
+            ' Chrome/47.0.2526.111 Safari/537.36',
+            'Chrome (Windows)',
+        ),
         # firefox on linux
-        ("Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1", "Firefox (Ubuntu)"),
+        (
+            'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1',
+            'Firefox (Ubuntu)',
+        ),
         # curl
-        ("curl/7.88.1", "curl (Other)"),
+        ('curl/7.88.1', 'curl (Other)'),
         # system browser on iPhone
-        ("Mozilla/5.0 (Apple-iPhone7C2/1202.466; U; CPU like Mac OS X; en) AppleWebKit/420+"
-         " (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3", "Mobile Safari (iOS)"),
+        (
+            'Mozilla/5.0 (Apple-iPhone7C2/1202.466; U; CPU like Mac OS X; en) AppleWebKit/420+'
+            ' (KHTML, like Gecko) Version/3.0 Mobile/1A543 Safari/419.3',
+            'Mobile Safari (iOS)',
+        ),
         # nonsense
-        ("Lizards!", "Other (Other)"),
+        ('Lizards!', 'Other (Other)'),
         # empty
-        ("", "No information available"),
+        ('', 'No information available'),
         # missing
-        (None, "No information available")
+        (None, 'No information available'),
     )
     @unpack
     def test_client_user_agent(self, ua_string, expected_result):
         factory = RequestFactory()
-        header = {"HTTP_USER_AGENT": ua_string}
-        request = factory.get("/", **header)
+        header = {'HTTP_USER_AGENT': ua_string}
+        request = factory.get('/', **header)
         result = get_human_readable_client_user_agent(request)
         self.assertEqual(result, expected_result)

--- a/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_viewer_tools.py
@@ -38,7 +38,9 @@ class TestViewerTools(TestBase):
         # nonsense
         ("Lizards!", "Other (Other)"),
         # empty
-        ("", "Other (Other)"),
+        ("", "No information available"),
+        # missing
+        (None, "No information available")
     )
     @unpack
     def test_client_user_agent(self, ua_string, expected_result):

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -108,7 +108,9 @@ def get_human_readable_client_user_agent(request):
     """
     Parse the user-agent into a human-readable <Browser> (<OS>) string
     """
-    user_agent = request.META['HTTP_USER_AGENT']
+    user_agent = request.META.get('HTTP_USER_AGENT', None)
+    if not user_agent or user_agent == '':
+        return "No information available"
     parsed = ua_parse.Parse(user_agent)
     browser = parsed['user_agent']['family']
     user_os = parsed['os']['family']

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -111,7 +111,7 @@ def get_human_readable_client_user_agent(request):
     """
     user_agent = request.META.get('HTTP_USER_AGENT', None)
     if not user_agent or user_agent == '':
-        return "No information available"
+        return 'No information available'
     parsed = ua_parse.Parse(user_agent)
     browser = parsed['user_agent']['family']
     user_os = parsed['os']['family']

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -13,6 +13,7 @@ from django.core.files.storage import FileSystemStorage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.mail import mail_admins
 from django.utils.translation import gettext as t
+from ua_parser import user_agent_parser as ua_parse
 
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
@@ -107,7 +108,11 @@ def get_human_readable_client_user_agent(request):
     """
     Parse the user-agent into a human-readable <Browser> (<OS>) string
     """
-    pass
+    user_agent = request.META['HTTP_USER_AGENT']
+    parsed = ua_parse.Parse(user_agent)
+    browser = parsed['user_agent']['family']
+    user_os = parsed['os']['family']
+    return f'{browser} ({user_os})'
 
 
 def enketo_url(

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -104,6 +104,7 @@ def get_client_ip(request):
         ip = request.META.get('REMOTE_ADDR')
     return ip
 
+
 def get_human_readable_client_user_agent(request):
     """
     Parse the user-agent into a human-readable <Browser> (<OS>) string

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -103,6 +103,12 @@ def get_client_ip(request):
         ip = request.META.get('REMOTE_ADDR')
     return ip
 
+def get_human_readable_client_user_agent(request):
+    """
+    Parse the user-agent into a human-readable <Browser> (<OS>) string
+    """
+    pass
+
 
 def enketo_url(
     form_url,


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation N/A
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE) N/A
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes N/A

## Description

Enable parsing the source (browser and OS) from a request.

## Notes

Adds a new method for parsing out the browser and OS from the HTTP_USER_AGENT header. Relies on a new ua_parser library. Also adds ddt to dev requirements for easier unit tests.

