### PR TITLE
fix(organizations): adjust self-ownership check logic TASK-1490

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -671,7 +671,7 @@ export function isSelfOwned(asset: AssetResponse | ProjectViewAsset) {
   return (
     asset &&
     sessionStore.currentAccount &&
-    asset.owner_label === sessionStore.currentAccount.username
+    asset.owner__username === sessionStore.currentAccount.username
   );
 }
 

--- a/jsapp/js/components/formSummary/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummary/formSummaryProjectInfo.tsx
@@ -3,7 +3,6 @@ import bem from 'js/bem';
 import {
   getCountryDisplayString,
   getSectorDisplayString,
-  isSelfOwned,
 } from 'js/assetUtils';
 import type {
   AssetResponse,
@@ -16,6 +15,7 @@ import {formatTime} from 'js/utils';
 import AssetStatusBadge from 'js/components/common/assetStatusBadge';
 import Avatar from 'js/components/common/avatar';
 import envStore from 'js/envStore';
+import sessionStore from 'js/stores/session';
 
 interface FormSummaryProjectInfoProps {
   asset: AssetResponse;
@@ -96,8 +96,10 @@ export default function FormSummaryProjectInfo(
           {/* owner */}
           <bem.FormView__cell m='padding'>
             <bem.FormView__label>{t('Owner')}</bem.FormView__label>
-            {isSelfOwned(props.asset) && t('me')}
-            {!isSelfOwned(props.asset) && (
+            {props.asset.owner_label ===
+            sessionStore.currentAccount.username ? (
+              t('me')
+            ) : (
               <Avatar
                 username={props.asset.owner_label}
                 size='s'

--- a/jsapp/js/components/modalForms/projectSettings.es6
+++ b/jsapp/js/components/modalForms/projectSettings.es6
@@ -872,7 +872,6 @@ class ProjectSettings extends React.Component {
     const operationalPurposeField = envStore.data.getProjectMetadataField('operational_purpose');
     const operationalPurposes = envStore.data.operational_purpose_choices;
     const collectsPiiField = envStore.data.getProjectMetadataField('collects_pii');
-    const isSelfOwned = assetUtils.isSelfOwned(this.state.formAsset);
     const descriptionField = envStore.data.getProjectMetadataField('description');
 
     return (
@@ -1060,7 +1059,8 @@ class ProjectSettings extends React.Component {
             </div>
           }
 
-          {isSelfOwned && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING &&
+          {userCan('delete_asset', this.state.formAsset) &&
+          this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING && (
             <div className={styles.input}>
               <Button
                 type='danger'
@@ -1071,7 +1071,7 @@ class ProjectSettings extends React.Component {
                 onClick={this.deleteProject}
               />
             </div>
-          }
+          )}
           </div>
       </form>
     );

--- a/jsapp/js/projects/projectsTable/projectsTableRow.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableRow.tsx
@@ -12,7 +12,8 @@ import Checkbox from 'js/components/common/checkbox';
 
 // Stores, hooks and utilities
 import {formatTime} from 'js/utils';
-import assetUtils, {isSelfOwned} from 'js/assetUtils';
+import assetUtils from 'js/assetUtils';
+import sessionStore from 'js/stores/session';
 
 // Constants and types
 import {ROUTES} from 'js/router/routerConstants';
@@ -55,17 +56,16 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
       case 'status':
         return <AssetStatusBadge deploymentStatus={props.asset.deployment_status} />;
       case 'ownerUsername':
-        if (isSelfOwned(props.asset)) {
-          return t('me');
-        } else {
-          return (
-            <Avatar
-              username={props.asset.owner_label}
-              size='s'
-              isUsernameVisible
-            />
-          );
-        }
+        return props.asset.owner_label ===
+          sessionStore.currentAccount.username ? (
+          t('me')
+        ) : (
+          <Avatar
+            username={props.asset.owner_label}
+            size='s'
+            isUsernameVisible
+          />
+        );
       case 'ownerFullName':
         return 'owner__name' in props.asset ? props.asset.owner__name : null;
       case 'ownerEmail':


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Updates `isSelfOwned()` util to check `owner__username` rather than `owner_label` and drops use of util for determining when to display 'me' vs. owner avatar.


### 💭 Notes
The basic issue here was that asset.owner_label will not match an asset owner's username when they are in an MMO, as the owner label will be the name of their organization. However, the isSelfOwned() util was being used both for determining when to display an asset owner avatar **and** for determining whether or not the user has an effective ownership role over the asset. These are separate questions and so I have removed the use of isSelfOwned() for the former purpose, leaving instances of the second as is. 

Bug template:
1. As the owner of an MMO, create a project and access the project settings view
2. On main, see that there is no "Delete Project and Data" button
3. On this branch, see that the button is displayed
4. Share project with another user without assigning permissions for deleting project
5. Login as second user and see that the button is not displayed
