### PR TITLE
feat(organizations): implement 'retry later' message for resend TASK-1532

### DIFF
--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -39,7 +39,7 @@ export default function InviteeActionsDropdown({
         )
         return
       }
-      notify(t('An error occurred while resending the invitation'), 'error')
+      // Generic error handling is done in the api client
     }
   }
 

--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -23,13 +23,20 @@ export default function InviteeActionsDropdown({
 
   const resendInvitation = async () => {
     try {
-      await patchInviteMutation.mutateAsync({ status: MemberInviteStatus.resent })
+      await patchInviteMutation.mutateAsync({
+        status: MemberInviteStatus.resent,
+      })
       notify(t('The invitation was resent'), 'success')
     } catch (e: any) {
-      if (e.responseText) {
-        const responseData = JSON.parse(e.responseText)
-        console.log(e.responseText, responseData)
-        notify(responseData.status.join(' '), 'error')
+      if (e.status === 429 && e.headers?.get('Retry-After')) {
+        const minutes = Math.ceil(parseInt(e.headers.get('Retry-After')) / 60)
+        notify(
+          t('Invitation resent too quickly, wait for ##MINUTES## minutes before retrying').replace(
+            '##MINUTES##',
+            minutes.toString(),
+          ),
+          'error',
+        )
         return
       }
       notify(t('An error occurred while resending the invitation'), 'error')

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -169,6 +169,7 @@ const fetchData = async <T>(
     const failResponse: FailResponse = {
       status: response.status,
       statusText: response.statusText,
+      headers: response.headers,
     }
 
     if (contentType && contentType.indexOf('application/json') !== -1) {

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -132,6 +132,7 @@ export interface FailResponse {
   responseText?: string
   status: number
   statusText: string
+  headers?: Headers
 }
 
 /** Have a list of errors for different fields. */


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
- Headers are now returned by API error handler FailResponse object
- When trying to resend an organization invitation too often now the user gets a proper message


### 📖 Description
We're using the response status 429 and the `retry-later` header information to properly format an error message to the user.

### 👀 Preview steps
1. ℹ️ be part of an organization
2. be admin or owner
3. invite a new member to the organization
4. Try to resend the invite via invitee actions 
5. There should be a proper message if the resend is sent too soon
