### PR TITLE
Log out user from all devices

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -105,6 +105,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount',
     'allauth.socialaccount.providers.microsoft',
     'allauth.socialaccount.providers.openid_connect',
+    'allauth.usersessions',
     'hub.HubAppConfig',
     'loginas',
     'webpack_loader',
@@ -154,6 +155,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'hub.middleware.LocaleMiddleware',
     'allauth.account.middleware.AccountMiddleware',
+    'allauth.usersessions.middleware.UserSessionsMiddleware',
     'django.middleware.common.CommonMiddleware',
     # Still needed really?
     'kobo.apps.openrosa.libs.utils.middleware.LocaleMiddlewareWithTweaks',

--- a/kpi/tests/api/v2/test_api_logout_all.py
+++ b/kpi/tests/api/v2/test_api_logout_all.py
@@ -1,0 +1,48 @@
+from allauth.usersessions.models import UserSession
+from django.urls import reverse
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.base_test_case import BaseTestCase
+
+
+class TestLogoutAll(BaseTestCase):
+
+    fixtures = ['test_data']
+
+    def test_logout_all_sessions(self):
+        # create 2 user sessions
+        user = User.objects.get(username='someuser')
+        UserSession.objects.create(user=user, session_key='12345', ip='1.2.3.4')
+        UserSession.objects.create(user=user, session_key='56789', ip='5.6.7.8')
+        count = UserSession.objects.filter(user=user).count()
+        self.assertEqual(count, 2)
+        self.client.force_login(user)
+        url = self._get_endpoint('logout_all')
+        self.client.post(reverse(url))
+
+        # ensure both sessions have been deleted
+        count = UserSession.objects.filter(user=user).count()
+        self.assertEqual(count, 0)
+
+    def test_logout_all_sessions_does_not_affect_other_users(self):
+        # create 2 user sessions
+        user1 = User.objects.get(username='someuser')
+        user2 = User.objects.get(username='anotheruser')
+        # create sessions for user1
+        UserSession.objects.create(
+            user=user1, session_key='12345', ip='1.2.3.4'
+        )
+        UserSession.objects.create(
+            user=user1, session_key='56789', ip='5.6.7.8'
+        )
+        count = UserSession.objects.count()
+        self.assertEqual(count, 2)
+
+        # login user2
+        self.client.force_login(user2)
+        url = self._get_endpoint('logout_all')
+        self.client.post(reverse(url))
+
+        # ensure no sessions have been deleted
+        count = UserSession.objects.filter().count()
+        self.assertEqual(count, 2)

--- a/kpi/tests/api/v2/test_api_logout_all.py
+++ b/kpi/tests/api/v2/test_api_logout_all.py
@@ -25,7 +25,6 @@ class TestLogoutAll(BaseTestCase):
         self.assertEqual(count, 0)
 
     def test_logout_all_sessions_does_not_affect_other_users(self):
-        # create 2 user sessions
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
         # create sessions for user1

--- a/kpi/urls/__init__.py
+++ b/kpi/urls/__init__.py
@@ -13,6 +13,7 @@ from kpi.views.token import TokenView
 
 from .router_api_v1 import router_api_v1
 from .router_api_v2 import router_api_v2, URL_NAMESPACE
+from ..views.v2.logout import logout_from_all_devices
 
 # TODO: Give other apps their own `urls.py` files instead of importing their
 # views directly! See
@@ -50,6 +51,7 @@ urlpatterns = [
     re_path(r'^private-media/', include(private_storage.urls)),
     # Statistics for superusers
     re_path(r'^superuser_stats/', include(('kobo.apps.superuser_stats.urls', 'superuser_stats'))),
+    path('logout-all/', logout_from_all_devices, name='logout_all')
 ]
 
 

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -21,7 +21,6 @@ from kpi.views.v2.attachment import AttachmentViewSet
 from kpi.views.v2.data import DataViewSet
 from kpi.views.v2.export_task import ExportTaskViewSet
 from kpi.views.v2.import_task import ImportTaskViewSet
-from kpi.views.v2.logout import logout_from_all_devices
 from kpi.views.v2.paired_data import PairedDataViewset
 from kpi.views.v2.permission import PermissionViewSet
 from kpi.views.v2.service_usage import ServiceUsageViewSet

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -21,6 +21,7 @@ from kpi.views.v2.attachment import AttachmentViewSet
 from kpi.views.v2.data import DataViewSet
 from kpi.views.v2.export_task import ExportTaskViewSet
 from kpi.views.v2.import_task import ImportTaskViewSet
+from kpi.views.v2.logout import logout_from_all_devices
 from kpi.views.v2.paired_data import PairedDataViewset
 from kpi.views.v2.permission import PermissionViewSet
 from kpi.views.v2.service_usage import ServiceUsageViewSet

--- a/kpi/views/v2/logout.py
+++ b/kpi/views/v2/logout.py
@@ -1,0 +1,32 @@
+from allauth.usersessions.adapter import get_adapter
+from allauth.usersessions.models import UserSession
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
+from kpi.permissions import IsAuthenticated
+
+
+@api_view(['POST'])
+@permission_classes((IsAuthenticated,))
+def logout_from_all_devices(request):
+    """
+    Log calling user out from all devices
+
+    <pre class="prettyprint">
+    <b>POST</b> /logout-all/
+    </pre>
+
+    > Example
+    >
+    >       curl -H 'Authorization Token 12345' -X POST https://[kpi-url]/logout-all
+
+    > Response 200
+
+    >  { "Logged out of all sessions" }
+
+    """
+    user = request.user
+    all_user_sessions = UserSession.objects.purge_and_list(user)
+    adapter = get_adapter()
+    adapter.end_sessions(all_user_sessions)
+    return Response('Logged out of all sessions')


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Adds a new endpoint that will log the calling user out of all sessions and devices.

## Notes

Adds `usersessions`  app from allauth, which keeps track of sessions by user using UserSession objects created by a middleware class.

Adds a new endpoint that looks for all UserSession objects associated with the calling user and uses the `usersessions` adapter to delete all the associated sessions.

To test, login in separate browsers (or the same browser with private windows). `curl` the new /logout-all endpoint. Refresh the page in all browsers and you should be taken to the login page.

