### PR TITLE
feat(projectHistoryLog): log exports TASK-944

### DIFF
--- a/kobo/apps/audit_log/audit_actions.py
+++ b/kobo/apps/audit_log/audit_actions.py
@@ -14,6 +14,7 @@ class AuditAction(models.TextChoices):
     DISABLE_SHARING = 'disable-sharing'
     DISCONNECT_PROJECT = 'disconnect-project'
     ENABLE_SHARING = 'enable-sharing'
+    EXPORT = 'export'
     IN_TRASH = 'in-trash'
     MODIFY_IMPORTED_FIELDS = 'modify-imported-fields'
     MODIFY_SERVICE = 'modify-service'

--- a/kobo/apps/audit_log/base_views.py
+++ b/kobo/apps/audit_log/base_views.py
@@ -86,7 +86,6 @@ class AuditLoggedViewSet(viewsets.GenericViewSet):
         self.perform_destroy_override(instance)
         self.request._request.initial_data = audit_log_data
 
-
     def perform_destroy_override(self, instance):
         super().perform_destroy(instance)
 

--- a/kobo/apps/audit_log/base_views.py
+++ b/kobo/apps/audit_log/base_views.py
@@ -83,8 +83,9 @@ class AuditLoggedViewSet(viewsets.GenericViewSet):
             field_label = field[0] if isinstance(field, tuple) else field
             value = get_nested_field(instance, field_path)
             audit_log_data[field_label] = value
-        self.request._request.initial_data = audit_log_data
         self.perform_destroy_override(instance)
+        self.request._request.initial_data = audit_log_data
+
 
     def perform_destroy_override(self, instance):
         super().perform_destroy(instance)

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -135,7 +135,6 @@ class ExportTaskViewSet(AuditLoggedNoUpdateModelViewSet):
     lookup_field = 'uid'
     log_type = 'project-history'
 
-
     def get_queryset(self, *args, **kwargs):
         if self.request.user.is_anonymous:
             return ExportTask.objects.none()

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -5,17 +5,17 @@ from rest_framework import (
 )
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
+from kobo.apps.audit_log.base_views import AuditLoggedNoUpdateModelViewSet
 from kpi.filters import SearchFilter
 from kpi.models import ExportTask
 from kpi.permissions import ExportTaskPermission
 from kpi.serializers.v2.export_task import ExportTaskSerializer
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
-from kpi.views.no_update_model import NoUpdateModelViewSet
 
 
 class ExportTaskViewSet(
-    AssetNestedObjectViewsetMixin, NestedViewSetMixin, NoUpdateModelViewSet
+    AssetNestedObjectViewsetMixin, NestedViewSetMixin, AuditLoggedNoUpdateModelViewSet
 ):
     """
     ## List of export tasks endpoints
@@ -159,6 +159,8 @@ class ExportTaskViewSet(
     search_default_field_lookups = [
         'uid__icontains',
     ]
+    log_type = 'project-history'
+    logged_fields = [('object_id', 'asset.id')]
 
     def get_queryset(self):
         user = get_database_user(self.request.user)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Record project history logs for when users export an asset.


### 👀 Preview steps

Bug template:
1. ℹ️ Log in as a super user. Create and deploy a project
2. Add at least 1 submission to the project
3. Go to Data > Downloads and hit Export. Note: the export may get stuck in processing. This is due to an unrelated bug (https://www.notion.so/kobotoolbox/Exports-fail-with-ExportTask-matching-query-does-not-exist-1377e515f65480328422e0c8fcfed1c0) but doesn't affect this work since we want to log every attempt to export, not just successful ones
5. 🟢 Go to `api/v2/audit-logs/?q=metadata__asset_uid:<asset_uid> AND log_type='project-history'`
6. There should be a new PH log with action=`export` (usual metadata)


### 💭 Notes
Uses the AuditLoggedViewSet and `create_from_related_request` flows (similar to asset files, paired data, etc.)
