### PR TITLE
feat(projectHistoryLogs): Sort filter options TASK-1381

### DIFF
--- a/jsapp/js/components/activity/activity.constants.ts
+++ b/jsapp/js/components/activity/activity.constants.ts
@@ -40,156 +40,187 @@ type AuditActionTypes = {
     name: AuditActions;
     label: string;
     message: string;
+    order: number;
   };
 };
 
 export const AUDIT_ACTION_TYPES: AuditActionTypes = {
   'add-media': {
+    order: 10,
     name: AuditActions['add-media'],
     label: t('add media attachment'),
     message: t('##username## added a media attachment'),
   },
   'allow-anonymous-submissions': {
+    order: 16,
     name: AuditActions['allow-anonymous-submissions'],
     label: t('enable anonymous submissions'),
     message: t('##username## enabled anonymous submissions'),
   },
   'archive': {
+    order: 4,
     name: AuditActions['archive'],
     label: t('archive project'),
     message: t('##username## archived project'),
   },
   'clone-permissions': {
+    order: 13,
     name: AuditActions['clone-permissions'],
     label: t('clone permissions'),
     message: t('##username## cloned permissions from another project'),
   },
   'connect-project': {
+    order: 24,
     name: AuditActions['connect-project'],
     label: t('connect project data'),
     message: t('##username## connected project data with another project'),
   },
   'delete-media': {
+    order: 11,
     name: AuditActions['delete-media'],
     label: t('remove media attachment'),
     message: t('##username## removed a media attachment'),
   },
   'delete-service': {
+    order: 29,
     name: AuditActions['delete-service'],
     label: t('delete a REST service'),
     message: t('##username## deleted a REST service'),
   },
   'deploy': {
+    order: 2,
     name: AuditActions['deploy'],
     label: t('deploy project'),
     message: t('##username## deployed project'),
   },
   'disable-sharing': {
+    order: 23,
     name: AuditActions['disable-sharing'],
     label: t('disable data sharing'),
     message: t('##username## disabled data sharing'),
   },
   'disallow-anonymous-submissions': {
+    order: 19,
     name: AuditActions['disallow-anonymous-submissions'],
     label: t('disable anonymous submissions'),
     message: t('##username## disallowed anonymous submissions'),
   },
   'disconnect-project': {
+    order: 26,
     name: AuditActions['disconnect-project'],
     label: t('disconnect project'),
     message: t('##username## disconnected project from another project'),
   },
   'enable-sharing': {
+    order: 21,
     name: AuditActions['enable-sharing'],
     label: t('enable data sharing'),
     message: t('##username## enabled data sharing'),
   },
   'export': {
+    order: 9,
     name: AuditActions['export'],
     label: t('export data'),
     message: t('##username## exported data'),
   },
   'modify-imported-fields': {
+    order: 25,
     name: AuditActions['modify-imported-fields'],
     label: t('change imported fields'),
     message: t('##username## changed imported fields from another project'),
   },
   'modify-service': {
+    order: 28,
     name: AuditActions['modify-service'],
     label: t('modify a REST service'),
     message: t('##username## modified a REST service'),
   },
   'modify-sharing': {
+    order: 22,
     name: AuditActions['modify-sharing'],
     label: t('modify data sharing'),
     message: t('##username## modified data sharing'),
   },
   'modify-user-permissions': {
+    order: 12,
     name: AuditActions['modify-user-permissions'],
     label: t('update permissions'),
     message: t('##username## updated permissions of ##username2##'),
   },
   'redeploy': {
+    order: 3,
     name: AuditActions['redeploy'],
     label: t('redeploy project'),
     message: t('##username## redeployed project'),
   },
   'register-service': {
+    order: 27,
     name: AuditActions['register-service'],
     label: t('register a new REST service'),
     message: t('##username## registered a new REST service'),
   },
   'replace-form': {
+    order: 6,
     name: AuditActions['replace-form'],
     label: t('upload new form'),
     message: t('##username## uploaded a new form'),
   },
   'share-data-publicly': {
+    order: 15,
     name: AuditActions['share-data-publicly'],
     label: t('share data publicly'),
     message: t('##username## shared data publicly'),
   },
   'share-form-publicly': {
+    order: 14,
     name: AuditActions['share-form-publicly'],
     label: t('make project public'),
     message: t('##username## made the project publicly accessible'),
   },
   'transfer': {
+    order: 20,
     name: AuditActions['transfer'],
     label: t('transfer project ownership'),
     message: t('##username## transferred project ownership to ##username2##'),
   },
   'unarchive': {
+    order: 5,
     name: AuditActions['unarchive'],
     label: t('unarchive project'),
     message: t('##username## unarchived project'),
   },
   'unshare-data-publicly': {
+    order: 18,
     name: AuditActions['unshare-data-publicly'],
     label: t('disable sharing data publicly'),
     message: t('##username## disabled sharing data publicly'),
   },
   'unshare-form-publicly': {
+    order: 17,
     name: AuditActions['unshare-form-publicly'],
     label: t('disable making project public'),
     message: t('##username## disabled making project publicly accessible'),
   },
   'update-content': {
+    order: 7,
     name: AuditActions['update-content'],
     label: t('edit form'),
     message: t('##username## edited the form in the form builder'),
   },
   'update-name': {
+    order: 0,
     name: AuditActions['update-name'],
     label: t('change name'),
     message: t('##username## changed project name'),
   },
   'update-settings': {
+    order: 1,
     name: AuditActions['update-settings'],
     label: t('update settings'),
     message: t('##username## updated project settings'),
   },
   'update-qa': {
+    order: 8,
     name: AuditActions['update-qa'],
     label: t('modify qualitative analysis questions'),
     message: t('##username## modified qualitative analysis questions'),

--- a/jsapp/js/components/activity/activityLogs.query.ts
+++ b/jsapp/js/components/activity/activityLogs.query.ts
@@ -50,7 +50,7 @@ const getActivityLogs = async ({
  * Filter options, for now, comes from AuditActions enum.
  * In the future we might change this to be fetched from the server.
  *
- * Items are filtered by specific order defined in the AUDIT_ACTION_TYPES.
+ * Items are sorted by an specific order defined in the AUDIT_ACTION_TYPES.
  *
  */
 const getFilterOptions = async () =>

--- a/jsapp/js/components/activity/activityLogs.query.ts
+++ b/jsapp/js/components/activity/activityLogs.query.ts
@@ -50,14 +50,17 @@ const getActivityLogs = async ({
  * Filter options, for now, comes from AuditActions enum.
  * In the future we might change this to be fetched from the server.
  *
+ * Items are filtered by specific order defined in the AUDIT_ACTION_TYPES.
+ *
  */
 const getFilterOptions = async () =>
   (Object.keys(AuditActions) as Array<keyof typeof AuditActions>)
-    .sort()
-    .map((value) => {
+    .map((key) => AUDIT_ACTION_TYPES[key])
+    .sort((a, b) => a.order - b.order)
+    .map((auditAction) => {
       return {
-        label: AUDIT_ACTION_TYPES[value].label,
-        value,
+        label: auditAction.label,
+        value: auditAction.name,
       };
     });
 


### PR DESCRIPTION
### 📣 Summary
Filter option for activity list are now sorted by a pre-defined relevance order


### 📖 Description
- An `order` property was added to the `AUDIT_ACTION` objects
- Order was set for the actions based on [this table](https://www.notion.so/kobotoolbox/Write-code-for-rendering-all-possible-activity-messages-in-the-UI-1287e515f65480868bbcdc19c085920f?pvs=4#1287e515f654808a83cce66d13abde6c)
- Actions were sorted based on the `order` property

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. ℹ️ have an account and a project
2. Have the activity logs feature flag on with: `?ff_activityLogsEnabled=true`
4. Navigate to Project > Settings > Activity
5. Open the `Filter by` select box
6. 🟢 Notice that the items are sorted according to [this table](https://www.notion.so/kobotoolbox/Write-code-for-rendering-all-possible-activity-messages-in-the-UI-1287e515f65480868bbcdc19c085920f?pvs=4#1287e515f654808a83cce66d13abde6c)
