### PR TITLE
fix(projectOwnership): allow re-requests for project transfers with expired invites TASK-1237

### DIFF
--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.db import models
-from django.utils import timezone
 
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1778,6 +1778,3 @@ SUPPORTED_MEDIA_UPLOAD_TYPES = [
 SILENCED_SYSTEM_CHECKS = ['guardian.W001']
 
 DIGEST_LOGIN_FACTORY = 'django_digest.NoEmailLoginFactory'
-
-
-DIGEST_LOGIN_FACTORY = 'django_digest.NoEmailLoginFactory'

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -687,9 +687,6 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         ).data
 
     def get_project_ownership(self, asset) -> Optional[dict]:
-        pass
-
-    def get_project_ownership(self, asset) -> Optional[dict]:
         if not (transfer := asset.transfers.order_by('-date_created').first()):
             return
 
@@ -711,7 +708,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             ),
             'sender': transfer.invite.sender.username,
             'recipient': transfer.invite.recipient.username,
-            'status': transfer.status
+            'status': transfer.invite.status
         }
 
     def get_exports(self, obj: Asset) -> str:

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -56,6 +56,12 @@ class AssetDetailApiTests(test_api_assets.AssetDetailApiTests):
     def test_assignable_permissions(self):
         pass
 
+    @unittest.skip(
+        reason='`project_ownership` property only exists in v2 endpoint'
+    )
+    def test_ownership_transfer_status(self):
+        pass
+
 
 class AssetsXmlExportApiTests(KpiTestCase):
     fixtures = ['test_data']


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Synchronize invite status in asset endpoint


### 📖 Description
This fix ensures that the invite status remains in sync within the asset endpoint under project ownership. It addresses cases where changes to an invite’s status were not reflected accurately in the asset data.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. Create a project and share it with another user
2. Go to the shell
3. Change the invite date creation to something in the past (more than 30 days)
4. 🔴 [in release/2.024.33] Go to Project > Settings > Sharing. See it's the button is still "Cancel transfer". Go to `http://[kpi_url]/api/v2/assets/<asset_uid>/` and see that `project_ownership.status` is `pending`.
5. 🟢 [on PR] Go to Project > Settings > Sharing. See it's the button is now "Transfer this project" (again). Go to `http://[kpi_url]/api/v2/assets/<asset_uid>/` and see that `project_ownership.status` is `expired`.
