### PR TITLE
fix(billing): remove indent of last item in nlp add-ons dropdown TASK-1509

### DIFF
--- a/jsapp/js/account/addOns/addOnList.module.scss
+++ b/jsapp/js/account/addOns/addOnList.module.scss
@@ -149,10 +149,6 @@
 
   .oneTime {
     justify-content: center;
-
-    :last-child {
-      margin-left: 8px;
-    }
   }
 
   .productName {


### PR DESCRIPTION
### 🗒️ Checklist

1. [X] run linter locally
2. [X] update all related docs (API, README, inline, etc.), if any
3. [X] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [X] tag PR: at least `frontend` or `backend` unless it's global
5. [X] fill in the template below and delete template comments
6. [X] review thyself: read the diff and repro the preview as written
7. [X] open PR & confirm that CI passes
8. [X] request reviewers, if needed
9. [ ] delete this section before merging


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. Check out the Account Settings < Add-ons
3. 🔴 [on main] notice that when any add-on dropdown is expanded, the last item is indented
4. 🟢 [on PR] notice that when any add-on dropdown is expanded, all items are properly aligned

