### PR TITLE
[TASK-1168] Implement feature flags functionality

### DIFF
--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -10,7 +10,7 @@ import {PERMISSIONS_CODENAMES} from 'js/components/permissions/permConstants';
 import {ROUTES} from 'js/router/routerConstants';
 import {withRouter} from 'js/router/legacy';
 import {userCan} from 'js/components/permissions/utils';
-import {getFeatureFlags} from 'js/featureFlags';
+import {checkFeatureFlag, FeatureFlag} from 'js/featureFlags';
 
 export function getFormDataTabs(assetUid) {
   return [
@@ -83,7 +83,7 @@ class FormViewSideTabs extends Reflux.Component {
   renderFormSideTabs() {
     var sideTabs = [];
 
-    const {activityLogsEnabled} = getFeatureFlags();
+    const isActivityLogsEnabled = checkFeatureFlag(FeatureFlag.activityLogsEnabled);
 
     if (
       this.state.asset &&
@@ -167,7 +167,7 @@ class FormViewSideTabs extends Reflux.Component {
       }
 
       if (
-        activityLogsEnabled &&
+        isActivityLogsEnabled &&
         userCan(
           PERMISSIONS_CODENAMES.manage_asset,
           this.state.asset

--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -84,7 +84,7 @@ class FormViewSideTabs extends Reflux.Component {
   renderFormSideTabs() {
     let sideTabs = [];
 
-    const featureFlags = getFeatureFlags();
+    const {activityLogsEnabled} = getFeatureFlags();
 
     if (
       this.state.asset &&
@@ -168,7 +168,7 @@ class FormViewSideTabs extends Reflux.Component {
       }
 
       if (
-        featureFlags.activityLogs &&
+        activityLogsEnabled &&
         userCan(
           PERMISSIONS_CODENAMES.manage_asset,
           this.state.asset

--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -13,7 +13,6 @@ import {userCan} from 'js/components/permissions/utils';
 import {getFeatureFlags} from 'js/featureFlags';
 
 export function getFormDataTabs(assetUid) {
-
   return [
     {
       label: t('Table'),
@@ -62,7 +61,7 @@ class FormViewSideTabs extends Reflux.Component {
   }
 
   assetLoad(data) {
-    const asset = data[this.currentAssetID()];
+    var asset = data[this.currentAssetID()];
     this.setState(Object.assign({asset: asset}));
   }
 
@@ -72,7 +71,7 @@ class FormViewSideTabs extends Reflux.Component {
         ROUTES.FORM_RESET.replace(':uid', this.state.asset.uid)
       );
 
-      const path = evt.target.getAttribute('data-path');
+      var path = evt.target.getAttribute('data-path');
       window.setTimeout(() => {
         this.props.router.navigate(path);
       }, 50);
@@ -82,7 +81,7 @@ class FormViewSideTabs extends Reflux.Component {
   }
 
   renderFormSideTabs() {
-    let sideTabs = [];
+    var sideTabs = [];
 
     const {activityLogsEnabled} = getFeatureFlags();
 

--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -10,8 +10,10 @@ import {PERMISSIONS_CODENAMES} from 'js/components/permissions/permConstants';
 import {ROUTES} from 'js/router/routerConstants';
 import {withRouter} from 'js/router/legacy';
 import {userCan} from 'js/components/permissions/utils';
+import {getFeatureFlags} from 'js/featureFlags';
 
 export function getFormDataTabs(assetUid) {
+
   return [
     {
       label: t('Table'),
@@ -60,7 +62,7 @@ class FormViewSideTabs extends Reflux.Component {
   }
 
   assetLoad(data) {
-    var asset = data[this.currentAssetID()];
+    const asset = data[this.currentAssetID()];
     this.setState(Object.assign({asset: asset}));
   }
 
@@ -70,7 +72,7 @@ class FormViewSideTabs extends Reflux.Component {
         ROUTES.FORM_RESET.replace(':uid', this.state.asset.uid)
       );
 
-      var path = evt.target.getAttribute('data-path');
+      const path = evt.target.getAttribute('data-path');
       window.setTimeout(() => {
         this.props.router.navigate(path);
       }, 50);
@@ -80,7 +82,9 @@ class FormViewSideTabs extends Reflux.Component {
   }
 
   renderFormSideTabs() {
-    var sideTabs = [];
+    let sideTabs = [];
+
+    const featureFlags = getFeatureFlags();
 
     if (
       this.state.asset &&
@@ -164,6 +168,7 @@ class FormViewSideTabs extends Reflux.Component {
       }
 
       if (
+        featureFlags.activityLogs &&
         userCan(
           PERMISSIONS_CODENAMES.manage_asset,
           this.state.asset

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -20,7 +20,7 @@ export enum FeatureFlag {
  * - Destructuring
  *  ```js
  *    // https://kf.kobotoolbox.org/#/projects/home?ff_featureNameEnable=true&ff_featureNameEnable2=true
- *    const {featureNameEnabled} = getFeatureFlags()`
+ *    const {featureNameEnabled} = getFeatureFlags()
  *    console.log(featureNameEnabled) // true
  *  ```
  *

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -9,7 +9,7 @@ export enum FeatureFlag {
 /**
  * This function reads query parameters and processes them to find feature flags
  * - The query parameters are read from the URL
- * - Recommended naming convention: `ff_FeatureNameEnabled`
+ * - Recommended naming convention: `ff_featureNameEnabled`
  * - Any parameter starting with "ff_" is considered to be a feature flag
  * - A feature flag parameter needs to have its value equals "true" to be set to true
  * - Enabled flags are stored on sessionStorage by its name **without the ff_**
@@ -19,16 +19,16 @@ export enum FeatureFlag {
  *  Uses:
  * - Destructuring
  *  ```js
- *    # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
- *    const {FeatureNameEnabled} = getFeatureFlags()`
- *    console.log(FeatureNameEnabled) # true
+ *    // https://kf.kobotoolbox.org/#/projects/home?ff_featureNameEnable=true&ff_featureNameEnable2=true
+ *    const {featureNameEnabled} = getFeatureFlags()`
+ *    console.log(featureNameEnabled) // true
  *  ```
  *
  * - Full object
  *  ```
- *    # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
+ *    // https://kf.kobotoolbox.org/#/projects/home?ff_featureNameEnable=true&ff_featureNameEnable2=true
  *    const flags = getFeatureFlags()
- *    console.log(flags) # {FeatureNameEnable: true, FeatureNameEnable2: true}
+ *    console.log(flags) // {featureNameEnable: true, featureNameEnable2: true}
  *  ```
  *
  * @returns {Record<FeatureFlag, boolean>} Object containing enabled flags as entries set as true
@@ -83,7 +83,7 @@ export const checkFeatureFlag = (flag: FeatureFlag): boolean =>
  * It uses the {@link getFeatureFlags} function to get the flags.
  *
  * - The query parameters from the URL are processed to find feature flags
- * - Recommended parameter naming convention: `ff_FeatureNameEnabled`
+ * - Recommended parameter naming convention: `ff_featureNameEnabled`
  * - Any query parameter starting with "ff_" is considered to be a feature flag
  * - A feature flag parameter needs to have its value equals "true" to be set to true
  * - Enabled flags are stored on session and will keep their state even if the query param is no longer present
@@ -91,10 +91,10 @@ export const checkFeatureFlag = (flag: FeatureFlag): boolean =>
  *
  * Use:
  * ```
- * # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
+ * // https://kf.kobotoolbox.org/#/projects/home?ff_featureNameEnable=true&ff_featureNameEnable2=true
  *
  * const isFeatureEnabled = useFeatureFlag(FeatureFlag.featureNameEnabled);
- * console.log(isFeatureEnabled) # true
+ * console.log(isFeatureEnabled) // true
  * ```
  * - If you can't use the hook, use the {@link checkFeatureFlag} function.
  *
@@ -102,7 +102,7 @@ export const checkFeatureFlag = (flag: FeatureFlag): boolean =>
  *
  * @param {FeatureFlag} flag - The feature flag to check
  *
- * @returns {Record<FeatureFlag, boolean>} Object containing enabled flags as entries set as true
+ * @returns {boolean} - True if the feature flag is enabled
  */
 export const useFeatureFlag = (flag: FeatureFlag): boolean =>
-  !!getFeatureFlags()[flag];
+  checkFeatureFlag(flag);

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -1,0 +1,53 @@
+
+/**
+ * This function reads query parameters and processes them to find feature flags
+ * - Any parameter starting with "ff_" is considered to be a feature flag
+ * - A feature flag parameter needs to have its value equals "true" to be set to true
+ * - Enabled flags are stored on sessionStorage by its name (without the ff_)
+ * - Disabled (false) flags are removed from the sessionStorage object
+ * - A flag won't disable itself unless it's set to false or the sessionStorage object is deleted
+ * - If no flags are enabled, the session storage object is removed
+ *
+ *  Uses:
+ * - Destructuring
+ *  ```
+ *    const {secret_function} = getFeatureFlags()`
+ *    if( secret_function ) ...
+ *  ```
+ *
+ * - Full object
+ *  ```
+ *    const flags = getFeatureFlags()
+ *    if( flags.secret_function ) ...
+ *  ```
+ *
+ * @returns {Record<string, boolean>} Object containing enabled flags as entries set as true
+ */
+export const getFeatureFlags = (): Record<string, boolean> => {
+
+  const flags = JSON.parse(sessionStorage.feature_flags || '{}');
+
+  // The # needs to be removed or the URL is not properly processed
+  const params = new URL(window.location.href.replace('/#', '')).searchParams;
+
+  params.forEach((value, key) => {
+    if (key.startsWith('ff_')) {
+      const flag = key.slice(3);
+      if (value === 'true') {
+        flags[flag] = true;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete flags[flag];
+      }
+    }
+  });
+
+  if (Object.keys(flags).length === 0) {
+    sessionStorage.removeItem('feature_flags');
+  } else {
+    sessionStorage.feature_flags = JSON.stringify(flags);
+  }
+
+  return flags;
+
+};

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -1,9 +1,11 @@
 
 /**
  * This function reads query parameters and processes them to find feature flags
+ * - The query parameters are read from the URL
+ * - Recommended naming convention: `ff_featureNameEnabled`
  * - Any parameter starting with "ff_" is considered to be a feature flag
  * - A feature flag parameter needs to have its value equals "true" to be set to true
- * - Enabled flags are stored on sessionStorage by its name (without the ff_)
+ * - Enabled flags are stored on sessionStorage by its name **without the ff_**
  * - Disabled (false) flags are removed from the sessionStorage object
  * - A flag won't disable itself unless it's set to false or the sessionStorage object is deleted
  * - If no flags are enabled, the session storage object is removed

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -1,55 +1,108 @@
+/**
+ * In URL use value, not key of enum.
+ * For our sanity, use camel case and match key with value.
+ */
+export enum FeatureFlag {
+  activityLogsEnabled = 'activityLogsEnabled',
+}
 
 /**
  * This function reads query parameters and processes them to find feature flags
  * - The query parameters are read from the URL
- * - Recommended naming convention: `ff_featureNameEnabled`
+ * - Recommended naming convention: `ff_FeatureNameEnabled`
  * - Any parameter starting with "ff_" is considered to be a feature flag
  * - A feature flag parameter needs to have its value equals "true" to be set to true
  * - Enabled flags are stored on sessionStorage by its name **without the ff_**
  * - Disabled (false) flags are removed from the sessionStorage object
- * - A flag won't disable itself unless it's set to false or the sessionStorage object is deleted
- * - If no flags are enabled, the session storage object is removed
+ * - A flag won't disable itself unless it's set to false or the sessionStorage object is deleted (manually or by session ending)
  *
  *  Uses:
  * - Destructuring
- *  ```
- *    const {secret_function} = getFeatureFlags()`
- *    if( secret_function ) ...
+ *  ```js
+ *    # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
+ *    const {FeatureNameEnabled} = getFeatureFlags()`
+ *    console.log(FeatureNameEnabled) # true
  *  ```
  *
  * - Full object
  *  ```
+ *    # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
  *    const flags = getFeatureFlags()
- *    if( flags.secret_function ) ...
+ *    console.log(flags) # {FeatureNameEnable: true, FeatureNameEnable2: true}
  *  ```
  *
- * @returns {Record<string, boolean>} Object containing enabled flags as entries set as true
+ * @returns {Record<FeatureFlag, boolean>} Object containing enabled flags as entries set as true
  */
-export const getFeatureFlags = (): Record<string, boolean> => {
+const getFeatureFlags = (): Record<FeatureFlag, boolean> => {
+  const flags = JSON.parse(sessionStorage.getItem('feature_flags') || '{}');
 
-  const flags = JSON.parse(sessionStorage.feature_flags || '{}');
-
-  // The # needs to be removed or the URL is not properly processed
+  // Due hash router used for kobo this fails to resolve the search parameters,
+  // so we need to remove the hash from the URL
   const params = new URL(window.location.href.replace('/#', '')).searchParams;
 
-  params.forEach((value, key) => {
-    if (key.startsWith('ff_')) {
-      const flag = key.slice(3);
-      if (value === 'true') {
-        flags[flag] = true;
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete flags[flag];
-      }
-    }
-  });
-
-  if (Object.keys(flags).length === 0) {
-    sessionStorage.removeItem('feature_flags');
-  } else {
-    sessionStorage.feature_flags = JSON.stringify(flags);
+  if (params.size === 0) {
+    return flags;
   }
 
-  return flags;
+  const newFlags: Partial<Record<FeatureFlag, boolean>> = {};
+  for (const [key, value] of params) {
+    if (!key.startsWith('ff_')) {
+      continue;
+    }
 
+    const flag = key.slice(3);
+    if (!Object.values(FeatureFlag).includes(flag as FeatureFlag)) {
+      continue;
+    }
+    // A flag will be removed from storage if set to anything different from 'true'
+    newFlags[flag as FeatureFlag] = value === 'true' ? true : undefined;
+  }
+
+  const totalFlags = {
+    ...flags,
+    ...newFlags,
+  };
+
+  sessionStorage.setItem('feature_flags', JSON.stringify(totalFlags));
+
+  // Stringifying and re-parsing to clean up undefined keys
+  return JSON.parse(sessionStorage.getItem('feature_flags')!);
 };
+
+/**
+ * This should only be used if a hook can't be used.
+ * See description of {@link useFeatureFlag}.
+ *
+ * @deprecated use {@link useFeatureFlag} instead.
+ */
+export const checkFeatureFlag = (flag: FeatureFlag): boolean =>
+  !!getFeatureFlags()[flag];
+
+/**
+ * This hook is used to check if a feature flag is enabled.
+ * It uses the {@link getFeatureFlags} function to get the flags.
+ *
+ * - The query parameters from the URL are processed to find feature flags
+ * - Recommended parameter naming convention: `ff_FeatureNameEnabled`
+ * - Any query parameter starting with "ff_" is considered to be a feature flag
+ * - A feature flag parameter needs to have its value equals "true" to be set to true
+ * - Enabled flags are stored on session and will keep their state even if the query param is no longer present
+ * - This hook will return true if the given flag is enabled
+ *
+ * Use:
+ * ```
+ * # https://kf.kobotoolbox.org/#/projects/home?ff_FeatureNameEnable=true&ff_FeatureNameEnable2=true
+ *
+ * const isFeatureEnabled = useFeatureFlag(FeatureFlag.featureNameEnabled);
+ * console.log(isFeatureEnabled) # true
+ * ```
+ * - If you can't use the hook, use the {@link checkFeatureFlag} function.
+ *
+ * P.S. For future-proofness when we will use a proper feature flag service, this hook should be easy to adapt.
+ *
+ * @param {FeatureFlag} flag - The feature flag to check
+ *
+ * @returns {Record<FeatureFlag, boolean>} Object containing enabled flags as entries set as true
+ */
+export const useFeatureFlag = (flag: FeatureFlag): boolean =>
+  !!getFeatureFlags()[flag];


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

This PR adds a feature flag functionality so that we can have users protected from some in development functionalities.

## Notes

✅ Once this PR is merged into the feature branch, the feature branch will be merged into `main` so the functionality will be available for everyone.

- The functionality is implemented in a single function and I tried to add all the information on it in JSDoc format.
- The function processes query parameters to include or delete entries from the session storage object
- The final processed flag keys are returned by the function
- I'm proposing the naming convention to be `featureNameEnabled`, so we'd have the query parameters as `ff_featureNameEnabled=true`

## Testing

- Open the `sessionStorage` viewer in your browser
- Access `http://kf.kobo.local/#/forms/a38DG8vdHWTz7EXJz2344L/settings` (since it's being used in the settings tabs bar in this PR)
- Add a query parameter: `?ff_activityLogsEnabled=true` or click [HERE](http://kf.kobo.local/#/forms/a38DG8vdHWTz7EXJz2344L/settings?ff_activityLogsEnabled=true)
- A new key should have been added to the sessionStorage entry
- A new item should have appeared in settings side tabs
