### PR TITLE
Fix bug causing transcriptions/translations and qualitative analysis responses to not be displayed in the Data table 

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -431,7 +431,11 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     key: string,
     rootParentGroup: string | undefined
   ) {
-    if (rootParentGroup && rootParentGroup in row) {
+    if (
+      rootParentGroup &&
+      rootParentGroup in row &&
+      !key.startsWith(SUPPLEMENTAL_DETAILS_PROP)
+    ) {
       return row[rootParentGroup];
     }
     return row[key];
@@ -921,7 +925,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
             this.state.translationIndex
           );
 
-          if (typeof row.value === 'object') {
+          if (typeof row.value === 'object' && !key.startsWith(SUPPLEMENTAL_DETAILS_PROP)) {
             const repeatGroupAnswers = getRepeatGroupAnswers(row.original, key);
             if (repeatGroupAnswers) {
               // display a list of answers from a repeat group question
@@ -1058,7 +1062,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
           ) {
             return (
               <TextModalCell
-                text={getSupplementalDetailsContent(row.original, key)}
+                text={getSupplementalDetailsContent(row.original, key) || ''}
                 columnName={columnName}
                 submissionIndex={row.index + 1}
                 submissionTotal={this.state.submissions.length}


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Notes

Supplemental details were [being processed as a repeated group](https://github.com/kobotoolbox/kpi/blob/8d0324d9c13be60709ae7567450f57cac5ff304a/jsapp/js/components/submissions/table.tsx#L429) causing the wrong `row[key]` index to be used when accessing the value of the supplemental detail resulting in nothing being displayed. 
