### PR TITLE
refactor(organizations): remove sessionStore from useOrganizationQuery TASK-1357

### DIFF
--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -5,7 +5,6 @@ import {useEffect} from 'react';
 // Stores, hooks and utilities
 import {fetchGetUrl, fetchPatch} from 'jsapp/js/api';
 import {FeatureFlag, useFeatureFlag} from 'js/featureFlags';
-import sessionStore from 'js/stores/session';
 import {useSession} from 'jsapp/js/stores/useSession';
 
 // Constants and types
@@ -107,8 +106,7 @@ export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<
   // the session data loaded. Account data is needed to fetch the organization
   // data.
   const isQueryEnabled =
-    !sessionStore.isPending &&
-    sessionStore.isInitialLoadComplete &&
+    !session.isPending &&
     !!organizationUrl;
 
   const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
@@ -125,7 +123,7 @@ export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<
   // DEBT: don't retry the failing url 3-4 times before switching to the new url.
   useEffect(() => {
     if (query.error?.status === 404) {
-      sessionStore.refreshAccount();
+      session.refreshAccount();
     }
   }, [query.error?.status]);
 

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -105,15 +105,12 @@ export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<
   // Setting the 'enabled' property so the query won't run until we have
   // the session data loaded. Account data is needed to fetch the organization
   // data.
-  const isQueryEnabled =
-    !session.isPending &&
-    !!organizationUrl;
 
   const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
     ...options,
     queryFn: fetchOrganization,
     queryKey: [QueryKeys.organization],
-    enabled: isQueryEnabled && options?.enabled !== false,
+    enabled: !!organizationUrl && options?.enabled !== false,
   });
 
   // `organizationUrl` must exist, unless it's changed (e.g. user added/removed


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
After migrating `useOrganizationQuery` to use the `useSession` hook, we still have some direct references to `sessionStore`. This PR removes `sessionStore` from `useOrganizationQuery` entirely.

### 👀 Preview steps
This PR should not change app behavior

1. Login as an MMO admin or owner 
2. Load the organization settings and members pages 
3. Observe no difference in displayed data or API calls between this branch and `main`