### PR TITLE
[TASK-1113] Fix createsuperuser not creating a valid email address

### DIFF
--- a/kobo/apps/kobo_auth/management/commands/createsuperuser.py
+++ b/kobo/apps/kobo_auth/management/commands/createsuperuser.py
@@ -1,17 +1,18 @@
+from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.management.commands.createsuperuser import (
     Command as CreateSuperuserCommand,
 )
-
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
 
 
 class Command(CreateSuperuserCommand):
-
     def handle(self, *args, **options):
         super().handle(*args, **options)
+
+        # Fix any superuser missing a user profile or email address
         UserProfile.objects.bulk_create(
             [
                 UserProfile(user_id=superuser_pk, validated_password=True)
@@ -19,10 +20,20 @@ class Command(CreateSuperuserCommand):
                 .values_list('pk', flat=True)
                 .filter(is_superuser=True)
                 .exclude(
-                    pk__in=UserProfile.objects.values_list(
-                        'user_id', flat=True
-                    ).filter(user__is_superuser=True)
+                    pk__in=UserProfile.objects.values_list('user_id', flat=True).filter(
+                        user__is_superuser=True
+                    )
                 )
+            ],
+            ignore_conflicts=True,
+        )
+
+        EmailAddress.objects.bulk_create(
+            [
+                EmailAddress(user=user, email=user.email, verified=True, primary=True)
+                for user in User.objects.filter(
+                    is_superuser=True, emailaddress=None
+                ).exclude(email='')
             ],
             ignore_conflicts=True,
         )

--- a/kobo/apps/kobo_auth/tests.py
+++ b/kobo/apps/kobo_auth/tests.py
@@ -1,0 +1,20 @@
+from allauth.account.models import EmailAddress
+from django.core.management import call_command
+from django.test import TestCase
+
+from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
+
+from .models import User
+
+
+class KoboAuthTestCase(TestCase):
+    def test_createsuperuser(self):
+        call_command(
+            'createsuperuser',
+            interactive=False,
+            username='admin',
+            email='admin@example.com',
+        )
+        self.assertTrue(User.objects.exists())
+        self.assertTrue(UserProfile.objects.exists())
+        self.assertTrue(EmailAddress.objects.exists())


### PR DESCRIPTION
## Description

When using the Django management command `./manage.py createsuperuser` a verified email address record is now created. This allows createsuperuser to create an immediately usable superuser account.

## Notes

I suspect the UserProfile code could be simplified but wanted to keep my scope low. Let me know if you'd like me to refactor it. I also added a code comment explaining what it does, as it's a bit weird to "fix" any user account and not just the one made.

Devops impact - in emergencies and local dev, this command is very handy. This change speeds up emergency response.

Ran ruff.

Needs unit test
