### PR TITLE
Log changes to project sharing

### DIFF
--- a/kobo/apps/audit_log/audit_actions.py
+++ b/kobo/apps/audit_log/audit_actions.py
@@ -15,3 +15,6 @@ class AuditAction(models.TextChoices):
     REDEPLOY = 'redeploy'
     UPDATE_NAME = 'update-name'
     UPDATE_SETTINGS = 'update-settings'
+    ENABLE_SHARING = 'enable-sharing'
+    DISABLE_SHARING = 'disable-sharing'
+    MODIFY_SHARING = 'modify_sharing'

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -318,16 +318,13 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
 
     def test_truthy_field_creates_sharing_enabled_log(self):
-        def verify_metadata(log_metadata):
-            self.assertEqual(log_metadata['shared_fields'][ADDED], [])
-
-        self._base_endpoint_test(
+        log_metadata = self._base_endpoint_test(
             patch=True,
             url_name=self.detail_url,
             request_data={'data_sharing': {'enabled': 'truthy'}},
-            verify_additional_metadata=verify_metadata,
             expected_action=AuditAction.ENABLE_SHARING,
         )
+        self.assertEqual(log_metadata['shared_fields'][ADDED], [])
 
     def test_disable_sharing_creates_log(self):
         self.asset.data_sharing = {
@@ -368,7 +365,6 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             patch=True,
             url_name=self.detail_url,
             request_data={'data_sharing': {'enabled': 0}},
-            verify_additional_metadata=lambda x: None,
             expected_action=AuditAction.DISABLE_SHARING,
         )
 

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -4,7 +4,7 @@ from django.test import override_settings
 from django.urls import reverse
 
 from kobo.apps.audit_log.audit_actions import AuditAction
-from kobo.apps.audit_log.models import ProjectHistoryLog
+from kobo.apps.audit_log.models import ADDED, NEW, OLD, REMOVED, ProjectHistoryLog
 from kobo.apps.audit_log.tests.test_models import BaseAuditLogTestCase
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.models import Asset
@@ -173,8 +173,8 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.UPDATE_NAME,
         )
 
-        self.assertEqual(log_metadata['name']['new'], 'new_name')
-        self.assertEqual(log_metadata['name']['old'], old_name)
+        self.assertEqual(log_metadata['name'][NEW], 'new_name')
+        self.assertEqual(log_metadata['name'][OLD], old_name)
 
     def test_change_standard_project_settings_creates_log(self):
         old_settings = copy.deepcopy(self.asset.settings)
@@ -196,16 +196,16 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         # check non-list settings just store old and new information
         settings_dict = log_metadata['settings']
         self.assertEqual(
-            settings_dict['description']['old'], old_settings['description']
+            settings_dict['description'][OLD], old_settings['description']
         )
-        self.assertEqual(settings_dict['description']['new'], 'New description')
+        self.assertEqual(settings_dict['description'][NEW], 'New description')
         # check list settings store added and removed fields
         self.assertListEqual(
-            settings_dict['country']['added'],
+            settings_dict['country'][ADDED],
             [{'label': 'Albania', 'value': 'ALB'}],
         )
         self.assertListEqual(
-            settings_dict['country']['removed'],
+            settings_dict['country'][REMOVED],
             [{'label': 'United States', 'value': 'USA'}],
         )
         # check default settings not recorded if not included in request
@@ -265,7 +265,6 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data={'settings': {}},
             expected_action=AuditAction.UPDATE_SETTINGS,
         )
-
         for setting, old_value in old_settings.items():
             if setting in Asset.STANDARDIZED_SETTINGS:
                 # if the setting is one of the standard ones, the new value after
@@ -283,14 +282,18 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 removed_values = [val for val in old_value if val not in new_value]
                 added_values = [val for val in new_value if val not in old_value]
                 self.assertListEqual(
-                    log_metadata['settings'][setting]['added'], added_values
+                    log_metadata['settings'][setting][ADDED], added_values
                 )
                 self.assertListEqual(
-                    log_metadata['settings'][setting]['removed'], removed_values
+                    log_metadata['settings'][setting][REMOVED], removed_values
                 )
             else:
-                self.assertEqual(log_metadata['settings'][setting]['new'], new_value)
-                self.assertEqual(log_metadata['settings'][setting]['old'], old_value)
+                self.assertEqual(
+                    log_metadata['settings'][setting][NEW], new_value
+                )
+                self.assertEqual(
+                    log_metadata['settings'][setting][OLD], old_value
+                )
 
     def test_add_new_settings_creates_log(self):
         log_metadata = self._base_endpoint_test(
@@ -301,5 +304,85 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.UPDATE_SETTINGS,
         )
 
-        self.assertEqual(log_metadata['settings']['new_setting']['new'], 'new_value')
-        self.assertEqual(log_metadata['settings']['new_setting']['old'], None)
+        self.assertEqual(log_metadata['settings']['new_setting'][NEW], 'new_value')
+        self.assertEqual(log_metadata['settings']['new_setting'][OLD], None)
+
+    def test_enable_sharing_creates_log(self):
+        log_metadata = self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {'enabled': True, 'fields': []}},
+            expected_action=AuditAction.ENABLE_SHARING,
+        )
+        self.assertEqual(log_metadata['shared_fields'][ADDED], [])
+
+
+    def test_truthy_field_creates_sharing_enabled_log(self):
+        def verify_metadata(log_metadata):
+            self.assertEqual(log_metadata['shared_fields'][ADDED], [])
+
+        self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {'enabled': 'truthy'}},
+            verify_additional_metadata=verify_metadata,
+            expected_action=AuditAction.ENABLE_SHARING,
+        )
+
+    def test_disable_sharing_creates_log(self):
+        self.asset.data_sharing = {
+            'enabled': True,
+            'fields': [],
+        }
+        self.asset.save()
+
+        self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {'enabled': False}},
+            expected_action=AuditAction.DISABLE_SHARING,
+        )
+
+    def test_nullify_sharing_creates_sharing_disabled_log(self):
+        self.asset.data_sharing = {
+            'enabled': True,
+            'fields': [],
+        }
+        self.asset.save()
+
+        self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {}},
+            expected_action=AuditAction.DISABLE_SHARING,
+        )
+
+    def test_falsy_field_creates_sharing_disabled_log(self):
+        self.asset.data_sharing = {
+            'enabled': True,
+            'fields': [],
+        }
+        self.asset.save()
+
+        self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {'enabled': 0}},
+            verify_additional_metadata=lambda x: None,
+            expected_action=AuditAction.DISABLE_SHARING,
+        )
+
+    def test_modify_sharing_creates_log(self):
+        self.asset.data_sharing = {
+            'enabled': True,
+            'fields': ['q1'],
+        }
+        self.asset.save()
+        log_metadata = self._base_endpoint_test(
+            patch=True,
+            url_name=self.detail_url,
+            request_data={'data_sharing': {'enabled': True, 'fields': ['q2']}},
+            expected_action=AuditAction.MODIFY_SHARING,
+        )
+        self.assertEqual(log_metadata['shared_fields'][ADDED], ['q2'])
+        self.assertEqual(log_metadata['shared_fields'][REMOVED], ['q1'])

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -195,9 +195,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
         # check non-list settings just store old and new information
         settings_dict = log_metadata['settings']
-        self.assertEqual(
-            settings_dict['description'][OLD], old_settings['description']
-        )
+        self.assertEqual(settings_dict['description'][OLD], old_settings['description'])
         self.assertEqual(settings_dict['description'][NEW], 'New description')
         # check list settings store added and removed fields
         self.assertListEqual(
@@ -288,12 +286,8 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                     log_metadata['settings'][setting][REMOVED], removed_values
                 )
             else:
-                self.assertEqual(
-                    log_metadata['settings'][setting][NEW], new_value
-                )
-                self.assertEqual(
-                    log_metadata['settings'][setting][OLD], old_value
-                )
+                self.assertEqual(log_metadata['settings'][setting][NEW], new_value)
+                self.assertEqual(log_metadata['settings'][setting][OLD], old_value)
 
     def test_add_new_settings_creates_log(self):
         log_metadata = self._base_endpoint_test(
@@ -315,7 +309,6 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.ENABLE_SHARING,
         )
         self.assertEqual(log_metadata['shared_fields'][ADDED], [])
-
 
     def test_truthy_field_creates_sharing_enabled_log(self):
         log_metadata = self._base_endpoint_test(

--- a/kpi/fixtures/asset_with_settings_and_qa.json
+++ b/kpi/fixtures/asset_with_settings_and_qa.json
@@ -37,9 +37,7 @@
                 "organization" : "An organization"
             },
             "data_sharing":{
-                "fields":[
-
-                ],
+                "fields":[],
                 "enabled":false
             },
             "advanced_features":{

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -380,8 +380,14 @@ class AssetViewSet(
         'uid__icontains',
     ]
 
-    logged_fields = ['has_deployment', 'id', 'name', 'settings', 'latest_version.uid']
-
+    logged_fields = [
+        'has_deployment',
+        'id',
+        'name',
+        'settings',
+        'latest_version.uid',
+        'data_sharing',
+    ]
     log_type = AuditType.PROJECT_HISTORY
 
     def get_object_override(self):


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section

## Description

Create project history logs whenever sharing is enabled, disabled, or modified. 

## Notes

Small refactor to use constants for "new","old","added", and "removed" since they are repeated keys and may be expected by the front end at some point.

Create a new method for handing changes to the 'data_sharing' dictionary on an Asset. If 'enabled' is True and was previously empty or False, the action will be sharing-enabled. If enabled is False (or 0, or anything false-y) and used to be True, the action will be sharing-disabled. Otherwise, the action will be `sharing modified` and show the fields added and removed.

## Testing

1. Log in as a super user
2. Create a new project
3. Add 3 questions to the project called q1, q2, and q3
4. Deploy the project
5. Go to Settings > Connect Project
6. Enable sharing
7. Go to `api/v2/audit-logs/?q=log_type:project-history AND metadata__asset_uid:<asset_uid>`
8. You should see an audit log that looks like
```
{
    "app_label":"kpi",
    "model_name":"asset",
    "user":"http://kf.kobo.local:8080/api/v2/users/<username>/?format=json",
    "user_uid":<useruid>,
    "username":<username>,
    "action":"enable-sharing",
    "metadata":{
        "source":<browser><OS>",
        "asset_uid":<asset uid>,
        "ip_address":"172.18.0.1",
        "log_subtype":"project",
        "shared_fields":{
            "added":[]
        },
        "latest_version_uid":<version uid>
    },
    "date_created":<date>,
    "log_type":"project-history"
}
```
You can check the version id in the shell with `Asset.objects.get(uid=<uid>).latest_version.uid`
9. Check 'Select specific questions to share' and choose 'q1' and 'q2'
10. Reload the endpoint. You should see a new audit log with `action: modify-sharing` and 
```
shared_fields: {
      added: [q1, q2]
      removed: []
}
``` 
in the metadata along with the usual stuff
11. Deselect 'q1'
12. Reload the endpoint. You should see a new audit log with `action: modify-sharing` and 
```
shared_fields: {
      added: []
      removed: [q1]
}
``` 
in the metadata
13. Disable sharing
14. Reload the endpoint. You should see a new audit log with `action: disable-sharing` (nothing new in the metadata)
15. Reenable sharing
16. From your terminal, run `curl -X PATCH -H "Authorization: Token 79da4c677535bdd01ce0b159a86ecf7a88992331" -H 'Content-Type: application/json' -H 'Accept: application/json' http://kf.kobo.local:8080/api/v2/assets/aVq7yMt4zKpUtTeZUnoeJF/ --data '{"data_sharing": {}}'`
17. Reload the endpoint. You should see a new audit log with `action: disable-sharing`
18. Run ``curl -X PATCH -H "Authorization: Token 79da4c677535bdd01ce0b159a86ecf7a88992331" -H 'Content-Type: application/json' -H 'Accept: application/json' http://kf.kobo.local:8080/api/v2/assets/aVq7yMt4zKpUtTeZUnoeJF/ --data '{"data_sharing": {"enabled": true}}'``
19. You should see a new audit log with `action: enable-sharing` and `metadata.shared_fields.added = []`
20. Run ``curl -X PATCH -H "Authorization: Token 79da4c677535bdd01ce0b159a86ecf7a88992331" -H 'Content-Type: application/json' -H 'Accept: application/json' http://kf.kobo.local:8080/api/v2/assets/aVq7yMt4zKpUtTeZUnoeJF/ --data '{"data_sharing": {"enabled": 0, "fields": ["q1"]}}'``
21. Reload the endpoint. You should see a new audit log with `action: disable-sharing` (nothing extra in the metadata)

