### PR TITLE
feat(auditLogs): add endpoint for retrieving actions TASK-1365

### DIFF
--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -635,7 +635,7 @@ class ApiProjectHistoryLogsTestCase(BaseTestCase, ProjectHistoryLogTestCaseMixin
         response = self.client.get(f'{self.url}actions/')
         self.assertListEqual(
             # order returned doesn't matter
-            sorted(response.data),
+            sorted(response.data['actions']),
             [AuditAction.DELETE_MEDIA, AuditAction.DELETE_SERVICE, AuditAction.DEPLOY],
         )
 

--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -263,6 +263,16 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
         assert response.data['count'] == 1
         assert response.data['results'] == expected
 
+    def test_all_actions_requires_authentication(self):
+        self.client.logout()
+        response = self.client.get(f'{self.url}actions/')
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_all_actions(self):
+        self.login_user(username='someuser', password='someuser')
+        response = self.client.get(f'{self.url}actions/')
+        assert response.data == AuditAction.choices
+
 
 class ApiAccessLogTestCase(BaseAuditLogTestCase):
 

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -1,5 +1,6 @@
 from rest_framework import mixins, status, viewsets
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.decorators import action
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework.response import Response
 
@@ -8,6 +9,7 @@ from kpi.models.import_export_task import AccessLogExportTask
 from kpi.permissions import IsAuthenticated
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 from kpi.tasks import export_task_in_background
+from .audit_actions import AuditAction
 from .filters import AccessLogPermissionsFilter
 from .models import AccessLog, AuditLog, ProjectHistoryLog
 from .permissions import SuperUserPermission, ViewProjectHistoryLogsPermission
@@ -162,6 +164,15 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         'model_name__icontains',
         'metadata__icontains',
     ]
+
+    @action(
+        detail=False,
+        methods=['GET'],
+        permission_classes=(IsAuthenticated,)
+    )
+    def actions(self, request):
+        data = AuditAction.choices
+        return Response(data)
 
 
 class AllAccessLogViewSet(AuditLogViewSet):

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -144,6 +144,32 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     *Notes: Do not forget to wrap search terms in double-quotes if they contain spaces
     (e.g. date and time "2022-11-15 20:34")*
 
+    ### Actions
+
+    Retrieves all possible audit log actions.
+    <pre class="prettyprint">
+    <b>GET</b> /api/v2/audit-logs/actions
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi]/api/v2/audit-log/actions/
+
+    > Response 200
+
+    >       [
+    >           [
+    >               "add-media",
+    >               "Add Media"
+    >           ],
+    >           [
+    >               "allow-anonymous-submisisons",
+    >               "Allow Anonymous Submissions"
+    >           ],
+    >           ...
+    >       ]
+
+
     ### CURRENT ENDPOINT
     """
 
@@ -171,8 +197,7 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         permission_classes=(IsAuthenticated,)
     )
     def actions(self, request):
-        data = AuditAction.choices
-        return Response(data)
+        return Response(AuditAction.choices)
 
 
 class AllAccessLogViewSet(AuditLogViewSet):

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -862,7 +862,7 @@ class ProjectHistoryLogViewSet(
             .distinct()
         )
         flattened = [action[0] for action in actions]
-        return Response(flattened)
+        return Response({'actions': flattened})
 
 
 class BaseAccessLogsExportViewSet(viewsets.ViewSet):

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -834,12 +834,14 @@ class ProjectHistoryLogViewSet(
 
     > Response 200
 
-    >       [
+    >   {
+    >       "actions": [
     >           "update-name",
     >           "update-content",
     >           "deploy",
     >           ...
     >       ]
+    >   }
 
     """
 

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -1,14 +1,14 @@
 from rest_framework import mixins, status, viewsets
-from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.decorators import action
-from rest_framework_extensions.mixins import NestedViewSetMixin
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from kpi.filters import SearchFilter
 from kpi.models.import_export_task import AccessLogExportTask
 from kpi.permissions import IsAuthenticated
-from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 from kpi.tasks import export_task_in_background
+from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 from .audit_actions import AuditAction
 from .filters import AccessLogPermissionsFilter
 from .models import AccessLog, AuditLog, ProjectHistoryLog
@@ -191,11 +191,7 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         'metadata__icontains',
     ]
 
-    @action(
-        detail=False,
-        methods=['GET'],
-        permission_classes=(IsAuthenticated,)
-    )
+    @action(detail=False, methods=['GET'], permission_classes=(IsAuthenticated,))
     def actions(self, request):
         return Response(AuditAction.choices)
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add a new endpoint for viewing all audit actions taken for an asset.


### 💭 Notes
Added as an `action` so it was easily nested in `api/v2/asset/<uid>/history`. Confirmed that this does not result in any unnecessary queries.


Feature/no-change template:
1. ℹ️ have an account 
2. Create a new project. Just give it a name (no other settings) and some questions in the form builder. Don't deploy it yet.
3. Go to `api/v2/assets/<project_uid>/history/actions`
5. 🟢 The response should be
```
{ "actions": [
    "update-content"
]}
```
6. Change the name
7. Deploy the project
7. 🟢 Reload the endpoint. The response should now be (order doesn't matter):
```
{ "actions": [
    "update-name",
    "update-content",
    "deploy",
]}
```


