### PR TITLE
chore: remove deprecated imports

### DIFF
--- a/kobo/apps/accounts/tests/test_backend.py
+++ b/kobo/apps/accounts/tests/test_backend.py
@@ -102,5 +102,5 @@ class SSOLoginTest(TestCase):
         self.assertTrue(response.wsgi_request.user.is_authenticated)
         # Ensure there is a record of the login
         audit_log: AuditLog = AuditLog.objects.filter(user=response.wsgi_request.user).first()
-        self.assertEquals(audit_log.action, AuditAction.AUTH)
+        self.assertEqual(audit_log.action, AuditAction.AUTH)
         assert response.wsgi_request.user.backend == settings.AUTHENTICATION_BACKENDS[0]

--- a/kobo/apps/audit_log/tests/test_models.py
+++ b/kobo/apps/audit_log/tests/test_models.py
@@ -80,7 +80,7 @@ class AccessLogModelTestCase(BaseAuditLogTestCase):
             date_created=yesterday,
         )
         self._check_common_fields(log, AccessLogModelTestCase.super_user)
-        self.assertEquals(log.date_created, yesterday)
+        self.assertEqual(log.date_created, yesterday)
         self.assertDictEqual(log.metadata, {'foo': 'bar'})
 
     @patch('kobo.apps.audit_log.models.logging.warning')

--- a/kobo/apps/audit_log/tests/test_signals.py
+++ b/kobo/apps/audit_log/tests/test_signals.py
@@ -76,7 +76,7 @@ class AuditLogSignalsTestCase(BaseTestCase):
         }
         self.client.post(reverse('kobo_login'), data=data, follow=True)
         # no audit log should be created yet because the email has not been verified
-        self.assertEquals(AuditLog.objects.count(), 0)
+        self.assertEqual(AuditLog.objects.count(), 0)
         # verify the email and try again
         email: EmailAddress = EmailAddress.objects.filter(user=user).first()
         email.verified = True

--- a/kobo/apps/help/views.py
+++ b/kobo/apps/help/views.py
@@ -1,8 +1,3 @@
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
-
 from django.db.models import Q
 from django.utils import timezone
 from private_storage.views import PrivateStorageView

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
@@ -1,9 +1,5 @@
 from datetime import datetime
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.http import Http404

--- a/kobo/apps/openrosa/apps/logger/tests/models/test_instance.py
+++ b/kobo/apps/openrosa/apps/logger/tests/models/test_instance.py
@@ -1,12 +1,10 @@
-# coding: utf-8
 import os
 import reversion
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from dateutil import parser
 from django_digest.test import DigestAuth
-from mock import patch
-
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.logger.models import XForm, Instance
 from kobo.apps.openrosa.apps.logger.models.instance import (

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
@@ -1,12 +1,12 @@
 # coding: utf-8
 import os
 import re
+from unittest.mock import patch
 
 from django.http import Http404
 from django_digest.test import DigestAuth
 from django_digest.test import Client as DigestClient
 from kobo.apps.openrosa.libs.utils.guardian import assign_perm
-from mock import patch
 
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase

--- a/kobo/apps/openrosa/apps/viewer/tasks.py
+++ b/kobo/apps/openrosa/apps/viewer/tasks.py
@@ -3,10 +3,7 @@ import logging
 import re
 import sys
 from datetime import datetime, timedelta
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from celery import shared_task
 from django.conf import settings

--- a/kobo/apps/openrosa/libs/data/tests/test_tools.py
+++ b/kobo/apps/openrosa/libs/data/tests/test_tools.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 import os
 from datetime import datetime, timedelta, date
+from unittest.mock import patch
 
 from django.conf import settings
-from mock import patch
 
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase

--- a/kobo/apps/openrosa/libs/mixins/openrosa_headers_mixin.py
+++ b/kobo/apps/openrosa/libs/mixins/openrosa_headers_mixin.py
@@ -1,9 +1,5 @@
-# coding: utf-8
 from datetime import datetime
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -10,11 +10,7 @@ from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
 from xml.etree import ElementTree as ET
 from xml.parsers.expat import ExpatError
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from wsgiref.util import FileWrapper
 from xml.dom import Node

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -1,11 +1,6 @@
 import timeit
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
-
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 from dateutil.relativedelta import relativedelta

--- a/kobo/apps/subsequences/actions/base.py
+++ b/kobo/apps/subsequences/actions/base.py
@@ -1,9 +1,5 @@
 import datetime
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.utils import timezone
 

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -5,11 +5,7 @@ from contextlib import contextmanager
 from datetime import date, datetime
 from typing import Generator, Literal, Optional, Union
 from urllib.parse import urlparse
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import redis.exceptions
 import requests

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import base64
 import datetime
 import os
@@ -9,15 +8,10 @@ from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
 from typing import Dict, Generator, List, Optional, Tuple
-
-import dateutil.parser
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import constance
+import dateutil.parser
 import formpack
 import requests
 from django.conf import settings
@@ -26,6 +20,7 @@ from django.core.files.storage import FileSystemStorage
 from django.db import models, transaction
 from django.db.models import F
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext as t
 from formpack.constants import KOBO_LOCK_SHEET
 from formpack.schema.fields import (
@@ -489,7 +484,7 @@ class ProjectViewExportTask(ImportExportTask):
     def _build_export_filename(
         self, export_type: str, username: str, view: str
     ) -> str:
-        time = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+        time = timezone.now().strftime('%Y-%m-%dT%H:%M:%SZ')
         return f'{export_type}-{username}-view_{view}-{time}.csv'
 
     def _run_task(self, messages: list) -> None:

--- a/kpi/serializers/v2/user.py
+++ b/kpi/serializers/v2/user.py
@@ -1,8 +1,4 @@
-# coding: utf-8
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django_request_cache import cache_for_request

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -1,12 +1,7 @@
-# coding: utf-8
 import json
 from copy import deepcopy
 from datetime import datetime
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 from django.utils import timezone

--- a/kpi/tests/test_deployment_backends.py
+++ b/kpi/tests/test_deployment_backends.py
@@ -184,7 +184,8 @@ class MockDeployment(TestCase):
             ).first()
 
             assert default_kobocat_storage.exists(str(meta_data.data_file))
-            assert not default_storage.exists(str(meta_data.data_file))
+            if default_storage.__class__.__name__ == 'FileSystemStorage':
+                assert not default_storage.exists(str(meta_data.data_file))
 
             with default_kobocat_storage.open(
                 str(meta_data.data_file), 'r'

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -1,9 +1,9 @@
-import datetime
 from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
+from django.utils import timezone
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.models.import_export_task import ProjectViewExportTask
@@ -46,7 +46,7 @@ class ExportTaskInBackgroundTests(TestCase):
             root_url,
             self.user.username,
             self.user.username,
-            datetime.datetime.now().strftime('%Y-%m-%dT%H%M%SZ'),
+            timezone.now().strftime('%Y-%m-%dT%H%M%SZ'),
         )
         mock_send_mail.assert_called_once_with(
             subject='Project View Report Complete',

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -1,15 +1,10 @@
 # flake8: noqa: F401
+import datetime
 import os
 import zipfile
 from collections import defaultdict
-
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
-
-import datetime
 from unittest import mock
+from zoneinfo import ZoneInfo
 
 import openpyxl
 from django.conf import settings

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from django.conf import settings
 
@@ -9,8 +9,7 @@ from kobo.celery import celery_app
 from kpi.constants import NESTED_MONGO_RESERVED_ATTRIBUTES
 from kpi.utils.strings import base64_encodestring
 
-# use `dict` when Python 3.8 is dropped
-PermissionFilter = Dict[str, Any]
+PermissionFilter = dict[str, Any]
 
 
 def drop_mock_only(func):

--- a/kpi/views/v2/open_rosa.py
+++ b/kpi/views/v2/open_rosa.py
@@ -1,9 +1,5 @@
-# coding: utf-8
 from datetime import datetime
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from rest_framework import status


### PR DESCRIPTION
### 📣 Summary
This PR removes imports that:
- Were marked as deprecated in previous versions in Python 3.8
- Are no longer supported in the Python 3.1x 