### PR TITLE
feat(organizations): add specific email template for project ownership transfer to organization TASK-1339

### DIFF
--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext as t
 
+from kobo.apps.organizations.utils import get_real_owner
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.mailer import EmailMessage, Mailer
@@ -104,6 +105,11 @@ class Invite(AbstractTimeStampedModel):
 
     def send_invite_email(self):
 
+        real_next_owner = get_real_owner(self.recipient)
+        template_suffix = ''
+        if real_next_owner != self.recipient:
+            template_suffix = '_org'
+
         template_variables = {
             'username': self.recipient.username,
             'sender_username': self.sender.username,
@@ -125,9 +131,9 @@ class Invite(AbstractTimeStampedModel):
             subject=t(
                 'Action required: KoboToolbox project ownership transfer request'
             ),
-            plain_text_content_or_template='emails/new_invite.txt',
+            plain_text_content_or_template=f'emails/new_invite{template_suffix}.txt',
             template_variables=template_variables,
-            html_content_or_template='emails/new_invite.html',
+            html_content_or_template=f'emails/new_invite{template_suffix}.html',
             language=self.recipient.extra_details.data.get('last_ui_language'),
         )
 

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.html
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.html
@@ -1,0 +1,49 @@
+{% load i18n %}
+{% load strings %}
+{% trans "Projects:" as projects_label %}
+
+<p>{% trans "Dear" %} {{ username }},</p>
+
+{% if transfers|length == 1 %}
+  <p>{% blocktrans with asset_uid=transfers.0.asset_uid asset_name=transfers.0.asset_name  %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the project <a href="{{ base_url }}/#/forms/{{ asset_uid }}/landing">{{ asset_name }}</a> to you.{% endblocktrans %}</p>
+
+  <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
+
+  <p>{% blocktrans %}
+    If you accept the transfer:
+    <ul>
+      <li>All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits</li>
+      <li>If you leave the team in the future, your account will still retain manage project permissions for this project</li>
+    </ul>
+    {% endblocktrans %}
+  </p>
+{% else %}
+  <p>{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+    <ul>
+    {% for transfer in transfers %}
+      <li><a href="{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing">{{ transfer.asset_name }}</a></li>
+    {% endfor %}
+    </ul>
+  </p>
+
+  <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
+
+  <p>{% blocktrans %}
+    If you accept the transfer:
+    <ul>
+      <li>All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits</li>
+      <li>If you leave the team in the future, your account will still retain manage project permissions for these projects</li>
+    </ul>
+    {% endblocktrans %}
+  </p>
+{% endif %}
+
+<p>{% trans "If you are unsure, please contact the current owner." %}</p>
+
+<p>{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
+
+<p>{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
+
+<p>
+&nbsp;-&nbsp;KoboToolbox
+</p>

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load strings %}
+{% trans "Projects:" as projects_label %}
+
+{% trans "Dear" %} {{ username }},
+{% if transfers|length == 1 %}
+{% blocktrans with asset_uid=transfers.0.asset_uid asset_name=transfers.0.asset_name  %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the project {{ asset_name }} ({{ base_url }}/#/forms/{{ asset_uid }}/landing) to you.{% endblocktrans %}
+
+{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}
+
+{% blocktrans %}
+If you accept the transfer:
+- All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits
+- If you leave the team in the future, your account will still retain manage project permissions for this project
+{% endblocktrans %}
+
+{% else %}
+{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+    {% for transfer in transfers %}
+    * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ asset_uid }}/landing]
+    {% endfor %}
+
+{% trans "Because you are part of a team, these projects will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own these projects, then don’t click on the link below." %}
+
+{% blocktrans %}
+If you accept the transfer:
+- All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits
+- If you leave the team in the future, your account will still retain manage project permissions for these projects
+{% endblocktrans %}
+
+{% endif %}
+
+{% trans "If you are unsure, please contact the current owner." %}
+
+{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
+
+{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
+
+- KoboToolbox


### PR DESCRIPTION
### 📣 Summary
Introduced a dedicated email template for notifying users about project ownership transfers to an organization.


### 📖 Description
A specific email template has been added to notify users about project ownership transfers to an organization. The new template provides clear and concise details, ensuring users understand the context and implications of the change.


### 👀 Preview steps
1. Ensure you have an existing account and an associated project
1. Create two additional accounts
1. Transfer a project from the first account to the third account
1. Verify that the email template does not mention teams or organizations
1. Create a new project, named ProjectB
1. Add the third account to the organization of the second account
1. Transfer ProjectB from the first account to the third account
1. Ensure the email template body includes the phrase: "Because you are part of a team."
