### PR TITLE
Expose organization user created timestamp in members endpoint

### DIFF
--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -26,7 +26,7 @@ class OrganizationUserSerializer(serializers.ModelSerializer):
     )
     url = serializers.SerializerMethodField()
     date_joined = serializers.DateTimeField(
-        source='user.date_joined', format='%Y-%m-%dT%H:%M:%SZ'
+        source='created', format='%Y-%m-%dT%H:%M:%SZ'
     )
     user__username = serializers.ReadOnlyField(source='user.username')
     user__extra_details__name = serializers.ReadOnlyField(


### PR DESCRIPTION
### 📣 Summary
Expose organization user created timestamp instead of `date_joined` in members endpoint.



### 📖 Description
The created timestamp for organization users is now exposed in the members endpoint, providing a clear indication of when each user was added to the organization. This timestamp is formatted as `%Y-%m-%dT%H:%M:%SZ`.