### PR TITLE
fix: remove plan dropdown cropping in addons view TASK-1361

### DIFF
--- a/jsapp/js/account/plans/plan.module.scss
+++ b/jsapp/js/account/plans/plan.module.scss
@@ -10,7 +10,6 @@ $plan-badge-height: 38px;
 
 .accountPlan {
   padding: 30px 40px;
-  overflow-y: auto;
   position: relative;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
### 📣 Summary
This fixes the unwanted cropping of the plan selection dropdown in addons view

### 💭 Notes
There was an `overflow-y: auto` style in the dropdown's container class that was forcing the crop of the list.

### 👀 Preview steps
Bug template:
1. ℹ️ have an account
2. Navigate to account > addons (`/account/addons`)
3. Open the plan selection dropdown (containing the 'Up to 5 GB...' text)
4. 🔴 [on main] Notice that the list gets cropped
5. 🟢 [on PR] Notice that the list is not being cropped
