### PR TITLE
feat(docker): Add PYTHONUNBUFFERED to Dockerfile TASK-1303

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV KPI_LOGS_DIR=/srv/logs \
     TMP_DIR=/srv/tmp \
     UWSGI_USER=kobo \
     UWSGI_GROUP=kobo \
-    INIT_PATH=/srv/init
+    INIT_PATH=/srv/init \
+    PYTHONUNBUFFERED=1
 
 ##########################################
 # Create build directories               #


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 📖 Description

Default docker image to PYTHONUNBUFFERED mode as recommended for Docker environments

### 💭 Notes

Can replace setting PYTHONUNBUFFERED in kobo-helm-chart, kobo-docker, and kobo-compose. Anyone using the Dockerfile, is inherently using Docker and should set this.