### PR TITLE
fix(auditLogs): do not try to create logs after 404s

### DIFF
--- a/kobo/apps/audit_log/middleware.py
+++ b/kobo/apps/audit_log/middleware.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponseNotFound
 from rest_framework import status
 
 from kobo.apps.audit_log.models import AuditType, ProjectHistoryLog
@@ -8,7 +9,7 @@ def create_project_history_log_middleware(get_response):
         response = get_response(request)
         if request.method in ['GET', 'HEAD']:
             return response
-        if response.status == status.HTTP_404_NOT_FOUND:
+        if response.status_code == status.HTTP_404_NOT_FOUND:
             return response
         log_type = getattr(request, 'log_type', None)
         url_name = request.resolver_match.url_name

--- a/kobo/apps/audit_log/middleware.py
+++ b/kobo/apps/audit_log/middleware.py
@@ -1,4 +1,3 @@
-from django.http import HttpResponseNotFound
 from rest_framework import status
 
 from kobo.apps.audit_log.models import AuditType, ProjectHistoryLog

--- a/kobo/apps/audit_log/middleware.py
+++ b/kobo/apps/audit_log/middleware.py
@@ -8,6 +8,8 @@ def create_project_history_log_middleware(get_response):
         response = get_response(request)
         if request.method in ['GET', 'HEAD']:
             return response
+        if response.status == status.HTTP_404_NOT_FOUND:
+            return response
         log_type = getattr(request, 'log_type', None)
         url_name = request.resolver_match.url_name
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Return correct error message when page isn't found.


### 📖 Description
404s were returning as 500s because of a bug in the audit log middleware. This fixes that.


### 💭 Notes
If a request 404s, `request.resolver_match` will be None. This was causing a 500 error in the middleware when non-GET requests were made to missing pages because it tries to look at `request.resolver_match.url_name`.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. From the terminal, run `curl -X POST kf.kobo.local:8080/api/v2/fake/`
3. 🔴 [on main] The response will be a 500 with the error `NoneType has no attribute 'url_name'`
4. 🟢 [on PR] The response will be a 404
