### PR TITLE
refactor(AccessLogsExport): export in background TASK-1145

### DIFF
--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -113,7 +113,7 @@ class ProjectViewViewSet(
             export_task_in_background.delay(
                 export_task_uid=export_task.uid,
                 username=user.username,
-                export_task_name='ProjectViewExportTask',
+                export_task_name='kpi.ProjectViewExportTask',
             )
 
             return Response({'status': export_task.status})

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -113,7 +113,7 @@ class ProjectViewViewSet(
             export_task_in_background.delay(
                 export_task_uid=export_task.uid,
                 username=user.username,
-                export_task_name="ProjectViewExportTask",
+                export_task_name='ProjectViewExportTask',
             )
 
             return Response({'status': export_task.status})

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -113,7 +113,7 @@ class ProjectViewViewSet(
             export_task_in_background.delay(
                 export_task_uid=export_task.uid,
                 username=user.username,
-                export_task_class=ProjectViewExportTask,
+                export_task_name="ProjectViewExportTask",
             )
 
             return Response({'status': export_task.status})

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -20,12 +20,12 @@ from kpi.paginators import FastAssetPagination
 from kpi.permissions import IsAuthenticated
 from kpi.serializers.v2.asset import AssetMetadataListSerializer
 from kpi.serializers.v2.user import UserListSerializer
+from kpi.tasks import export_task_in_background
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.project_views import (
     get_region_for_view,
     user_has_view_perms,
 )
-from kpi.tasks import project_view_export_in_background
 from .models.project_view import ProjectView
 from .serializers import ProjectViewSerializer
 
@@ -110,9 +110,10 @@ class ProjectViewViewSet(
             )
 
             # Have Celery run the export in the background
-            project_view_export_in_background.delay(
+            export_task_in_background.delay(
                 export_task_uid=export_task.uid,
                 username=user.username,
+                export_task_class=ProjectViewExportTask,
             )
 
             return Response({'status': export_task.status})

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 import time
-from typing import Type
 
 import constance
 import requests
+from django.apps import apps
 from django.conf import settings
 from django.core import mail
 from django.core.management import call_command
@@ -14,7 +14,7 @@ from kobo.celery import celery_app
 from kpi.constants import LIMIT_HOURS_23
 from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_tasks
 from kpi.models.asset import Asset
-from kpi.models.import_export_task import ExportTask, ImportExportTask, ImportTask
+from kpi.models.import_export_task import ExportTask, ImportTask
 
 
 @celery_app.task
@@ -31,10 +31,10 @@ def export_in_background(export_task_uid):
 
 @celery_app.task
 def export_task_in_background(
-    export_task_uid: str, username: str, export_task_class: Type[ImportExportTask]
+    export_task_uid: str, username: str, export_task_name: str
 ) -> None:
     user = User.objects.get(username=username)
-
+    export_task_class = apps.get_model(f'kpi.{export_task_name}')
     export_task = export_task_class.objects.get(uid=export_task_uid)
     export = export_task.run()
     if export.status == 'complete' and export.result:

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -34,7 +34,7 @@ def export_task_in_background(
     export_task_uid: str, username: str, export_task_name: str
 ) -> None:
     user = User.objects.get(username=username)
-    export_task_class = apps.get_model(f'kpi.{export_task_name}')
+    export_task_class = apps.get_model(export_task_name)
     export_task = export_task_class.objects.get(uid=export_task_uid)
     export = export_task.run()
     if export.status == 'complete' and export.result:

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -12,15 +12,15 @@ from kpi.tasks import export_task_in_background
 class ExportTaskInBackgroundTests(TestCase):
     def setUp(self):
         self.user = User.objects.create(username='someuser', email='test@example.com')
-        self.mock_data = {"type": "assets", "view": "summary"}
+        self.mock_data = {'type': 'assets', 'view': 'summary'}
         self.task = ProjectViewExportTask.objects.create(
-            uid="test_uid", data=self.mock_data, user=self.user
+            uid='test_uid', data=self.mock_data, user=self.user
         )
         self.project_view = Mock()
         self.project_view.get_countries.return_value = []
 
-    @patch("django.core.mail.send_mail")
-    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    @patch('django.core.mail.send_mail')
+    @patch('kobo.apps.project_views.models.project_view.ProjectView.objects.get')
     def test_export_task_success(self, mock_get_project_view, mock_send_mail):
         mock_get_project_view.return_value = self.project_view
         self.task.run = Mock(return_value=self.task)
@@ -30,71 +30,71 @@ class ExportTaskInBackgroundTests(TestCase):
         )
 
         self.task.refresh_from_db()
-        self.assertEqual(self.task.status, "complete")
+        self.assertEqual(self.task.status, 'complete')
 
         mock_send_mail.assert_called_once()
         args, kwargs = mock_send_mail.call_args
         expected_message = (
-            f"Hello {self.user.username},\n\n"
-            f"Your report is complete: "
-            f"http://kf.kobo.local:8080/private-media/{self.user.username}/exports/"
-            f"assets-{self.user.username}-view_summary-"
-            f"{datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ')}.csv\n\n"
-            f"Regards,\n"
-            f"KoboToolbox"
+            f'Hello {self.user.username},\n\n'
+            f'Your report is complete: '
+            f'http://kf.kobo.local:8080/private-media/{self.user.username}/exports/'
+            f'assets-{self.user.username}-view_summary-'
+            + datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ') + '.csv\n\n'
+            f'Regards,\n'
+            f'KoboToolbox'
         )
-        self.assertEqual(kwargs["subject"], "Project View Report Complete")
-        self.assertEqual(expected_message, kwargs["message"])
+        self.assertEqual(kwargs['subject'], 'Project View Report Complete')
+        self.assertEqual(expected_message, kwargs['message'])
 
-    @patch("django.core.mail.send_mail")
-    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    @patch('django.core.mail.send_mail')
+    @patch('kobo.apps.project_views.models.project_view.ProjectView.objects.get')
     def test_invalid_export_task_uid(self, mock_get_project_view, mock_send_mail):
         mock_get_project_view.side_effect = ObjectDoesNotExist
         with self.assertRaisesMessage(
-            ObjectDoesNotExist, "ProjectViewExportTask matching query does not exist."
+            ObjectDoesNotExist, 'ProjectViewExportTask matching query does not exist.'
         ):
             export_task_in_background(
-                "invalid_uid", self.user.username, ProjectViewExportTask
+                'invalid_uid', self.user.username, ProjectViewExportTask
             )
 
         mock_send_mail.assert_not_called()
 
-    @patch("django.core.mail.send_mail")
-    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    @patch('django.core.mail.send_mail')
+    @patch('kobo.apps.project_views.models.project_view.ProjectView.objects.get')
     def test_invalid_username(self, mock_get_project_view, mock_send_mail):
         with self.assertRaisesMessage(
-            ObjectDoesNotExist, "User matching query does not exist."
+            ObjectDoesNotExist, 'User matching query does not exist.'
         ):
             export_task_in_background(
-                self.task.uid, "invalid_username", ProjectViewExportTask
+                self.task.uid, 'invalid_username', ProjectViewExportTask
             )
 
         mock_send_mail.assert_not_called()
 
-    @patch("django.core.mail.send_mail")
-    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
-    @patch("kpi.models.ProjectViewExportTask._run_task")
+    @patch('django.core.mail.send_mail')
+    @patch('kobo.apps.project_views.models.project_view.ProjectView.objects.get')
+    @patch('kpi.models.ProjectViewExportTask._run_task')
     def test_export_task_error(
         self, mock_run_task, mock_get_project_view, mock_send_mail
     ):
         mock_get_project_view.return_value = self.project_view
-        mock_run_task.side_effect = Exception("Simulated task failure")
+        mock_run_task.side_effect = Exception('Simulated task failure')
 
         export_task_in_background(
             self.task.uid, self.user.username, ProjectViewExportTask
         )
 
         self.task.refresh_from_db()
-        self.assertEqual(self.task.status, "error")
+        self.assertEqual(self.task.status, 'error')
 
-    @patch("django.core.mail.send_mail")
-    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
-    @patch("kpi.models.ProjectViewExportTask._run_task")
+    @patch('django.core.mail.send_mail')
+    @patch('kobo.apps.project_views.models.project_view.ProjectView.objects.get')
+    @patch('kpi.models.ProjectViewExportTask._run_task')
     def test_email_not_sent_if_export_errors(
         self, mock_run_task, mock_get_project_view, mock_send_mail
     ):
         mock_get_project_view.return_value = self.project_view
-        mock_run_task.side_effect = Exception("Simulated task failure")
+        mock_run_task.side_effect = Exception('Simulated task failure')
 
         export_task_in_background(
             self.task.uid, self.user.username, ProjectViewExportTask

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -27,7 +27,7 @@ class ExportTaskInBackgroundTests(TestCase):
         self.task.run = Mock(return_value=self.task)
 
         export_task_in_background(
-            self.task.uid, self.user.username, ProjectViewExportTask
+            self.task.uid, self.user.username, 'ProjectViewExportTask'
         )
 
         self.task.refresh_from_db()
@@ -61,7 +61,7 @@ class ExportTaskInBackgroundTests(TestCase):
             ObjectDoesNotExist, 'ProjectViewExportTask matching query does not exist.'
         ):
             export_task_in_background(
-                'invalid_uid', self.user.username, ProjectViewExportTask
+                'invalid_uid', self.user.username, 'ProjectViewExportTask'
             )
 
         mock_send_mail.assert_not_called()
@@ -73,7 +73,7 @@ class ExportTaskInBackgroundTests(TestCase):
             ObjectDoesNotExist, 'User matching query does not exist.'
         ):
             export_task_in_background(
-                self.task.uid, 'invalid_username', ProjectViewExportTask
+                self.task.uid, 'invalid_username', 'ProjectViewExportTask'
             )
 
         mock_send_mail.assert_not_called()
@@ -88,7 +88,7 @@ class ExportTaskInBackgroundTests(TestCase):
         mock_run_task.side_effect = Exception('Simulated task failure')
 
         export_task_in_background(
-            self.task.uid, self.user.username, ProjectViewExportTask
+            self.task.uid, self.user.username, 'ProjectViewExportTask'
         )
 
         self.task.refresh_from_db()
@@ -104,7 +104,7 @@ class ExportTaskInBackgroundTests(TestCase):
         mock_run_task.side_effect = Exception('Simulated task failure')
 
         export_task_in_background(
-            self.task.uid, self.user.username, ProjectViewExportTask
+            self.task.uid, self.user.username, 'ProjectViewExportTask'
         )
 
         mock_send_mail.assert_not_called()

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -1,0 +1,103 @@
+import datetime
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.models.import_export_task import ProjectViewExportTask
+from kpi.tasks import export_task_in_background
+
+
+class ExportTaskInBackgroundTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username='someuser', email='test@example.com')
+        self.mock_data = {"type": "assets", "view": "summary"}
+        self.task = ProjectViewExportTask.objects.create(
+            uid="test_uid", data=self.mock_data, user=self.user
+        )
+        self.project_view = Mock()
+        self.project_view.get_countries.return_value = []
+
+    @patch("django.core.mail.send_mail")
+    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    def test_export_task_success(self, mock_get_project_view, mock_send_mail):
+        mock_get_project_view.return_value = self.project_view
+        self.task.run = Mock(return_value=self.task)
+
+        export_task_in_background(
+            self.task.uid, self.user.username, ProjectViewExportTask
+        )
+
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "complete")
+
+        mock_send_mail.assert_called_once()
+        args, kwargs = mock_send_mail.call_args
+        expected_message = (
+            f"Hello {self.user.username},\n\n"
+            f"Your report is complete: "
+            f"http://kf.kobo.local:8080/private-media/{self.user.username}/exports/"
+            f"assets-{self.user.username}-view_summary-"
+            f"{datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ')}.csv\n\n"
+            f"Regards,\n"
+            f"KoboToolbox"
+        )
+        self.assertEqual(kwargs["subject"], "Project View Report Complete")
+        self.assertEqual(expected_message, kwargs["message"])
+
+    @patch("django.core.mail.send_mail")
+    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    def test_invalid_export_task_uid(self, mock_get_project_view, mock_send_mail):
+        mock_get_project_view.side_effect = ObjectDoesNotExist
+        with self.assertRaisesMessage(
+            ObjectDoesNotExist, "ProjectViewExportTask matching query does not exist."
+        ):
+            export_task_in_background(
+                "invalid_uid", self.user.username, ProjectViewExportTask
+            )
+
+        mock_send_mail.assert_not_called()
+
+    @patch("django.core.mail.send_mail")
+    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    def test_invalid_username(self, mock_get_project_view, mock_send_mail):
+        with self.assertRaisesMessage(
+            ObjectDoesNotExist, "User matching query does not exist."
+        ):
+            export_task_in_background(
+                self.task.uid, "invalid_username", ProjectViewExportTask
+            )
+
+        mock_send_mail.assert_not_called()
+
+    @patch("django.core.mail.send_mail")
+    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    @patch("kpi.models.ProjectViewExportTask._run_task")
+    def test_export_task_error(
+        self, mock_run_task, mock_get_project_view, mock_send_mail
+    ):
+        mock_get_project_view.return_value = self.project_view
+        mock_run_task.side_effect = Exception("Simulated task failure")
+
+        export_task_in_background(
+            self.task.uid, self.user.username, ProjectViewExportTask
+        )
+
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "error")
+
+    @patch("django.core.mail.send_mail")
+    @patch("kobo.apps.project_views.models.project_view.ProjectView.objects.get")
+    @patch("kpi.models.ProjectViewExportTask._run_task")
+    def test_email_not_sent_if_export_errors(
+        self, mock_run_task, mock_get_project_view, mock_send_mail
+    ):
+        mock_get_project_view.return_value = self.project_view
+        mock_run_task.side_effect = Exception("Simulated task failure")
+
+        export_task_in_background(
+            self.task.uid, self.user.username, ProjectViewExportTask
+        )
+
+        mock_send_mail.assert_not_called()

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest.mock import Mock, patch
 
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 
@@ -34,15 +35,17 @@ class ExportTaskInBackgroundTests(TestCase):
 
         mock_send_mail.assert_called_once()
         args, kwargs = mock_send_mail.call_args
+        root_url = settings.KOBOCAT_URL
         expected_message = (
             'Hello {},\n\n'
-            'Your report is complete: '
-            'http://kf.kobo.local:8080/private-media/{}/exports/'
+            'Your report is complete: {}'
+            '/private-media/{}/exports/'
             'assets-{}-view_summary-{}.csv\n\n'
             'Regards,\n'
             'KoboToolbox'
         ).format(
             self.user.username,
+            root_url,
             self.user.username,
             self.user.username,
             datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ'),

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -35,7 +35,7 @@ class ExportTaskInBackgroundTests(TestCase):
 
         mock_send_mail.assert_called_once()
         args, kwargs = mock_send_mail.call_args
-        root_url = settings.KOBOCAT_URL
+        root_url = settings.KOBOFORM_URL
         expected_message = (
             'Hello {},\n\n'
             'Your report is complete: {}'

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -35,13 +35,17 @@ class ExportTaskInBackgroundTests(TestCase):
         mock_send_mail.assert_called_once()
         args, kwargs = mock_send_mail.call_args
         expected_message = (
-            f'Hello {self.user.username},\n\n'
-            f'Your report is complete: '
-            f'http://kf.kobo.local:8080/private-media/{self.user.username}/exports/'
-            f'assets-{self.user.username}-view_summary-'
-            + datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ') + '.csv\n\n'
-            f'Regards,\n'
-            f'KoboToolbox'
+            'Hello {},\n\n'
+            'Your report is complete: '
+            'http://kf.kobo.local:8080/private-media/{}/exports/'
+            'assets-{}-view_summary-{}.csv\n\n'
+            'Regards,\n'
+            'KoboToolbox'
+        ).format(
+            self.user.username,
+            self.user.username,
+            self.user.username,
+            datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ'),
         )
         self.assertEqual(kwargs['subject'], 'Project View Report Complete')
         self.assertEqual(expected_message, kwargs['message'])


### PR DESCRIPTION
## Checklist

1. [X] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [X] Ensure the tests pass
4. [X] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [X] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [ ] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [X] Create a testing plan for the reviewer and add it to the Testing section
9. [X] Add frontend or backend tag and any other appropriate tags to this pull request

## Description

Refactor our export task function to handle different project type inputs. 

## Notes

`send_mail` is now accessed via the `mail` module instead of being imported directly. This was changed to allow for mocking of `send_mail` in the tests. 

## Testing

Most testing is covered by the tests but you can also ensure that the `Export all data` button in _Project views_ is exporting data and sending an email. 


