### PR TITLE
feat(OrgInviteModal): better handling of custom errors TASK-1093

### DIFF
--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -14,6 +14,7 @@ import { getSimpleMMOLabel } from 'js/account/organization/organization.utils'
 import envStore from 'jsapp/js/envStore'
 import subscriptionStore from 'jsapp/js/account/subscriptionStore'
 import { notify } from 'jsapp/js/utils'
+import { useSession } from 'jsapp/js/stores/useSession'
 // Constants and types
 import { endpoints } from 'jsapp/js/api.endpoints'
 
@@ -30,8 +31,11 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
   )
 
   const [isModalOpen, setIsModalOpen] = useState(true)
+  const session = useSession()
   const orgMemberInviteQuery = useOrgMemberInviteQuery(props.orgId, props.inviteId)
-  const patchMemberInvite = usePatchMemberInvite(inviteUrl)
+  const patchMemberInvite = usePatchMemberInvite(inviteUrl, false)
+  // We handle all the errors through query and BE responses, but for some edge cases we have this:
+  const [miscError, setMiscError] = useState<string | undefined>()
 
   const mmoLabel = getSimpleMMOLabel(envStore.data, subscriptionStore.activeSubscriptions[0])
 
@@ -44,7 +48,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
       setIsModalOpen(false)
       notify(t('Invitation successfully declined'))
     } catch (error) {
-      notify(t('Failed to decline the invitation'), 'error')
+      setMiscError(t('Unknown error while trying to update an invitation'))
     }
   }
 
@@ -54,20 +58,24 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
       setIsModalOpen(false)
       notify(t('Invitation successfully accepted'))
     } catch (error) {
-      notify(t('Failed to accept the invitation'), 'error')
+      setMiscError(t('Unknown error while trying to update an invitation'))
     }
+  }
+
+  const handleSignOut = () => {
+    session.logOut()
   }
 
   let content: React.ReactNode = null
   let title: React.ReactNode = null
 
-  // Case 1: loading data
+  // Case 1: loading data.
   if (orgMemberInviteQuery.isLoading) {
     content = <LoadingSpinner />
   }
-  // Case 2: failed to get the invite
+  // Case 2: failed to get the invitation data from API.
   else if (orgMemberInviteQuery.isError) {
-    title = t('Unable to join ##TEAM_OR_ORGANIZATION_NAME##').replace('##TEAM_OR_ORGANIZATION_NAME##', orgName)
+    title = t('Invitation not found')
     content = (
       <Alert type='error'>
         {t('Could not find invitation ##invite_id## from organization ##org_id##')
@@ -75,6 +83,41 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
           .replace('##org_id##', props.orgId)}
       </Alert>
     )
+  }
+  // Case 3: failed to accept or decline invitation (API response).
+  else if (patchMemberInvite.isError) {
+    title = t('Unable to join ##TEAM_OR_ORGANIZATION_NAME##').replace('##TEAM_OR_ORGANIZATION_NAME##', orgName)
+    // Fallback message
+    let patchMemberInviteErrorMessage = t('Failed to respond to invitation')
+    if (patchMemberInvite.error?.responseJSON?.detail) {
+      patchMemberInviteErrorMessage = patchMemberInvite.error.responseJSON.detail
+    }
+    content = (
+      <Stack>
+        <Alert type='error'>{patchMemberInviteErrorMessage}</Alert>
+
+        <Group justify='flex-end'>
+          <Button
+            variant='light'
+            size='lg'
+            onClick={() => {
+              setIsModalOpen(false)
+            }}
+          >
+            {t('Cancel')}
+          </Button>
+
+          <Button variant='filled' size='lg' onClick={handleSignOut}>
+            {t('Sign out')}
+          </Button>
+        </Group>
+      </Stack>
+    )
+  }
+  // Case 4: failed to accept or decline invitation (misc error)
+  else if (miscError) {
+    title = t('Unable to join ##TEAM_OR_ORGANIZATION_NAME##').replace('##TEAM_OR_ORGANIZATION_NAME##', orgName)
+    content = <Alert type='error'>{miscError}</Alert>
   }
   // Case 3: got the invite, its status is pending, so we display form
   else if (orgMemberInviteQuery.data?.status === MemberInviteStatus.pending) {

--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -32,7 +32,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
 
   const [isModalOpen, setIsModalOpen] = useState(true)
   const session = useSession()
-  const orgMemberInviteQuery = useOrgMemberInviteQuery(props.orgId, props.inviteId)
+  const orgMemberInviteQuery = useOrgMemberInviteQuery(props.orgId, props.inviteId, false)
   const patchMemberInvite = usePatchMemberInvite(inviteUrl, false)
   // We handle all the errors through query and BE responses, but for some edge cases we have this:
   const [miscError, setMiscError] = useState<string | undefined>()
@@ -76,13 +76,14 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
   // Case 2: failed to get the invitation data from API.
   else if (orgMemberInviteQuery.isError) {
     title = t('Invitation not found')
-    content = (
-      <Alert type='error'>
-        {t('Could not find invitation ##invite_id## from organization ##org_id##')
-          .replace('##invite_id##', props.inviteId)
-          .replace('##org_id##', props.orgId)}
-      </Alert>
-    )
+    // Fallback message
+    let memberInviteErrorMessage = t('Could not find invitation ##invite_id## from organization ##org_id##')
+      .replace('##invite_id##', props.inviteId)
+      .replace('##org_id##', props.orgId)
+    if (orgMemberInviteQuery.error?.responseJSON?.detail) {
+      memberInviteErrorMessage = orgMemberInviteQuery.error.responseJSON.detail
+    }
+    content = <Alert type='error'>{memberInviteErrorMessage}</Alert>
   }
   // Case 3: failed to accept or decline invitation (API response).
   else if (patchMemberInvite.isError) {

--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react'
 // Partial components
 import Alert from 'js/components/common/alert'
-import { Modal, Button, Stack, Text, Group } from '@mantine/core'
+import { Modal, Button, Stack, Text, Group, FocusTrap } from '@mantine/core'
 import LoadingSpinner from 'jsapp/js/components/common/loadingSpinner'
 // Stores, hooks and utilities
 import {
@@ -168,6 +168,8 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
       }}
       title={title}
     >
+      {/* We don't want "x" button to get focus (see https://mantine.dev/core/modal/#initial-focus) */}
+      <FocusTrap.InitialFocus />
       {content}
     </Modal>
   )

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
-import { fetchPost, fetchGet, fetchPatchUrl, fetchDeleteUrl } from 'js/api'
+import { fetchPost, fetchGet, fetchPatchUrl, fetchDeleteUrl, FetchDataOptions } from 'js/api'
 import { type OrganizationUserRole, useOrganizationQuery } from './organizationQuery'
 import { QueryKeys } from 'js/query/queryKeys'
 import { endpoints } from 'jsapp/js/api.endpoints'
@@ -123,9 +123,11 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string) => {
  */
 export function usePatchMemberInvite(inviteUrl?: string, displayErrorNotification = true) {
   const queryClient = useQueryClient()
-  let fetchOptions = {}
+  const fetchOptions: FetchDataOptions = {}
   if (displayErrorNotification) {
-    fetchOptions = {errorMessageDisplay: t('There was an error updating this invitation.')}
+    fetchOptions.errorMessageDisplay = t('There was an error updating this invitation.')
+  } else {
+    fetchOptions.notifyAboutError = false
   }
   return useMutation<MemberInvite | null, Error & FailResponse, Partial<MemberInviteUpdate>>({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -102,13 +102,19 @@ export function useRemoveMemberInvite() {
 /**
  * A hook that gives you a single organization member invite.
  */
-export const useOrgMemberInviteQuery = (orgId: string, inviteId: string) => {
+export const useOrgMemberInviteQuery = (orgId: string, inviteId: string, displayErrorNotification = true) => {
   const apiPath = endpoints.ORG_MEMBER_INVITE_DETAIL_URL.replace(':organization_id', orgId!).replace(
     ':invite_id',
     inviteId,
   )
+  const fetchOptions: FetchDataOptions = {}
+  if (displayErrorNotification) {
+    fetchOptions.errorMessageDisplay = t('There was an error getting this invitation.')
+  } else {
+    fetchOptions.notifyAboutError = false
+  }
   return useQuery<MemberInvite, FailResponse>({
-    queryFn: () => fetchGet<MemberInvite>(apiPath),
+    queryFn: () => fetchGet<MemberInvite>(apiPath, fetchOptions),
     queryKey: [QueryKeys.organizationMemberInviteDetail, apiPath],
   })
 }

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -118,15 +118,19 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string) => {
  * the status of the invite (e.g. decline invite). It ensures that both
  * `membersQuery` and `useOrgMemberInviteQuery` will refetch data (by
  * invalidation).
+ *
+ * If you want to handle errors in your component, use `displayErrorNotification`.
  */
-export function usePatchMemberInvite(inviteUrl?: string) {
+export function usePatchMemberInvite(inviteUrl?: string, displayErrorNotification = true) {
   const queryClient = useQueryClient()
-  return useMutation({
+  let fetchOptions = {}
+  if (displayErrorNotification) {
+    fetchOptions = {errorMessageDisplay: t('There was an error updating this invitation.')}
+  }
+  return useMutation<MemberInvite | null, Error & FailResponse, Partial<MemberInviteUpdate>>({
     mutationFn: async (newInviteData: Partial<MemberInviteUpdate>) => {
       if (inviteUrl) {
-        return fetchPatchUrl<MemberInvite>(inviteUrl, newInviteData, {
-          errorMessageDisplay: t('There was an error updating this invitation.'),
-        })
+        return fetchPatchUrl<MemberInvite>(inviteUrl, newInviteData, fetchOptions)
       } else return null
     },
     onMutate: async (mutationData) => {

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -115,7 +115,7 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string, display
   }
   return useQuery<MemberInvite, FailResponse>({
     queryFn: () => fetchGet<MemberInvite>(apiPath, fetchOptions),
-    queryKey: [QueryKeys.organizationMemberInviteDetail, apiPath],
+    queryKey: [QueryKeys.organizationMemberInviteDetail, apiPath, fetchOptions],
   })
 }
 

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -84,7 +84,7 @@ const JSON_HEADER = 'application/json'
 
 type FetchHttpMethod = 'GET' | 'PUT' | 'POST' | 'PATCH' | 'DELETE'
 
-interface FetchDataOptions {
+export interface FetchDataOptions {
   /**
    * By default we display an error toast notification when response is not good
    * and the error code is clearly error. If you need to handle the notification


### PR DESCRIPTION
### 📣 Summary
Use error message provided by the endpoint if possible. Otherwise use generic error. Also avoid displaying multiple error notifications in the modal.

### 💭 Notes
Changed `usePatchMemberInvite` to make the error notification optional. Also fixed "x" button getting auto focused when modal was opened.

### 👀 Preview steps

Reproduction:
1. ℹ️ create an invite for "joe" (not a member of organization)
2. log in as other user (member of organizatio)
3. open invite link
4. notice that the invitation modal opens
5. click "Accept" or "Decline"
6. 🟢 notice that the content of the modal changes into error message
7. 🟢 notice that error notification no longer appear (they appear in `main`)
