### PR TITLE
build(frontend): windows-compatible path.join

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -96,12 +96,12 @@ const commonOptions = {
   resolve: {
     extensions: ['.jsx', '.js', '.coffee', '.ts', '.tsx', '.scss'],
     alias: {
-      app: path.join(__dirname, '../app'),
-      jsapp: path.join(__dirname, '../jsapp'),
-      js: path.join(__dirname, '../jsapp/js'),
-      scss: path.join(__dirname, '../jsapp/scss'),
-      utils: path.join(__dirname, '../jsapp/js/utils'),
-      test: path.join(__dirname, '../test'),
+      app: path.join(__dirname, '..', 'app'),
+      jsapp: path.join(__dirname, '..', 'jsapp'),
+      js: path.join(__dirname, '..', 'jsapp', 'js'),
+      scss: path.join(__dirname, '..', 'jsapp', 'scss'),
+      utils: path.join(__dirname, '..', 'jsapp', 'js', 'utils'),
+      test: path.join(__dirname, '..', 'test'),
     },
     // HACKFIX: needed because of https://github.com/react-dnd/react-dnd/issues/3423
     fallback: {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes

Found this along the way, let's use `path.join` in a windows compatible way to have backslash in all path segments instead of only the first one.


### 👀 Preview steps

Build frontend from windows command shell (not Git Bash, it uses slashes the unix way)