### PR TITLE
fix(billing): check default plan limits on backend TASK-1364

### DIFF
--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -18,6 +18,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization, OrganizationUser
 from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.stripe.tests.utils import (
+    generate_free_plan,
     generate_mmo_subscription,
     generate_plan_subscription,
 )
@@ -461,11 +462,11 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         self.organization.add_user(self.anotheruser, is_admin=True)
 
     def test_get_plan_community_limit(self):
-        generate_mmo_subscription(self.organization)
+        generate_free_plan()
         limit = get_organization_plan_limit(self.organization, 'seconds')
-        assert limit == 2000  # TODO get the limits from the community plan, overrides
+        assert limit == 600
         limit = get_organization_plan_limit(self.organization, 'characters')
-        assert limit == 2000  # TODO get the limits from the community plan, overrides
+        assert limit == 6000
 
     @data('characters', 'seconds')
     def test_get_suscription_limit(self, usage_type):

--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -8,6 +8,26 @@ from model_bakery import baker
 from kobo.apps.organizations.models import Organization
 
 
+def generate_free_plan():
+    product_metadata = {
+        'product_type': 'plan',
+        'submission_limit': '5000',
+        'asr_seconds_limit': '600',
+        'mt_characters_limit': '6000',
+        'storage_bytes_limit': '1000000000',
+    }
+
+    product = baker.make(Product, active=True, metadata=product_metadata)
+
+    baker.make(
+        Price,
+        active=True,
+        recurring={'interval': 'month'},
+        unit_amount=0,
+        product=product,
+    )
+
+
 def generate_plan_subscription(
     organization: Organization,
     metadata: dict = None,

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -5,7 +5,7 @@ from django.db.models import F
 
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.types import UsageType
-from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, USAGE_LIMIT_MAP
+from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 
 
 def generate_return_url(product_metadata):
@@ -30,51 +30,44 @@ def get_organization_plan_limit(
     organization: Organization, usage_type: UsageType
 ) -> int | float:
     """
-    Get organization plan limit for a given usage type
+    Get organization plan limit for a given usage type,
+    will fall back to infinite value if no subscription or
+    default free tier plan found.
     """
     if not settings.STRIPE_ENABLED:
-        return None
-    stripe_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
-    query_product_type = (
-        'djstripe_customers__subscriptions__items__price__'
-        'product__metadata__product_type'
-    )
-    query_status__in = 'djstripe_customers__subscriptions__status__in'
-    organization_filter = Organization.objects.filter(
-        id=organization.id,
-        **{
-            query_status__in: ACTIVE_STRIPE_STATUSES,
-            query_product_type: 'plan',
-        },
-    )
+        return inf
 
-    field_price_limit = (
-        'djstripe_customers__subscriptions__items__' f'price__metadata__{stripe_key}'
-    )
-    field_product_limit = (
-        'djstripe_customers__subscriptions__items__'
-        f'price__product__metadata__{stripe_key}'
-    )
-    current_limit = organization_filter.values(
-        price_limit=F(field_price_limit),
-        product_limit=F(field_product_limit),
-        prod_metadata=F(
-            'djstripe_customers__subscriptions__items__price__product__metadata'
-        ),
-    ).first()
+    limit_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
+
     relevant_limit = None
-    if current_limit is not None:
-        relevant_limit = current_limit.get('price_limit') or current_limit.get(
-            'product_limit'
+    if subscription := organization.active_subscription_billing_details():
+        price_metadata = subscription['price_metadata']
+        product_metadata = subscription['product_metadata']
+        price_limit = price_metadata[limit_key] if price_metadata else None
+        product_limit = product_metadata[limit_key] if product_metadata else None
+        relevant_limit = price_limit or product_limit
+    else:
+        from djstripe.models.core import Product
+
+        # Anyone who does not have a subscription is on the free tier plan by default
+        default_plan = (
+            Product.objects.filter(
+                prices__unit_amount=0, prices__recurring__interval='month'
+            )
+            .values(limit=F(f'metadata__{limit_key}'))
+            .first()
         )
-    if relevant_limit is None:
-        # TODO: get the limits from the community plan, overrides
-        relevant_limit = 2000
-    # Limits in Stripe metadata are strings. They may be numbers or 'unlimited'
+
+        if default_plan:
+            relevant_limit = default_plan['limit']
+
     if relevant_limit == 'unlimited':
         return inf
 
-    return int(relevant_limit)
+    if relevant_limit:
+        return int(relevant_limit)
+
+    return inf
 
 
 def get_total_price_for_quantity(price: 'djstripe.models.Price', quantity: int):


### PR DESCRIPTION
### 📣 Summary
Updates backend code to check Stripe products for default "community plan" limits when determining organization usage.

### 📖 Description
Currently, the frontend gets billing usage limits for the free Community Plan from the corresponding Stripe product (returned by the products endpoint). The backend, however, does not reference these limits at all. This has not been a problem previously, because the backend currently does not enforce usage limits (only NLP limits are enforced, and this is handled by the frontend at present) and had no other need for these limits. 

Now that the backend is tracking addon usage, however, it does need to be aware of community plan usage limits. This PR updates the get_organization_plan_limit util function to use the limits from the metadata of the default community plan when an organization does not have a subscription.

### 👀 Preview steps
Change covered by unit test