### PR TITLE
refactor(billing): normalize asr/mt limit naming TASK-1015

### DIFF
--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -239,8 +239,8 @@ export const PlanContainer = ({
   const asrMinutes = useMemo(() => {
     return (
       (adjustedQuantity *
-        (parseInt(product.metadata?.nlp_seconds_limit || '0') ||
-          parseInt(product.price.metadata?.nlp_seconds_limit || '0'))) /
+        (parseInt(product.metadata?.asr_seconds_limit || '0') ||
+          parseInt(product.price.metadata?.asr_seconds_limit || '0'))) /
       60
     );
   }, [adjustedQuantity, product]);
@@ -248,8 +248,8 @@ export const PlanContainer = ({
   const mtCharacters = useMemo(() => {
     return (
       adjustedQuantity *
-      (parseInt(product.metadata?.nlp_character_limit || '0') ||
-        parseInt(product.price.metadata?.nlp_character_limit || '0'))
+      (parseInt(product.metadata?.mt_characters_limit || '0') ||
+        parseInt(product.price.metadata?.mt_characters_limit || '0'))
     );
   }, [adjustedQuantity, product]);
 

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -23,8 +23,8 @@ import sessionStore from 'js/stores/session';
 
 const DEFAULT_LIMITS: AccountLimit = Object.freeze({
   submission_limit: Limits.unlimited,
-  nlp_seconds_limit: Limits.unlimited,
-  nlp_character_limit: Limits.unlimited,
+  asr_seconds_limit: Limits.unlimited,
+  mt_characters_limit: Limits.unlimited,
   storage_bytes_limit: Limits.unlimited,
 });
 
@@ -208,10 +208,10 @@ const getFreeTierLimits = async (limits: AccountLimit) => {
     newLimits['submission_limit'] = thresholds.data;
   }
   if (thresholds.translation_chars) {
-    newLimits['nlp_character_limit'] = thresholds.translation_chars;
+    newLimits['mt_characters_limit'] = thresholds.translation_chars;
   }
   if (thresholds.transcription_minutes) {
-    newLimits['nlp_seconds_limit'] = thresholds.transcription_minutes * 60;
+    newLimits['asr_seconds_limit'] = thresholds.transcription_minutes * 60;
   }
   return newLimits;
 };
@@ -259,15 +259,15 @@ const addRemainingOneTimeAddOnLimits = (
       }
       if (
         addon.limits_remaining.asr_seconds_limit &&
-        limits.nlp_seconds_limit !== Limits.unlimited
+        limits.asr_seconds_limit !== Limits.unlimited
       ) {
-        limits.nlp_seconds_limit += addon.limits_remaining.asr_seconds_limit;
+        limits.asr_seconds_limit += addon.limits_remaining.asr_seconds_limit;
       }
       if (
         addon.limits_remaining.mt_characters_limit &&
-        limits.nlp_character_limit !== Limits.unlimited
+        limits.mt_characters_limit !== Limits.unlimited
       ) {
-        limits.nlp_character_limit +=
+        limits.mt_characters_limit +=
           addon.limits_remaining.mt_characters_limit;
       }
     });

--- a/jsapp/js/account/stripe.types.ts
+++ b/jsapp/js/account/stripe.types.ts
@@ -180,8 +180,8 @@ export type LimitAmount = number | 'unlimited';
 
 export interface AccountLimit {
   submission_limit: LimitAmount;
-  nlp_seconds_limit: LimitAmount;
-  nlp_character_limit: LimitAmount;
+  asr_seconds_limit: LimitAmount;
+  mt_characters_limit: LimitAmount;
   storage_bytes_limit: LimitAmount;
 }
 

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -121,17 +121,17 @@ export default function Usage() {
           storageByteRemainingLimit: limits.remainingLimits.storage_bytes_limit,
           storageByteRecurringLimit: limits.recurringLimits.storage_bytes_limit,
           nlpCharacterRemainingLimit:
-            limits.remainingLimits.nlp_character_limit,
+            limits.remainingLimits.mt_characters_limit,
           nlpCharacterRecurringLimit:
-            limits.recurringLimits.nlp_character_limit,
+            limits.recurringLimits.mt_characters_limit,
           nlpMinuteRemainingLimit:
-            typeof limits.remainingLimits.nlp_seconds_limit === 'number'
-              ? convertSecondsToMinutes(limits.remainingLimits.nlp_seconds_limit)
-              : limits.remainingLimits.nlp_seconds_limit,
+            typeof limits.remainingLimits.asr_seconds_limit === 'number'
+              ? convertSecondsToMinutes(limits.remainingLimits.asr_seconds_limit)
+              : limits.remainingLimits.asr_seconds_limit,
           nlpMinuteRecurringLimit:
-            typeof limits.recurringLimits.nlp_seconds_limit === 'number'
-              ? convertSecondsToMinutes(limits.recurringLimits.nlp_seconds_limit)
-              : limits.recurringLimits.nlp_seconds_limit,
+            typeof limits.recurringLimits.asr_seconds_limit === 'number'
+              ? convertSecondsToMinutes(limits.recurringLimits.asr_seconds_limit)
+              : limits.recurringLimits.asr_seconds_limit,
           submissionsRemainingLimit: limits.remainingLimits.submission_limit,
           submissionsRecurringLimit: limits.recurringLimits.submission_limit,
           isLoaded: true,

--- a/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
+++ b/jsapp/js/components/usageLimits/useExceedingLimits.hook.ts
@@ -54,8 +54,8 @@ export const useExceedingLimits = () => {
       ).then((limits) => {
         setSubscribedSubmissionLimit(limits.remainingLimits.submission_limit);
         setSubscribedStorageLimit(limits.remainingLimits.storage_bytes_limit);
-        setTranscriptionMinutes(limits.remainingLimits.nlp_seconds_limit);
-        setTranslationChars(limits.remainingLimits.nlp_character_limit);
+        setTranscriptionMinutes(limits.remainingLimits.asr_seconds_limit);
+        setTranslationChars(limits.remainingLimits.mt_characters_limit);
         setAreLimitsLoaded(true);
       });
     }


### PR DESCRIPTION
### 📣 Summary
Removes `nlp_` prefix on usage limits in favor of `asr_` and `mt_` to match backend and Stripe.

### 👀 Preview steps
Feature/no-change template:
1. Set up instance for Stripe and NLP
2. Create a user and purchase an addon
3. Make a project with an audio question, submit a response
4. Open NLP processing and make a translation (I just upload an empty audio file and make the transcript manually, then use automatic translation)
5. Check usage page to make sure limits and usage are displayed correctly (make sure you set ENDPOINT_CACHE_DURATION to 1 in your env if you don't want to wait forever to see the change)
