### PR TITLE
[TASK-1078] Directly Access Organization Owners for Improved Performance

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import F
 from django_request_cache import cache_for_request
 
@@ -20,14 +21,6 @@ from kpi.fields import KpiUidField
 
 class Organization(AbstractOrganization):
     id = KpiUidField(uid_prefix='org', primary_key=True)
-
-    @property
-    def email(self):
-        """
-        As organization is our customer model for Stripe, Stripe requires that
-        it has an email address attribute
-        """
-        return self.owner.organization_user.user.email
 
     @cache_for_request
     def active_subscription_billing_details(self):
@@ -51,7 +44,7 @@ class Organization(AbstractOrganization):
                 ).first()
 
         return None
-    
+
     @cache_for_request
     def canceled_subscription_billing_cycle_anchor(self):
         """
@@ -69,8 +62,27 @@ class Organization(AbstractOrganization):
                 ).first()
             if qs:
                 return qs['anchor']
-            
+
         return None
+
+    @property
+    def email(self):
+        """
+        As organization is our customer model for Stripe, Stripe requires that
+        it has an email address attribute
+        """
+        try:
+            return self.owner_user_object.email
+        except AttributeError:
+            return
+
+    @property
+    @cache_for_request
+    def owner_user_object(self) -> 'User':
+        try:
+            return self.owner.organization_user.user
+        except ObjectDoesNotExist:
+            return
 
 
 class OrganizationUser(AbstractOrganizationUser):
@@ -96,9 +108,10 @@ class OrganizationUser(AbstractOrganizationUser):
     @property
     def active_subscription_status(self):
         """
-        Return a comma-separated string of active subscriptions for the organization user.
+        Return a comma-separated string of active subscriptions for the organization
+        user.
         """
-        return ", ".join(self.active_subscription_statuses)
+        return ', '.join(self.active_subscription_statuses)
 
 
 class OrganizationOwner(AbstractOrganizationOwner):

--- a/kobo/apps/subsequences/tests/test_proj_advanced_features.py
+++ b/kobo/apps/subsequences/tests/test_proj_advanced_features.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
-
 from model_bakery import baker
 
 from kpi.models import Asset

--- a/kpi/tests/test_organization.py
+++ b/kpi/tests/test_organization.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+from model_bakery import baker
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.organizations.models import Organization
+
+
+class OrganizationTestCase(TestCase):
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.user = User.objects.get(username='someuser')
+        self.organization = baker.make(
+            Organization,
+            id='orgSALFMLFMSDGmgdlsgmsd',
+            slug='orgSALFMLFMSDGmgdlsgmsd',
+        )
+
+    def test_owner_user_object_property(self):
+        # The organization has no members yet, the first user is set as the owner
+        self.organization.add_user(self.user)
+        anotheruser = User.objects.get(username='anotheruser')
+        self.organization.add_user(anotheruser)
+        assert self.organization.owner_user_object == self.user
+        assert not self.organization.owner_user_object == anotheruser
+
+    def test_no_owner_user_object_property(self):
+        assert self.organization.owner_user_object is None


### PR DESCRIPTION
## Description

For developers interest only.
This update improves efficiency by allowing direct access to the owner of an organization, reducing database complexity and improving speed.

## Notes

It is a shortcut to be put in cache to avoid calling multiple JOINs in a request. 
It aims to be called multiple times in the code for Organizations feature.


