### PR TITLE
refactor(organizations): add configurable redirect route to org validator TASK-975

### DIFF
--- a/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
+++ b/jsapp/js/account/organizations/validateOrgPermissions.component.tsx
@@ -7,9 +7,9 @@ import {OrganizationUserRole} from '../stripe.types';
 
 interface Props {
   children: React.ReactNode;
+  redirectRoute: string;
   validRoles?: OrganizationUserRole[];
   mmoOnly?: boolean;
-  redirect?: boolean;
 }
 
 /**
@@ -19,9 +19,9 @@ interface Props {
  */
 export const ValidateOrgPermissions = ({
   children,
+  redirectRoute,
   validRoles = undefined,
   mmoOnly = false,
-  redirect = true,
 }: Props) => {
   const navigate = useNavigate();
   const orgQuery = useOrganizationQuery();
@@ -30,18 +30,16 @@ export const ValidateOrgPermissions = ({
   ) : true;
   const hasValidOrg = mmoOnly ? orgQuery.data?.is_mmo : true;
 
-  // Redirect to Account Settings if conditions not met
   useEffect(() => {
     if (
-      redirect &&
       orgQuery.data &&
       (!hasValidRole || !hasValidOrg)
     ) {
-      navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
+      navigate(redirectRoute);
     }
-  }, [redirect, orgQuery.data, navigate]);
+  }, [redirectRoute, orgQuery.data, navigate]);
 
-  return redirect && hasValidRole && hasValidOrg ? (
+  return hasValidRole && hasValidOrg ? (
     <Suspense fallback={null}>{children}</Suspense>
   ) : (
     <LoadingSpinner />

--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -36,7 +36,10 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <ValidateOrgPermissions validRoles={[OrganizationUserRole.owner]}>
+            <ValidateOrgPermissions
+              validRoles={[OrganizationUserRole.owner]}
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
+            >
               <PlansRoute />
             </ValidateOrgPermissions>
           </RequireAuth>
@@ -47,7 +50,10 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <ValidateOrgPermissions validRoles={[OrganizationUserRole.owner]}>
+            <ValidateOrgPermissions
+              validRoles={[OrganizationUserRole.owner]}
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
+            >
               <AddOnsRoute />
             </ValidateOrgPermissions>
           </RequireAuth>
@@ -63,6 +69,7 @@ export default function routes() {
                 OrganizationUserRole.owner,
                 OrganizationUserRole.admin,
               ]}
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
             >
               <DataStorage activeRoute={ACCOUNT_ROUTES.USAGE} />
             </ValidateOrgPermissions>
@@ -78,6 +85,7 @@ export default function routes() {
                 OrganizationUserRole.owner,
                 OrganizationUserRole.admin,
               ]}
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
             >
               <DataStorage
                 activeRoute={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}
@@ -108,7 +116,10 @@ export default function routes() {
             path={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
             element={
               <RequireAuth>
-                <ValidateOrgPermissions mmoOnly>
+                <ValidateOrgPermissions
+                  mmoOnly
+                  redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
+                >
                   <div>Organization members view to be implemented</div>
                 </ValidateOrgPermissions>
               </RequireAuth>
@@ -124,6 +135,7 @@ export default function routes() {
                     OrganizationUserRole.admin,
                   ]}
                   mmoOnly
+                  redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
                 >
                   <div>Organization settings view to be implemented</div>
                 </ValidateOrgPermissions>

--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
-import {ValidateOrgPermissions} from 'js/account/organizations/validateOrgPermissions.component';
+import { ValidateOrgPermissions } from 'js/router/validateOrgPermissions.component';
 import {OrganizationUserRole} from './stripe.types';
 import {
   ACCOUNT_ROUTES,

--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
-import { ValidateOrgPermissions } from 'js/router/validateOrgPermissions.component';
+import {ValidateOrgPermissions} from 'js/router/validateOrgPermissions.component';
 import {OrganizationUserRole} from './stripe.types';
 import {
   ACCOUNT_ROUTES,

--- a/jsapp/js/router/validateOrgPermissions.component.tsx
+++ b/jsapp/js/router/validateOrgPermissions.component.tsx
@@ -1,9 +1,8 @@
 import React, {Suspense, useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
-import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
 import {useOrganizationQuery} from 'js/account/stripe.api';
-import {OrganizationUserRole} from '../stripe.types';
+import {OrganizationUserRole} from '../account/stripe.types';
 
 interface Props {
   children: React.ReactNode;


### PR DESCRIPTION
### 📣 Summary
Makes the `ValidateOrgPermissions` component require a redirect route so it can be used outside of the account settings area of the app. Moves the component file to the root router folder. 

### 💭 Notes
I made the redirect route a required prop. Previously redirect was a boolean that defaulted to true. We don't currently have any use case for not doing a redirect with this component and requiring it reduces boolean checks.
