### PR TITLE
[TASK-1102] Improve login error message readability

### DIFF
--- a/jsapp/scss/stylesheets/partials/_registration.scss
+++ b/jsapp/scss/stylesheets/partials/_registration.scss
@@ -31,7 +31,7 @@
     margin: 0 auto;
     position: relative;
     max-width: 400px;
-    background: rgba(colors.$kobo-gray-800, 0.8);
+    background: rgba(colors.$kobo-gray-800, 0.9);
     padding: 20px 30px;
     border-radius: 10px;
 
@@ -305,7 +305,7 @@
 
   ul.errorlist {
     padding: 0px;
-    color: colors.$kobo-red;
+    color: colors.$kobo-mid-red;
     margin: 8px 0px;
   }
 }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/master/CONTRIBUTING.md)
5. [ ] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Colors for background and error text were changed to achieve a better readability.

## Notes

- I've changed the error color from `kobo-red` to `kobo-mid-red`, but there was still much room to improve
- I've bumped the opacity from the gray background from `0.8` to `0.9` to make it darker and help on the color contrast.
- Even so, the color contrast is not ideal for a message that size. (based on this [Contrast checker tool](https://coolors.co/contrast-checker/ff8080-333847)), and this tool won't take in consideration the transparent background with an underlay image, which also may impact the readability of the text.
- We may need to review some of the colors to offer a better readability for impaired users.

## Related issues

Fixes [#ISSUE](https://github.com/orgs/kobotoolbox/projects/78?pane=issue&itemId=80967765)
