### PR TITLE
fix(auditLogs): correctly serialize audit logs from deleted users

### DIFF
--- a/kobo/apps/audit_log/serializers.py
+++ b/kobo/apps/audit_log/serializers.py
@@ -45,7 +45,7 @@ class AuditLogSerializer(serializers.ModelSerializer):
         return audit_log.date_created.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def get_username(self, audit_log):
-        return audit_log.user.username
+        return getattr(audit_log.user, 'username', None)
 
 
 class AccessLogSerializer(serializers.Serializer):
@@ -66,14 +66,7 @@ class AccessLogSerializer(serializers.Serializer):
         return audit_log['date_created'].strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-class ProjectHistoryLogSerializer(serializers.ModelSerializer):
-    user = serializers.HyperlinkedRelatedField(
-        queryset=get_user_model().objects.all(),
-        lookup_field='username',
-        view_name='user-kpi-detail',
-    )
-    date_created = serializers.SerializerMethodField()
-    username = serializers.SerializerMethodField()
+class ProjectHistoryLogSerializer(AuditLogSerializer):
 
     class Meta:
         model = ProjectHistoryLog
@@ -94,9 +87,3 @@ class ProjectHistoryLogSerializer(serializers.ModelSerializer):
             'metadata',
             'date_created',
         )
-
-    def get_date_created(self, audit_log):
-        return audit_log.date_created.strftime('%Y-%m-%dT%H:%M:%SZ')
-
-    def get_username(self, audit_log):
-        return audit_log.user.username

--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -281,6 +281,8 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['username'] is None
+        assert response.data['results'][0]['user'] is None
+
 
 class ApiAccessLogTestCase(BaseAuditLogTestCase):
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a 500 error from the various audit log endpoints when there are actions by deleted users.



### 📖 Description
Return empty user and username fields in the response if the user was deleted after the log was created. This applies to `/api/v2/audit-logs`, `api/v2/assets/<uid>/history`, and  `api/v2/project-history-logs`.


### 💭 Notes
Small fix in the serializer. Also updates the ProjectHistoryLog serializer to inherit from the AuditLogSerializer so we don't have to duplicate the method fields.



### 👀 Preview steps

Bug template:
1. ℹ️ have a super user account and a project
2. Create a new user (user1) and give them the `Edit Form` permission on the project.
3. Log in as user1 and make an edit to the project.
4. Log out user1 and log back in as the super user
5. Delete user1. You can do this from the admin page if you delete the user from the User list, then from the Trash Bin.
6. Go to:
  a. `api/v2/audit-logs`
  b. `api/v2/project-history-logs`
  c. `api/v2/assets/<uid>/history`
7. 🔴 [on main] All will return a 500 error (`AttributeError: 'NoneType' object has no attribute 'username'`)
8. 🟢 [on PR] The endpoint will return the expected logs. For all user1's actions, the user and username fields will be empty. but the user_uid should still refer to the old user.

