### PR TITLE
fix(Library): Fix collection child route not loading properly TASK-1216

### DIFF
--- a/jsapp/js/router/permProtectedRoute.tsx
+++ b/jsapp/js/router/permProtectedRoute.tsx
@@ -61,6 +61,17 @@ class PermProtectedRoute extends React.Component<
       return;
     }
 
+    // Listen to incoming load of asset
+    this.unlisteners.push(
+      actions.resources.loadAsset.completed.listen(
+        this.onLoadAssetCompleted.bind(this)
+      ),
+      actions.resources.loadAsset.failed.listen(
+        this.onLoadAssetFailed.bind(this)
+      )
+    );
+
+    // See if the asset is already loaded in the store
     const assetFromStore = assetStore.getAsset(this.props.params.uid);
     if (assetFromStore) {
       // If this asset was already loaded before, we are not going to be picky
@@ -68,17 +79,12 @@ class PermProtectedRoute extends React.Component<
       // those are most probably up to date.
       // This helps us avoid unnecessary API calls and spinners being displayed
       // in the UI (from this component; see `render()` below).
-      this.onLoadAssetCompleted(assetFromStore);
+      // This code previously was simply calling `onLoadAssetCompleted`, but it
+      // caused some edge cases bugs. We will instead call the usual load action
+      // but telling the function to return cached result
+      actions.resources.loadAsset({id: this.props.params.uid}, false);
     } else {
       this.setState({initialAssetLoadNotNeeded: true});
-      this.unlisteners.push(
-        actions.resources.loadAsset.completed.listen(
-          this.onLoadAssetCompleted.bind(this)
-        ),
-        actions.resources.loadAsset.failed.listen(
-          this.onLoadAssetFailed.bind(this)
-        )
-      );
       actions.resources.loadAsset({id: this.props.params.uid}, true);
     }
   }

--- a/jsapp/js/router/permProtectedRoute.tsx
+++ b/jsapp/js/router/permProtectedRoute.tsx
@@ -27,6 +27,10 @@ interface PermProtectedRouteState {
   userHasRequiredPermissions: boolean | null;
   errorMessage?: string;
   asset: AssetResponse | null;
+  /**
+   * Tells the `dmix` mixin (from `mixins.tsx`) that this route component
+   * already handled asset load, so `dmix` doesn't have to.
+   */
   initialAssetLoadNotNeeded: boolean;
 }
 


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [x] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [x] Create a testing plan for the reviewer and add it to the Testing section
9. [x] Add frontend or backend tag and any other appropriate tags to this pull request

## Description

Fix collection child not loading (UI displays infinite spinner) when trying to navigate into the collection child consecutive times.

## Notes

For cached asset `PermProtectedRoute` was skipping the Reflux action call, and using the callback function directly. Unfortunately `AssetRoute` is expecting the Reflux action to happen (regardless if response comes from cache). This is sign of a bigger issue in our codebase - #4835 brought asset cache that is causing bugs, but the fact that we have a mess in the ways of loading the asset is the real culprit.

## Testing

Given the fact that `PermProtectedRoute` is being used for many (27!) different routes, so it would be best if tester would visit each of them, just to verify they still load properly :)

Besides that, please follow reproduction steps from Notion task description.

## Related issues

This is caused by the dreaded #4835 