### PR TITLE
feat(organizations): Fix styling for new organization badge and add it to the profile dropdown TASK-979

### DIFF
--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -12,6 +12,7 @@ import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
 import {isAnyRouteBlockerActive} from 'js/router/routerUtils';
 import Button from 'js/components/common/button';
 import Avatar from 'js/components/common/avatar';
+import OrganizationBadge from './organizationBadge.component';
 
 /**
  * UI element that display things only for logged-in user. An avatar that gives
@@ -95,6 +96,8 @@ export default function AccountMenu() {
               <span className='account-username'>{accountName}</span>
               <span className='account-email'>{accountEmail}</span>
             </bem.AccountBox__menuItem>
+
+            <OrganizationBadge style='dropdown'/>
 
             {/*
               There is no UI we can show to a user who sees a router blocker, so

--- a/jsapp/js/components/header/mainHeader.component.tsx
+++ b/jsapp/js/components/header/mainHeader.component.tsx
@@ -160,9 +160,10 @@ const MainHeader = class MainHeader extends React.Component<MainHeaderProps> {
           </React.Fragment>
         )}
 
-        <OrganizationBadge/>
-
-        <AccountMenu />
+        <div className={styles.accountSection}>
+          <OrganizationBadge />
+          <AccountMenu />
+        </div>
 
         {!isLoggedIn && this.renderLoginButton()}
       </MainHeaderBase>

--- a/jsapp/js/components/header/mainHeader.component.tsx
+++ b/jsapp/js/components/header/mainHeader.component.tsx
@@ -161,7 +161,7 @@ const MainHeader = class MainHeader extends React.Component<MainHeaderProps> {
         )}
 
         <div className={styles.accountSection}>
-          <OrganizationBadge />
+          <OrganizationBadge style='header'/>
           <AccountMenu />
         </div>
 

--- a/jsapp/js/components/header/mainHeader.module.scss
+++ b/jsapp/js/components/header/mainHeader.module.scss
@@ -17,3 +17,9 @@
     display: none;
   }
 }
+
+.accountSection {
+  display: flex;
+  margin-left: auto;
+  position: relative;
+}

--- a/jsapp/js/components/header/organizationBadge.component.tsx
+++ b/jsapp/js/components/header/organizationBadge.component.tsx
@@ -1,7 +1,12 @@
 import {useOrganizationQuery} from 'jsapp/js/account/stripe.api';
 import styles from './organizationBadge.module.scss';
+import cx from 'classnames';
 
-export default function OrganizationBadge() {
+interface OrganizationBadgeProps {
+  style: 'header' | 'dropdown';
+}
+
+export default function OrganizationBadge(props: OrganizationBadgeProps) {
   // TODO: move this logic to the parent component when we refactor it
   // into a functional component. OrganizationBadge should just be a
   // purely presentational component.
@@ -9,7 +14,9 @@ export default function OrganizationBadge() {
 
   if (orgQuery.data?.is_mmo) {
     return (
-      <div className={styles.root}>{orgQuery.data.name.toUpperCase()}</div>
+      <div className={cx(styles.root, styles[props.style])}>
+        {orgQuery.data.name.toUpperCase()}
+      </div>
     );
   } else {
     return null;

--- a/jsapp/js/components/header/organizationBadge.module.scss
+++ b/jsapp/js/components/header/organizationBadge.module.scss
@@ -1,11 +1,20 @@
 @use 'scss/colors';
 
 .root {
-  color: colors.$kobo-white;
-  background-color: colors.$kobo-gray-700;
   padding: 6px 10px;
   border-radius: 48px;
   font-weight: 600;
   font-size: .85em;
   margin-right: 20px;
+  width: fit-content;
+}
+
+.header {
+  color: colors.$kobo-white;
+  background-color: colors.$kobo-gray-700;
+}
+
+.dropdown {
+  color: colors.$kobo-dark-blue;
+  background-color: colors.$kobo-light-blue;
 }

--- a/jsapp/js/components/header/organizationBadge.module.scss
+++ b/jsapp/js/components/header/organizationBadge.module.scss
@@ -7,6 +7,5 @@
   border-radius: 48px;
   font-weight: 600;
   font-size: .85em;
-  line-height: 12px;
   margin-right: 20px;
 }

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -151,7 +151,7 @@
     width: calc(100% - 70px);
     line-height: 20px;
     margin-top: 5px;
-    margin-bottom: 12px;
+    margin-bottom: 16px;
 
     span {
       display: inline-block;
@@ -168,6 +168,7 @@
 
   .account-box__menu-item--settings {
     text-align: right;
+    margin-top: 16px;
   }
 
   .account-box__menu-li {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Fix some styling issues with the new organization header badge and add the badge to the profile dropdown.

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

Tiny reshuffle of header elements to make it match the designs.

### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->



### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. Have an MMO with some users in it
2. The badge should display alongside the profile icon always
3. Click the profile icon
4. The badge should be present under the email and above the button
