### PR TITLE
feat(organizations): optimistic updates for members table changes TASK-1520

### DIFF
--- a/jsapp/js/account/organization/MemberRoleSelector.tsx
+++ b/jsapp/js/account/organization/MemberRoleSelector.tsx
@@ -22,9 +22,9 @@ export default function MemberRoleSelector({ username, role, inviteUrl }: Member
     if (newRole) {
       const role = newRole as OrganizationUserRole
       if (!inviteUrl) {
-        patchMember.mutateAsync({ role });
+        patchMember.mutateAsync({ role })
       } else {
-        patchInvite.mutateAsync({ role });
+        patchInvite.mutateAsync({ role })
       }
     }
   }

--- a/jsapp/js/account/organization/MemberRoleSelector.tsx
+++ b/jsapp/js/account/organization/MemberRoleSelector.tsx
@@ -22,15 +22,16 @@ export default function MemberRoleSelector({ username, role, inviteUrl }: Member
     if (newRole) {
       const role = newRole as OrganizationUserRole
       if (!inviteUrl) {
-        patchMember.mutateAsync({ role })
+        patchMember.mutateAsync({ role });
+      } else {
+        patchInvite.mutateAsync({ role });
       }
-      patchInvite.mutateAsync({ role })
     }
   }
 
   return (
     <>
-      <LoadingOverlay visible={patchMember.isPending} />
+      <LoadingOverlay visible={patchMember.isPending || patchInvite.isPending} />
       <Select
         size='sm'
         data={[

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -3,8 +3,8 @@ import { fetchPost, fetchGet, fetchPatchUrl, fetchDeleteUrl } from 'js/api'
 import { type OrganizationUserRole, useOrganizationQuery } from './organizationQuery'
 import { QueryKeys } from 'js/query/queryKeys'
 import { endpoints } from 'jsapp/js/api.endpoints'
-import type {FailResponse, PaginatedResponse} from 'jsapp/js/dataInterface';
-import type {OrganizationMember, OrganizationMemberListItem} from './membersQuery';
+import type { FailResponse, PaginatedResponse } from 'jsapp/js/dataInterface'
+import type { OrganizationMember, OrganizationMemberListItem } from './membersQuery'
 import type { Json } from 'jsapp/js/components/common/common.interfaces'
 
 /*
@@ -136,49 +136,40 @@ export function usePatchMemberInvite(inviteUrl?: string) {
       } else return null
     },
     onMutate: (inviteUpdate) => {
-      let previousMembersQuery:
-        | PaginatedResponse<OrganizationMemberListItem>
-        | undefined = undefined;
+      let previousMembersQuery: PaginatedResponse<OrganizationMemberListItem> | undefined = undefined
       // For invitee role updates, we optimistically update relevant member
       // in the organization members list
       if (inviteUpdate.role) {
         queryClient.cancelQueries({
           queryKey: [QueryKeys.organizationMembers],
-        });
-        previousMembersQuery = queryClient.getQueryData([
-          QueryKeys.organizationMembers,
-        ]);
+        })
+        previousMembersQuery = queryClient.getQueryData([QueryKeys.organizationMembers])
         if (previousMembersQuery) {
-          const updatedMembersQuery = previousMembersQuery.results.map(
-            (member) => {
-              if (member.invite?.url === inviteUrl) {
-                const updatedInvite = {
-                  ...member.invite,
-                  invitee_role: inviteUpdate.role,
-                };
-                const updatedMember = {
-                  ...member,
-                  invite: updatedInvite,
-                };
-                return updatedMember;
+          const updatedMembersQuery = previousMembersQuery.results.map((member) => {
+            if (member.invite?.url === inviteUrl) {
+              const updatedInvite = {
+                ...member.invite,
+                invitee_role: inviteUpdate.role,
               }
-              return member;
+              const updatedMember = {
+                ...member,
+                invite: updatedInvite,
+              }
+              return updatedMember
             }
-          );
+            return member
+          })
           const newData = {
             ...previousMembersQuery,
             results: updatedMembersQuery,
-          };
-          queryClient.setQueryData([QueryKeys.organizationMembers], newData);
+          }
+          queryClient.setQueryData([QueryKeys.organizationMembers], newData)
         }
       }
-      return { previousMembersQuery };
+      return { previousMembersQuery }
     },
     onError: (_err, _inviteUpdate, context) => {
-      queryClient.setQueryData(
-        [QueryKeys.organizationMembers],
-        context?.previousMembersQuery
-      );
+      queryClient.setQueryData([QueryKeys.organizationMembers], context?.previousMembersQuery)
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -3,8 +3,8 @@ import { fetchPost, fetchGet, fetchPatchUrl, fetchDeleteUrl } from 'js/api'
 import { type OrganizationUserRole, useOrganizationQuery } from './organizationQuery'
 import { QueryKeys } from 'js/query/queryKeys'
 import { endpoints } from 'jsapp/js/api.endpoints'
-import type { FailResponse } from 'jsapp/js/dataInterface'
-import type { OrganizationMember } from './membersQuery'
+import type {FailResponse, PaginatedResponse} from 'jsapp/js/dataInterface';
+import type {OrganizationMember, OrganizationMemberListItem} from './membersQuery';
 import type { Json } from 'jsapp/js/components/common/common.interfaces'
 
 /*
@@ -130,10 +130,55 @@ export function usePatchMemberInvite(inviteUrl?: string) {
   return useMutation({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
       if (inviteUrl) {
-        return fetchPatchUrl<OrganizationMember>(inviteUrl, newInviteData, {
+        return fetchPatchUrl<MemberInvite>(inviteUrl, newInviteData, {
           errorMessageDisplay: t('There was an error updating this invitation.'),
         })
       } else return null
+    },
+    onMutate: (inviteUpdate) => {
+      let previousMembersQuery:
+        | PaginatedResponse<OrganizationMemberListItem>
+        | undefined = undefined;
+      // For invitee role updates, we optimistically update relevant member
+      // in the organization members list
+      if (inviteUpdate.role) {
+        queryClient.cancelQueries({
+          queryKey: [QueryKeys.organizationMembers],
+        });
+        previousMembersQuery = queryClient.getQueryData([
+          QueryKeys.organizationMembers,
+        ]);
+        if (previousMembersQuery) {
+          const updatedMembersQuery = previousMembersQuery.results.map(
+            (member) => {
+              if (member.invite?.url === inviteUrl) {
+                const updatedInvite = {
+                  ...member.invite,
+                  invitee_role: inviteUpdate.role,
+                };
+                const updatedMember = {
+                  ...member,
+                  invite: updatedInvite,
+                };
+                return updatedMember;
+              }
+              return member;
+            }
+          );
+          const newData = {
+            ...previousMembersQuery,
+            results: updatedMembersQuery,
+          };
+          queryClient.setQueryData([QueryKeys.organizationMembers], newData);
+        }
+      }
+      return { previousMembersQuery };
+    },
+    onError: (_err, _inviteUpdate, context) => {
+      queryClient.setQueryData(
+        [QueryKeys.organizationMembers],
+        context?.previousMembersQuery
+      );
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/jsapp/js/account/organization/membersQuery.ts
+++ b/jsapp/js/account/organization/membersQuery.ts
@@ -146,7 +146,7 @@ export default function useOrganizationMembersQuery({ limit, offset }: Paginated
   const orgId = orgQuery.data?.id
 
   return useQuery({
-    queryKey: [QueryKeys.organizationMembers, limit, offset, orgId!],
+    queryKey: [QueryKeys.organizationMembers, limit, offset, orgId],
     // `orgId!` because it's ensured to be there in `enabled` property :ok:
     queryFn: () => getOrganizationMembers(limit, offset, orgId!),
     placeholderData: keepPreviousData,

--- a/jsapp/js/account/organization/membersQuery.ts
+++ b/jsapp/js/account/organization/membersQuery.ts
@@ -129,7 +129,7 @@ export default function useOrganizationMembersQuery({ limit, offset }: Paginated
   const orgId = orgQuery.data?.id
 
   return useQuery({
-    queryKey: [QueryKeys.organizationMembers, limit, offset, orgId],
+    queryKey: [QueryKeys.organizationMembers],
     // `orgId!` because it's ensured to be there in `enabled` property :ok:
     queryFn: () => getOrganizationMembers(limit, offset, orgId!),
     placeholderData: keepPreviousData,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds optimistic updates for member role updates via the organization members table.

### 👀 Preview steps
1. As an MMO admin or owner, invite a user to join organization
2. Update the role of the invitee
3. On main, you will briefly see the role revert back to the original invitee role. On this branch, that should not happen. (Note: Step 3 may not work well if you have multiple invites pending for the org due to an unrelated bug with list ordering)
4. Try updating the role of an existing org member
5. Repeat observations in 3