### PR TITLE
feat(organization): export organization users asynchronously from Admin interface TASK-1478

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -158,6 +158,7 @@ django==4.2.15
     #   django-filter
     #   django-guardian
     #   django-import-export
+    #   django-import-export-celery
     #   django-markdownx
     #   django-oauth-toolkit
     #   django-organizations
@@ -174,6 +175,8 @@ django-allauth==65.1.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in
+django-author==1.2.0
+    # via django-import-export-celery
 django-braces==1.15.0
     # via -r dependencies/pip/requirements.in
 django-celery-beat==2.6.0
@@ -197,6 +200,10 @@ django-filter==24.2
 django-guardian==2.4.0
     # via -r dependencies/pip/requirements.in
 django-import-export==4.1.0
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   django-import-export-celery
+django-import-export-celery==1.7.1
     # via -r dependencies/pip/requirements.in
 django-loginas==0.3.11
     # via -r dependencies/pip/requirements.in
@@ -331,6 +338,8 @@ grpcio==1.62.1
     #   grpcio-status
 grpcio-status==1.62.1
     # via google-api-core
+html2text==2024.2.26
+    # via django-import-export-celery
 httmock==1.4.0
     # via -r dependencies/pip/dev_requirements.in
 httplib2==0.22.0
@@ -578,6 +587,8 @@ sentinels==1.0.0
     # via mongomock
 sentry-sdk==1.44.0
     # via -r dependencies/pip/requirements.in
+setuptools-git==1.2
+    # via django-author
 shortuuid==1.0.13
     # via -r dependencies/pip/requirements.in
 simplejson==3.19.2

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -38,6 +38,7 @@ django-debug-toolbar
 django-environ
 django-filter
 django-import-export
+django-import-export-celery
 django-extensions
 django-oauth-toolkit
 django-organizations

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -127,6 +127,7 @@ django==4.2.15
     #   django-filter
     #   django-guardian
     #   django-import-export
+    #   django-import-export-celery
     #   django-markdownx
     #   django-oauth-toolkit
     #   django-organizations
@@ -142,6 +143,8 @@ django-allauth==65.1.0
     # via -r dependencies/pip/requirements.in
 django-amazon-ses==4.0.1
     # via -r dependencies/pip/requirements.in
+django-author==1.2.0
+    # via django-import-export-celery
 django-braces==1.15.0
     # via -r dependencies/pip/requirements.in
 django-celery-beat==2.6.0
@@ -165,6 +168,10 @@ django-filter==24.2
 django-guardian==2.4.0
     # via -r dependencies/pip/requirements.in
 django-import-export==4.1.0
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   django-import-export-celery
+django-import-export-celery==1.7.1
     # via -r dependencies/pip/requirements.in
 django-loginas==0.3.11
     # via -r dependencies/pip/requirements.in
@@ -277,6 +284,8 @@ grpcio==1.62.1
     #   grpcio-status
 grpcio-status==1.62.1
     # via google-api-core
+html2text==2024.2.26
+    # via django-import-export-celery
 httplib2==0.22.0
     # via
     #   google-api-python-client
@@ -447,6 +456,8 @@ s3transfer==0.10.1
     # via boto3
 sentry-sdk==1.44.0
     # via -r dependencies/pip/requirements.in
+setuptools-git==1.2
+    # via django-author
 shortuuid==1.0.13
     # via -r dependencies/pip/requirements.in
 six==1.16.0

--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -4,6 +4,7 @@ from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 from import_export.fields import Field
 from import_export.widgets import ForeignKeyWidget
+from import_export_celery.admin_actions import create_export_job_action
 from organizations.base_admin import (
     BaseOrganizationAdmin,
     BaseOrganizationOwnerAdmin,
@@ -52,6 +53,10 @@ class OrgUserResource(resources.ModelResource):
 @admin.register(OrganizationUser)
 class OrgUserAdmin(ImportExportModelAdmin, BaseOrganizationUserAdmin):
     resource_classes = [OrgUserResource]
+
+    actions = (
+        create_export_job_action,
+    )
 
 
 @admin.register(OrganizationOwner)

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -113,6 +113,13 @@ class OrganizationUser(AbstractOrganizationUser):
         """
         return ', '.join(self.active_subscription_statuses)
 
+    @classmethod
+    def export_resource_classes(cls):
+        from .admin import OrgUserResource
+        return {
+            'organization_users': ('Organization users resource', OrgUserResource),
+        }
+
 
 class OrganizationOwner(AbstractOrganizationOwner):
     pass

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -105,6 +105,7 @@ INSTALLED_APPS = (
     'allauth.usersessions',
     'hub.HubAppConfig',
     'import_export',
+    'import_export_celery',
     'loginas',
     'webpack_loader',
     'django_extensions',
@@ -168,6 +169,7 @@ MIDDLEWARE = [
     'hub.middleware.UsernameInResponseHeaderMiddleware',
     'django_userforeignkey.middleware.UserForeignKeyMiddleware',
     'django_request_cache.middleware.RequestCacheMiddleware',
+    'author.middlewares.AuthorDefaultBackendMiddleware',
 ]
 
 
@@ -1795,3 +1797,13 @@ ACCESS_LOG_DELETION_BATCH_SIZE = 1000
 SILENCED_SYSTEM_CHECKS = ['guardian.W001']
 
 DIGEST_LOGIN_FACTORY = 'django_digest.NoEmailLoginFactory'
+
+# Import/Export Celery
+IMPORT_EXPORT_CELERY_INIT_MODULE = 'kobo.celery'
+
+IMPORT_EXPORT_CELERY_MODELS = {
+    'OrganizationUser': {
+        'app_label': 'organization',
+        'model_name': 'OrganizationUser',
+    },
+}

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -14,7 +14,6 @@ from django.conf import global_settings
 from django.urls import reverse_lazy
 from django.utils.translation import get_language_info
 from django.utils.translation import gettext_lazy as t
-from private_storage.appconfig import PRIVATE_STORAGE_CLASS as DEFAULT_PRIVATE_STORAGE_CLASS
 from pymongo import MongoClient
 
 from kobo.apps.stripe.constants import FREE_TIER_EMPTY_DISPLAY, FREE_TIER_NO_THRESHOLDS
@@ -1364,11 +1363,18 @@ default_file_storage = env.str(
 )
 if 'KPI_DEFAULT_FILE_STORAGE' in os.environ:
     warnings.warn(
-        'KPI_DEFAULT_FILE_STORAGE is renamed DEFAULT_FILE_STORAGE, update the environment variable.',
+        'KPI_DEFAULT_FILE_STORAGE is renamed DEFAULT_FILE_STORAGE, '
+        'update the environment variable.',
         DeprecationWarning,
     )
 
-PRIVATE_STORAGE_CLASS = DEFAULT_PRIVATE_STORAGE_CLASS
+# ToDo Find out why `private_storage.appconfig.PRIVATE_STORAGE_CLASS`
+#  cannot be imported. Otherwise, some tests are failing.
+# from private_storage.appconfig import (
+#   PRIVATE_STORAGE_CLASS as DEFAULT_PRIVATE_STORAGE_CLASS
+# )
+# PRIVATE_STORAGE_CLASS = DEFAULT_PRIVATE_STORAGE_CLASS
+PRIVATE_STORAGE_CLASS = 'private_storage.storage.files.PrivateFileSystemStorage'
 
 if default_file_storage:
 


### PR DESCRIPTION
### 📣 Summary
Added asynchronous export functionality for organization usersImproved performance for exporting users in large databases.

### 📖 Description
This update introduces asynchronous processing for exporting organization users, enabling smoother handling of large datasets. The new functionality ensures that user exports can be performed efficiently without overloading the system, even on large databases.


### 👀 Preview steps
Feature/no-change template:
1. Set your SMTP if it has not been set already
2. Go to Organizations > Organizations Users
3. Select the users you want to export
4. Use bulk action "Export with Celery" (confirm the export)
5. Wait for the confirmation email that the export has succeeded
