### PR TITLE
Fix misalignment of columns in data table after paginating

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -142,6 +142,11 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
    * horizontally or vertically.
    */
   tableScrollTop = 0;
+  /**
+   * Store this value of the 'left' value of frozen columns, maintaining
+   * their alignment during horizontal scrolling or pagination.
+   */
+  frozenLeftRef = 0;
 
   /** We store it for future checks. */
   previousOverrides: AssetTableSettings = {};
@@ -1139,6 +1144,12 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
         );
       };
 
+      // Ensure frozen columns stay correctly aligned to the left, even after
+      // scrolling or reloads.
+      if (col.className?.includes('frozen')) {
+        col.style = {...col.style, left: this.frozenLeftRef};
+      }
+
       if (frozenColumn === col.id) {
         col.className = col.className
           ? `is-frozen is-last-frozen ${col.className}`
@@ -1146,6 +1157,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
         col.headerClassName = col.headerClassName
           ? `is-frozen is-last-frozen ${col.headerClassName}`
           : 'is-frozen is-last-frozen';
+          col.style = {...col.style, left: this.frozenLeftRef};
       }
     });
 
@@ -1488,6 +1500,9 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
       }
 
       $frozenColumnCells.css({left: left});
+
+      // Save the reference position for the frozen column's left offset.
+      this.frozenLeftRef = left;
     } else {
       this.tableScrollTop = eventTarget.scrollTop;
     }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Allow users to see the full height of frozen columns after paginating. 

## Notes

To test:
1. Create a project, deploy, and submit enough data so that you use the pagination on the data table. 
2. Navigate to the data table, scroll horizontally to the end of the data table, then go to the next page. 
3. Now navigate back to the previous page
4. The frozen columns are not displaying their full height. 

![92i0gk](https://github.com/user-attachments/assets/71179499-bc05-4857-8225-7d07022bae21)




