### PR TITLE
feat(accessLogsExport): add export button TASK-860

### DIFF
--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -55,9 +55,8 @@ export default function useAccessLogsQuery(
  * Starts the exporting process of the access logs.
  * @returns {Promise<void>} A promise that starts the export.
  */
-export const startAccessLogsExport = (): Promise<void> =>
+export const startAccessLogsExport = () =>
   fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {notifyAboutError: false})
-    .then(() => {})
     .catch((error) => {
       const failResponse: FailResponse = {
         status: 500,

--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -55,24 +55,18 @@ export default function useAccessLogsQuery(
  * Starts the exporting process of the access logs.
  * @returns {Promise<void>} A promise that starts the export.
  */
-const startAccessLogsExport = (): Promise<void> =>
+export const startAccessLogsExport = (): Promise<void> =>
   new Promise<void>((resolve, reject) => {
-
     fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {})
       .then(() => {
-          resolve();
+        resolve();
       })
       .catch((error) => {
         const failResponse: FailResponse = {
           status: 500,
-          statusText: error.message || 'An error occurred while exporting the logs.',
+          statusText:
+            error.message || 'An error occurred while exporting the logs.',
         };
         reject(failResponse);
       });
   });
-
-/**
- * This is a hook to start the exporting process of the access logs.
- * @returns {() => void} The function to start the export
- */
-export const useExportAccessLogs = () => startAccessLogsExport;

--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -1,7 +1,7 @@
 import {keepPreviousData, useQuery} from '@tanstack/react-query';
 import {endpoints} from 'js/api.endpoints';
-import type {PaginatedResponse} from 'js/dataInterface';
-import {fetchGet} from 'js/api';
+import type {FailResponse, PaginatedResponse} from 'js/dataInterface';
+import {fetchGet, fetchPost} from 'js/api';
 import {QueryKeys} from 'js/query/queryKeys';
 
 export interface AccessLog {
@@ -50,3 +50,29 @@ export default function useAccessLogsQuery(
     refetchOnWindowFocus: true,
   });
 }
+
+/**
+ * Starts the exporting process of the access logs.
+ * @returns {Promise<void>} A promise that starts the export.
+ */
+const startAccessLogsExport = (): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+
+    fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {})
+      .then(() => {
+          resolve();
+      })
+      .catch((error) => {
+        const failResponse: FailResponse = {
+          status: 500,
+          statusText: error.message || 'An error occurred while exporting the logs.',
+        };
+        reject(failResponse);
+      });
+  });
+
+/**
+ * This is a hook to start the exporting process of the access logs.
+ * @returns {() => void} The function to start the export
+ */
+export const useExportAccessLogs = () => startAccessLogsExport;

--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -56,17 +56,13 @@ export default function useAccessLogsQuery(
  * @returns {Promise<void>} A promise that starts the export.
  */
 export const startAccessLogsExport = (): Promise<void> =>
-  new Promise<void>((resolve, reject) => {
-    fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {})
-      .then(() => {
-        resolve();
-      })
-      .catch((error) => {
-        const failResponse: FailResponse = {
-          status: 500,
-          statusText:
-            error.message || 'An error occurred while exporting the logs.',
-        };
-        reject(failResponse);
-      });
-  });
+  fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {notifyAboutError: false})
+    .then(() => {})
+    .catch((error) => {
+      const failResponse: FailResponse = {
+        status: 500,
+        statusText:
+          error.message || 'An error occurred while exporting the logs.',
+      };
+      throw failResponse;
+    });

--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -61,7 +61,7 @@ export const startAccessLogsExport = () =>
       const failResponse: FailResponse = {
         status: 500,
         statusText:
-          error.message || 'An error occurred while exporting the logs.',
+          error.message || t('An error occurred while exporting the logs'),
       };
       throw failResponse;
     });

--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -7,14 +7,15 @@ import PaginatedQueryUniversalTable from 'js/universalTable/paginatedQueryUniver
 import ExportToEmailButton from 'jsapp/js/components/exportToEmailButton/exportToEmailButton.component';
 
 // Utilities
-import useAccessLogsQuery, {useExportAccessLogs, type AccessLog} from './accessLogs.query';
+import useAccessLogsQuery, {
+  startAccessLogsExport,
+  type AccessLog,
+} from './accessLogs.query';
 import {formatTime} from 'js/utils';
 // import sessionStore from 'js/stores/session';
 
 // Styles
 import securityStyles from 'js/account/security/securityRoute.module.scss';
-
-const exportData = useExportAccessLogs();
 
 export default function AccessLogsSection() {
   // function logOutAllSessions() {
@@ -40,8 +41,8 @@ export default function AccessLogsSection() {
           />
         </div>*/}
         <ExportToEmailButton
-            label={t('Export log data')}
-            exportFunction={exportData}
+          label={t('Export log data')}
+          exportFunction={startAccessLogsExport}
         />
       </header>
 

--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -4,14 +4,17 @@ import React from 'react';
 // Partial components
 // import Button from 'js/components/common/button';
 import PaginatedQueryUniversalTable from 'js/universalTable/paginatedQueryUniversalTable.component';
+import ExportToEmailButton from 'jsapp/js/components/exportToEmailButton/exportToEmailButton.component';
 
 // Utilities
-import useAccessLogsQuery, {type AccessLog} from './accessLogs.query';
+import useAccessLogsQuery, {useExportAccessLogs, type AccessLog} from './accessLogs.query';
 import {formatTime} from 'js/utils';
 // import sessionStore from 'js/stores/session';
 
 // Styles
 import securityStyles from 'js/account/security/securityRoute.module.scss';
+
+const exportData = useExportAccessLogs();
 
 export default function AccessLogsSection() {
   // function logOutAllSessions() {
@@ -36,6 +39,10 @@ export default function AccessLogsSection() {
             startIcon='logout'
           />
         </div>*/}
+        <ExportToEmailButton
+            label={t('Export log data')}
+            exportFunction={exportData}
+        />
       </header>
 
       <PaginatedQueryUniversalTable<AccessLog>

--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -13,5 +13,6 @@ export const endpoints = {
   /** Expected parameters: price_id and subscription_id **/
   CHANGE_PLAN_URL: '/api/v2/stripe/change-plan',
   ACCESS_LOGS_URL: '/api/v2/access-logs/me',
+  ACCESS_LOGS_EXPORT_URL: '/api/v2/access-logs/me/export/',
   LOGOUT_ALL: '/logout-all/',
 } as const;

--- a/jsapp/js/components/exportToEmailButton/exportToEmailButton.component.tsx
+++ b/jsapp/js/components/exportToEmailButton/exportToEmailButton.component.tsx
@@ -31,7 +31,7 @@ export default function ExportToEmailButton({
   exportFunction,
   label,
 }: {
-  exportFunction: () => Promise<void>;
+  exportFunction: () => Promise<unknown>;
   label: string;
 }) {
   const [isMessageOpen, setIsMessageOpen] = useState(false);


### PR DESCRIPTION
### 📣 Summary
Add an Export button to the Security page that allows users to initiate an access logs export.

### 👀 Preview steps

1. ℹ️ have account
2. navigate to _Account Settings < Security_ 
4. 🟢 notice that there is an "Export log data" button by the _Recent Account Activity_ 
5. click the button
6. 🟢 notice that you receive an email with a link to your export


