### PR TITLE
fix: update failing export test with correct default support email TASK-1264

### DIFF
--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -51,7 +51,7 @@ class ExportTaskInBackgroundTests(TestCase):
         mock_send_mail.assert_called_once_with(
             subject='Project View Report Complete',
             message=expected_message,
-            from_email='help@kobotoolbox.org',
+            from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=['test@example.com'],
             fail_silently=False,
         )


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

Bug template:
1. 🔴 [on main] notice that `test_export_task_success` is failing
2. 🟢 [on PR] notice that it passes

### 💭 Notes
This test was failing due to changes from #5242
