### PR TITLE
fix(organizations): limit useOrganizationQuery refetches TASK-1347

### DIFF
--- a/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
+++ b/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
@@ -28,6 +28,9 @@ import styles from 'js/account/organization/organizationSettingsRoute.module.scs
  */
 export default function OrganizationSettingsRoute() {
   const orgQuery = useOrganizationQuery();
+  useEffect(() => {
+    orgQuery.refetch()
+  }, []);
   const [subscriptions] = useState(() => subscriptionStore);
   const [isStripeEnabled, setIsStripeEnabled] = useState(false);
   const patchOrganization = usePatchOrganization();

--- a/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
+++ b/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
@@ -11,8 +11,6 @@ import KoboSelect from 'jsapp/js/components/common/koboSelect';
 // Stores, hooks and utilities
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {OrganizationUserRole, useOrganizationQuery, usePatchOrganization} from 'js/account/organization/organizationQuery';
-import { queryClient } from 'jsapp/js/query/queryClient';
-import { QueryKeys } from 'jsapp/js/query/queryKeys';
 import subscriptionStore from 'js/account/subscriptionStore';
 import envStore from 'js/envStore';
 import {getSimpleMMOLabel} from './organization.utils';
@@ -29,13 +27,8 @@ import styles from 'js/account/organization/organizationSettingsRoute.module.scs
  * they can edit available fields.
  */
 export default function OrganizationSettingsRoute() {
-  const orgQuery = useOrganizationQuery();
-  useEffect(() => {
-    queryClient.invalidateQueries({
-      queryKey: [QueryKeys.organization],
-      refetchType: 'none',
-    });
-  }, []);
+  const orgQuery = useOrganizationQuery({shouldForceInvalidation: true});
+
   const [subscriptions] = useState(() => subscriptionStore);
   const [isStripeEnabled, setIsStripeEnabled] = useState(false);
   const patchOrganization = usePatchOrganization();
@@ -84,7 +77,7 @@ export default function OrganizationSettingsRoute() {
   );
   const mmoLabelLowercase = mmoLabel.toLowerCase();
 
-  if (orgQuery.isLoading) {
+  if (orgQuery.isFetching) {
     return <LoadingSpinner />;
   }
 

--- a/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
+++ b/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
@@ -38,13 +38,15 @@ export default function OrganizationSettingsRoute() {
   const [website, setWebsite] = useState<string>('');
   const [orgType, setOrgType] = useState<OrganizationTypeName | null>(null);
 
+  // We are invalidating the org query data when this component loads,
+  // so we want to wait for a fetch fresh before setting the form data
   useEffect(() => {
-    if (orgQuery.data) {
+    if (orgQuery.data && orgQuery.isFetchedAfterMount) {
       setName(orgQuery.data.name);
       setWebsite(orgQuery.data.website);
       setOrgType(orgQuery.data.organization_type);
     }
-  }, [orgQuery.data]);
+  }, [orgQuery.data, orgQuery.isFetchedAfterMount]);
 
   useWhenStripeIsEnabled(() => {
     setIsStripeEnabled(true);
@@ -77,7 +79,7 @@ export default function OrganizationSettingsRoute() {
   );
   const mmoLabelLowercase = mmoLabel.toLowerCase();
 
-  if (orgQuery.isFetching) {
+  if (orgQuery.isLoading || !orgQuery.isFetchedAfterMount) {
     return <LoadingSpinner />;
   }
 

--- a/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
+++ b/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
@@ -35,7 +35,7 @@ export default function OrganizationSettingsRoute() {
       queryKey: [QueryKeys.organization],
       refetchType: 'none',
     });
-  }, []);;
+  }, []);
   const [subscriptions] = useState(() => subscriptionStore);
   const [isStripeEnabled, setIsStripeEnabled] = useState(false);
   const patchOrganization = usePatchOrganization();

--- a/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
+++ b/jsapp/js/account/organization/OrganizationSettingsRoute.tsx
@@ -11,6 +11,8 @@ import KoboSelect from 'jsapp/js/components/common/koboSelect';
 // Stores, hooks and utilities
 import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {OrganizationUserRole, useOrganizationQuery, usePatchOrganization} from 'js/account/organization/organizationQuery';
+import { queryClient } from 'jsapp/js/query/queryClient';
+import { QueryKeys } from 'jsapp/js/query/queryKeys';
 import subscriptionStore from 'js/account/subscriptionStore';
 import envStore from 'js/envStore';
 import {getSimpleMMOLabel} from './organization.utils';
@@ -29,8 +31,11 @@ import styles from 'js/account/organization/organizationSettingsRoute.module.scs
 export default function OrganizationSettingsRoute() {
   const orgQuery = useOrganizationQuery();
   useEffect(() => {
-    orgQuery.refetch()
-  }, []);
+    queryClient.invalidateQueries({
+      queryKey: [QueryKeys.organization],
+      refetchType: 'none',
+    });
+  }, []);;
   const [subscriptions] = useState(() => subscriptionStore);
   const [isStripeEnabled, setIsStripeEnabled] = useState(false);
   const patchOrganization = usePatchOrganization();

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -113,6 +113,7 @@ export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<
 
   const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
     ...options,
+    staleTime: 1000 * 60 * 2,
     queryFn: fetchOrganization,
     queryKey: [QueryKeys.organization],
     enabled: isQueryEnabled && options?.enabled !== false,

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -1,5 +1,5 @@
 // Libraries
-import {useMutation, useQuery, useQueryClient, type UndefinedInitialDataOptions} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 import {useEffect} from 'react';
 
 // Stores, hooks and utilities
@@ -11,6 +11,7 @@ import {useSession} from 'jsapp/js/stores/useSession';
 // Constants and types
 import type {FailResponse} from 'js/dataInterface';
 import {QueryKeys} from 'js/query/queryKeys';
+import {queryClient} from 'jsapp/js/query/queryClient';
 
 // Comes from `kobo/apps/accounts/forms.py`
 export type OrganizationTypeName = 'non-profit' | 'government' | 'educational' | 'commercial' | 'none';
@@ -52,22 +53,24 @@ export enum OrganizationUserRole {
  * refetch data (are invalidated).
  */
 export function usePatchOrganization() {
-  const queryClient = useQueryClient();
   const session = useSession();
   const organizationUrl = session.currentLoggedAccount?.organization?.url;
 
   return useMutation({
-    mutationFn: async (data: Partial<Organization>) => (
+    mutationFn: async (data: Partial<Organization>) =>
       // We're asserting the `organizationUrl` is not `undefined` here, because
       // the parent query (`useOrganizationQuery`) wouldn't be enabled without
       // it. Plus all the organization-related UI is accessible only to
       // logged in users.
-      fetchPatch<Organization>(organizationUrl!, data, {prependRootUrl: false})
-    ),
+      fetchPatch<Organization>(organizationUrl!, data, {prependRootUrl: false}),
     onSettled: () => {
       queryClient.invalidateQueries({queryKey: [QueryKeys.organization]});
     },
   });
+}
+
+interface OrganizationQueryParams {
+  shouldForceInvalidation?: boolean;
 }
 
 /**
@@ -75,8 +78,17 @@ export function usePatchOrganization() {
  * For convenience, errors are handled once at the top, see `RequireOrg`.
  * No need to handle errors at every usage.
  */
-export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<Organization, FailResponse, Organization, QueryKeys[]>, 'queryFn' | 'queryKey'>) => {
+export const useOrganizationQuery = (params?: OrganizationQueryParams) => {
   const isMmosEnabled = useFeatureFlag(FeatureFlag.mmosEnabled);
+
+  useEffect(() => {
+    if (params?.shouldForceInvalidation) {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.organization],
+        refetchType: 'none',
+      });
+    }
+  }, [params?.shouldForceInvalidation]);
 
   const session = useSession();
   const organizationUrl = session.currentLoggedAccount?.organization?.url;
@@ -112,11 +124,10 @@ export const useOrganizationQuery = (options?: Omit<UndefinedInitialDataOptions<
     !!organizationUrl;
 
   const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
-    ...options,
     staleTime: 1000 * 60 * 2,
     queryFn: fetchOrganization,
     queryKey: [QueryKeys.organization],
-    enabled: isQueryEnabled && options?.enabled !== false,
+    enabled: isQueryEnabled,
   });
 
   // `organizationUrl` must exist, unless it's changed (e.g. user added/removed

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -76,7 +76,8 @@ interface OrganizationQueryParams {
 /**
  * Organization object is used globally.
  * For convenience, errors are handled once at the top, see `RequireOrg`.
- * No need to handle errors at every usage.
+ * No need to handle errors at every usage. Has custom staleTime, so use params
+ * to invalidate data and refetch when absolute latest data is needed.
  */
 export const useOrganizationQuery = (params?: OrganizationQueryParams) => {
   const isMmosEnabled = useFeatureFlag(FeatureFlag.mmosEnabled);


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
Avoid unnecessary fetches of organization data


### 📖 Description
After patching changes to organization members react-query was making two (sometimes one) refetches of backend data for `useOrganizationQuery`. This was undesired behavior. We want the organization members list to be refetched, but not the organization detail itself. To resolve this, I have set the `staleTime` option on `useOrganizationQuery` to 2 minutes.  Since the data will not be considered stale until 2 minutes passes since the last refresh, these unnecessary API calls will not be made. Additionally, we have added an optional param to the Organization query to invalidate cached data on mount. This is used by the settings page. Since this page is intended for editing organization data, I think it is preferable to always fetch the latest data when opening it. 


### 👀 Preview steps
1. Sign in as an MMO admin or owner for an org with a few members
2. On the organization members table, change the role of one of the other members
3. On main, observe the organization data being fetched after a successful member patch request
4. On this branch, observe no org data fetch
5. On this branch, navigate to the Organization settings page and see that the organization data is refetched.

### 💭 Notes
I set a very low stale time for the organization. There had been some discussion about setting a long staleTime, but my thinking here is that our real goal with this change is to prevent the frontend from spamming the backend with requests for organization data on every member mutation. A low staleTime achieves this while still allowing for fairly frequent automatic updates of the data.