### PR TITLE
fix(organizations): include `organization_id` in the organization invitation link TASK-1491

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -348,7 +348,7 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
         # To avoid circular import
         User = apps.get_model('kobo_auth', 'User')
         has_multiple_accounts = User.objects.filter(email=to_email).count() > 1
-        organization_name = self.invited_by.organization.name
+        organization = self.invited_by.organization
         current_language = settings.LANGUAGE_CODE
         invitee_language = (
             self.invitee.extra_details.data.get(
@@ -369,7 +369,8 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
             ),
             'recipient_email': to_email,
             'recipient_role': recipient_role,
-            'organization_name': organization_name,
+            'organization_name': organization.name,
+            'organization_id': organization.id,
             'base_url': settings.KOBOFORM_URL,
             'invite_uid': self.guid,
             'is_registered_user': is_registered_user,
@@ -388,7 +389,7 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
             # by EmailMessage
             subject = replace_placeholders(
                 t("You're invited to join ##organization_name## organization"),
-                organization_name=organization_name
+                organization_name=organization.name,
             )
 
         email_message = EmailMessage(

--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -305,7 +305,7 @@ class OrgMembershipInviteSerializer(serializers.ModelSerializer):
             self._update_invitee_organization(instance)
 
             # Transfer ownership of invitee's assets to the organization
-            transfer_member_data_ownership_to_org(instance.invitee.id)
+            transfer_member_data_ownership_to_org.delay(instance.invitee.id)
         self._handle_status_update(instance, status)
         return instance
 

--- a/kobo/apps/organizations/templates/emails/registered_user_invite.html
+++ b/kobo/apps/organizations/templates/emails/registered_user_invite.html
@@ -19,6 +19,6 @@
 
 <p>{% trans "If you want to transfer any projects to another account or remove a project, please do so before accepting the invitation. This action cannot be undone." %}</p>
 
-<p>{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization-invite={{ invite_uid }}{% endblocktrans %}</p>
+<p>{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
 
 <p>&nbsp;-&nbsp;KoboToolbox</p>

--- a/kobo/apps/organizations/templates/emails/registered_user_invite.txt
+++ b/kobo/apps/organizations/templates/emails/registered_user_invite.txt
@@ -17,6 +17,6 @@
 
 {% trans "If you want to transfer any projects to another account or remove a project, please do so before accepting the invitation. This action cannot be undone." %}
 
-{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization-invite={{ invite_uid }}{% endblocktrans %}
+{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/organizations/templates/emails/unregistered_user_invite.html
+++ b/kobo/apps/organizations/templates/emails/unregistered_user_invite.html
@@ -13,6 +13,6 @@
 <p>{% blocktrans %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}</p>
 <p>{% trans "Once you have finished creating your account, respond to this invitation using the following link:" %}</p>
 
-<p>{% blocktrans %}{{ base_url }}/#/projects/home?organization-invite={{ invite_uid }}{% endblocktrans %}</p>
+<p>{% blocktrans %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
 
 <p>&nbsp;-&nbsp;KoboToolbox</p>

--- a/kobo/apps/organizations/templates/emails/unregistered_user_invite.txt
+++ b/kobo/apps/organizations/templates/emails/unregistered_user_invite.txt
@@ -11,6 +11,6 @@
 {% blocktrans %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}
 
 {% trans "Once you have finished creating your account, respond to this invitation using the following link:" %}
-{% blocktrans %}{{ base_url }}/#/projects/home?organization-invite={{ invite_uid }}{% endblocktrans %}
+{% blocktrans %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
 
 - KoboToolbox


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Improved the organization invitation email by including `organization_id` in the invitation link, allowing the frontend to correctly build API requests for accepting invitations.