### PR TITLE
fix(sso): 500 on admin login (#5334)

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -29,6 +29,7 @@ amqp==5.2.0
 asgiref==3.8.1
     # via
     #   django
+    #   django-allauth
     #   django-cors-headers
 asttokens==2.4.1
     # via stack-data
@@ -109,7 +110,6 @@ cryptography==42.0.5
     #   azure-storage-blob
     #   jwcrypto
     #   paramiko
-    #   pyjwt
     #   pyopenssl
 cssselect==1.2.0
     # via pyquery
@@ -131,7 +131,6 @@ defusedxml==0.7.1
     # via
     #   -r dependencies/pip/requirements.in
     #   djangorestframework-xml
-    #   python3-openid
     #   pyxform
 deprecated==1.2.14
     # via fabric
@@ -171,7 +170,7 @@ django==4.2.15
     #   djangorestframework
     #   jsonfield
     #   model-bakery
-django-allauth==0.61.1
+django-allauth==65.1.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in
@@ -488,10 +487,8 @@ pygments==2.17.2
     # via
     #   -r dependencies/pip/requirements.in
     #   ipython
-pyjwt[crypto]==2.8.0
-    # via
-    #   django-allauth
-    #   twilio
+pyjwt==2.8.0
+    # via twilio
 pymongo==4.6.3
     # via -r dependencies/pip/requirements.in
 pynacl==1.5.0
@@ -531,8 +528,6 @@ python-dateutil==2.9.0.post0
     #   freezegun
     #   pandas
     #   python-crontab
-python3-openid==3.2.0
-    # via django-allauth
 pytz==2024.1
     # via
     #   flower
@@ -559,19 +554,15 @@ requests==2.31.0
     #   -r dependencies/pip/requirements.in
     #   azure-core
     #   coveralls
-    #   django-allauth
     #   django-oauth-toolkit
     #   google-api-core
     #   google-cloud-storage
     #   httmock
-    #   requests-oauthlib
     #   responses
     #   smsapi-client
     #   stripe
     #   twilio
     #   yubico-client
-requests-oauthlib==2.0.0
-    # via django-allauth
 responses==0.25.0
     # via -r dependencies/pip/requirements.in
 rpds-py==0.18.0

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -29,6 +29,7 @@ amqp==5.2.0
 asgiref==3.8.1
     # via
     #   django
+    #   django-allauth
     #   django-cors-headers
 async-timeout==4.0.3
     # via
@@ -92,7 +93,6 @@ cryptography==42.0.5
     # via
     #   azure-storage-blob
     #   jwcrypto
-    #   pyjwt
     #   pyopenssl
 cssselect==1.2.0
     # via pyquery
@@ -102,7 +102,6 @@ defusedxml==0.7.1
     # via
     #   -r dependencies/pip/requirements.in
     #   djangorestframework-xml
-    #   python3-openid
     #   pyxform
 dict2xml==1.7.5
     # via -r dependencies/pip/requirements.in
@@ -139,7 +138,7 @@ django==4.2.15
     #   django-timezone-field
     #   djangorestframework
     #   jsonfield
-django-allauth==0.61.1
+django-allauth==65.1.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in
@@ -381,10 +380,8 @@ pycparser==2.22
     # via cffi
 pygments==2.17.2
     # via -r dependencies/pip/requirements.in
-pyjwt[crypto]==2.8.0
-    # via
-    #   django-allauth
-    #   twilio
+pyjwt==2.8.0
+    # via twilio
 pymongo==4.6.3
     # via -r dependencies/pip/requirements.in
 pyopenssl==24.1.0
@@ -406,8 +403,6 @@ python-dateutil==2.9.0.post0
     #   celery
     #   pandas
     #   python-crontab
-python3-openid==3.2.0
-    # via django-allauth
 pytz==2024.1
     # via
     #   flower
@@ -433,18 +428,14 @@ requests==2.31.0
     # via
     #   -r dependencies/pip/requirements.in
     #   azure-core
-    #   django-allauth
     #   django-oauth-toolkit
     #   google-api-core
     #   google-cloud-storage
-    #   requests-oauthlib
     #   responses
     #   smsapi-client
     #   stripe
     #   twilio
     #   yubico-client
-requests-oauthlib==2.0.0
-    # via django-allauth
 responses==0.25.0
     # via -r dependencies/pip/requirements.in
 rpds-py==0.18.0

--- a/kobo/apps/accounts/tests/test_backend.py
+++ b/kobo/apps/accounts/tests/test_backend.py
@@ -49,9 +49,9 @@ class SSOLoginTest(TestCase):
 
     @override_settings(SOCIALACCOUNT_PROVIDERS=SOCIALACCOUNT_PROVIDERS)
     @responses.activate
-    @patch('allauth.socialaccount.models.SocialLogin.verify_and_unstash_state')
-    def test_keep_django_auth_backend_with_sso(self, mock_verify_and_unstash_state):
-        mock_verify_and_unstash_state.return_value = {'process': 'login'}
+    @patch('allauth.socialaccount.providers.oauth2.views.statekit.unstash_state')
+    def test_keep_django_auth_backend_with_sso(self, mock_unstash_state):
+        mock_unstash_state.return_value = {'process': 'login'}
 
         # Mock `requests` responses to fool django-allauth
         responses.add(
@@ -91,7 +91,7 @@ class SSOLoginTest(TestCase):
         )
 
         # Simulate GET request to SSO provider
-        mock_sso_response = {'code': 'foobar'}
+        mock_sso_response = {'code': 'foobar', 'state': '12345'}
         response = self.client.get(sso_login_url, data=mock_sso_response)
 
         # Ensure user is logged in


### PR DESCRIPTION
Fixes a 500 being thrown when a non-superuser goes to /admin and then tries to log in as a superuser.

Upgrade django-allauth to 65.1.0.

The simplest solution seemed to be just to upgrade django-allauth. It's unclear which exact commit fixes the bug and we are very behind in versions so upgraded to the latest. Nothing obvious broke except one unit test.

Bug template:
1. ℹ️ Have 2 accounts, one super and one not
2. Log in as the non-superuser
3. Go to /admin
4. You should be redirected to the login page.
5. Log in as the super user
6. 🔴 [on main] 500 error
7. Checkout the PR branch. Make sure to reinstall requirements.
8. Do 1-5 again.
9. 🟢 [on PR] You should be correctly logged in and sent to the admin page
