### PR TITLE
feat(projectHistory): handle submission related audit actions TASK-1409

### DIFF
--- a/jsapp/js/components/activity/activity.constants.ts
+++ b/jsapp/js/components/activity/activity.constants.ts
@@ -11,6 +11,7 @@ export enum AuditActions {
   'connect-project' = 'connect-project',
   'delete-media' = 'delete-media',
   'delete-service' = 'delete-service',
+  'delete-submission' = 'delete-submission',
   'deploy' = 'deploy',
   'disable-sharing' = 'disable-sharing',
   'disallow-anonymous-submissions' = 'disallow-anonymous-submissions',
@@ -95,6 +96,12 @@ export const AUDIT_ACTION_TYPES: AuditActionTypes = {
     label: t('delete a REST service'),
     message: t('##username## deleted a REST service'),
   },
+  'delete-submission': {
+    order: 32,
+    name: AuditActions['delete-submission'],
+    label: t('delete a submission'),
+    message: t('##username## deleted a submission'),
+  },
   'deploy': {
     order: 2,
     name: AuditActions['deploy'],
@@ -152,8 +159,8 @@ export const AUDIT_ACTION_TYPES: AuditActionTypes = {
   'modify-submission': {
     order: 31,
     name: AuditActions['modify-submission'],
-    label: t('modify submission'),
-    message: t('##username## modified a submission'),
+    label: t('edit submission'),
+    message: t('##username## edited a submission'),
   },
   'modify-user-permissions': {
     order: 12,

--- a/jsapp/js/components/activity/activity.constants.ts
+++ b/jsapp/js/components/activity/activity.constants.ts
@@ -4,6 +4,7 @@
  */
 export enum AuditActions {
   'add-media' = 'add-media',
+  'add-submission' = 'add-submission',
   'allow-anonymous-submissions' = 'allow-anonymous-submissions',
   'archive' = 'archive',
   'clone-permissions' = 'clone-permissions',
@@ -19,6 +20,7 @@ export enum AuditActions {
   'modify-imported-fields' = 'modify-imported-fields',
   'modify-service' = 'modify-service',
   'modify-sharing' = 'modify-sharing',
+  'modify-submission' = 'modify-submission',
   'modify-user-permissions' = 'modify-user-permissions',
   'redeploy' = 'redeploy',
   'register-service' = 'register-service',
@@ -50,6 +52,12 @@ export const AUDIT_ACTION_TYPES: AuditActionTypes = {
     name: AuditActions['add-media'],
     label: t('add media attachment'),
     message: t('##username## added a media attachment'),
+  },
+  'add-submission': {
+    order: 30,
+    name: AuditActions['add-submission'],
+    label: t('add submission'),
+    message: t('##username## added a submission'),
   },
   'allow-anonymous-submissions': {
     order: 16,
@@ -141,6 +149,12 @@ export const AUDIT_ACTION_TYPES: AuditActionTypes = {
     label: t('modify data sharing'),
     message: t('##username## modified data sharing'),
   },
+  'modify-submission': {
+    order: 31,
+    name: AuditActions['modify-submission'],
+    label: t('modify submission'),
+    message: t('##username## modified a submission'),
+  },
   'modify-user-permissions': {
     order: 12,
     name: AuditActions['modify-user-permissions'],
@@ -228,6 +242,8 @@ export const AUDIT_ACTION_TYPES: AuditActionTypes = {
 };
 
 export const FALLBACK_MESSAGE = '##username## did action ##action##';
+
+export const HIDDEN_AUDIT_ACTIONS = [AuditActions['add-submission']];
 
 /**
  * All possible log item types.

--- a/jsapp/js/components/activity/activityLogs.query.ts
+++ b/jsapp/js/components/activity/activityLogs.query.ts
@@ -4,7 +4,7 @@ import type {
   LabelValuePair,
   PaginatedResponse,
 } from 'js/dataInterface';
-import {AUDIT_ACTION_TYPES} from './activity.constants';
+import {AUDIT_ACTION_TYPES, HIDDEN_AUDIT_ACTIONS} from './activity.constants';
 import type {AuditActions, ActivityLogsItem} from './activity.constants';
 import {QueryKeys} from 'js/query/queryKeys';
 import {fetchGet} from 'jsapp/js/api';
@@ -27,13 +27,18 @@ const getActivityLogs = async ({
   limit: number;
   offset: number;
 }) => {
+  // Filter out unwanted actions (e.g. UI doesn't support them yet).
+  let q = `NOT action:'${HIDDEN_AUDIT_ACTIONS.join(',')}'`;
+  // Alternatively filter by only single selected action.
+  if (actionFilter !== '') {
+    q = `action:${actionFilter}`;
+  }
+
   const params = new URLSearchParams({
     limit: limit.toString(),
     offset: offset.toString(),
+    q: q,
   });
-  if (actionFilter) {
-    params.append('q', `action:${actionFilter}`);
-  }
 
   const endpointUrl = endpoints.ASSET_HISTORY.replace(':asset_uid', assetUid);
 
@@ -70,6 +75,7 @@ const getFilterOptions = async (
 
   return filterOptions.actions
     .map((key) => AUDIT_ACTION_TYPES[key])
+    .filter((auditAction) => !HIDDEN_AUDIT_ACTIONS.includes(auditAction.name))
     .sort((a, b) => a.order - b.order)
     .map((auditAction) => {
       return {


### PR DESCRIPTION
### 📣 Summary

Handle `modified-submission` audit action properly in Project -> Settings -> Activity table UI. Hide `add-submission` audit action from the UI for now.

### 👀 Preview steps

Testing:
1. ℹ️ have a deployed project and organization with multiple users
2. add submissions with some of the users
3. go to Project -> Settings -> Activity
4. 🟢 notice that `add-submission` audit actions don't appear in the table and that the filter dropdown doesn't have an option to filter by this action
5. modify existing submissions with some of the users
6. go to Project -> Settings -> Activity
7. 🟢 notice that `modify-submission` audit actions do appear in the table and that the filter dropdown has an option to filter by this action
8. filter by `modify-submission`
9. 🟢 notice that only `modify-submission` audit actions appear in the table
