### PR TITLE
feat(organizations): Use `owner_label` for asset ownership display  TASK-1181

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -671,7 +671,7 @@ export function isSelfOwned(asset: AssetResponse | ProjectViewAsset) {
   return (
     asset &&
     sessionStore.currentAccount &&
-    asset.owner__username === sessionStore.currentAccount.username
+    asset.owner_label === sessionStore.currentAccount.username
   );
 }
 

--- a/jsapp/js/components/assetsTable/assetsTableRow.tsx
+++ b/jsapp/js/components/assetsTable/assetsTableRow.tsx
@@ -61,7 +61,7 @@ class AssetsTableRow extends React.Component<AssetsTableRowProps> {
         </bem.AssetsTableRow__column>
 
         <bem.AssetsTableRow__column m='owner'>
-          {assetUtils.getAssetOwnerDisplayName(this.props.asset.owner__username)}
+          {assetUtils.getAssetOwnerDisplayName(this.props.asset.owner_label)}
         </bem.AssetsTableRow__column>
 
         {this.props.context === ASSETS_TABLE_CONTEXTS.PUBLIC_COLLECTIONS &&

--- a/jsapp/js/components/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummaryProjectInfo.tsx
@@ -99,7 +99,7 @@ export default function FormSummaryProjectInfo(
             {isSelfOwned(props.asset) && t('me')}
             {!isSelfOwned(props.asset) && (
               <Avatar
-                username={props.asset.owner__username}
+                username={props.asset.owner_label}
                 size='s'
                 isUsernameVisible
               />

--- a/jsapp/js/components/library/assetInfoBox.tsx
+++ b/jsapp/js/components/library/assetInfoBox.tsx
@@ -89,7 +89,7 @@ export default class AssetInfoBox extends React.Component<
           {this.state.areDetailsVisible &&
           <bem.AssetInfoBox__cell>
             <label>{t('Owner')}</label>
-            {assetUtils.getAssetOwnerDisplayName(this.props.asset.owner__username)}
+            {assetUtils.getAssetOwnerDisplayName(this.props.asset.owner_label)}
           </bem.AssetInfoBox__cell>
           }
 

--- a/jsapp/js/components/submissions/tableUtils.mocks.ts
+++ b/jsapp/js/components/submissions/tableUtils.mocks.ts
@@ -5,6 +5,7 @@ export const assetWithBgAudioAndNLP: AssetResponse = {
   'url': 'http://kf.kobo.local/api/v2/assets/am5q2MmVckuLBXPKsbHjEt',
   'owner': 'http://kf.kobo.local/api/v2/users/kobo.json',
   'owner__username': 'kobo',
+  'owner_label': 'kobo',
   'parent': null,
   'settings': {
     'sector': {},
@@ -893,6 +894,7 @@ export const assetWithNestedGroupsAndNLP: AssetResponse = {
   'url': 'http://kf.kobo.local/api/v2/assets/aRai4qmXVG4eukrzpHXAQC.json',
   'owner': 'http://kf.kobo.local/api/v2/users/kobo.json',
   'owner__username': 'kobo',
+  'owner_label': 'kobo',
   'parent': null,
   'settings': {
     'sector': {},

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -588,6 +588,7 @@ export interface AssetResponse extends AssetRequestObject {
   url: string;
   owner: string;
   owner__username: string;
+  owner_label: string;
   date_created: string;
   summary: AssetSummary;
   date_modified: string;
@@ -684,6 +685,7 @@ export interface ProjectViewAsset {
   date_deployed: string | null;
   owner: string;
   owner__username: string;
+  owner_label: string;
   owner__email: string;
   /** Full name */
   owner__name: string;

--- a/jsapp/js/projects/projectsTable/projectsTableRow.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableRow.tsx
@@ -60,7 +60,7 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
         } else {
           return (
             <Avatar
-              username={props.asset.owner__username}
+              username={props.asset.owner_label}
               size='s'
               isUsernameVisible
             />


### PR DESCRIPTION
### 📣 Summary
Updated the frontend to read `owner_label` from the `assets` endpoint instead of `owner__username` for displaying the owner field in the asset list.



### 📖 Description
The owner field in the asset list UI now utilizes the `owner_label` field from the `assets` API endpoint. 

The `owner_label` field in the Asset API dynamically displays:

- The username of the asset owner if the organization is not a multi-member organization (MMO).
- The name of the organization if the organization is a multi-member organization (MMO) and the user is the organization owner.



### 💭 Notes
- Sorting and filtering are not yet updated to work with `owner_label` instead of `owner__username`.
- No visual changes or additional functionality were introduced apart from reading and displaying the owner_label.
