### PR TITLE
feat(organizations): add theming/story for Mantine Modal TASK-1423

### DIFF
--- a/jsapp/js/components/common/modal.stories.tsx
+++ b/jsapp/js/components/common/modal.stories.tsx
@@ -2,7 +2,6 @@ import type {ModalProps} from '@mantine/core';
 import {Button, Center, Modal, Stack, Text, Group} from '@mantine/core';
 import type {Meta, StoryObj} from '@storybook/react';
 import {useArgs} from '@storybook/preview-api';
-import {useDisclosure} from '@mantine/hooks';
 
 const RenderModal = ({...args}: ModalProps) => {
   const [{opened}, updateArgs] = useArgs();
@@ -39,7 +38,7 @@ const meta: Meta<typeof Modal> = {
       type: 'boolean',
     },
     size: {
-      description: 'Modal size',
+      description: 'Modal size - influences the width of the modal, height depends on the content',
       type: 'string',
       control: {
         type: 'select',
@@ -51,7 +50,7 @@ const meta: Meta<typeof Modal> = {
       type: 'boolean',
     },
     centered: {
-      description: 'Center modal content',
+      description: 'Center modal vertically on the viewport',
       type: 'boolean',
     },
     withCloseButton: {

--- a/jsapp/js/components/common/modal.stories.tsx
+++ b/jsapp/js/components/common/modal.stories.tsx
@@ -1,8 +1,30 @@
 import type {ModalProps} from '@mantine/core';
-import {Button, Center, Modal, Stack, Text} from '@mantine/core';
+import {Button, Center, Modal, Stack, Text, Group} from '@mantine/core';
 import type {Meta, StoryObj} from '@storybook/react';
 import {useArgs} from '@storybook/preview-api';
-import {Group} from '@mantine/core';
+import {useDisclosure} from '@mantine/hooks';
+
+const RenderModal = ({...args}: ModalProps) => {
+  const [{opened}, updateArgs] = useArgs();
+
+  return (
+    <Center w={400} h={80}>
+      <Button onClick={() => updateArgs({opened: !opened})}>Open modal</Button>
+      <Modal {...args} onClose={() => updateArgs({opened: !opened})}>
+        <Stack>
+          <Text p='md'>
+            Example modal content. Press esc, click outside or close button to
+            close.
+          </Text>
+          <Group justify='flex-end'>
+            <Button variant='danger'>Won&apos;t close</Button>
+            <Button onClick={() => updateArgs({opened: false})}>Close</Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Center>
+  );
+};
 
 /**
  * Mantine [Modal](https://mantine.dev/core/modal/) component stories.
@@ -10,29 +32,7 @@ import {Group} from '@mantine/core';
 const meta: Meta<typeof Modal> = {
   title: 'Common/Modal',
   component: Modal,
-  render: ({...args}: ModalProps) => {
-    const [{opened}, updateArgs] = useArgs();
-
-    return (
-      <Center w={400} h={80}>
-        <Button onClick={() => updateArgs({opened: !opened})}>
-          Open modal
-        </Button>
-        <Modal {...args} onClose={() => updateArgs({opened: !opened})}>
-          <Stack>
-            <Text p='md'>
-              Example modal content. Press esc, click outside or close button to
-              close.
-            </Text>
-            <Group justify='flex-end'>
-              <Button variant='danger'>Won&apos;t close</Button>
-              <Button onClick={() => updateArgs({opened: false})}>Close</Button>
-            </Group>
-          </Stack>
-        </Modal>
-      </Center>
-    );
-  },
+  render: RenderModal,
   argTypes: {
     opened: {
       description: 'Modal opened state',

--- a/jsapp/js/components/common/modal.stories.tsx
+++ b/jsapp/js/components/common/modal.stories.tsx
@@ -1,0 +1,83 @@
+import type {ModalProps} from '@mantine/core';
+import {Button, Center, Modal, Stack, Text} from '@mantine/core';
+import type {Meta, StoryObj} from '@storybook/react';
+import {useArgs} from '@storybook/preview-api';
+import {Group} from '@mantine/core';
+
+/**
+ * Mantine [Modal](https://mantine.dev/core/modal/) component stories.
+ */
+const meta: Meta<typeof Modal> = {
+  title: 'Common/Modal',
+  component: Modal,
+  render: ({...args}: ModalProps) => {
+    const [{opened}, updateArgs] = useArgs();
+
+    return (
+      <Center w={400} h={80}>
+        <Button onClick={() => updateArgs({opened: !opened})}>
+          Open modal
+        </Button>
+        <Modal {...args} onClose={() => updateArgs({opened: !opened})}>
+          <Stack>
+            <Text p='md'>
+              Example modal content. Press esc, click outside or close button to
+              close.
+            </Text>
+            <Group justify='flex-end'>
+              <Button variant='danger'>Won&apos;t close</Button>
+              <Button onClick={() => updateArgs({opened: false})}>Close</Button>
+            </Group>
+          </Stack>
+        </Modal>
+      </Center>
+    );
+  },
+  argTypes: {
+    opened: {
+      description: 'Modal opened state',
+      type: 'boolean',
+    },
+    size: {
+      description: 'Modal size',
+      type: 'string',
+      control: {
+        type: 'select',
+      },
+      options: ['auto', 'xs', 'sm', 'md', 'lg', 'xl', '50%', '75%', '100%'],
+    },
+    fullScreen: {
+      description: 'Modal fullscreen state',
+      type: 'boolean',
+    },
+    centered: {
+      description: 'Center modal content',
+      type: 'boolean',
+    },
+    withCloseButton: {
+      description: 'Render close button',
+      type: 'boolean',
+    },
+    title: {
+      description: 'Modal title',
+      type: 'string',
+    },
+  },
+  args: {
+    opened: false,
+    closeOnClickOutside: true,
+    withCloseButton: true,
+    title: 'Modal title',
+    centered: false,
+    size: 'md',
+    fullScreen: false,
+  },
+};
+
+type Story = StoryObj<typeof Modal>;
+
+export const Basic: Story = {
+  args: {},
+};
+
+export default meta;

--- a/jsapp/js/components/modals/koboModal.stories.tsx
+++ b/jsapp/js/components/modals/koboModal.stories.tsx
@@ -8,7 +8,7 @@ import Button from '../common/button';
 import KoboPrompt from './koboPrompt';
 
 export default {
-  title: 'common/KoboModal',
+  title: 'commonDeprecated/KoboModal',
   component: KoboModal,
   argTypes: {
     isOpen: {control: 'boolean'},

--- a/jsapp/js/theme/kobo/Modal.module.css
+++ b/jsapp/js/theme/kobo/Modal.module.css
@@ -1,0 +1,15 @@
+.close {
+  color: var(--mantine-color-gray-4);
+  background-color: transparent;
+
+  &:hover {
+    color: var(--mantine-color-gray-2);
+    background-color: transparent;
+  }
+}
+
+.title {
+  font-size: var(--mantine-font-size-xl);
+  font-weight: var(--mantine-heading-font-weight);
+  color: var(--mantine-color-gray-0);
+}

--- a/jsapp/js/theme/kobo/Modal.tsx
+++ b/jsapp/js/theme/kobo/Modal.tsx
@@ -10,7 +10,6 @@ export const ModalThemeKobo = Modal.extend({
     overlayProps: {
       backgroundOpacity: 0.5,
       color: 'var(--mantine-color-blue-9)',
-      blur: 2,
       zIndex: 3000,
     },
     zIndex: 4000,

--- a/jsapp/js/theme/kobo/Modal.tsx
+++ b/jsapp/js/theme/kobo/Modal.tsx
@@ -1,0 +1,19 @@
+import {Modal} from '@mantine/core';
+import Icon from 'jsapp/js/components/common/icon';
+import classes from './Modal.module.css';
+
+export const ModalThemeKobo = Modal.extend({
+  defaultProps: {
+    closeButtonProps: {
+      icon: <Icon name='close' />,
+    },
+    overlayProps: {
+      backgroundOpacity: 0.5,
+      color: 'var(--mantine-color-blue-9)',
+      blur: 2,
+      zIndex: 3000,
+    },
+    zIndex: 4000,
+  },
+  classNames: classes,
+});

--- a/jsapp/js/theme/kobo/index.ts
+++ b/jsapp/js/theme/kobo/index.ts
@@ -7,6 +7,7 @@ import {MenuThemeKobo} from './Menu';
 import {AlertThemeKobo} from './Alert';
 import {SelectThemeKobo} from './Select';
 import {LoaderThemeKobo} from './Loader';
+import {ModalThemeKobo} from './Modal';
 
 export const themeKobo = createTheme({
   primaryColor: 'blue',
@@ -110,5 +111,6 @@ export const themeKobo = createTheme({
     Table: TableThemeKobo,
     Select: SelectThemeKobo,
     Loader: LoaderThemeKobo,
+    Modal: ModalThemeKobo,
   },
 });


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Theming for Mantine's Modal was added to match Kobo's current KoboModal used for general purpose.



### 📖 Description
* Co-authored by @duvld 

- We don't have a direct reference of an existing Kobo component, so we've came up a middle ground between the existing modals using though the application.
- We have added a Story with a big set of configurations to showcase the possibilities of the Modal
- The story also displays a way of 
- We added a theme and style to the Modal component
- Title is using the default heading weight



### 👀 Preview steps
- Use storybook to check the visual of the component.