### PR TITLE
Fix asset clone UI crash

### DIFF
--- a/jsapp/js/components/formLanding.js
+++ b/jsapp/js/components/formLanding.js
@@ -637,7 +637,7 @@ class FormLanding extends React.Component {
           )}
 
           {isLoggedIn && (
-            <bem.PopoverMenu__link onClick={this.saveCloneAs}>
+            <bem.PopoverMenu__link onClick={() => this.saveCloneAs()}>
               <i className='k-icon k-icon-duplicate' />
               {t('Clone this project')}
             </bem.PopoverMenu__link>


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Fixes "Clone this project" button not working (UI crashes) from "Project > Form" route.

## Notes

Problem happened with `.bind`, my guess is because of how mixins are set up (non stantard way of doing things). Haven't got time to go deeper into this, but the PR fixes the problem.

This PR superseeds https://github.com/kobotoolbox/kpi/pull/5098 as it targets proper release branch.

## Related issues
