### PR TITLE
fix(NLP): 500 error when transcribing audio TASK-1485 

### DIFF
--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -494,6 +494,17 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         limit = get_organization_plan_limit(self.organization, usage_type)
         assert limit == float('inf')
 
+    @data('submission', 'storage', 'characters', 'seconds')
+    def test_get_suscription_limit_missing(self, usage_type):
+        stripe_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
+        product_metadata = {
+            'product_type': 'plan',
+            'plan_type': 'enterprise',
+        }
+        generate_plan_subscription(self.organization, metadata=product_metadata)
+        limit = get_organization_plan_limit(self.organization, usage_type)
+        assert limit == float('inf')
+
 
 @override_settings(STRIPE_ENABLED=True)
 class OrganizationsModelIntegrationTestCase(BaseTestCase):

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -508,8 +508,8 @@ class OrganizationsUtilsTestCase(BaseTestCase):
 
     def test_get_addon_suscription_limits(self):
         generate_free_plan()
-        characters_key = stripe_key = f'{USAGE_LIMIT_MAP["characters"]}_limit'
-        seconds_key = stripe_key = f'{USAGE_LIMIT_MAP["seconds"]}_limit'
+        characters_key = f'{USAGE_LIMIT_MAP["characters"]}_limit'
+        seconds_key = f'{USAGE_LIMIT_MAP["seconds"]}_limit'
         product_metadata = {
             'product_type': 'addon',
             'plan_type': 'enterprise',

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -498,7 +498,6 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         generate_free_plan()
         product_metadata = {
             'product_type': 'addon',
-            'plan_type': 'enterprise',
         }
         generate_plan_subscription(self.organization, metadata=product_metadata)
         limit = get_organization_plan_limit(self.organization, 'seconds')
@@ -512,7 +511,6 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         seconds_key = f'{USAGE_LIMIT_MAP["seconds"]}_limit'
         product_metadata = {
             'product_type': 'addon',
-            'plan_type': 'enterprise',
             characters_key: 1234,
             seconds_key: 123,
         }

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -65,7 +65,7 @@ def get_organization_plan_limit(
         # Anyone who does not have a subscription is on the free tier plan by default
         default_plan = (
             Product.objects.filter(
-                prices__unit_amount=0, prices__recurring__interval__in=('month', 'year')
+                prices__unit_amount=0, prices__recurring__interval='month'
             )
             .values(limit=F(f'metadata__{limit_key}'))
             .first()

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -65,7 +65,7 @@ def get_organization_plan_limit(
         # Anyone who does not have a subscription is on the free tier plan by default
         default_plan = (
             Product.objects.filter(
-                prices__unit_amount=0, prices__recurring__interval='month'
+                prices__unit_amount=0, prices__recurring__interval__in=('month', 'year')
             )
             .values(limit=F(f'metadata__{limit_key}'))
             .first()

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -43,8 +43,8 @@ def get_organization_plan_limit(
     if subscription := organization.active_subscription_billing_details():
         price_metadata = subscription['price_metadata']
         product_metadata = subscription['product_metadata']
-        price_limit = price_metadata[limit_key] if price_metadata else None
-        product_limit = product_metadata[limit_key] if product_metadata else None
+        price_limit = price_metadata.get(limit_key) if price_metadata else None
+        product_limit = product_metadata.get(limit_key) if product_metadata else None
         relevant_limit = price_limit or product_limit
     else:
         from djstripe.models.core import Product


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Take into account subscriptions plan that are addon product type when calculating an organization plan usage limits


### 👀 Preview steps
1. On a stripe and NLP-enabled instance (after setting both up, these are the guides to [setup stripe](https://www.notion.so/kobotoolbox/Setting-Up-Stripe-9a958a84d6324ec8a4ca887b820eb8cf) and [NLP](https://www.notion.so/kobotoolbox/Setting-up-NLP-and-Languages-bb607e3fed114993bb14338fe56c6ed4)), set up an account or use an existing one
2. Purchase an addon through the UI, go to Account Settings, then to Add-Ons and select a File Storage monthly add on. Go through the test mode Stripe (use card number 4242 4242 4242 4242, and dummy data)
3. On the KPI docker container, execute the following command to synchronize the stripe test subscription table:
  i.  `./manage.py djstripe_sync_models Subscription`
4. Verify on the plans tab that the purchased add on is active
5. Use a survey with an audio question (or create one) and make a submission with an audio file
6. Write a manual transcription (i.e. "this is a test")
7. Attempt to use automated translation to translate the transcription from English to another language
8. On main, this will throw a 500. On the PR branch, the attempt should succeed.