### PR TITLE
feat(organizations): transfer projects to organization owner when the recipient belongs to a MMO TASK-1338

### DIFF
--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -6,6 +6,7 @@ from django.apps import apps
 from django.utils import timezone
 from zoneinfo import ZoneInfo
 
+from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
 from kpi.models.object_permission import ObjectPermission
 
@@ -67,6 +68,13 @@ def get_monthly_billing_dates(organization: Union['Organization', None]):
         period_start -= relativedelta(months=1)
     period_end = period_start + relativedelta(months=1)
     return period_start, period_end
+
+
+def get_real_owner(user: User) -> User:
+    organization = user.organization
+    if organization.is_mmo:
+        return organization.owner_user_object
+    return user
 
 
 def get_yearly_billing_dates(organization: Union['Organization', None]):

--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext as t
 
+from kobo.apps.organizations.utils import get_real_owner
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.mailer import EmailMessage, Mailer
@@ -104,6 +105,11 @@ class Invite(AbstractTimeStampedModel):
 
     def send_invite_email(self):
 
+        real_next_owner = get_real_owner(self.recipient)
+        template_suffix = ''
+        if real_next_owner != self.recipient:
+            template_suffix = '_org'
+
         template_variables = {
             'username': self.recipient.username,
             'sender_username': self.sender.username,
@@ -125,9 +131,9 @@ class Invite(AbstractTimeStampedModel):
             subject=t(
                 'Action required: KoboToolbox project ownership transfer request'
             ),
-            plain_text_content_or_template='emails/new_invite.txt',
+            plain_text_content_or_template=f'emails/new_invite{template_suffix}.txt',
             template_variables=template_variables,
-            html_content_or_template='emails/new_invite.html',
+            html_content_or_template=f'emails/new_invite{template_suffix}.html',
             language=self.recipient.extra_details.data.get('last_ui_language'),
         )
 

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.html
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.html
@@ -1,0 +1,49 @@
+{% load i18n %}
+{% load strings %}
+{% trans "Projects:" as projects_label %}
+
+<p>{% trans "Dear" %} {{ username }},</p>
+
+{% if transfers|length == 1 %}
+  <p>{% blocktrans with asset_uid=transfers.0.asset_uid asset_name=transfers.0.asset_name  %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the project <a href="{{ base_url }}/#/forms/{{ asset_uid }}/landing">{{ asset_name }}</a> to you.{% endblocktrans %}</p>
+
+  <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
+
+  <p>{% blocktrans %}
+    If you accept the transfer:
+    <ul>
+      <li>All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits</li>
+      <li>If you leave the team in the future, your account will still retain manage project permissions for this project</li>
+    </ul>
+    {% endblocktrans %}
+  </p>
+{% else %}
+  <p>{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+    <ul>
+    {% for transfer in transfers %}
+      <li><a href="{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing">{{ transfer.asset_name }}</a></li>
+    {% endfor %}
+    </ul>
+  </p>
+
+  <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
+
+  <p>{% blocktrans %}
+    If you accept the transfer:
+    <ul>
+      <li>All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits</li>
+      <li>If you leave the team in the future, your account will still retain manage project permissions for these projects</li>
+    </ul>
+    {% endblocktrans %}
+  </p>
+{% endif %}
+
+<p>{% trans "If you are unsure, please contact the current owner." %}</p>
+
+<p>{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
+
+<p>{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
+
+<p>
+&nbsp;-&nbsp;KoboToolbox
+</p>

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load strings %}
+{% trans "Projects:" as projects_label %}
+
+{% trans "Dear" %} {{ username }},
+{% if transfers|length == 1 %}
+{% blocktrans with asset_uid=transfers.0.asset_uid asset_name=transfers.0.asset_name  %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the project {{ asset_name }} ({{ base_url }}/#/forms/{{ asset_uid }}/landing) to you.{% endblocktrans %}
+
+{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}
+
+{% blocktrans %}
+If you accept the transfer:
+- All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits
+- If you leave the team in the future, your account will still retain manage project permissions for this project
+{% endblocktrans %}
+
+{% else %}
+{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+    {% for transfer in transfers %}
+    * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ asset_uid }}/landing]
+    {% endfor %}
+
+{% trans "Because you are part of a team, these projects will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own these projects, then don’t click on the link below." %}
+
+{% blocktrans %}
+If you accept the transfer:
+- All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits
+- If you leave the team in the future, your account will still retain manage project permissions for these projects
+{% endblocktrans %}
+
+{% endif %}
+
+{% trans "If you are unsure, please contact the current owner." %}
+
+{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
+
+{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
+
+- KoboToolbox

--- a/kobo/apps/project_ownership/tests/api/v2/test_api.py
+++ b/kobo/apps/project_ownership/tests/api/v2/test_api.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E501
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -5,7 +6,6 @@ from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
-from django.utils import timezone
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -262,7 +262,6 @@ class ProjectOwnershipInviteAPITestCase(KpiTestCase):
 
 
 class ProjectOwnershipTransferDataAPITestCase(BaseAssetTestCase):
-
     """
     Tests in this class use the mock library a lot because transferring a
     deployed project implies accessing KoboCAT tables. However, KPI does not
@@ -364,7 +363,6 @@ class ProjectOwnershipTransferDataAPITestCase(BaseAssetTestCase):
     )
     @override_config(PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES=True)
     def test_account_usage_transferred_to_new_user(self):
-        today = timezone.now()
         expected_data = {
             'total_nlp_usage': {
                 'asr_seconds_current_year': 120,

--- a/kobo/apps/project_ownership/tests/test_permissions.py
+++ b/kobo/apps/project_ownership/tests/test_permissions.py
@@ -1,0 +1,68 @@
+from constance.test import override_config
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.constants import PERM_MANAGE_ASSET
+from kpi.models import Asset
+from kpi.tests.utils.transaction import immediate_on_commit
+from ..utils import create_invite
+
+
+@override_config(PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES=True)
+class ProjectOwnershipPermissionTestCase(TestCase):
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+
+        self.someuser = User.objects.get(username='someuser')
+        self.anotheruser = User.objects.get(username='anotheruser')
+        self.thirduser = User.objects.create_user(
+            username='thirduser',
+            password='thirduser',
+            email='thirduser@example.com',
+        )
+        self.asset = Asset.objects.get(pk=1)
+
+    def test_recipient_as_regular_user_is_owner(self):
+        assert self.asset.owner == self.someuser
+        with immediate_on_commit():
+            create_invite(
+                sender=self.someuser,
+                recipient=self.anotheruser,
+                assets=[self.asset],
+                invite_class_name='Invite',
+            )
+
+        self.asset.refresh_from_db()
+        # New owner should anotheruser
+        assert self.asset.owner == self.anotheruser
+        # The previous owner should have received "manage_asset" permission
+        assert self.asset.has_perm(self.someuser, PERM_MANAGE_ASSET)
+
+    def test_recipient_as_org_member_is_owner(self):
+        # Make anotheruser's organization a MMO…
+        organization = self.anotheruser.organization
+        organization.mmo_override = True
+        organization.save()
+        # … and add thirduser to it
+        organization.add_user(self.thirduser)
+        assert self.asset.owner == self.someuser
+        # send the invite to thirduser
+        with immediate_on_commit():
+            create_invite(
+                sender=self.someuser,
+                recipient=self.thirduser,
+                assets=[self.asset],
+                invite_class_name='Invite',
+            )
+
+        self.asset.refresh_from_db()
+        # anotheruser should be the owner now (because they are the owner of
+        # thirduser's organization
+        assert self.asset.owner == self.anotheruser
+
+        # The previous owner should have received "manage_asset" permission
+        assert self.asset.has_perm(self.someuser, PERM_MANAGE_ASSET)
+        # The invite recipient should have received "manage_asset" permission too
+        assert self.asset.has_perm(self.thirduser, PERM_MANAGE_ASSET)

--- a/kobo/apps/project_ownership/tests/test_permissions.py
+++ b/kobo/apps/project_ownership/tests/test_permissions.py
@@ -10,6 +10,12 @@ from ..utils import create_invite
 
 @override_config(PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES=True)
 class ProjectOwnershipPermissionTestCase(TestCase):
+    """
+    The purpose of this test suite is solely to verify permission assignment.
+    To achieve this, PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES is set to True, allowing
+    the email invitation system to be bypassed and eliminating the need to process it
+    during testing.
+    """
 
     fixtures = ['test_data']
 

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from __future__ import annotations
 
 import json
@@ -19,6 +18,7 @@ from rest_framework.reverse import reverse
 from rest_framework.utils.serializer_helpers import ReturnList
 
 from kobo.apps.organizations.constants import ORG_ADMIN_ROLE
+from kobo.apps.organizations.utils import get_real_owner
 from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kobo.apps.reports.report_data import build_formpack
 from kobo.apps.subsequences.utils.deprecation import WritableAdvancedFeaturesField
@@ -421,7 +421,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def create(self, validated_data):
         current_owner = validated_data['owner']
-        real_owner = self._get_real_owner(current_owner)
+        real_owner = get_real_owner(current_owner)
         if real_owner != current_owner:
             with transaction.atomic():
                 validated_data['owner'] = real_owner
@@ -943,16 +943,6 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def _content(self, obj):
         # FIXME: Is this dead code?
         return json.dumps(obj.content)
-
-    def _get_real_owner(self, current_owner: 'User') -> 'User':
-
-        if current_owner.is_org_owner:
-            return current_owner
-
-        # If `owner` is not the owner of the organization they belong to,
-        # they must belong to a multi-member organization. Thus, the asset
-        # must be owned by the organization('s owner).
-        return current_owner.organization.owner_user_object
 
     def _get_status(self, perm_assignments):
         """


### PR DESCRIPTION
### 📣 Summary
Added logic to transfer project ownership to the organization when the recipient belongs to a Multi-Member Organization (MMO).



### 📖 Description
This PR introduces functionality to automatically transfer project ownership to the organization when the recipient of the transfer is a member of a Multi-Member Organization (MMO). 

### 💭 Notes
Some unit tests have been added to test permissions after the transfer. 

### 👀 Preview steps
1. ℹ️ have account and a project
2. Create a two other accounts
3. Add the third account to the organization of the second account 
4. Transfer a project from first account to 3rd one
5. In  `main`, the new owner is the 3rd account
6. In this PR, the new owner is the 2nd account and the 3rd account has "managed asset" permission
