### PR TITLE
fix(submissions): deletion issue after project transfer TASK-1504

### DIFF
--- a/kobo/apps/openrosa/apps/logger/utils/database_query.py
+++ b/kobo/apps/openrosa/apps/logger/utils/database_query.py
@@ -27,7 +27,9 @@ def build_db_queries(xform: XForm, request_data: dict) -> tuple[dict, dict]:
 
     """
 
-    mongo_query = ParsedInstance.get_base_query(xform.user.username, xform.id_string)
+    mongo_query = ParsedInstance.get_base_query(
+        xform.user.username, xform.id_string, xform
+    )
     postgres_query = {'xform_id': xform.id}
     instance_ids = None
     # Remove empty values

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 import lxml
 import pytest
 import responses
+from constance.test import override_config
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -22,6 +23,7 @@ from kobo.apps.openrosa.apps.logger.exceptions import InstanceIdMissingError
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
 from kobo.apps.openrosa.libs.utils.logger_tools import dict2xform
+from kobo.apps.project_ownership.utils import create_invite
 from kpi.constants import (
     ASSET_TYPE_SURVEY,
     PERM_ADD_SUBMISSIONS,
@@ -49,6 +51,7 @@ from kpi.tests.utils.mock import (
     enketo_edit_instance_response_with_uuid_validation,
     enketo_view_instance_response,
 )
+from kpi.tests.utils.transaction import immediate_on_commit
 from kpi.tests.utils.xml import get_form_and_submission_tag_names
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.object_permission import get_anonymous_user
@@ -154,6 +157,25 @@ class BulkDeleteSubmissionsApiTests(
                 'parent_lookup_asset': self.asset.uid,
             },
         )
+
+    @override_config(PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES=True)
+    def test_delete_submissions_after_transfer(self):
+        """
+        someuser has transfered the project to anotheruser
+        someuser can delete anotheruser's project data after transfer
+        """
+        # Transfer the project to anotheruser
+        with immediate_on_commit():
+            create_invite(
+                self.someuser,
+                self.anotheruser,
+                [self.asset],
+                'Invite'
+            )
+        self.asset.refresh_from_db()
+        assert self.asset.owner == self.anotheruser
+
+        self._delete_submissions()
 
     def test_delete_submissions_as_owner(self):
         """


### PR DESCRIPTION
### 📣 Summary
Fixed a bug where submissions were not being fully deleted after a project transfer, ensuring proper cleanup in both PostgreSQL and MongoDB. This issue was introduced during the development of the current release and never appeared in a published version.

### 📖 Description
A bug prevented submissions from being deleted after a project was transferred. While they were successfully removed from PostgreSQL, they remained in MongoDB, leading to data inconsistencies and preventing proper cleanup. This fix ensures that submissions are deleted from both databases, restoring expected behavior.

