### PR TITLE
feat(OpenRosa)!: exclude forms owned by inactive users from `formList`

### DIFF
--- a/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
@@ -103,6 +103,10 @@ class XFormListApi(OpenRosaReadOnlyModelViewSet):
         else:
             queryset = queryset.filter(id_string=id_string_filter)
 
+        # Submissions for forms owned by inactive users are already blocked by
+        # #5321; those forms should be excluded from `formList` as well
+        queryset = queryset.exclude(user__is_active=False)
+
         return queryset
 
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
### 📣 Summary
Previously, blank forms for projects owned by deactivated accounts could still be downloaded, e.g. if the project allowed anonymous submissions, or if a still-active user was granted access to submit to the project. This change prevents access for data collection purposes, i.e. by Enketo or Collect, to forms owned by inactive users. See also #5321.

### 👀 Preview steps

1. Log in as a normal user (let's call them "Psy")
2. Create a project and deploy it
3. Set the project to allow anonymous submissions
4. Open Enketo for the project and note the URL
6. Use a superuser account to deactivate Psy's account (uncheck the "active" box in Django admin)
7. In a separate browser session, attempt to access the same Enketo URL
    * If you use the same browser session where you initially loaded Enketo, you may need to wait several minutes or refresh multiple times before you observe a change
9. See "Loading Error / This form is no longer available"