### PR TITLE
feat(organizations): check use_team_label in product metadata on frontend TASK-1249

### DIFF
--- a/jsapp/js/account/organizations/organizations.utils.tsx
+++ b/jsapp/js/account/organizations/organizations.utils.tsx
@@ -13,7 +13,7 @@ export function shouldUseTeamLabel(
 ) {
   if (subscription) {
     return (
-      subscription.items[0].price.product.metadata?.plan_type !== 'enterprise'
+      subscription.items[0].price.product.metadata?.use_team_label === 'true'
     );
   }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
We have updated stripe metadata in the Stripe testing environment so we can now use the 'use_team_label' field when checking how to label MMOs.


### 👀 Preview steps
1. Create an organization signed up for the professional teams plan.
2. Check account sidenav. It should show now display "team instead of organization"
