### PR TITLE
fix(frontend): add `background-geopoint` question type to display in data table TASK-1457

### DIFF
--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -173,6 +173,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       case QUESTION_TYPES.geopoint.id:
       case QUESTION_TYPES.geotrace.id:
       case QUESTION_TYPES.geoshape.id:
+      case QUESTION_TYPES['background-geopoint'].id:
         return this.renderPointsData(item.data)
       default:
         // all types not specified above just returns raw data

--- a/jsapp/js/constants.ts
+++ b/jsapp/js/constants.ts
@@ -188,6 +188,7 @@ export enum QuestionTypeName {
   acknowledge = 'acknowledge',
   audio = 'audio',
   'background-audio' = 'background-audio',
+  'background-geopoint' = 'background-geopoint',
   barcode = 'barcode',
   calculate = 'calculate',
   date = 'date',
@@ -255,6 +256,11 @@ export const QUESTION_TYPES: QuestionTypes = Object.freeze({
     label: t('Background Audio'),
     icon: 'qt-background-audio',
     id: QuestionTypeName['background-audio'],
+  },
+  'background-geopoint': {
+    label: t('Background Geopoint'),
+    icon: 'qt-point',
+    id: QuestionTypeName['background-geopoint'],
   },
   barcode: {
     label: t('Barcode / QR Code'),


### PR DESCRIPTION
### 👀 Preview steps

1. ℹ️ have an account 
2. Create a project with a background-geopoint question (upload this form: 
[Simple_background_geo.xlsx](https://github.com/user-attachments/files/18790862/Simple_background_geo.xlsx))
3. deploy the project and make some submissions
4. Go to the Data table 
5. 🔴 [on main] notice that the data is displayed as a text in the Data table and missing in the single submission view
6. 🟢 [on PR] notice that the background-geopoint data is displayed as a geopoint in the Data table and single submission view
