### PR TITLE
fix(submissions): avoid adding XML declaration when rewriting submission XML and creating asset snapshot

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_set_meta_function.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_set_meta_function.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import set_meta
+
+
+class TestSetMetaFunction(TestCase):
+    def test_set_meta_updates_xml_correctly(self):
+        """
+        Test that the set_meta() does not add an XML declaration
+        """
+        xml_input = """
+        <data>
+            <meta>
+                <instanceID>uuid:original-id</instanceID>
+            </meta>
+            <question1>Answer1</question1>
+        </data>
+        """
+        updated_xml = set_meta(
+            xml_input, 'instanceID', 'uuid:new-id'
+        )
+
+        # Ensure XML declaration is not added
+        self.assertNotIn("<?xml version='1.0' ?>", updated_xml)
+
+        # Ensure the instanceID is updated
+        self.assertIn('<instanceID>uuid:new-id</instanceID>', updated_xml)
+
+    def test_set_meta_raises_error_for_missing_node(self):
+        xml_input = """
+        <data>
+            <meta>
+                <otherID>uuid:other-id</otherID>
+            </meta>
+            <question1>Answer1</question1>
+        </data>
+        """
+        with self.assertRaises(ValueError) as context:
+            set_meta(xml_input, 'instanceID', 'uuid:new-id')
+
+        self.assertEqual(str(context.exception), 'instanceID node not found')

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -135,7 +135,9 @@ def set_meta(xml_str: str, meta_name: str, new_value: str) -> str:
     if node.firstChild:
         node.firstChild.nodeValue = new_value
 
-    return root.toxml()
+    xml_output = root.toprettyxml(indent='  ')
+    xml_output = xml_output.replace('<?xml version="1.0" ?>', '').strip()
+    return xml_output
 
 
 def _xml_node_to_dict(node: Node, repeats: list = []) -> dict:


### PR DESCRIPTION
### 📣 Summary
The clean_duplicated_submissions command has been updated to save XML files without the declaration.


### 📖 Description
This update modifies the behavior of the clean_duplicated_submissions command to save XML files without including the declaration. This change ensures cleaner XML outputs by removing unnecessary declaration headers, making it easier to work with the files programmatically.
