### PR TITLE
feat(accesslogs) display logout all button TASK-859

### DIFF
--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -2,21 +2,21 @@
 import React from 'react';
 
 // Partial components
-// import Button from 'js/components/common/button';
+import Button from 'js/components/common/button';
 import PaginatedQueryUniversalTable from 'js/universalTable/paginatedQueryUniversalTable.component';
 
 // Utilities
 import useAccessLogsQuery, {type AccessLog} from 'js/query/queries/accessLogs.query';
 import {formatTime} from 'js/utils';
-// import sessionStore from 'js/stores/session';
+import sessionStore from 'js/stores/session';
 
 // Styles
 import securityStyles from 'js/account/security/securityRoute.module.scss';
 
 export default function AccessLogsSection() {
-  // function logOutAllSessions() {
-  //   sessionStore.logOutAll();
-  // }
+  function logOutAllSessions() {
+    sessionStore.logOutAll();
+  }
 
   return (
     <>
@@ -24,10 +24,7 @@ export default function AccessLogsSection() {
         <h2 className={securityStyles.securityHeaderText}>
           {t('Recent account activity')}
         </h2>
-
-        {/* TODO: we comment this out until we know how to handle exsiting
-        sessions for the moment of release of the feature. */}
-        {/*<div className={securityStyles.securityHeaderActions}>
+        <div className={securityStyles.securityHeaderActions}>
           <Button
             type='text'
             size='m'
@@ -35,7 +32,7 @@ export default function AccessLogsSection() {
             label={t('Log out of all devices')}
             startIcon='logout'
           />
-        </div>*/}
+        </div>
       </header>
 
       <PaginatedQueryUniversalTable<AccessLog>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Makes previously hidden logout-all button accessible

### 👀 Preview steps
1. Log in on two separate browsers
2. Access security settings page in one browser and press logout all button
3. See that you are logged out from other browser session
