### PR TITLE
Change access log endpoints

### DIFF
--- a/kobo/apps/audit_log/urls.py
+++ b/kobo/apps/audit_log/urls.py
@@ -5,9 +5,9 @@ from .views import AccessLogViewSet, AllAccessLogViewSet, AuditLogViewSet
 
 router = DefaultRouter()
 router.register(r'audit-logs', AuditLogViewSet, basename='audit-log')
-router.register(r'access-logs/me', AccessLogViewSet, basename='access-log')
+router.register(r'access-logs', AllAccessLogViewSet, basename='all-access-logs')
 router.register(
-    r'access-logs', AllAccessLogViewSet, basename='all-access-logs'
+    r'access-logs/me', AccessLogViewSet, basename='access-log'
 )
 
 urlpatterns = []

--- a/kobo/apps/audit_log/urls.py
+++ b/kobo/apps/audit_log/urls.py
@@ -5,9 +5,9 @@ from .views import AccessLogViewSet, AllAccessLogViewSet, AuditLogViewSet
 
 router = DefaultRouter()
 router.register(r'audit-logs', AuditLogViewSet, basename='audit-log')
-router.register(r'access-logs', AccessLogViewSet, basename='access-log')
+router.register(r'access-logs/me', AccessLogViewSet, basename='access-log')
 router.register(
-    r'access-logs/all', AllAccessLogViewSet, basename='all-access-logs'
+    r'access-logs', AllAccessLogViewSet, basename='all-access-logs'
 )
 
 urlpatterns = []

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -93,7 +93,7 @@ class AllAccessLogViewSet(AuditLogViewSet):
     Lists all access logs for all users. Only available to superusers.
 
     <pre class="prettyprint">
-    <b>GET</b> /api/v2/access-logs/all
+    <b>GET</b> /api/v2/access-logs
     </pre>
 
     > Example
@@ -144,12 +144,12 @@ class AccessLogViewSet(AuditLogViewSet):
     Lists all access logs for the authenticated user
 
     <pre class="prettyprint">
-    <b>GET</b> /api/v2/access-logs/
+    <b>GET</b> /api/v2/access-logs/me
     </pre>
 
     > Example
     >
-    >       curl -X GET https://[kpi-url]/access-logs/
+    >       curl -X GET https://[kpi-url]/access-logs/me
 
     > Response 200
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [ ] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [ ] Create a testing plan for the reviewer and add it to the Testing section

## Description

Rename access log endpoints to `/api/v2/access-logs` for all access logs and `/api/v2/access-logs/me` for an individual user's logs

## Notes

Patch release with https://github.com/kobotoolbox/kpi/commit/658825c5fa21fd69500c82636f9a1a9fbcbc7e31
