### PR TITLE
feat(organizations): auto-refresh on orgId change TASK-1247

### DIFF
--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -100,8 +100,8 @@ export const useOrganizationQuery = () => {
 
   // `organizationUrl` must exist, unless it's changed (e.g. user added/removed from organization).
   // In such case, refetch organizationUrl to fetch the new `organizationUrl`.
-  // TODO: don't throw toash within fetchGetUrl.
-  // TODO: don't retry the failing url 3-4 times before switching to the new url.
+  // DEBT: don't throw toast within fetchGetUrl.
+  // DEBT: don't retry the failing url 3-4 times before switching to the new url.
   useEffect(() => {
     if (query.error?.status === 404) {
       sessionStore.refreshAccount();

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -2,7 +2,7 @@ import {when} from 'mobx';
 import subscriptionStore from 'js/account/subscriptionStore';
 import {endpoints} from 'js/api.endpoints';
 import {ACTIVE_STRIPE_STATUSES} from 'js/constants';
-import type {PaginatedResponse} from 'js/dataInterface';
+import type {FailResponse, PaginatedResponse} from 'js/dataInterface';
 import envStore from 'js/envStore';
 import {fetchGet, fetchGetUrl, fetchPost} from 'jsapp/js/api';
 import type {
@@ -20,6 +20,7 @@ import {useQuery} from '@tanstack/react-query';
 import {QueryKeys} from 'js/query/queryKeys';
 import {FeatureFlag, useFeatureFlag} from '../featureFlags';
 import sessionStore from 'js/stores/session';
+import {useEffect} from 'react';
 
 const DEFAULT_LIMITS: AccountLimit = Object.freeze({
   submission_limit: Limits.unlimited,
@@ -91,11 +92,23 @@ export const useOrganizationQuery = () => {
     sessionStore.isInitialLoadComplete &&
     !!organizationUrl;
 
-  return useQuery({
+  const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
     queryFn: fetchOrganization,
     queryKey: [QueryKeys.organization],
     enabled: isQueryEnabled,
   });
+
+  // `organizationUrl` must exist, unless it's changed (e.g. user added/removed from organization).
+  // In such case, refetch organizationUrl to fetch the new `organizationUrl`.
+  // TODO: don't throw toash within fetchGetUrl.
+  // TODO: don't retry the failing url 3-4 times before switching to the new url.
+  useEffect(() => {
+    if (query.error?.status === 404) {
+      sessionStore.refreshAccount();
+    }
+  }, [query.error?.status]);
+
+  return query;
 };
 
 /**
@@ -121,7 +134,7 @@ export async function postCheckout(
  */
 export async function postCustomerPortal(
   organizationId: string,
-  priceId: string = '',
+  priceId = '',
   quantity = 1
 ) {
   return fetchPost<Checkout>(
@@ -247,7 +260,7 @@ const addRemainingOneTimeAddOnLimits = (
   oneTimeAddOns: OneTimeAddOn[]
 ) => {
   // This yields a separate object, so we need to make a copy
-  limits = {...limits}
+  limits = {...limits};
   oneTimeAddOns
     .filter((addon) => addon.is_available)
     .forEach((addon) => {
@@ -345,7 +358,7 @@ export async function getAccountLimits(
   }
 
   // create separate object with one-time addon limits added to the limits calculated so far
-  let remainingLimits = addRemainingOneTimeAddOnLimits(
+  const remainingLimits = addRemainingOneTimeAddOnLimits(
     recurringLimits,
     oneTimeAddOns
   );

--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -3,9 +3,9 @@ export const endpoints = {
   ORG_ASSETS_URL: '/api/v2/organizations/:organization_id/assets/',
   ME_URL: '/me/',
   PRODUCTS_URL: '/api/v2/stripe/products/',
-  SUBSCRIPTION_URL: '/api/v2/stripe/subscriptions/',
+  SUBSCRIPTION_URL: '/api/v2/stripe/subscriptions/', // TODO: unused, delete?
   ADD_ONS_URL: '/api/v2/stripe/addons/',
-  ORGANIZATION_URL: '/api/v2/organizations/',
+  ORGANIZATION_URL: '/api/v2/organizations/', // TODO: unused, delete?
   /** Expected parameters: price_id and organization_id **/
   CHECKOUT_URL: '/api/v2/stripe/checkout-link',
   /** Expected parameter: organization_id  **/

--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -3,9 +3,8 @@ export const endpoints = {
   ORG_ASSETS_URL: '/api/v2/organizations/:organization_id/assets/',
   ME_URL: '/me/',
   PRODUCTS_URL: '/api/v2/stripe/products/',
-  SUBSCRIPTION_URL: '/api/v2/stripe/subscriptions/', // TODO: unused, delete?
+  SUBSCRIPTION_URL: '/api/v2/stripe/subscriptions/',
   ADD_ONS_URL: '/api/v2/stripe/addons/',
-  ORGANIZATION_URL: '/api/v2/organizations/', // TODO: unused, delete?
   /** Expected parameters: price_id and organization_id **/
   CHECKOUT_URL: '/api/v2/stripe/checkout-link',
   /** Expected parameter: organization_id  **/
@@ -14,4 +13,4 @@ export const endpoints = {
   CHANGE_PLAN_URL: '/api/v2/stripe/change-plan',
   ACCESS_LOGS_URL: '/api/v2/access-logs/me',
   LOGOUT_ALL: '/logout-all/',
-};
+} as const;


### PR DESCRIPTION
### 📣 Summary

On organization change auto-refresh the new organization for logged-in user.



### 👀 Preview steps

1. ℹ️ have an account and MMO enabled organization (belonging to another user)
2. log in, keep tab open
3. switch to admin panel, add account to the organization
4. switch back to account tab, notice "No Organization matches the given query." error toast.
5. 🔴 [on main] notice that toast keep going forever once a second or so.
6. 🟢 [on PR] notice that toast stops after 3-4 instances.
