### PR TITLE
feat(organizations): always return `use_team_label` config value TASK-1167

### DIFF
--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -126,7 +126,7 @@ class EnvironmentTests(BaseTestCase):
             ),
             'open_rosa_server': settings.KOBOCAT_URL,
             'terms_of_service__sitewidemessage__exists': False,
-            'use_team_label': False
+            'use_team_label': constance.config.USE_TEAM_LABEL,
         }
 
     def _check_response_dict(self, response_dict):
@@ -365,31 +365,3 @@ class EnvironmentTests(BaseTestCase):
         response = self.client.get(self.url, format='json')
         assert response.status_code == status.HTTP_200_OK
         assert response.data['stripe_public_key'] == 'fake_public_key'
-
-    @override_settings(STRIPE_ENABLED=False)
-    def test_use_team_label_without_stripe_enabled(self):
-        # Set the USE_TEAM_LABEL in the constance config to True
-        with override_config(USE_TEAM_LABEL=True):
-            response = self.client.get(self.url, format='json')
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertTrue(response.data['use_team_label'])
-
-        # Set the USE_TEAM_LABEL in the constance config to False
-        with override_config(USE_TEAM_LABEL=False):
-            response = self.client.get(self.url, format='json')
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertFalse(response.data['use_team_label'])
-
-    @override_settings(STRIPE_ENABLED=True)
-    def test_use_team_label_with_stripe_enabled(self):
-        # Set the USE_TEAM_LABEL in the constance config to True
-        with override_config(USE_TEAM_LABEL=True):
-            response = self.client.get(self.url, format='json')
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertFalse(response.data['use_team_label'])
-
-        # Set the USE_TEAM_LABEL in the constance config to False
-        with override_config(USE_TEAM_LABEL=False):
-            response = self.client.get(self.url, format='json')
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            self.assertFalse(response.data['use_team_label'])

--- a/kpi/views/environment.py
+++ b/kpi/views/environment.py
@@ -49,6 +49,7 @@ class EnvironmentView(APIView):
         'COMMUNITY_URL',
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
+        'USE_TEAM_LABEL',
     ]
 
     @classmethod
@@ -175,7 +176,6 @@ class EnvironmentView(APIView):
                 data['stripe_public_key'] = str(
                     APIKey.objects.get(type='publishable', livemode=settings.STRIPE_LIVE_MODE).secret
                 )
-                data['use_team_label'] = False
             except MultipleObjectsReturned as e:
                 raise MultipleObjectsReturned(
                     'Remove extra api keys from the django admin.'
@@ -186,7 +186,6 @@ class EnvironmentView(APIView):
                 ) from e
         else:
             data['stripe_public_key'] = None
-            data['use_team_label'] = constance.config.USE_TEAM_LABEL
 
         # If the user isn't eligible for the free tier override, don't send free tier data to the frontend
         if request.user.id:


### PR DESCRIPTION
### 📣 Summary
Always return the configured Constance value of `use_team_label` regardless of Stripe status.

### 👀 Preview steps
No need for a preview, as this is covered in the unit tests for the environment API. 


### 💭 Notes
I also removed the unit tests that were assuming the API would tie this return value to Stripe status. The initial tests cover simple config returns.
