### PR TITLE
feat(organizations): handle query error once at root TASK-1271

### DIFF
--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
-import {ValidateOrgPermissions} from 'js/router/validateOrgPermissions.component';
+import {RequireOrgPermissions} from 'js/router/RequireOrgPermissions.component';
 import {OrganizationUserRole} from './stripe.types';
 import {
   ACCOUNT_ROUTES,
@@ -37,12 +37,12 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <ValidateOrgPermissions
+            <RequireOrgPermissions
               validRoles={[OrganizationUserRole.owner]}
               redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
             >
               <PlansRoute />
-            </ValidateOrgPermissions>
+            </RequireOrgPermissions>
           </RequireAuth>
         }
       />
@@ -51,12 +51,12 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <ValidateOrgPermissions
+            <RequireOrgPermissions
               validRoles={[OrganizationUserRole.owner]}
               redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
             >
               <AddOnsRoute />
-            </ValidateOrgPermissions>
+            </RequireOrgPermissions>
           </RequireAuth>
         }
       />
@@ -65,7 +65,7 @@ export default function routes() {
         index
         element={
           <RequireAuth>
-            <ValidateOrgPermissions
+            <RequireOrgPermissions
               validRoles={[
                 OrganizationUserRole.owner,
                 OrganizationUserRole.admin,
@@ -73,7 +73,7 @@ export default function routes() {
               redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
             >
               <DataStorage activeRoute={ACCOUNT_ROUTES.USAGE} />
-            </ValidateOrgPermissions>
+            </RequireOrgPermissions>
           </RequireAuth>
         }
       />
@@ -81,7 +81,7 @@ export default function routes() {
         path={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}
         element={
           <RequireAuth>
-            <ValidateOrgPermissions
+            <RequireOrgPermissions
               validRoles={[
                 OrganizationUserRole.owner,
                 OrganizationUserRole.admin,
@@ -91,7 +91,7 @@ export default function routes() {
               <DataStorage
                 activeRoute={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}
               />
-            </ValidateOrgPermissions>
+            </RequireOrgPermissions>
           </RequireAuth>
         }
       />
@@ -117,12 +117,12 @@ export default function routes() {
             path={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
             element={
               <RequireAuth>
-                <ValidateOrgPermissions
+                <RequireOrgPermissions
                   mmoOnly
                   redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
                 >
                   <div>Organization members view to be implemented</div>
-                </ValidateOrgPermissions>
+                </RequireOrgPermissions>
               </RequireAuth>
             }
           />
@@ -130,7 +130,7 @@ export default function routes() {
             path={ACCOUNT_ROUTES.ORGANIZATION_SETTINGS}
             element={
               <RequireAuth>
-                <ValidateOrgPermissions
+                <RequireOrgPermissions
                   validRoles={[
                     OrganizationUserRole.owner,
                     OrganizationUserRole.admin,
@@ -139,7 +139,7 @@ export default function routes() {
                   redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
                 >
                   <OrganizationSettingsRoute />
-                </ValidateOrgPermissions>
+                </RequireOrgPermissions>
               </RequireAuth>
             }
           />

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -16,6 +16,7 @@ import type {
 } from 'js/account/stripe.types';
 import {Limits} from 'js/account/stripe.types';
 import {getAdjustedQuantityForPrice} from 'js/account/stripe.utils';
+import type {UndefinedInitialDataOptions} from '@tanstack/react-query';
 import {useQuery} from '@tanstack/react-query';
 import {QueryKeys} from 'js/query/queryKeys';
 import {FeatureFlag, useFeatureFlag} from '../featureFlags';
@@ -58,7 +59,12 @@ export async function changeSubscription(
   });
 }
 
-export const useOrganizationQuery = () => {
+/**
+ * Organization object is used globally.
+ * For convenience, errors are handled once at the top, see `RequireOrg`.
+ * No need to handle errors at every usage.
+ */
+export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<Organization, FailResponse, Organization, QueryKeys[]>, 'queryFn' | 'queryKey'>) => {
   const isMmosEnabled = useFeatureFlag(FeatureFlag.mmosEnabled);
 
   const currentAccount = sessionStore.currentAccount;
@@ -93,9 +99,10 @@ export const useOrganizationQuery = () => {
     !!organizationUrl;
 
   const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
+    ...options,
     queryFn: fetchOrganization,
     queryKey: [QueryKeys.organization],
-    enabled: isQueryEnabled,
+    enabled: isQueryEnabled && options?.enabled !== false,
   });
 
   // `organizationUrl` must exist, unless it's changed (e.g. user added/removed from organization).

--- a/jsapp/js/app.jsx
+++ b/jsapp/js/app.jsx
@@ -30,9 +30,10 @@ import {isAnyProcessingRouteActive} from 'js/components/processing/routes.utils'
 import pageState from 'js/pageState.store';
 
 // Query-related
-import { QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { queryClient } from './query/queryClient.ts'
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from './query/queryClient.ts';
+import { RequireOrg } from './router/RequireOrg';
 
 class App extends React.Component {
   constructor(props) {
@@ -107,42 +108,44 @@ class App extends React.Component {
       <DocumentTitle title='KoboToolbox'>
         <QueryClientProvider client={queryClient}>
           <RootContextProvider>
-            <Tracking />
-            <ToasterConfig />
+            <RequireOrg>
+              <Tracking />
+              <ToasterConfig />
 
-            {this.shouldDisplayMainLayoutElements() &&
-              <div className='header-stretch-bg' />
-            }
+              {this.shouldDisplayMainLayoutElements() &&
+                <div className='header-stretch-bg' />
+              }
 
-            <bem.PageWrapper
-              m={pageWrapperModifiers}
-              className='mdl-layout mdl-layout--fixed-header'
-            >
-              {this.state.pageState.modal && (
-                <BigModal params={this.state.pageState.modal} />
-              )}
-
-              {this.shouldDisplayMainLayoutElements() && (
-                <>
-                  <MainHeader assetUid={assetid} />
-                  <Drawer />
-                </>
-              )}
-
-              <bem.PageWrapper__content
-                className='mdl-layout__content'
-                m={pageWrapperContentModifiers}
+              <bem.PageWrapper
+                m={pageWrapperModifiers}
+                className='mdl-layout mdl-layout--fixed-header'
               >
+                {this.state.pageState.modal && (
+                  <BigModal params={this.state.pageState.modal} />
+                )}
+
                 {this.shouldDisplayMainLayoutElements() && (
                   <>
-                    {this.isFormSingle() && <ProjectTopTabs />}
-                    <FormViewSideTabs show={this.isFormSingle()} />
+                    <MainHeader assetUid={assetid} />
+                    <Drawer />
                   </>
                 )}
 
-                <Outlet />
-              </bem.PageWrapper__content>
-            </bem.PageWrapper>
+                <bem.PageWrapper__content
+                  className='mdl-layout__content'
+                  m={pageWrapperContentModifiers}
+                >
+                  {this.shouldDisplayMainLayoutElements() && (
+                    <>
+                      {this.isFormSingle() && <ProjectTopTabs />}
+                      <FormViewSideTabs show={this.isFormSingle()} />
+                    </>
+                  )}
+
+                  <Outlet />
+                </bem.PageWrapper__content>
+              </bem.PageWrapper>
+            </RequireOrg>
           </RootContextProvider>
 
 

--- a/jsapp/js/projects/routes.tsx
+++ b/jsapp/js/projects/routes.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Navigate, Route} from 'react-router-dom';
 import RequireAuth from 'js/router/requireAuth';
 import {PROJECTS_ROUTES} from 'js/router/routerConstants';
-import {ValidateOrgPermissions} from 'js/router/validateOrgPermissions.component';
+import {RequireOrgPermissions} from 'js/router/RequireOrgPermissions.component';
 
 const MyProjectsRoute = React.lazy(
   () => import(/* webpackPrefetch: true */ './myProjectsRoute')
@@ -33,12 +33,12 @@ export default function routes() {
         path={PROJECTS_ROUTES.MY_ORG_PROJECTS}
         element={
           <RequireAuth>
-            <ValidateOrgPermissions
+            <RequireOrgPermissions
               mmoOnly
               redirectRoute={PROJECTS_ROUTES.MY_PROJECTS}
             >
               <MyOrgProjectsRoute />
-            </ValidateOrgPermissions>
+            </RequireOrgPermissions>
           </RequireAuth>
         }
       />

--- a/jsapp/js/router/RequireOrg.tsx
+++ b/jsapp/js/router/RequireOrg.tsx
@@ -1,0 +1,20 @@
+import type React from 'react';
+import LoadingSpinner from 'js/components/common/loadingSpinner';
+import {useOrganizationQuery} from 'js/account/stripe.api';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+/**
+ * Organization object is used globally.
+ * Handle error once at the top for convenience to avoid error handling every time.
+ */
+export const RequireOrg = ({children}: Props) => {
+  const orgQuery = useOrganizationQuery();
+
+  if (orgQuery.isPending) {return <LoadingSpinner />;}
+  if (orgQuery.error) {return <LoadingSpinner />;} // TODO: Nicier error page.
+
+  return children;
+};

--- a/jsapp/js/router/RequireOrgPermissions.component.tsx
+++ b/jsapp/js/router/RequireOrgPermissions.component.tsx
@@ -1,4 +1,5 @@
-import React, {Suspense, useEffect} from 'react';
+import type React from 'react';
+import {Suspense, useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 import {useOrganizationQuery} from 'js/account/stripe.api';
@@ -16,7 +17,7 @@ interface Props {
  * or members of MMOs. Defaults to allowing access for all users, so you must supply
  * any restrictions.
  */
-export const ValidateOrgPermissions = ({
+export const RequireOrgPermissions = ({
   children,
   redirectRoute,
   validRoles = undefined,


### PR DESCRIPTION
### 📣 Summary

Display full-screen spinner if organizations endpoint returns an error.

### 👀 Preview steps

1. ℹ️ have an account and MMO enabled organization (belonging to another user)
2. log in, keep tab open
3. switch to admin panel, add account to the organization
4. switch back to account tab, notice "No Organization matches the given query." error toast.
5. 🔴 [on main] notice that toast keep going forever once a second or so.
6. 🟢 [on PR] notice the brief moment of spinner view after error toasts and before fetching the new value.

### 💭 Notes

1. Nice error screen is out of scope.
2. I think we should do the same with few other global queries.