### PR TITLE
feat(organizations): Add isEmpty to avatar component and use it for members table TASK-1420

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -36,13 +36,13 @@ export default function MembersRoute() {
       label: t('Name'),
       cellFormatter: (member: OrganizationMember) => (
         <Avatar
-          variant={member.invite?.status ? 'ghost' : 'default'}
+          isEmpty={!!member.invite?.status}
           size='m'
           username={member.user__username}
           isUsernameVisible
-          email={member.user__email}
+          email={!member.invite?.status ? member.user__email : undefined}
           // We pass `undefined` for the case it's an empty string
-          fullName={member.user__extra_details__name || undefined}
+          fullName={!member.invite?.status ? member.user__extra_details__name : undefined}
         />
       ),
       size: 360,

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -36,6 +36,7 @@ export default function MembersRoute() {
       label: t('Name'),
       cellFormatter: (member: OrganizationMember) => (
         <Avatar
+          variant={member.invite?.status ? 'ghost' : 'default'}
           size='m'
           username={member.user__username}
           isUsernameVisible

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -36,13 +36,12 @@ export default function MembersRoute() {
       label: t('Name'),
       cellFormatter: (member: OrganizationMember) => (
         <Avatar
-          isEmpty={!!member.invite?.status}
           size='m'
           username={member.user__username}
           isUsernameVisible
-          email={!member.invite?.status ? member.user__email : undefined}
+          email={member.user__email}
           // We pass `undefined` for the case it's an empty string
-          fullName={!member.invite?.status ? member.user__extra_details__name : undefined}
+          fullName={member.user__extra_details__name || undefined}
         />
       ),
       size: 360,

--- a/jsapp/js/components/common/avatar.module.scss
+++ b/jsapp/js/components/common/avatar.module.scss
@@ -32,7 +32,15 @@ $avatar-size-m: 32px;
 .avatar-size-s {@include avatar-size($avatar-size-s);}
 .avatar-size-m {@include avatar-size($avatar-size-m);}
 
-.ghost {
+.empty {
+  svg {
+    width: 100%;
+    height: 100%;
+    position: absolute; // Needed to avoid a slight shift when the circle is empty
+    left: 0;
+    top: 0;
+  }
+
   svg circle {
     fill: transparent;
     stroke: colors.$kobo-gray-400;
@@ -52,6 +60,7 @@ $avatar-size-m: 32px;
   color: colors.$kobo-white;
   // actual background color is provided by JS, this is just safeguard
   background-color: colors.$kobo-storm;
+  position: relative;
 }
 
 .text {

--- a/jsapp/js/components/common/avatar.module.scss
+++ b/jsapp/js/components/common/avatar.module.scss
@@ -32,6 +32,18 @@ $avatar-size-m: 32px;
 .avatar-size-s {@include avatar-size($avatar-size-s);}
 .avatar-size-m {@include avatar-size($avatar-size-m);}
 
+.ghost {
+  svg circle {
+    fill: transparent;
+    stroke: colors.$kobo-gray-400;
+    stroke-dasharray: 3.14px;
+    stroke-width: 1px;
+  }
+
+  // Need to make sure that the transparent will be applied when ghost
+  background-color: transparent !important;
+}
+
 .initials {
   text-align: center;
   text-transform: uppercase;

--- a/jsapp/js/components/common/avatar.stories.tsx
+++ b/jsapp/js/components/common/avatar.stories.tsx
@@ -27,9 +27,8 @@ export default {
       description: 'Allows testing `email` being empty string or not existing',
     },
     email: {type: 'string', if: {arg: 'hasEmail', truthy: true}},
-    variant: {
-      options: ['default', 'ghost'],
-      control: {type: 'select'},
+    isEmpty: {
+      type: 'boolean',
     },
   },
 } as ComponentMeta<typeof Avatar>;

--- a/jsapp/js/components/common/avatar.stories.tsx
+++ b/jsapp/js/components/common/avatar.stories.tsx
@@ -18,7 +18,8 @@ export default {
     isUsernameVisible: {type: 'boolean'},
     hasFullName: {
       type: 'boolean',
-      description: 'Allows testing `fullName` being empty string or not existing',
+      description:
+        'Allows testing `fullName` being empty string or not existing',
     },
     fullName: {type: 'string', if: {arg: 'hasFullName', truthy: true}},
     hasEmail: {
@@ -26,18 +27,14 @@ export default {
       description: 'Allows testing `email` being empty string or not existing',
     },
     email: {type: 'string', if: {arg: 'hasEmail', truthy: true}},
+    variant: {
+      options: ['default', 'ghost'],
+      control: {type: 'select'},
+    },
   },
 } as ComponentMeta<typeof Avatar>;
 
-const Template: ComponentStory<typeof Avatar> = (args) => (
-  <Avatar
-    size={args.size}
-    username={args.username}
-    isUsernameVisible={args.isUsernameVisible}
-    fullName={args.fullName}
-    email={args.email}
-  />
-);
+const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
 
 export const Simple = Template.bind({});
 Simple.args = {

--- a/jsapp/js/components/common/avatar.tsx
+++ b/jsapp/js/components/common/avatar.tsx
@@ -32,7 +32,7 @@ interface AvatarProps {
   isUsernameVisible?: boolean;
   fullName?: string;
   email?: string;
-  variant?: 'default' | 'ghost';
+  isEmpty?: boolean;
 }
 
 /**
@@ -45,11 +45,9 @@ export default function Avatar(props: AvatarProps) {
     props.fullName !== undefined ||
     props.email !== undefined;
 
-  const isGhost = props.variant === 'ghost';
-
   return (
     <div className={cx(styles.avatar, styles[`avatar-size-${props.size}`])}>
-      {isGhost ? (
+      {props.isEmpty ? (
         <div className={cx(styles.initials, styles.ghost)}>
           <svg width='100%' viewBox='0 0 24 24'>
             <circle cx='12' cy='12' r='11' />
@@ -70,7 +68,7 @@ export default function Avatar(props: AvatarProps) {
             [styles.hasFullName]: props.fullName !== undefined,
           })}
         >
-          {!isGhost && props.fullName !== undefined && (
+          {props.fullName !== undefined && (
             <span className={styles.fullName}>{props.fullName}</span>
           )}
 
@@ -79,7 +77,7 @@ export default function Avatar(props: AvatarProps) {
             <span className={styles.username}>{props.username}</span>
           )}
 
-          {!isGhost && props.email !== undefined && (
+          {props.email !== undefined && (
             <div className={styles.email}>{props.email}</div>
           )}
         </div>

--- a/jsapp/js/components/common/avatar.tsx
+++ b/jsapp/js/components/common/avatar.tsx
@@ -48,8 +48,9 @@ export default function Avatar(props: AvatarProps) {
   return (
     <div className={cx(styles.avatar, styles[`avatar-size-${props.size}`])}>
       {props.isEmpty ? (
-        <div className={cx(styles.initials, styles.ghost)}>
-          <svg width='100%' viewBox='0 0 24 24'>
+        <div className={cx(styles.initials, styles.empty)}>
+          &nbsp; {/* Empty space to keep the div from shifting sizes for being empty */}
+          <svg viewBox='0 0 24 24'>
             <circle cx='12' cy='12' r='11' />
           </svg>
         </div>

--- a/jsapp/js/components/common/avatar.tsx
+++ b/jsapp/js/components/common/avatar.tsx
@@ -32,6 +32,7 @@ interface AvatarProps {
   isUsernameVisible?: boolean;
   fullName?: string;
   email?: string;
+  variant?: 'default' | 'ghost';
 }
 
 /**
@@ -39,42 +40,50 @@ interface AvatarProps {
  * name and email.
  */
 export default function Avatar(props: AvatarProps) {
-  const isAnyTextBeingDisplayed = (
+  const isAnyTextBeingDisplayed =
     props.isUsernameVisible ||
     props.fullName !== undefined ||
-    props.email !== undefined
-  );
+    props.email !== undefined;
+
+  const isGhost = props.variant === 'ghost';
 
   return (
     <div className={cx(styles.avatar, styles[`avatar-size-${props.size}`])}>
-      <div
-        className={styles.initials}
-        style={{backgroundColor: `${stringToHSL(props.username, 80, 40)}`}}
-      >
-        {props.username.charAt(0)}
-      </div>
-
-      {isAnyTextBeingDisplayed &&
+      {isGhost ? (
+        <div className={cx(styles.initials, styles.ghost)}>
+          <svg width='100%' viewBox='0 0 24 24'>
+            <circle cx='12' cy='12' r='11' />
+          </svg>
+        </div>
+      ) : (
         <div
-          className={cx(
-            styles.text,
-            {[styles.hasFullName]: props.fullName !== undefined}
-          )}
+          className={styles.initials}
+          style={{backgroundColor: `${stringToHSL(props.username, 80, 40)}`}}
         >
-          {props.fullName !== undefined &&
+          {props.username.charAt(0)}
+        </div>
+      )}
+
+      {isAnyTextBeingDisplayed && (
+        <div
+          className={cx(styles.text, {
+            [styles.hasFullName]: props.fullName !== undefined,
+          })}
+        >
+          {!isGhost && props.fullName !== undefined && (
             <span className={styles.fullName}>{props.fullName}</span>
-          }
+          )}
 
           {/* Sometimes will be prefixed with "@" symbol */}
-          {props.isUsernameVisible &&
+          {props.isUsernameVisible && (
             <span className={styles.username}>{props.username}</span>
-          }
+          )}
 
-          {props.email !== undefined &&
+          {!isGhost && props.email !== undefined && (
             <div className={styles.email}>{props.email}</div>
-          }
+          )}
         </div>
-      }
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ghost variant was added to display a "ghost" state in members table when user is invited but still not active

### 📖 Description
- Added a `isEmpty` prop for our existent `Avatar` component for it to render the empty-dashed circle.
- At first I intended to add theme and use Mantine's Avatar component, but since our avatar has so many specific details the effort wouldn't be worth it, so I just customized the existent component.
- In the future we can migrate the internal structure of our avatar component to use Mantine's layout components.
- Avatar story was changed to add the isEmpty as a config option

### 👀 Preview steps
One can check the implementation result in Avatar's storybook story
For reference, I'm adding a screenshot of the property in use:
![image](https://github.com/user-attachments/assets/70b8b366-8c26-49ac-aff9-cff27cda8ffa)

