### PR TITLE
Add non-recursive ownership reset for media directory to improve KPI startup performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV KPI_LOGS_DIR=/srv/logs \
     NGINX_STATIC_DIR=/srv/static \
     KPI_SRC_DIR=/srv/src/kpi \
     KPI_MEDIA_DIR=/srv/src/kpi/media \
+    OPENROSA_MEDIA_DIR=/srv/src/kobocat/media \
     KPI_NODE_PATH=/srv/src/kpi/node_modules \
     TMP_DIR=/srv/tmp \
     UWSGI_USER=kobo \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -81,14 +81,16 @@ chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_LOGS_DIR}"
 
 # `chown -R` becomes very slow once a fair amount of media has been collected,
 # so reset ownership of the media directory *only* (i.e., non-recursive)
-echo 'Resetting ownership of media directory...'
+echo 'Resetting ownership of media directories...'
 chown "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_MEDIA_DIR}"
+chown "${UWSGI_USER}:${UWSGI_GROUP}" "${OPENROSA_MEDIA_DIR}"
 echo 'Done.'
 echo '%%%%%%% NOTICE %%%%%%%'
 echo '% To avoid long delays, we no longer reset ownership *recursively*'
 echo '% every time this container starts. If you have trouble with'
 echo '% permissions, please run the following command inside the KPI container:'
 echo "% chown -R \"${UWSGI_USER}:${UWSGI_GROUP}\" \"${KPI_MEDIA_DIR}\""
+echo "% chown -R \"${UWSGI_USER}:${UWSGI_GROUP}\" \"${OPENROSA_MEDIA_DIR}\""
 echo '%%%%%%%%%%%%%%%%%%%%%%'
 
 echo 'KPI initialization completed.'

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -79,10 +79,17 @@ fi
 echo 'Restore permissions on logs folder'
 chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_LOGS_DIR}"
 
-# This can take a while when starting a container with lots of media files.
-# Maybe we should add a disclaimer as we do in KoBoCAT to let the users
-# do it themselves
-chown -R "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_MEDIA_DIR}"
+# `chown -R` becomes very slow once a fair amount of media has been collected,
+# so reset ownership of the media directory *only* (i.e., non-recursive)
+echo 'Resetting ownership of media directory...'
+chown "${UWSGI_USER}:${UWSGI_GROUP}" "${KPI_MEDIA_DIR}"
+echo 'Done.'
+echo '%%%%%%% NOTICE %%%%%%%'
+echo '% To avoid long delays, we no longer reset ownership *recursively*'
+echo '% every time this container starts. If you have trouble with'
+echo '% permissions, please run the following command inside the KPI container:'
+echo "% chown -R \"${UWSGI_USER}:${UWSGI_GROUP}\" \"${KPI_MEDIA_DIR}\""
+echo '%%%%%%%%%%%%%%%%%%%%%%'
 
 echo 'KPI initialization completed.'
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes

## Description

Improved KPI container startup performance by modifying how ownership of the media directory is set. Ownership is now applied non-recursively, with a notice included to inform users how to handle permissions issues manually if necessary.

## Notes

The previous recursive ownership reset (chown -R) on the media directory was causing delays during startup, especially when dealing with a large number of media files. This PR changes the ownership reset to non-recursive (chown without -R) to speed up the process. A notice is added to inform users about the change and provide instructions for manually resetting ownership recursively if they experience permission issues. The redundant recursive ownership code has also been removed to align with the new behavior.

## Related issues

Fixes #5149 
