### PR TITLE
feat(Badge): add light-green and make label optional

### DIFF
--- a/jsapp/js/components/common/badge.module.scss
+++ b/jsapp/js/components/common/badge.module.scss
@@ -62,7 +62,11 @@ $badge-font-l: 14px;
   line-height: $size;
   font-size: $font;
   border-radius: $size * 0.5;
-  padding: 0 $size * 0.4;
+  padding: 0 $size * 0.2;
+
+  &.hasLabel {
+    padding: 0 $size * 0.4;
+  }
 
   .icon + .label {
     margin-left: $size * 0.15;

--- a/jsapp/js/components/common/badge.module.scss
+++ b/jsapp/js/components/common/badge.module.scss
@@ -50,6 +50,11 @@ $badge-font-l: 14px;
   background-color: colors.$kobo-light-teal;
 }
 
+.color-light-green {
+  color: colors.$kobo-dark-green;
+  background-color: colors.$kobo-light-green;
+}
+
 @mixin badge-size($size, $font) {
   // NOTE: icon size is already handled by badge.tsx file rendering proper <Icon> component
   height: $size;

--- a/jsapp/js/components/common/badge.stories.tsx
+++ b/jsapp/js/components/common/badge.stories.tsx
@@ -9,7 +9,9 @@ const badgeColors: BadgeColor[] = [
   'light-storm',
   'light-amber',
   'light-blue',
+  'light-red',
   'light-teal',
+  'light-green',
 ];
 const badgeSizes: BadgeSize[] = ['s', 'm', 'l'];
 

--- a/jsapp/js/components/common/badge.tsx
+++ b/jsapp/js/components/common/badge.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import cx from 'classnames';
-import {ButtonToIconMap} from 'js/components/common/button';
 import styles from './badge.module.scss';
 import type {IconName} from 'jsapp/fonts/k-icons';
 import Icon from './icon';
@@ -24,7 +23,8 @@ interface BadgeProps {
   color: BadgeColor;
   size: BadgeSize;
   icon?: IconName;
-  label: React.ReactNode;
+  /** Optional to allow icon-only badges */
+  label?: React.ReactNode;
   /**
    * Use it to ensure that the badge will always be display in whole. Without
    * this (the default behaviour) the badge will take as much space as it gets,
@@ -40,16 +40,21 @@ export default function Badge(props: BadgeProps) {
         styles.root,
         styles[`color-${props.color}`],
         styles[`size-${props.size}`],
-      ], {[styles.disableShortening]: props.disableShortening})}
+      ], {
+        [styles.disableShortening]: props.disableShortening,
+        [styles.hasLabel]: props.label !== undefined,
+      })}
     >
       {props.icon && (
         <Icon
-          size={ButtonToIconMap.get(props.size)}
+          size={BadgeToIconMap.get(props.size)}
           className={styles.icon}
           name={props.icon}
         />
       )}
-      <span className={styles.label}>{props.label}</span>
+      {props.label && (
+        <span className={styles.label}>{props.label}</span>
+      )}
     </div>
   );
 }

--- a/jsapp/js/components/common/badge.tsx
+++ b/jsapp/js/components/common/badge.tsx
@@ -11,7 +11,8 @@ export type BadgeColor =
   | 'light-amber'
   | 'light-blue'
   | 'light-red'
-  | 'light-teal';
+  | 'light-teal'
+  | 'light-green';
 export type BadgeSize = 'l' | 'm' | 's';
 
 export const BadgeToIconMap: Map<BadgeSize, IconSize> = new Map();


### PR DESCRIPTION
### Description

Add light-green color to Badge component. Make label optional. Update Badge stories to also include light-red color. Use existing BadgeToIconMap instead of ButtonToIconMap.