### PR TITLE
fix(BugFixes) Fix error handling for invalid XLS forms TASK-1353

### DIFF
--- a/jsapp/js/actions.es6
+++ b/jsapp/js/actions.es6
@@ -189,9 +189,10 @@ actions.resources.deployAsset.failed.listen(function(data, redeployment){
     // failed to retrieve a valid response from the server
     // setContent() removes the input box, but the value is retained
     var msg;
-    if (data.status == 500 && data.responseJSON && data.responseJSON.error) {
+    const has_error_code = data.status == 500 || data.status == 400;
+    if (has_error_code && data.responseJSON && data.responseJSON.error) {
       msg = `<pre>${data.responseJSON.error}</pre>`;
-    } else if (data.status == 500 && data.responseText) {
+    } else if (has_error_code && data.responseText) {
       msg = `<pre>${data.responseText}</pre>`;
     } else {
       msg = t('please check your connection and try again.');

--- a/kpi/serializers/v2/deployment.py
+++ b/kpi/serializers/v2/deployment.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from django.conf import settings
-from rest_framework import serializers
 from pyxform.errors import PyXFormError
+from rest_framework import serializers
 
 from .asset import AssetSerializer
 
@@ -36,13 +36,7 @@ class DeploymentSerializer(serializers.Serializer):
         try:
             asset.deploy(backend=backend_id, active=validated_data.get('active', False))
         except PyXFormError as e:
-            raise serializers.ValidationError(
-                {
-                    'error': (
-                        f'ODK Validation Error: {e}'
-                    )
-                }
-            )
+            raise serializers.ValidationError({'error': (f'ODK Validation Error: {e}')})
         return asset.deployment
 
     def update(self, instance, validated_data):

--- a/kpi/serializers/v2/deployment.py
+++ b/kpi/serializers/v2/deployment.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from django.conf import settings
 from rest_framework import serializers
+from pyxform.errors import PyXFormError
 
 from .asset import AssetSerializer
 
@@ -32,7 +33,16 @@ class DeploymentSerializer(serializers.Serializer):
 
         # `asset.deploy()` deploys the latest version and updates that versions'
         # 'deployed' boolean value
-        asset.deploy(backend=backend_id, active=validated_data.get('active', False))
+        try:
+            asset.deploy(backend=backend_id, active=validated_data.get('active', False))
+        except PyXFormError as e:
+            raise serializers.ValidationError(
+                {
+                    'error': (
+                        f'ODK Validation Error: {e}'
+                    )
+                }
+            )
         return asset.deployment
 
     def update(self, instance, validated_data):

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1735,39 +1735,50 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
                     'type': 'start',
                     '$kuid': 'O23MoETkI',
                     '$xpath': 'start',
-                    '$autoname': 'start'},
-                    {'name': 'end',
+                    '$autoname': 'start',
+                },
+                {
+                    'name': 'end',
                     'type': 'end',
                     '$kuid': '9rvIvjnrP',
                     '$xpath': 'end',
-                    '$autoname': 'end'},
-                    {'name': 'Enter_a_float_number',
+                    '$autoname': 'end',
+                },
+                {
+                    'name': 'Enter_a_float_number',
                     'type': 'decimal',
                     '$kuid': 'e2v7ZTcDw',
                     'label': ['Enter a float number'],
                     '$xpath': 'Enter_a_float_number',
                     'required': False,
-                    '$autoname': 'Enter_a_float_number'},
-                    {'name': 'What_s_your_name',
+                    '$autoname': 'Enter_a_float_number',
+                },
+                {
+                    'name': 'What_s_your_name',
                     'type': 'text',
                     '$kuid': 'w8nnstZ1r',
                     'label': ["What's your name?"],
                     '$xpath': 'What_s_your_name',
                     'required': False,
-                    '$autoname': 'What_s_your_name'},
-                    {'name': 'Enter_an_int_number',
+                    '$autoname': 'What_s_your_name',
+                },
+                {
+                    'name': 'Enter_an_int_number',
                     'type': 'integer',
                     '$kuid': 'hpw7EKED0',
                     '$xpath': 'Enter_an_int_number',
                     'required': False,
-                    '$autoname': 'Enter_an_int_number'},
-                    {'name': 'Enter_a_time',
+                    '$autoname': 'Enter_an_int_number',
+                },
+                {
+                    'name': 'Enter_a_time',
                     'type': 'time',
                     '$kuid': 'rwf9XqdlC',
                     'label': ['Enter a time'],
                     '$xpath': 'Enter_a_time',
                     'required': False,
-                    '$autoname': 'Enter_a_time'},
+                    '$autoname': 'Enter_a_time',
+                },
             ],
             'choices': [],
             'settings': {},
@@ -1780,8 +1791,9 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
         )
         asset = Asset.objects.get(uid=asset_response.data.get('uid'))
 
-        deployment_url = reverse(self._get_endpoint('asset-deployment'),
-                                 kwargs={'uid': asset.uid})
+        deployment_url = reverse(
+            self._get_endpoint('asset-deployment'), kwargs={'uid': asset.uid}
+        )
 
         deploy_response = self.client.post(
             deployment_url,
@@ -1792,9 +1804,13 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
         )
 
         self.assertEqual(deploy_response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(deploy_response.data['error'], ('ODK Validation Error: '
-        'The survey element named \'Enter_an_int_number\' has no label or hint.'))
-
+        self.assertEqual(
+            deploy_response.data['error'],
+            (
+                'ODK Validation Error: '
+                "The survey element named 'Enter_an_int_number' has no label or hint."
+            ),
+        )
 
     def test_asset_redeployment(self):
         self.test_asset_deployment()

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1726,6 +1726,76 @@ class AssetDeploymentTest(BaseAssetDetailTestCase):
             == AssetDeploymentStatus.DEPLOYED.value
         )
 
+    def test_asset_deployment_validation_error(self):
+        bad_content = {
+            'schema': '1',
+            'survey': [
+                {
+                    'name': 'start',
+                    'type': 'start',
+                    '$kuid': 'O23MoETkI',
+                    '$xpath': 'start',
+                    '$autoname': 'start'},
+                    {'name': 'end',
+                    'type': 'end',
+                    '$kuid': '9rvIvjnrP',
+                    '$xpath': 'end',
+                    '$autoname': 'end'},
+                    {'name': 'Enter_a_float_number',
+                    'type': 'decimal',
+                    '$kuid': 'e2v7ZTcDw',
+                    'label': ['Enter a float number'],
+                    '$xpath': 'Enter_a_float_number',
+                    'required': False,
+                    '$autoname': 'Enter_a_float_number'},
+                    {'name': 'What_s_your_name',
+                    'type': 'text',
+                    '$kuid': 'w8nnstZ1r',
+                    'label': ["What's your name?"],
+                    '$xpath': 'What_s_your_name',
+                    'required': False,
+                    '$autoname': 'What_s_your_name'},
+                    {'name': 'Enter_an_int_number',
+                    'type': 'integer',
+                    '$kuid': 'hpw7EKED0',
+                    '$xpath': 'Enter_an_int_number',
+                    'required': False,
+                    '$autoname': 'Enter_an_int_number'},
+                    {'name': 'Enter_a_time',
+                    'type': 'time',
+                    '$kuid': 'rwf9XqdlC',
+                    'label': ['Enter a time'],
+                    '$xpath': 'Enter_a_time',
+                    'required': False,
+                    '$autoname': 'Enter_a_time'},
+            ],
+            'choices': [],
+            'settings': {},
+        }
+        assets_url = reverse(self._get_endpoint('asset-list'))
+        asset_response = self.client.post(
+            assets_url,
+            {'content': bad_content, 'asset_type': 'survey'},
+            format='json',
+        )
+        asset = Asset.objects.get(uid=asset_response.data.get('uid'))
+
+        deployment_url = reverse(self._get_endpoint('asset-deployment'),
+                                 kwargs={'uid': asset.uid})
+
+        deploy_response = self.client.post(
+            deployment_url,
+            {
+                'backend': 'mock',
+                'active': True,
+            },
+        )
+
+        self.assertEqual(deploy_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(deploy_response.data['error'], ('ODK Validation Error: '
+        'The survey element named \'Enter_an_int_number\' has no label or hint.'))
+
+
     def test_asset_redeployment(self):
         self.test_asset_deployment()
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fix the error handling for invalid survey JSON content when deploying


### 📖 Description
This PR adds error handling for the case when Pyxform fails when attempting to deploy a survey with invalid content. A unit test was included to ensure this works ok.


### 👀 Preview steps
1. Create a new survey using a bad xls form (see the notion page for a test file with bad format)
2. Attempt to deploy the form
3. The frontend should show a validation error with a hint of how to fix it
4. Edit and save the form (labels are added automatically when you enter the form editor, so there's no need to do anything in this case, just edit and hit the save button)
5. Attempt to deploy again
6. It should be deployed without issues
