### PR TITLE
fix(projectHistoryLogs): incorrect message on ph log export email TASK-1486

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -605,7 +605,7 @@ class ProjectHistoryLogExportTask(
 
     @property
     def default_email_subject(self) -> str:
-        return 'Project History Log Report Complete'
+        return 'Project activity log export complete'
 
     def get_data(self, filtered_queryset: QuerySet) -> QuerySet:
         return filtered_queryset.annotate(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Update subject line for project history log export email

### 👀 Preview steps
Easiest to test this within kobo-compose so you can see emails in the kpi logs.

Bug template:
1. ℹ️ have an account and a project
2. Go to `api/v2/asset/<uid>/history/export`
3. 🔴 [on main] The email subject is in title case
4. 🟢 [on PR] The email subject is in sentence case

