### PR TITLE
test: rename admin user in fixture

### DIFF
--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -440,7 +440,6 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
     def test_can_search_access_logs_by_username(self):
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
-        admin = User.objects.get(username='adminuser')
         AccessLog.objects.create(user=user1)
         AccessLog.objects.create(user=user2)
         self.force_login_user(User.objects.get(username='adminuser'))

--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -200,7 +200,7 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
             action=AuditAction.DELETE,
             log_type=AuditType.DATA_EDITING,
         )
-        self.login_user(username='admin', password='pass')
+        self.login_user(username='adminuser', password='pass')
         expected = [
             {
                 'app_label': 'foo',
@@ -242,7 +242,7 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
             action=AuditAction.DELETE,
             log_type=AuditType.DATA_EDITING,
         )
-        self.login_user(username='admin', password='pass')
+        self.login_user(username='adminuser', password='pass')
         expected = [
             {
                 'app_label': 'foo',
@@ -363,14 +363,14 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_show_all_access_logs_succeeds_for_superuser(self):
-        self.force_login_user(User.objects.get(username='admin'))
+        self.force_login_user(User.objects.get(username='adminuser'))
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_show_all_access_logs_includes_all_users(self):
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
-        admin = User.objects.get(username='admin')
+        admin = User.objects.get(username='adminuser')
         AccessLog.objects.create(user=user1)
         AccessLog.objects.create(user=user2)
         self.force_login_user(admin)
@@ -384,7 +384,7 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
         # this is just to ensure that we're using the grouping query
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
-        admin = User.objects.get(username='admin')
+        admin = User.objects.get(username='adminuser')
 
         self.force_login_user(admin)
         jan_1_1_30_am = datetime.fromisoformat('2024-01-01T01:30:25.123456+00:00')
@@ -440,10 +440,10 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
     def test_can_search_access_logs_by_username(self):
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
-        admin = User.objects.get(username='admin')
+        admin = User.objects.get(username='adminuser')
         AccessLog.objects.create(user=user1)
         AccessLog.objects.create(user=user2)
-        self.force_login_user(User.objects.get(username='admin'))
+        self.force_login_user(User.objects.get(username='adminuser'))
         response = self.client.get(f'{self.url}?q=user__username:anotheruser')
 
         # only return logs from user1
@@ -456,7 +456,7 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
     ):
         user1 = User.objects.get(username='someuser')
         user2 = User.objects.get(username='anotheruser')
-        admin = User.objects.get(username='admin')
+        admin = User.objects.get(username='adminuser')
         self.force_login_user(admin)
 
         # create two submissions that will be grouped together
@@ -489,7 +489,7 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
     def test_can_search_access_logs_by_date(self):
         user = User.objects.get(username='someuser')
         with skip_login_access_log():
-            self.client.force_login(User.objects.get(username='admin'))
+            self.client.force_login(User.objects.get(username='adminuser'))
         tomorrow = timezone.now() + timedelta(days=1)
         tomorrow_str = tomorrow.strftime('%Y-%m-%d')
         # create one log from today and one from tomorrow
@@ -514,7 +514,7 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
     def test_can_search_access_logs_by_date_including_submission_groups(self):
         user = User.objects.get(username='someuser')
         with skip_login_access_log():
-            self.client.force_login(User.objects.get(username='admin'))
+            self.client.force_login(User.objects.get(username='adminuser'))
         tomorrow = timezone.now() + timedelta(days=1)
         two_days_from_now = tomorrow + timedelta(days=1)
         tomorrow_str = tomorrow.strftime('%Y-%m-%d')
@@ -649,7 +649,7 @@ class ApiAllProjectHistoryLogsTestCase(
 
     def setUp(self):
         super().setUp()
-        self.user = User.objects.get(username='admin')
+        self.user = User.objects.get(username='adminuser')
         self.asset = Asset.objects.get(pk=1)
         self.force_login_user(self.user)
 
@@ -705,7 +705,7 @@ class ApiAccessLogsExportTestCase(BaseAuditLogTestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_export_for_superuser_commences(self):
-        self.force_login_user(User.objects.get(username='admin'))
+        self.force_login_user(User.objects.get(username='adminuser'))
         response = self.client.post(self.url)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
@@ -790,12 +790,12 @@ class AllApiAccessLogsExportTestCase(BaseAuditLogTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_export_access_logs_for_superuser_returns_success(self):
-        self.force_login_user(User.objects.get(username='admin'))
+        self.force_login_user(User.objects.get(username='adminuser'))
         response = self.client.post(self.url)
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_superuser_create_export_task_on_post(self):
-        test_superuser = User.objects.get(username='admin')
+        test_superuser = User.objects.get(username='adminuser')
         self.force_login_user(test_superuser)
 
         response = self.client.post(self.url)
@@ -811,7 +811,7 @@ class AllApiAccessLogsExportTestCase(BaseAuditLogTestCase):
         self.assertTrue(task.get_all_logs)
 
     def test_superuser_get_status_tasks(self):
-        test_superuser = User.objects.get(username='admin')
+        test_superuser = User.objects.get(username='adminuser')
         self.force_login_user(test_superuser)
 
         AccessLogExportTask.objects.create(
@@ -844,7 +844,7 @@ class AllApiAccessLogsExportTestCase(BaseAuditLogTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_multiple_export_tasks_not_allowed(self):
-        test_superuser = User.objects.get(username='admin')
+        test_superuser = User.objects.get(username='adminuser')
         self.force_login_user(test_superuser)
 
         response_first = self.client.post(self.url)

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -57,7 +57,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
     def setUp(self):
         super().setUp()
         # log in as admin
-        user = User.objects.get(username='admin')
+        user = User.objects.get(username='adminuser')
         self.user = user
         self.client.force_login(user=user)
         # use the same asset
@@ -1390,7 +1390,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 'permission': reverse(
                     'api_v2:permission-detail', kwargs={'codename': PERM_VIEW_ASSET}
                 ),
-                'user': reverse('api_v2:user-kpi-detail', kwargs={'username': 'admin'}),
+                'user': reverse('api_v2:user-kpi-detail', kwargs={'username': 'adminuser'}),
             },
         ]
         self.client.post(
@@ -1476,9 +1476,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         )
         self.assertEqual(ProjectHistoryLog.objects.count(), 0)
 
-    @data('admin', 'someuser')
+    @data('adminuser', 'someuser')
     def test_log_created_for_duplicate_submission(self, duplicating_user):
-        self._add_submission('admin')
+        self._add_submission('adminuser')
         submissions = self.asset.deployment.get_submissions(
             self.asset.owner, fields=['_id']
         )
@@ -1505,7 +1505,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         )
         self.assertEqual(metadata['submission']['submitted_by'], duplicating_user)
 
-    @data('admin', None)
+    @data('adminuser', None)
     def test_update_one_submission_content(self, username):
         self._add_submission(username)
         submissions_xml = self.asset.deployment.get_submissions(
@@ -1550,7 +1550,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         self.assertEqual(log.metadata['submission']['submitted_by'], submitted_by)
 
     def test_update_multiple_submissions_content(self):
-        self._add_submission('admin')
+        self._add_submission('adminuser')
         self._add_submission('someuser')
         self._add_submission(None)
 
@@ -1574,7 +1574,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
         self.assertEqual(ProjectHistoryLog.objects.count(), 3)
         log1 = ProjectHistoryLog.objects.filter(
-            metadata__submission__submitted_by='admin'
+            metadata__submission__submitted_by='adminuser'
         ).first()
         self._check_common_metadata(log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
         self.assertEqual(log1.action, AuditAction.MODIFY_SUBMISSION)
@@ -1591,7 +1591,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         self._check_common_metadata(log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
         self.assertEqual(log2.action, AuditAction.MODIFY_SUBMISSION)
 
-    @data('admin', None)
+    @data('adminuser', None)
     def test_update_single_submission_validation_status(self, username):
         self._add_submission(username)
         submissions_json = self.asset.deployment.get_submissions(
@@ -1615,7 +1615,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         self.assertEqual(log_metadata['submission']['status'], 'On Hold')
 
     def test_multiple_submision_validation_statuses(self):
-        self._add_submission('admin')
+        self._add_submission('adminuser')
         self._add_submission('someuser')
         self._add_submission(None)
         submissions_json = self.asset.deployment.get_submissions(
@@ -1639,7 +1639,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
         self.assertEqual(ProjectHistoryLog.objects.count(), 3)
         log1 = ProjectHistoryLog.objects.filter(
-            metadata__submission__submitted_by='admin'
+            metadata__submission__submitted_by='adminuser'
         ).first()
         self._check_common_metadata(log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
         self.assertEqual(log1.action, AuditAction.MODIFY_SUBMISSION)

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1390,7 +1390,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 'permission': reverse(
                     'api_v2:permission-detail', kwargs={'codename': PERM_VIEW_ASSET}
                 ),
-                'user': reverse('api_v2:user-kpi-detail', kwargs={'username': 'adminuser'}),
+                'user': reverse(
+                    'api_v2:user-kpi-detail', kwargs={'username': 'adminuser'}
+                ),
             },
         ]
         self.client.post(

--- a/kobo/apps/organizations/tests/admin/test_organization_admin.py
+++ b/kobo/apps/organizations/tests/admin/test_organization_admin.py
@@ -19,7 +19,7 @@ class TestOrganizationAdminTestCase(TestCase):
 
         self.someuser = User.objects.get(username='someuser')
         self.anotheruser = User.objects.get(username='anotheruser')
-        self.admin = User.objects.get(username='admin')
+        self.admin = User.objects.get(username='adminuser')
 
         self.organization.add_user(self.someuser)  # someuser becomes the owner
 

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -28,7 +28,7 @@ class AccountTrashTestCase(TestCase):
         someuser = get_user_model().objects.get(username='someuser')
         someuser_uid = someuser.extra_details.uid
         someuser_id = someuser.pk
-        admin = get_user_model().objects.get(username='admin')
+        admin = get_user_model().objects.get(username='adminuser')
 
         # Create dummy logs for someuser
         audit_log = AuditLog.objects.create(
@@ -114,7 +114,7 @@ class AccountTrashTestCase(TestCase):
     def test_put_back(self):
         self.test_move_to_trash()
         someuser = get_user_model().objects.get(username='someuser')
-        admin = get_user_model().objects.get(username='admin')
+        admin = get_user_model().objects.get(username='adminuser')
         assert not someuser.is_active
         account_trash = AccountTrash.objects.get(user=someuser)
         periodic_task_id = account_trash.periodic_task_id
@@ -154,7 +154,7 @@ class AccountTrashTestCase(TestCase):
         everything from their account is deleted except their username
         """
         someuser = get_user_model().objects.get(username='someuser')
-        admin = get_user_model().objects.get(username='admin')
+        admin = get_user_model().objects.get(username='adminuser')
         someuser.extra_details.data['name'] = 'someuser'
         someuser.extra_details.save(update_fields=['data'])
 

--- a/kpi/fixtures/test_data.json
+++ b/kpi/fixtures/test_data.json
@@ -12,7 +12,7 @@
             "last_name": "",
             "password": "pbkdf2_sha256$15000$fsiY4ICrvcIa$z8esAlmJ/ip0sR7TZkmpxxt4CWw1O1+cfWLbZ3/ip4E=",
             "user_permissions": [],
-            "username": "admin"
+            "username": "adminuser"
         },
         "model": "kobo_auth.user",
         "pk": 1

--- a/kpi/tests/api/v1/test_api_permissions.py
+++ b/kpi/tests/api/v1/test_api_permissions.py
@@ -40,7 +40,7 @@ class ApiAssignedPermissionsTestCase(KpiTestCase):
     def setUp(self):
         super().setUp()
         self.anon = get_anonymous_user()
-        self.super = User.objects.get(username='admin')
+        self.super = User.objects.get(username='adminuser')
         self.super_password = 'pass'
         self.someuser = User.objects.get(username='someuser')
         self.someuser_password = 'someuser'

--- a/kpi/tests/api/v1/test_api_permissions.py
+++ b/kpi/tests/api/v1/test_api_permissions.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import ASSET_TYPE_COLLECTION
 from kpi.models import Asset, ObjectPermission
+
 # importing module instead of the class, avoid running the tests twice
 from kpi.tests.api.v2 import test_api_permissions
 from kpi.tests.kpi_test_case import KpiTestCase

--- a/kpi/tests/api/v2/test_api_asset_bulk_actions.py
+++ b/kpi/tests/api/v2/test_api_asset_bulk_actions.py
@@ -92,7 +92,7 @@ class BaseAssetBulkActionsTestCase(BaseTestCase):
 
     def _login_superuser(self):
         self.client.logout()
-        self.client.login(username='admin', password='pass')
+        self.client.login(username='adminuser', password='pass')
 
     def _login_user(self, userpass: str):
         self.client.logout()

--- a/kpi/tests/api/v2/test_api_asset_permission_assignment.py
+++ b/kpi/tests/api/v2/test_api_asset_permission_assignment.py
@@ -30,11 +30,11 @@ class BaseApiAssetPermissionTestCase(PermissionAssignmentTestCaseMixin, KpiTestC
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     def setUp(self):
-        self.admin = User.objects.get(username='admin')
+        self.admin = User.objects.get(username='adminuser')
         self.someuser = User.objects.get(username='someuser')
         self.anotheruser = User.objects.get(username='anotheruser')
 
-        self.client.login(username='admin', password='pass')
+        self.client.login(username='adminuser', password='pass')
         self.asset = self.create_asset('An asset to be shared')
 
     def _grant_perm_as_logged_in_user(self, username, codename):
@@ -342,7 +342,7 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
         self._grant_perm_as_logged_in_user('someuser', PERM_MANAGE_ASSET)
         self.client.login(username='someuser', password='someuser')
         response = self._assign_perms_as_logged_in_user(
-            [('admin', PERM_VIEW_ASSET), ('admin', PERM_CHANGE_ASSET)]
+            [('adminuser', PERM_VIEW_ASSET), ('adminuser', PERM_CHANGE_ASSET)]
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -381,14 +381,14 @@ class ApiBulkAssetPermissionTestCase(BaseApiAssetPermissionTestCase):
             ),
             sorted(
                 [
-                    ('admin', PERM_VIEW_ASSET),
-                    ('admin', PERM_CHANGE_ASSET),
-                    ('admin', PERM_MANAGE_ASSET),
-                    ('admin', PERM_ADD_SUBMISSIONS),
-                    ('admin', PERM_DELETE_SUBMISSIONS),
-                    ('admin', PERM_VIEW_SUBMISSIONS),
-                    ('admin', PERM_CHANGE_SUBMISSIONS),
-                    ('admin', PERM_VALIDATE_SUBMISSIONS),
+                    ('adminuser', PERM_VIEW_ASSET),
+                    ('adminuser', PERM_CHANGE_ASSET),
+                    ('adminuser', PERM_MANAGE_ASSET),
+                    ('adminuser', PERM_ADD_SUBMISSIONS),
+                    ('adminuser', PERM_DELETE_SUBMISSIONS),
+                    ('adminuser', PERM_VIEW_SUBMISSIONS),
+                    ('adminuser', PERM_CHANGE_SUBMISSIONS),
+                    ('adminuser', PERM_VALIDATE_SUBMISSIONS),
                     ('someuser', PERM_VIEW_ASSET),
                     ('anotheruser', PERM_VIEW_ASSET),
                     ('anotheruser', PERM_CHANGE_ASSET),

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1098,7 +1098,7 @@ class AssetDetailApiTests(BaseAssetDetailTestCase):
 
         # Verify an admin user has access to the data
         self.client.logout()
-        self.client.login(username='admin', password='pass')
+        self.client.login(username='adminuser', password='pass')
         response = self.client.get(report_url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/kpi/tests/api/v2/test_api_permissions.py
+++ b/kpi/tests/api/v2/test_api_permissions.py
@@ -64,7 +64,7 @@ class ApiPermissionsPublicAssetTestCase(KpiTestCase):
         KpiTestCase.setUp(self)
 
         self.anon = get_anonymous_user()
-        self.admin = User.objects.get(username='admin')
+        self.admin = User.objects.get(username='adminuser')
         self.admin_password = 'pass'
         self.someuser = User.objects.get(username='someuser')
         self.someuser_password = 'someuser'
@@ -125,7 +125,7 @@ class ApiPermissionsTestCase(KpiTestCase):
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     def setUp(self):
-        self.admin = User.objects.get(username='admin')
+        self.admin = User.objects.get(username='adminuser')
         self.admin_password = 'pass'
         self.someuser = User.objects.get(username='someuser')
         self.someuser_password = 'someuser'
@@ -147,7 +147,7 @@ class ApiPermissionsTestCase(KpiTestCase):
                              self.admin_password)
 
     def test_viewable_asset_in_asset_list(self):
-        # Give "someuser" view permissions on an asset owned by "admin".
+        # Give "someuser" view permissions on an asset owned by "adminuser".
         self.add_perm(self.admin_asset, self.someuser, 'view_')
 
         # Test that "someuser" can now view the asset.
@@ -157,7 +157,7 @@ class ApiPermissionsTestCase(KpiTestCase):
     def test_non_viewable_asset_not_in_asset_list(self):
         # Wow, that's quite a function name...
         # Ensure that "someuser" doesn't have permission to view the survey
-        #   asset owned by "admin".
+        #   asset owned by "adminuser".
         perm_name = self._get_perm_name('view_', self.admin_asset)
         self.assertFalse(self.someuser.has_perm(perm_name, self.admin_asset))
 
@@ -166,8 +166,8 @@ class ApiPermissionsTestCase(KpiTestCase):
                              self.someuser_password, viewable=False)
 
     def test_inherited_viewable_assets_in_asset_list(self):
-        # Give "someuser" view permissions on a collection owned by "admin" and
-        #   add an asset also owned by "admin" to that collection.
+        # Give "someuser" view permissions on a collection owned by "adminuser" and
+        #   add an asset also owned by "adminuser" to that collection.
         self.add_perm(self.admin_asset, self.someuser, 'view_')
 
         self.add_to_collection(self.admin_asset, self.admin_collection,
@@ -216,7 +216,7 @@ class ApiPermissionsTestCase(KpiTestCase):
                              self.someuser_password, viewable=False)
 
     def test_viewable_asset_not_deletable(self):
-        # Give "someuser" view permissions on an asset owned by "admin".
+        # Give "someuser" view permissions on an asset owned by "adminuser".
         self.add_perm(self.admin_asset, self.someuser, 'view_')
 
         # Confirm that "someuser" is not allowed to delete the asset.
@@ -231,8 +231,8 @@ class ApiPermissionsTestCase(KpiTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_inherited_viewable_asset_not_deletable(self):
-        # Give "someuser" view permissions on a collection owned by "admin" and
-        #   add an asset also owned by "admin" to that collection.
+        # Give "someuser" view permissions on a collection owned by "adminuser" and
+        #   add an asset also owned by "adminuser" to that collection.
         self.add_perm(self.admin_asset, self.someuser, 'view_')
         self.add_to_collection(self.admin_asset, self.admin_collection,
                                self.admin, self.admin_password)
@@ -398,7 +398,7 @@ class ApiPermissionsTestCase(KpiTestCase):
         assert not yetanotheruser.has_perm(PERM_VIEW_ASSET, new_asset)
 
     def test_copy_permissions_between_assets(self):
-        # Give "someuser" edit permissions on an asset owned by "admin"
+        # Give "someuser" edit permissions on an asset owned by "adminuser"
         self.add_perm(self.admin_asset, self.someuser, 'change_')
         # Confirm that "someuser" has received the implied permissions
         expected_perms = [PERM_CHANGE_ASSET, PERM_VIEW_ASSET]
@@ -441,7 +441,7 @@ class ApiPermissionsTestCase(KpiTestCase):
         )
 
     def test_cannot_copy_permissions_between_non_owned_assets(self):
-        # Give "someuser" view permissions on an asset owned by "admin"
+        # Give "someuser" view permissions on an asset owned by "adminuser"
         self.add_perm(self.admin_asset, self.someuser, 'view_')
         self.assertTrue(self.someuser.has_perm(PERM_VIEW_ASSET, self.admin_asset))
         # Create another asset to receive the copied permissions
@@ -449,7 +449,7 @@ class ApiPermissionsTestCase(KpiTestCase):
             name='destination asset', owner=self.admin,
             owner_password=self.admin_password
         )
-        # Give "someuser" edit permissions on the new asset owned by "admin"
+        # Give "someuser" edit permissions on the new asset owned by "adminuser"
         self.add_perm(new_asset, self.someuser, 'change_')
         self.assertTrue(self.someuser.has_perm(PERM_CHANGE_ASSET, new_asset))
         new_asset_perms_before_copy_attempt = new_asset.get_users_with_perms(
@@ -479,7 +479,7 @@ class ApiPermissionsTestCase(KpiTestCase):
         )
 
     def test_user_cannot_copy_permissions_from_non_viewable_asset(self):
-        # Make sure "someuser" cannot view the asset owned by "admin"
+        # Make sure "someuser" cannot view the asset owned by "adminuser"
         self.assertFalse(
             self.someuser.has_perm(PERM_VIEW_ASSET, self.admin_asset)
         )
@@ -517,7 +517,7 @@ class ApiPermissionsTestCase(KpiTestCase):
         )
 
     def test_user_cannot_copy_permissions_to_non_editable_asset(self):
-        # Give "someuser" view permissions on an asset owned by "admin"
+        # Give "someuser" view permissions on an asset owned by "adminuser"
         self.add_perm(self.admin_asset, self.someuser, 'view_')
         self.assertTrue(self.someuser.has_perm(PERM_VIEW_ASSET, self.admin_asset))
         # Create another asset to receive the copied permissions
@@ -525,7 +525,7 @@ class ApiPermissionsTestCase(KpiTestCase):
             name='destination asset', owner=self.admin,
             owner_password=self.admin_password
         )
-        # Give "someuser" view permissions on the new asset owned by "admin"
+        # Give "someuser" view permissions on the new asset owned by "adminuser"
         self.add_perm(new_asset, self.someuser, 'view_')
         self.assertTrue(self.someuser.has_perm(PERM_VIEW_ASSET, new_asset))
         # Take note of the destination asset's permissions to make sure they
@@ -563,7 +563,7 @@ class ApiPermissionsTestCase(KpiTestCase):
                              self.admin_password)
 
     def test_viewable_collection_in_collection_list(self):
-        # Give "someuser" view permissions on a collection owned by "admin".
+        # Give "someuser" view permissions on a collection owned by "adminuser".
         self.add_perm(self.admin_collection, self.someuser, 'view_')
 
         # Test that "someuser" can now view the collection.
@@ -573,7 +573,7 @@ class ApiPermissionsTestCase(KpiTestCase):
     def test_non_viewable_collection_not_in_collection_list(self):
         # Wow, that's quite a function name...
         # Ensure that "someuser" doesn't have permission to view the survey
-        #   collection owned by "admin".
+        #   collection owned by "adminuser".
         perm_name = self._get_perm_name('view_', self.admin_collection)
         self.assertFalse(self.someuser.has_perm(perm_name, self.admin_collection))
 
@@ -628,7 +628,7 @@ class ApiPermissionsTestCase(KpiTestCase):
                              self.someuser_password, viewable=False)
 
     def test_viewable_collection_not_deletable(self):
-        # Give "someuser" view permissions on a collection owned by "admin".
+        # Give "someuser" view permissions on a collection owned by "adminuser".
         self.add_perm(self.admin_collection, self.someuser, 'view_')
 
         # Confirm that "someuser" is not allowed to delete the collection.
@@ -645,7 +645,7 @@ class ApiPermissionsTestCase(KpiTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_inherited_viewable_collection_not_deletable(self):
-        # Give "someuser" view permissions on a collection owned by "admin".
+        # Give "someuser" view permissions on a collection owned by "adminuser".
         self.add_perm(self.admin_collection, self.someuser, 'view_')
 
         # Confirm that "someuser" is not allowed to delete the child collection.
@@ -684,7 +684,7 @@ class ApiAssignedPermissionsTestCase(PermissionAssignmentTestCaseMixin, KpiTestC
     def setUp(self):
         super().setUp()
         self.anon = get_anonymous_user()
-        self.super = User.objects.get(username='admin')
+        self.super = User.objects.get(username='adminuser')
         self.super_password = 'pass'
         self.someuser = User.objects.get(username='someuser')
         self.someuser_password = 'someuser'

--- a/kpi/tests/api/v2/test_api_users.py
+++ b/kpi/tests/api/v2/test_api_users.py
@@ -12,7 +12,7 @@ class UserListTests(BaseTestCase):
     URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     def setUp(self):
-        self.client.login(username='admin', password='pass')
+        self.client.login(username='adminuser', password='pass')
 
     def test_user_list_allowed_superuser(self):
         """
@@ -23,11 +23,11 @@ class UserListTests(BaseTestCase):
         assert response.status_code == status.HTTP_200_OK
 
         # test filtering by username
-        q = '?q=admin'
+        q = '?q=adminuser'
         response = self.client.get(url + q, format='json')
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) == 1
-        assert response.data['results'][0]['username'] == 'admin'
+        assert response.data['results'][0]['username'] == 'adminuser'
 
     def test_user_list_forbidden_non_superuser(self):
         """
@@ -52,7 +52,7 @@ class UserListTests(BaseTestCase):
         """
         we can retrieve user details
         """
-        username = 'admin'
+        username = 'adminuser'
         url = reverse(self._get_endpoint('user-kpi-detail'), args=[username])
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/kpi/tests/test_permissions.py
+++ b/kpi/tests/test_permissions.py
@@ -165,7 +165,7 @@ class PermissionsTestCase(BasePermissionsTestCase):
     fixtures = ['test_data']
 
     def setUp(self):
-        self.admin = User.objects.get(username='admin')
+        self.admin = User.objects.get(username='adminuser')
         self.someuser = User.objects.get(username='someuser')
         self.anotheruser = User.objects.get(username='anotheruser')
 

--- a/kpi/tests/test_token.py
+++ b/kpi/tests/test_token.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 

--- a/kpi/tests/test_token.py
+++ b/kpi/tests/test_token.py
@@ -79,7 +79,7 @@ class UserListTests(BaseTestCase):
 
     def test_superuser_can_get_token_for_another_user(self):
         self.client.logout()
-        self.client.login(username='admin', password='pass')
+        self.client.login(username='adminuser', password='pass')
         response = self.client.get(self.url, {'username': self.username})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Developer-facing changes only. Changes the username of the admin user to `adminuser` in preparation for disallowing the name `admin` as part of https://www.notion.so/kobotoolbox/Anonymous-submissions-dont-work-if-user-named-admin-owns-asset-1767e515f65480608dfcee76ba9b3710

