### PR TITLE
chore(organizations): add search field to organization user admin page

### DIFF
--- a/kobo/apps/organizations/admin.py
+++ b/kobo/apps/organizations/admin.py
@@ -53,6 +53,7 @@ class OrgUserResource(resources.ModelResource):
 @admin.register(OrganizationUser)
 class OrgUserAdmin(ImportExportModelAdmin, BaseOrganizationUserAdmin):
     resource_classes = [OrgUserResource]
+    search_fields = ['user__username', 'organization__name', 'organization__id']
 
     actions = (
         create_export_job_action,


### PR DESCRIPTION
### 📣 Summary
Added a search field to the organization user admin page to simplify user lookup and enable narrowing down the export list.

### 📖 Description
A search field has been added to the organization user admin page, allowing administrators to efficiently find organization users by username or organization name and id. Additionally, this search functionality can be used to narrow down the export list, making it easier to export only the desired subset of users.

