### PR TITLE
[TASK-1129] Remove BEM styling from project settings form and fix modal sizing issue

### DIFF
--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -337,6 +337,9 @@ $modal-custom-header-height: sizes.$x60;
   cursor: pointer;
 }
 
+// TODO: This class has been removed from the actual ProjectSettings component,
+// but this rule is still used in a few places. We should remove it once we have
+// switched them to style modules.
 .project-settings {
   // make sure it doesn't get too small (but only inside modal)
   .modal & {
@@ -434,16 +437,6 @@ $modal-custom-header-height: sizes.$x60;
     &:hover {border-color: colors.$kobo-blue;}
     &.dropzone-active {border-color: colors.$kobo-blue;}
     &.dropzone-reject {border-color: colors.$kobo-red;}
-  }
-}
-
-@media screen and (min-height: 600px) {
-  // on bigger screens make templates-list scrollable to always display back/next buttons
-  .project-settings.project-settings--choose-template {
-    .templates-list {
-      max-height: 380px;
-      overflow-y: auto;
-    }
   }
 }
 

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -740,7 +740,7 @@ class ProjectSettings extends React.Component {
           </div>
         }
 
-        <div className={styles.formSourceButton}>
+        <div className={styles.sourceButtons}>
           {this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW &&
             <button onClick={this.displayStep.bind(this, this.STEPS.PROJECT_DETAILS)}>
               <i className='k-icon k-icon-edit' />
@@ -837,7 +837,7 @@ class ProjectSettings extends React.Component {
           }
         </div>
 
-        <div className={styles.formItem}>
+        <div className={styles.input}>
           <TextBox
             type='url'
             label={t('URL')}
@@ -881,7 +881,7 @@ class ProjectSettings extends React.Component {
         onChange={this.onProjectDetailsFormChange}
         className={cx(
           styles.projectDetails,
-          this.checkModalStyle() ?? styles.formView,
+          this.checkModalStyle() ?? styles.projectDetailsView,
         )}
       >
         {this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
@@ -895,9 +895,9 @@ class ProjectSettings extends React.Component {
             />
           </div>
         }
-        <div className={styles.formItemWrapper}>
+        <div className={styles.inputWrapper}>
           {/* Project Name */}
-          <div className={styles.formItem}>
+          <div className={styles.input}>
             <TextBox
               value={this.state.fields.name}
               onChange={this.onNameChange.bind(this)}
@@ -910,7 +910,7 @@ class ProjectSettings extends React.Component {
 
           {/* Description */}
           {descriptionField &&
-          <div className={styles.formItem}>
+          <div className={styles.input}>
             <TextBox
               type='text-multiline'
               value={this.state.fields.description}
@@ -927,7 +927,7 @@ class ProjectSettings extends React.Component {
           {sectorField &&
             <div
               className={cx(
-                styles.formItem,
+                styles.input,
                 bothCountryAndSector ? styles.sector : null
               )}
             >
@@ -949,7 +949,7 @@ class ProjectSettings extends React.Component {
           {countryField &&
             <div
             className={cx(
-              styles.formItem,
+              styles.input,
               bothCountryAndSector ? styles.country : null
             )}
             >
@@ -970,7 +970,7 @@ class ProjectSettings extends React.Component {
 
           {/* Operational Purpose of Data */}
           {operationalPurposeField &&
-            <div className={styles.formItem}>
+            <div className={styles.input}>
               <WrappedSelect
                 label={addRequiredToLabel(operationalPurposeField.label, operationalPurposeField.required)}
                 value={this.state.fields.operational_purpose}
@@ -985,7 +985,7 @@ class ProjectSettings extends React.Component {
 
           {/* Does this project collect personally identifiable information? */}
           {collectsPiiField &&
-            <div className={styles.formItem}>
+            <div className={styles.input}>
               <WrappedSelect
                 label={addRequiredToLabel(collectsPiiField.label, collectsPiiField.required)}
                 value={this.state.fields.collects_pii}
@@ -1025,8 +1025,8 @@ class ProjectSettings extends React.Component {
           }
 
           {userCan('manage_asset', this.state.formAsset) && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
-            <div className={styles.formItem}>
-              <div className={cx(styles.formItem, styles.formItemInline)}>
+            <div className={styles.input}>
+              <div className={cx(styles.input, styles.inputInline)}>
                 {this.isArchived() &&
                   <Button
                     type='secondary'
@@ -1047,12 +1047,12 @@ class ProjectSettings extends React.Component {
               </div>
 
               {this.isArchivable() &&
-                <div className={cx(styles.formItem, styles.formItemInline)}>
+                <div className={cx(styles.input, styles.inputInline)}>
                   {t('Archive project to stop accepting submissions.')}
                 </div>
               }
               {this.isArchived() &&
-                <div className={cx(styles.formItem, styles.formItemInline)}>
+                <div className={cx(styles.input, styles.inputInline)}>
                   {t('Unarchive project to resume accepting submissions.')}
                 </div>
               }
@@ -1061,7 +1061,7 @@ class ProjectSettings extends React.Component {
           }
 
           {isSelfOwned && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
-            <div className={styles.formItem}>
+            <div className={styles.input}>
               <Button
                 type='danger'
                 size='l'

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -8,7 +8,8 @@ import Button from 'js/components/common/button';
 import clonedeep from 'lodash.clonedeep';
 import TextBox from 'js/components/common/textBox';
 import WrappedSelect from 'js/components/common/wrappedSelect';
-import bem from 'js/bem';
+import cx from 'classnames';
+import styles from 'js/components/modalForms/projectSettings.module.scss';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import InlineMessage from 'js/components/common/inlineMessage';
 import assetUtils from 'js/assetUtils';
@@ -46,7 +47,6 @@ const VIA_URL_SUPPORT_URL = 'xls_url.html';
  * 1. When creating new project
  * 2. When replacing project with new one
  * 3. When editing project in /settings
- * 4. When editing or creating asset in Form Builder
  *
  * Identifying the purpose is done by checking `context` and `formAsset`.
  *
@@ -157,7 +157,6 @@ class ProjectSettings extends React.Component {
       case PROJECT_SETTINGS_CONTEXTS.REPLACE:
         return this.displayStep(this.STEPS.FORM_SOURCE);
       case PROJECT_SETTINGS_CONTEXTS.EXISTING:
-      case PROJECT_SETTINGS_CONTEXTS.BUILDER:
         return this.displayStep(this.STEPS.PROJECT_DETAILS);
       default:
         throw new Error(`Unknown context: ${this.props.context}!`);
@@ -171,7 +170,6 @@ class ProjectSettings extends React.Component {
       case PROJECT_SETTINGS_CONTEXTS.REPLACE:
         return t('Replace form');
       case PROJECT_SETTINGS_CONTEXTS.EXISTING:
-      case PROJECT_SETTINGS_CONTEXTS.BUILDER:
       default:
         return t('Project settings');
     }
@@ -720,6 +718,10 @@ class ProjectSettings extends React.Component {
     return label;
   }
 
+  checkModalStyle() {
+    return this.props.context !== PROJECT_SETTINGS_CONTEXTS.EXISTING ? styles.modal : null;
+  }
+
   renderChooseTemplateButton() {
     return (
       <button onClick={this.displayStep.bind(this, this.STEPS.CHOOSE_TEMPLATE)}>
@@ -731,14 +733,14 @@ class ProjectSettings extends React.Component {
 
   renderStepFormSource() {
     return (
-      <bem.FormModal__form className='project-settings project-settings--form-source'>
+      <form className={this.checkModalStyle()}>
         {this.props.context !== PROJECT_SETTINGS_CONTEXTS.REPLACE &&
-          <bem.Modal__subheader>
+          <div className={styles.modalSubheader}>
             {t('Choose one of the options below to continue. You will be prompted to enter name and other details in further steps.')}
-          </bem.Modal__subheader>
+          </div>
         }
 
-        <bem.FormModal__item m='form-source-buttons'>
+        <div className={styles.formSourceButton}>
           {this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW &&
             <button onClick={this.displayStep.bind(this, this.STEPS.PROJECT_DETAILS)}>
               <i className='k-icon k-icon-edit' />
@@ -763,17 +765,17 @@ class ProjectSettings extends React.Component {
           {this.props.context !== PROJECT_SETTINGS_CONTEXTS.NEW &&
             this.renderChooseTemplateButton()
           }
-        </bem.FormModal__item>
-      </bem.FormModal__form>
+        </div>
+      </form>
     );
   }
 
   renderStepChooseTemplate() {
     return (
-      <bem.FormModal__form className='project-settings project-settings--choose-template'>
+      <form className={cx(styles.chooseTemplate, this.checkModalStyle())}>
         <TemplatesList onSelectTemplate={this.onTemplateChange}/>
 
-        <bem.Modal__footer>
+        <footer className={styles.modalFooter}>
           {this.renderBackButton()}
 
           <Button
@@ -783,17 +785,17 @@ class ProjectSettings extends React.Component {
             isDisabled={!this.state.chosenTemplateUid || this.state.isApplyTemplatePending}
             label={this.state.applyTemplateButton}
           />
-        </bem.Modal__footer>
-      </bem.FormModal__form>
+        </footer>
+      </form>
     );
   }
 
   renderStepUploadFile() {
     return (
-      <bem.FormModal__form className='project-settings'>
-        <bem.Modal__subheader>
+      <form className={this.checkModalStyle()}>
+        <div className={styles.modalSubheader}>
           {t('Import an XLSForm from your computer.')}
-        </bem.Modal__subheader>
+        </div>
 
         {!this.state.isUploadFilePending &&
           <Dropzone
@@ -814,17 +816,17 @@ class ProjectSettings extends React.Component {
           </div>
         }
 
-        <bem.Modal__footer>
+        <footer className={styles.modalFooter}>
           {this.renderBackButton()}
-        </bem.Modal__footer>
-      </bem.FormModal__form>
+        </footer>
+      </form>
     );
   }
 
   renderStepImportUrl() {
     return (
-      <bem.FormModal__form className='project-settings project-settings--import-url'>
-        <div className='intro'>
+      <form className={this.checkModalStyle()}>
+        <div className={styles.uploadInstructions}>
           {t('Enter a valid XLSForm URL in the field below.')}<br/>
 
           { envStore.isReady &&
@@ -835,7 +837,7 @@ class ProjectSettings extends React.Component {
           }
         </div>
 
-        <bem.FormModal__item>
+        <div className={styles.formItem}>
           <TextBox
             type='url'
             label={t('URL')}
@@ -843,9 +845,9 @@ class ProjectSettings extends React.Component {
             value={this.state.importUrl}
             onChange={this.onImportUrlChange}
           />
-        </bem.FormModal__item>
+        </div>
 
-        <bem.Modal__footer>
+        <footer className={styles.modalFooter}>
           {this.renderBackButton()}
 
           <Button
@@ -856,8 +858,8 @@ class ProjectSettings extends React.Component {
             isDisabled={!this.state.importUrlButtonEnabled}
             label={this.state.importUrlButton}
           />
-        </bem.Modal__footer>
-      </bem.FormModal__form>
+        </footer>
+      </form>
     );
   }
 
@@ -874,17 +876,16 @@ class ProjectSettings extends React.Component {
     const descriptionField = envStore.data.getProjectMetadataField('description');
 
     return (
-      <bem.FormModal__form
+      <form
         onSubmit={this.handleSubmit}
         onChange={this.onProjectDetailsFormChange}
-        className={[
-          'project-settings',
-          'project-settings--project-details',
-          this.props.context === PROJECT_SETTINGS_CONTEXTS.BUILDER ? 'project-settings--narrow' : null,
-        ].join(' ')}
+        className={cx(
+          styles.projectDetails,
+          this.checkModalStyle() ?? styles.formView,
+        )}
       >
         {this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
-          <bem.Modal__footer>
+          <div className={styles.saveChanges}>
             <Button
               type='primary'
               size='l'
@@ -892,28 +893,24 @@ class ProjectSettings extends React.Component {
               onClick={this.handleSubmit.bind(this)}
               label={t('Save Changes')}
             />
-          </bem.Modal__footer>
+          </div>
         }
-
-        {/* Project Name */}
-        <bem.FormModal__item m='wrapper'>
-          {/* form builder displays name in different place */}
-          {this.props.context !== PROJECT_SETTINGS_CONTEXTS.BUILDER &&
-            <bem.FormModal__item>
-              <TextBox
-                value={this.state.fields.name}
-                onChange={this.onNameChange.bind(this)}
-                errors={this.hasFieldError('name') ? t('Please enter a title for your project!') : false}
-                label={addRequiredToLabel(this.getNameInputLabel(this.state.fields.name))}
-                placeholder={t('Enter title of project here')}
-                data-cy='title'
-              />
-            </bem.FormModal__item>
-          }
+        <div className={styles.formItemWrapper}>
+          {/* Project Name */}
+          <div className={styles.formItem}>
+            <TextBox
+              value={this.state.fields.name}
+              onChange={this.onNameChange.bind(this)}
+              errors={this.hasFieldError('name') ? t('Please enter a title for your project!') : false}
+              label={addRequiredToLabel(this.getNameInputLabel(this.state.fields.name))}
+              placeholder={t('Enter title of project here')}
+              data-cy='title'
+            />
+          </div>
 
           {/* Description */}
           {descriptionField &&
-          <bem.FormModal__item>
+          <div className={styles.formItem}>
             <TextBox
               type='text-multiline'
               value={this.state.fields.description}
@@ -923,12 +920,17 @@ class ProjectSettings extends React.Component {
               placeholder={t('Enter short description here')}
               data-cy='description'
             />
-          </bem.FormModal__item>
+          </div>
           }
 
           {/* Sector */}
           {sectorField &&
-            <bem.FormModal__item m={bothCountryAndSector ? 'sector' : null}>
+            <div
+              className={cx(
+                styles.formItem,
+                bothCountryAndSector ? styles.sector : null
+              )}
+            >
               <WrappedSelect
                 label={addRequiredToLabel(sectorField.label, sectorField.required)}
                 value={this.state.fields.sector}
@@ -940,12 +942,17 @@ class ProjectSettings extends React.Component {
                 error={this.hasFieldError('sector') ? t('Please choose a sector') : false}
                 data-cy='sector'
               />
-            </bem.FormModal__item>
+            </div>
           }
 
           {/* Country */}
           {countryField &&
-            <bem.FormModal__item m={bothCountryAndSector ? 'country' : null}>
+            <div
+            className={cx(
+              styles.formItem,
+              bothCountryAndSector ? styles.country : null
+            )}
+            >
               <WrappedSelect
                 label={addRequiredToLabel(countryField.label, countryField.required)}
                 isMulti
@@ -958,12 +965,12 @@ class ProjectSettings extends React.Component {
                 error={this.hasFieldError('country') ? t('Please select at least one country') : false}
                 data-cy='country'
               />
-            </bem.FormModal__item>
+            </div>
           }
 
           {/* Operational Purpose of Data */}
           {operationalPurposeField &&
-            <bem.FormModal__item>
+            <div className={styles.formItem}>
               <WrappedSelect
                 label={addRequiredToLabel(operationalPurposeField.label, operationalPurposeField.required)}
                 value={this.state.fields.operational_purpose}
@@ -973,12 +980,12 @@ class ProjectSettings extends React.Component {
                 isClearable
                 error={this.hasFieldError('operational_purpose') ? t('Please specify the operational purpose of your project') : false}
               />
-            </bem.FormModal__item>
+            </div>
           }
 
           {/* Does this project collect personally identifiable information? */}
           {collectsPiiField &&
-            <bem.FormModal__item>
+            <div className={styles.formItem}>
               <WrappedSelect
                 label={addRequiredToLabel(collectsPiiField.label, collectsPiiField.required)}
                 value={this.state.fields.collects_pii}
@@ -990,11 +997,11 @@ class ProjectSettings extends React.Component {
                 isClearable
                 error={this.hasFieldError('collects_pii') ? t('Please indicate whether or not your project collects personally identifiable information') : false}
               />
-            </bem.FormModal__item>
+            </div>
           }
 
           {(this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW || this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE) &&
-            <bem.Modal__footer>
+            <div className={styles.modalFooter}>
               {/* Don't allow going back if asset already exist */}
               {!this.state.formAsset &&
                 this.renderBackButton()
@@ -1014,12 +1021,12 @@ class ProjectSettings extends React.Component {
                   </>
                 )}
               />
-            </bem.Modal__footer>
+            </div>
           }
 
           {userCan('manage_asset', this.state.formAsset) && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
-            <bem.FormModal__item>
-              <bem.FormModal__item m='inline'>
+            <div className={styles.formItem}>
+              <div className={cx(styles.formItem, styles.formItemInline)}>
                 {this.isArchived() &&
                   <Button
                     type='secondary'
@@ -1037,24 +1044,24 @@ class ProjectSettings extends React.Component {
                     onClick={this.archiveProject}
                   />
                 }
-              </bem.FormModal__item>
+              </div>
 
               {this.isArchivable() &&
-                <bem.FormModal__item m='inline'>
+                <div className={cx(styles.formItem, styles.formItemInline)}>
                   {t('Archive project to stop accepting submissions.')}
-                </bem.FormModal__item>
+                </div>
               }
               {this.isArchived() &&
-                <bem.FormModal__item m='inline'>
+                <div className={cx(styles.formItem, styles.formItemInline)}>
                   {t('Unarchive project to resume accepting submissions.')}
-                </bem.FormModal__item>
+                </div>
               }
 
-            </bem.FormModal__item>
+            </div>
           }
 
           {isSelfOwned && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
-            <bem.FormModal__item>
+            <div className={styles.formItem}>
               <Button
                 type='danger'
                 size='l'
@@ -1063,10 +1070,10 @@ class ProjectSettings extends React.Component {
                   t('Delete Project')}
                 onClick={this.deleteProject}
               />
-            </bem.FormModal__item>
+            </div>
           }
-        </bem.FormModal__item>
-      </bem.FormModal__form>
+          </div>
+      </form>
     );
   }
 

--- a/jsapp/js/components/modalForms/projectSettings.module.scss
+++ b/jsapp/js/components/modalForms/projectSettings.module.scss
@@ -1,9 +1,5 @@
 @use 'scss/colors';
 @use 'scss/breakpoints';
-@use 'scss/sizes';
-@use 'scss/libs/_mdl';
-@use 'scss/_variables';
-@use 'scss/mixins';
 
 .uploadInstructions {
   margin-bottom: 20px;

--- a/jsapp/js/components/modalForms/projectSettings.module.scss
+++ b/jsapp/js/components/modalForms/projectSettings.module.scss
@@ -1,0 +1,157 @@
+@use 'scss/colors';
+@use 'scss/breakpoints';
+@use 'scss/sizes';
+@use 'scss/libs/_mdl';
+@use 'scss/_variables';
+@use 'scss/mixins';
+
+.uploadInstructions {
+  margin-bottom: 20px;
+  text-align: initial;
+}
+
+.formItem[disabled] {
+  pointer-events: none;
+}
+
+.modal {
+  width: 100%;
+
+  @media screen and (min-width: breakpoints.$b768) {
+    min-width: 600px;
+    max-width: 750px;
+  }
+}
+
+.formView {
+  margin-bottom: 30px;
+}
+
+.projectDetails > .formItemWrapper {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  column-gap: 4%;
+  .formItem {
+    min-width: 75%; // Most rows are wide enough to get their own row,
+    flex: 1; // and when they do, they grow to occupy the full available width
+  }
+  .sector,
+  .country {
+    min-width: 40%; // These fields can sit next to each other in pairs.
+  }
+}
+
+.formItem {
+  &:not(:last-child) {
+    margin-bottom: 15px;
+  }
+
+  textarea {
+    overflow: hidden;
+    resize: none;
+    height: auto;
+  }
+}
+
+.formItemInline {
+  display: inline-block;
+  &:not(:last-child) {
+    margin-bottom: 0;
+    margin-right: 20px;
+  }
+}
+
+.modalSubheader {
+  background: colors.$kobo-gray-200;
+  padding: 20px 30px;
+  margin: -30px -30px 20px;
+  color: colors.$kobo-gray-700;
+
+  i {
+    margin: 5px 10px 10px 3px;
+    font-size: 24px;
+    float: left;
+  }
+}
+
+$buttons-spacing: 10px;
+
+.formSourceButton {
+  margin: 0 auto;
+  max-width: 500px;
+
+  button {
+    display: inline-block;
+    vertical-align: top;
+    border: none;
+    background: colors.$kobo-gray-200;
+    border-radius: 6px;
+    color: colors.$kobo-gray-700;
+    cursor: pointer;
+    margin: 0.5 * $buttons-spacing;
+    padding: $buttons-spacing;
+    width: calc(50% - #{$buttons-spacing});
+    min-height: 120px;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
+
+    @media screen and (min-width: breakpoints.$b768) {
+      margin: $buttons-spacing;
+      padding: 2 * $buttons-spacing;
+      width: calc(50% - #{2 * $buttons-spacing});
+    }
+
+    i {
+      display: block;
+      margin: 3px auto;
+      font-size: 34px;
+      color: currentColor;
+    }
+
+    &:hover {
+      color: colors.$kobo-gray-800;
+      background-color: colors.$kobo-gray-300;
+    }
+
+    &:active {
+      // makes the shadow smaller and moves button down by small bit
+      // to make it look pressed-in
+      transform: translateY(1px);
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.25);
+    }
+  }
+}
+
+@media screen and (min-height: 600px) {
+  // on bigger screens make templates-list scrollable to always display back/next buttons
+  .chooseTemplate:first-child {
+    max-height: 380px;
+    overflow-y: auto;
+  }
+}
+
+.modalFooter {
+  margin-top: 20px;
+  text-align: right;
+
+  &::before,
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+
+  &:first-child {
+    margin-top: 0;
+    margin-bottom: 20px;
+  }
+
+  button:not(:first-of-type) {
+    margin-left: 10px;
+  }
+}
+
+.saveChanges {
+  text-align: right;
+}

--- a/jsapp/js/components/modalForms/projectSettings.module.scss
+++ b/jsapp/js/components/modalForms/projectSettings.module.scss
@@ -6,30 +6,21 @@
   text-align: initial;
 }
 
-.formItem[disabled] {
-  pointer-events: none;
-}
-
 .modal {
   width: 100%;
-
-  @media screen and (min-width: breakpoints.$b768) {
-    min-width: 600px;
-    max-width: 750px;
-  }
 }
 
-.formView {
+.projectDetailsView {
   margin-bottom: 30px;
 }
 
-.projectDetails > .formItemWrapper {
+.projectDetails .inputWrapper {
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
   align-items: flex-end;
   column-gap: 4%;
-  .formItem {
+  .input {
     min-width: 75%; // Most rows are wide enough to get their own row,
     flex: 1; // and when they do, they grow to occupy the full available width
   }
@@ -39,7 +30,7 @@
   }
 }
 
-.formItem {
+.input {
   &:not(:last-child) {
     margin-bottom: 15px;
   }
@@ -51,7 +42,7 @@
   }
 }
 
-.formItemInline {
+.inputInline {
   display: inline-block;
   &:not(:last-child) {
     margin-bottom: 0;
@@ -74,7 +65,7 @@
 
 $buttons-spacing: 10px;
 
-.formSourceButton {
+.sourceButtons {
   margin: 0 auto;
   max-width: 500px;
 
@@ -91,12 +82,6 @@ $buttons-spacing: 10px;
     width: calc(50% - #{$buttons-spacing});
     min-height: 120px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
-
-    @media screen and (min-width: breakpoints.$b768) {
-      margin: $buttons-spacing;
-      padding: 2 * $buttons-spacing;
-      width: calc(50% - #{2 * $buttons-spacing});
-    }
 
     i {
       display: block;
@@ -119,35 +104,37 @@ $buttons-spacing: 10px;
   }
 }
 
+.modalFooter {
+  margin-top: 20px;
+  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 10px;
+}
+
+.saveChanges {
+  text-align: right;
+  margin-bottom: 20px;
+}
+
+@media screen and (min-width: breakpoints.$b768) {
+  .modal {
+    min-width: 600px;
+    max-width: 750px;
+  }
+
+  .sourceButtons button {
+    margin: $buttons-spacing;
+    padding: 2 * $buttons-spacing;
+    width: calc(50% - #{2 * $buttons-spacing});
+  }
+}
+
 @media screen and (min-height: 600px) {
   // on bigger screens make templates-list scrollable to always display back/next buttons
   .chooseTemplate:first-child {
     max-height: 380px;
     overflow-y: auto;
   }
-}
-
-.modalFooter {
-  margin-top: 20px;
-  text-align: right;
-
-  &::before,
-  &::after {
-    content: '';
-    display: table;
-    clear: both;
-  }
-
-  &:first-child {
-    margin-top: 0;
-    margin-bottom: 20px;
-  }
-
-  button:not(:first-of-type) {
-    margin-left: 10px;
-  }
-}
-
-.saveChanges {
-  text-align: right;
 }

--- a/jsapp/js/constants.ts
+++ b/jsapp/js/constants.ts
@@ -89,7 +89,6 @@ export const PROJECT_SETTINGS_CONTEXTS = Object.freeze({
   NEW: 'newForm',
   EXISTING: 'existingForm',
   REPLACE: 'replaceProject',
-  BUILDER: 'formBuilderAside',
 });
 
 export const update_states = {

--- a/jsapp/js/editorMixins/editableForm.es6
+++ b/jsapp/js/editorMixins/editableForm.es6
@@ -9,13 +9,11 @@ import SurveyScope from '../models/surveyScope';
 import {cascadeMixin} from './cascadeMixin';
 import AssetNavigator from './assetNavigator';
 import alertify from 'alertifyjs';
-import ProjectSettings from '../components/modalForms/projectSettings';
 import MetadataEditor from 'js/components/metadataEditor';
 import {escapeHtml} from '../utils';
 import {
   ASSET_TYPES,
   AVAILABLE_FORM_STYLES,
-  PROJECT_SETTINGS_CONTEXTS,
   update_states,
   NAME_MAX_LENGTH,
   META_QUESTION_TYPES,

--- a/jsapp/scss/components/_kobo.bem.ui.scss
+++ b/jsapp/scss/components/_kobo.bem.ui.scss
@@ -48,29 +48,6 @@ iframe {
   border: none;
 }
 
-// Flexbox helps us maintain a layout when some fields may be customized
-// or removed.
-// Place sector and country side-by-side, when both fields exist and we're
-// not in the narrow form builder sidebar. Similar to registration screen.
-.form-modal__form.project-settings--project-details:not(
-    .project-settings--narrow
-  )
-  > .form-modal__item--wrapper {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-  align-items: flex-end;
-  column-gap: 4%;
-  .form-modal__item {
-    min-width: 75%; // Most rows are wide enough to get their own row,
-    flex: 1; // and when they do, they grow to occupy the full available width
-  }
-  .form-modal__item--sector,
-  .form-modal__item--country {
-    min-width: 40%; // These fields can sit next to each other in pairs.
-  }
-}
-
 // modal forms
 .form-modal__item {
   &:not(:last-child) {


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

This PR fixes a small issue where the Kobo select for sector in a new project settings form was causing the containing modal to resize slightly. In the process, however, I have switched this component over to style modules away from bem styling. 

## Notes

1. There is a pre-existing issue causing the labels for textbox inputs in this form to be a slightly different font size from the KoboSelect inputs. I have ignored that to avoid scope creep. We should migrate KoboSelect to style modules at some point and we can fix it then.

2. As far as I could determine, this component was used in the form builder in the past but no longer is. I have thus removed 'builder' from `PROJECT_SETTINGS_CONTEXTS` and updated the className logic accordingly.

## Testing

Aside from the resizing issue, the goal here was to keep everything the same visually. To test, navigate around all four project creation options in the new project modal. Additionally, try replacing a project with another project and viewing project settings in the form view.
