### PR TITLE
ci(darker): improve comparison refs for focused errors

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -26,7 +26,7 @@ jobs:
           # Run darker only on file changes introduced in this PR.
           # Allows incremental adoption of linter rules on a per-file basis.
 
-          # For this scenario:
+          # Prevents this scenario:
           #  - PR A is opened, modifying file A; CI passes.
           #  - PR B is opened & merged, with linter errors in file B.
           #  - PR A is updated again, modifying file A. CI fails from file B.
@@ -45,6 +45,6 @@ jobs:
           output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH)
 
           # darker still exits with code 1 even with no errors on changes
-          # So, make this 'fail' CI only if there is output from darker.
+          # So, make this fail CI only if there is output from darker.
           [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
         shell: /usr/bin/bash {0}

--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 100
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -22,8 +22,9 @@ jobs:
       # annotations with string, e.g. def my_method(my_model: 'ModelName')
 
       # darker still exit with code 1 even with no errors on changes
-      - name: Run Darker with base commit
+      - name: Run Darker with tip of base branch
         run: |
-          output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r ${{ github.event.pull_request.base.sha }})
+          LATEST_IN_BASE_BRANCH=$(git rev-parse ${{ github.sha }}^@ | grep -Fvx ${{ github.event.pull_request.head.sha}})
+          output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH)
           [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
         shell: /usr/bin/bash {0}

--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -8,6 +8,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # In addition to checking out the 'merge commit', we also want to
+          # fetch enough commits to find the most recent commit in the base
+          # branch (typically 'main')
           fetch-depth: 100
 
       - name: Set up Python
@@ -18,13 +21,30 @@ jobs:
       - name: Install pip dependencies
         run: python -m pip install darker[isort] flake8 flake8-quotes isort --quiet
 
-      # use `--ignore=F821` to avoid raising false positive error in typing
-      # annotations with string, e.g. def my_method(my_model: 'ModelName')
-
-      # darker still exit with code 1 even with no errors on changes
-      - name: Run Darker with tip of base branch
+      - name: Run Darker, comparing '${{github.ref_name}}' with the latest in '${{github.event.pull_request.base.ref}}'
         run: |
-          LATEST_IN_BASE_BRANCH=$(git rev-parse ${{ github.sha }}^@ | grep -Fvx ${{ github.event.pull_request.head.sha}})
+          # Run darker only on file changes introduced in this PR.
+          # Allows incremental adoption of linter rules on a per-file basis.
+
+          # For this scenario:
+          #  - PR A is opened, modifying file A; CI passes.
+          #  - PR B is opened & merged, with linter errors in file B.
+          #  - PR A is updated again, modifying file A. CI fails from file B.
+          # Get the latest commit in the base branch (usually 'main') at time of
+          # CI run, to compare with this PR's merge branch.
+          # GitHub doesn't provide a nice name for this SHA, but we can find it:
+          # https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/#extracting-the-base-sha
+          MERGE_PARENTS=($(git rev-list --parents -1 ${{ github.sha }}))
+          LATEST_IN_BASE_BRANCH=${MERGE_PARENTS[1]}
+
+          # Run darker. (https://github.com/akaihola/darker)
+          # -L runs the linter
+          #  `--ignore=F821` avoids raising false positive error in typing
+          #   annotations with string, e.g. def my_method(my_model: 'ModelName')
+          # -r REV specifies a commit to compare with the worktree
           output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH)
+
+          # darker still exits with code 1 even with no errors on changes
+          # So, make this 'fail' CI only if there is output from darker.
           [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
         shell: /usr/bin/bash {0}


### PR DESCRIPTION
### 👀 Preview steps

1. 🔴 run darker on a branch with an old base ref. 
    - [darker fails (from changes in main) ❌](https://github.com/kobotoolbox/kpi/actions/runs/12101616979/job/33741677418?pr=5295)
 2. 🟢 after this fix
     - [darker passes (no .py files changed on that pr branch) ✅](https://github.com/kobotoolbox/kpi/actions/runs/12101731195/job/33741915134?pr=5295)
3. 🟢 edit tasks.py to break a flake8 rule
    - [darker fails, but only for tasks.py, not other  ✔️](https://github.com/kobotoolbox/kpi/actions/runs/12101753387/job/33741965750?pr=5295)

Screenshots from test commits in #5295

1. <details><summary>🔴🖼️ unrelated files linted</summary><img src="https://github.com/user-attachments/assets/8736ff0f-d7e3-4700-be53-15aaf02bbd98"/></details>
2. <details><summary>🟢🖼️ no unrelated files linted</summary><img src="https://github.com/user-attachments/assets/205bd2ce-ac34-455c-9809-a859e103acf4"/></details>
3.  <details><summary>🟢🖼️ related file(s) linted</summary><img src="https://github.com/user-attachments/assets/fa7ea70c-f122-47be-9d52-04dde739cbe5"/></details>

### 💭 Notes

Change which commits we compare in **darker.yml** so that their diffs don't include changes introduced by other branches.

**More detailed explanation [here](https://github.com/kobotoolbox/kpi/pull/5282#issuecomment-2489489645)**

xref [internal chat](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Python.20formating.20and.20linters/near/461640) 