### PR TITLE
chore(eslint): allow leading underscore and in-between double underscore in snake_case

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,11 +144,16 @@ const tsRules = Object.assign({}, jsRules, {
       selector: 'variableLike',
       format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
     },
-    {selector: 'memberLike', format: ['camelCase', 'PascalCase', 'snake_case']},
     {selector: 'typeLike', format: ['PascalCase']},
     {
-      selector: 'property',
-      format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
+      selector: 'memberLike',
+      format: ['camelCase', 'PascalCase', 'snake_case'],
+      leadingUnderscore: 'allow',
+      filter: {
+        // Allow snake_case with in-between double underscores
+        regex: '^([a-zA-Z]+(?:_{1,2}[a-zA-Z]+)*)$',
+        match: false,
+      },
     },
     {selector: 'method', format: ['camelCase']},
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,7 +148,8 @@ const tsRules = Object.assign({}, jsRules, {
     {
       selector: 'memberLike',
       format: ['camelCase', 'PascalCase', 'snake_case'],
-      leadingUnderscore: 'allow',
+      leadingUnderscore: 'allowSingleOrDouble',
+      trailingUnderscore: 'allowSingleOrDouble',
       filter: {
         // Allow snake_case with in-between double underscores
         regex: '^([a-zA-Z]+(?:_{1,2}[a-zA-Z]+)*)$',
@@ -158,6 +159,8 @@ const tsRules = Object.assign({}, jsRules, {
     {
       selector: 'property',
       format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
+      leadingUnderscore: 'allowSingleOrDouble',
+      trailingUnderscore: 'allowSingleOrDouble',
       filter: {
         // Allow snake_case with in-between double underscores
         regex: '^([a-zA-Z]+(?:_{1,2}[a-zA-Z]+)*)$',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,6 +155,15 @@ const tsRules = Object.assign({}, jsRules, {
         match: false,
       },
     },
+    {
+      selector: 'property',
+      format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
+      filter: {
+        // Allow snake_case with in-between double underscores
+        regex: '^([a-zA-Z]+(?:_{1,2}[a-zA-Z]+)*)$',
+        match: false,
+      },
+    },
     {selector: 'method', format: ['camelCase']},
     {
       selector: [


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### Description
Allow leading and trailing underscore (or double underscore) and in-between double underscore in snake_case. This is needed to not display warnings on things that we receive from API calls.