### PR TITLE
fix(projectTransferOwnership): typo causing attachment transfers to fail

### DIFF
--- a/kobo/apps/project_ownership/management/commands/resume_failed_transfers_2_024_33f_fix.py
+++ b/kobo/apps/project_ownership/management/commands/resume_failed_transfers_2_024_33f_fix.py
@@ -1,0 +1,70 @@
+from django.core.management.base import BaseCommand
+
+from ...models import (
+    Transfer,
+    TransferStatus,
+    TransferStatusChoices,
+    TransferStatusTypeChoices,
+)
+from ...utils import move_attachments
+
+
+class Command(BaseCommand):
+    help = (
+        'Resume project ownership transfers done under `2.024.33f` (and later) '
+        'which failed with error: "Model.save() got an unexpected keyword argument'
+        ' \'updated_fields\'"'
+    )
+
+    def handle(self, *args, **options):
+
+        verbosity = options['verbosity']
+
+        for transfer_status in TransferStatus.objects.filter(
+            status=TransferStatusChoices.FAILED,
+            status_type=TransferStatusTypeChoices.ATTACHMENTS,
+            error__icontains="got an unexpected keyword argument 'updated_fields'",
+        ).iterator():
+            transfer = transfer_status.transfer
+            if transfer.asset.pending_delete:
+                if verbosity:
+                    self.stdout.write(
+                        f'Project `{transfer.asset}` is in trash bin, skip it!'
+                    )
+                continue
+
+            if not self._validate_whether_transfer_can_be_fixed(transfer):
+                if verbosity:
+                    self.stdout.write(
+                        f'Project `{transfer.asset}` transfer cannot be fixed'
+                        f' automatically'
+                    )
+                continue
+
+            if not transfer.asset.has_deployment:
+                continue
+
+            if verbosity:
+                self.stdout.write(f'Resuming `{transfer.asset}` transfer…')
+
+            # We do not want any error to break the management command,
+            # so we catch any exception and log it for later purpose.
+            try:
+                if verbosity:
+                    self.stdout.write('\tMoving attachments…')
+                move_attachments(transfer)
+            except Exception as e:
+                self.stderr.write(f'Failed to move attachments: {e}')
+                TransferStatus.objects.filter(
+                    transfer=transfer,
+                    status_type=TransferStatusTypeChoices.ATTACHMENTS,
+                ).update(error=str(e), status=TransferStatusChoices.FAILED)
+
+            if verbosity:
+                self.stdout.write('\tDone!')
+
+    def _validate_whether_transfer_can_be_fixed(self, transfer: Transfer) -> bool:
+        original_new_owner_id = transfer.invite.recipient_id
+        current_owner_id = transfer.asset.owner_id
+
+        return current_owner_id == original_new_owner_id

--- a/kobo/apps/project_ownership/models/transfer.py
+++ b/kobo/apps/project_ownership/models/transfer.py
@@ -348,8 +348,8 @@ class TransferStatus(AbstractTimeStampedModel):
                 transfer_id=transfer_id, status_type=status_type
             )
             transfer_status.status = status
-            transfer_status.error = error
             transfer_status.date_modified = timezone.now()
+            transfer_status.error = cls._add_error(transfer_status, error)
             transfer_status.save(
                 update_fields=['status', 'error', 'date_modified']
             )
@@ -372,3 +372,16 @@ class TransferStatus(AbstractTimeStampedModel):
 
         if success:
             self.transfer.status = TransferStatusChoices.SUCCESS
+
+    @classmethod
+    def _add_error(cls, transfer_status, error):
+        if not error:
+            return transfer_status.error
+
+        log_date = transfer_status.date_modified.strftime('%Y-%m-%d %H:%M:%S')
+        error_message = f'[{log_date}] - {error}'
+        return (
+            f'{error_message}\n{transfer_status.error}'
+            if transfer_status.error
+            else error_message
+        )

--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -76,7 +76,7 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
             # object to the database. Fingers crossed that the process doesn't get
             # interrupted between these two operations.
             attachment.media_file.move(target_folder)
-            attachment.save(updated_fields=['media_file'])
+            attachment.save(update_fields=['media_file'])
 
             heartbeat = _update_heartbeat(heartbeat, transfer, async_task_type)
 


### PR DESCRIPTION
### 📣 Summary
Fixed a typo that caused attachment transfers to fail during project ownership transfer.


### 📖 Description
A typo in the project ownership transfer logic prevented attachments from being properly transferred along with the project. This issue caused attachments to remain associated with the previous owner, leading to inconsistencies and potential data access problems.

### Notes
A new management comments has been added to fix failed transfers `resume_failed_transfers_2_024_33f`

### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project (with attachments)
2.  Submit data with attachments
3. Transfer the project to another user
4. 🔴 [on main] notice that the transfer fails
5. 🟢 [on PR] notice that the transfer succeeds
