### PR TITLE
Reduce number of DB queries while transferring a project to another user

### DIFF
--- a/kobo/apps/project_ownership/constants.py
+++ b/kobo/apps/project_ownership/constants.py
@@ -1,0 +1,2 @@
+ASYNC_TASK_HEARTBEAT = 60 * 5  # every 5 minutes
+FILE_MOVE_CHUNK_SIZE = 1000

--- a/kobo/apps/project_ownership/management/commands/resume_failed_transfers_2_024_25_fix.py
+++ b/kobo/apps/project_ownership/management/commands/resume_failed_transfers_2_024_25_fix.py
@@ -1,4 +1,3 @@
-from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 from ...models import (
@@ -22,7 +21,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        usernames = set()
         verbosity = options['verbosity']
 
         for transfer_status in TransferStatus.objects.filter(
@@ -54,20 +52,33 @@ class Command(BaseCommand):
                     f'Resuming `{transfer.asset}` transfer…'
                 )
             self._move_data(transfer)
-            move_attachments(transfer)
-            move_media_files(transfer)
+
+            # We do not want any error to break the management command,
+            # so we catch any exception and log it for later purpose.
+            try:
+                if verbosity:
+                    self.stdout.write('\tMoving attachments…')
+                move_attachments(transfer)
+            except Exception as e:
+                self.stderr.write(f'Failed to move attachments: {e}')
+                TransferStatus.objects.filter(
+                    transfer=transfer,
+                    status_type=TransferStatusTypeChoices.ATTACHMENTS,
+                ).update(error=str(e), status=TransferStatusChoices.FAILED)
+
+            try:
+                if verbosity:
+                    self.stdout.write('\tMoving media files…')
+                move_media_files(transfer)
+            except Exception as e:
+                self.stderr.write(f'Failed to move media files: {e}')
+                TransferStatus.objects.filter(
+                    transfer=transfer,
+                    status_type=TransferStatusTypeChoices.MEDIA_FILES,
+                ).update(error=str(e), status=TransferStatusChoices.FAILED)
+
             if verbosity:
                 self.stdout.write('\tDone!')
-            usernames.add(transfer.invite.recipient.username)
-
-        # Update attachment storage bytes counters
-        for username in usernames:
-            call_command(
-                'update_attachment_storage_bytes',
-                verbosity=verbosity,
-                force=True,
-                username=username,
-            )
 
     def _move_data(self, transfer: Transfer):
 

--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -1,9 +1,11 @@
 import os
+import time
 from typing import Optional
 
 from django.apps import apps
 from django.utils import timezone
 
+from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kpi.deployment_backends.kc_access.shadow_models import (
     KobocatAttachment,
     KobocatMetadata,
@@ -11,6 +13,7 @@ from kpi.deployment_backends.kc_access.shadow_models import (
 from kpi.models.asset import AssetFile
 from .models.choices import TransferStatusChoices, TransferStatusTypeChoices
 from .exceptions import AsyncTaskException
+from .constants import ASYNC_TASK_HEARTBEAT, FILE_MOVE_CHUNK_SIZE
 
 
 def get_target_folder(
@@ -59,27 +62,39 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
         instance_id__in=submission_ids
     ).exclude(media_file__startswith=f'{transfer.asset.owner.username}/')
 
-    for attachment in attachments.iterator():
-        # Pretty slow but it should run in celery task. We want to be the
-        # path of the file is saved right away. It lets us resume when it stopped
-        # in case of failure.
-        if not (
-            target_folder := get_target_folder(
-                transfer.invite.sender.username,
-                transfer.invite.recipient.username,
-                attachment.media_file.name,
-            )
-        ):
-            continue
-        else:
-            attachment.media_file.move(target_folder)
-            attachment.save(update_fields=['media_file'])
+    attachments_to_update = []
+    try:
+        heartbeat = int(time.time())
+        # Moving files is pretty slow, thus it should run in a celery task.
+        for attachment in attachments.iterator():
+            if not (
+                target_folder := get_target_folder(
+                    transfer.invite.sender.username,
+                    transfer.invite.recipient.username,
+                    attachment.media_file.name,
+                )
+            ):
+                continue
+            else:
+                # We want to be sure the path of the file is saved no matter what.
+                # Thanks to try/finally block, if updates are still pending, they
+                # should be saved in case of errors.
+                # It lets us resume when it stopped in case of failure.
+                attachment.media_file.move(target_folder)
+                attachments_to_update.append(attachment)
 
-            # We only need to update `date_modified` to update task heart beat.
-            # No need to use `TransferStatus.update_status()` and
-            # its lock mechanism.
-            transfer.statuses.filter(status_type=async_task_type).update(
-                date_modified=timezone.now()
+                if len(attachments_to_update) > FILE_MOVE_CHUNK_SIZE:
+                    Attachment.objects.bulk_update(
+                        attachments_to_update, fields=['media_file']
+                    )
+                    attachments_to_update = []
+
+                heartbeat = _update_heartbeat(heartbeat, transfer, async_task_type)
+
+    finally:
+        if attachments_to_update:
+            Attachment.objects.bulk_update(
+                attachments_to_update, fields=['media_file']
             )
 
     _mark_task_as_successful(transfer, async_task_type)
@@ -102,41 +117,53 @@ def move_media_files(transfer: 'project_ownership.Transfer'):
             )
         }
 
-    for media_file in media_files:
-        if not (
-            target_folder := get_target_folder(
-                transfer.invite.sender.username,
-                transfer.invite.recipient.username,
-                media_file.content.name,
-            )
-        ):
-            continue
-        else:
-            # Pretty slow but it should run in celery task. We want to be sure the
-            # path of the file is saved right away. It lets us resume when it stopped
-            # in case of failure.
-            media_file.content.move(target_folder)
-            old_md5 = media_file.metadata.pop('hash', None)
-            media_file.set_md5_hash()
-            if old_md5 in kc_files.keys():
-                kc_obj = kc_files[old_md5]
-                if kc_target_folder := get_target_folder(
+    media_files_to_update = []
+    metadata_to_update = []
+    try:
+        heartbeat = int(time.time())
+        # Moving files is pretty slow, thus it should run in a celery task.
+        for media_file in media_files:
+            if not (
+                target_folder := get_target_folder(
                     transfer.invite.sender.username,
                     transfer.invite.recipient.username,
-                    kc_obj.data_file.name,
-                ):
-                    kc_obj.data_file.move(kc_target_folder)
-                    kc_obj.file_hash = media_file.md5_hash
-                    kc_obj.save(update_fields=['data_file', 'file_hash'])
+                    media_file.content.name,
+                )
+            ):
+                continue
+            else:
+                # We want to be sure the path of the file is saved no matter what.
+                # Thanks to try/finally block, if updates are still pending, they
+                # should be saved in case of errors.
+                # It lets us resume when it stopped in case of failure.
+                media_file.content.move(target_folder)
+                old_md5 = media_file.metadata.pop('hash', None)
+                media_file.set_md5_hash()
+                if old_md5 in kc_files.keys():
+                    kc_obj = kc_files[old_md5]
+                    if kc_target_folder := get_target_folder(
+                        transfer.invite.sender.username,
+                        transfer.invite.recipient.username,
+                        kc_obj.data_file.name,
+                    ):
+                        kc_obj.data_file.move(kc_target_folder)
+                        kc_obj.file_hash = media_file.md5_hash
+                        metadata_to_update.append(kc_obj)
 
-            media_file.save(update_fields=['content', 'metadata'])
+                media_files_to_update.append(media_file)
+                heartbeat = _update_heartbeat(heartbeat, transfer, async_task_type)
 
-        # We only need to update `date_modified` to update task heart beat.
-        # No need to use `TransferStatus.update_status()` and
-        # its lock mechanism.
-        transfer.statuses.filter(status_type=async_task_type).update(
-            date_modified=timezone.now()
-        )
+    finally:
+        # No need to use chunk size for media files like we do for attachments,
+        # because the odds are pretty low that more than 100 media files are
+        # linked to the project.
+        if metadata_to_update:
+            media_files_to_update.append(media_file)
+
+        if media_files_to_update:
+            AssetFile.objects.bulk_update(
+                media_files_to_update, update_fields=['content', 'metadata']
+            )
 
     _mark_task_as_successful(transfer, async_task_type)
 
@@ -166,3 +193,19 @@ def _mark_task_as_successful(
     TransferStatus.update_status(
         transfer.pk, TransferStatusChoices.SUCCESS, async_task_type
     )
+
+
+def _update_heartbeat(
+    heartbeat: int, transfer: 'project_ownership.Transfer', async_task_type: str
+) -> int:
+
+    if heartbeat + ASYNC_TASK_HEARTBEAT >= time.time():
+        # We only need to update `date_modified` to update task heartbeat.
+        # No need to use `TransferStatus.update_status()` and
+        # its lock mechanism.
+        transfer.statuses.filter(status_type=async_task_type).update(
+            date_modified=timezone.now()
+        )
+        return int(time.time())
+
+    return heartbeat

--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -162,7 +162,7 @@ def move_media_files(transfer: 'project_ownership.Transfer'):
 
         if media_files_to_update:
             AssetFile.objects.bulk_update(
-                media_files_to_update, update_fields=['content', 'metadata']
+                media_files_to_update, fields=['content', 'metadata']
             )
 
     _mark_task_as_successful(transfer, async_task_type)


### PR DESCRIPTION
## Description

Try to avoid running one update query per attachment while maintaining the atomicity of the transaction.

## Notes

The former choice to run `Attachment.save()` right after `.move()` was done in purpose. The idea was to be sure that the new path of the file was saved in the DB before processing another file. Unfortunately, this created as many DB queries as there were existing attachments (or media files), which was slowing down the process even more. Using `bulk_update` is (way) more efficient. Using the `try/finally` block should ensure the atomicity if an error occurs while looping on attachments (or media files).

`resume_failed_transfers_2_024_25_fix` has been revisited. The call of the command `update_attachment_storage_bytes` was useless because counters were not affected by the bug and were still accurate. 
Moving files are now wrapped in try/except to avoid the command to crash if one transfer cannot be fixed


## Testing

1. Test the management command

- Create a project with `2.024.25b`. It should include attachments and media files. 
- Deploy it
- Submit data with Enketo
- Go to Project settings > Sharing and transfer to another user
- Open another browser and log in as the other user
- Open the invite link you received in the other user browser and click accept.
- Look at the celery logs and see that at least of the celery tasks failed
- Reload other user browser page and see the project is there but data is missing
- Checkout the PR branch (don't forget to restart workers)
- Run the management command
- See data is back
- Transfer it back to former owner

Every should work as expected.

2. Ensure attachment or media_file move and DB update atomicity

- use `mockobo` to add several submissions to project created in 1), assuming the project has one "image" question.
```
./mockobo.py -a <asset_uid> -c <number_submissions_to_add> -mf image:<local_path_to_image>
```
- Force `move_attachments()` and/or `move_media_files()` to raise an error in the middle of the process (before the `FILE_MOVE_CHUNK_SIZE` is reached)
- Confirm that every object moved before the crash has a path that starts with correct owner username.

For example: 
previous_owner: `user_a`
new_owner: `user_b`

All object paths moved before crashed should start with `user_b`. All others are still starting with `user_a`.


