### PR TITLE
feat(organizations): update page access permissions TASK-977

### DIFF
--- a/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
+++ b/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
@@ -30,14 +30,13 @@ export const ValidateOrgPermissions = ({
   ) : true;
   const hasValidOrg = mmoOnly ? orgQuery.data?.is_mmo : true;
 
-  // Redirect to Account Settings if you're not the owner
+  // Redirect to Account Settings if conditions not met
   useEffect(() => {
     if (
       redirect &&
       !orgQuery.isPending &&
       orgQuery.data &&
-      !hasValidRole &&
-      !hasValidOrg
+      (!hasValidRole || !hasValidOrg)
     ) {
       navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
     }

--- a/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
+++ b/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
@@ -34,13 +34,12 @@ export const ValidateOrgPermissions = ({
   useEffect(() => {
     if (
       redirect &&
-      !orgQuery.isPending &&
       orgQuery.data &&
       (!hasValidRole || !hasValidOrg)
     ) {
       navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
     }
-  }, [redirect, orgQuery.isSuccess, orgQuery.data, navigate]);
+  }, [redirect, orgQuery.data, navigate]);
 
   return redirect && hasValidRole && hasValidOrg ? (
     <Suspense fallback={null}>{children}</Suspense>

--- a/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
+++ b/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
@@ -3,15 +3,32 @@ import {useNavigate} from 'react-router-dom';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
 import {useOrganizationQuery} from 'js/account/stripe.api';
+import {OrganizationUserRole} from '../stripe.types';
 
 interface Props {
   children: React.ReactNode;
+  validRoles?: OrganizationUserRole[];
+  mmoOnly?: boolean;
   redirect?: boolean;
 }
 
-export const RequireOrgOwner = ({children, redirect = true}: Props) => {
+/**
+ * Use to handle display of pages that should only be accessible to certain user roles
+ * or members of MMOs. Defaults to allowing access for all users, so you must supply
+ * any restrictions.
+ */
+export const ValidateOrgPermissions = ({
+  children,
+  validRoles = undefined,
+  mmoOnly = false,
+  redirect = true,
+}: Props) => {
   const navigate = useNavigate();
   const orgQuery = useOrganizationQuery();
+  const hasValidRole = validRoles ? validRoles.includes(
+    orgQuery.data?.request_user_role ?? OrganizationUserRole.member
+  ) : true;
+  const hasValidOrg = mmoOnly ? orgQuery.data?.is_mmo : true;
 
   // Redirect to Account Settings if you're not the owner
   useEffect(() => {
@@ -19,13 +36,14 @@ export const RequireOrgOwner = ({children, redirect = true}: Props) => {
       redirect &&
       !orgQuery.isPending &&
       orgQuery.data &&
-      !orgQuery.data.is_owner
+      !hasValidRole &&
+      !hasValidOrg
     ) {
       navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
     }
   }, [redirect, orgQuery.isSuccess, orgQuery.data, navigate]);
 
-  return redirect && orgQuery.data?.is_owner ? (
+  return redirect && hasValidRole && hasValidOrg ? (
     <Suspense fallback={null}>{children}</Suspense>
   ) : (
     <LoadingSpinner />

--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
-import {RequireOrgOwner} from 'js/account/organizations/requireOrgOwner.component';
+import {ValidateOrgPermissions} from 'js/account/organizations/validateOrgPermissions.component';
+import {OrganizationUserRole} from './stripe.types';
 import {
   ACCOUNT_ROUTES,
   AccountSettings,
@@ -35,9 +36,9 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <RequireOrgOwner>
+            <ValidateOrgPermissions validRoles={[OrganizationUserRole.owner]}>
               <PlansRoute />
-            </RequireOrgOwner>
+            </ValidateOrgPermissions>
           </RequireAuth>
         }
       />
@@ -46,9 +47,9 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <RequireOrgOwner>
+            <ValidateOrgPermissions validRoles={[OrganizationUserRole.owner]}>
               <AddOnsRoute />
-            </RequireOrgOwner>
+            </ValidateOrgPermissions>
           </RequireAuth>
         }
       />
@@ -57,9 +58,14 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <RequireOrgOwner>
+            <ValidateOrgPermissions
+              validRoles={[
+                OrganizationUserRole.owner,
+                OrganizationUserRole.admin,
+              ]}
+            >
               <DataStorage activeRoute={ACCOUNT_ROUTES.USAGE} />
-            </RequireOrgOwner>
+            </ValidateOrgPermissions>
           </RequireAuth>
         }
       />
@@ -67,7 +73,16 @@ export default function routes() {
         path={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}
         element={
           <RequireAuth>
-            <DataStorage activeRoute={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN} />
+            <ValidateOrgPermissions
+              validRoles={[
+                OrganizationUserRole.owner,
+                OrganizationUserRole.admin,
+              ]}
+            >
+              <DataStorage
+                activeRoute={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}
+              />
+            </ValidateOrgPermissions>
           </RequireAuth>
         }
       />
@@ -93,7 +108,9 @@ export default function routes() {
             path={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
             element={
               <RequireAuth>
-                <div>Organization members view to be implemented</div>
+                <ValidateOrgPermissions mmoOnly>
+                  <div>Organization members view to be implemented</div>
+                </ValidateOrgPermissions>
               </RequireAuth>
             }
           />
@@ -101,7 +118,15 @@ export default function routes() {
             path={ACCOUNT_ROUTES.ORGANIZATION_SETTINGS}
             element={
               <RequireAuth>
-                <div>Organization settings view to be implemented</div>
+                <ValidateOrgPermissions
+                  validRoles={[
+                    OrganizationUserRole.owner,
+                    OrganizationUserRole.admin,
+                  ]}
+                  mmoOnly
+                >
+                  <div>Organization settings view to be implemented</div>
+                </ValidateOrgPermissions>
               </RequireAuth>
             }
           />


### PR DESCRIPTION
## Checklist

1. [x] If you've added code that should be tested, add tests
2. [x] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [x] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [x] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section
9. [x] Add frontend or backend tag and any other appropriate tags to this pull request

## Description

For various pages in account settings, we previously used a wrapper component to verify whether the user was the owner of their org before allowing them to access the page. With the organizations project, this permissions check needs to allow for checking multiple role options. We also need to be able to check whether an org is an mmo for the members page. This PR overhauls the old wrapper component to allow for these checks.

## Testing

With Stripe enabled (and products synced), create a new user. Check the routes in the sidenav that were previously wrapped with `RequireOrgOwner`. There should be no difference with current behavior on main. 

Then turn on mmo_override for the org. Create a second user and then add them to the org via django admin. Logged in as the second user, check the routes again. You will have to enter the url manually for members, usage and org settings. You should be redirected to the account settings page, because the second user only has the org role of `member`. Finally, open the organization in django admin  and check "is_admin" for the second user. Check the routes again. The admin should be able to view the members, usage and settings pages but still not the plans page.
