### PR TITLE
feat(projectHistoryLogs): log new submissions

### DIFF
--- a/kobo/apps/audit_log/serializers.py
+++ b/kobo/apps/audit_log/serializers.py
@@ -66,7 +66,14 @@ class AccessLogSerializer(serializers.Serializer):
         return audit_log['date_created'].strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-class ProjectHistoryLogSerializer(AuditLogSerializer):
+class ProjectHistoryLogSerializer(serializers.ModelSerializer):
+    user = serializers.HyperlinkedRelatedField(
+        queryset=get_user_model().objects.all(),
+        lookup_field='username',
+        view_name='user-kpi-detail',
+    )
+    date_created = serializers.SerializerMethodField()
+    username = serializers.SerializerMethodField()
 
     class Meta:
         model = ProjectHistoryLog
@@ -87,3 +94,9 @@ class ProjectHistoryLogSerializer(AuditLogSerializer):
             'metadata',
             'date_created',
         )
+
+    def get_date_created(self, audit_log):
+        return audit_log.date_created.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    def get_username(self, audit_log):
+        return audit_log.user.username

--- a/kobo/apps/audit_log/serializers.py
+++ b/kobo/apps/audit_log/serializers.py
@@ -66,14 +66,7 @@ class AccessLogSerializer(serializers.Serializer):
         return audit_log['date_created'].strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-class ProjectHistoryLogSerializer(serializers.ModelSerializer):
-    user = serializers.HyperlinkedRelatedField(
-        queryset=get_user_model().objects.all(),
-        lookup_field='username',
-        view_name='user-kpi-detail',
-    )
-    date_created = serializers.SerializerMethodField()
-    username = serializers.SerializerMethodField()
+class ProjectHistoryLogSerializer(AuditLogSerializer):
 
     class Meta:
         model = ProjectHistoryLog
@@ -94,9 +87,3 @@ class ProjectHistoryLogSerializer(serializers.ModelSerializer):
             'metadata',
             'date_created',
         )
-
-    def get_date_created(self, audit_log):
-        return audit_log.date_created.strftime('%Y-%m-%dT%H:%M:%SZ')
-
-    def get_username(self, audit_log):
-        return audit_log.user.username

--- a/kobo/apps/audit_log/signals.py
+++ b/kobo/apps/audit_log/signals.py
@@ -77,8 +77,13 @@ def add_instance_to_request(instance, created, **kwargs):
     request = get_current_request()
     if request is None:
         return
+    if getattr(instance.asset.asset, 'id', None) is None:
+        # if an XForm doesn't have a real associated Asset, ignore it
+        return
     if getattr(request, 'instances', None) is None:
         request.instances = {}
+    if getattr(request, 'asset', None) is None:
+        request.asset = instance.asset.asset
     username = instance.user.username if instance.user else None
     request.instances.update(
         {

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1678,8 +1678,8 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         submission_data = {
             'q1': 'answer',
             'q2': 'answer',
-            'meta/instanceID': f'uuid:{uuid_}',
-            'formhub/uuid': self.asset.deployment.xform.uuid,
+            'meta': {'instanceID': f'uuid:{uuid_}'},
+            'formhub': {'uuid': self.asset.deployment.xform.uuid},
             '_uuid': str(uuid_),
         }
         xml = ET.fromstring(

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -472,33 +472,37 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
 
     **Filterable fields by action:**
 
-    1. add-media
+    * add-media
 
         a. metadata__asset-file__uid
 
         b. metadata__asset-file__filename
 
-    2. archive
+    * add-submission
+
+        a. metadata__submission__submitted_by
+
+    * archive
 
         a. metadata__latest_version_uid
 
-    3. clone-permissions
+    * clone-permissions
 
         a. metadata__cloned_from
 
-    4. connect-project
+    * connect-project
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    5. delete-media
+    * delete-media
 
         a. metadata__asset-file__uid
 
         b. metadata__asset-file__filename
 
-    6. delete-service
+    * delete-service
 
         a. metadata__hook__uid
 
@@ -506,25 +510,25 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
 
         c. metadata__hook__active
 
-    7. deploy
+    * deploy
 
         a. metadata__latest_version_uid
 
         b. metadata__latest_deployed_version_uid
 
-    8. disconnect-project
+    * disconnect-project
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    9. modify-imported-fields
+    * modify-imported-fields
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    10. modify-service
+    * modify-service
 
         a. metadata__hook__uid
 
@@ -532,23 +536,23 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
 
         c. metadata__hook__active
 
-    11. modify-submission
+    * modify-submission
 
         a. metadata__submission__submitted_by
 
         b. metadata__submission__status (only present if changed)
 
-    12. modify-user-permissions
+    * modify-user-permissions
 
         a. metadata__permissions__username
 
-    13. redeploy
+    * redeploy
 
         a. metadata__latest_version_uid
 
         b. metadata__latest_deployed_version_uid
 
-    14. register-service
+    * register-service
 
         a. metadata__hook__uid
 
@@ -556,21 +560,21 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
 
         c. metadata__hook__active
 
-    15. transfer
+    * transfer
 
         a. metadata__username
 
-    16. unarchive
+    * unarchive
 
         a. metadata__latest_version_uid
 
-    17. update-name
+    * update-name
 
         a. metadata__name__old
 
         b. metadata__name__new
 
-    18. update-settings
+    * update-settings
 
         a. metadata__settings__description__old
 
@@ -730,33 +734,37 @@ class ProjectHistoryLogViewSet(
 
     **Filterable fields by action:**
 
-    1. add-media
+    * add-media
 
         a. metadata__asset-file__uid
 
         b. metadata__asset-file__filename
 
-    2. archive
+    * add-submission
+
+        a. metadata__submission__submitted_by
+
+    * archive
 
         a. metadata__latest_version_uid
 
-    3. clone-permissions
+    * clone-permissions
 
         a. metadata__cloned_from
 
-    4. connect-project
+    * connect-project
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    5. delete-media
+    * delete-media
 
         a. metadata__asset-file__uid
 
         b. metadata__asset-file__filename
 
-    6. delete-service
+    * delete-service
 
         a. metadata__hook__uid
 
@@ -764,25 +772,25 @@ class ProjectHistoryLogViewSet(
 
         c. metadata__hook__active
 
-    7. deploy
+    * deploy
 
         a. metadata__latest_version_uid
 
         b. metadata__latest_deployed_version_uid
 
-    8. disconnect-project
+    * disconnect-project
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    9. modify-imported-fields
+    * modify-imported-fields
 
         a. metadata__paired-data__source_uid
 
         b. metadata__paired-data__source_name
 
-    10. modify-service
+    * modify-service
 
         a. metadata__hook__uid
 
@@ -790,23 +798,23 @@ class ProjectHistoryLogViewSet(
 
         c. metadata__hook__active
 
-    11. modify-submission
+    * modify-submission
 
         a. metadata__submission__submitted_by
 
         b. metadata__submission__status (only present if changed)
 
-    12. modify-user-permissions
+    * modify-user-permissions
 
         a. metadata__permissions__username
 
-    13. redeploy
+    * redeploy
 
         a. metadata__latest_version_uid
 
         b. metadata__latest_deployed_version_uid
 
-    14. register-service
+    * register-service
 
         a. metadata__hook__uid
 
@@ -814,21 +822,21 @@ class ProjectHistoryLogViewSet(
 
         c. metadata__hook__active
 
-    15. transfer
+    * transfer
 
         a. metadata__username
 
-    16. unarchive
+    * unarchive
 
         a. metadata__latest_version_uid
 
-    17. update-name
+    * update-name
 
         a. metadata__name__old
 
         b. metadata__name__new
 
-    18. update-settings
+    * update-settings
 
         a. metadata__settings__description__old
 

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
@@ -8,6 +8,8 @@ from rest_framework.exceptions import NotAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 
+from kobo.apps.audit_log.base_views import AuditLoggedViewSet
+from kobo.apps.audit_log.models import AuditType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.openrosa.libs import filters
@@ -27,7 +29,6 @@ from kpi.authentication import (
     TokenAuthentication,
 )
 from kpi.utils.object_permission import get_database_user
-
 from ..utils.rest_framework.viewsets import OpenRosaGenericViewSet
 from ..utils.xml import extract_confirmation_message
 
@@ -64,7 +65,10 @@ def create_instance_from_json(username, request):
 
 
 class XFormSubmissionApi(
-    OpenRosaHeadersMixin, mixins.CreateModelMixin, OpenRosaGenericViewSet
+    OpenRosaHeadersMixin,
+    mixins.CreateModelMixin,
+    OpenRosaGenericViewSet,
+    AuditLoggedViewSet,
 ):
     """
     Implements OpenRosa Api [FormSubmissionAPI](\
@@ -124,6 +128,7 @@ class XFormSubmissionApi(
                         BrowsableAPIRenderer)
     serializer_class = SubmissionSerializer
     template_name = 'submission.xml'
+    log_type = AuditType.PROJECT_HISTORY
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -150,7 +155,6 @@ class XFormSubmissionApi(
         ]
 
     def create(self, request, *args, **kwargs):
-
         username = self.kwargs.get('username')
 
         if self.request.user.is_anonymous:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Create logs when new submissions are added to projects.


### 👷 Description for instance maintainers
Allow null user_uids in AuditLogs so we can log anonymous submissions.


### 💭 Notes
We previously had no need for null users in audit logs because the actions we logged were all restricted to authenticated users, but since we allow anonymous submissions, we needed a way to log those. 



### 👀 Preview steps

Feature/no-change template:
1. ℹ️ have an account and a project. Make sure the account username is not `admin` (see [this notion task](https://www.notion.so/kobotoolbox/Anonymous-submissions-dont-work-if-user-named-admin-owns-asset-1767e515f65480608dfcee76ba9b3710?pvs=4))
2. Deploy the project
3. Add a submission to the project
4. Go to `api/v2/asset/<asset-uid>/history`
5. 🟢 There should be a new project history log with `action='add-submission'` and all the usual metadata, plus
```
"submission": {
    "submitted_by": "user1"
}
```
6. Enable submissions without username/email to the project
7. To make sure you're submitting anonymously, copy and paste the enketo link into a new private tab and add a new submission
8. 🟢 Reload the endpoint. There should be a new audit log with `action='add-submission'`
  a. The user should be `http://kf.kobo.local:8080/api/v2/users/AnonymousUser/`
  b. The user_uid will be the uid of the anonymous user in the database
  c. The username should be `AnonymousUser`
  d. The metadata should contain `{"submission": {"submitted_by": "AnonymousUser"}` in addition to the usual 

