### PR TITLE
build(backend): fix broken and slow `pip-compile.sh`

### DIFF
--- a/pip-compile.sh
+++ b/pip-compile.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-if [ -z "$(dpkg -l|grep 'libpq-dev')" ]; then
-  echo "Installing dependencies needed to pip-compile..."
-  apt-get -qq update && apt-get -qq -y install gcc libpq-dev
-fi
+set -x  # give the human some hope of progress
 
 for in_file in dependencies/pip/*.in
 do
@@ -11,4 +8,3 @@ do
     # useful for switches like `--upgrade-package`
     pip-compile "$@" "$in_file" || exit $?
 done
-for out_file in dependencies/pip/*.txt


### PR DESCRIPTION
### 💭 Notes
Script was broken due to incomplete removals in #5125 and #5127.
Slow steps of installing `gcc` and `libpq-dev` are unnecessary, even when upgrading `psycopg`. Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/pip-tools/near/482296