### PR TITLE
fix(SSO): only allow SSO email when registering TASK-1493

### DIFF
--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -32,9 +32,11 @@ class AccountFormsTestCase(TestCase):
         assert 'readonly' in email_input[0].attrib
 
     def test_social_signup_email_must_match(self):
+        # replace something@email.com with something+bad@email.com
+        bad_email = self.user.email.replace('@', '+bad@')
         form = SocialSignupForm(
             sociallogin=self.sociallogin,
-            data={'email': 'bad@bad.com', 'name': 'name', 'username': 'uname'},
+            data={'email': bad_email, 'name': 'name', 'username': 'uname'},
         )
         self.assertEquals(form.errors['email'], ['Email must match SSO server email'])
 

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -419,5 +419,7 @@ class AccountFormsTestCase(TestCase):
 
     def test_organization_field_skip_logic_sso_form(self):
         self._organization_field_skip_logic(
-            SocialSignupForm, form_kwargs={'sociallogin': self.sociallogin}, email=self.sociallogin.user.email
+            SocialSignupForm,
+            form_kwargs={'sociallogin': self.sociallogin},
+            email=self.sociallogin.user.email,
         )

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -36,7 +36,7 @@ class AccountFormsTestCase(TestCase):
             sociallogin=self.sociallogin,
             data={'email': 'bad@bad.com', 'name': 'name', 'username': 'uname'},
         )
-        self.assertEquals(form.errors['email'], 'Email must match SSO server email')
+        self.assertEquals(form.errors['email'], ['Email must match SSO server email'])
 
     def test_only_configurable_fields_can_be_removed(self):
         with override_config(USER_METADATA_FIELDS='{}'):

--- a/kobo/apps/accounts/tests/test_forms.py
+++ b/kobo/apps/accounts/tests/test_forms.py
@@ -18,7 +18,7 @@ from kpi.utils.json import LazyJSONSerializable
 class AccountFormsTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = baker.make(settings.AUTH_USER_MODEL)
+        cls.user = baker.make(settings.AUTH_USER_MODEL, email='email@email.com')
         cls.sociallogin = baker.make('socialaccount.SocialAccount', user=cls.user)
 
     def setUp(self):
@@ -297,7 +297,7 @@ class AccountFormsTestCase(TestCase):
         """
         basic_data = {
             'username': 'foo',
-            'email': 'double@foo.bar',
+            'email': kwargs.get('email', 'double@foo.bar'),
             'password1': 'tooxox',
             'password2': 'tooxox',
         }
@@ -317,6 +317,7 @@ class AccountFormsTestCase(TestCase):
             data = basic_data.copy()
             data['organization_type'] = 'government'
             form = form_type(data, **kwargs.get('form_kwargs', {}))
+
             # No other organization fields should be required
             assert form.is_valid()
 
@@ -416,5 +417,5 @@ class AccountFormsTestCase(TestCase):
 
     def test_organization_field_skip_logic_sso_form(self):
         self._organization_field_skip_logic(
-            SocialSignupForm, form_kwargs={'sociallogin': self.sociallogin}
+            SocialSignupForm, form_kwargs={'sociallogin': self.sociallogin}, email=self.sociallogin.user.email
         )

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1338,11 +1338,7 @@ SOCIALACCOUNT_AUTO_SIGNUP = False
 SOCIALACCOUNT_FORMS = {
     'signup': 'kobo.apps.accounts.forms.SocialSignupForm',
 }
-# For SSO, the signup form is prepopulated with the account email
-# If set True, the email field in the SSO signup form will be readonly
-UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE = env.bool(
-    'UNSAFE_SSO_REGISTRATION_EMAIL_DISABLE', False
-)
+
 
 WEBPACK_LOADER = {
     'DEFAULT': {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Do not allow SSO users to register with a different email then the one provided by the server.


### 📖 Description
Make the `email` field readonly when creating an account with SSO.


### 💭 Notes
This was originally a setting, but we've decided we want the field to always be read-only. In addition to the UI change, this PR also adds a validator on the email field to make sure that no one can register with a different email via a clever POST request. The error message will require translation.
This should also fix TASK-1493.

### 👀 Preview steps

Bug template:
1. ℹ️ Enable Kobo Google Apps SSO
2. On the login page, click `Create an account` -> `Register with SSO` -> `Log In` 
3. Sign in to your Google account
4. 🔴 [on main] Change the email field in the registration form and click 'Register and Save'
5. :red_circle:  [on main] Go to Account Settings -> Security. Under the email address you'll see "Check your email <new_email>. A verification link has been sent to confirm your ownership. Once confirmed, this address will replace <correct_email>"
6. 🟢 [on PR] The email field is read-only
