### PR TITLE
Task 934 update canceled sub handling frontend

### DIFF
--- a/jsapp/js/account/subscriptionStore.ts
+++ b/jsapp/js/account/subscriptionStore.ts
@@ -15,6 +15,7 @@ class SubscriptionStore {
   public planResponse: SubscriptionInfo[] = [];
   public addOnsResponse: SubscriptionInfo[] = [];
   public activeSubscriptions: SubscriptionInfo[] = [];
+  public canceledPlans: SubscriptionInfo[] = [];
   public isPending = false;
   public isInitialised = false;
 
@@ -49,6 +50,11 @@ class SubscriptionStore {
     // get all active subscriptions for the user
     this.activeSubscriptions = response.results.filter((sub) =>
       ACTIVE_STRIPE_STATUSES.includes(sub.status)
+    );
+    this.canceledPlans = response.results.filter(
+      (sub) =>
+        sub.items[0]?.price.product.metadata?.product_type == 'plan' &&
+        sub.status === 'canceled'
     );
     // get any active plan subscriptions for the user
     this.planResponse = this.activeSubscriptions.filter(

--- a/jsapp/js/account/usage/usage.api.ts
+++ b/jsapp/js/account/usage/usage.api.ts
@@ -35,8 +35,9 @@ export interface AssetWithUsage {
 
 export interface UsageResponse {
   current_month_start: string;
+  current_month_end: string;
   current_year_start: string;
-  billing_period_end: string | null;
+  current_year_end: string;
   total_submission_count: {
     current_month: number;
     current_year: number;

--- a/jsapp/js/account/usage/useUsage.hook.ts
+++ b/jsapp/js/account/usage/useUsage.hook.ts
@@ -57,7 +57,7 @@ const loadUsage = async (
       usage.total_nlp_usage[`mt_characters_current_${trackingPeriod}`],
     currentMonthStart: usage.current_month_start,
     currentYearStart: usage.current_year_start,
-    billingPeriodEnd: usage.billing_period_end,
+    billingPeriodEnd: usage[`current_${trackingPeriod}_end`],
     trackingPeriod,
     lastUpdated,
   };

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -51,6 +51,10 @@ export const YourPlan = () => {
     let date;
     if (subscriptions.planResponse.length) {
       date = subscriptions.planResponse[0].start_date;
+    } else if (subscriptions.canceledPlans.length){
+      date =
+        subscriptions.canceledPlans[subscriptions.canceledPlans.length - 1]
+          .ended_at;
     } else {
       date = session.currentAccount.date_joined;
     }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Frontend adjustments to work with updated service_usage API from [this PR](https://github.com/kobotoolbox/kpi/pull/5052), which should be merged first.

## Notes

Instead of a billing_period_end that is always null as before, the service usage endpoint will now return current_month_end and current_year_end date strings. This PR adjusts the frontend to use these fields and also derives an appropriate start date for customers returning to the "community plan" after canceling a paid subscription.
