### PR TITLE
fix(mantine): adjust theme color hsl formatting

### DIFF
--- a/jsapp/js/theme/kobo/index.ts
+++ b/jsapp/js/theme/kobo/index.ts
@@ -8,38 +8,38 @@ export const themeKobo = createTheme({
   primaryColor: 'blue',
   colors: {
     gray: [
-      'hsl(225deg 17% 14%)', // [0] #1e212a, $kobo-gray-900, (accessible) our black, very very rare, only use if necessary for contrast
-      'hsl(225deg 16% 24%)', // [1] #333847, $kobo-gray-800, (accessible) active text, important text, text on background, top navigation background
-      'hsl(226deg 16% 42%)', // [2] #5a627d, $kobo-gray-700, (accessible) default text, inactive text, options text, buttons text, tabs text, notifications background, hover for popups and dropdowns
-      'hsl(225deg 16% 58%)', // [3] #828ba5, $kobo-gray-600, (readable) clickable icons on hover
-      'hsl(226deg 16% 70%)', // [4] #a6acbf, $kobo-gray-500, icons default (clickable), arrows and indicators default
-      'hsl(228deg 16% 82%)', // [5] #cacdd9, $kobo-gray-400, inactive icons, some decorative icons
-      'hsl(227deg 18% 90%)', // [6] #e1e3ea, $kobo-gray-300, scroll bars, table lines, dividers, background of clickable icons on hover when also in a highlighted table row
-      'hsl(228deg 16% 94%)', // [7] #edeef2, $kobo-gray-200, default light background, icons on hover, sidebar menu, table headings, …
-      'hsl(240deg 20% 98%)', // [8] #f9f9fb, $kobo-gray-100, table row highlight on hover
-      'hsl(0deg 0% 100%)', // [9] #ffffff, white background
+      'hsl(225, 17%, 14%)', // [0] #1e212a, $kobo-gray-900, (accessible) our black, very very rare, only use if necessary for contrast
+      'hsl(225, 16%, 24%)', // [1] #333847, $kobo-gray-800, (accessible) active text, important text, text on background, top navigation background
+      'hsl(226, 16%, 42%)', // [2] #5a627d, $kobo-gray-700, (accessible) default text, inactive text, options text, buttons text, tabs text, notifications background, hover for popups and dropdowns
+      'hsl(225, 16%, 58%)', // [3] #828ba5, $kobo-gray-600, (readable) clickable icons on hover
+      'hsl(226, 16%, 70%)', // [4] #a6acbf, $kobo-gray-500, icons default (clickable), arrows and indicators default
+      'hsl(228, 16%, 82%)', // [5] #cacdd9, $kobo-gray-400, inactive icons, some decorative icons
+      'hsl(227, 18%, 90%)', // [6] #e1e3ea, $kobo-gray-300, scroll bars, table lines, dividers, background of clickable icons on hover when also in a highlighted table row
+      'hsl(228, 16%, 94%)', // [7] #edeef2, $kobo-gray-200, default light background, icons on hover, sidebar menu, table headings, …
+      'hsl(240, 20%, 98%)', // [8] #f9f9fb, $kobo-gray-100, table row highlight on hover
+      'hsl(0, 0%, 100%)', // [9] #ffffff, white background
     ],
     blue: [
       '#000',
       '#000',
       '#000',
       '#000',
-      'hsl(207deg 77% 32%)', // #135991,
-      'hsl(207deg 77% 43%)', // #1977c2,
-      'hsl(207deg 90% 54%)', // #2095f3,
-      'hsl(207deg 90% 77%)', // #8fcaf9, (previously $kobo-alt-blue)
-      'hsl(207deg 88% 91%)', // #d2e9fc, (previously $kobo-mid-blue)
-      'hsl(206deg 84% 95%)', // #e8f4fd, (previously $kobo-light-blue)
+      'hsl(207, 77%, 32%)', // #135991,
+      'hsl(207, 77%, 43%)', // #1977c2,
+      'hsl(207, 90%, 54%)', // #2095f3,
+      'hsl(207, 90%, 77%)', // #8fcaf9, (previously $kobo-alt-blue)
+      'hsl(207, 88%, 91%)', // #d2e9fc, (previously $kobo-mid-blue)
+      'hsl(206, 84%, 95%)', // #e8f4fd, (previously $kobo-light-blue)
     ],
     teal: [
       '#000',
       '#000',
-      'hsl(185deg 57% 25%)', // #1b5e64
-      'hsl(185deg 57% 35%)', // #26838c
-      'hsl(185deg 57% 57%)', // #52c5d0
-      'hsl(186deg 57% 75%)', // #9bdde4
-      'hsl(185deg 58% 85%)', // #c3ebef
-      'hsl(188deg 60% 95%)', // #ebf8fa
+      'hsl(185, 57%, 25%)', // #1b5e64
+      'hsl(185, 57%, 35%)', // #26838c
+      'hsl(185, 57%, 57%)', // #52c5d0
+      'hsl(186, 57%, 75%)', // #9bdde4
+      'hsl(185, 58%, 85%)', // #c3ebef
+      'hsl(188, 60%, 95%)', // #ebf8fa
       '#000',
       '#000',
     ],
@@ -49,11 +49,11 @@ export const themeKobo = createTheme({
       '#000',
       '#000',
       '#000',
-      'hsl(0deg 100% 26%)', // #850000
-      'hsl(0deg 100% 31%)', // #9d0000
-      'hsl(0deg 100% 75%)', // #ff8080
-      'hsl(0deg 100% 90%)', // #ffcccc
-      'hsl(0deg 100% 96%)', // #ffe9e9
+      'hsl(0, 100%, 26%)', // #850000
+      'hsl(0, 100%, 31%)', // #9d0000
+      'hsl(0, 100%, 75%)', // #ff8080
+      'hsl(0, 100%, 90%)', // #ffcccc
+      'hsl(0, 100%, 96%)', // #ffe9e9
     ],
   },
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes formatting of our Mantine HSL theme color codes.



### 📖 Description
Mantine sometimes attempts to parse HSL codes with a regex that does not recognize 'deg' as a unit and expects comma-separated values. 


### 👀 Preview steps
This shouldn't have any impact on existing designs. Can be confirmed in storybook