### PR TITLE
fix: handle case sensitivity for "Settings" sheet name with explicit error TASK-1353

### DIFF
--- a/kpi/mixins/xls_exportable.py
+++ b/kpi/mixins/xls_exportable.py
@@ -14,9 +14,7 @@ from formpack.utils.kobo_locking import (
 
 
 class XlsExportableMixin:
-    def ordered_xlsform_content(self,
-                                kobo_specific_types=False,
-                                append=None):
+    def ordered_xlsform_content(self, kobo_specific_types=False, append=None):
         # currently, this method depends on "FormpackXLSFormUtilsMixin"
         content = copy.deepcopy(self.content)
         if append:

--- a/kpi/serializers/v2/deployment.py
+++ b/kpi/serializers/v2/deployment.py
@@ -1,7 +1,7 @@
-# coding: utf-8
 from django.conf import settings
 from pyxform.errors import PyXFormError
 from rest_framework import serializers
+from xlsxwriter.exceptions import DuplicateWorksheetName
 
 from .asset import AssetSerializer
 
@@ -16,8 +16,9 @@ class DeploymentSerializer(serializers.Serializer):
     def _raise_unless_current_version(asset, validated_data):
         # Stop if the requester attempts to deploy any version of the asset
         # except the current one
-        if 'version_id' in validated_data and \
-                validated_data['version_id'] != str(asset.version_id):
+        if 'version_id' in validated_data and validated_data[
+            'version_id'
+        ] != str(asset.version_id):
             raise NotImplementedError(
                 'Only the current version_id can be deployed')
 
@@ -35,8 +36,8 @@ class DeploymentSerializer(serializers.Serializer):
         # 'deployed' boolean value
         try:
             asset.deploy(backend=backend_id, active=validated_data.get('active', False))
-        except PyXFormError as e:
-            raise serializers.ValidationError({'error': (f'ODK Validation Error: {e}')})
+        except (DuplicateWorksheetName, PyXFormError) as e:
+            raise serializers.ValidationError({'error': str(e)})
         return asset.deployment
 
     def update(self, instance, validated_data):


### PR DESCRIPTION

### 📣 Summary
Improved error handling for case-sensitive "Settings" sheet names.


### 📖 Description
This update addresses an issue where a sheet named "Settings" with uppercase or mixed case letters causes unexpected behavior. An explicit error message is now raised to alert users of the case sensitivity, ensuring they can resolve the issue easily.


### 👀 Preview steps
1. Upload [this project](https://github.com/user-attachments/files/18401159/aWsYfemsVMzhXBoFjvsNVs.xlsx) 
2. Try to deploy the project.
3. 🔴 [on main] notice the modal returns a 500 
5. 🟢 [on PR] notice the modal exposes a human-readable error
