### PR TITLE
chore: upgrade pyxform TASK-1467

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@894d285b1d2955b2990500427158e845af32259d#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
@@ -427,10 +427,6 @@ paramiko==3.4.0
     # via fabric
 parso==0.8.3
     # via jedi
-path==16.10.0
-    # via path-py
-path-py==12.5.0
-    # via formpack
 pathspec==0.12.1
     # via black
 pexpect==4.9.0
@@ -531,7 +527,7 @@ pytz==2024.1
     # via
     #   flower
     #   pandas
-pyxform==2.2.0
+pyxform==3.0.0
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@894d285b1d2955b2990500427158e845af32259d#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.
@@ -75,7 +75,7 @@ openpyxl
 psycopg
 pymongo
 python-dateutil
-pyxform==2.2.0
+pyxform==3.0.0
 requests
 regex
 responses

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@894d285b1d2955b2990500427158e845af32259d#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in
@@ -340,10 +340,6 @@ openpyxl==3.1.3
     #   pyxform
 pandas==2.0.3
     # via -r dependencies/pip/requirements.in
-path==16.10.0
-    # via path-py
-path-py==12.5.0
-    # via formpack
 pillow==10.3.0
     # via django-markdownx
 prometheus-client==0.20.0
@@ -406,7 +402,7 @@ pytz==2024.1
     # via
     #   flower
     #   pandas
-pyxform==2.2.0
+pyxform==3.0.0
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -415,8 +415,13 @@ def get_xform_media_question_xpaths(
 
 
 def get_abbreviated_xpath(element: SurveyElement) -> str:
+    """
+    Construct the xpath of an element, leaving out the root element.
+
+    If the element itself is the root element, just return the element name.
+    """
     def is_flat(elem):
-        return hasattr(elem, 'flat') and elem.get('flat')
+        return elem.get('flat', False)
 
     lineage = [
         parent[0] for parent in element.iter_ancestors() if not is_flat(parent[0])
@@ -424,6 +429,6 @@ def get_abbreviated_xpath(element: SurveyElement) -> str:
     lineage.reverse()
     lineage.append(element)
     if len(lineage) > 1:
-        return '/'.join([str(n.name) for n in lineage[1:]])
+        return '/'.join([n.name for n in lineage[1:]])
     else:
         return lineage[0].name

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -421,6 +421,8 @@ def get_abbreviated_xpath(element: SurveyElement) -> str:
     If the element itself is the root element, just return the element name.
     """
     def is_flat(elem):
+        # can't use elem.get('flat', False) here because SurveyElement overrides
+        # __getitem__ and it doesn't work with defaults
         return hasattr(elem, 'flat') and elem.get('flat')
 
     lineage = [

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -11,6 +11,7 @@ import six
 from defusedxml import minidom
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext as t
+from pyxform.survey_element import SurveyElement
 
 from kobo.apps.openrosa.apps.logger.exceptions import InstanceEmptyError
 from kobo.apps.openrosa.libs.utils.common_tags import XFORM_ID_STRING
@@ -308,7 +309,7 @@ class XFormInstanceParser:
         self._xml_obj = clean_and_parse_xml(xml_str)
         self._root_node = self._xml_obj.documentElement
         repeats = [
-            e.get_abbreviated_xpath()
+            get_abbreviated_xpath(e)
             for e in self.dd.get_survey_elements_of_type('repeat')
         ]
         self._dict = _xml_node_to_dict(self._root_node, repeats)
@@ -411,3 +412,18 @@ def get_xform_media_question_xpaths(
             media_field_xpaths.append(next_attribute_value[1:])
 
     return media_field_xpaths
+
+
+def get_abbreviated_xpath(element: SurveyElement) -> str:
+    def is_flat(elem):
+        return hasattr(elem, 'flat') and elem.get('flat')
+
+    lineage = [
+        parent[0] for parent in element.iter_ancestors() if not is_flat(parent[0])
+    ]
+    lineage.reverse()
+    lineage.append(element)
+    if len(lineage) > 1:
+        return '/'.join([str(n.name) for n in lineage[1:]])
+    else:
+        return lineage[0].name

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -421,7 +421,7 @@ def get_abbreviated_xpath(element: SurveyElement) -> str:
     If the element itself is the root element, just return the element name.
     """
     def is_flat(elem):
-        return elem.get('flat', False)
+        return hasattr(elem, 'flat') and elem.get('flat')
 
     lineage = [
         parent[0] for parent in element.iter_ancestors() if not is_flat(parent[0])

--- a/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
+++ b/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
@@ -222,7 +222,7 @@ class DataDictionary(XForm):
         geo_xpaths = []
 
         for e in self.get_survey_elements():
-            if e.bind.get('type') == 'geopoint':
+            if isinstance(e, Question) and e.bind.get('type') == 'geopoint':
                 geo_xpaths.append(e.get_abbreviated_xpath())
 
         return geo_xpaths
@@ -421,4 +421,4 @@ class DataDictionary(XForm):
 
     def get_survey_elements_of_type(self, element_type):
         return [e for e in self.get_survey_elements()
-                if e.type == element_type]
+                if hasattr(e, 'type') and e.type == element_type]

--- a/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
+++ b/kobo/apps/openrosa/apps/viewer/models/data_dictionary.py
@@ -220,7 +220,7 @@ class DataDictionary(XForm):
         """
         names = {}
         for elem in self.get_survey_elements():
-            names[MongoHelper.encode(str(get_abbreviated_xpath(elem)))] = (
+            names[MongoHelper.encode(get_abbreviated_xpath(elem))] = (
                 get_abbreviated_xpath(elem)
             )
         return names
@@ -259,7 +259,7 @@ class DataDictionary(XForm):
         if result is None:
             result = []
         path = '/'.join([prefix, str(survey_element.name)])
-        if hasattr(survey_element, 'children') and survey_element.children is not None:
+        if getattr(survey_element, 'children', None) is not None:
             # add xpaths to result for each child
             indices = [''] if type(survey_element) != RepeatingSection else \
                 ['[%d]' % (i + 1) for i in range(repeat_iterations)]

--- a/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
+++ b/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
@@ -128,7 +128,7 @@ class AbstractDataFrameBuilder:
         return dict([(e.get_abbreviated_xpath(), [c.get_abbreviated_xpath()
                     for c in e.children])
                     for e in dd.get_survey_elements()
-                    if e.type == SELECT_ALL_THAT_APPLY])
+                    if isinstance(e,Question) and  e.type == SELECT_ALL_THAT_APPLY])
 
     @classmethod
     def _split_select_multiples(cls, record, select_multiples,
@@ -172,7 +172,7 @@ class AbstractDataFrameBuilder:
     @classmethod
     def _collect_gps_fields(cls, dd):
         return [e.get_abbreviated_xpath() for e in dd.get_survey_elements()
-                if e.bind.get("type") == "geopoint"]
+                if isinstance(e, Question) and e.bind.get("type") == "geopoint"]
 
     @classmethod
     def _tag_edit_string(cls, record):
@@ -577,7 +577,6 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
         are not considered columns
         """
         for child in survey_element.children:
-            # child_xpath = child.get_abbreviated_xpath()
             if isinstance(child, Section):
                 child_is_repeating = False
                 if isinstance(child, RepeatingSection):

--- a/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
+++ b/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
@@ -551,8 +551,8 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                         # generate ["children", index, "immunization/polio_1"]
                         xpaths = [
                             '%s[%s]'
-                            % (nested_key[ : nested_key.index(key) + len(key)], index),
-                            nested_key[nested_key.index(key) + len(key) + 1 :],
+                            % (nested_key[: nested_key.index(key) + len(key)], index),
+                            nested_key[nested_key.index(key) + len(key) + 1:],
                         ]
                         # re-create xpath the split on /
                         xpaths = '/'.join(xpaths).split('/')

--- a/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
+++ b/kobo/apps/openrosa/apps/viewer/pandas_mongo_bridge.py
@@ -551,7 +551,7 @@ class CSVDataFrameBuilder(AbstractDataFrameBuilder):
                         # generate ["children", index, "immunization/polio_1"]
                         xpaths = [
                             '%s[%s]'
-                            % (nested_key[: nested_key.index(key) + len(key)], index),
+                            % (nested_key[ : nested_key.index(key) + len(key)], index),
                             nested_key[nested_key.index(key) + len(key) + 1 :],
                         ]
                         # re-create xpath the split on /

--- a/kobo/apps/openrosa/libs/data/query.py
+++ b/kobo/apps/openrosa/libs/data/query.py
@@ -2,6 +2,7 @@
 from django.conf import settings
 from django.db import connections
 
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import get_abbreviated_xpath
 from kobo.apps.openrosa.libs.utils.common_tags import SUBMISSION_TIME
 
 
@@ -9,7 +10,7 @@ def _count_group(field, name, xform):
     if using_postgres:
         result = _postgres_count_group(field, name, xform)
     else:
-        raise Exception("Unsupported Database")
+        raise Exception('Unsupported Database')
 
     return result
 
@@ -39,7 +40,7 @@ def _get_fields_of_type(xform, types):
         [dd.get_survey_elements_of_type(t) for t in types])
 
     for element in survey_elements:
-        name = element.get_abbreviated_xpath()
+        name = get_abbreviated_xpath(element)
         k.append(name)
 
     return k
@@ -56,23 +57,27 @@ def _postgres_count_group(field, name, xform):
     string_args = _query_args(field, name, xform)
     if is_date_field(xform, field):
         if not settings.USE_POSTGRESQL:
-            string_args['json'] = "date(%(json)s)" % string_args
+            string_args['json'] = 'date(%(json)s)' % string_args
         else:
             string_args['json'] = (
                 "to_char(to_date(%(json)s, 'YYYY-MM-DD'), 'YYYY"
                 "-MM-DD')" % string_args
             )
 
-    return "SELECT %(json)s AS \"%(name)s\", COUNT(*) AS count FROM "\
-           "%(table)s WHERE %(restrict_field)s=%(restrict_value)s "\
-           "GROUP BY %(json)s" % string_args
+    return (
+        'SELECT %(json)s AS "%(name)s", COUNT(*) AS count FROM '
+        '%(table)s WHERE %(restrict_field)s=%(restrict_value)s '
+        'GROUP BY %(json)s' % string_args
+    )
 
 
 def _postgres_select_key(field, name, xform):
     string_args = _query_args(field, name, xform)
 
-    return "SELECT %(json)s AS \"%(name)s\" FROM %(table)s WHERE "\
-           "%(restrict_field)s=%(restrict_value)s" % string_args
+    return (
+        'SELECT %(json)s AS "%(name)s" FROM %(table)s WHERE '
+        '%(restrict_field)s=%(restrict_value)s' % string_args
+    )
 
 
 def _query_args(field, name, xform):
@@ -88,7 +93,7 @@ def _select_key(field, name, xform):
     if using_postgres:
         result = _postgres_select_key(field, name, xform)
     else:
-        raise Exception("Unsupported Database")
+        raise Exception('Unsupported Database')
 
     return result
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Developer-facing changes only. 
Pxyform 3.0.0 has a number of breaking changes. Most notable for our purposes are the refactoring of `SurveyElement`s into a bunch of subclasses and the removal of the `get_abbreviated_xpath` method, which we made extensive use of.

The refactoring of `SurveyElement` mostly resulted in a lot of Attribute Not Found errors as, for example, `Survey `objects no longer have a `bind` property (when everything was a `SurveyElement`, that property would just be an empty dict). In all places where this broke things, we updated the code to either check the existence of the attribute first or check the class of the object.

To deal with the removal of `get_abbreviated_path,` we just recreated the method within the repo, using the `iter_ancestors` method that replaced `get_lineage`.

It turns out some of the files touched had a lot of formatting issues (mostly double quotes instead of single), which the formatter picked up and fixed, resulting in several changes that are not actually part of the upgrade. Hopefully those are relatively obvious.

