### PR TITLE
Add new base viewset for audit logging

### DIFF
--- a/kobo/apps/audit_log/base_views.py
+++ b/kobo/apps/audit_log/base_views.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+from rest_framework import viewsets
+from rest_framework import mixins
+
+
+def get_nested_field(obj, field: str):
+    """
+    Retrieve a period-separated nested field from an object or dict
+
+    Raises an exception if the field is not found
+    """
+    split = field.split('.')
+    attribute = getattr(obj, split[0])
+    if len(split) > 1:
+        for inner_field in split[1:]:
+            if isinstance(attribute, dict):
+                attribute = attribute.get(inner_field)
+            else:
+                attribute = getattr(attribute, inner_field)
+    return attribute
+
+
+class AuditLoggedViewSet(viewsets.GenericViewSet):
+    """
+    A ViewSet for adding arbitrary object data to a request before and after request
+
+    Useful for storing information for audit logs on create/update. Allows inheriting
+    ViewSets to implement additional logic for get_object, perform_update,
+    perform_create, and perform_destroy via the get_object_override,
+    perform_update_override, perform_create_override, and perform_destroy_override
+    methods.
+
+    Sets the values on the inner HttpRequest object rather than the DRF Request
+    so middleware can access them.
+    """
+    logged_fields = []
+
+    def get_object(self):
+        # actually fetch the object
+        obj = self.get_object_override()
+        if self.request.method in ['GET','HEAD']:
+            # since this is for audit logs, don't worry about read-only requests
+            return obj
+        audit_log_data = {}
+        for field in self.logged_fields:
+            value = get_nested_field(obj, field)
+            audit_log_data[field] = value
+        self.request._request.initial_data = audit_log_data
+        return obj
+
+    def perform_update(self, serializer):
+        self.perform_update_override(serializer)
+        audit_log_data = {}
+        for field in self.logged_fields:
+            value = get_nested_field(serializer.instance, field)
+            audit_log_data[field] = value
+        self.request._request.updated_data = audit_log_data
+
+    def perform_create(self, serializer):
+        self.perform_create_override(serializer)
+        audit_log_data = {}
+        for field in self.logged_fields:
+            value = get_nested_field(serializer.instance, field)
+            audit_log_data[field] = value
+        self.request._request.updated_data = audit_log_data
+
+    def perform_destroy(self, instance):
+        audit_log_data = {}
+        for field in self.logged_fields:
+            value = get_nested_field(instance, field)
+            audit_log_data[field] = value
+        self.request._request.initial_data = audit_log_data
+        self.perform_destroy_override(instance)
+
+    def perform_destroy_override(self, instance):
+        super().perform_destroy(instance)
+
+    def perform_create_override(self, serializer):
+        super().perform_create(serializer)
+
+    def perform_update_override(self, serializer):
+        super().perform_update(serializer)
+
+    def get_object_override(self):
+        return super().get_object()
+
+
+class AuditLoggedModelViewSet(AuditLoggedViewSet, mixins.CreateModelMixin,
+                   mixins.RetrieveModelMixin,
+                   mixins.UpdateModelMixin,
+                   mixins.DestroyModelMixin,
+                   mixins.ListModelMixin):
+    pass
+
+class AuditLoggedNoUpdateModelViewSet(AuditLoggedModelViewSet,
+                                    mixins.CreateModelMixin,
+                                    mixins.RetrieveModelMixin,
+                                    mixins.DestroyModelMixin,
+                                    mixins.ListModelMixin):
+    pass

--- a/kobo/apps/audit_log/base_views.py
+++ b/kobo/apps/audit_log/base_views.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from rest_framework import mixins, viewsets
 
 

--- a/kobo/apps/audit_log/base_views.py
+++ b/kobo/apps/audit_log/base_views.py
@@ -1,6 +1,5 @@
 # coding: utf-8
-from rest_framework import viewsets
-from rest_framework import mixins
+from rest_framework import mixins, viewsets
 
 
 def get_nested_field(obj, field: str):
@@ -33,12 +32,13 @@ class AuditLoggedViewSet(viewsets.GenericViewSet):
     Sets the values on the inner HttpRequest object rather than the DRF Request
     so middleware can access them.
     """
+
     logged_fields = []
 
     def get_object(self):
         # actually fetch the object
         obj = self.get_object_override()
-        if self.request.method in ['GET','HEAD']:
+        if self.request.method in ['GET', 'HEAD']:
             # since this is for audit logs, don't worry about read-only requests
             return obj
         audit_log_data = {}
@@ -85,16 +85,22 @@ class AuditLoggedViewSet(viewsets.GenericViewSet):
         return super().get_object()
 
 
-class AuditLoggedModelViewSet(AuditLoggedViewSet, mixins.CreateModelMixin,
-                   mixins.RetrieveModelMixin,
-                   mixins.UpdateModelMixin,
-                   mixins.DestroyModelMixin,
-                   mixins.ListModelMixin):
+class AuditLoggedModelViewSet(
+    AuditLoggedViewSet,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+):
     pass
 
-class AuditLoggedNoUpdateModelViewSet(AuditLoggedModelViewSet,
-                                    mixins.CreateModelMixin,
-                                    mixins.RetrieveModelMixin,
-                                    mixins.DestroyModelMixin,
-                                    mixins.ListModelMixin):
+
+class AuditLoggedNoUpdateModelViewSet(
+    AuditLoggedModelViewSet,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+):
     pass

--- a/kobo/apps/audit_log/tests/test_base_views.py
+++ b/kobo/apps/audit_log/tests/test_base_views.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+from django.urls import include, path, reverse
+from django.test import override_settings
+from django.db import models
+
+
+from kobo.apps.accounts.serializers import EmailAddressSerializer
+from kobo.apps.audit_log.base_views import AuditLoggedModelViewSet
+from kobo.apps.kobo_auth.shortcuts import User
+
+
+from kobo.apps.audit_log.views import AuditLogViewSet
+from kobo.settings.base import ROOT_URLCONF
+from kpi.models import Asset
+from kpi.serializers.v2.asset import AssetSerializer
+from kpi.serializers.v2.user import UserSerializer
+from kpi.tests.kpi_test_case import KpiTestCase
+from rest_framework.routers import DefaultRouter
+from rest_framework import permissions
+from allauth.account.models import EmailAddress
+from django.test.utils import isolate_apps
+from rest_framework import serializers, renderers
+
+class DummyEmailSerializer(serializers.ModelSerializer):
+    """
+    Basic model serializer for EmailAddresses
+    """
+    class Meta:
+        model = EmailAddress
+        fields = '__all__'
+
+
+class DummyViewSet(AuditLoggedModelViewSet):
+    """
+    DummyViewSet for testing the functionality of the AuditLoggedModelViewSet
+
+    Uses the email address model because it's simple
+    """
+    permission_classes = (permissions.AllowAny,)
+    queryset = EmailAddress.objects.all()
+    serializer_class = DummyEmailSerializer
+    logged_fields = ['email', 'verified']
+
+
+class TestUrls:
+    """
+    Register our DummyViewSet at a test-only url
+    """
+    router = DefaultRouter()
+    router.register(f'test', DummyViewSet, basename='test-vs')
+    urlpatterns = router.urls
+
+@override_settings(ROOT_URLCONF=TestUrls)
+class TestAuditLoggedViewSet(KpiTestCase):
+    fixtures = ['test_data']
+
+    def test_creating_model_records_fields(self):
+        response = self.client.post(reverse('test-vs-list'), data={'user': 1, 'email': 'new_email@example.com'})
+        request = response.wsgi_request
+        self.assertDictEqual(request.updated_data, {'email': 'new_email@example.com', 'verified': False})
+
+    def test_updating_model_records_fields(self):
+        user = User.objects.get(pk=1)
+        email_address, _ = EmailAddress.objects.get_or_create(user=user, email='initial_email@example.com')
+        email_address.save()
+        response = self.client.patch(reverse('test-vs-detail', args=[email_address.pk]), data={'email': 'newer_email@example.com'})
+        request = response.wsgi_request
+        self.assertEqual(request.initial_data, {'email': 'initial_email@example.com', 'verified': False})
+        self.assertEqual(request.updated_data, {'email': 'newer_email@example.com', 'verified': False})
+
+    def test_destroying_model_records_fields(self):
+        user = User.objects.get(pk=1)
+        email_address, _ = EmailAddress.objects.get_or_create(user=user, email='initial_email@example.com')
+        email_address.save()
+        response = self.client.delete(reverse('test-vs-detail', args=[email_address.pk]))
+        request = response.wsgi_request
+        self.assertEqual(request.initial_data, {'email': 'initial_email@example.com', 'verified': False})

--- a/kobo/apps/audit_log/tests/test_base_views.py
+++ b/kobo/apps/audit_log/tests/test_base_views.py
@@ -38,7 +38,7 @@ class TestUrls:
     """
 
     router = DefaultRouter()
-    router.register(f'test', DummyViewSet, basename='test-vs')
+    router.register(r'test', DummyViewSet, basename='test-vs')
     urlpatterns = router.urls
 
 


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

Developer-only changes.

## Notes

Creates a new AuditLoggedViewSet subclass of GenericViewSet that stores attributes of a model before and after modification/creation/deletion on the request object. This will allow middleware to access it and create the appropriate audit logs. 

## Testing

Since this is an implementation convenience rather than an actual feature it's hard to test besides just running the unit tests. It can be more thoroughly tested in later PRs that actually use the viewset.

