### PR TITLE
Canceled subscription date fix

### DIFF
--- a/dependencies/pip/dev_requirements.in
+++ b/dependencies/pip/dev_requirements.in
@@ -13,6 +13,7 @@ pytest-cov
 pytest-django
 pytest-env
 pytest-xdist
+freezegun
 
 # KoboCAT
 httmock

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -688,3 +688,4 @@ yubico-client==1.13.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+backports-zoneinfo==0.2.1; python_version < '3.9'

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -267,6 +267,8 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
+freezegun==1.5.1
+    # via -r dependencies/pip/dev_requirements.in
 frozenlist==1.4.1
     # via
     #   aiohttp
@@ -521,6 +523,7 @@ python-dateutil==2.9.0.post0
     #   -r dependencies/pip/requirements.in
     #   botocore
     #   celery
+    #   freezegun
     #   pandas
     #   python-crontab
 python3-openid==3.2.0
@@ -685,4 +688,3 @@ yubico-client==1.13.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
-backports-zoneinfo==0.2.1; python_version < '3.9'

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -16,7 +16,9 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
     """Returns start and end dates of an organization's monthly billing cycle"""
 
     now = timezone.now().replace(tzinfo=ZoneInfo('UTC'))
-    first_of_this_month = datetime(now.year, now.month, 1, tzinfo=ZoneInfo('UTC'))
+    first_of_this_month = datetime(
+        now.year, now.month, 1, tzinfo=ZoneInfo('UTC')
+    )
     first_of_next_month = (
         first_of_this_month
         + relativedelta(months=1)
@@ -25,7 +27,7 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
     # If no organization, just use the calendar month
     if not organization:
         return first_of_this_month, first_of_next_month
-    
+
     # If no active subscription, check for canceled subscription 
     if not (billing_details := organization.active_subscription_billing_details()):
         if not (
@@ -33,7 +35,7 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
             := organization.canceled_subscription_billing_cycle_anchor()
         ):
             return first_of_this_month, first_of_next_month
-        
+
         canceled_subscription_anchor = canceled_subscription_anchor.replace(
             tzinfo=ZoneInfo('UTC')
         )
@@ -46,7 +48,7 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
             canceled_subscription_anchor,
         )
         return period_start, period_end
-    
+
     if not billing_details.get('billing_cycle_anchor'):
         return first_of_this_month, first_of_next_month
 
@@ -61,7 +63,9 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
         return period_start, period_end
 
     # Subscription is billed yearly - count backwards from the end of the current billing year
-    period_start = billing_details.get('current_period_end').replace(tzinfo=ZoneInfo('UTC'))
+    period_start = billing_details.get('current_period_end').replace(
+        tzinfo=ZoneInfo('UTC')
+    )
     while period_start > now:
         period_start -= relativedelta(months=1)
     period_end = period_start + relativedelta(months=1)
@@ -93,8 +97,8 @@ def get_yearly_billing_dates(organization: Union[Organization, None]):
 
     # Subscription is monthly, calculate this year's start based on anchor date
     period_start = anchor_date.replace(
-        tzinfo=ZoneInfo('UTC')) + relativedelta(years=1
-    )
+        tzinfo=ZoneInfo('UTC')
+    ) + relativedelta(years=1)
     while period_start < now:
         anchor_date += relativedelta(years=1)
     period_end = period_start + relativedelta(years=1)

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -6,10 +6,6 @@ except ImportError:
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
 
 from django.utils import timezone
 

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -30,10 +30,12 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
         ):
             return first_of_this_month, first_of_next_month
         
-        period_end = canceled_subscription_anchor.replace(tzinfo=pytz.UTC)
+        canceled_subscription_anchor = canceled_subscription_anchor.replace(tzinfo=pytz.UTC)
+        period_end = canceled_subscription_anchor
         while period_end < now:
             period_end += relativedelta(months=1)
-        period_start = period_end - relativedelta(months=1)
+        # Avoid pushing billing cycle back to before cancelation date
+        period_start = max(period_end - relativedelta(months=1), canceled_subscription_anchor)
         return period_start, period_end
     
     if not billing_details.get('billing_cycle_anchor'):

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -30,12 +30,17 @@ def get_monthly_billing_dates(organization: Union[Organization, None]):
         ):
             return first_of_this_month, first_of_next_month
         
-        canceled_subscription_anchor = canceled_subscription_anchor.replace(tzinfo=pytz.UTC)
+        canceled_subscription_anchor = canceled_subscription_anchor.replace(
+            tzinfo=pytz.UTC
+        )
         period_end = canceled_subscription_anchor
         while period_end < now:
             period_end += relativedelta(months=1)
         # Avoid pushing billing cycle back to before cancelation date
-        period_start = max(period_end - relativedelta(months=1), canceled_subscription_anchor)
+        period_start = max(
+            period_end - relativedelta(months=1),
+            canceled_subscription_anchor,
+        )
         return period_start, period_end
     
     if not billing_details.get('billing_cycle_anchor'):

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -314,7 +314,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
         """
         cancel_date = datetime(year=2024, month=8, day=31, tzinfo=pytz.UTC)
         with freeze_time(cancel_date.replace(day=1)):
-            subscription = generate_plan_subscription(self.organization, age_days=1095)
+            subscription = generate_plan_subscription(self.organization)
 
         subscription.status = 'canceled'
         subscription.ended_at = cancel_date

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -2,9 +2,13 @@ import timeit
 import itertools
 
 import pytest
-import pytz
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
@@ -196,7 +200,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
 
         response = self.client.get(self.detail_url)
         now = timezone.now()
-        first_of_month = datetime(now.year, now.month, 1, tzinfo=pytz.UTC)
+        first_of_month = datetime(now.year, now.month, 1, tzinfo=ZoneInfo('UTC'))
         first_of_next_month = first_of_month + relativedelta(months=1)
 
         assert response.data['total_submission_count']['current_month'] == num_submissions
@@ -312,7 +316,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
         billing cycle to end on the last day of the next month, but we also need to make
         sure the cycle starts on the cancelation date
         """
-        cancel_date = datetime(year=2024, month=8, day=31, tzinfo=pytz.UTC)
+        cancel_date = datetime(year=2024, month=8, day=31, tzinfo=ZoneInfo('UTC'))
         with freeze_time(cancel_date.replace(day=1)):
             subscription = generate_plan_subscription(self.organization)
 

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -8,10 +8,6 @@ except ImportError:
 import pytest
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
 
 from django.core.cache import cache
 from django.test import override_settings

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -309,7 +309,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
     def test_plan_canceled_edge_date(self):
         """
         If a plan is canceled on the last day of a 31-day month, we want the subsequent
-        billing cycle to end on the last day of the next month, but we also need to make 
+        billing cycle to end on the last day of the next month, but we also need to make
         sure the cycle starts on the cancelation date
         """
         cancel_date = datetime(year=2024, month=8, day=31, tzinfo=pytz.UTC)
@@ -322,8 +322,12 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
 
         with freeze_time(cancel_date.replace(month=9, day=1)):
             response = self.client.get(self.detail_url)
-        current_month_start = datetime.fromisoformat(response.data['current_month_start'])
-        current_month_end = datetime.fromisoformat(response.data['current_month_end'])
+        current_month_start = datetime.fromisoformat(
+            response.data['current_month_start']
+        )
+        current_month_end = datetime.fromisoformat(
+            response.data['current_month_end']
+        )
 
         assert current_month_start.month == cancel_date.month
         assert current_month_start.day == cancel_date.day

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -318,15 +318,22 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
         billing cycle to end on the last day of the next month, but we also need to make
         sure the cycle starts on the cancelation date
         """
-        cancel_date = datetime(year=2024, month=8, day=31, tzinfo=ZoneInfo('UTC'))
-        with freeze_time(cancel_date.replace(day=1)):
+        frozen_datetime_now = datetime(
+            year=2024,
+            month=9,
+            day=1,
+            tzinfo=ZoneInfo('UTC'),
+        )
+        subscribe_date = frozen_datetime_now.replace(month=8, day=1)
+        cancel_date = frozen_datetime_now.replace(month=8, day=31)
+        with freeze_time(subscribe_date):
             subscription = generate_plan_subscription(self.organization)
 
         subscription.status = 'canceled'
         subscription.ended_at = cancel_date
         subscription.save()
 
-        with freeze_time(cancel_date.replace(month=9, day=1)):
+        with freeze_time(frozen_datetime_now):
             response = self.client.get(self.detail_url)
         current_month_start = datetime.fromisoformat(
             response.data['current_month_start']

--- a/kobo/apps/subsequences/actions/base.py
+++ b/kobo/apps/subsequences/actions/base.py
@@ -1,5 +1,9 @@
 import datetime
-import pytz
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
 from django.utils import timezone
 
 from kobo.apps.subsequences.constants import (GOOGLETS, GOOGLETX)
@@ -19,7 +23,7 @@ class BaseAction:
         self.load_params(params)
 
     def cur_time(self):
-        return datetime.datetime.now(tz=pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
+        return datetime.datetime.now(tz=ZoneInfo('UTC')).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def load_params(self, params):
         raise NotImplementedError('subclass must define a load_params method')


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

We recently had a billing unit test fail because it was testing for a subscription canceled on the last day of a 31-day month followed by a 30-day month. The billing cycle start date was being returned as August 30 instead of August 31. This PR ensures that the default plan billing cycle start date will not be earlier than the cancelation date. 
## Notes

This PR also adds the freezegun library to dev dependencies for testing. This should be useful for billing-related tests moving forward.
