### PR TITLE
[TASK-1165] Fix project header title serving old asset name

### DIFF
--- a/jsapp/js/components/header/headerTitleEditor.tsx
+++ b/jsapp/js/components/header/headerTitleEditor.tsx
@@ -36,7 +36,11 @@ class HeaderTitleEditor extends React.Component<
   }
 
   componentDidMount() {
-    this.unlisteners.push(assetStore.listen(this.onAssetLoad, this));
+    // Note: there is a risk/vulnerability in this component connected to
+    // the usage of the `assetStore`. As `assetStore` is listening to
+    // `actions.resources.loadAsset` which is using our faulty `assetCache`,
+    // there is a chance `assetStore` would give us a cached (old) asset object.
+    this.unlisteners.push(assetStore.listen(this.onAssetStoreUpdated, this));
   }
 
   componentWillUnmount() {
@@ -45,11 +49,14 @@ class HeaderTitleEditor extends React.Component<
     });
   }
 
-  onAssetLoad() {
-    this.setState({
-      name: this.props.asset.name,
-      isPending: false,
-    });
+  onAssetStoreUpdated() {
+    const foundAsset = assetStore.getAsset(this.props.asset.uid);
+    if (foundAsset) {
+      this.setState({
+        name: foundAsset.name,
+        isPending: false,
+      });
+    }
   }
 
   updateAssetTitle() {


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

Fixes a problem when editing project title using top header - after successful update API call, component was reverting back to old name. This was a bug in the UI, database was storing the updated name - it was possible to overwrite the updated name due to confusing bug in the UI though.

## Notes

For some reason this component was using props name when successful API call response was received - instead of relying on the response data. There still is a risko of bugs due to asset cache, so I left a comment for future debugger. I was testing out UI to try to break it and didn't find any bug as of yet.

## Testing

Try changing title using header editor. See video at #5170

## Related issues

Fixes #5170

