### PR TITLE
fix(organization)!: Ensure email is sent on invitation resent status TASK-1549

### DIFF
--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -498,8 +498,6 @@ class OrgMembershipInviteSerializer(serializers.ModelSerializer):
                         retry_after=remaining_seconds,
                     )
 
-                value = OrganizationInviteStatusChoices.PENDING
-
         return value
 
     def update(self, instance, validated_data):
@@ -537,15 +535,21 @@ class OrgMembershipInviteSerializer(serializers.ModelSerializer):
                 raise NotFound({'detail': t(INVITE_NOT_FOUND_ERROR)})
 
     def _handle_status_update(self, instance, status):
-        instance.status = OrganizationInviteStatusChoices[status.upper()]
+        if status == OrganizationInviteStatusChoices.RESENT:
+            instance.status = OrganizationInviteStatusChoices.PENDING
+        else:
+            instance.status = OrganizationInviteStatusChoices[status.upper()]
         instance.save(update_fields=['status', 'modified'])
         self._send_status_email(instance, status)
 
     def _send_status_email(self, instance, status):
         status_map = {
-            'accepted': instance.send_acceptance_email,
-            'declined': instance.send_refusal_email,
-            'resent': instance.send_invite_email
+            OrganizationInviteStatusChoices.ACCEPTED:
+                instance.send_acceptance_email,
+            OrganizationInviteStatusChoices.DECLINED:
+                instance.send_refusal_email,
+            OrganizationInviteStatusChoices.RESENT:
+                instance.send_invite_email,
         }
 
         email_func = status_map.get(status)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure that an email is sent when an invitation is resent.



### 📖 Description
Fixed the logic for handling the "resent" status in invitations and updated the unit test to verify that an email is correctly sent when an invitation is resent.
