### PR TITLE
fix(account): icon name typo

### DIFF
--- a/jsapp/js/account/accountSidebar.tsx
+++ b/jsapp/js/account/accountSidebar.tsx
@@ -124,7 +124,7 @@ function renderMmoSidebar(
       <div className={styles.navGroup}>
         <div className={styles.subhead}>{mmoLabel.toUpperCase()}</div>
         <AccountNavLink
-          iconName='users'
+          iconName='user'
           name={t('Members')}
           to={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
         />
@@ -176,9 +176,7 @@ function AccountSidebar() {
     setIsStripeEnabled(true);
   }, [subscriptionStore.isInitialised]);
 
-  const showAddOnsLink = useMemo(() => {
-    return !subscriptionStore.planResponse.length;
-  }, [subscriptionStore.isInitialised]);
+  const showAddOnsLink = useMemo(() => !subscriptionStore.planResponse.length, [subscriptionStore.isInitialised]);
 
   const mmoLabel = getSimpleMMOLabel(
     envStore.data,


### PR DESCRIPTION
### 👀 Preview steps
1. ℹ️ launch frontend in watch mode
2. 🔴 [on main] notice typescript error
```
ERROR in ./jsapp/js/account/accountSidebar.tsx:127:11
TS2820: Type '"users"' is not assignable to type 'IconName'. Did you mean '"user"'?
    125 |         <div className={styles.subhead}>{mmoLabel.toUpperCase()}</div>
    126 |         <AccountNavLink
  > 127 |           iconName='users'
        |           ^^^^^^^^
    128 |           name={t('Members')}
    129 |           to={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
    130 |         />
```

3. 🟢 [on PR] notice no typescript errors


### 💭 Notes

Looks like a typo.