### PR TITLE
Regenerate snapshots when downloading XForm XML

### DIFF
--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -237,6 +237,8 @@ class XMLRenderer(DRFXMLRenderer):
         accepted_media_type=None,
         renderer_context=None,
         relationship=None,
+        relationship_args=None,
+        relationship_kwargs=None,
     ):
         if hasattr(renderer_context.get('view'), 'get_object'):
             obj = renderer_context.get('view').get_object()
@@ -246,7 +248,10 @@ class XMLRenderer(DRFXMLRenderer):
             if relationship is not None and hasattr(obj, relationship):
                 var_or_callable = getattr(obj, relationship)
                 if isinstance(var_or_callable, Callable):
-                    return var_or_callable().xml
+                    return var_or_callable(
+                        *(relationship_args or tuple()),
+                        **(relationship_kwargs or dict())
+                    ).xml
                 return var_or_callable.xml
             return add_xml_declaration(obj.xml)
         else:
@@ -260,10 +265,13 @@ class XMLRenderer(DRFXMLRenderer):
 class XFormRenderer(XMLRenderer):
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        return super().render(data=data,
-                              accepted_media_type=accepted_media_type,
-                              renderer_context=renderer_context,
-                              relationship="snapshot")
+        return super().render(
+            data=data,
+            accepted_media_type=accepted_media_type,
+            renderer_context=renderer_context,
+            relationship='snapshot',
+            relationship_kwargs={'regenerate': 'True'},
+        )
 
 
 class XlsRenderer(renderers.BaseRenderer):


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Invokes pyxform every time "Download XML" is clicked, which avoids serving stale XForm XML in certain situations. For example, prior to this work, if a form had *not* been changed since its XForm XML was last generated, but the behavior of pyxform *had* changed, clicking "Download XML" would have ignored the pyxform changes.

Please note that the XForm XML obtained from "Download XML" is *not* identical to the XForm XML generated when deploying a form. Deploying or redeploying a form was *not* affected by this stale XML issue, even prior to this change.

## Notes

I did not add a unit test or attempt to mock the response by pyxform to simulate changes to its behavior. The reviewer may make the determination about the sufficiency of my approach.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Pyxform.20updates/near/458832