### PR TITLE
chore: remove unused import to pass flake8 on main

### DIFF
--- a/kobo/apps/hook/tasks.py
+++ b/kobo/apps/hook/tasks.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import time
 
-import constance
 from celery import shared_task
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection


### PR DESCRIPTION
### 👀 Preview steps

- 🔴 [on main] recent (but not related) PR failing 'darker' flake8 linter test due to unused import — [❌ #5264](https://github.com/kobotoolbox/kpi/actions/runs/11921554213/job/33277327577)
- 🟢 [on PR] i think this might fix it? — [✅ here](https://github.com/kobotoolbox/kpi/actions/runs/11939497061/job/33280140792?pr=5282)
