### PR TITLE
fix(button): projects filter button styles

### DIFF
--- a/jsapp/js/components/common/button.scss
+++ b/jsapp/js/components/common/button.scss
@@ -102,7 +102,8 @@ $button-border-radius: 6px;
     left: calc(50% - #{$iconAlone * 0.5});
   }
 
-  &.k-button--type-text {
+  // We need bigger specificity here to override paddings for has-label
+  &.k-button--type-text.k-button--type-text {
     // We need the text button to align better with other UI elements, so we
     // want to avoid the transparent space on both sides.
     padding-left: 0;

--- a/jsapp/js/projects/projectViews/projectsFilter.module.scss
+++ b/jsapp/js/projects/projectViews/projectsFilter.module.scss
@@ -35,6 +35,10 @@
   }
 }
 
+// We want the button to look distinct if there are any filters enabled, so that
+// user is not confused why some of their projects might not appear on the list.
 .buttonHasFilters {
   background-color: colors.$kobo-bg-blue;
+  padding-left: 8px !important;
+  padding-right: 8px !important;
 }


### PR DESCRIPTION
### 📣 Summary
Fix paddings on all text-type buttons. Fix paddings on highlighted Projects Filter button.

### 👀 Preview steps
1. ℹ️ have an account and a project
2. go to "My projects" route
3. use "filter" button to display modal
4. define some filters and "Apply"
5. 🔴 [on main] notice that "filter" button has wrong paddings
6. 🟢 [on PR] notice that "filter" button has correct paddings

### 💭 Notes
All `text` type `<Button>` instances should have zero paddings on left/right. They were getting paddings because of `has-label` class name. Projects Filter button needed `!important` overrides for the paddings, because it uses `text` type `<Button>`, but with added background (whenever any filters are defined).