### PR TITLE
fix(exports): tasks stuck in processing TASK-1243

### DIFF
--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
@@ -618,12 +619,14 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
                 'type': 'project_history_logs_export',
             },
         )
-
-        export_task_in_background.delay(
-            export_task_uid=export_task.uid,
-            username=export_task.user.username,
-            export_task_name='kpi.ProjectHistoryLogExportTask',
+        transaction.on_commit(
+            lambda: export_task_in_background.delay(
+                export_task_uid=export_task.uid,
+                username=export_task.user.username,
+                export_task_name='kpi.ProjectHistoryLogExportTask',
+            )
         )
+
         return Response(
             {f'status: {export_task.status}'},
             status=status.HTTP_202_ACCEPTED,
@@ -961,10 +964,12 @@ class ProjectHistoryLogViewSet(
             },
         )
 
-        export_task_in_background.delay(
-            export_task_uid=export_task.uid,
-            username=export_task.user.username,
-            export_task_name='kpi.ProjectHistoryLogExportTask',
+        transaction.on_commit(
+            lambda: export_task_in_background.delay(
+                export_task_uid=export_task.uid,
+                username=export_task.user.username,
+                export_task_name='kpi.ProjectHistoryLogExportTask',
+            )
         )
         return Response(
             {f'status: {export_task.status}'},
@@ -985,12 +990,14 @@ class BaseAccessLogsExportViewSet(viewsets.ViewSet):
                 'type': 'access_logs_export',
             },
         )
-
-        export_task_in_background.delay(
-            export_task_uid=export_task.uid,
-            username=export_task.user.username,
-            export_task_name='kpi.AccessLogExportTask',
+        transaction.on_commit(
+            lambda: export_task_in_background.delay(
+                export_task_uid=export_task.uid,
+                username=export_task.user.username,
+                export_task_name='kpi.AccessLogExportTask',
+            )
         )
+
         return Response(
             {f'status: {export_task.status}'},
             status=status.HTTP_202_ACCEPTED,

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models.query import QuerySet
 from django.http import Http404
 from rest_framework import viewsets
@@ -110,11 +111,12 @@ class ProjectViewViewSet(
             )
 
             # Have Celery run the export in the background
+            transaction.on_commit(lambda:
             export_task_in_background.delay(
                 export_task_uid=export_task.uid,
                 username=user.username,
                 export_task_name='kpi.ProjectViewExportTask',
-            )
+            ))
 
             return Response({'status': export_task.status})
 

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Optional, Union
 
 from django.conf import settings
 from django.db import transaction
@@ -10,10 +10,7 @@ from rest_framework.response import Response
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import ASSET_TYPE_SURVEY
-from kpi.filters import (
-    AssetOrderingFilter,
-    SearchFilter,
-)
+from kpi.filters import AssetOrderingFilter, SearchFilter
 from kpi.mixins.asset import AssetViewSetListMixin
 from kpi.mixins.object_permission import ObjectPermissionViewSetMixin
 from kpi.models import Asset, ProjectViewExportTask
@@ -23,10 +20,7 @@ from kpi.serializers.v2.asset import AssetMetadataListSerializer
 from kpi.serializers.v2.user import UserListSerializer
 from kpi.tasks import export_task_in_background
 from kpi.utils.object_permission import get_database_user
-from kpi.utils.project_views import (
-    get_region_for_view,
-    user_has_view_perms,
-)
+from kpi.utils.project_views import get_region_for_view, user_has_view_perms
 from .models.project_view import ProjectView
 from .serializers import ProjectViewSerializer
 
@@ -111,12 +105,13 @@ class ProjectViewViewSet(
             )
 
             # Have Celery run the export in the background
-            transaction.on_commit(lambda:
-            export_task_in_background.delay(
-                export_task_uid=export_task.uid,
-                username=user.username,
-                export_task_name='kpi.ProjectViewExportTask',
-            ))
+            transaction.on_commit(
+                lambda: export_task_in_background.delay(
+                    export_task_uid=export_task.uid,
+                    username=user.username,
+                    export_task_name='kpi.ProjectViewExportTask',
+                )
+            )
 
             return Response({'status': export_task.status})
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -864,6 +864,8 @@ SYNCHRONOUS_REQUEST_TIME_LIMIT = 120  # seconds
 # REMOVE the oldest if a user exceeds this many exports for a particular form
 MAXIMUM_EXPORTS_PER_USER_PER_FORM = 10
 
+MAX_RETRIES_FOR_IMPORT_EXPORT_TASK = 10
+
 # Private media file configuration
 PRIVATE_STORAGE_ROOT = os.path.join(BASE_DIR, 'media')
 PRIVATE_STORAGE_AUTH_FUNCTION = \

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from typing import Optional
 
+from django.db import transaction
 from django.utils.translation import gettext as t
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -65,7 +66,7 @@ class ExportTaskSerializer(serializers.ModelSerializer):
             user=user, data=validated_data
         )
         # Have Celery run the export in the background
-        export_in_background.delay(export_task_uid=export_task.uid)
+        transaction.on_commit(lambda: export_in_background.delay(export_task_uid=export_task.uid))
 
         return export_task
 

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -13,12 +13,12 @@ from kpi.constants import LIMIT_HOURS_23
 from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_tasks
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import ImportTask, SubmissionExportTask
-from kpi.utils.log import logging
 
 SLEEP_TIME = 2
 RETRIES = 10
 
-def _get_task_with_retry(model_class:type, uid:str):
+
+def _get_task_with_retry(model_class: type, uid: str):
     for i in range(RETRIES):
         try:
             return model_class.objects.get(uid=uid)

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -24,8 +24,8 @@ def _get_task_with_retry(model_class: type, uid: str):
             return model_class.objects.get(uid=uid)
         except model_class.DoesNotExist:
             time.sleep(SLEEP_TIME)
-    raise model_class.DoesNotExist
-
+            if i == RETRIES - 1:
+                raise
 
 @celery_app.task
 def import_in_background(import_task_uid):

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -27,6 +27,7 @@ def _get_task_with_retry(model_class: type, uid: str):
             if i == RETRIES - 1:
                 raise
 
+
 @celery_app.task
 def import_in_background(import_task_uid):
     import_task = _get_task_with_retry(ImportTask, import_task_uid)

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -15,12 +15,11 @@ from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import ImportTask, SubmissionExportTask
 
-SLEEP_TIME = 2
-RETRIES = 10
-
 
 @celery_app.task(
-    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+    autoretry_for=(ObjectDoesNotExist,),
+    max_retries=settings.MAX_RETRIES_FOR_IMPORT_EXPORT_TASK,
+    retry_backoff=True,
 )
 def import_in_background(import_task_uid):
     import_task = ImportTask.objects.get(uid=import_task_uid)
@@ -29,7 +28,9 @@ def import_in_background(import_task_uid):
 
 
 @celery_app.task(
-    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+    autoretry_for=(ObjectDoesNotExist,),
+    max_retries=settings.MAX_RETRIES_FOR_IMPORT_EXPORT_TASK,
+    retry_backoff=True,
 )
 def export_in_background(export_task_uid):
     export_task = SubmissionExportTask.objects.get(uid=export_task_uid)
@@ -37,7 +38,9 @@ def export_in_background(export_task_uid):
 
 
 @celery_app.task(
-    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+    autoretry_for=(ObjectDoesNotExist,),
+    max_retries=settings.MAX_RETRIES_FOR_IMPORT_EXPORT_TASK,
+    retry_backoff=True,
 )
 def export_task_in_background(
     export_task_uid: str, username: str, export_task_name: str

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -4,6 +4,7 @@ import requests
 from django.apps import apps
 from django.conf import settings
 from django.core import mail
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 
 from kobo.apps.kobo_auth.shortcuts import User
@@ -28,27 +29,27 @@ def _get_task_with_retry(model_class: type, uid: str):
                 raise
 
 
-@celery_app.task
+@celery_app.task()
 def import_in_background(import_task_uid):
     import_task = _get_task_with_retry(ImportTask, import_task_uid)
     import_task.run()
     return import_task.uid
 
 
-@celery_app.task
+@celery_app.task(autoretry_for=ObjectDoesNotExist, max_retries=RETRIES, retry_backoff=True)
 def export_in_background(export_task_uid):
-    export_task = _get_task_with_retry(SubmissionExportTask, export_task_uid)
+    export_task = SubmissionExportTask.get(uid=export_task_uid)
     export_task.run()
 
 
-@celery_app.task
+@celery_app.task(autoretry_for=ObjectDoesNotExist, max_retries=RETRIES, retry_backoff=True)
 def export_task_in_background(
     export_task_uid: str, username: str, export_task_name: str
 ) -> None:
     user = User.objects.get(username=username)
     export_task_class = apps.get_model(export_task_name)
 
-    export_task = _get_task_with_retry(export_task_class, export_task_uid)
+    export_task = export_task_class.get(uid=export_task_uid)
     export = export_task.run()
     if export.status == 'complete' and export.result:
         file_url = f'{settings.KOBOFORM_URL}{export.result.url}'

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -19,20 +19,26 @@ SLEEP_TIME = 2
 RETRIES = 10
 
 
-@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(
+    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+)
 def import_in_background(import_task_uid):
     import_task = ImportTask.objects.get(uid=import_task_uid)
     import_task.run()
     return import_task.uid
 
 
-@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(
+    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+)
 def export_in_background(export_task_uid):
     export_task = SubmissionExportTask.objects.get(uid=export_task_uid)
     export_task.run()
 
 
-@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(
+    autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True
+)
 def export_task_in_background(
     export_task_uid: str, username: str, export_task_name: str
 ) -> None:

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -19,27 +19,27 @@ SLEEP_TIME = 2
 RETRIES = 10
 
 
-@celery_app.task(autoretry_for=ObjectDoesNotExist, max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
 def import_in_background(import_task_uid):
-    import_task = ImportTask.get(uid=import_task_uid)
+    import_task = ImportTask.objects.get(uid=import_task_uid)
     import_task.run()
     return import_task.uid
 
 
-@celery_app.task(autoretry_for=ObjectDoesNotExist, max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
 def export_in_background(export_task_uid):
-    export_task = SubmissionExportTask.get(uid=export_task_uid)
+    export_task = SubmissionExportTask.objects.get(uid=export_task_uid)
     export_task.run()
 
 
-@celery_app.task(autoretry_for=ObjectDoesNotExist, max_retries=RETRIES, retry_backoff=True)
+@celery_app.task(autoretry_for=(ObjectDoesNotExist,), max_retries=RETRIES, retry_backoff=True)
 def export_task_in_background(
     export_task_uid: str, username: str, export_task_name: str
 ) -> None:
     user = User.objects.get(username=username)
     export_task_class = apps.get_model(export_task_name)
 
-    export_task = export_task_class.get(uid=export_task_uid)
+    export_task = export_task_class.objects.get(uid=export_task_uid)
     export = export_task.run()
     if export.status == 'complete' and export.result:
         file_url = f'{settings.KOBOFORM_URL}{export.result.url}'

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -26,6 +26,7 @@ def _get_task_with_retry(model_class: type, uid: str):
             time.sleep(SLEEP_TIME)
     raise model_class.DoesNotExist
 
+
 @celery_app.task
 def import_in_background(import_task_uid):
     import_task = _get_task_with_retry(ImportTask, import_task_uid)

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -11,9 +11,10 @@ from kpi.constants import (
     PERM_VIEW_ASSET,
     PERM_VIEW_SUBMISSIONS,
 )
-from kpi.models import Asset, SubmissionExportTask, AssetExportSettings
+from kpi.models import Asset, AssetExportSettings, SubmissionExportTask
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.tests.test_mock_data_exports import MockDataExportsBase
+from kpi.tests.utils.transaction import immediate_on_commit
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.object_permission import get_anonymous_user
 
@@ -335,9 +336,10 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
             self._get_endpoint('asset-export-list'),
             kwargs={'format': 'json', 'parent_lookup_asset': self.asset.uid},
         )
-        exports_list_response = self.client.post(
-            exports_list_url, data=es.export_settings
-        )
+        with immediate_on_commit():
+            exports_list_response = self.client.post(
+                exports_list_url, data=es.export_settings
+            )
         assert exports_list_response.status_code == status.HTTP_201_CREATED
 
         exports_detail_response = self.client.get(
@@ -473,7 +475,8 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
             'fields_from_all_versions': 'false',
             'multiple_select': 'both',
         }
-        response = self.client.post(list_url, data=data)
+        with immediate_on_commit():
+            response = self.client.post(list_url, data=data)
         assert response.status_code == status.HTTP_201_CREATED
         export_response = self.client.get(response.data['url'])
         filepath = export_response.data['result']

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -1,7 +1,5 @@
 # coding: utf-8
-from functools import partial
 from django.db import transaction
-
 from django.db.models import TextField
 from django.db.models.functions import Cast
 from rest_framework import exceptions, serializers, status
@@ -214,7 +212,9 @@ class ExportTaskViewSet(AuditLoggedNoUpdateModelViewSet):
             user=request.user, data=task_data
         )
         # Have Celery run the export in the background
-        transaction.on_commit(lambda: export_in_background.delay(export_task_uid=export_task.uid))
+        transaction.on_commit(
+            lambda: export_in_background.delay(export_task_uid=export_task.uid)
+        )
 
         return Response({
             'uid': export_task.uid,

--- a/kpi/views/v1/export_task.py
+++ b/kpi/views/v1/export_task.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+from functools import partial
+from django.db import transaction
+
 from django.db.models import TextField
 from django.db.models.functions import Cast
 from rest_framework import exceptions, serializers, status
@@ -211,7 +214,8 @@ class ExportTaskViewSet(AuditLoggedNoUpdateModelViewSet):
             user=request.user, data=task_data
         )
         # Have Celery run the export in the background
-        export_in_background.delay(export_task_uid=export_task.uid)
+        transaction.on_commit(lambda: export_in_background.delay(export_task_uid=export_task.uid))
+
         return Response({
             'uid': export_task.uid,
             'url': reverse(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes occasional problem where tasks end up showing as 'Processing' forever.


### 💭 Notes
Tasks were failing when the celery task started too quickly and tried to fetch the task before it had actually hit the database. This PR implements 2 guards against this:
1. Call the tasks from within an on_commit block to ensure they only start after the task object has made it to the database
2. Automatically catch ObjectDoesNotExist exceptions and retry the task a hardcoded number of times. `task.retry` takes care of putting some time in between retries



### 👀 Preview steps
This bug tends to only appear in low traffic when the celery queue is empty. Make sure `CELERY_TASK_ALWAYS_EAGER` is false. 

1. ℹ️ have an account and a project
3. Export the project submissions
4. 🔴 [on main] The job will show as 'Processing' indefinitely. In the worker logs, you'll see `kpi.models.import_export_task.SubmissionExportTask.DoesNotExist: SubmissionExportTask matching query does not exist`
5. 🟢 [on PR] The job will only show as 'Processing' for a few seconds and then will complete.

