### PR TITLE
fix(MainHeader): disappearing on small screens

### DIFF
--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -222,9 +222,8 @@
 
 // Form title + desc in header, editable
 
-// On smaller screens we hide both of them
-.main-header .main-header__icon,
-.main-header {
+// On smaller screens we hide the icon
+.main-header .main-header__icon {
   display: none;
 }
 
@@ -287,8 +286,7 @@
 }
 
 @include breakpoints.breakpoint(mediumAndUp) {
-  .main-header .main-header__icon,
-  .main-header {
+  .main-header .main-header__icon {
     display: initial;
   }
 


### PR DESCRIPTION
### 💭 Notes
Fixes bug introduced in #5215 - instead of removing `.main-header .main-header__counter` line, it was changed to `.main-header`.