### PR TITLE
Fix SSRFProtect validation options to properly handle Constance settings

### DIFF
--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -108,18 +108,26 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
 
                 ssrf_protect_options = {}
                 if constance.config.SSRF_ALLOWED_IP_ADDRESS.strip():
-                    ssrf_protect_options['allowed_ip_addresses'] = constance.\
-                        config.SSRF_ALLOWED_IP_ADDRESS.strip().split('\r\n')
+                    allowed_ip_addresses = (
+                        constance.config.SSRF_ALLOWED_IP_ADDRESS.strip().split('\n')
+                    )
+                    ssrf_protect_options['allowed_ip_addresses'] = [
+                        ip.strip() for ip in allowed_ip_addresses if ip.strip()
+                    ]
 
                 if constance.config.SSRF_DENIED_IP_ADDRESS.strip():
-                    ssrf_protect_options['denied_ip_addresses'] = constance.\
-                        config.SSRF_DENIED_IP_ADDRESS.strip().split('\r\n')
+                    denied_ip_addresses = (
+                        constance.config.SSRF_DENIED_IP_ADDRESS.strip().split('\n')
+                    )
+                    ssrf_protect_options['denied_ip_addresses'] = [
+                        ip.strip() for ip in denied_ip_addresses if ip.strip()
+                    ]
 
-                SSRFProtect.validate(self._hook.endpoint,
-                                     options=ssrf_protect_options)
+                SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
 
-                response = requests.post(self._hook.endpoint, timeout=30,
-                                         **request_kwargs)
+                response = requests.post(
+                    self._hook.endpoint, timeout=30, **request_kwargs
+                )
                 response.raise_for_status()
                 self.save_log(response.status_code, response.text, True)
                 success = True

--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -9,6 +9,7 @@ import requests
 from ssrf_protect.ssrf_protect import SSRFProtect, SSRFProtectException
 
 from kpi.utils.log import logging
+from kpi.utils.strings import split_lines_to_list
 from .hook import Hook
 from .hook_log import HookLog
 from ..constants import (
@@ -108,20 +109,18 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
 
                 ssrf_protect_options = {}
                 if constance.config.SSRF_ALLOWED_IP_ADDRESS.strip():
-                    allowed_ip_addresses = (
-                        constance.config.SSRF_ALLOWED_IP_ADDRESS.strip().split('\n')
+                    ssrf_protect_options['allowed_ip_addresses'] = (
+                        split_lines_to_list(
+                            constance.config.SSRF_ALLOWED_IP_ADDRESS
+                        )
                     )
-                    ssrf_protect_options['allowed_ip_addresses'] = [
-                        ip.strip() for ip in allowed_ip_addresses if ip.strip()
-                    ]
 
                 if constance.config.SSRF_DENIED_IP_ADDRESS.strip():
-                    denied_ip_addresses = (
-                        constance.config.SSRF_DENIED_IP_ADDRESS.strip().split('\n')
+                    ssrf_protect_options['denied_ip_addresses'] = (
+                        split_lines_to_list(
+                            constance.config.SSRF_DENIED_IP_ADDRESS
+                        )
                     )
-                    ssrf_protect_options['denied_ip_addresses'] = [
-                        ip.strip() for ip in denied_ip_addresses if ip.strip()
-                    ]
 
                 SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
 

--- a/kobo/apps/hook/tests/test_ssrf.py
+++ b/kobo/apps/hook/tests/test_ssrf.py
@@ -1,9 +1,11 @@
-# coding: utf-8
+from unittest.mock import patch, call
 
+import pytest
 import responses
 from constance.test import override_config
-from mock import patch
 from rest_framework import status
+from ssrf_protect.ssrf_protect import SSRFProtect, SSRFProtectException
+from ipaddress import ip_address
 
 from kobo.apps.hook.constants import (
     HOOK_LOG_PENDING,
@@ -27,11 +29,12 @@ class SSRFHookTestCase(HookTestCase):
         submissions = self.asset.deployment.get_submissions(self.asset.owner)
         submission_id = submissions[0]['_id']
         service_definition = ServiceDefinition(hook, submission_id)
-        first_mock_response = {'error': 'not found'}
-
-        responses.add(responses.POST, hook.endpoint,
-                      status=status.HTTP_200_OK,
-                      content_type='application/json')
+        responses.add(
+            responses.POST,
+            hook.endpoint,
+            status=status.HTTP_200_OK,
+            content_type='application/json',
+        )
 
         # Try to send data to external endpoint
         success = service_definition.send()
@@ -40,3 +43,34 @@ class SSRFHookTestCase(HookTestCase):
         self.assertEqual(hook_log.status_code, KOBO_INTERNAL_ERROR_STATUS_CODE)
         self.assertEqual(hook_log.status, HOOK_LOG_PENDING)
         self.assertTrue('is not allowed' in hook_log.message)
+
+    @patch('ssrf_protect.ssrf_protect.SSRFProtect._get_ip_address',
+           new=MockSSRFProtect._get_ip_address)
+    @override_config(
+        SSRF_ALLOWED_IP_ADDRESS='\r\n1.2.3.4\r\n6.7.8.9\n',
+        SSRF_DENIED_IP_ADDRESS='\n10.11.12.13\r\n14.15.16.17\r\n'
+    )
+    @responses.activate
+    def test_constance_settings_parsing(self):
+        hook = self._create_hook()
+
+        ServiceDefinition = hook.get_service_definition()
+        submissions = self.asset.deployment.get_submissions(self.asset.owner)
+        submission_id = submissions[0]['_id']
+        service_definition = ServiceDefinition(hook, submission_id)
+
+        with patch('kobo.apps.hook.models.service_definition_interface.SSRFProtect.validate') as mock_ssrf_validate:  # noqa
+            service_definition.send()
+
+        # \r should be stripped for IPs in options
+        mock_ssrf_validate.assert_has_calls(
+            [
+                call(
+                    hook.endpoint,
+                    options={
+                        'allowed_ip_addresses': ['1.2.3.4', '6.7.8.9'],
+                        'denied_ip_addresses': ['10.11.12.13', '14.15.16.17'],
+                    },
+                )
+            ]
+        )

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import os
 import re
 from copy import deepcopy
@@ -17,6 +16,7 @@ from kpi.utils.autoname import autovalue_choices_in_place
 from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
+from kpi.utils.strings import split_lines_to_list
 from kpi.utils.xml import (
     edit_submission_xml,
     fromstring_preserve_root_xmlns,
@@ -300,6 +300,12 @@ class UtilsTestCase(TestCase):
             surv['settings']['allow_choice_duplicates']
             == 'no'
         )
+
+    def test_split_lines_to_list(self):
+
+        value = '\r\nfoo\r\nbar\n\n'
+        expected = ['foo', 'bar']
+        assert split_lines_to_list(value) == expected
 
 
 class XmlUtilsTestCase(TestCase):

--- a/kpi/utils/strings.py
+++ b/kpi/utils/strings.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import base64
 
 
@@ -13,5 +12,5 @@ def to_str(obj):
 
 
 def split_lines_to_list(value: str) -> list:
-    ip_addresses = value.strip().split('\n')
-    return [ip.strip() for ip in ip_addresses if ip.strip()]
+    values = value.strip().split('\n')
+    return [ip.strip() for ip in values if ip.strip()]

--- a/kpi/utils/strings.py
+++ b/kpi/utils/strings.py
@@ -10,3 +10,8 @@ def to_str(obj):
     if isinstance(obj, bytes):
         return obj.decode()
     return obj
+
+
+def split_lines_to_list(value: str) -> list:
+    ip_addresses = value.strip().split('\n')
+    return [ip.strip() for ip in ip_addresses if ip.strip()]


### PR DESCRIPTION
## Description :
This PR addresses an issue where SSRF Protect validation fails to consider the Constance settings correctly. It now strips line break characters from the IP input before performing the SSRF Protect validation.

## Testing

- Create a project (deploy it first) with RestService (Project > Settings > Rest Services)
- Use local ip (of your host machine) for the endpoint URL (e.g, http://192.168.0.10)
- Add `192.168.0.10` and `192.168.0.11` in `SSRF_ALLOWED_IP_ADDRESS` in Constance
- Submit data
- SSRFProtect Validation:
   1. Without this PR, it should raise error `ssrf_protect.exceptions.SSRFProtectException: URL "http://192.168.0.10" is not allowed because it resolves to a private IP address` 
   2. With this PR, it should not raise the error (but could still fail because you don't have a webserver which listens on local computer). 

