### PR TITLE
build(frontend): use pinned, active and current node version

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -13,10 +13,9 @@ jobs:
 
       matrix:
         node-version:
-          - '16.15.0'  # prior pinned Node version supported by kpi
-          - '20.17.0'  # version pinned for kpi release
-          - '20'       # latest available v20
-          - '22'       # latest available v22
+          - '20.17.0'  # version that's pinned in Dockerfile for kpi release
+          - '22'       # version that's active (v22 until Nov, 2025), see https://nodejs.org/en/about/previous-releases
+          # - '24'       # version that's current (v24 since May, 2025), see https://nodejs.org/en/about/previous-releases
       fail-fast: false # Let each job finish
 
     steps:


### PR DESCRIPTION
### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->

Support only pinned (v20.17), active (v22 until Nov 2025) and current (v24 after May 2025) node versions.
