### PR TITLE
Add GitHub Actions for ruff for Python linting

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,12 @@
+name: Python linter (Ruff)
+
+on: [pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@491342200cdd1cf4d5132a30ddc546b3b5bc531b
+        with:
+          args: 'check --preview'
+          changed-files: true

--- a/dependencies/pip/dev_requirements.in
+++ b/dependencies/pip/dev_requirements.in
@@ -12,6 +12,7 @@ pytest
 pytest-cov
 pytest-django
 pytest-env
+ruff
 
 
 # Kobocat

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -540,6 +540,8 @@ rpds-py==0.18.0
     #   referencing
 rsa==4.9
     # via google-auth
+ruff==0.6.2
+    # via -r dependencies/pip/dev_requirements.in
 s3transfer==0.10.1
     # via boto3
 sentinels==1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,28 @@
 # verbose = true
 line-length = 80
 skip-string-normalization = true
+
 [tool.isort]
 profile = "black"
 known_first_party = "kobo"
 no_lines_before = ["LOCALFOLDER"]
 
 [tool.ruff]
-line-length = 80
+line-length = 88
 [tool.ruff.format]
 quote-style = "single"  # Preserve is coming soon to ruff
 [tool.ruff.lint]
-# Enable ruff isort
-extend-select = ["I"]
+extend-select = [
+    "I", # Enable ruff isort
+    "Q", # Flake quotes
+    "E", # pycodestyle, some needs `--preview` to be enable
+    "N", # PEP-8 naming convention
+    "W1", # Indentation warning
+    "W292", # no newline at end of file
+    "T20", # (p)print found
+]
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single" # To prefer single quotes over double quote
 [tool.ruff.lint.isort]
 known-first-party = ["kobo"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,25 @@ extend-select = [
     "Q", # Flake quotes
     "E", # pycodestyle, some needs `--preview` to be enable
     "N", # PEP-8 naming convention
+    "UP026", # deprecated mock
+    "UP034", # extraneous-parentheses
+    "UP039", # Unnecessary parentheses after class definition
     "W1", # Indentation warning
     "W292", # no newline at end of file
     "T20", # (p)print found
 ]
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "single" # To prefer single quotes over double quote
+multiline-quotes = "double"
+docstring-quotes = "double"
 [tool.ruff.lint.isort]
 known-first-party = ["kobo"]
+
+[tool.flake8]
+inline-quotes = "single"
+multiline-quotes = "double"
+docstring-quotes = "double"
+max-line-length = 88
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
## Description

For developers interest, GitHub Actions is used to raise errors when the python code does not lint

