### PR TITLE
fix: update type select after fetching default export settings TASK-1296

### DIFF
--- a/jsapp/js/components/projectDownloads/projectExportsCreator.es6
+++ b/jsapp/js/components/projectDownloads/projectExportsCreator.es6
@@ -352,6 +352,8 @@ export default class ProjectExportsCreator extends React.Component {
       }
     });
 
+    exportsStore.setExportType(newStateObj.selectedExportType);
+
     this.setState(newStateObj);
   }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Type selector for export now reflects the actual last export settings fetched from history 


### 📖 Description
- The export type selection box was not being updated on component mount when the last exported setting is loaded
- That was causing the silent selection of the export type fetched without updating the actual selection box
- This way, if the first export of the project was a CSV, then after fetching this export setting the type selection box would still be displaying XLS as the default selected, even though the actual selection in the state was changed to CSV.
- The component is displaying the information from the store, and not from state
- I added an update to the type in the exportStore when applying the fetched export settings to the state, so it displays the actual selection.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. ℹ️ have an account and a deployed project with no exports
2. navigate to project > data > downloads
3. select the CSV (or any other than XSL) type to export
4. export the project data
5. leave the Downloads view (by clicking on Gallery, for example)
6. Go back to Downloads view
8. 🔴 [on main] notice that XSL appears as the selected type, even though it's not. You can check Network tab or just click export to see it exporting in the actual selected type
9. 🟢 [on PR] notice that the selection box updated to reflect the actual selected type