### PR TITLE
fix(OpenRosa): assign default `openrosa` model-level permissions to the correct database

### DIFF
--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -130,7 +130,8 @@ def grant_kc_model_level_perms(user: 'kobo_auth.User'):
             'Searched for content types {}.'.format(content_types)
         )
 
-    user.user_permissions.add(*permissions_to_assign)
+    with use_db(settings.OPENROSA_DB_ALIAS):
+        user.user_permissions.add(*permissions_to_assign)
 
 
 def set_kc_anonymous_permissions_xform_flags(


### PR DESCRIPTION
Fixes a 500 error when attempting to create an account on certain servers, e.g. the Global KoboToolbox instance (kf.kobotoolbox.org).

This is a critical fix, so please excuse the terseness of this description.