### PR TITLE
fix(organizations): remove outlated line in MMO transfer email

### DIFF
--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.html
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.html
@@ -32,7 +32,6 @@
     If you accept the transfer:
     <ul>
       <li>All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits</li>
-      <li>If you leave the team in the future, your account will still retain manage project permissions for these projects</li>
     </ul>
     {% endblocktrans %}
   </p>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Line in transferring ownership email for MMOs is no longer relevant and is removed.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. Have 2 accounts and emails enabled
3. User A is in an MMO, user B is not
4. Transfer project from user B to user A
5. Email should be sent without the removed line