### PR TITLE
fix(frontend): modal width on large screens TASK-1551

### DIFF
--- a/jsapp/js/components/common/modal.scss
+++ b/jsapp/js/components/common/modal.scss
@@ -31,7 +31,6 @@ $z-modal-x: 10;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  min-width: 40%;
   max-width: 90%;
   max-height: 95%;
   overflow-x: auto;


### PR DESCRIPTION
### 👀 Preview steps

Bug template:
1. ℹ️ have an account
2. Click on NEW button to create a project
3. Increase screen width or zoom out 
4. 🔴 [on main] notice how the modal expands and the content is not centered
5. 🟢 [on PR] notice how the modal has a fixed width
