### PR TITLE
refactor(organizations): add of useSession hook TASK-1305 

### DIFF
--- a/jsapp/js/stores/useSession.tsx
+++ b/jsapp/js/stores/useSession.tsx
@@ -8,13 +8,13 @@ import type {AccountResponse} from '../dataInterface';
  * This hook provides a way to access teh current logged account, information
  * regarding the anonymous state of the login and session methods.
  *
- * This hook uses mob-x reactions to track the current account and update the
+ * This hook uses MobX reactions to track the current account and update the
  * state accordingly.
  * In the future we should update this hook to use react-query and drop the usage of mob-x
  */
 export const useSession = () => {
-
-  const [currentLoggedAccount, setCurrentLoggedAccount] = useState<AccountResponse>();
+  const [currentLoggedAccount, setCurrentLoggedAccount] =
+    useState<AccountResponse>();
   const [isAnonymous, setIsAnonymous] = useState<boolean>(true);
   const [isPending, setIsPending] = useState<boolean>(false);
 
@@ -29,7 +29,8 @@ export const useSession = () => {
           setIsAnonymous(false);
           setIsPending(sessionStore.isPending);
         }
-      }, {fireImmediately: true}
+      },
+      {fireImmediately: true}
     );
 
     return () => {
@@ -45,5 +46,4 @@ export const useSession = () => {
     logOutAll: sessionStore.logOutAll.bind(sessionStore),
     refreshAccount: sessionStore.refreshAccount.bind(sessionStore),
   };
-
 };

--- a/jsapp/js/stores/useSession.tsx
+++ b/jsapp/js/stores/useSession.tsx
@@ -1,0 +1,44 @@
+import sessionStore from './session';
+import {useEffect, useState} from 'react';
+import {reaction} from 'mobx';
+import type {AccountResponse} from '../dataInterface';
+
+
+export const useSession = () => {
+
+  const [currentLoggedAccount, setCurrentLoggedAccount] = useState<AccountResponse>();
+  const [isAnonymous, setIsAnonymous] = useState<boolean>(true);
+  const [isPending, setIsPending] = useState<boolean>(false);
+
+  useEffect(() => {
+    // using mobx reaction in the hook (the reaction can be used anywhere)
+
+    const reactionDisposer = reaction(
+      // should pass the required store.
+      // Could be done by DI, direct instance injection
+      // or passing into hook from the parent component etc.
+      () => sessionStore,
+      (session) => {
+        setIsPending(session.isPending);
+        if (session.isLoggedIn) {
+          setCurrentLoggedAccount(session.currentAccount as AccountResponse);
+          setIsAnonymous(false);
+        }
+      }, {fireImmediately: true}
+    );
+
+    return () => {
+      reactionDisposer();
+    };
+  }, []);
+
+  return {
+    currentLoggedAccount,
+    isAnonymous,
+    isPending,
+    logOut: sessionStore.logOut,
+    logOutAll: sessionStore.logOutAll,
+    refreshAccount: sessionStore.refreshAccount,
+  };
+
+};


### PR DESCRIPTION
### 👀 Preview steps
No behavior will change with this implementation, but it can be tested by using the new hook somewhere.
As a test I've modified `MyProjectRoute` to verify that `currentLoggedAccount` was properly dispatching component re-render and that using hooks methods are working properly as well:
```typescript
...
export default function MyProjectsRoute() {

  const [counter, setCounter] = React.useState(0);

  const {currentLoggedAccount, refreshAccount} = useSession();

  useEffect(() => {
    setCounter((prev) => prev + 1);
  }, [currentLoggedAccount]);

  return (
    <>
    <button onClick={refreshAccount}>Refresh {counter} - {currentLoggedAccount?.username}</button>
    <UniversalProjectsRoute
...
```
Result:
![KPI_5303](https://github.com/user-attachments/assets/be5f9c7f-ce37-459b-90a7-9848bb88db7d)

### 💭 Notes

- This PR adds the `useSession` hook, aimed to be used instead of the current `sessionStore` class to access the session data and methods.
- The `useSession` hook returns the `currentLoggedAccount` user, which is already filtered to be an existent account returned from the `/me` endpoint and verified not to be an anonymous account, which is currently done in several places around the codebase where the `currentAccount` from `sessionStore` is used.
- The internal implementation of this hook will eventually migrate to use `react-query`, keeping the hook's signature.
- This implementation can be used as a base for the migration of the other existing stores to allow for future dropping of `mob-x` in favor of using react-query to cache data.
- First usage of this hook can be seen in https://github.com/kobotoolbox/kpi/pull/5290
