### PR TITLE
refactor(TextFormatter): create TextFormatter component TASK-996

### DIFF
--- a/jsapp/js/components/textFormatter/textFormatter.component.tsx
+++ b/jsapp/js/components/textFormatter/textFormatter.component.tsx
@@ -1,0 +1,56 @@
+import type {ReactNode} from 'react';
+
+const regExpMatchParts = /[^*[\]]+|(\*\*[^*]*(?:\*[^*]+)*\*\*)|(\*[^*]+\*)|(\[.+?\]\(.+?\)({:.+})?)/g;
+
+const processText = (text: string): ReactNode[] => {
+  const parts = text.match(regExpMatchParts);
+
+  if (!parts) {return [text];}
+
+  const formattedParts: ReactNode[] = [];
+
+  for (const part of parts) {
+    if (part.startsWith('**')) {
+      formattedParts.push(<strong>{processText(part.slice(2, -2))}</strong>);
+    } else if (part.startsWith('*')) {
+      formattedParts.push(<em>{processText(part.slice(1, -1))}</em>);
+    } else if (part.startsWith('[')) {
+      const [label, link, target] = part
+        .slice(1, -1)
+        .split(/\]\(|\)\{:target=/);
+      formattedParts.push(
+        <a href={link} target={target ? target.slice(1, -1) : '_self'}>
+          {processText(label)}
+        </a>
+      );
+    } else {
+      formattedParts.push(part);
+    }
+  }
+
+  return formattedParts;
+};
+
+interface TextFormatterProps {
+  /**
+   * Text will be processed and formatted with markdown-like syntax. It accepts the following:
+   * - *<text>* for italic
+   * - **<text>** for bold
+   * - [text](link) for links with target _self
+   * - [text](link){:target="_blank"} for links with target _blank or other target
+   * - Formatting can be nested to be combined
+   */
+  text: string;
+}
+
+/**
+ * This component process text and applies simple formatting rules with markdown-like syntax.
+ * This is meant to be used with long sentences that need formatting and cannot be broken down
+ * into smaller components duo to translation issues that broken down components would cause.
+ * The formatting options mimics markdown syntax for italic, bold and links.
+ *
+ * @returns ReactNode[]
+ */
+export default function TextFormatter({text}: TextFormatterProps) {
+  return processText(text);
+}

--- a/jsapp/js/components/textFormatter/textFormatter.stories.tsx
+++ b/jsapp/js/components/textFormatter/textFormatter.stories.tsx
@@ -1,0 +1,22 @@
+import type {Meta, StoryFn} from '@storybook/react';
+import TextFormatter from './textFormatter.component';
+
+export default {
+  title: 'misc/TextFormatter',
+  component: TextFormatter,
+  argTypes: {
+    text: {
+      description: 'Text containing markdown-like syntax for formatting. Accepts italic, bold and links with and without target indication. Formatting can be nested to be combined.',
+      control: 'text',
+    },
+  },
+} as Meta<typeof TextFormatter>;
+
+const Template: StoryFn<typeof TextFormatter> = (args) => (
+  <TextFormatter {...args} />
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  text: 'Formatted text with **bold** and *italic* and [link](https://www.kobotoolbox.org/pricing/){:target="_blank"}. Formatting can be **bold and *italic* combined**, [also **on** *links*](http://kobotoolbox.org).',
+};


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 👀 Preview steps
- The component is available for visualization and tests in storybook

### 💭 Notes

A `TextFormatter` component is being added to support long strings formatted in a markdown-like fashion.
Such component is needed to support long sentences to be properly translated without having to break out words just to add simple styles like bold, italic or links.
- The `TextFormatter` component suports an input of a `text` prop containing an string to be processed and generates the output based on the processing of the string.
- Formatting can be nested if needed
