### PR TITLE
feat(OpenRosa): Block submissions when owning account is inactive TASK-1323

### DIFF
--- a/kobo/apps/openrosa/apps/logger/exceptions.py
+++ b/kobo/apps/openrosa/apps/logger/exceptions.py
@@ -2,6 +2,10 @@
 from django.utils.translation import gettext as t
 
 
+class AccountInactiveError(Exception):
+    pass
+
+
 class DuplicateUUIDError(Exception):
     pass
 

--- a/kobo/apps/openrosa/apps/logger/models/instance.py
+++ b/kobo/apps/openrosa/apps/logger/models/instance.py
@@ -16,6 +16,7 @@ from taggit.managers import TaggableManager
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import (
+    AccountInactiveError,
     FormInactiveError,
     TemporarilyUnavailableError,
 )
@@ -135,6 +136,8 @@ class Instance(AbstractTimeStampedModel):
             return
         if profile.metadata.get('submissions_suspended', False):
             raise TemporarilyUnavailableError()
+        if not self.xform.user.is_active:
+            raise AccountInactiveError()
 
     def _set_geom(self):
         xform = self.xform

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -39,6 +39,7 @@ from xml.dom import Node
 from wsgiref.util import FileWrapper
 
 from kobo.apps.openrosa.apps.logger.exceptions import (
+    AccountInactiveError,
     DuplicateUUIDError,
     FormInactiveError,
     TemporarilyUnavailableError,
@@ -546,6 +547,8 @@ def safe_create_instance(username, xml_file, media_files, uuid, request):
         error = OpenRosaResponseNotAllowed(t("Form is not active"))
     except TemporarilyUnavailableError:
         error = OpenRosaTemporarilyUnavailable(t("Temporarily unavailable"))
+    except AccountInactiveError:
+        error = OpenRosaResponseNotAllowed(t('Account is not active'))
     except XForm.DoesNotExist:
         error = OpenRosaResponseNotFound(
             t("Form does not exist on this account")


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Previously, projects owned by deactivated accounts could still receive submissions, e.g. if the project allowed anonymous submissions, or if a still-active user was granted access to submit to the project.

This change categorically prevents all submissions to projects owned by inactive users.

### 👀 Preview steps

1. Log in as a normal user (let's call them "Psy")
2. Create a project and deploy it
3. Set the project to allow anonymous submissions
4. Open Enketo, create a submission, and keep the Enketo tab open
5. In a separate browser session, use a superuser account to deactivate Psy's account (uncheck the "active" box in Django admin)
6. Go back to Enketo and attempt to submit
7. See submission fail with error message XXX