### PR TITLE
fix(AccountSidebar): avoid top gap when scrollbar appears

### DIFF
--- a/jsapp/js/account/accountSidebar.module.scss
+++ b/jsapp/js/account/accountSidebar.module.scss
@@ -1,8 +1,7 @@
 @use 'scss/colors';
 
 .accountSidebar {
-  margin-top: 10px;
-  padding: 14px 20px 20px 0;
+  padding: 24px 20px 20px 0;
   overflow-y: auto;
   overflow-x: hidden;
   flex: 1;


### PR DESCRIPTION
### 💭 Notes
This tiny issue was introduced in #5118
