### PR TITLE
refactor(billingAddons): normalize NLP usage naming TASK-1015

### DIFF
--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -27,10 +27,3 @@ USAGE_LIMIT_MAP = {
     'storage': 'storage_bytes',
     'submission': 'submission',
 }
-
-USAGE_LIMIT_MAP_STRIPE = {
-    'characters': 'nlp_character',
-    'seconds': 'nlp_seconds',
-    'storage': 'storage_bytes',
-    'submission': 'submission',
-}

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -21,7 +21,7 @@ from rest_framework import status
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization, OrganizationUser
-from kobo.apps.stripe.constants import USAGE_LIMIT_MAP_STRIPE
+from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.stripe.tests.utils import (
     generate_enterprise_subscription,
     generate_plan_subscription,
@@ -486,7 +486,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
 
     @data('characters', 'seconds')
     def test_get_suscription_limit(self, usage_type):
-        stripe_key = f'{USAGE_LIMIT_MAP_STRIPE[usage_type]}_limit'
+        stripe_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
         product_metadata = {
             stripe_key: 1234,
             'product_type': 'plan',

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -5,7 +5,7 @@ from django.db.models import F
 
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.types import UsageType
-from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, USAGE_LIMIT_MAP_STRIPE
+from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, USAGE_LIMIT_MAP
 
 
 def get_default_add_on_limits():
@@ -50,7 +50,7 @@ def get_organization_plan_limit(
     """
     if not settings.STRIPE_ENABLED:
         return None
-    stripe_key = f'{USAGE_LIMIT_MAP_STRIPE[usage_type]}_limit'
+    stripe_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
     query_product_type = (
         'djstripe_customers__subscriptions__items__price__'
         'product__metadata__product_type'

--- a/kobo/apps/trackers/tests/test_utils.py
+++ b/kobo/apps/trackers/tests/test_utils.py
@@ -5,7 +5,7 @@ from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
-from kobo.apps.stripe.constants import USAGE_LIMIT_MAP, USAGE_LIMIT_MAP_STRIPE
+from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.stripe.tests.utils import generate_plan_subscription
 from kobo.apps.trackers.utils import (
     get_organization_remaining_usage,
@@ -86,10 +86,9 @@ class TrackersUtilitiesTestCase(BaseTestCase):
 
     @data('characters', 'seconds')
     def test_organization_usage_utils(self, usage_type):
-        stripe_key = f'{USAGE_LIMIT_MAP_STRIPE[usage_type]}_limit'
         usage_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
         sub_metadata = {
-            stripe_key: 1000,
+            usage_key: 1000,
             'product_type': 'plan',
             'plan_type': 'enterprise',
         }


### PR DESCRIPTION
## Checklist

1. [ ] If you've added code that should be tested, add tests
2. [ ] If you've changed APIs, update (or create!) the documentation
3. [ ] Ensure the tests pass
4. [ ] Run `./python-format.sh` to make sure that your code lints and that you've followed [our coding style](https://github.com/kobotoolbox/kpi/blob/main/CONTRIBUTING.md)
5. [x] Write a title and, if necessary, a description of your work suitable for publishing in our [release notes](https://community.kobotoolbox.org/tag/release-notes)
6. [x] Mention any related issues in this repository (as #ISSUE) and in other repositories (as kobotoolbox/other#ISSUE)
7. [ ] Open an issue in the [docs](https://github.com/kobotoolbox/docs/issues/new) if there are UI/UX changes
8. [ ] Create a testing plan for the reviewer and add it to the Testing section
9. [ ] Add frontend or backend tag and any other appropriate tags to this pull request

## Description

Previously we were using 'nlp_character_limit' and 'nlp_minutes_limit' as the keys for nlp usage limits in Stripe metadata. Elsewhere in the code we have been using 'asr_minutes' and 'mt_characters'. This PR removes the Stripe-specific language for consistency. A separate PR will be submitted to update the frontend accordingly.

