### PR TITLE
fix(organizations): limit my org projects query to surveys TASK-1389

### DIFF
--- a/jsapp/js/projects/myOrgProjectsRoute.tsx
+++ b/jsapp/js/projects/myOrgProjectsRoute.tsx
@@ -43,7 +43,7 @@ export default function MyOrgProjectsRoute() {
       viewUid={ORG_VIEW.uid}
       baseUrl={`${ROOT_URL}${apiUrl}`}
       defaultVisibleFields={HOME_DEFAULT_VISIBLE_FIELDS}
-      includeTypeFilter={false}
+      includeTypeFilter
       defaultOrderableFields={HOME_ORDERABLE_FIELDS}
       defaultExcludedFields={HOME_EXCLUDED_FIELDS}
       isExportButtonVisible={false}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds query param to asset API request on `myOrgProjectsRoute` to restrict query to only surveys.

### 👀 Preview steps
1. Create an MMO and a collection
2. View MMO org project list 
3. On main, the collection will appear on this list
4. On this branch, the collection will not appear (because a query param is added to the API request)