### PR TITLE
feat(xlsform): support `background-geopoint`… TASK-1195

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -537,7 +537,7 @@ pytz==2024.1
     # via
     #   flower
     #   pandas
-pyxform==2.1.1
+pyxform==2.2.0
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -75,7 +75,7 @@ openpyxl
 psycopg
 pymongo
 python-dateutil
-pyxform==2.1.1
+pyxform==2.2.0
 requests
 regex
 responses

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -412,7 +412,7 @@ pytz==2024.1
     # via
     #   flower
     #   pandas
-pyxform==2.1.1
+pyxform==2.2.0
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack


### PR DESCRIPTION
### 📣 Summary
Support the new `background-geopoint` question type [[read more]](https://github.com/XLSForm/pyxform/issues/716) by upgrading pyxform to v2.2.0, which includes XLSForm/pyxform#726


### 👀 Preview steps

1. Create a project by uploading an XLSForm with a `background-geopoint` question, for example ([Simple_background_geo.xlsx](https://github.com/user-attachments/files/17510897/Simple_background_geo.xlsx))
1. Deploy the project
1. Download the project's XML XForm and verify it against the example here: https://github.com/XLSForm/pyxform/issues/716#issuecomment-2344817692.