### PR TITLE
feat(organizations): add queryclientprovider to basic layout TASK-1324

### DIFF
--- a/jsapp/js/router/basicLayout.component.tsx
+++ b/jsapp/js/router/basicLayout.component.tsx
@@ -6,6 +6,8 @@ import MainHeaderLogo from 'js/components/header/mainHeaderLogo.component';
 import AccountMenu from 'js/components/header/accountMenu';
 import {Tracking} from './useTracking';
 import ToasterConfig from '../toasterConfig';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '../query/queryClient';
 
 interface BasicLayoutProps {
   children: React.ReactNode;
@@ -18,7 +20,7 @@ interface BasicLayoutProps {
 export default function BasicLayout(props: BasicLayoutProps) {
   return (
     <DocumentTitle title='KoboToolbox'>
-      <>
+      <QueryClientProvider client={queryClient}>
         <Tracking />
         <ToasterConfig />
         <div className='header-stretch-bg' />
@@ -33,7 +35,7 @@ export default function BasicLayout(props: BasicLayoutProps) {
             {props.children}
           </bem.PageWrapper__content>
         </bem.PageWrapper>
-      </>
+        </QueryClientProvider>
     </DocumentTitle>
   );
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add QueryClientProvider to BasicLayout so react-query is accessible for TOS and invalidated password views.

### 👀 Preview steps
1. Set up an MMO member account that has not accepted required TOS agreement
2. Login.
3. On main, an error will be thrown by react-query
4. On this branch, no error will be thrown.

