### PR TITLE
fix(InlineMessage): link styles

### DIFF
--- a/jsapp/js/components/common/inlineMessage.scss
+++ b/jsapp/js/components/common/inlineMessage.scss
@@ -13,11 +13,11 @@
   line-height: 22px;
 
   a {
-    text-decoration: underline;
-    color: inherit;
+    text-decoration: none;
+    color: colors.$kobo-dark-blue;
 
     &:hover {
-      text-decoration: none;
+      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
### 📣 Summary
Links inside `InlineMessage` are now dark blue with underline on hover.
