### PR TITLE
Fix PlanAddOn creation logic

### DIFF
--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -154,11 +154,9 @@ class PlanAddOn(models.Model):
 
     @admin.display(boolean=True, description='available')
     def is_available(self):
-        return (
-            self.charge.payment_intent.status == PaymentIntentStatus.succeeded and not (
-                self.is_expended or self.charge.refunded
-            ) and bool(self.organization)
-        )
+        return  not (
+            self.is_expended or self.charge.refunded
+        ) and bool(self.organization)
 
     def deduct(self, limit_type, amount_used):
         """

--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -154,7 +154,7 @@ class PlanAddOn(models.Model):
 
     @admin.display(boolean=True, description='available')
     def is_available(self):
-        return  not (
+        return not (
             self.is_expended or self.charge.refunded
         ) and bool(self.organization)
 

--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -77,7 +77,7 @@ class PlanAddOn(models.Model):
 
     @admin.display(boolean=True, description='available')
     def is_available(self):
-        return self.charge.payment_intent.status == PaymentIntentStatus.succeeded and not (
+        return not (
             self.is_expended or self.charge.refunded
         ) and bool(self.organization)
 

--- a/kobo/apps/stripe/tests/test_one_time_addons_api.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_api.py
@@ -139,13 +139,12 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         assert response.data['count'] == 1
         assert not response.data['results'][0]['is_available']
 
-    def test_addon_inactive_for_cancelled_charge(self):
+    def test_no_addon_for_cancelled_charge(self):
         self._create_product()
         self._create_payment(payment_status='cancelled')
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert not response.data['results'][0]['is_available']
+        assert response.data['count'] == 0
 
     def test_total_limits_reflect_addon_quantity(self):
         limit = 2000


### PR DESCRIPTION
## Description

Fix the PlanAddOn creation logic to avoid unnecessary instances when the payment is not successful 

## Notes

The stripe PlanAddOn model was modified.

## Testing

This is covered in unit tests, no manual testing necessary.

## Related issues

Notion [TASK-1118](https://www.notion.so/kobotoolbox/Fix-PlanAddon-creation-logic-1147e515f65480e399f5cccbd74095da)