### PR TITLE
Fix bug that causes XLS exports to fail on UNWOMEN

### DIFF
--- a/kobo/apps/subsequences/jsonschemas/qual_schema.py
+++ b/kobo/apps/subsequences/jsonschemas/qual_schema.py
@@ -59,7 +59,7 @@ DEFINITIONS['qual_select_one'] = {
     'type': 'object',
     'properties': {
         'type': {'const': 'qual_select_one'},
-        'val': {'type': 'string'},
+        'val': {'type': 'string', 'minLength': 1},
     },
 }
 DEFINITIONS['qual_select_multiple'] = {
@@ -68,7 +68,7 @@ DEFINITIONS['qual_select_multiple'] = {
         'type': {'const': 'qual_select_multiple'},
         'val': {
             'type': 'array',
-            'items': {'type': 'string'},
+            'items': {'type': 'string', 'minLength': 1},
         },
     },
 }

--- a/kobo/apps/subsequences/tests/test_submission_stream.py
+++ b/kobo/apps/subsequences/tests/test_submission_stream.py
@@ -285,3 +285,39 @@ class TestSubmissionStream(TestCase):
 
         # Clear all mocked submissions to avoid duplicate submission errors
         self.asset.deployment.mock_submissions([])
+
+    def test_stream_with_extras_ignores_empty_qual_responses(self):
+        # Modify submission extras 'val' to be an empty string
+        submission_extras = SubmissionExtras.objects.get(
+            submission_uuid='1c05898e-b43c-491d-814c-79595eb84e81'
+        )
+        content = submission_extras.content
+        content['Tell_me_a_story']['qual'][1]['val'] = ''
+        submission_extras.content = content
+        submission_extras.save()
+
+        # Process submissions with extras
+        output = list(
+            stream_with_extras(
+                self.asset.deployment.get_submissions(user=self.asset.owner),
+                self.asset,
+            )
+        )
+
+        # Ensure that the empty 'val' fields are skipped and not processed
+        for submission in output:
+            supplemental_details = submission.get('_supplementalDetails', {})
+            for key, details in supplemental_details.items():
+                qual_responses = details.get('qual', [])
+                for qual_response in qual_responses:
+                    if qual_response['type'] in [
+                        'qual_select_one',
+                        'qual_select_multiple',
+                    ]:
+                        val = qual_response['val']
+
+                        if isinstance(val, list):
+                            for v in val:
+                                self.assertEqual(v, '')
+                        else:
+                            self.assertEqual(val, '')

--- a/kobo/apps/subsequences/utils/__init__.py
+++ b/kobo/apps/subsequences/utils/__init__.py
@@ -176,6 +176,8 @@ def stream_with_extras(submission_stream, asset):
                         val = [val]
                     val_expanded = []
                     for v in val:
+                        if v == '':
+                            continue
                         try:
                             v_ex = qual_choices_per_question_by_uuid[
                                 qual_q['uuid']
@@ -186,7 +188,7 @@ def stream_with_extras(submission_stream, asset):
                             # added. They should simply be hidden
                             v_ex = {'uuid': v, 'error': 'unknown choice'}
                         val_expanded.append(v_ex)
-                    if single_choice:
+                    if single_choice and val_expanded:
                         val_expanded = val_expanded[0]
                     qual_response['val'] = val_expanded
                 qual_response.update(qual_q)


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

To test:
1. Create a project with an audio question, deploy, and submit some responses
2. Open the qualitative analysis feature and add some single and multiple choice analysis questions with responses
3. Enter the Django shell and edit the submission extras so that the `val` is empty. For example
```python3
"qual": [
      {
        "val": "",
        "type": "qual_select_one",
        "uuid": "56564117-52c6-4b5c-a34f-04c681d17dc6"
      }, 
      ...
]
```
4. Create an XLS export for this project and it should fail. 
5. Checkout this branch and rebuild environment and the export should succeed. 


References:
Issue: https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/UNWOMEN.20support/near/428434
Fix: https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/UNWOMEN.20support/near/431140