### PR TITLE
fix(projectHistoryLogs):fix metadata username replacement TASK-1370

### DIFF
--- a/jsapp/js/components/activity/activity.constants.ts
+++ b/jsapp/js/components/activity/activity.constants.ts
@@ -239,7 +239,7 @@ export interface ActivityLogsItem {
     latest_deployed_version_id?: string;
     latest_version_id?: string;
     version_uid?: string;
-    second_user?: string;
+    username?: string;
     // a lot of more optional metadata props…
   };
 }

--- a/jsapp/js/components/activity/activityMessage.component.tsx
+++ b/jsapp/js/components/activity/activityMessage.component.tsx
@@ -15,10 +15,11 @@ export function ActivityMessage(props: {data: ActivityLogsItem}) {
   // doesn't nothing will happen.
   message = message
     .replace('##username##', `<strong>${props.data.username}</strong>`)
+    .replace('##username2##', `<strong>${props.data.metadata.username}</strong>`)
     .replace('##action##', props.data.action);
   // We only replace it if metadata is provided.
-  if (props.data.metadata.second_user) {
-    message = message.replace('##username2##', `<strong>${props.data.metadata.second_user}</strong>`);
+  if (props.data.metadata.username) {
+    message = message.replace('##username2##', `<strong>${props.data.metadata.username}</strong>`);
   }
 
   return (


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📖 Description
This PR fixed the situation where, in the activity logs list, the destination username of a transfer was not being properly displayed.

### 💭 Notes
The activity log details is using a different metadata field than the expected, so we need to change the field for the username to be properly replaced in the activity message.

### 👀 Preview steps
Bug template:
1. ℹ️ have an account and a project
2. Have the activity logs feature flag on with: `?ff_activityLogsEnabled=true`
3. Transfer a project to another user
4. Navigate to Project > Settings > Activity
5. 🟢 The transfer should be displayed in the activity log
6. 🟢 The destination username should be properly displayed