### PR TITLE
fix(organization): expose `owner_label` in ProjectView endpoint response TASK-1384

### DIFF
--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 from django.conf import settings
 from django.db.models.query import QuerySet
@@ -134,7 +134,7 @@ class ProjectViewViewSet(
             queryset, serializer_class=UserListSerializer
         )
 
-    def get_serializer_context(self, data: list = None):
+    def get_serializer_context(self, data: Optional[list] = None):
         context_ = super().get_serializer_context()
         context_['request'] = self.request
         if not data:
@@ -142,7 +142,7 @@ class ProjectViewViewSet(
 
         asset_ids = [asset.pk for asset in data]
         context_['organizations_per_asset'] = (
-            self.get_organizations_per_asset(asset_ids)
+            self.get_organizations_per_asset_ids(asset_ids)
         )
 
         return context_

--- a/kpi/mixins/asset.py
+++ b/kpi/mixins/asset.py
@@ -7,7 +7,7 @@ from kpi.models.asset import Asset
 
 class AssetViewSetListMixin:
 
-    def get_organizations_per_asset(self, asset_ids: list) -> dict:
+    def get_organizations_per_asset_ids(self, asset_ids: list) -> dict:
 
         assets = (
             Asset.objects.only('owner', 'uid', 'name')

--- a/kpi/mixins/asset.py
+++ b/kpi/mixins/asset.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+from django.db.models import Prefetch
+
+from kobo.apps.organizations.models import Organization
+from kpi.models.asset import Asset
+
+
+class AssetViewSetListMixin:
+
+    def get_organizations_per_asset(self, asset_ids: list) -> dict:
+
+        assets = (
+            Asset.objects.only('owner', 'uid', 'name')
+            .filter(id__in=asset_ids)
+            .select_related('owner')
+            .prefetch_related(
+                Prefetch(
+                    'owner__organizations_organization',
+                    queryset=Organization.objects.all().order_by(
+                        '-organization_users__created'
+                    ),
+                    to_attr='organizations',
+                )
+            )
+        )
+        organizations_per_asset = defaultdict(dict)
+        for asset in assets:
+            try:
+                organizations_per_asset[asset.id] = asset.owner.organizations[0]
+            except IndexError:
+                pass
+
+        return organizations_per_asset

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -819,7 +819,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             access_types.append('superuser')
 
         try:
-            organization = self.context['organization_by_asset'].get(asset.id)
+            organization = self.context['organizations_per_asset'].get(asset.id)
         except KeyError:
             # Fallback on context if it exists (i.e.: asset lists of an organization).
             # Otherwise, retrieve from the asset owner.
@@ -840,7 +840,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_owner_label(self, asset):
         try:
-            organization = self.context['organization_by_asset'].get(asset.id)
+            organization = self.context['organizations_per_asset'].get(asset.id)
         except KeyError:
             # Fallback on context if it exists (i.e.: asset lists of an organization).
             # Otherwise, retrieve from the asset owner.
@@ -1135,6 +1135,7 @@ class AssetMetadataListSerializer(AssetListSerializer):
             'deployment_status',
             'asset_type',
             'downloads',
+            'owner_label',
         )
 
     def get_deployment__submission_count(self, obj: Asset) -> int:

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -51,7 +51,10 @@ from kpi.utils.ss_structure_to_mdtable import ss_structure_to_mdtable
 
 
 class AssetViewSet(
-    AssetViewSetListMixin, ObjectPermissionViewSetMixin, NestedViewSetMixin, AuditLoggedModelViewSet
+    AssetViewSetListMixin,
+    ObjectPermissionViewSetMixin,
+    NestedViewSetMixin,
+    AuditLoggedModelViewSet,
 ):
     """
     * Assign an asset to a collection

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -3,7 +3,7 @@ import json
 from collections import OrderedDict, defaultdict
 from operator import itemgetter
 
-from django.db.models import Count, Prefetch
+from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import exceptions, renderers, status
@@ -13,7 +13,6 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from kobo.apps.audit_log.base_views import AuditLoggedModelViewSet
 from kobo.apps.audit_log.models import AuditType
-from kobo.apps.organizations.models import Organization
 from kpi.constants import (
     ASSET_TYPE_ARG_NAME,
     ASSET_TYPE_SURVEY,
@@ -26,6 +25,7 @@ from kpi.constants import (
 from kpi.exceptions import BadAssetTypeException
 from kpi.filters import AssetOrderingFilter, KpiObjectPermissionsFilter, SearchFilter
 from kpi.highlighters import highlight_xform
+from kpi.mixins.asset import AssetViewSetListMixin
 from kpi.mixins.object_permission import ObjectPermissionViewSetMixin
 from kpi.models import Asset, UserAssetSubscription
 from kpi.paginators import AssetPagination
@@ -51,7 +51,7 @@ from kpi.utils.ss_structure_to_mdtable import ss_structure_to_mdtable
 
 
 class AssetViewSet(
-    ObjectPermissionViewSetMixin, NestedViewSetMixin, AuditLoggedModelViewSet
+    AssetViewSetListMixin, ObjectPermissionViewSetMixin, NestedViewSetMixin, AuditLoggedModelViewSet
 ):
     """
     * Assign an asset to a collection
@@ -731,28 +731,9 @@ class AssetViewSet(
             else:
                 # …per asset
                 # e.g.: /api/v2/organizations/assets/`
-                assets = (
-                    Asset.objects.only('owner', 'uid', 'name')
-                    .filter(id__in=asset_ids)
-                    .select_related('owner')
-                    .prefetch_related(
-                        Prefetch(
-                            'owner__organizations_organization',
-                            queryset=Organization.objects.all().order_by(
-                                '-organization_users__created'
-                            ),
-                            to_attr='organizations',
-                        )
-                    )
+                context_['organizations_per_asset'] = (
+                    self.get_organizations_per_asset(asset_ids)
                 )
-                organization_by_asset = defaultdict(dict)
-                for asset in assets:
-                    try:
-                        organization_by_asset[asset.id] = asset.owner.organizations[0]
-                    except IndexError:
-                        pass
-
-                context_['organization_by_asset'] = organization_by_asset
 
         return context_
 

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -735,7 +735,7 @@ class AssetViewSet(
                 # …per asset
                 # e.g.: /api/v2/organizations/assets/`
                 context_['organizations_per_asset'] = (
-                    self.get_organizations_per_asset(asset_ids)
+                    self.get_organizations_per_asset_ids(asset_ids)
                 )
 
         return context_


### PR DESCRIPTION
### 📣 Summary
The Project view endpoint has been updated to include the owner label in its response. 


### 📖 Description
The Project view endpoint has been updated to include the owner label in its response. This fix ensures that the front end can retrieve the owner information directly from the endpoint, improving usability across the application.

