### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       KOBOFORM_URL: http://kpi
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgis/postgis:14-3.4

--- a/dependencies/pip/dev_requirements.in
+++ b/dependencies/pip/dev_requirements.in
@@ -4,7 +4,7 @@ Fabric
 coverage
 coveralls
 ddt
-ipython==8.12.3 # Max supported version by Python 3.8
+ipython
 mock
 model-bakery
 mongomock

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -47,8 +47,6 @@ azure-core==1.30.1
     #   django-storages
 azure-storage-blob==12.19.1
     # via django-storages
-backcall==0.2.0
-    # via ipython
 bcrypt==4.1.2
     # via paramiko
 begins==0.9
@@ -257,7 +255,9 @@ drf-extensions==0.7.1
 et-xmlfile==1.1.0
     # via openpyxl
 exceptiongroup==1.2.0
-    # via pytest
+    # via
+    #   ipython
+    #   pytest
 execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
@@ -348,7 +348,7 @@ iniconfig==2.0.0
     # via pytest
 invoke==2.2.0
     # via fabric
-ipython==8.12.3
+ipython==8.28.0
     # via -r dependencies/pip/dev_requirements.in
 isodate==0.6.1
     # via azure-storage-blob
@@ -434,8 +434,6 @@ path-py==12.5.0
 pathspec==0.12.1
     # via black
 pexpect==4.9.0
-    # via ipython
-pickleshare==0.7.5
     # via ipython
 pillow==10.3.0
     # via django-markdownx
@@ -643,6 +641,7 @@ typing-extensions==4.10.0
     #   azure-core
     #   azure-storage-blob
     #   black
+    #   ipython
     #   jwcrypto
     #   psycopg
 tzdata==2024.1

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -364,17 +364,7 @@ class OmitDefaultNamespacePrefixTreeBuilder(ET.TreeBuilder):
         if self.default_namespace_uri:
             # Remove the Clark notation prefix if it matches the default
             # namespace
-            # TODO remove try/except when Python 3.8 support is removed
-            try:
-                tag = tag.removeprefix('{' + self.default_namespace_uri + '}')
-            except AttributeError:
-                remove_prefix = (
-                    lambda text, prefix: text[len(prefix):]
-                    if text.startswith(prefix)
-                    else text
-                )
-                tag = remove_prefix(tag, '{' + self.default_namespace_uri + '}')
-
+            tag = tag.removeprefix('{' + self.default_namespace_uri + '}')
         return super().start(tag, attrs)
 
 


### PR DESCRIPTION
## Checklist

3. [x] Ensure the tests pass
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)

## Description

Remove tests for Python 3.8 and constraints to maintain compatibility with it. Python 3.8 has reached the end of its life; see https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983.

Most self-hosters will _not_ notice any change, because all Docker images began using Python 3.10 [in April of 2022](https://github.com/kobotoolbox/kpi/pull/3759). Highly technical self-hosters who do not use our Docker images may need to update their environments.

## Testing

Please watch to see if the CI tests pass, and if the CI even uses the new configuration proposed in this PR. Let me know if I need to create a fork to test CI properly.