### PR TITLE
fix(organizations): hide member table role selectors for members TASK-1557

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -96,23 +96,13 @@ export default function MembersRoute() {
       size: 140,
       cellFormatter: (obj: OrganizationMemberListItem) => {
         const { invite, member } = getMemberOrInviteDetails(obj)
-        if (invite) {
-          return (
-            <MemberRoleSelector
-              username={invite.invitee}
-              role={invite.invitee_role}
-              currentUserRole={orgQuery.data.request_user_role}
-              inviteUrl={invite.url}
-            />
-          )
-        }
         if (
-          member!.role === OrganizationUserRole.owner ||
+          member?.role === OrganizationUserRole.owner ||
           !['owner', 'admin'].includes(orgQuery.data.request_user_role)
         ) {
           // If the member is the Owner or
           // If the user is not an owner or admin, we don't show the selector
-          switch (member!.role) {
+          switch (member?.role || invite?.invitee_role) {
             case OrganizationUserRole.owner:
               return t('Owner')
             case OrganizationUserRole.admin:
@@ -122,6 +112,16 @@ export default function MembersRoute() {
             default:
               return t('Unknown')
           }
+        }
+        if (invite) {
+          return (
+            <MemberRoleSelector
+              username={invite.invitee}
+              role={invite.invitee_role}
+              currentUserRole={orgQuery.data.request_user_role}
+              inviteUrl={invite.url}
+            />
+          )
         }
         return (
           <MemberRoleSelector


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes bug that was rendering invitee role selectors for users who were not MMO  admins or owners.

### 👀 Preview steps
1. As an MMO owner, invite a new member to your organization
2. As a member of the same MMO, open the members table
3. On main, you will see a role selector for the invitee. On this branch, you should only see text reflecting the invitee's role with no option for changing it.