### PR TITLE
feat(organizations): display org name for project owner in sharing form TASK-1383

### DIFF
--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -165,6 +165,13 @@ export default class SharingForm extends React.Component<
     }
   }
 
+  getOwnerOrOrgLabel(name: string, isOwner: boolean) {
+    if (isOwner) {
+      return this.state.asset ? this.state.asset.owner_label : name;
+    }
+    return name;
+  }
+
   /** Check if the recipient of the transfer is the specified user */
   isPendingOwner(username: string) {
     return this.state.asset?.project_ownership?.status ===
@@ -261,7 +268,7 @@ export default class SharingForm extends React.Component<
                 permissions={perm.permissions}
                 isUserOwner={perm.user.isOwner}
                 isPendingOwner={this.isPendingOwner(perm.user.name)}
-                username={perm.user.name}
+                username={this.getOwnerOrOrgLabel(perm.user.name, perm.user.isOwner)}
               />
             );
           })}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
When a project is owned by an organization, the sharing form will display the name of that organization instead of the user name of the organization owner.

### 👀 Preview steps
1. Create an MMO and a project owned by that MMO
2. Share project with one user who is a member of the MMO and another user outside of the MMO
3. Log in as other user and open sharing form
4. Notice that the MMO name is displayed, rather than the owner's name, on the owner row
5. Notice that the non-owner MMO member's username is displayed, rather than the org name