### PR TITLE
Adjust addon details modal

### DIFF
--- a/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
+++ b/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import KoboModal from 'js/components/modals/koboModal';
 import KoboModalHeader from 'js/components/modals/koboModalHeader';
 import KoboModalContent from 'js/components/modals/koboModalContent';
@@ -30,11 +30,10 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
     [USAGE_TYPE.TRANSLATION]: 'Translation characters',
   };
 
-  const recurringUsage = useMemo(
-    () =>
-      props.usage < props.recurringLimit ? props.usage : props.recurringLimit,
-    [props.usage, props.recurringLimit]
-  );
+  const periodAdjectiveDisplay: {[key in RecurringInterval]: string} = {
+    year: 'yearly',
+    month: 'monthly',
+  };
 
   return (
     <>
@@ -50,25 +49,36 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
         <KoboModalContent>
           <div className={styles.addonUsageDetails}>
             <div className={styles.addonTypeHeader}>
-              {t('##TYPE## available').replace(
-                '##TYPE##',
-                typeTitles[props.type]
-              )}
+              {t('##TYPE##').replace('##TYPE##', typeTitles[props.type])}
             </div>
             <ul className={styles.usageBreakdown}>
               <li>
-                <label>{t('Included with plan')}</label>
+                <label>
+                  {t('Included with ##PERIOD## plan').replace(
+                    '##PERIOD##',
+                    periodAdjectiveDisplay[props.period]
+                  )}
+                </label>
                 <data>{limitDisplay(props.type, props.recurringLimit)}</data>
               </li>
               <li>
+                <label>{t('From add-ons')}</label>
+                <data>
+                  {limitDisplay(
+                    props.type,
+                    props.recurringLimit,
+                    props.remainingLimit
+                  )}
+                </data>
+              </li>
+              <li>
                 <label>
-                  {t('Add-ons this ##PERIOD##').replace(
+                  {t('Used this ##PERIOD##').replace(
                     '##PERIOD##',
                     props.period
                   )}
                 </label>
-                {/* TODO: Get correct figure when period calculations are available */}
-                <data>0</data>
+                <data>{limitDisplay(props.type, props.usage)}</data>
               </li>
               <li>
                 <label>
@@ -81,75 +91,12 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
                 </data>
               </li>
             </ul>
-
-            <div className={styles.addonTypeHeader}>
-              {t('##TYPE## used').replace('##TYPE##', typeTitles[props.type])}
-            </div>
-            <ul className={styles.usageBreakdown}>
-              <li>
-                <label>{t('Included with plan')}</label>
-                <data>{limitDisplay(props.type, recurringUsage)}</data>
-              </li>
-              <li>
-                <label>{t('Add-ons')}</label>
-                {/* TODO: Get correct figure when period calculations are available */}
-                <data>0</data>
-              </li>
-              <li>
-                <label>
-                  <strong>{t('Total used')}</strong>
-                </label>
-                <data>
-                  <strong>{limitDisplay(props.type, props.usage)}</strong>
-                </data>
-              </li>
-            </ul>
-
-            <div className={styles.addonTypeHeader}>
-              {t('##TYPE## balance').replace(
-                '##TYPE##',
-                typeTitles[props.type]
-              )}
-            </div>
-            <ul className={styles.usageBreakdown}>
-              <li>
-                <label>{t('Included with plan')}</label>
-                <data>
-                  {limitDisplay(
-                    props.type,
-                    recurringUsage,
-                    props.recurringLimit
-                  )}
-                </data>
-              </li>
-              <li>
-                <label>{t('Add-ons')}</label>
-                <data>
-                  {limitDisplay(
-                    props.type,
-                    props.recurringLimit,
-                    props.remainingLimit
-                  )}
-                </data>
-              </li>
-              <li>
-                <label>
-                  <strong>{t('Total remaining')}</strong>
-                </label>
-                <data>
-                  <strong>
-                    {limitDisplay(
-                      props.type,
-                      props.usage,
-                      props.remainingLimit
-                    )}
-                  </strong>
-                </data>
-              </li>
-            </ul>
           </div>
           <h2 className={styles.listHeaderText}>{t('Purchased add-ons')}</h2>
-          < OneTimeAddOnList oneTimeAddOns={props.oneTimeAddOns} type={props.type} />
+          <OneTimeAddOnList
+            oneTimeAddOns={props.oneTimeAddOns}
+            type={props.type}
+          />
         </KoboModalContent>
       </KoboModal>
     </>

--- a/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
+++ b/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
@@ -79,7 +79,7 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
                 </label>
                 <data>{limitDisplay(props.type, props.usage)}</data>
               </li>
-              <li>
+              <li className={styles.totalAvailable}>
                 <label>
                   <strong>{t('Total available')}</strong>
                 </label>

--- a/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
+++ b/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.component.tsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 import KoboModal from 'js/components/modals/koboModal';
 import KoboModalHeader from 'js/components/modals/koboModalHeader';
-import KoboModalContent from 'js/components/modals/koboModalContent';
 import styles from './oneTimeAddOnUsageModal.module.scss';
 import {OneTimeAddOn, RecurringInterval, USAGE_TYPE} from '../../stripe.types';
 import {useLimitDisplay} from '../../stripe.utils';
@@ -46,7 +45,7 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
         <KoboModalHeader headerColor='white' onRequestCloseByX={toggleModal}>
           {t('Add-on details')}
         </KoboModalHeader>
-        <KoboModalContent>
+        <section className={styles.addonModalContent}>
           <div className={styles.addonUsageDetails}>
             <div className={styles.addonTypeHeader}>
               {t('##TYPE##').replace('##TYPE##', typeTitles[props.type])}
@@ -97,7 +96,7 @@ function OneTimeAddOnUsageModal(props: OneTimeAddOnUsageModalProps) {
             oneTimeAddOns={props.oneTimeAddOns}
             type={props.type}
           />
-        </KoboModalContent>
+        </section>
       </KoboModal>
     </>
   );

--- a/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.module.scss
+++ b/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.module.scss
@@ -42,6 +42,12 @@
   }
 }
 
+.totalAvailable {
+  padding: sizes.$x8 0;
+  border: colors.$kobo-gray-96 sizes.$x1;
+  border-style: solid none;
+}
+
 .listHeaderText {
   font-size: sizes.$r18;
   font-weight: 700;

--- a/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.module.scss
+++ b/jsapp/js/account/usage/one-time-add-on-usage-modal/oneTimeAddOnUsageModal.module.scss
@@ -11,7 +11,7 @@
     margin-top: sizes.$x20;
   }
 
-  margin-bottom: sizes.$x20;
+  margin-bottom: sizes.$x32;
 }
 
 .addonTypeHeader {
@@ -19,6 +19,10 @@
   font-size: sizes.$x12;
   color: colors.$kobo-gray-55;
   text-transform: uppercase;
+}
+
+.addonModalContent {
+  padding: 0 sizes.$x24 sizes.$x24 sizes.$x24
 }
 
 .usageBreakdown {
@@ -43,4 +47,5 @@
   font-weight: 700;
   color: colors.$kobo-storm;
   text-transform: uppercase;
+  margin: 0 0 sizes.$x16 0;
 }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

We are no longer planning to return historical addon usage data (for example. how much of an addons additional limits have been used in the past month). The previous modal design required these, so this PR greatly simplifies the modal. See design [here](https://www.figma.com/design/NonWWcfadc3QfS3q3D8hRB/%E2%9A%99%EF%B8%8F-KPI-%2F-Account-Settings?node-id=5834-9961&t=1cPor6jJtlbx9m9b-4). 

## Notes

While it's not in the designs, I added a display field for "Used this <interval>". This is already displayed on the usage page, but it generally won't be visible there when the modal is open so I thought it best to add it here, as well.
