### PR TITLE
fix(submissions): verify submission exists before adding or modifying extras

### DIFF
--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError as APIValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.subsequences.models import SubmissionExtras
 from kobo.apps.subsequences.utils.deprecation import get_sanitized_dict_keys
 from kpi.models import Asset

--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -82,6 +82,7 @@ class AdvancedSubmissionView(APIView):
             s_uuid = request.data.get('submission')
         else:
             s_uuid = request.query_params.get('submission')
+        get_object_or_404(Instance, uuid=s_uuid)
         return get_submission_processing(self.asset, s_uuid)
 
     def post(self, request, asset_uid, format=None):

--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from django.shortcuts import get_object_or_404
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework.exceptions import PermissionDenied
@@ -89,6 +90,8 @@ class AdvancedSubmissionView(APIView):
             validate(posted_data, schema)
         except SchemaValidationError as err:
             raise APIValidationError({'error': err})
+        # ensure the submission exists
+        get_object_or_404(Instance, uuid=posted_data['submission'])
 
         _check_asr_mt_access_if_applicable(request.user, posted_data)
 

--- a/kobo/apps/subsequences/api_view.py
+++ b/kobo/apps/subsequences/api_view.py
@@ -82,7 +82,8 @@ class AdvancedSubmissionView(APIView):
             s_uuid = request.data.get('submission')
         else:
             s_uuid = request.query_params.get('submission')
-        get_object_or_404(Instance, uuid=s_uuid)
+        if s_uuid is not None:
+            get_object_or_404(Instance, uuid=s_uuid)
         return get_submission_processing(self.asset, s_uuid)
 
     def post(self, request, asset_uid, format=None):

--- a/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
+++ b/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
@@ -66,6 +66,7 @@ class ValidateSubmissionTest(APITestCase):
 
         validate(package, schema)
         rr = self.client.post(schema['url'], package, format='json')
+        breakpoint()
 
         package['q1']['transcript'] = {'value': 'they said goodbye'}
         validate(package, schema)

--- a/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
+++ b/kobo/apps/subsequences/tests/test_submission_extras_api_post.py
@@ -64,6 +64,29 @@ class ValidateSubmissionTest(APITestCase):
         self.asset.advanced_features = features
         self.asset.save()
 
+    def test_get_submission_with_nonexistent_instance_404s(self):
+        self.set_asset_advanced_features({'transcript': {'values': ['q1']}})
+        resp = self.client.get(self.asset_url)
+        base_url = resp.json()['advanced_submission_schema']['url']
+        url = f'{base_url}?submission=bad-uuid'
+        rr = self.client.get(url)
+        assert rr.status_code == 404
+
+    def test_post_submission_extra_with_nonexistent_instance_404s(self):
+        self.set_asset_advanced_features({'transcript': {'values': ['q1']}})
+        resp = self.client.get(self.asset_url)
+        schema = resp.json()['advanced_submission_schema']
+        package = {
+            'submission': 'bad-uuid',
+            'q1': {
+                'transcript': {
+                    'value': 'they said hello',
+                }
+            },
+        }
+        rr = self.client.post(schema['url'], package, format='json')
+        assert rr.status_code == 404
+
     def test_asset_post_submission_extra_with_transcript(self):
         self.set_asset_advanced_features({'transcript': {'values': ['q1']}})
         resp = self.client.get(self.asset_url)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Return 404 when retrieving or updating submission extras if submission does not exist.

### 💭 Notes
Update the GET and POST endpoints for submission extras to check that an `Instance` with the given `uuid` exists, otherwise 404. We can't enforce this at a database level because `SubmissionExtra`s and `Instance`s live in different databases, but this at least provides some gating to prevent us from having orphaned `SubmissionExtra`s lying around. It also will make project history logs easier if we can ensure that we always have an `Instance` containing information about the updated submission.


Bug template:
1. ℹ️ have an account and a project
2. In Django admin, add English (code 'en') as a language
3. Add an audio question to the project with the label "audio"
4. Create a submission to the project including an audio upload
5. Add a transcript to the submission
6. From the terminal, run `curl -X POST -H 'Authorization: Token <your token>' -H 'Content-type: application/json' kf.kobo.local:8080/advanced_submission_post/<asset_uid> -d '{"submission": "bad-uuid", {"audio": {"transcript": {"languageCode":"en", "value":"something"}}}}'`
7. 🔴 [on main] The request will succeed. In the shell, you will see a SubmissionExtra object with a `submission_uuid` of `"bad-uuid"`
8. In the browser, go to `kf.kobo.local:8080/advanced_submission_post/<asset_uid>?submission="also-bad"`
9. :red_circle: [on main] The response will be a 200 (though it will say in the info that the submission doesn't exist)
10. 🟢 [on PR] Both requests will 404

