### PR TITLE
Patch AlertifyJS to avoid errors during dialog transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/react": "^7.61.0",
         "@tanstack/react-query": "^5.49.2",
         "@tanstack/react-table": "^8.20.5",
-        "alertifyjs": "^1.13.1",
+        "alertifyjs": "^1.14.0",
         "backbone": "^1.4.0",
         "backbone-validation": "^0.11.5",
         "chai-deep-equal-ignore-undefined": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sentry/react": "^7.61.0",
     "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-table": "^8.20.5",
-    "alertifyjs": "^1.13.1",
+    "alertifyjs": "^1.14.0",
     "backbone": "^1.4.0",
     "backbone-validation": "^0.11.5",
     "chai-deep-equal-ignore-undefined": "^1.1.1",

--- a/patches/alertifyjs+1.14.0.patch
+++ b/patches/alertifyjs+1.14.0.patch
@@ -1,0 +1,56 @@
+diff --git a/node_modules/alertifyjs/build/alertify.js b/node_modules/alertifyjs/build/alertify.js
+index 56f9264..0b88932 100644
+--- a/node_modules/alertifyjs/build/alertify.js
++++ b/node_modules/alertifyjs/build/alertify.js
+@@ -1507,6 +1507,9 @@
+          * @return {undefined}
+          */
+         function handleTransitionInEvent(event, instance) {
++            // https://github.com/MohammadYounes/AlertifyJS/issues/274
++            if (!instance.__internal || !instance.elements) return; // defensive patch
++
+             // clear the timer
+             clearTimeout(instance.__internal.timerIn);
+ 
+@@ -1534,6 +1537,9 @@
+          * @return {undefined}
+          */
+         function handleTransitionOutEvent(event, instance) {
++            // https://github.com/MohammadYounes/AlertifyJS/issues/274
++            if (!instance.__internal || !instance.elements) return; // defensive patch
++
+             // clear the timer
+             clearTimeout(instance.__internal.timerOut);
+             // unbind the event
+@@ -1554,6 +1560,7 @@
+                 instance.__internal.destroy.apply(instance);
+             }
+         }
++
+         /* Controls moving a dialog around */
+         //holde the current moving instance
+         var movable = null,
+diff --git a/node_modules/alertifyjs/src/js/dialog/transition.js b/node_modules/alertifyjs/src/js/dialog/transition.js
+index 93c6b0f..5578fed 100644
+--- a/node_modules/alertifyjs/src/js/dialog/transition.js
++++ b/node_modules/alertifyjs/src/js/dialog/transition.js
+@@ -7,6 +7,9 @@
+          * @return {undefined}
+          */
+         function handleTransitionInEvent(event, instance) {
++            // https://github.com/MohammadYounes/AlertifyJS/issues/274
++            if (!instance.__internal || !instance.elements) return; // defensive patch
++
+             // clear the timer
+             clearTimeout(instance.__internal.timerIn);
+ 
+@@ -34,6 +37,9 @@
+          * @return {undefined}
+          */
+         function handleTransitionOutEvent(event, instance) {
++            // https://github.com/MohammadYounes/AlertifyJS/issues/274
++            if (!instance.__internal || !instance.elements) return; // defensive patch
++
+             // clear the timer
+             clearTimeout(instance.__internal.timerOut);
+             // unbind the event


### PR DESCRIPTION
## Description

Patch upstream AlertifyJS library to improve stability when confirmation dialogs are opening or closing.

## Related Issues

Provides fallback coverage for issues like:

- #5151 
- https://github.com/MohammadYounes/AlertifyJS/issues/274

## Testing

Test the **Archive / Unarchive** of a single selected project in the Projects Table.

- [ ] **Reproduce:** Without this fix (or the fix in #5151), if you're lucky, this will trigger an error about 1 second after confirming the dialog.
- [ ] **Confirm fix:** With this branch, reinstall node modules and rebuild, and confirm the issue is gone.

`npm install` is necessary because (1) I upgraded alertify to the latest version because that seemed like a good basis for a patch, and (2) the patch applies as a post-install step. 

- Also, if you have more bugs you think might be related to this issue, see if this patch circumvents them (yes/no/unconfirmed) and list them here.
  - …

## Notes

This patch adds defensive check for `instance.__internal` to catch a timing-related crash reported here: https://github.com/MohammadYounes/AlertifyJS/issues/274

- [xref](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/bug.20in.20beta-refactored.3F/near/464925) internal discussion

---

This is a 'simple' fix that I wrote, hoping it will prevent user-facing problems in the near term.

This symptom may disappear before we end up investigating it more, due to our following priorities:

1. **Rewrite calling code w/ React Query**: Some of our component code has acquired non-deterministic timing and/or duplicate calls — which might be disrupting Alertify's internal lifecycle. We plan to replace most of our Reflux action listener setups with functional components + react-query hooks, making UI events streamlined and predictable.
2. **Rewrite modals w/o Alertify**: We've removed Alertify from our toast notifications and some of our modals already, and we might do so for the rest of our modals too.

It's interesting that this behavior is reproduceable to Alertify versions from 5 years ago, yet we're only noticing the problem now. If we want we can try to measure this in production by adding a Sentry/Glitchtip invocation, but I consider that out of scope.


## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

---

## Ad-hoc reference: How to make a patch like this one

Here's a quick guide if you want to edit one of these patches, using Alertify as an example.

**Install package deps, edit Alertify source and generate a build**
```sh

# kpi $
  # Install our dependencies, including AlertifyJS
  npm install
  # Enter the AlertifyJS folder
  cd ./node_modules/alertifyjs
  
# kpi/node_modules/alertifyjs $
    # Install AlertifyJS's dev dependencies
    npm install
    #  Read Alertify's package.json
    #  - Script is "grunt build"
    #  - Compiled entrypoint is ./build/alertify.js
    npx grunt build
    # Edit the source files in ./src/js, then re-build again:
    npx grunt build
    # Alertify doesn't provide a 'watch' command, but you
    # could use 'entr' for this (https://github.com/eradman/entr)
    find ./src/js | entr -dccp npx grunt build # watch-build alertify
```

**Restart the webpack dev server** and refresh the page to see the change.
- `node_modules` changes are ignored by our webpack. Maybe there's a cool workaround but I didn't bother with it.

**Generate a patch for patch-package**
```sh
# kpi $
  npx patch-package alertifyjs \
    --include '(src/js/.*\.js|build/alertify\.js)' \
    --exclude 'docpad'
```
- I chose the include/exclude above for a lean patch. `build/alertify.js` is the only necessary file, but I included the modified source file to make it easier to understand.

