### PR TITLE
feat(projectHistoryLogs): remove activity logs feature flag TASK-1385

### DIFF
--- a/jsapp/js/components/formViewSideTabs.es6
+++ b/jsapp/js/components/formViewSideTabs.es6
@@ -83,8 +83,6 @@ class FormViewSideTabs extends Reflux.Component {
   renderFormSideTabs() {
     var sideTabs = [];
 
-    const isActivityLogsEnabled = checkFeatureFlag(FeatureFlag.activityLogsEnabled);
-
     if (
       this.state.asset &&
       this.state.asset.has_deployment &&
@@ -167,7 +165,6 @@ class FormViewSideTabs extends Reflux.Component {
       }
 
       if (
-        isActivityLogsEnabled &&
         userCan(
           PERMISSIONS_CODENAMES.manage_asset,
           this.state.asset

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -3,7 +3,6 @@
  * For our sanity, use camel case and match key with value.
  */
 export enum FeatureFlag {
-  activityLogsEnabled = 'activityLogsEnabled',
   mmosEnabled = 'mmosEnabled',
   oneTimeAddonsEnabled = 'oneTimeAddonsEnabled',
   exportActivityLogsEnabled = 'exportActivityLogsEnabled',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Activity logs is no longer hidden behind a feature flag and i snow accessible via Project > Settings > Activity


### 📖 Description
- The feature flag was removed from the enum
- The link to the route is now always visible

### 👀 Preview steps
1. ℹ️ have an account and a project
2. Remove or disable the activity logs feature flag on with: `?ff_activityLogsEnabled=false` if needed
4. Navigate to Project > Settings
5. 🟢 The `Activity` session should be accessible