### PR TITLE
fix(frontend root): redirect to log in

### DIFF
--- a/jsapp/js/app.jsx
+++ b/jsapp/js/app.jsx
@@ -32,7 +32,6 @@ import { MantineProvider } from '@mantine/core'
 // Query-related
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from './query/queryClient.ts'
-import { RequireOrg } from './router/RequireOrg'
 import { themeKobo } from './theme'
 
 class App extends React.Component {
@@ -107,34 +106,32 @@ class App extends React.Component {
         <QueryClientProvider client={queryClient}>
           <MantineProvider theme={themeKobo}>
             <RootContextProvider>
-              <RequireOrg>
-                <Tracking />
-                <ToasterConfig />
+              <Tracking />
+              <ToasterConfig />
 
-                {this.shouldDisplayMainLayoutElements() && <div className='header-stretch-bg' />}
+              {this.shouldDisplayMainLayoutElements() && <div className='header-stretch-bg' />}
 
-                <bem.PageWrapper m={pageWrapperModifiers} className='mdl-layout mdl-layout--fixed-header'>
-                  {this.state.pageState.modal && <BigModal params={this.state.pageState.modal} />}
+              <bem.PageWrapper m={pageWrapperModifiers} className='mdl-layout mdl-layout--fixed-header'>
+                {this.state.pageState.modal && <BigModal params={this.state.pageState.modal} />}
 
+                {this.shouldDisplayMainLayoutElements() && (
+                  <>
+                    <MainHeader assetUid={assetid} />
+                    <Drawer />
+                  </>
+                )}
+
+                <bem.PageWrapper__content className='mdl-layout__content' m={pageWrapperContentModifiers}>
                   {this.shouldDisplayMainLayoutElements() && (
                     <>
-                      <MainHeader assetUid={assetid} />
-                      <Drawer />
+                      {this.isFormSingle() && <ProjectTopTabs />}
+                      <FormViewSideTabs show={this.isFormSingle()} />
                     </>
                   )}
 
-                  <bem.PageWrapper__content className='mdl-layout__content' m={pageWrapperContentModifiers}>
-                    {this.shouldDisplayMainLayoutElements() && (
-                      <>
-                        {this.isFormSingle() && <ProjectTopTabs />}
-                        <FormViewSideTabs show={this.isFormSingle()} />
-                      </>
-                    )}
-
-                    <Outlet />
-                  </bem.PageWrapper__content>
-                </bem.PageWrapper>
-              </RequireOrg>
+                  <Outlet />
+                </bem.PageWrapper__content>
+              </bem.PageWrapper>
             </RootContextProvider>
           </MantineProvider>
 

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -2,20 +2,27 @@ import React, { Suspense, useEffect, useState } from 'react'
 import sessionStore from 'js/stores/session'
 import LoadingSpinner from '../components/common/loadingSpinner'
 import { redirectToLogin } from './routerUtils'
+import { useOrganizationQuery } from '../account/organization/organizationQuery'
+import { RequireOrg } from './RequireOrg'
 
 interface Props {
   children: React.ReactNode
-  redirect?: boolean
 }
 
-export default function RequireAuth({ children, redirect = true }: Props) {
+export default function RequireAuth({ children }: Props) {
   const [session] = useState(() => sessionStore)
 
   useEffect(() => {
-    if (redirect && !session.isLoggedIn) {
+    if (!session.isLoggedIn) {
       redirectToLogin()
     }
-  }, [session.isLoggedIn, redirect])
+  }, [session.isLoggedIn])
 
-  return redirect && session.isLoggedIn ? <Suspense fallback={null}>{children}</Suspense> : <LoadingSpinner />
+  return session.isLoggedIn ? (
+    <Suspense fallback={null}>
+      <RequireOrg>{children}</RequireOrg>
+    </Suspense>
+  ) : (
+    <LoadingSpinner />
+  )
 }

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -2,7 +2,6 @@ import React, { Suspense, useEffect, useState } from 'react'
 import sessionStore from 'js/stores/session'
 import LoadingSpinner from '../components/common/loadingSpinner'
 import { redirectToLogin } from './routerUtils'
-import { useOrganizationQuery } from '../account/organization/organizationQuery'
 import { RequireOrg } from './RequireOrg'
 
 interface Props {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Not logged users are now properly redirected to login screen when accessing parts of the app that requires auth

### 📖 Description
- `RequireOrg` component was locking app into loading state and not moving forward to redirect
- `RequireOrg` was moved into `requireAuth` component so Org is only fetched when user is logged in

### 👀 Preview steps
1. ℹ️ log out of the app
2. try to access `/#/forms`
3. 🔴 [on main] user gets locked in an infinite loading
4. 🟢 [on PR] user is properly redirected to login screen
