### PR TITLE
chore(CODEOWNERS): frontend tooling co-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,12 @@
 /pip-compile.sh                     @jnm @noliveleger
 /pyproject.toml                     @jnm @noliveleger
 
+# Django Static Templates, HTML, JS, CSS
+/kpi/static/css/                    @magicznyleszek @p2edwards
+/kpi/templates/                     @magicznyleszek @p2edwards
+/kpi/templates/search/              @jnm
+/kobo/apps/accounts/templates/      @magicznyleszek @p2edwards
+_registration.scss                  @magicznyleszek @p2edwards
 
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,10 +80,9 @@
 /pyproject.toml                     @jnm @noliveleger
 
 # Django Static Templates, HTML, JS, CSS
+/kobo/apps/accounts/templates/      @magicznyleszek @p2edwards @jnm @noliveleger
+/kpi/templates/                     @magicznyleszek @p2edwards @jnm @noliveleger
 /kpi/static/css/                    @magicznyleszek @p2edwards
-/kpi/templates/                     @magicznyleszek @p2edwards
-/kpi/templates/search/              @jnm
-/kobo/apps/accounts/templates/      @magicznyleszek @p2edwards
 _registration.scss                  @magicznyleszek @p2edwards
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,20 +36,21 @@
 /jsapp/                             @magicznyleszek
 /patches/                           @p2edwards
 /static/                            @magicznyleszek
-/webpack/                           @magicznyleszek
-/.babelrc.json                      @magicznyleszek
-/.browserslistrc                    @magicznyleszek
-/.eslintignore                      @magicznyleszek
-/.eslintrc.js                       @magicznyleszek
-/.node-version                      @magicznyleszek
-/.nvmrc                             @magicznyleszek
-/.prettierrc.js                     @magicznyleszek
-/.stylelintrc.js                    @magicznyleszek
-/.swcrc                             @magicznyleszek
-/.coffeelint.json                   @magicznyleszek
-/package-lock.json                  @magicznyleszek
-/package.json                       @magicznyleszek
-/tsconfig.json                      @magicznyleszek
+/static/js/                         @magicznyleszek @p2edwards
+/webpack/                           @magicznyleszek @p2edwards
+/.babelrc.json                      @magicznyleszek @p2edwards
+/.browserslistrc                    @magicznyleszek @p2edwards
+/.eslintignore                      @magicznyleszek @p2edwards
+/.eslintrc.js                       @magicznyleszek @p2edwards
+/.node-version                      @magicznyleszek @p2edwards
+/.nvmrc                             @magicznyleszek @p2edwards
+/.prettierrc.js                     @magicznyleszek @p2edwards
+/.stylelintrc.js                    @magicznyleszek @p2edwards
+/.swcrc                             @magicznyleszek @p2edwards
+/.coffeelint.json                   @magicznyleszek @p2edwards
+/package-lock.json                  @magicznyleszek @p2edwards
+/package.json                       @magicznyleszek @p2edwards
+/tsconfig.json                      @magicznyleszek @p2edwards
 
 # Billing
 /jsapp/js/account/                  @jamesrkiger

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,10 @@
 /.gitlab-ci.yml                     @bufke
 /Dockerfile                         @bufke @jnm @noliveleger
 
+# FE infrastructure
+/.github/workflows/npm-test.yml     @magicznyleszek @p2edwards
+/scripts/*.js                       @magicznyleszek @p2edwards
+/scripts/hints.js                   @p2edwards
 
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,7 +97,7 @@ _registration.scss                  @magicznyleszek @p2edwards
 /.gitlab-ci.yml                     @bufke
 /Dockerfile                         @bufke @jnm @noliveleger
 
-# FE infrastructure
+# Frontend infrastructure
 /.github/workflows/npm-test.yml     @magicznyleszek @p2edwards
 /scripts/*.js                       @magicznyleszek @p2edwards
 /scripts/hints.js                   @p2edwards

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,14 +93,11 @@ _registration.scss                  @magicznyleszek @p2edwards
 
 /docker/                            @bufke @jnm @noliveleger
 /scripts/                           @bufke @jnm @noliveleger
+/scripts/*.js                       @magicznyleszek @p2edwards
 /.github/                           @bufke @jnm @noliveleger @magicznyleszek
+/.github/workflows/npm-test.yml     @bufke @jnm @noliveleger @magicznyleszek @p2edwards
 /.gitlab-ci.yml                     @bufke
 /Dockerfile                         @bufke @jnm @noliveleger
-
-# Frontend infrastructure
-/.github/workflows/npm-test.yml     @magicznyleszek @p2edwards
-/scripts/*.js                       @magicznyleszek @p2edwards
-/scripts/hints.js                   @p2edwards
 
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,6 +88,7 @@ _registration.scss                  @magicznyleszek @p2edwards
 
 
 
+
 ################
 #### Infrastructure section
 
@@ -101,6 +102,7 @@ _registration.scss                  @magicznyleszek @p2edwards
 /.github/workflows/npm-test.yml     @magicznyleszek @p2edwards
 /scripts/*.js                       @magicznyleszek @p2edwards
 /scripts/hints.js                   @p2edwards
+
 
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 /patches/                           @p2edwards
 /static/                            @magicznyleszek
 /static/js/                         @magicznyleszek @p2edwards
+/test/                              @magicznyleszek @p2edwards
 /webpack/                           @magicznyleszek @p2edwards
 /.babelrc.json                      @magicznyleszek @p2edwards
 /.browserslistrc                    @magicznyleszek @p2edwards
@@ -65,11 +66,12 @@
 # Default owner
 /dependencies/                      @jnm @noliveleger
 /hub/                               @jnm @noliveleger
+/hub/tests/                         @jnm @noliveleger
 /kobo/                              @jnm @noliveleger
 /kobo/apps/audit_log/               @rgraber
 /kobo/apps/subsequences/            @Guitlle
 /kpi/                               @jnm @noliveleger
-/test/                              @jnm @noliveleger
+/kpi/tests/                         @jnm @noliveleger
 /.coveragerc                        @jnm
 /.dockerignore                      @jnm @noliveleger
 /format-python.sh                   @noliveleger


### PR DESCRIPTION
### 💭 Notes

- **Frontend**: Adding @p2edwards as co-maintainer for tooling/build systems
  - @magicznyleszek, feel free to stay on or delegate some of these to me
- **Backend**
  - Treat Django-rendered HTML like frontend code, add self as co-owner for files I'm familiar with
  - Fix `/test/` — this folder is frontend, replaced with `/kpi/tests/`, `/hub/tests/` in backend section
- **Infrastructure**: Add @p2edwards for `npm-test.yml`