### PR TITLE
feat(projectHistoryLogs): log deleted submissions

### DIFF
--- a/kobo/apps/audit_log/middleware.py
+++ b/kobo/apps/audit_log/middleware.py
@@ -1,7 +1,6 @@
 from rest_framework import status
 
 from kobo.apps.audit_log.models import AuditType, ProjectHistoryLog
-from kpi.utils import log
 
 
 def create_project_history_log_middleware(get_response):
@@ -23,9 +22,8 @@ def create_project_history_log_middleware(get_response):
         elif (
             log_type == AuditType.PROJECT_HISTORY
             and url_name == 'submission-bulk'
-            and request.METHOD == 'DELETE'
+            and request.method == 'DELETE'
         ):
-            log.info('Creating anyway')
             ProjectHistoryLog.create_from_request(request)
         return response
 

--- a/kobo/apps/audit_log/middleware.py
+++ b/kobo/apps/audit_log/middleware.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 
 from kobo.apps.audit_log.models import AuditType, ProjectHistoryLog
+from kpi.utils import log
 
 
 def create_project_history_log_middleware(get_response):
@@ -9,10 +10,22 @@ def create_project_history_log_middleware(get_response):
         if request.method in ['GET', 'HEAD']:
             return response
         log_type = getattr(request, 'log_type', None)
+        url_name = request.resolver_match.url_name
+
         if (
             status.is_success(response.status_code) and
             log_type == AuditType.PROJECT_HISTORY
         ):
+            ProjectHistoryLog.create_from_request(request)
+        # special case: log bulk delete requests even if there is an
+        # error. Things may have been deleted in mongo before the request timed out,
+        # and we'd rather have false positives than missing records
+        elif (
+            log_type == AuditType.PROJECT_HISTORY
+            and url_name == 'submission-bulk'
+            and request.METHOD == 'DELETE'
+        ):
+            log.info('Creating anyway')
             ProjectHistoryLog.create_from_request(request)
         return response
 

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -399,6 +399,7 @@ class ProjectHistoryLog(AuditLog):
             'assetsnapshot-submission-alias': cls._create_from_submission_request,
             'submissions': cls._create_from_submission_request,
             'submissions-list': cls._create_from_submission_request,
+            'submission-detail': cls._create_from_submission_request,
         }
         url_name = request.resolver_match.url_name
         method = url_name_to_action.get(url_name, None)
@@ -615,6 +616,8 @@ class ProjectHistoryLog(AuditLog):
         for instance in instances.values():
             if instance.action == 'add':
                 action = AuditAction.ADD_SUBMISSION
+            elif instance.action == 'delete':
+                action = AuditAction.DELETE_SUBMISSION
             else:
                 action = AuditAction.MODIFY_SUBMISSION
             metadata = {

--- a/kobo/apps/audit_log/signals.py
+++ b/kobo/apps/audit_log/signals.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from celery.signals import task_success
 from django.contrib.auth.signals import user_logged_in
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django_userforeignkey.request import get_current_request
 
@@ -72,8 +72,7 @@ def add_assigned_partial_perms(sender, instance, user, perms, **kwargs):
     request.partial_permissions_added[user.username] = perms_as_list_of_dicts
 
 
-@receiver(post_save, sender=Instance)
-def add_instance_to_request(instance, created, **kwargs):
+def add_instance_to_request(instance, action):
     request = get_current_request()
     if request is None:
         return
@@ -90,11 +89,22 @@ def add_instance_to_request(instance, created, **kwargs):
             instance.id: SubmissionUpdate(
                 username=username,
                 status=instance.get_validation_status().get('label', 'None'),
-                action='add' if created else 'modify',
+                action=action,
                 id=instance.id,
             )
         }
     )
+
+
+@receiver(post_save, sender=Instance)
+def add_instance_to_request_post_save(instance, created, **kwargs):
+    action = 'add' if created else 'modify'
+    add_instance_to_request(instance, action)
+
+
+@receiver(post_delete, sender=Instance)
+def add_instance_to_request_post_delete(instance, *args, **kwargs):
+    add_instance_to_request(instance, 'delete')
 
 
 @receiver(post_remove_perm, sender=Asset)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 
 @dataclass
 class SubmissionUpdate:
-    status: str
-    action: str
     id: int
+    action: str
     username: str = 'AnonymousUser'
+    status: str | None = None
 
     def __post_init__(self):
         self.username = 'AnonymousUser' if self.username is None else self.username

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -430,6 +430,7 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
     >        connect-project
     >        delete-media
     >        delete-service
+    >        delete-submission
     >        deploy
     >        disable-sharing
     >        disallow-anonymous-submissions
@@ -509,6 +510,10 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
         b. metadata__hook__endpoint
 
         c. metadata__hook__active
+
+    * delete-submission
+
+        a. metadata__submission__submitted_by
 
     * deploy
 
@@ -692,6 +697,7 @@ class ProjectHistoryLogViewSet(
     >        connect-project
     >        delete-media
     >        delete-service
+    >        delete-submission
     >        deploy
     >        disable-sharing
     >        disallow-anonymous-submissions
@@ -771,6 +777,10 @@ class ProjectHistoryLogViewSet(
         b. metadata__hook__endpoint
 
         c. metadata__hook__active
+
+    * delete-submission
+
+        a. metadata__submission__submitted_by
 
     * deploy
 

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -349,20 +349,6 @@ class DataViewSet(
         # Coerce to int because back end only finds matches with same type
         submission_id = positive_int(pk)
 
-        # Need to get `uuid` before the data is gone
-        submission = deployment.get_submission(
-            submission_id=submission_id,
-            user=request.user,
-            fields=['_id', '_uuid', '_submitted_by'],
-        )
-        request._request.instances = {
-            submission_id: SubmissionUpdate(
-                username=submission['_submitted_by'],
-                action='delete',
-                id=submission_id,
-            )
-        }
-
         if deployment.delete_submission(submission_id, user=request.user):
             response = {
                 'content_type': 'application/json',
@@ -592,9 +578,7 @@ class DataViewSet(
         # Prepare audit logs
         data = copy.deepcopy(bulk_actions_validator.data)
         # Retrieve all submissions matching `submission_ids` or `query`.
-        # If user is not allowed to see some of the submissions (i.e.: user
-        # with partial permissions), the request will be rejected
-        # (aka `PermissionDenied`) before AuditLog objects are saved in DB.
+
         submissions = deployment.get_submissions(
             user=request.user,
             submission_ids=data['submission_ids'],

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -16,9 +16,9 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.base_views import AuditLoggedViewSet
-from kobo.apps.audit_log.models import AuditLog, AuditType
+from kobo.apps.audit_log.models import AuditType
+from kobo.apps.audit_log.utils import SubmissionUpdate
 from kobo.apps.openrosa.libs.utils.logger_tools import http_open_rosa_error_handler
 from kpi.authentication import EnketoSessionAuthentication
 from kpi.constants import (
@@ -353,22 +353,17 @@ class DataViewSet(
         submission = deployment.get_submission(
             submission_id=submission_id,
             user=request.user,
-            fields=['_id', '_uuid']
+            fields=['_id', '_uuid', '_submitted_by'],
         )
+        request._request.instances = {
+            submission_id: SubmissionUpdate(
+                username=submission['_submitted_by'],
+                action='delete',
+                id=submission_id,
+            )
+        }
 
         if deployment.delete_submission(submission_id, user=request.user):
-            AuditLog.objects.create(
-                app_label='logger',
-                model_name='instance',
-                object_id=pk,
-                user=request.user,
-                metadata={
-                    'asset_uid': self.asset.uid,
-                    'uuid': submission['_uuid'],
-                },
-                action=AuditAction.DELETE,
-                log_type=AuditType.SUBMISSION_MANAGEMENT,
-            )
             response = {
                 'content_type': 'application/json',
                 'status': status.HTTP_204_NO_CONTENT,
@@ -604,27 +599,16 @@ class DataViewSet(
             user=request.user,
             submission_ids=data['submission_ids'],
             query=data['query'],
-            fields=['_id', '_uuid'],
+            fields=['_id', '_uuid', '_submitted_by'],
         )
 
         # Prepare logs before deleting all submissions.
-        audit_logs = []
-        for submission in submissions:
-            audit_logs.append(
-                AuditLog(
-                    app_label='logger',
-                    model_name='instance',
-                    object_id=submission['_id'],
-                    user=request.user,
-                    user_uid=request.user.extra_details.uid,
-                    metadata={
-                        'asset_uid': self.asset.uid,
-                        'uuid': submission['_uuid'],
-                    },
-                    action=AuditAction.DELETE,
-                    log_type=AuditType.SUBMISSION_MANAGEMENT,
-                )
+        request._request.instances = {
+            sub['_id']: SubmissionUpdate(
+                id=sub['_id'], username=sub['_submitted_by'], action='delete'
             )
+            for sub in submissions
+        }
 
         try:
             deleted = deployment.delete_submissions(
@@ -636,10 +620,6 @@ class DataViewSet(
                 'content_type': 'application/json',
                 'status': status.HTTP_400_BAD_REQUEST,
             }
-
-        # If requests has succeeded, let's log deletions (if any)
-        if audit_logs and deleted:
-            AuditLog.objects.bulk_create(audit_logs)
 
         return {
             'data': {'detail': f'{deleted} submissions have been deleted'},


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Create logs when submissions are deleted.


### 📖 Description
Each deletion is logged individually even if it was done in bulk. Unlike other actions, even failed deletions will be logged as long as the process of deletion was started, since some of the submissions may have been deleted before the failure. In this case, we prefer false positives to missing logs.


### 💭 Notes
The more robust way to handle this would probably be to redo the bulk-deletion process entirely such that each deletion is done as a single transaction with deletion from mongo, deleting docs from storage, creating a log. This would obviously take a lot more time and probably would work better as a celery task than an API endpoint.. At this moment we did not think it was worth it to rethink the whole process, and instead settled on just logging every *attempt* to delete, even if that attempt failed. This is in-keeping with our logging strategy so far, which has focused on intent more than effect.

For single deletes, this just adds a listener on the post_delete signal for Instances which attaches the necessary information to the request, similar to how individual updates were handled. 


### 👀 Preview steps
Feature/no-change template:
1. ℹ️ have 2 accounts and a project
2. Give user2 permission to add submissions to the project
3. Add at least 2 submissions as user1 and 2 as user 2
4. Enable anonymous submissions
5. Add at least 2 anonymous submissions 
6. Go to Project > Data and get the _ids of 1 submission each for user1, user2, and anonymous
7. For each submission, in the terminal, run `curl -X DELETE -H 'Authorization: Token <your token>' localhost/api/v2/assets/<asset_uid>/data/<submission _id>/ `
8. Go to `api/v2/assets/<asset_uid>/history`
9. 🟢 There should be a project history log with `action="delete-submission"` and the usual metadata, along with `"submission":{"submitted_by": <user1/user2/AnonymousUser>}`
10. Go back to Project > Data
11. Select one submission each for user1, user2, and anonymous
12. Hit the Delete button and confirm
13. 🟢 Go back to `api/v2/assets/<asset_uid>/history`. There should be three new project history logs (the same ones as were created with a single delete)
14. To test that we still get logs in case of a database timeout, use [mockobo](https://github.com/kobotoolbox/mockobo) to submit a 4000 submissions to your project (may want to do this in groups).
15. Go to Project > Data and select all submissions
16. Hit Delete and confirm
17. Before the request finishes (it should take a few seconds), kill your mongo server locally (`docker compose stop mongo` if you're using kobo-compose)
18. 🟢 Go back to `api/v2/assets/<asset_uid>/history`. The log count should have gone up by 4000. You can spot check a few to make sure they are deletion logs.
  * sometimes it takes a minute for the logs to show up because the front end times out before the backend does. you may need to reload a few times.
