### PR TITLE
Fix Help menu display bug - Task-1211

### DIFF
--- a/jsapp/js/components/support/helpBubble.tsx
+++ b/jsapp/js/components/support/helpBubble.tsx
@@ -74,7 +74,8 @@ class HelpBubble extends React.Component<{}, HelpBubbleState> {
           $targetEl.parents('.help-bubble__popup').length === 0 &&
           $targetEl.parents('.help-bubble__popup-content').length === 0 &&
           $targetEl.parents('.help-bubble__row').length === 0 &&
-          $targetEl.parents('.help-bubble__row-wrapper').length === 0
+          $targetEl.parents('.help-bubble__row-wrapper').length === 0 &&
+          $targetEl.parents('.help-bubble').length === 0
         ) {
           this.close();
         }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [X] Create a testing plan for the reviewer and add it to the Testing section
9. [X] Add frontend or backend tag and any other appropriate tags to this pull request

## Notes

`watchOutsideClose()` was called whenever the `HelpBubble` was clicked and displayed the Help Resources popup content. This added a click handler (`outsideClickHandler`) that checked if the click event happened on any of the elements in the popup content. If a click event matched the conditions specified, it would trigger the `close()` function.

The bug was due to the fact that clicks on the `HelpBubble itself` were not being excluded. This means that even if the user clicked on the `HelpBubble` in order to open the popup, it would register as an "outside click" and close the popup. This fix ensures that the popup will only close if the click occurs outside the entire `HelpBubble` component. 

Note: this behavior was only triggered when there are no notifications because `watchOutsideClose()` is only called when [there are no active in-app messages](https://github.com/kobotoolbox/kpi/blob/1c7cceab32e8155b2c817d49bcf9d44c27bcc6a7/jsapp/js/components/support/helpBubble.tsx#L43). This explains why the Help menu is displayed on `kf.beta` due to a notification message being present. 

## Testing

1. Checkout `main` and try clicking on the Help button in the lower left-hand corner. 
2. Verify that nothing shows up. 
3. Checkout this branch and verify that clicking on the Help button displays the Help Resources popup. 
4. Verify that the `esc` key closes the popup.
5. Verify that clicking outside the popup closes it as well. 
6. Verify that clicking the `X` closes the popup.
7. Verify that toggling the Help button closes the popup. 

