### PR TITLE
[TASK-1108] Reset checkboxes in Projects Table after loading fresh results

### DIFF
--- a/jsapp/js/projects/customViewRoute.tsx
+++ b/jsapp/js/projects/customViewRoute.tsx
@@ -46,6 +46,14 @@ function CustomViewRoute() {
     );
   }, [viewUid]);
 
+  // Whenever we do a full page (of results) reload, we need to clear up
+  // `selectedRows` to not end up with a project selected (e.g. on page of
+  // results that wasn't loaded/scrolled down into yet) and user not knowing
+  // about it.
+  useEffect(() => {
+    setSelectedRows([]);
+  }, [customView.isFirstLoadComplete]);
+
   /** Returns a list of names for fields that have at least 1 filter defined. */
   const getFilteredFieldsNames = () => {
     const outcome: ProjectFieldName[] = [];

--- a/jsapp/js/projects/myProjectsRoute.tsx
+++ b/jsapp/js/projects/myProjectsRoute.tsx
@@ -73,6 +73,14 @@ function MyProjectsRoute() {
     }
   }, [searchParams]);
 
+  // Whenever we do a full page (of results) reload, we need to clear up
+  // `selectedRows` to not end up with a project selected (e.g. on page of
+  // results that wasn't loaded/scrolled down into yet) and user not knowing
+  // about it.
+  useEffect(() => {
+    setSelectedRows([]);
+  }, [customView.isFirstLoadComplete]);
+
   /** Returns a list of names for fields that have at least 1 filter defined. */
   const getFilteredFieldsNames = () => {
     const outcome: ProjectFieldName[] = [];

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -24,6 +24,9 @@ interface ProjectQuickActionsProps {
 /**
  * Quick Actions (Archive, Share, Delete) buttons. Use these when a single
  * project is selected in the Project Table.
+ *
+ * Note that for zero projects selected we display `ProjectQuickActionsEmpty`
+ * instead.
  */
 const ProjectQuickActions = ({asset}: ProjectQuickActionsProps) => {
   // The `userCan` method requires `permissions` property to be present in the


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

After user selects a project and e.g. archives it, scrolling down to see it again would reveal that it's still being selected. This PR fixes that bug.

## Notes

After `customViewStore` is loading fresh results (i.e. reloads whole table), both `CustomViewRoute` and `MyProjectsRoute` will reset the list of selected rows.

## Testing

Reproduction steps to be found at https://www.notion.so/kobotoolbox/Make-sure-project-checkboxes-are-unchecked-after-Projects-Table-reloads-itself-1127e515f65480eaa518f94191d09361?pvs=4