### PR TITLE
feat(organization): restrict user management to organization form

### DIFF
--- a/kobo/apps/organizations/admin/__init__.py
+++ b/kobo/apps/organizations/admin/__init__.py
@@ -1,6 +1,5 @@
 from .organization import OrgAdmin
-from .organization_invite import OrgInvitationAdmin
 from .organization_owner import OrgOwnerAdmin
 from .organization_user import OrgUserAdmin
 
-__all__ = ['OrgAdmin', 'OrgOwnerAdmin', 'OrgInvitationAdmin', 'OrgUserAdmin']
+__all__ = ['OrgAdmin', 'OrgOwnerAdmin', 'OrgUserAdmin']

--- a/kobo/apps/organizations/admin/organization_invite.py
+++ b/kobo/apps/organizations/admin/organization_invite.py
@@ -1,8 +1,0 @@
-from django.contrib import admin
-
-from ..models import OrganizationInvitation
-
-
-@admin.register(OrganizationInvitation)
-class OrgInvitationAdmin(admin.ModelAdmin):
-    pass

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -40,7 +40,8 @@ OrganizationRole = Literal[
 class Organization(AbstractOrganization):
     id = KpiUidField(uid_prefix='org', primary_key=True)
     mmo_override = models.BooleanField(
-        default=False, verbose_name='Make organization multi-member (necessary for adding users)'
+        default=False,
+        verbose_name='Make organization multi-member (necessary for adding users)'
     )
 
     def add_user(self, user, is_admin=False):

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -40,7 +40,7 @@ OrganizationRole = Literal[
 class Organization(AbstractOrganization):
     id = KpiUidField(uid_prefix='org', primary_key=True)
     mmo_override = models.BooleanField(
-        default=False, verbose_name='Multi-members override'
+        default=False, verbose_name='Make organization multi-member (necessary for adding users)'
     )
 
     def add_user(self, user, is_admin=False):
@@ -219,7 +219,7 @@ class Organization(AbstractOrganization):
 class OrganizationUser(AbstractOrganizationUser):
 
     def __str__(self):
-        return f'<OrganizationUser #{self.pk}: {self.user.username}>'
+        return f'{self.user.username} (#{self.pk})'
 
     @property
     def active_subscription_statuses(self):


### PR DESCRIPTION
### 📣 Summary
Limit user management (add/edit) exclusively to the organization form in (Django) admin interface


### 📖 Description
This PR removes the ability to add or edit users outside the organization form. It ensures centralized and consistent user management within the organization.
Updated relevant components and endpoints to enforce this restriction.

### 💭 Notes
Organization invitations section has also been removed (until further notice).
