### PR TITLE
Fix ignore list for flake8

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -24,6 +24,6 @@ jobs:
       # darker still exit with code 1 even with no errors on changes
       - name: Run Darker with base commit
         run: |
-          output=$(darker --check --isort -L "flake8 --max-line-length=88 --ignore=F821" kpi kobo hub -r ${{ github.event.pull_request.base.sha }})
+          output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r ${{ github.event.pull_request.base.sha }})
           [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
         shell: /usr/bin/bash {0}


### PR DESCRIPTION
## Description
Developer-facing changes only.

## Notes

Use `--extend-ignore` instead of just `--ignore` with `flake8` so everything that is ignored by default (including conflicting requirements W503 and W504) remains ignored

