### PR TITLE
feat(organizations): handle user removes itself flow TASK-1354

### DIFF
--- a/jsapp/js/account/organization/MemberActionsDropdown.tsx
+++ b/jsapp/js/account/organization/MemberActionsDropdown.tsx
@@ -18,9 +18,6 @@ import {OrganizationUserRole} from './organizationQuery';
 
 // Styles
 import styles from './memberActionsDropdown.module.scss';
-import {queryClient} from 'jsapp/js/query/queryClient';
-import {QueryKeys} from 'jsapp/js/query/queryKeys';
-import { useNavigation } from 'react-router-dom';
 import router from 'jsapp/js/router/router';
 import { ROUTES } from 'jsapp/js/router/routerConstants';
 

--- a/jsapp/js/account/organization/MemberActionsDropdown.tsx
+++ b/jsapp/js/account/organization/MemberActionsDropdown.tsx
@@ -18,6 +18,11 @@ import {OrganizationUserRole} from './organizationQuery';
 
 // Styles
 import styles from './memberActionsDropdown.module.scss';
+import {queryClient} from 'jsapp/js/query/queryClient';
+import {QueryKeys} from 'jsapp/js/query/queryKeys';
+import { useNavigation } from 'react-router-dom';
+import router from 'jsapp/js/router/router';
+import { ROUTES } from 'jsapp/js/router/routerConstants';
 
 interface MemberActionsDropdownProps {
   targetUsername: string;
@@ -69,15 +74,21 @@ export default function MemberActionsDropdown(
       .replace('##TEAM_OR_ORGANIZATION##', mmoLabel);
   }
 
+  const onRemovalConfirmation = () => {
+    setIsRemoveModalVisible(false);
+    if (isAdminRemovingSelf) {
+      // Redirect to account root after leaving the organization
+      router.navigate(ROUTES.ACCOUNT_ROOT);
+    }
+  };
+
   return (
     <>
       {isRemoveModalVisible &&
         <MemberRemoveModal
           username={targetUsername}
           isRemovingSelf={isAdminRemovingSelf}
-          onConfirmDone={() => {
-            setIsRemoveModalVisible(false);
-          }}
+          onConfirmDone={onRemovalConfirmation}
           onCancel={() => setIsRemoveModalVisible(false)}
         />
       }

--- a/jsapp/js/account/organization/MemberRemoveModal.tsx
+++ b/jsapp/js/account/organization/MemberRemoveModal.tsx
@@ -12,8 +12,6 @@ import envStore from 'jsapp/js/envStore';
 import subscriptionStore from 'jsapp/js/account/subscriptionStore';
 import {useRemoveOrganizationMember} from './membersQuery';
 import {notify} from 'alertifyjs';
-import {ROUTES} from 'jsapp/js/router/routerConstants';
-import router from 'jsapp/js/router/router';
 
 interface MemberRemoveModalProps {
   username: string;
@@ -37,7 +35,7 @@ export default function MemberRemoveModal(
     onCancel,
   }: MemberRemoveModalProps
 ) {
-  const removeMember = useRemoveOrganizationMember({isRemovingSelf});
+  const removeMember = useRemoveOrganizationMember();
   const mmoLabel = getSimpleMMOLabel(
     envStore.data,
     subscriptionStore.activeSubscriptions[0],

--- a/jsapp/js/account/organization/MemberRemoveModal.tsx
+++ b/jsapp/js/account/organization/MemberRemoveModal.tsx
@@ -12,6 +12,8 @@ import envStore from 'jsapp/js/envStore';
 import subscriptionStore from 'jsapp/js/account/subscriptionStore';
 import {useRemoveOrganizationMember} from './membersQuery';
 import {notify} from 'alertifyjs';
+import {ROUTES} from 'jsapp/js/router/routerConstants';
+import router from 'jsapp/js/router/router';
 
 interface MemberRemoveModalProps {
   username: string;
@@ -35,7 +37,7 @@ export default function MemberRemoveModal(
     onCancel,
   }: MemberRemoveModalProps
 ) {
-  const removeMember = useRemoveOrganizationMember();
+  const removeMember = useRemoveOrganizationMember({isRemovingSelf});
   const mmoLabel = getSimpleMMOLabel(
     envStore.data,
     subscriptionStore.activeSubscriptions[0],
@@ -66,6 +68,16 @@ export default function MemberRemoveModal(
       .replaceAll('##TEAM_OR_ORGANIZATION##', mmoLabel);
   }
 
+  const handleRemoveMember = async () => {
+    try {
+      await removeMember.mutateAsync(username);
+    } catch (error) {
+      notify('Failed to remove member', 'error');
+    } finally {
+      onConfirmDone();
+    }
+  };
+
   return (
     <KoboModal isOpen size='medium' onRequestClose={() => onCancel()}>
       <KoboModalHeader>{textToDisplay.title}</KoboModalHeader>
@@ -87,15 +99,7 @@ export default function MemberRemoveModal(
         <Button
           type='danger'
           size='m'
-          onClick={async () => {
-            try {
-              removeMember.mutateAsync(username);
-            } catch (error) {
-              notify('Failed to remove member', 'error');
-            } finally {
-              onConfirmDone();
-            }
-          }}
+          onClick={handleRemoveMember}
           label={textToDisplay.confirmButtonLabel}
           isPending={removeMember.isPending}
         />

--- a/jsapp/js/account/organization/membersQuery.ts
+++ b/jsapp/js/account/organization/membersQuery.ts
@@ -50,9 +50,10 @@ export interface OrganizationMember {
 }
 
 function getMemberEndpoint(orgId: string, username: string) {
-  return endpoints.ORGANIZATION_MEMBER_URL
-    .replace(':organization_id', orgId)
-    .replace(':username', username);
+  return endpoints.ORGANIZATION_MEMBER_URL.replace(
+    ':organization_id',
+    orgId
+  ).replace(':username', username);
 }
 
 /**
@@ -66,29 +67,27 @@ export function usePatchOrganizationMember(username: string) {
   const orgId = orgQuery.data?.id;
 
   return useMutation({
-    mutationFn: async (data: Partial<OrganizationMember>) => (
+    mutationFn: async (data: Partial<OrganizationMember>) =>
       // We're asserting the `orgId` is not `undefined` here, because the parent
       // query (`useOrganizationMembersQuery`) wouldn't be enabled without it.
       // Plus all the organization-related UI (that would use this hook) is
       // accessible only to logged in users.
-      fetchPatch<OrganizationMember>(getMemberEndpoint(orgId!, username), data)
-    ),
+      fetchPatch<OrganizationMember>(getMemberEndpoint(orgId!, username), data),
     onSettled: () => {
       // We invalidate query, so it will refetch (instead of refetching it
       // directly, see: https://github.com/TanStack/query/discussions/2468)
-      queryClient.invalidateQueries({queryKey: [QueryKeys.organizationMembers]});
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.organizationMembers],
+      });
     },
   });
 }
 
 /**
- * Mutation hook for removing member from organiztion. It ensures that all
+ * Mutation hook for removing member from organization. It ensures that all
  * related queries refetch data (are invalidated).
  */
-interface RemoveOrganizationMemberParams {
-  isRemovingSelf?: boolean;
-}
-export function useRemoveOrganizationMember(params?: RemoveOrganizationMemberParams) {
+export function useRemoveOrganizationMember() {
   const queryClient = useQueryClient();
 
   const session = useSession();
@@ -97,23 +96,21 @@ export function useRemoveOrganizationMember(params?: RemoveOrganizationMemberPar
   const orgId = orgQuery.data?.id;
 
   return useMutation({
-    mutationFn: async (username: string) => {
-      if (username === session.currentLoggedAccount?.username) {
-        // If user is removing themselves, we need to clear the session
-        session.refreshAccount();
-      }
-
+    mutationFn: async (username: string) =>
       // We're asserting the `orgId` is not `undefined` here, because the parent
       // query (`useOrganizationMembersQuery`) wouldn't be enabled without it.
       // Plus all the organization-related UI (that would use this hook) is
       // accessible only to logged in users.
-      return fetchDelete(getMemberEndpoint(orgId!, username));
-    },
-    onSettled: () => {
-      if (params?.isRemovingSelf) {
+       fetchDelete(getMemberEndpoint(orgId!, username))
+    ,
+    onSuccess: (_data, username) => {
+      if (username === session.currentLoggedAccount?.username) {
+        // If user is removing themselves, we need to clear the session
         session.refreshAccount();
       } else {
-        queryClient.invalidateQueries({queryKey: [QueryKeys.organizationMembers]});
+        queryClient.invalidateQueries({
+          queryKey: [QueryKeys.organizationMembers],
+        });
       }
     },
   });
@@ -134,8 +131,10 @@ async function getOrganizationMembers(
     offset: offset.toString(),
   });
 
-  const apiUrl = endpoints.ORGANIZATION_MEMBERS_URL
-    .replace(':organization_id', orgId);
+  const apiUrl = endpoints.ORGANIZATION_MEMBERS_URL.replace(
+    ':organization_id',
+    orgId
+  );
 
   return fetchGet<PaginatedResponse<OrganizationMember>>(
     apiUrl + '?' + params,
@@ -149,7 +148,10 @@ async function getOrganizationMembers(
  * A hook that gives you paginated list of organization members. Uses
  * `useOrganizationQuery` to get the id.
  */
-export default function useOrganizationMembersQuery({limit, offset}: PaginatedQueryHookParams) {
+export default function useOrganizationMembersQuery({
+  limit,
+  offset,
+}: PaginatedQueryHookParams) {
   const orgQuery = useOrganizationQuery();
   const orgId = orgQuery.data?.id;
 

--- a/jsapp/js/account/organization/organizationQuery.ts
+++ b/jsapp/js/account/organization/organizationQuery.ts
@@ -93,12 +93,11 @@ export const useOrganizationQuery = (params?: OrganizationQueryParams) => {
   }, [params?.shouldForceInvalidation]);
 
   const session = useSession();
-  const organizationUrl = session.currentLoggedAccount?.organization?.url;
+  const organizationUrl = !session.isPending ? session.currentLoggedAccount?.organization?.url : undefined;
 
   // Setting the 'enabled' property so the query won't run until we have
   // the session data loaded. Account data is needed to fetch the organization
   // data.
-
   const query = useQuery<Organization, FailResponse>({
     staleTime: 1000 * 60 * 2,
     // We're asserting the `organizationUrl` is not `undefined` here because

--- a/jsapp/js/stores/useSession.tsx
+++ b/jsapp/js/stores/useSession.tsx
@@ -33,8 +33,17 @@ export const useSession = () => {
       {fireImmediately: true}
     );
 
+    const isPendingReactionDisposer = reaction(
+      () => sessionStore.isPending,
+      () => {
+          setIsPending(sessionStore.isPending);
+      },
+      {fireImmediately: true}
+    );
+
     return () => {
       currentAccountReactionDisposer();
+      isPendingReactionDisposer();
     };
   }, []);
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
The navigation and data flow is improved when an MMO organization admin removes itself from the organization.


### 📖 Description
The objective of this PR is to:
- Minimize wrong API calls due to permissions and session data that needs to be updated
- Present a better flow for the user, redirecting them to the correct view after the removal
There's still a big margin for improving, mainly due to some work needed in `useUsage`, but it unfolds into several other files and flows, so it's better to be handled in a separated PR

### 👀 Preview steps
1. ℹ️ have an account and a project
2. Be the admin in an MMO
3. Navigate to Account Settings > Members
4. Remove yourself from the organization
5. 🔴 [on main] notice that the user is not redirected and there are some failed attempts to API calls due to permissions
6. 🟢 [on PR] notice that the user is redirected and there's only 1 failed attempt to usage API