### PR TITLE
feat(organizations): remove mmos feature flag TASK-1397

### DIFF
--- a/jsapp/js/account/accountSidebar.tsx
+++ b/jsapp/js/account/accountSidebar.tsx
@@ -14,7 +14,6 @@ import {
   useOrganizationQuery,
   OrganizationUserRole,
 } from 'js/account/organization/organizationQuery';
-import {useFeatureFlag, FeatureFlag} from 'js/featureFlags';
 import {getSimpleMMOLabel} from './organization/organization.utils';
 import LoadingSpinner from 'js/components/common/loadingSpinner';
 
@@ -168,7 +167,6 @@ function renderMmoSidebar(
 
 function AccountSidebar() {
   const [isStripeEnabled, setIsStripeEnabled] = useState(false);
-  const enableMMORoutes = useFeatureFlag(FeatureFlag.mmosEnabled);
   const orgQuery = useOrganizationQuery();
 
   useWhenStripeIsEnabled(() => {
@@ -191,7 +189,7 @@ function AccountSidebar() {
     return <LoadingSpinner />;
   }
 
-  if (orgQuery.data.is_mmo && enableMMORoutes) {
+  if (orgQuery.data.is_mmo) {
     return renderMmoSidebar(
       orgQuery.data?.request_user_role,
       isStripeEnabled,

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -12,10 +12,15 @@ import {QueryKeys} from 'js/query/queryKeys';
 import {queryClient} from 'jsapp/js/query/queryClient';
 
 // Comes from `kobo/apps/accounts/forms.py`
-export type OrganizationTypeName = 'non-profit' | 'government' | 'educational' | 'commercial' | 'none';
+export type OrganizationTypeName =
+  | 'non-profit'
+  | 'government'
+  | 'educational'
+  | 'commercial'
+  | 'none';
 
 export const ORGANIZATION_TYPES: {
-  [P in OrganizationTypeName]: {name: OrganizationTypeName; label: string}
+  [P in OrganizationTypeName]: {name: OrganizationTypeName; label: string};
 } = {
   'non-profit': {name: 'non-profit', label: t('Non-profit organization')},
   government: {name: 'government', label: t('Government institution')},
@@ -78,7 +83,6 @@ interface OrganizationQueryParams {
  * to invalidate data and refetch when absolute latest data is needed.
  */
 export const useOrganizationQuery = (params?: OrganizationQueryParams) => {
-
   useEffect(() => {
     if (params?.shouldForceInvalidation) {
       queryClient.invalidateQueries({
@@ -91,23 +95,16 @@ export const useOrganizationQuery = (params?: OrganizationQueryParams) => {
   const session = useSession();
   const organizationUrl = session.currentLoggedAccount?.organization?.url;
 
-  // Using a separated function to fetch the organization data to prevent
-  // feature flag dependencies from being added to the hook
-  const fetchOrganization = async (): Promise<Organization> =>
-    // `organizationUrl` is a full url with protocol and domain name, so we're
-    // using fetchGetUrl.
-    // We're asserting the `organizationUrl` is not `undefined` here because
-    // the query is disabled without it.
-     await fetchGetUrl<Organization>(organizationUrl!);
-
   // Setting the 'enabled' property so the query won't run until we have
   // the session data loaded. Account data is needed to fetch the organization
   // data.
 
-  const query = useQuery<Organization, FailResponse, Organization, QueryKeys[]>({
+  const query = useQuery<Organization, FailResponse>({
     staleTime: 1000 * 60 * 2,
-    queryFn: fetchOrganization,
-    queryKey: [QueryKeys.organization],
+    // We're asserting the `organizationUrl` is not `undefined` here because
+    // the query is disabled without it.
+    queryFn: () => fetchGetUrl<Organization>(organizationUrl!),
+    queryKey: [QueryKeys.organization, organizationUrl],
     enabled: !!organizationUrl,
   });
 

--- a/jsapp/js/account/routes.tsx
+++ b/jsapp/js/account/routes.tsx
@@ -14,10 +14,8 @@ import {
   MembersRoute,
   OrganizationSettingsRoute,
 } from 'js/account/routes.constants';
-import {useFeatureFlag, FeatureFlag} from 'js/featureFlags';
 
 export default function routes() {
-  const enableMMORoutes = useFeatureFlag(FeatureFlag.mmosEnabled);
 
   return (
     <>
@@ -112,40 +110,36 @@ export default function routes() {
           </RequireAuth>
         }
       />
-      {enableMMORoutes && (
-        <>
-          <Route
-            path={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
-            element={
-              <RequireAuth>
-                <RequireOrgPermissions
-                  mmoOnly
-                  redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
-                >
-                  <MembersRoute />
-                </RequireOrgPermissions>
-              </RequireAuth>
-            }
-          />
-          <Route
-            path={ACCOUNT_ROUTES.ORGANIZATION_SETTINGS}
-            element={
-              <RequireAuth>
-                <RequireOrgPermissions
-                  validRoles={[
-                    OrganizationUserRole.owner,
-                    OrganizationUserRole.admin,
-                  ]}
-                  mmoOnly
-                  redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
-                >
-                  <OrganizationSettingsRoute />
-                </RequireOrgPermissions>
-              </RequireAuth>
-            }
-          />
-        </>
-      )}
+      <Route
+        path={ACCOUNT_ROUTES.ORGANIZATION_MEMBERS}
+        element={
+          <RequireAuth>
+            <RequireOrgPermissions
+              mmoOnly
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
+            >
+              <MembersRoute />
+            </RequireOrgPermissions>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path={ACCOUNT_ROUTES.ORGANIZATION_SETTINGS}
+        element={
+          <RequireAuth>
+            <RequireOrgPermissions
+              validRoles={[
+                OrganizationUserRole.owner,
+                OrganizationUserRole.admin,
+              ]}
+              mmoOnly
+              redirectRoute={ACCOUNT_ROUTES.ACCOUNT_SETTINGS}
+            >
+              <OrganizationSettingsRoute />
+            </RequireOrgPermissions>
+          </RequireAuth>
+        }
+      />
     </>
   );
 }

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -15,7 +15,6 @@ import {ProductsContext} from '../useProducts.hook';
 import {getSubscriptionChangeDetails} from '../stripe.utils';
 import {ACCOUNT_ROUTES} from 'js/account/routes.constants';
 import {useOrganizationQuery} from '../organization/organizationQuery';
-import {FeatureFlag, useFeatureFlag} from 'jsapp/js/featureFlags';
 
 const BADGE_COLOR_KEYS: {[key in SubscriptionChangeType]: BadgeColor} = {
   [SubscriptionChangeType.RENEWAL]: 'light-blue',
@@ -35,7 +34,6 @@ export const YourPlan = () => {
   const [session] = useState(() => sessionStore);
   const [productsContext] = useContext(ProductsContext);
   const orgQuery = useOrganizationQuery();
-  const areMmosEnabled = useFeatureFlag(FeatureFlag.mmosEnabled);
 
   const planName = subscriptions.planName;
 
@@ -62,9 +60,7 @@ export const YourPlan = () => {
     }
   }, [env.isReady, subscriptions.isInitialised]);
 
-  const showPlanUpdateLink = areMmosEnabled
-    ? orgQuery.data?.request_user_role === 'owner'
-    : true;
+  const showPlanUpdateLink = orgQuery.data?.request_user_role === 'owner';
 
   const subscriptionUpdate = useMemo(() => {
     return getSubscriptionChangeDetails(currentPlan, productsContext.products);

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -3,7 +3,6 @@
  * For our sanity, use camel case and match key with value.
  */
 export enum FeatureFlag {
-  mmosEnabled = 'mmosEnabled',
   oneTimeAddonsEnabled = 'oneTimeAddonsEnabled',
   exportActivityLogsEnabled = 'exportActivityLogsEnabled',
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Now the Organizations feature implemented up to this point is no longer hidden behind a feature flag


### 📖 Description
- `isMMosEnabled` feature flag was removed
- routes and menus hidden behind it are now enabled by default
- organizationQuery no longer returns fixed result for `is_mmo`

### 👀 Preview steps
Feature/no-change template:
1. ℹ️ have account
2. ℹ️ have or be part of an organization
3. ℹ️ Make sure to disable the active feature flag with `?ff_isMMosEnabled=false` or cleaning your session storage
4. Navigate to account settings
5. 🟢 notice that the organization links are visible
6. 🟢 notice that you can navigate and operate organization feature freely without the feature flag