### PR TITLE
fix(organization): ensure data transfer occurs upon invite acceptance TASK-1556

### DIFF
--- a/kobo/apps/organizations/tests/test_organization_invitations.py
+++ b/kobo/apps/organizations/tests/test_organization_invitations.py
@@ -28,6 +28,7 @@ from kobo.apps.organizations.tests.test_organizations_api import (
     BaseOrganizationAssetApiTestCase
 )
 from kpi.models import Asset
+from kpi.tests.utils.transaction import immediate_on_commit
 from kpi.urls.router_api_v2 import URL_NAMESPACE
 from kpi.utils.placeholders import replace_placeholders
 
@@ -309,11 +310,12 @@ class OrganizationInviteTestCase(BaseOrganizationInviteTestCase):
         invitation = OrganizationInvitation.objects.get(
             invitee=self.external_user
         )
-        response = self._update_invite(
-            self.external_user,
-            invitation.guid,
-            OrganizationInviteStatusChoices.ACCEPTED,
-        )
+        with immediate_on_commit():
+            response = self._update_invite(
+                self.external_user,
+                invitation.guid,
+                OrganizationInviteStatusChoices.ACCEPTED,
+            )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data['status'], OrganizationInviteStatusChoices.ACCEPTED


### PR DESCRIPTION
### 📣 Summary
Fixed an issue where data transfer was not triggered when an invite was accepted.


### 📖 Description
A bug prevented data from being transferred when an invited user accepted an organization invitation. This fix ensures that upon acceptance, the transfer process is correctly triggered, allowing data associated with the user to be reassigned to the organization as intended.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project from a standalone user (UserA)
2. login as a MMO owner/admin 
3. invite UserA to join the MMO 
4. 🔴 [on main] notice that project is never transferred to the org
5. 🟢 [on PR] notice that project is transferred to the org
