### PR TITLE
fix(billing): adjust frontend service usage billing period handling TASK-1328

### DIFF
--- a/jsapp/js/account/usage/usage.api.ts
+++ b/jsapp/js/account/usage/usage.api.ts
@@ -14,11 +14,7 @@ export interface AssetWithUsage {
   asset: string;
   uid: string;
   asset__name: string;
-  nlp_usage_current_month: {
-    total_nlp_asr_seconds: number;
-    total_nlp_mt_characters: number;
-  };
-  nlp_usage_current_year: {
+  nlp_usage_current_period: {
     total_nlp_asr_seconds: number;
     total_nlp_mt_characters: number;
   };
@@ -27,28 +23,22 @@ export interface AssetWithUsage {
     total_nlp_mt_characters: number;
   };
   storage_bytes: number;
-  submission_count_current_month: number;
-  submission_count_current_year: number;
+  submission_count_current_period: number;
   submission_count_all_time: number;
   deployment_status: string;
 }
 
 export interface UsageResponse {
-  current_month_start: string;
-  current_month_end: string;
-  current_year_start: string;
-  current_year_end: string;
+  current_period_start: string;
+  current_period_end: string;
   total_submission_count: {
-    current_month: number;
-    current_year: number;
+    current_period: number;
     all_time: number;
   };
   total_storage_bytes: number;
   total_nlp_usage: {
-    asr_seconds_current_month: number;
-    mt_characters_current_month: number;
-    asr_seconds_current_year: number;
-    mt_characters_current_year: number;
+    asr_seconds_current_period: number;
+    mt_characters_current_period: number;
     asr_seconds_all_time: number;
     mt_characters_all_time: number;
   };

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -14,7 +14,6 @@ import useWhenStripeIsEnabled from 'js/hooks/useWhenStripeIsEnabled.hook';
 import {ProductsContext} from '../useProducts.hook';
 import {UsageContext} from 'js/account/usage/useUsage.hook';
 import {OneTimeAddOnsContext} from '../useOneTimeAddonList.hook';
-import moment from 'moment';
 import {YourPlan} from 'js/account/usage/yourPlan.component';
 import cx from 'classnames';
 import LimitNotifications from 'js/components/usageLimits/limitNotifications.component';
@@ -55,27 +54,14 @@ export default function Usage() {
   const location = useLocation();
 
   const dateRange = useMemo(() => {
-    let startDate: string;
-    const endDate = usage.billingPeriodEnd
-      ? formatDate(usage.billingPeriodEnd)
-      : formatDate(
-          moment(usage.currentMonthStart).add(1, 'month').toISOString()
-        );
-    switch (usage.trackingPeriod) {
-      case 'year':
-        startDate = formatDate(usage.currentYearStart);
-        break;
-      default:
-        startDate = formatDate(usage.currentMonthStart);
-        break;
-    }
+    const startDate = formatDate(usage.currentPeriodStart);
+    const endDate = formatDate(usage.currentPeriodEnd);
     return t('##start_date## to ##end_date##')
       .replace('##start_date##', startDate)
       .replace('##end_date##', endDate);
   }, [
-    usage.currentYearStart,
-    usage.currentMonthStart,
-    usage.billingPeriodEnd,
+    usage.currentPeriodStart,
+    usage.currentPeriodEnd,
     usage.trackingPeriod,
   ]);
 

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -129,18 +129,14 @@ const ProjectBreakdown = () => {
 
   const renderProjectRow = (project: AssetWithUsage) => {
     const periodSubmissions =
-      project[
-        `submission_count_current_${usage.trackingPeriod}`
-      ].toLocaleString();
+      project.submission_count_current_period.toLocaleString();
 
     const periodASRSeconds = convertSecondsToMinutes(
-      project[`nlp_usage_current_${usage.trackingPeriod}`].total_nlp_asr_seconds
+      project.nlp_usage_current_period.total_nlp_asr_seconds
     ).toLocaleString();
 
     const periodMTCharacters =
-      project[
-        `nlp_usage_current_${usage.trackingPeriod}`
-      ].total_nlp_mt_characters.toLocaleString();
+      project.nlp_usage_current_period.total_nlp_mt_characters.toLocaleString();
 
     return (
       <tr key={project.asset}>

--- a/jsapp/js/account/usage/useUsage.hook.ts
+++ b/jsapp/js/account/usage/useUsage.hook.ts
@@ -10,9 +10,8 @@ export interface UsageState {
   submissions: number;
   transcriptionMinutes: number;
   translationChars: number;
-  currentMonthStart: string;
-  currentYearStart: string;
-  billingPeriodEnd: string | null;
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
   trackingPeriod: RecurringInterval;
   lastUpdated?: String | null;
 }
@@ -22,9 +21,8 @@ const INITIAL_USAGE_STATE: UsageState = Object.freeze({
   submissions: 0,
   transcriptionMinutes: 0,
   translationChars: 0,
-  currentMonthStart: '',
-  currentYearStart: '',
-  billingPeriodEnd: null,
+  currentPeriodStart: '',
+  currentPeriodEnd: '',
   trackingPeriod: 'month',
   lastUpdated: '',
 });
@@ -49,15 +47,14 @@ const loadUsage = async (
   }
   return {
     storage: usage.total_storage_bytes,
-    submissions: usage.total_submission_count[`current_${trackingPeriod}`],
+    submissions: usage.total_submission_count.current_period,
     transcriptionMinutes: convertSecondsToMinutes(
-      usage.total_nlp_usage[`asr_seconds_current_${trackingPeriod}`]
+      usage.total_nlp_usage.asr_seconds_current_period
     ),
     translationChars:
-      usage.total_nlp_usage[`mt_characters_current_${trackingPeriod}`],
-    currentMonthStart: usage.current_month_start,
-    currentYearStart: usage.current_year_start,
-    billingPeriodEnd: usage[`current_${trackingPeriod}_end`],
+      usage.total_nlp_usage.mt_characters_current_period,
+    currentPeriodStart: usage.current_period_start,
+    currentPeriodEnd: usage.current_period_end,
     trackingPeriod,
     lastUpdated,
   };


### PR DESCRIPTION
### 📣 Summary
Adjusts frontend types and handling of data service/asset usage data according to the changes in #5326.

### 📖 Description
Previously, the ServiceUsageSerializer and AssetUsageSerializer returned usage information calculated according to a monthly billing cycle and a yearly billing cycle, regardless of what kind of billing cycle a user was actually subscribed to. So if a user was on a monthly plan, we made up a hypothetical yearly cycle and returned data for that in addition to the actual monthly cycle they are on. The frontend, in turn, selected the correct cycle information to display based on a separate request fetching the user’s subscription information. The hypothetical periods have been removed from the backend, which now returns only data for "current_period". This PR updates the frontend to handle this new data format.


### 💭 Notes
This currently targets the relevant backend branch so it can be tested, but I will retarget it to main after it is approved and the backend work (already approved) is merged.

### 👀 Preview steps
1. Create a new user on a Stripe-enabled instance

2. Navigate to usage page. Observe that user is on community plan with start date corresponding to account creation date. Displayed usage period should correspond to either first day of this month or last day of previous month (most likely the latter, though it currently depends on one’s timezone) and the last day of this month.

3. Purchase a monthly plan and sync djstripe Subscriptions, navigate to usage page. Observe that start date is still account creation date. Displayed usage period should now correspond to start date and one month after start date.

4. Cancel plan as the user, then cancel the plan via Stripe (or ask someone to do this), and sync subscriptions. Visit 
usage page and observe dates have not changed (because your community plan dates now correspond to date of cancellation and one month later).

5. Sign up for a yearly plan and sync subscriptions. Visit usage page and observe that start date remains the same, while displayed usage period ends a year from today.
