### PR TITLE
feat(organizations): adjust members table for invitees TASK-1499

### DIFF
--- a/jsapp/js/account/organization/MemberRoleSelector.tsx
+++ b/jsapp/js/account/organization/MemberRoleSelector.tsx
@@ -1,6 +1,6 @@
 import {Select} from 'jsapp/js/components/common/Select';
 import {usePatchOrganizationMember} from './membersQuery';
-import {MemberInviteStatus, usePatchMemberInvite} from './membersInviteQuery';
+import {usePatchMemberInvite} from './membersInviteQuery';
 import {OrganizationUserRole} from './organizationQuery';
 import {LoadingOverlay} from '@mantine/core';
 

--- a/jsapp/js/account/organization/MemberRoleSelector.tsx
+++ b/jsapp/js/account/organization/MemberRoleSelector.tsx
@@ -1,5 +1,6 @@
 import {Select} from 'jsapp/js/components/common/Select';
 import {usePatchOrganizationMember} from './membersQuery';
+import {MemberInviteStatus, usePatchMemberInvite} from './membersInviteQuery';
 import {OrganizationUserRole} from './organizationQuery';
 import {LoadingOverlay} from '@mantine/core';
 
@@ -9,17 +10,25 @@ interface MemberRoleSelectorProps {
   role: OrganizationUserRole;
   /** The role of the currently logged in user. */
   currentUserRole: OrganizationUserRole;
+  /** URL for patching org member invites. Should only be passed if invite is still open */
+  inviteUrl?: string;
 }
 
 export default function MemberRoleSelector({
   username,
   role,
+  inviteUrl,
 }: MemberRoleSelectorProps) {
   const patchMember = usePatchOrganizationMember(username);
+  const patchInvite = usePatchMemberInvite(inviteUrl);
 
   const handleRoleChange = (newRole: string | null) => {
     if (newRole) {
-      patchMember.mutateAsync({role: newRole as OrganizationUserRole});
+      const role = newRole as OrganizationUserRole
+      if (!inviteUrl) {
+        patchMember.mutateAsync({role});
+      }
+      patchInvite.mutateAsync({role});
     }
   };
 

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -42,16 +42,19 @@ export default function MembersRoute() {
     {
       key: 'user__extra_details__name',
       label: t('Name'),
-      cellFormatter: (member: OrganizationMember) => (
-        <Avatar
-          size='m'
-          username={member.user__username}
-          isUsernameVisible
-          email={member.user__email}
-          // We pass `undefined` for the case it's an empty string
-          fullName={member.user__extra_details__name || undefined}
-        />
-      ),
+      cellFormatter: (member: OrganizationMember) => {
+        const isOrgInvite = member.invite?.status === 'pending' || member.invite?.status === 'resent'
+          return (
+            <Avatar
+              size='m'
+              username={member.user__username}
+              isUsernameVisible={!isOrgInvite}
+              email={member.user__email}
+              // We pass `undefined` for the case it's an empty string
+              fullName={isOrgInvite ? undefined : member.user__extra_details__name || undefined}
+            />
+          )
+      },
       size: 360,
     },
     {
@@ -64,7 +67,6 @@ export default function MembersRoute() {
         } else {
           return <Badge color='light-green' size='s' label={t('Active')} />;
         }
-        return null;
       },
     },
     {
@@ -79,6 +81,19 @@ export default function MembersRoute() {
       label: t('Role'),
       size: 140,
       cellFormatter: (member: OrganizationMember) => {
+        if (
+          member.invite?.status === 'pending' ||
+          member.invite?.status === 'resent'
+        ) {
+          return (
+            <MemberRoleSelector
+              username={member.user__username}
+              role={member.invite.invitee_role}
+              currentUserRole={orgQuery.data.request_user_role}
+              inviteUrl={member.invite.url}
+            />
+          );
+        }
         if (
           member.role === OrganizationUserRole.owner ||
           !['owner', 'admin'].includes(orgQuery.data.request_user_role)

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -30,6 +30,10 @@ export default function MembersRoute() {
   const orgQuery = useOrganizationQuery();
   const [opened, {open, close}] = useDisclosure(false);
 
+  /**
+ * Checks whether object should be treated as organization member or invitee.
+ * Returns both an invite and member, but one of these will be null depending on status
+ */
   function getMemberOrInviteDetails(obj: OrganizationMemberListItem) {
     const invite =
       obj.invite?.status === 'pending' || obj.invite?.status === 'resent'

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -65,6 +65,7 @@ export default function MembersRoute() {
               email={member ? member.user__email : undefined}
               // We pass `undefined` for the case it's an empty string
               fullName={invite ? undefined : member?.user__extra_details__name || undefined}
+              isEmpty={!member}
             />
           )
       },

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -30,7 +30,7 @@ import {type Json} from 'jsapp/js/components/common/common.interfaces';
  * The source of truth of statuses are at `OrganizationInviteStatusChoices` in
  * `kobo/apps/organizations/models.py`. This enum should be kept in sync.
  */
-export enum MemberInviteStatus {
+enum MemberInviteStatus {
   accepted = 'accepted',
   cancelled = 'cancelled',
   complete = 'complete',

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -131,14 +131,14 @@ export function usePatchMemberInvite(inviteUrl?: string) {
   return useMutation({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
       if (inviteUrl) {
-        return await fetchPatchUrl<OrganizationMember>(
+        return fetchPatchUrl<OrganizationMember>(
           inviteUrl,
           newInviteData,
           {
             errorMessageDisplay: t('There was an error updating this invitation.'),
           }
         );
-      } else return;
+      } else return null;
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -30,7 +30,7 @@ import {type Json} from 'jsapp/js/components/common/common.interfaces';
  * The source of truth of statuses are at `OrganizationInviteStatusChoices` in
  * `kobo/apps/organizations/models.py`. This enum should be kept in sync.
  */
-enum MemberInviteStatus {
+export enum MemberInviteStatus {
   accepted = 'accepted',
   cancelled = 'cancelled',
   complete = 'complete',
@@ -58,11 +58,19 @@ export interface MemberInvite {
   date_modified: string;
 }
 
-interface SendMemberInviteParams {
+interface MemberInviteRequestBase {
+  role: OrganizationUserRole;
+}
+
+interface SendMemberInviteParams extends MemberInviteRequestBase {
   /** List of usernames. */
   invitees: string[];
   /** Target role for the invitied users. */
   role: OrganizationUserRole;
+}
+
+interface MemberInviteUpdate extends MemberInviteRequestBase{
+  status: MemberInviteStatus
 }
 
 /**
@@ -120,11 +128,13 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string) => {
  * `membersQuery` and `useOrgMemberInviteQuery` will refetch data (by
  * invalidation).
  */
-export function usePatchMemberInvite(inviteUrl: string) {
+export function usePatchMemberInvite(inviteUrl?: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (newInviteData: Partial<MemberInvite>) => {
-      fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData);
+    mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
+      if (inviteUrl) {
+        fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData);
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({queryKey: [

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -131,8 +131,14 @@ export function usePatchMemberInvite(inviteUrl?: string) {
   return useMutation({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
       if (inviteUrl) {
-        return await fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData);
-      }
+        return await fetchPatchUrl<OrganizationMember>(
+          inviteUrl,
+          newInviteData,
+          {
+            errorMessageDisplay: t('There was an error updating this invitation.'),
+          }
+        );
+      } else return;
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -135,10 +135,12 @@ export function usePatchMemberInvite(inviteUrl?: string) {
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({queryKey: [
-        QueryKeys.organizationMemberInviteDetail,
-        QueryKeys.organizationMembers,
-      ]});
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.organizationMemberInviteDetail],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.organizationMembers],
+      });
     },
   });
 }

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -131,7 +131,7 @@ export function usePatchMemberInvite(inviteUrl?: string) {
   return useMutation({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
       if (inviteUrl) {
-        fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData);
+        return await fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData);
       }
     },
     onSettled: () => {

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -65,8 +65,6 @@ interface MemberInviteRequestBase {
 interface SendMemberInviteParams extends MemberInviteRequestBase {
   /** List of usernames. */
   invitees: string[];
-  /** Target role for the invitied users. */
-  role: OrganizationUserRole;
 }
 
 interface MemberInviteUpdate extends MemberInviteRequestBase{

--- a/jsapp/js/account/organization/membersQuery.ts
+++ b/jsapp/js/account/organization/membersQuery.ts
@@ -14,6 +14,7 @@ import {
 } from './organizationQuery';
 
 // Constants and types
+import type { Nullable } from 'jsapp/js/constants';
 import {endpoints} from 'js/api.endpoints';
 import type {PaginatedResponse} from 'js/dataInterface';
 import {QueryKeys} from 'js/query/queryKeys';
@@ -40,8 +41,12 @@ export interface OrganizationMember {
   user__is_active: boolean;
   /** yyyy-mm-dd HH:MM:SS */
   date_joined: string;
-  invite?: MemberInvite;
 }
+
+export interface OrganizationMemberListItem
+  extends Nullable<OrganizationMember> {
+    invite?: MemberInvite;
+  }
 
 function getMemberEndpoint(orgId: string, username: string) {
   return endpoints.ORGANIZATION_MEMBER_URL.replace(
@@ -130,7 +135,7 @@ async function getOrganizationMembers(
     orgId
   );
 
-  return fetchGet<PaginatedResponse<OrganizationMember>>(
+  return fetchGet<PaginatedResponse<OrganizationMemberListItem>>(
     apiUrl + '?' + params,
     {
       errorMessageDisplay: t('There was an error getting the list.'),

--- a/jsapp/js/constants.ts
+++ b/jsapp/js/constants.ts
@@ -9,6 +9,13 @@ interface IEnum {
 }
 
 /**
+ * Make all fields of a type or interface nullable
+ */
+export type Nullable<T> = {
+  [P in keyof T]: T[P] | null;
+};
+
+/**
  * An enum creator function. Will create a frozen object of `foo: "foo"` pairs.
  * Will make sure the returned values are unique.
  */

--- a/jsapp/js/theme/kobo/Select.module.css
+++ b/jsapp/js/theme/kobo/Select.module.css
@@ -7,6 +7,11 @@
   }
 }
 
+/* Hides caret in FF */
+.input[readonly] {
+  caret-color: transparent;
+}
+
 .dropdown {
   border-color: var(--mantine-color-gray-6);
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adjusts members table columns to handle data for both organization members and invited organization members.


### 💭 Notes
I have mostly left the 'actions' column untouched, aside from changes necessary to work with new types. This column will be changed in a separate task.

This PR depends on #5477 and should be merged after it. It also anticipates work that is yet to be done on the members list API (see [here](https://www.notion.so/kobotoolbox/Do-not-reveal-user-information-until-they-accept-invites-1907e515f65480739575da841e8bd6ac)), but the change there is going to be that member details are null for invited members and all data should be retrieved from the invite field. So this should be fine to merge before that later work is done.

### 👀 Preview steps
Feature/no-change template:
1. Use django shell or direct API to create an invitation for a user to join an MMO
2. As an owner or admin of the MMO, navigate to the members table
3. Columns for organization members should not change between this branch and `main`
4. The invitee's row should match what we have in the figma designs for this project