### PR TITLE
Fix django-import-export dependencies

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -141,6 +141,8 @@ deprecated==1.2.14
     # via fabric
 dict2xml==1.7.5
     # via -r dependencies/pip/requirements.in
+diff-match-patch==20230430
+    # via django-import-export
 dj-static==0.0.6
     # via -r dependencies/pip/requirements.in
 dj-stripe==2.8.3
@@ -160,6 +162,7 @@ django==4.2.15
     #   django-extensions
     #   django-filter
     #   django-guardian
+    #   django-import-export
     #   django-markdownx
     #   django-oauth-toolkit
     #   django-organizations
@@ -609,6 +612,8 @@ statistics==1.0.3.5
     # via formpack
 stripe==4.2.0
     # via dj-stripe
+tablib==3.5.0
+    # via django-import-export
 tabulate==0.9.0
     # via -r dependencies/pip/requirements.in
 toml==0.10.2

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -108,6 +108,8 @@ defusedxml==0.7.1
     #   pyxform
 dict2xml==1.7.5
     # via -r dependencies/pip/requirements.in
+diff-match-patch==20230430
+    # via django-import-export
 dj-static==0.0.6
     # via -r dependencies/pip/requirements.in
 dj-stripe==2.8.3
@@ -127,6 +129,7 @@ django==4.2.15
     #   django-extensions
     #   django-filter
     #   django-guardian
+    #   django-import-export
     #   django-markdownx
     #   django-oauth-toolkit
     #   django-organizations
@@ -479,6 +482,8 @@ statistics==1.0.3.5
     # via formpack
 stripe==4.2.0
     # via dj-stripe
+tablib==3.5.0
+    # via django-import-export
 tabulate==0.9.0
     # via -r dependencies/pip/requirements.in
 tornado==6.4


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

For developers: fixes "ModuleNotFoundError: No module named 'tablib'" error that would occur when attempting to install Python dependencies for development.

## Notes

Add subdependencies that were missing from #4986, presumably as a result of manually editing `*requirements.txt` files instead of running `pip-compile.sh`. The incomplete requirements files did not cause a problem with an initial `pip-sync` call, which allowed the subdependencies like `tablib` to remain, but future calls to `pip-sync` _removed_ these subdependencies since they were missing from the `*requirements.txt` files. Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/KPI.3A.20ModuleNotFoundError.3A.20No.20module.20named.20'tablib'

## Related issues

Related to #4986