### PR TITLE
fix(Organizations): add org name to org users report TASK-1330

### DIFF
--- a/kobo/apps/organizations/admin/organization_user.py
+++ b/kobo/apps/organizations/admin/organization_user.py
@@ -119,12 +119,12 @@ class OrgUserResource(resources.ModelResource):
     )
     organization = Field(
         attribute='organization',
-        column_name='Organization',
+        column_name='organization',
         widget=ForeignKeyWidget(Organization, field='name'),
     )
     organization_id = Field(
         attribute='organization_id',
-        column_name='Organization Id',
+        column_name='organization_id',
     )
 
     class Meta:

--- a/kobo/apps/organizations/admin/organization_user.py
+++ b/kobo/apps/organizations/admin/organization_user.py
@@ -117,6 +117,15 @@ class OrgUserResource(resources.ModelResource):
         column_name='user',
         widget=ForeignKeyWidget(User, field='username'),
     )
+    organization = Field(
+        attribute='organization',
+        column_name='Organization',
+        widget=ForeignKeyWidget(Organization, field='name'),
+    )
+    organization_id = Field(
+        attribute='organization_id',
+        column_name='Organization Id',
+    )
 
     class Meta:
         model = OrganizationUser


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add organization name to organization users export reports


### 👀 Preview steps
1. Login as super_admin
2. Go to the Organization Users admin
3. Click on the export button at the top
4. Check that the file  contains the columns organization and organization_id with the correct information