### PR TITLE
feat(organizations): prevent creation of invites for ongoing transfers

### DIFF
--- a/kobo/apps/organizations/admin/organization.py
+++ b/kobo/apps/organizations/admin/organization.py
@@ -7,7 +7,7 @@ from organizations.base_admin import BaseOrganizationAdmin
 from kobo.apps.kobo_auth.shortcuts import User
 
 from ..models import Organization, OrganizationUser
-from ..tasks import transfer_user_ownership_to_org
+from ..tasks import transfer_member_data_ownership_to_org
 from ..utils import revoke_org_asset_perms
 from .organization_owner import OwnerInline
 from .organization_user import OrgUserInline, max_users_for_edit_mode
@@ -104,7 +104,7 @@ class OrgAdmin(BaseOrganizationAdmin):
             html_username_list = []
             for user in new_members:
                 html_username_list.append(f"<b>{user['username']}</b>")
-                transfer_user_ownership_to_org.delay(user['pk'])
+                transfer_member_data_ownership_to_org.delay(user['pk'])
 
             message = (
                 'The following new members have been added, and their project '

--- a/kobo/apps/organizations/admin/organization_user.py
+++ b/kobo/apps/organizations/admin/organization_user.py
@@ -14,7 +14,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 
 from ..forms import OrgUserAdminForm
 from ..models import Organization, OrganizationUser
-from ..tasks import transfer_user_ownership_to_org
+from ..tasks import transfer_member_data_ownership_to_org
 from ..utils import revoke_org_asset_perms
 
 
@@ -136,7 +136,7 @@ class OrgUserResource(resources.ModelResource):
                     'user_id', flat=True
                 ).filter(pk__in=new_organization_user_ids)
                 for user_id in user_ids:
-                    transfer_user_ownership_to_org.delay(user_id)
+                    transfer_member_data_ownership_to_org.delay(user_id)
 
     def before_import_row(self, row, **kwargs):
 
@@ -193,7 +193,7 @@ class OrgUserAdmin(ImportExportModelAdmin, BaseOrganizationUserAdmin):
         previous_organization = form.cleaned_data.get('previous_organization')
         super().save_model(request, obj, form, change)
         if previous_organization:
-            transfer_user_ownership_to_org.delay(obj.user.pk)
+            transfer_member_data_ownership_to_org.delay(obj.user.pk)
             message = (
                 f'User <b>{obj.user.username}</b> has been added to '
                 f'<b>{obj.organization.name}</b>, and their project transfers have '

--- a/kobo/apps/organizations/tasks.py
+++ b/kobo/apps/organizations/tasks.py
@@ -11,7 +11,7 @@ from kobo.celery import celery_app
     soft_time_limit=settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT,
     time_limit=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT,
 )
-def transfer_user_ownership_to_org(user_id: int):
+def transfer_member_data_ownership_to_org(user_id: int):
     sender = User.objects.get(pk=user_id)
     recipient = sender.organization.owner_user_object
     user_assets = sender.assets.only('pk', 'uid').iterator()

--- a/kobo/apps/organizations/tasks.py
+++ b/kobo/apps/organizations/tasks.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from more_itertools import chunked
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.project_ownership.models import Transfer
 from kobo.apps.project_ownership.utils import create_invite
 from kobo.celery import celery_app
 
@@ -14,7 +15,15 @@ from kobo.celery import celery_app
 def transfer_member_data_ownership_to_org(user_id: int):
     sender = User.objects.get(pk=user_id)
     recipient = sender.organization.owner_user_object
-    user_assets = sender.assets.only('pk', 'uid').iterator()
+    user_assets = (
+        sender.assets.only('pk', 'uid')
+        .exclude(
+            pk__in=Transfer.objects.values_list('asset_id', flat=True).filter(
+                invite__sender=sender, invite__recipient=recipient
+            )
+        )
+        .iterator()
+    )
 
     # Splitting assets into batches to avoid creating a long-running
     # Celery task that could exceed Celery's soft time limit or consume


### PR DESCRIPTION
### 📣 Summary
Added validation to block the creation of invites for already existing transfers.

### 📖 Description
This update prevents the creation of duplicate invites when a transfer for the same resource already exists. By avoiding redundant invites, the system ensures better consistency and prevents confusion or potential conflicts arising from simultaneous transfers.

