### PR TITLE
feat(organizations): hide organization fields from settings for mmo organizations - TASK-978

### DIFF
--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -20,7 +20,7 @@ import type {
 } from './account.constants';
 import {HELP_ARTICLE_ANON_SUBMISSIONS_URL} from 'js/constants';
 import {useSession} from '../stores/useSession';
-import {useOrganizationQuery} from './stripe.api';
+import {useOrganizationQuery} from './organization/organizationQuery';
 
 bem.AccountSettings = makeBem(null, 'account-settings', 'form');
 bem.AccountSettings__left = makeBem(bem.AccountSettings, 'left');
@@ -45,6 +45,7 @@ const AccountSettings = () => {
   const orgQuery = useOrganizationQuery();
 
   useEffect(() => {
+
     if (!currentLoggedAccount || !orgQuery.data) {
       return;
     }

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -74,8 +74,8 @@ const AccountSettings = () => {
 
     const organization = orgQuery.data;
 
-    // We will not display organization fields if it's and MMO organization
-    // in favor of only displaying those fields in organization settings view
+    // We will not display organization fields if user is a member of an MMO,
+    // only displaying these fields in organization settings view
     setDisplayedFields(
       !organization?.is_mmo
         ? fieldKeys


### PR DESCRIPTION
### 📣 Summary
Organization fields are not displayed anymore in setting screens for MMOs.

### 👀 Preview steps
Feature/no-change template:
1. ℹ️ have account
2. Go to "settings" view at `/#/account/settings`
3. Use the feature flag `?ff_mmoEnabled=true`
4. Set the organization as MMO
5. 🟢 Fields should not be displayed
6. Set the feature flag to false as in `?ff_mmoEnabled=false`
7. 🟢 Fields should be displayed again

### 💭 Notes
The 'organization', 'organization_type' and 'organization_website' are now being hidden when the current organization has the `is_mmo` flag.

