### PR TITLE
[TASK-1164] Fix function that renders language in the downloads table

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsList.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsList.es6
@@ -178,7 +178,7 @@ export default class ProjectExportsList extends React.Component {
     // doesn't exist in current form version
     let languageDisplay = (<em>{t('Unknown')}</em>);
     const langIndex = getLanguageIndex(this.props.asset, exportLang);
-    if (langIndex !== null) {
+    if (langIndex !== -1) {
       languageDisplay = exportLang;
     } else if (EXPORT_FORMATS[exportLang]) {
       languageDisplay = EXPORT_FORMATS[exportLang].label;


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

Fixed Project > Data > Downloads table displaying wrong text in the "Language" column. This was happening when "XML values and headers" or "Labels" was selected in "Value and header format".

## Notes

We broke this in #4933. It would be immediately spotted if `/jsapp/js/components/projectDownloads` was typescriptized.

## Testing

Test this without fix first. The steps are:

1. Create a small project
2. Deploy project
3. Add one submission
4. Go to Poject > Data > Downloads
5. Set "Value and header format" to "Labels" and click "Export"
6. Observe export being added (after a short moment), and in the column "Language" you will see "_default" (:bug:)
7. Set "Value and header format" to "XML values and headers" and click "Export"
8. Observe export being added (after a short moment), and in the column "Language" you will see "_xml" (:bug:)

There is a screenshot at #5171 

## Related issues

Fixes #5171
Followup to #4933
