### PR TITLE
feat(organizations): remove hardcoded team label env var TASK-1083

### DIFF
--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -22,8 +22,7 @@ export interface EnvironmentResponse {
   transcription_languages: TransxLanguages;
   translation_languages: TransxLanguages;
   submission_placeholder: string;
-  // TODO: Remove optional marker when PR#5182 is merged
-  use_team_label?: boolean;
+  use_team_label: boolean;
   frontend_min_retry_time: number;
   frontend_max_retry_time: number;
   asr_mt_features_enabled: boolean;
@@ -215,8 +214,7 @@ class EnvStore {
     this.data.project_metadata_fields = response.project_metadata_fields;
     this.data.user_metadata_fields = response.user_metadata_fields;
     this.data.submission_placeholder = response.submission_placeholder;
-    // TODO: Assign response value when PR#5182 is merged
-    this.data.use_team_label = true;
+    this.data.use_team_label = response.use_team_label;
     this.data.mfa_localized_help_text = response.mfa_localized_help_text;
     this.data.mfa_enabled = response.mfa_enabled;
     this.data.mfa_per_user_availability = response.mfa_per_user_availability;


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Use the backend env response to set `use_team_label` in the `envStore`.

### 👀 Preview steps

1. console log envStore.data.use_team_label in the accountSettings component
2. Adjust the use_team_label constance variable in django admin
3. Observe proper bool value being logged in the console 


### 💭 Notes
I hardcoded this variable when I added it to the envStore because the backend work for including it in the API hadn't been merged yet. It has been merged now, so the hardcoding can be removed.
