### PR TITLE
Fix bug in yearly subscription handling, add unit tests and clean up …

### DIFF
--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from djstripe.models import Customer, Product, SubscriptionItem, Subscription, Price
@@ -7,10 +9,15 @@ from kobo.apps.organizations.models import Organization
 
 
 def generate_plan_subscription(
-    organization: Organization, metadata: dict = None, customer: Customer = None, age_days=0
+    organization: Organization,
+    metadata: dict = None,
+    customer: Customer = None,
+    interval: Literal['year', 'month'] = 'month',
+    age_days: int = 0,
 ) -> Subscription:
     """Create a subscription for a product with custom metadata"""
-    now = timezone.now()
+    created_date = timezone.now() - relativedelta(days=age_days)
+    price_id = 'price_sfmOFe33rfsfd36685657'
 
     if not customer:
         customer = baker.make(Customer, subscriber=organization, livemode=False)
@@ -22,23 +29,33 @@ def generate_plan_subscription(
     if metadata:
         product_metadata = {**product_metadata, **metadata}
     product = baker.make(Product, active=True, metadata=product_metadata)
-    price = baker.make(
-        Price,
-        active=True,
-        id='price_sfmOFe33rfsfd36685657',
-        product=product,
-    )
 
-    subscription_item = baker.make(SubscriptionItem, price=price, quantity=1, livemode=False)
+    if not (price := Price.objects.filter(id=price_id).first()):
+        price = baker.make(
+            Price,
+            active=True,
+            id=price_id,
+            recurring={'interval': interval},
+            product=product,
+        )
+
+    period_offset = relativedelta(weeks=2)
+
+    if interval == 'year':
+        period_offset = relativedelta(months=6)
+
+    subscription_item = baker.make(
+        SubscriptionItem, price=price, quantity=1, livemode=False
+    )
     return baker.make(
         Subscription,
         customer=customer,
         status='active',
         items=[subscription_item],
         livemode=False,
-        billing_cycle_anchor=now - relativedelta(weeks=2),
-        current_period_end=now + relativedelta(weeks=2),
-        current_period_start=now - relativedelta(weeks=2),
+        billing_cycle_anchor=created_date - period_offset,
+        current_period_end=created_date + period_offset,
+        current_period_start=created_date - period_offset,
     )
 
 


### PR DESCRIPTION
…date handling

## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

This PR fixes [an error](https://github.com/kobotoolbox/kpi/pull/5060/files#diff-8e177732fde8167315e822fc0bc310bd301d6ffc835bf914cb0eb80ea0676689R74) in the code where we were checking for 'subscription_interval' instead of 'recurring_interval' on a subscription. But because this error slipped through our tests I have also added a few more unit tests and adjusted some of the date handling. There are now unit tests for all the below cases:

1. Default "community plan": If a user does not have a subscription, they will be on our default plan. The billing cycle for this will be from the first day of the month to the first day of the next month.

2. Monthly and yearly subscriptions: If a user signs up for a monthly or annual plan, the billing cycle dates are handled by Stripe. We return the dates stored on the Subscription object.

3. Canceled subscriptions: If a user cancels a subscription without signing up for another subscription, they will return to the community plan, but now their billing cycle will be anchored to the date at which their most recently canceled subscription ended.
