### PR TITLE
fix(mediaFiles): fix wrong path when syncing media files to OpenRosa server storage TASK-1238

### DIFF
--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -1139,7 +1139,6 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 'md5': metadata['file_hash'],
                 'from_kpi': metadata['from_kpi'],
             }
-
         metadata_filenames = metadata_files.keys()
 
         queryset = self._get_metadata_queryset(file_type=file_type)
@@ -1339,7 +1338,11 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         }
 
         if not file_.is_remote_url:
-            metadata['data_file'] = file_.content
+            # Ensure file has not been read before
+            file_.content.seek(0)
+            file_content = file_.content.read()
+            file_.content.seek(0)
+            metadata['data_file'] = ContentFile(file_content, file_.filename)
 
         MetaData.objects.create(**metadata)
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -5,12 +5,12 @@ import random
 import string
 import uuid
 from datetime import datetime
+from unittest import mock
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 
-from unittest import mock
 
 import lxml
 import pytest
@@ -1972,7 +1972,6 @@ class SubmissionDuplicateApiTests(SubmissionDuplicateBaseApiTests):
         someuser is the owner of the project.
         someuser is allowed to duplicate their own data
         """
-        print('URL :', self.submission_url, flush=True)
         response = self.client.post(self.submission_url, {'format': 'json'})
         assert response.status_code == status.HTTP_201_CREATED
         self._check_duplicate(response)

--- a/kpi/tests/test_extended_file_field.py
+++ b/kpi/tests/test_extended_file_field.py
@@ -1,6 +1,6 @@
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
-from django.test import override_settings, TestCase
+from django.test import TestCase
 
 from kpi.models.asset import Asset
 from kpi.models.asset_file import AssetFile


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Corrected file path to ensure media files synchronization to OpenRosa server storage


### 📖 Description
This fix addresses an issue where media files were not properly copied to the OpenRosa server storage, instead using the same file location as KPI. With this update, media files are now correctly synchronized to the OpenRosa server, ensuring that each system maintains its own file storage as intended. 


### 👀 Preview steps

Bug template:
1. Create a project with media files. 
   - You can import this one [Birds.xlsx](https://github.com/user-attachments/files/17668672/Birds.xlsx) and its media files in Projects > Settings > Media:
   - [eagle](https://github.com/user-attachments/assets/a23956d5-cef5-4362-a351-8becaa53082e)
   - [goose](https://github.com/user-attachments/assets/b475450b-39d7-415c-a40b-20d19db99a36)
   - [heron](https://github.com/user-attachments/assets/c330592b-6140-4e93-a091-51a7f3f754d2)
   - [kingfisher](https://github.com/user-attachments/assets/e87ad4d4-c6ee-4e8c-beb5-6a9302a826ff)
   - [pelican](https://github.com/user-attachments/assets/41935e2d-2f74-4bc7-8ff2-99438a124d05)
   - [pigeon](https://github.com/user-attachments/assets/1cb1d0b9-7319-497a-921b-5ca2d0e5dc5a)
   - [robin](https://github.com/user-attachments/assets/9ad1174f-0a95-42ed-a162-b55046cf84ff)
   - [sparrow](https://github.com/user-attachments/assets/3ad646f9-1c9f-4963-974f-49b5b15a2ccf)
   - [tit](https://github.com/user-attachments/assets/2e6a1718-b4c6-49b1-8e02-4d6abaed9834)
   - [woodpecker](https://github.com/user-attachments/assets/ab623113-c15e-4bb6-a4ef-cd45900e5ed0)
   - ⚠️  One is missing `nuthatch.webp` because GitHub does not allow `webp` uploads
2. Deploy the project
3. Open Enketo 
5. 🔴 [on `2.024.36`] notice that none of the media files are loading
6. 🟢 [on PR] notice that all of the media files are loading


### 💭 Notes
This bug was introduced in version `.36` and never impacted the production release. 
The bug affected all types of storage supported by KoboToolbox (S3, Azure, LocalStorage), but it is only noticeable (because images do not load) when using LocalStorage.