### PR TITLE
Ensure usersession app is not adding extra queries after login

### DIFF
--- a/kpi/tests/api/v2/test_api_logout_all.py
+++ b/kpi/tests/api/v2/test_api_logout_all.py
@@ -71,8 +71,8 @@ class TestUserSessionQueries(TransactionTestCase):
                 'remove': 'allauth.usersessions.middleware.UserSessionsMiddleware'
             }
         ):
-            # the middleware chain is set on the first request, so log in with a different client
-            # while the UserSessionsMiddleware is turned off
+            # the middleware chain is set on the first request, so log in with a
+            # different client while the UserSessionsMiddleware is turned off
             no_middleware_client = Client()
             no_middleware_client.post(reverse('kobo_login'), data=data)
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

Developer-only changes.

## Notes

Adds a unit test to check the number of queries being issued with and without the UserSessionMiddleware active. 

This is not a perfect test since it only makes sure the *middleware* is not issuing any extra queries. Theoretically, the usersessions app could be issuing queries elsewhere. However, it is prohibitively difficult to enable and disable an entire app within a single unit test to do a comparison. Moreover, one can manually test that there are no new queries being issued by looking at the sql logs. 
Looking at the `https://github.com/pennersr/django-allauth/tree/main/allauth/usersessions` you can see that the only places `UserSession.create_from_request` is called are from the middleware and the login signal, so it should be enough to just test the middleware. 
Note that if we decide to turn on usersession_tracking, which updates the sessions when the ip of the caller changes, this test will break.

## Testing
To run the unit test:
`pytest --reuse-db kpi/tests/api/v2/test_api_logout_all.py::TestUserSessionQueries`

To more thoroughly test:

1. run kpi with `runserver_plus --print-sql` (this is easy to do by editing the docker-compose file in kobo-compose)
2. log in 
3. grep the kpi logs logs for queries against the `usersession` table - there should be a select and an insert
4. click around the app for a while
5. no more queries against the `usersession` table should appear

