### PR TITLE
fix(billing): plan page always redirecting to settings TASK-1473

### DIFF
--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -223,13 +223,6 @@ export default function Plan(props: PlanProps) {
     [searchParams, shouldRevalidate]
   );
 
-  // if the user is not the owner of their org, send them back to the settings page
-  useEffect(() => {
-    if (!orgQuery.data?.is_owner) {
-      navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
-    }
-  }, [orgQuery.data]);
-
   // Re-fetch data from API and re-enable buttons if displaying from back/forward cache
   useEffect(() => {
     const handlePersisted = (event: PageTransitionEvent) => {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug that was causing the plans page to always redirect current user to account settings page.

### 💭 Notes
There was a redundant check for org ownership in the page component. It seems to be triggering even if user *is* an org owner, probably because of a race condition. But we handle ownership checks elsewhere already, so I am simply removing the code.

### 👀 Preview steps
As an org owner on a Stripe-enabled instance, navigate to the plans page. On `main` you will be redirected to account settings. On this branch the plans page should successfully load.