### PR TITLE
feat(projectHistoryLogs): record logs for transfering ownership TASK-944

### DIFF
--- a/kobo/apps/audit_log/audit_actions.py
+++ b/kobo/apps/audit_log/audit_actions.py
@@ -38,3 +38,4 @@ class AuditAction(models.TextChoices):
     UPDATE_NAME = 'update-name'
     UPDATE_SETTINGS = 'update-settings'
     UPDATE_QA = 'update-qa'
+    TRANSFER = 'transfer'

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -17,6 +17,7 @@ from kobo.apps.audit_log.tests.test_models import BaseAuditLogTestCase
 from kobo.apps.hook.models import Hook
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import (
+    ASSET_TYPE_TEMPLATE,
     CLONE_ARG_NAME,
     PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_SUBMISSIONS,
@@ -1302,3 +1303,60 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_subtype=PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
         )
         self.assertEqual(log_metadata['cloned_from'], second_asset.uid)
+
+    def test_transfer_creates_log(self):
+        log_metadata = self._base_project_history_log_test(
+            method=self.client.post,
+            url=reverse(
+                'api_v2:project-ownership-invite-list',
+            ),
+            request_data={
+                'recipient': reverse(
+                    'api_v2:user-kpi-detail', kwargs={'username': 'someuser'}
+                ),
+                'assets': [self.asset.uid],
+            },
+            expected_action=AuditAction.TRANSFER,
+            expected_subtype=PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+        )
+        self.assertEqual(log_metadata['username'], 'someuser')
+
+    def test_transfer_multiple_creates_logs(self):
+        second_asset = Asset.objects.get(pk=2)
+        # make admin the owner of the other asset so we can transfer it
+        second_asset.owner = self.user
+        second_asset.save()
+        self.client.post(
+            path=reverse('api_v2:project-ownership-invite-list'),
+            data={
+                'recipient': reverse(
+                    'api_v2:user-kpi-detail', kwargs={'username': 'someuser'}
+                ),
+                'assets': [self.asset.uid, second_asset.uid],
+            },
+        )
+        self.assertEqual(ProjectHistoryLog.objects.count(), 2)
+        first_log = ProjectHistoryLog.objects.filter(
+            metadata__asset_uid=self.asset.uid, action=AuditAction.TRANSFER
+        )
+        self.assertTrue(first_log.exists())
+        second_log = ProjectHistoryLog.objects.filter(
+            metadata__asset_uid=second_asset.uid, action=AuditAction.TRANSFER
+        )
+        self.assertTrue(second_log.exists())
+
+    def test_no_log_created_for_non_project_transfer(self):
+        new_asset = Asset.objects.create(
+            owner=self.user,
+            asset_type=ASSET_TYPE_TEMPLATE,
+        )
+        self.client.post(
+            path=reverse('api_v2:project-ownership-invite-list'),
+            data={
+                'recipient': reverse(
+                    'api_v2:user-kpi-detail', kwargs={'username': 'someuser'}
+                ),
+                'assets': [new_asset.uid],
+            },
+        )
+        self.assertEqual(ProjectHistoryLog.objects.count(), 0)

--- a/kobo/apps/project_ownership/views/invite.py
+++ b/kobo/apps/project_ownership/views/invite.py
@@ -1,12 +1,12 @@
-from rest_framework import viewsets
 
 from kpi.permissions import IsAuthenticated
+from ...audit_log.base_views import AuditLoggedModelViewSet
 from ..filters import InviteFilter
 from ..models import Invite
 from ..serializers import InviteSerializer
 
 
-class InviteViewSet(viewsets.ModelViewSet):
+class InviteViewSet(AuditLoggedModelViewSet):
     """
     ## List of invites
 
@@ -225,6 +225,8 @@ class InviteViewSet(viewsets.ModelViewSet):
     serializer_class = InviteSerializer
     permission_classes = (IsAuthenticated,)
     filter_backends = (InviteFilter, )
+    log_type = 'project-history'
+    logged_fields = ['recipient.username', 'status', 'transfers']
 
     def get_queryset(self):
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Record project history logs for project ownership transfers.


### 👀 Preview steps


Feature/no-change template:
1. ℹ️ Have at least 2 users and a project
2. Go to Project > Settings > Sharing
3. Transfer ownership to user2
4. Go to `http://localhost/api/v2/audit-logs/?q=log_type:project-history AND metadata__asset_uid:<asset_uid>&format=json`
6. 🟢 There should be a new log with action="transfer" and the usual metadata, plus an additional `metadata.username = "user2"` field


### 💭 Notes
This does not rely on the transfer being successful/accepted. We want to log any attempt to transfer. Canceled requests will be handled in v2.
