### PR TITLE
Restrict email updates to organization owners and admins only

### DIFF
--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -1,5 +1,6 @@
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
+from django.utils.translation import gettext as t
 from rest_framework import serializers
 
 
@@ -20,6 +21,19 @@ class EmailAddressSerializer(serializers.ModelSerializer):
             request.user,
             validated_data['email'],
             confirm=True,
+        )
+
+    def validate(self, attrs):
+        """
+        Validates that only owners or admins of the organization can update
+        their email
+        """
+        user = self.context['request'].user
+        organization = user.organization
+        if organization.is_owner(user) or organization.is_admin(user):
+            return attrs
+        raise serializers.ValidationError(
+            {'email': t('This action is not allowed.')}
         )
 
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Restrict email updates to organization owners and admins only to ensure proper access control within multi-member organizations.



### 📖 Description
Previously, any member of an organization could update their email address, regardless of their role. This update enforces a restriction where only organization owners and admins can update their email addresses. Members without these roles are now prevented from making such changes.



### 👷 Description for instance maintainers
This update introduces a new restriction to the email update endpoint. It checks the role of the user within the organization and ensures that only users with the `owner` or `admin` role in organizations can update their email. This ensures better security and role-based access control. No changes are required for single-member organizations.



### 👀 Preview steps
1. ℹ️ Have an account and belong to an organization:

- `owner`, `admin`, or `member` role within an MMO.
- Or not associated with an MMO.

2. Login as:

- Owner: Attempt to update your email. 🟢 Email should be updated successfully.
- Admin: Attempt to update your email. 🟢 Email should be updated successfully.
- Member: Attempt to update your email. 🔴 Email update should be blocked with a 400 response.
- Non-MMO user: Attempt to update your email. 🟢 Email should be updated successfully.
