### PR TITLE
Remove unused field in audit log API responses

### DIFF
--- a/kobo/apps/audit_log/serializers.py
+++ b/kobo/apps/audit_log/serializers.py
@@ -19,7 +19,6 @@ class AuditLogSerializer(serializers.ModelSerializer):
         fields = (
             'app_label',
             'model_name',
-            'object_id',
             'user',
             'user_uid',
             'username',
@@ -32,7 +31,6 @@ class AuditLogSerializer(serializers.ModelSerializer):
         read_only_fields = (
             'app_label',
             'model_name',
-            'object_id',
             'user',
             'user_uid',
             'username',

--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -106,7 +106,6 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
             {
                 'app_label': 'foo',
                 'model_name': 'bar',
-                'object_id': 1,
                 'user': 'http://testserver/api/v2/users/someuser/',
                 'user_uid': someuser.extra_details.uid,
                 'action': 'delete',
@@ -149,7 +148,6 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
             {
                 'app_label': 'foo',
                 'model_name': 'bar',
-                'object_id': 1,
                 'user': 'http://testserver/api/v2/users/anotheruser/',
                 'user_uid': anotheruser.extra_details.uid,
                 'action': 'delete',

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -36,7 +36,6 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     >               {
     >                    "app_label": "foo",
     >                    "model_name": "bar",
-    >                    "object_id": 1,
     >                    "user": "http://kf.kobo.local/users/kobo_user/",
     >                    "action": "delete",
     >                    "log_type": "asset-management",
@@ -111,7 +110,6 @@ class AllAccessLogViewSet(AuditLogViewSet):
     >                {
     >                   "app_label": "kobo_auth",
     >                    "model_name": "User",
-    >                    "object_id": 1,
     >                    "user": "http://localhost/api/v2/users/admin/",
     >                    "user_uid": "uBMZxx9tVfepvTRp3e9Twj",
     >                    "username": "admin",
@@ -163,7 +161,6 @@ class AccessLogViewSet(AuditLogViewSet):
     >                {
     >                   "app_label": "kobo_auth",
     >                    "model_name": "User",
-    >                    "object_id": 1,
     >                    "user": "http://localhost/api/v2/users/admin/",
     >                    "user_uid": "uBMZxx9tVfepvTRp3e9Twj",
     >                    "username": "admin",


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description
Removes unneeded field from audit log response.

## Notes

Removes `object_id` from the AuditLog serializer since we don't want to display it to end users. 

