### PR TITLE
fix(form deployment): fix failing to deploy after initial failure

### DIFF
--- a/kpi/deployment_backends/mixin.py
+++ b/kpi/deployment_backends/mixin.py
@@ -8,6 +8,7 @@ from kpi.models.asset_file import AssetFile
 
 from .backends import DEPLOYMENT_BACKENDS
 from .base_backend import BaseDeploymentBackend
+from .kc_access.utils import kc_transaction_atomic
 
 
 class DeployableMixin:
@@ -29,7 +30,8 @@ class DeployableMixin:
 
     def connect_deployment(self, backend: str, **kwargs):
         deployment_backend = self.__get_deployment_backend(backend)
-        deployment_backend.connect(**kwargs)
+        with kc_transaction_atomic():
+            deployment_backend.connect(**kwargs)
 
     def deploy(self, backend=False, active=True):
         """

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -143,11 +143,10 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         )
         xlsx_file = ContentFile(xlsx_io.read(), name=f'{self.asset.uid}.xlsx')
 
-        with kc_transaction_atomic():
-            self._xform = publish_xls_form(xlsx_file, self.asset.owner)
-            self._xform.downloadable = active
-            self._xform.kpi_asset_uid = self.asset.uid
-            self._xform.save(update_fields=['downloadable', 'kpi_asset_uid'])
+        self._xform = publish_xls_form(xlsx_file, self.asset.owner)
+        self._xform.downloadable = active
+        self._xform.kpi_asset_uid = self.asset.uid
+        self._xform.save(update_fields=['downloadable', 'kpi_asset_uid'])
 
         self.store_data(
             {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Fixes an issue where a form will not deploy if it fails one time already.

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

Connecting to openrosa needed to be wrapped in an atomic transaction.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Feature/no-change template:
1. ℹ️ have account and a new project
2. make the project fail to deploy (add `1/0` inside `connect()` in `openrosa_backend.py`
3. deploy the form (it fails)
4. remove the `1/0`
5. deploy form again (should deploy normally)

See https://www.notion.so/kobotoolbox/Library-locked-form-cannot-be-deployed-1527e515f654806ab4f9c4d42a59ac52
