### PR TITLE
Fix Python formatter error with owner discrepancy in the container

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -5,14 +5,25 @@ jobs:
   darker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
-      - name: Install pip dependencies
-        run: python -m pip install flake8 flake8-quotes isort
-      - uses: akaihola/darker@master
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          options: '--check --isort -L "flake8 --max-line-length=88"'
-          revision: "origin/${{ github.event.pull_request.base.ref }}"
-          version: "~=2.1.1"
+          python-version: '3.10'
+
+      - name: Install pip dependencies
+        run: python -m pip install darker[isort] flake8 flake8-quotes isort --quiet
+
+      # use `--ignore=F821` to avoid raising false positive error in typing
+      # annotations with string, e.g. def my_method(my_model: 'ModelName')
+
+      # darker still exit with code 1 even with no errors on changes
+      - name: Run Darker with base commit
+        run: |
+          output=$(darker --check --isort -L "flake8 --max-line-length=88 --ignore=F821" kpi kobo hub -r ${{ github.event.pull_request.base.sha }})
+          [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
+        shell: /usr/bin/bash {0}


### PR DESCRIPTION
## Description

Fix git error (i.e.: `Not a git repository. Use --no-index to compare two paths outside a working tree`) which does not find its config because of user permissions.

## Notes

There is a "breaking" change. The script does not fallback on `beta` by default. The base branch must always be specified. 

e.g.: `./format-python.sh <base_branch>` 

`-l` option still remains though.
