### PR TITLE
[TASK-1199] Fix geo-points now displaying in map

### DIFF
--- a/jsapp/js/components/map.es6
+++ b/jsapp/js/components/map.es6
@@ -330,9 +330,10 @@ export class FormMap extends React.Component {
           });
         }
 
-        this.setState({submissions: results});
-        this.buildMarkers(map);
-        this.buildHeatMap(map);
+        this.setState({submissions: results}, () => {
+          this.buildMarkers(map);
+          this.buildHeatMap(map);
+        });
       })
       .fail((error) => {
         if (error.responseText) {


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section
9. [x] Add frontend or backend tag and any other appropriate tags to this pull request

## Description

This PR fixes a bug where sometimes the geo-points are not properly plotted in form > data > map

## Notes

Issue was in `map.es6`:
- The `buildMarkers` function did not have submissions data set when called
- The issue was due to the async nature of `setState`
- `buildMarkers` was being called right after the `setState`, so the state wasn't yet ready when the function was executed.
- To fix it, `buildMarkers` (and `buildHeatMap`) were moved to the callback of `setState` function, so they'll have the data to be processed.

## Testing

- Create a form with a GeoPoint, Line or Area question
- Save + deploy the form
- Collect data with either Enketo or Collect
- Go to Data → Maps
- The submitted points should now be properly plotted in the map
