### PR TITLE
docs(projectHistoryLogs): show correct URL in endpoint documentation

### DIFF
--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -587,12 +587,12 @@ class ProjectHistoryLogViewSet(
     those with 'manage_asset' permissions.
 
     <pre class="prettyprint">
-    <b>GET</b> /api/v2/asset/<code>{asset_uid}</code>/history/
+    <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/history/
     </pre>
 
     > Example
     >
-    >       curl -X GET https://[kpi-url]/api/v2/asset/aSAvYreNzVEkrWg5Gdcvg/history/
+    >       curl -X GET https://[kpi-url]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/history/
 
 
     > Response 200


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Show the correct URL in the documentation for the single-asset project history log endpoint.

