### PR TITLE
feat(organizations): add UI actions to resend and remove invitations TASK-1372

### DIFF
--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -1,0 +1,84 @@
+import {Modal, Stack, Group, Text, Menu, LoadingOverlay} from '@mantine/core';
+import {useDisclosure} from '@mantine/hooks';
+import ButtonNew from 'jsapp/js/components/common/ButtonNew';
+import type {ReactNode} from 'react';
+import type {MemberInvite} from './membersInviteQuery';
+import {usePatchMemberInvite, useRemoveMemberInvite} from './membersInviteQuery';
+import {notify} from 'alertifyjs';
+
+/**
+ * A dropdown with all actions that can be taken towards an organization invitee.
+ */
+export default function InviteeActionsDropdown({
+  target,
+  invite,
+}: {
+  target: ReactNode;
+  invite: MemberInvite;
+}) {
+  const [opened, {open, close}] = useDisclosure();
+
+  const patchInviteMutation = usePatchMemberInvite(invite.url);
+  const removeInviteMutation = useRemoveMemberInvite();
+
+  const handleResendInvitationAction = async () => {
+    await patchInviteMutation.mutateAsync(invite);
+  };
+
+  const handleRemoveInvitationAction = () => {
+    open();
+  };
+
+  const handleRemoveInvitation = async () => {
+    // console.log(invite)
+    try {
+      await removeInviteMutation.mutateAsync(invite.url);
+      close();
+      notify(t('Invitation removed'), 'success');
+    } catch (e) {
+      close();
+      notify(t('An error occurred while removing the invitation'), 'error');
+    }
+  };
+
+  return (
+    <>
+      <Modal opened={opened} onClose={close} title={t('Remove invitation?')}>
+        <LoadingOverlay visible={removeInviteMutation.isPending} />
+        <Stack>
+          <Text>
+            {t(
+              "Are you sure you want to remove this user's invitation to join the team?"
+            )}
+          </Text>
+          <Group justify='flex-end'>
+            <ButtonNew size='md' onClick={close}>
+              {t('Cancel')}
+            </ButtonNew>
+            <ButtonNew
+              size='md'
+              onClick={handleRemoveInvitation}
+              variant='danger'
+            >
+              {t('Remove invitation')}
+            </ButtonNew>
+          </Group>
+        </Stack>
+      </Modal>
+
+      <Menu offset={0} position='bottom-end'>
+        <Menu.Target>{target}</Menu.Target>
+
+        <Menu.Dropdown>
+          <Menu.Item onClick={handleResendInvitationAction}>
+            {t('Resend invitation')}
+          </Menu.Item>
+          <Menu.Divider />
+          <Menu.Item variant='danger' onClick={handleRemoveInvitationAction}>
+            {t('Remove invitation')}
+          </Menu.Item>
+        </Menu.Dropdown>
+      </Menu>
+    </>
+  );
+}

--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -25,21 +25,26 @@ export default function InviteeActionsDropdown({
   const patchInviteMutation = usePatchMemberInvite(invite.url);
   const removeInviteMutation = useRemoveMemberInvite();
 
-  const handleResendInvitationAction = async () => {
+  const resendInvitation = async () => {
     try {
       await patchInviteMutation.mutateAsync({status: MemberInviteStatus.resent});
       notify(t('The invitation was resent'), 'success');
-    } catch (e) {
+    } catch (e: any) {
+      if(e.responseText) {
+        const responseData = JSON.parse(e.responseText);
+        console.log(e.responseText, responseData);
+        notify(responseData.status.join(' '), 'error');
+        return;
+      }
       notify(t('An error occurred while resending the invitation'), 'error');
     }
   };
 
-  const handleRemoveInvitationAction = () => {
+  const showRemovalConfirmation = () => {
     open();
   };
 
-  const handleRemoveInvitation = async () => {
-    // console.log(invite)
+  const removeInvitation = async () => {
     try {
       await removeInviteMutation.mutateAsync(invite.url);
       notify(t('Invitation removed'), 'success');
@@ -66,7 +71,7 @@ export default function InviteeActionsDropdown({
             </ButtonNew>
             <ButtonNew
               size='md'
-              onClick={handleRemoveInvitation}
+              onClick={removeInvitation}
               variant='danger'
             >
               {t('Remove invitation')}
@@ -80,11 +85,11 @@ export default function InviteeActionsDropdown({
         <Menu.Target>{target}</Menu.Target>
 
         <Menu.Dropdown>
-          <Menu.Item onClick={handleResendInvitationAction}>
+          <Menu.Item onClick={resendInvitation}>
             {t('Resend invitation')}
           </Menu.Item>
           <Menu.Divider />
-          <Menu.Item variant='danger' onClick={handleRemoveInvitationAction}>
+          <Menu.Item variant='danger' onClick={showRemovalConfirmation}>
             {t('Remove invitation')}
           </Menu.Item>
         </Menu.Dropdown>

--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -33,11 +33,11 @@ export default function InviteeActionsDropdown({
     // console.log(invite)
     try {
       await removeInviteMutation.mutateAsync(invite.url);
-      close();
       notify(t('Invitation removed'), 'success');
     } catch (e) {
-      close();
       notify(t('An error occurred while removing the invitation'), 'error');
+    } finally {
+      close();
     }
   };
 

--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -3,7 +3,11 @@ import {useDisclosure} from '@mantine/hooks';
 import ButtonNew from 'jsapp/js/components/common/ButtonNew';
 import type {ReactNode} from 'react';
 import type {MemberInvite} from './membersInviteQuery';
-import {usePatchMemberInvite, useRemoveMemberInvite} from './membersInviteQuery';
+import {
+  MemberInviteStatus,
+  usePatchMemberInvite,
+  useRemoveMemberInvite,
+} from './membersInviteQuery';
 import {notify} from 'alertifyjs';
 
 /**
@@ -22,7 +26,12 @@ export default function InviteeActionsDropdown({
   const removeInviteMutation = useRemoveMemberInvite();
 
   const handleResendInvitationAction = async () => {
-    await patchInviteMutation.mutateAsync(invite);
+    try {
+      await patchInviteMutation.mutateAsync({status: MemberInviteStatus.resent});
+      notify(t('The invitation was resent'), 'success');
+    } catch (e) {
+      notify(t('An error occurred while resending the invitation'), 'error');
+    }
   };
 
   const handleRemoveInvitationAction = () => {
@@ -66,6 +75,7 @@ export default function InviteeActionsDropdown({
         </Stack>
       </Modal>
 
+      <LoadingOverlay visible={patchInviteMutation.isPending} />
       <Menu offset={0} position='bottom-end'>
         <Menu.Target>{target}</Menu.Target>
 

--- a/jsapp/js/account/organization/MemberActionsDropdown.tsx
+++ b/jsapp/js/account/organization/MemberActionsDropdown.tsx
@@ -1,8 +1,8 @@
 // Libraries
+import type {ReactNode} from 'react';
 import {useState} from 'react';
 
 // Partial components
-import ActionIcon from 'jsapp/js/components/common/ActionIcon';
 import MemberRemoveModal from './MemberRemoveModal';
 import {Menu} from '@mantine/core';
 
@@ -20,6 +20,7 @@ import router from 'jsapp/js/router/router';
 import {ROUTES} from 'jsapp/js/router/routerConstants';
 
 interface MemberActionsDropdownProps {
+  target: ReactNode;
   targetUsername: string;
   /**
    * The role of the currently logged in user, i.e. the role of the user that
@@ -32,6 +33,7 @@ interface MemberActionsDropdownProps {
  * A dropdown with all actions that can be taken towards an organization member.
  */
 export default function MemberActionsDropdown({
+  target,
   targetUsername,
   currentUserRole,
 }: MemberActionsDropdownProps) {
@@ -88,10 +90,8 @@ export default function MemberActionsDropdown({
         />
       }
 
-      <Menu width={100} offset={0}>
-        <Menu.Target>
-          <ActionIcon variant='transparent' size='md' iconName='more' />
-        </Menu.Target>
+      <Menu offset={0} position='bottom-end'>
+        <Menu.Target>{target}</Menu.Target>
 
         <Menu.Dropdown>
           <Menu.Item

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -25,6 +25,8 @@ import type {UniversalTableColumn} from 'jsapp/js/universalTable/universalTable.
 // Styles
 import styles from './membersRoute.module.scss';
 import {FeatureFlag, useFeatureFlag} from 'jsapp/js/featureFlags';
+import ActionIcon from 'jsapp/js/components/common/ActionIcon';
+import InviteeActionsDropdown from './InviteeActionsDropdown';
 
 export default function MembersRoute() {
   const orgQuery = useOrganizationQuery();
@@ -169,12 +171,26 @@ export default function MembersRoute() {
           return null;
         }
 
-        return (
-          <MemberActionsDropdown
-            targetUsername={member?.user__username ?? invite!.invitee}
-            currentUserRole={orgQuery.data.request_user_role}
-          />
+        const target = (
+          <ActionIcon variant='transparent' size='md' iconName='more' />
         );
+
+        if (member) {
+          return (
+            <MemberActionsDropdown
+              target={target}
+              targetUsername={member?.user__username ?? invite!.invitee}
+              currentUserRole={orgQuery.data.request_user_role}
+            />
+          );
+        } else if (invite) {
+          return (
+            <InviteeActionsDropdown target={target} invite={invite} />
+          );
+        }
+
+        return null;
+
       },
     });
   }

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -30,7 +30,7 @@ import {type Json} from 'jsapp/js/components/common/common.interfaces';
  * The source of truth of statuses are at `OrganizationInviteStatusChoices` in
  * `kobo/apps/organizations/models.py`. This enum should be kept in sync.
  */
-export enum MemberInviteStatus {
+enum MemberInviteStatus {
   accepted = 'accepted',
   cancelled = 'cancelled',
   complete = 'complete',

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -68,7 +68,7 @@ interface SendMemberInviteParams extends MemberInviteRequestBase {
 }
 
 interface MemberInviteUpdate extends MemberInviteRequestBase{
-  status: MemberInviteStatus
+  status: MemberInviteStatus;
 }
 
 interface MemberInviteUpdate extends MemberInviteRequestBase{
@@ -87,7 +87,7 @@ export function useSendMemberInvite() {
   return useMutation({
     mutationFn: async (payload: SendMemberInviteParams & Json) => {
       const apiPath = endpoints.ORG_MEMBER_INVITES_URL.replace(':organization_id', orgId!);
-      fetchPost<OrganizationMember>(apiPath, payload);
+      return fetchPost<OrganizationMember>(apiPath, payload);
     },
     onSettled: () => {
       queryClient.invalidateQueries({queryKey: [QueryKeys.organizationMembers]});
@@ -102,9 +102,7 @@ export function useSendMemberInvite() {
 export function useRemoveMemberInvite() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (inviteUrl: string) => {
-      fetchDeleteUrl<OrganizationMember>(inviteUrl);
-    },
+    mutationFn: async (inviteUrl: string) => fetchDeleteUrl<OrganizationMember>(inviteUrl),
     onSettled: () => {
       queryClient.invalidateQueries({queryKey: [QueryKeys.organizationMembers]});
     },

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -30,7 +30,7 @@ import {type Json} from 'jsapp/js/components/common/common.interfaces';
  * The source of truth of statuses are at `OrganizationInviteStatusChoices` in
  * `kobo/apps/organizations/models.py`. This enum should be kept in sync.
  */
-enum MemberInviteStatus {
+export enum MemberInviteStatus {
   accepted = 'accepted',
   cancelled = 'cancelled',
   complete = 'complete',
@@ -65,6 +65,10 @@ interface MemberInviteRequestBase {
 interface SendMemberInviteParams extends MemberInviteRequestBase {
   /** List of usernames. */
   invitees: string[];
+}
+
+interface MemberInviteUpdate extends MemberInviteRequestBase{
+  status: MemberInviteStatus
 }
 
 interface MemberInviteUpdate extends MemberInviteRequestBase{

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -30,7 +30,7 @@ import {type Json} from 'jsapp/js/components/common/common.interfaces';
  * The source of truth of statuses are at `OrganizationInviteStatusChoices` in
  * `kobo/apps/organizations/models.py`. This enum should be kept in sync.
  */
-enum MemberInviteStatus {
+export enum MemberInviteStatus {
   accepted = 'accepted',
   cancelled = 'cancelled',
   complete = 'complete',

--- a/jsapp/js/theme/kobo/Menu.module.css
+++ b/jsapp/js/theme/kobo/Menu.module.css
@@ -1,5 +1,14 @@
+.dropdown {
+  padding: 0;
+  box-shadow: 0 0 6px var(--mantine-color-gray-4);
+  border: none;
+}
+
 .item {
+  padding: var(--mantine-spacing-sm);
   color: var(--mantine-color-blue-4);
+
+  font-size: var(--mantine-font-size-md);
 
   &[data-hovered] {
     color: var(--mantine-color-blue-5);
@@ -13,4 +22,9 @@
       color: var(--mantine-color-red-6);
     }
   }
+}
+
+.divider {
+  border-color: var(--mantine-color-gray-6);
+  margin: 0;
 }

--- a/jsapp/js/theme/kobo/Menu.ts
+++ b/jsapp/js/theme/kobo/Menu.ts
@@ -9,19 +9,4 @@ declare module '@mantine/core' {
 
 export const MenuThemeKobo = Menu.extend({
   classNames: classes,
-  vars: (theme) => {
-    return {
-      dropdown: {
-        padding: 0,
-        '--popover-shadow': `0 0 6px ${theme.colors.gray[4]}`,
-        border: 'none',
-      },
-      divider: {
-        borderColor: theme.colors.gray[6],
-      },
-      item: {
-        fontSize: theme.fontSizes.md
-      }
-    };
-  },
 });


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
The following invitation actions are now displayed for invited members
- Resend the invitation
- Remove the invitation

### 💭 Notes
- A new menu of actions was created to handle the invitation actions
- Some style adjustments were needed for the Menu component
- Since I was adjusting the style I centralized all the styling in the CSS module
- A confirmation modal for the Removing action was added

### 👀 Preview steps
1. ℹ️ be part of an organization
2. Open organization members page
3. Have some user/email invited for the organization
4. 🟢 notice that there are actions on the right side of the table for the invited member
5. Resending the invitation should work properly
6. Removing the invitation should work properly
