### PR TITLE
fix(translations): use trimmed in all blocktrans blocks TASK-1553

### DIFF
--- a/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_message.txt
@@ -1,11 +1,11 @@
 {% load i18n %}
 {% load url_creation %}
-{% blocktrans %}To confirm the new email address associated with your KoboToolbox account, please follow the link below.{% endblocktrans %}
+{% blocktrans trimmed %}To confirm the new email address associated with your KoboToolbox account, please follow the link below.{% endblocktrans %}
 
 {{ activate_url }}
 
-{% blocktrans %}This link will expire in one hour. To request a new verification link, please go to your account settings and re-enter your new email address:{% endblocktrans %}
+{% blocktrans trimmed %}This link will expire in one hour. To request a new verification link, please go to your account settings and re-enter your new email address:{% endblocktrans %}
 {% account_security %}
 
-{% blocktrans %}Best,{% endblocktrans %}
+{% blocktrans trimmed %}Best,{% endblocktrans %}
 KoboToolbox

--- a/kobo/apps/accounts/templates/account/email/email_confirmation_signup_message.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_signup_message.txt
@@ -7,13 +7,13 @@
 {% if content.section_one or content.section_one == '' %}
 {% convert_placeholders content.section_one activate_url user %}
 {% else %}
-{% blocktrans %}Thanks for signing up with KoboToolbox!{% endblocktrans %}
+{% blocktrans trimmed %}Thanks for signing up with KoboToolbox!{% endblocktrans %}
 
-{% blocktrans %}Confirming your account will give you access to KoboToolbox applications. Please visit the following URL to finish activation of your new account.{% endblocktrans %}
+{% blocktrans trimmed %}Confirming your account will give you access to KoboToolbox applications. Please visit the following URL to finish activation of your new account.{% endblocktrans %}
 
 {{ activate_url }}
 
-{% blocktrans %}Your username is: {% endblocktrans %}{{ user }}
+{% blocktrans trimmed %}Your username is: {% endblocktrans %}{{ user }}
 
 {% endif %}
 {% endspaceless %}
@@ -22,11 +22,11 @@
 {% if content.section_two or content.section_two == '' %}
 {% convert_placeholders content.section_two activate_url user %}
 {% else %}
-{% blocktrans %}For help getting started, check out the KoboToolbox user documentation: https://support.kobotoolbox.com {% endblocktrans %}
+{% blocktrans trimmed %}For help getting started, check out the KoboToolbox user documentation: https://support.kobotoolbox.com {% endblocktrans %}
 
-{% blocktrans %}You can also join the KoboToolbox community forum to ask questions, share solutions, and chat with thousands of users: https://community.kobotoolbox.org{% endblocktrans %}
+{% blocktrans trimmed %}You can also join the KoboToolbox community forum to ask questions, share solutions, and chat with thousands of users: https://community.kobotoolbox.org{% endblocktrans %}
 
-{% blocktrans %}Best,{% endblocktrans %}
+{% blocktrans trimmed %}Best,{% endblocktrans %}
 KoboToolbox
 {% endif %}
 {% endspaceless %}

--- a/kobo/apps/accounts/templates/account/email/email_confirmation_signup_subject.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_signup_subject.txt
@@ -7,7 +7,7 @@
 {% if content.subject %}
     {{ content.subject }}
 {% else %}
-    {% blocktrans %}Activate your KoboToolbox Account{% endblocktrans %}
+    {% blocktrans trimmed %}Activate your KoboToolbox Account{% endblocktrans %}
 {% endif %}
 {% endwith %}
 {% endspaceless %}

--- a/kobo/apps/accounts/templates/account/email/email_confirmation_subject.txt
+++ b/kobo/apps/accounts/templates/account/email/email_confirmation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}KoboToolbox account email address verification{% endblocktrans %}
+{% blocktrans trimmed %}KoboToolbox account email address verification{% endblocktrans %}
 {% endautoescape %}

--- a/kobo/apps/accounts/templates/account/email/password_reset_key_message.txt
+++ b/kobo/apps/accounts/templates/account/email/password_reset_key_message.txt
@@ -1,16 +1,16 @@
 {% load i18n %}
 
 {% block content %}{% autoescape off %}
-{% blocktrans %}Hello from KoboToolbox,{% endblocktrans %}
+{% blocktrans trimmed %}Hello from KoboToolbox,{% endblocktrans %}
 
-{% blocktrans %}We’ve received a password reset request for your user account.{% endblocktrans %}
+{% blocktrans trimmed %}We’ve received a password reset request for your user account.{% endblocktrans %}
 
-{% blocktrans %}To reset your password, click the link below.{% endblocktrans %}
+{% blocktrans trimmed %}To reset your password, click the link below.{% endblocktrans %}
 {{ password_reset_url }}
 
-{% blocktrans %}Your username is {{ username }}.{% endblocktrans %}{% endautoescape %}{% endblock %}
+{% blocktrans trimmed %}Your username is {{ username }}.{% endblocktrans %}{% endautoescape %}{% endblock %}
 
-{% blocktrans %}If you did not request a password reset, you can safely ignore this email.{% endblocktrans %}
+{% blocktrans trimmed %}If you did not request a password reset, you can safely ignore this email.{% endblocktrans %}
 
-{% blocktrans %}Best,{% endblocktrans %}
+{% blocktrans trimmed %}Best,{% endblocktrans %}
 KoboToolbox

--- a/kobo/apps/accounts/templates/account/email/password_reset_key_subject.txt
+++ b/kobo/apps/accounts/templates/account/email/password_reset_key_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}KoboToolbox Password Reset{% endblocktrans %}
+{% blocktrans trimmed %}KoboToolbox Password Reset{% endblocktrans %}
 {% endautoescape %}

--- a/kobo/apps/accounts/templates/account/email/unknown_account_message.txt
+++ b/kobo/apps/accounts/templates/account/email/unknown_account_message.txt
@@ -2,15 +2,15 @@
 
 {% block content %}{% autoescape off %}
 
-{% blocktrans %}Hello from KoboToolbox,{% endblocktrans %}
-{% blocktrans %}You are receiving this email because you or someone else has requested a password for their KoboToolbox account.{% endblocktrans %}
-{% blocktrans %}However, we do not have any record of an account with email {{ email }} in our database.{% endblocktrans %}
+{% blocktrans trimmed %}Hello from KoboToolbox,{% endblocktrans %}
+{% blocktrans trimmed %}You are receiving this email because you or someone else has requested a password for their KoboToolbox account.{% endblocktrans %}
+{% blocktrans trimmed %}However, we do not have any record of an account with email {{ email }} in our database.{% endblocktrans %}
 
-{% blocktrans %}If you did not request a password reset, you can safely ignore this email.{% endblocktrans %}
+{% blocktrans trimmed %}If you did not request a password reset, you can safely ignore this email.{% endblocktrans %}
 
-{% blocktrans %}If it was you, please try another email address you might have used to create your account, or double check that your account was not registered on a different KoboToolbox server.{% endblocktrans %}
+{% blocktrans trimmed %}If it was you, please try another email address you might have used to create your account, or double check that your account was not registered on a different KoboToolbox server.{% endblocktrans %}
 
 {{ signup_url }}{% endautoescape %}{% endblock %}
 
-{% blocktrans %}Best,{% endblocktrans %}
+{% blocktrans trimmed %}Best,{% endblocktrans %}
 KoboToolbox

--- a/kobo/apps/accounts/templates/account/email/unknown_account_subject.txt
+++ b/kobo/apps/accounts/templates/account/email/unknown_account_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}KoboToolbox Password Reset Unsuccessful{% endblocktrans %}
+{% blocktrans trimmed %}KoboToolbox Password Reset Unsuccessful{% endblocktrans %}
 {% endautoescape %}

--- a/kobo/apps/accounts/templates/account/email_confirm.html
+++ b/kobo/apps/accounts/templates/account/email_confirm.html
@@ -36,7 +36,7 @@
     {% url 'account_email' as email_url %}
 
     <p class="registration__message">
-      {% blocktrans %}This e-mail confirmation link expired or is invalid.
+      {% blocktrans trimmed %}This e-mail confirmation link expired or is invalid.
       If you need to request a new link to verify your email address change,
       please go to your account settings page and enter your email address again.{% endblocktrans %}
     </p>

--- a/kobo/apps/accounts/templates/socialaccount/authentication_error.html
+++ b/kobo/apps/accounts/templates/socialaccount/authentication_error.html
@@ -14,7 +14,7 @@
     {% endslot %}
     {% slot body %}
 
-      <p>{% blocktrans %}An error occurred while attempting to login using your SSO account.{% endblocktrans %}</p>
+      <p>{% blocktrans trimmed %}An error occurred while attempting to login using your SSO account.{% endblocktrans %}</p>
     {% endslot %}
     {% slot actions %}
       <p><a href="{% url 'account_login' %}">{% trans "Go back" %}</a></p>

--- a/kobo/apps/accounts/templates/socialaccount/connections.html
+++ b/kobo/apps/accounts/templates/socialaccount/connections.html
@@ -12,7 +12,7 @@
     {% slot body %}
     {% if form.accounts %}
         <p>
-            {% blocktrans %}You can sign in to your KoboToolbox account using any of the following SSO providers:{% endblocktrans %}
+            {% blocktrans trimmed %}You can sign in to your KoboToolbox account using any of the following SSO providers:{% endblocktrans %}
         </p>
         {% url 'socialaccount_connections' as action_url %}
         {% element form form=form method="post" action=action_url %}

--- a/kobo/apps/accounts/templates/socialaccount/login.html
+++ b/kobo/apps/accounts/templates/socialaccount/login.html
@@ -13,25 +13,25 @@
     {# "Connect" #}
     <h1>{% trans "Set up Single Sign On" %}</h1>
                    {# "Connect with SSO" #}
-    <p>{% blocktrans %}Click the button below to connect your KoboToolbox account with your {{ appname }} account.{% endblocktrans %}
+    <p>{% blocktrans trimmed %}Click the button below to connect your KoboToolbox account with your {{ appname }} account.{% endblocktrans %}
     </p>
     <p>{% trans "This will allow you to use single sign-on (SSO) in the future." %}</p>
     <button
       type="submit"
       class="kobo-button kobo-button--sso kobo-button--fullwidth"
     >
-      {% blocktrans %}Connect with {{ appname }}{% endblocktrans %}
+      {% blocktrans trimmed %}Connect with {{ appname }}{% endblocktrans %}
     </button>
   {% else %}
     {# "Log in" #}
     <h1>{% trans "Log in with " %} {{ appname }}</h1>
 
-    <p>{% blocktrans %}Log in to KoboToolbox with your {{ appname }} account.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed %}Log in to KoboToolbox with your {{ appname }} account.{% endblocktrans %}</p>
     <button
       type="submit"
       class="kobo-button kobo-button--sso kobo-button--fullwidth"
     >
-      {% blocktrans %}Log in{% endblocktrans %}
+      {% blocktrans trimmed %}Log in{% endblocktrans %}
     </button>
   {% endif %}
   {% csrf_token %}

--- a/kobo/apps/accounts/templates/socialaccount/signup.html
+++ b/kobo/apps/accounts/templates/socialaccount/signup.html
@@ -10,12 +10,12 @@
   {% if form.username and form.username.value %}
   <h1>{% blocktrans with username=form.username.value %}Welcome to KoboToolbox, {{username}}!{% endblocktrans %}</h1>
   {% else %}
-  <h1>{% blocktrans %}Welcome to KoboToolbox!{% endblocktrans %}</h1>
+  <h1>{% blocktrans trimmed %}Welcome to KoboToolbox!{% endblocktrans %}</h1>
   {% endif %}
 
   {# Helptext #}
   {% get_provider_appname account.get_provider as appname %}
-  <p>{% blocktrans %}You are about to use your {{ appname }} account to login to KoboToolbox.{% endblocktrans %} {% trans "As a final step, please complete the following form" %}:</p>
+  <p>{% blocktrans trimmed %}You are about to use your {{ appname }} account to login to KoboToolbox.{% endblocktrans %} {% trans "As a final step, please complete the following form" %}:</p>
 
   {% csrf_token %}
 

--- a/kobo/apps/accounts/tests/test_email_content.py
+++ b/kobo/apps/accounts/tests/test_email_content.py
@@ -135,6 +135,7 @@ class EmailContentModelTestCase(TestCase):
         ENABLE_PASSWORD_CUSTOM_CHARACTER_RULES_VALIDATION=False,
     )
     def test_default_activation_email_template(self):
+        self.maxDiff = None
         username = 'user003'
         email = username + '@example.com'
         data = {
@@ -150,7 +151,7 @@ class EmailContentModelTestCase(TestCase):
                        "KoboToolbox applications. Please visit the following " \
                        "URL to finish activation of your new account."
         default_closing = "For help getting started, check out the KoboToolbox " \
-                          "user documentation: https://support.kobotoolbox.com "
+                          "user documentation: https://support.kobotoolbox.com"
         request = self.client.post(self.signup_url, data)
         user = get_user_model().objects.get(email=email)
         assert request.status_code == status.HTTP_302_FOUND

--- a/kobo/apps/accounts/tests/test_email_content.py
+++ b/kobo/apps/accounts/tests/test_email_content.py
@@ -135,7 +135,6 @@ class EmailContentModelTestCase(TestCase):
         ENABLE_PASSWORD_CUSTOM_CHARACTER_RULES_VALIDATION=False,
     )
     def test_default_activation_email_template(self):
-        self.maxDiff = None
         username = 'user003'
         email = username + '@example.com'
         data = {

--- a/kobo/apps/accounts/tests/test_email_content.py
+++ b/kobo/apps/accounts/tests/test_email_content.py
@@ -150,8 +150,8 @@ class EmailContentModelTestCase(TestCase):
         default_body = "Confirming your account will give you access to " \
                        "KoboToolbox applications. Please visit the following " \
                        "URL to finish activation of your new account."
-        default_closing = "For help getting started, check out the KoboToolbox " \
-                          "user documentation: https://support.kobotoolbox.com"
+        default_closing = 'For help getting started, check out the KoboToolbox ' \
+                          'user documentation: https://support.kobotoolbox.com'
         request = self.client.post(self.signup_url, data)
         user = get_user_model().objects.get(email=email)
         assert request.status_code == status.HTTP_302_FOUND

--- a/kobo/apps/openrosa/apps/main/templates/restricted_access.html
+++ b/kobo/apps/openrosa/apps/main/templates/restricted_access.html
@@ -5,7 +5,7 @@
     {% trans "403 - Restricted access" %}
   </h3>
 
-  {% blocktrans %}
+  {% blocktrans trimmed %}
     Your access is restricted. Please reclaim your access by <a href="{{ koboform_url }}/accounts/password/reset/">changing your password</a>.
   {% endblocktrans %}
 

--- a/kobo/apps/openrosa/apps/viewer/templates/export_list.html
+++ b/kobo/apps/openrosa/apps/viewer/templates/export_list.html
@@ -7,7 +7,7 @@
 
 <header class="data-page__header">
     <hgroup class="container">
-      <h1>{{ export_type_name|upper }} {% blocktrans %}Exports{% endblocktrans %}</h1>
+      <h1>{{ export_type_name|upper }} {% blocktrans trimmed %}Exports{% endblocktrans %}</h1>
     </hgroup>
 </header>
 

--- a/kobo/apps/organizations/templates/emails/accepted_org_invite.html
+++ b/kobo/apps/organizations/templates/emails/accepted_org_invite.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <p>{% trans "Dear" %} {{ sender_username }},</p>
 
-<p>{% blocktrans %}{{ recipient_username }} ({{ recipient_email }}) has accepted your request to join {{ organization_name }} organization.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}{{ recipient_username }} ({{ recipient_email }}) has accepted your request to join {{ organization_name }} organization.{% endblocktrans %}</p>
 
 <p>{% trans "All projects, submissions, data storage, transcription and translation usage for their projects will be transferred to you." %}</p>
 

--- a/kobo/apps/organizations/templates/emails/accepted_org_invite.txt
+++ b/kobo/apps/organizations/templates/emails/accepted_org_invite.txt
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% trans "Dear" %} {{ sender_username }},
 
-{% blocktrans %}{{ recipient_username }} ({{ recipient_email }}) has accepted your request to join {{ organization_name }} organization.{% endblocktrans %}
+{% blocktrans trimmed %}{{ recipient_username }} ({{ recipient_email }}) has accepted your request to join {{ organization_name }} organization.{% endblocktrans %}
 
 {% trans "All projects, submissions, data storage, transcription and translation usage for their projects will be transferred to you." %}
 

--- a/kobo/apps/organizations/templates/emails/declined_org_invite.html
+++ b/kobo/apps/organizations/templates/emails/declined_org_invite.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <p>{% trans "Dear" %} {{ sender_username }},</p>
 
-<p>{% blocktrans %}{{ recipient }} has declined your request to join {{ organization_name }} organization.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}{{ recipient }} has declined your request to join {{ organization_name }} organization.{% endblocktrans %}</p>
 <p>
 &nbsp;-&nbsp;KoboToolbox
 </p>

--- a/kobo/apps/organizations/templates/emails/declined_org_invite.txt
+++ b/kobo/apps/organizations/templates/emails/declined_org_invite.txt
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% trans "Dear" %} {{ sender_username }},
 
-{% blocktrans %}{{ recipient }} has declined your request to join {{ organization_name }} organization.{% endblocktrans %}
+{% blocktrans trimmed %}{{ recipient }} has declined your request to join {{ organization_name }} organization.{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/organizations/templates/emails/expired_org_invite.html
+++ b/kobo/apps/organizations/templates/emails/expired_org_invite.html
@@ -2,7 +2,7 @@
 {% load strings %}
 
 <p>{% trans "Dear" %} {{ username }},</p>
-<p>{% blocktrans %}The request you have sent to <b>{{ recipient }}</b> to join the {{ organization }} organization has expired.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}The request you have sent to <b>{{ recipient }}</b> to join the {{ organization }} organization has expired.{% endblocktrans %}</p>
 
 <p>
 &nbsp;-&nbsp;KoboToolbox

--- a/kobo/apps/organizations/templates/emails/expired_org_invite.txt
+++ b/kobo/apps/organizations/templates/emails/expired_org_invite.txt
@@ -2,6 +2,6 @@
 {% load strings %}
 
 {% trans "Dear" %} {{ username }},
-{% blocktrans %}The request you have sent to <b>{{ recipient }}</b> to join the {{ organization }} organization has expired.{% endblocktrans %}
+{% blocktrans trimmed %}The request you have sent to <b>{{ recipient }}</b> to join the {{ organization }} organization has expired.{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/organizations/templates/emails/registered_user_invite.html
+++ b/kobo/apps/organizations/templates/emails/registered_user_invite.html
@@ -5,20 +5,20 @@
 <p>{% trans "Hello" %} {{ recipient_username }},</p>
 {% endif %}
 
-<p>{% blocktrans %}{{ sender_name }} ({{ sender_email }}, username {{ sender_username }}) has invited you to join {{ organization_name }} organization as {{recipient_role}}.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}{{ sender_name }} ({{ sender_email }}, username {{ sender_username }}) has invited you to join {{ organization_name }} organization as {{recipient_role}}.{% endblocktrans %}</p>
 {% if has_multiple_accounts %}
-<p>{% blocktrans %}If you already have an account (or have several accounts), please sign in with the correct account. If you don't already have a KoboToolbox account, you can create one <a href="{{ base_url }}/accounts/signup/" target="_blank">here</a>. After creating your account, click on the link below to accept the invite.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}If you already have an account (or have several accounts), please sign in with the correct account. If you don't already have a KoboToolbox account, you can create one <a href="{{ base_url }}/accounts/signup/" target="_blank">here</a>. After creating your account, click on the link below to accept the invite.{% endblocktrans %}</p>
 {% endif %}
 
 <p>{% trans "What joining the organization means for you:" %}</p>
 <ul>
   <li>{% trans "You will benefit from higher usage limits and additional features, as well as priority user support." %}</li>
-  <li>{% blocktrans %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}</li>
+  <li>{% blocktrans trimmed %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}</li>
   <li>{% trans "You will continue to have full management permissions for all projects previously owned by you." %}</li>
 </ul>
 
 <p>{% trans "If you want to transfer any projects to another account or remove a project, please do so before accepting the invitation. This action cannot be undone." %}</p>
 
-<p>{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
 
 <p>&nbsp;-&nbsp;KoboToolbox</p>

--- a/kobo/apps/organizations/templates/emails/registered_user_invite.txt
+++ b/kobo/apps/organizations/templates/emails/registered_user_invite.txt
@@ -5,18 +5,18 @@
 {% trans "Hello" %} {{ recipient_username }},
 {% endif %}
 
-{% blocktrans %}{{ sender_name }} ({{ sender_email }}, username {{ sender_username }}) has invited you to join {{ organization_name }} organization as {{recipient_role}}.{% endblocktrans %}
+{% blocktrans trimmed %}{{ sender_name }} ({{ sender_email }}, username {{ sender_username }}) has invited you to join {{ organization_name }} organization as {{recipient_role}}.{% endblocktrans %}
 {% if has_multiple_accounts %}
-{% blocktrans %}If you already have an account (or have several accounts), please sign in with the correct account. If you don't already have a KoboToolbox account, you can create one <a href="{{ base_url }}/accounts/signup/" target="_blank">here</a>. After creating your account, click on the link below to accept the invite.{% endblocktrans %}
+{% blocktrans trimmed %}If you already have an account (or have several accounts), please sign in with the correct account. If you don't already have a KoboToolbox account, you can create one <a href="{{ base_url }}/accounts/signup/" target="_blank">here</a>. After creating your account, click on the link below to accept the invite.{% endblocktrans %}
 {% endif %}
 
 {% trans "What joining the organization means for you:" %}
 * {% trans "You will benefit from higher usage limits and additional features, as well as priority user support." %}
-* {% blocktrans %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}
+* {% blocktrans trimmed %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}
 * {% trans "You will continue to have full management permissions for all projects previously owned by you." %}
 
 {% trans "If you want to transfer any projects to another account or remove a project, please do so before accepting the invitation. This action cannot be undone." %}
 
-{% blocktrans %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
+{% blocktrans trimmed %}To respond to this invitation, please use the following link: {{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/organizations/templates/emails/unregistered_user_invite.html
+++ b/kobo/apps/organizations/templates/emails/unregistered_user_invite.html
@@ -1,18 +1,18 @@
 {% load i18n %}
 <p>{% trans "Hello," %}</p>
 
-<p>{% blocktrans %}We’d like to give you a warm welcome to KoboToolbox. You’re invited to join {{ organization_name }} organization as {{recipient_role}} with {{ recipient_username }}.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}We’d like to give you a warm welcome to KoboToolbox. You’re invited to join {{ organization_name }} organization as {{recipient_role}} with {{ recipient_username }}.{% endblocktrans %}</p>
 
 <p>{% trans "What joining the organization means for you:" %}</p>
 <ul>
   <li>{% trans "You will benefit from higher usage limits and additional features, as well as priority user support." %}</li>
-  <li>{% blocktrans %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}</li>
+  <li>{% blocktrans trimmed %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}</li>
   <li>{% trans "You will continue to have full management permissions for all projects previously owned by you." %}</li>
 </ul>
 
-<p>{% blocktrans %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}</p>
 <p>{% trans "Once you have finished creating your account, respond to this invitation using the following link:" %}</p>
 
-<p>{% blocktrans %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}</p>
 
 <p>&nbsp;-&nbsp;KoboToolbox</p>

--- a/kobo/apps/organizations/templates/emails/unregistered_user_invite.txt
+++ b/kobo/apps/organizations/templates/emails/unregistered_user_invite.txt
@@ -1,16 +1,16 @@
 {% load i18n %}
 {% trans "Hello," %}
 
-{% blocktrans %}We’d like to give you a warm welcome to KoboToolbox. You’re invited to join {{ organization_name }} organization as {{recipient_role}} with {{ recipient_username }}. {% endblocktrans %}
+{% blocktrans trimmed %}We’d like to give you a warm welcome to KoboToolbox. You’re invited to join {{ organization_name }} organization as {{recipient_role}} with {{ recipient_username }}. {% endblocktrans %}
 
 {% trans "What joining the organization means for you:" %}
 * {% trans "You will benefit from higher usage limits and additional features, as well as priority user support." %}
-* {% blocktrans %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}
+* {% blocktrans trimmed %}Any projects owned by your account will be transferred to {{ organization_name }} and all admins in that organization will have access to your projects and data. {% endblocktrans %}
 * {% trans "You will continue to have full management permissions for all projects previously owned by you." %}
 
-{% blocktrans %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}
+{% blocktrans trimmed %}It takes less than 2 minutes to create your account to join the organization. Please create your account here: {{ base_url }}/accounts/signup/{% endblocktrans %}
 
 {% trans "Once you have finished creating your account, respond to this invitation using the following link:" %}
-{% blocktrans %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
+{% blocktrans trimmed %}{{ base_url }}/#/projects/home?organization_invite={{ invite_uid }}&organization_id={{ organization_id }}{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/project_ownership/templates/emails/accepted_invite.html
+++ b/kobo/apps/project_ownership/templates/emails/accepted_invite.html
@@ -11,7 +11,7 @@
 
   <p>{% trans "Note: You will continue to have permissions to manage the project until the user permissions are changed." %}</p>
 {% else %}
-  <p>{% blocktrans %}{{ recipient }} has accepted your request to transfer ownership of these projects:{% endblocktrans %}
+  <p>{% blocktrans trimmed %}{{ recipient }} has accepted your request to transfer ownership of these projects:{% endblocktrans %}
     <ul>
     {% for transfer in transfers %}
       {% url 'api_v2:asset-detail' uid=transfer.asset_uid as asset_url %}

--- a/kobo/apps/project_ownership/templates/emails/accepted_invite.txt
+++ b/kobo/apps/project_ownership/templates/emails/accepted_invite.txt
@@ -9,7 +9,7 @@
 
 {% trans "Note: You will continue to have permissions to manage the project until the user permissions are changed." %}
 {% else %}
-{% blocktrans %}{{ recipient }} has accepted your request to transfer ownership of these projects:{% endblocktrans %}
+{% blocktrans trimmed %}{{ recipient }} has accepted your request to transfer ownership of these projects:{% endblocktrans %}
 {% for transfer in transfers %}
     * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing]
 {% endfor %}

--- a/kobo/apps/project_ownership/templates/emails/declined_invite.html
+++ b/kobo/apps/project_ownership/templates/emails/declined_invite.html
@@ -9,7 +9,7 @@
 
   <p>{% trans "You will remain the owner of the project. The submissions, data storage, and transcription and translation usage for the project have not been transferred." %}</p>
 {% else %}
-  <p>{% blocktrans %}{{ recipient }} has declined your request to transfer ownership of these projects:{% endblocktrans %}
+  <p>{% blocktrans trimmed %}{{ recipient }} has declined your request to transfer ownership of these projects:{% endblocktrans %}
     <ul>
     {% for transfer in transfers %}
       <li><a href="{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing">{{ transfer.asset_name }}</a></li>

--- a/kobo/apps/project_ownership/templates/emails/declined_invite.txt
+++ b/kobo/apps/project_ownership/templates/emails/declined_invite.txt
@@ -8,7 +8,7 @@
 
 {% trans "You will remain the owner of the project. The submissions, data storage, and transcription and translation usage for the project have not been transferred." %}
 {% else %}
-{% blocktrans %}{{ recipient }} has declined your request to transfer ownership of these projects:{% endblocktrans %}
+{% blocktrans trimmed %}{{ recipient }} has declined your request to transfer ownership of these projects:{% endblocktrans %}
     {% for transfer in transfers %}
     * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing]
     {% endfor %}

--- a/kobo/apps/project_ownership/templates/emails/expired_invite.html
+++ b/kobo/apps/project_ownership/templates/emails/expired_invite.html
@@ -3,7 +3,7 @@
 {% trans "Projects:" as projects_label %}
 
 <p>{% trans "Dear" %} {{ username }},</p>
-<p>{% blocktrans %}The request you have sent to <b>{{ recipient }}</b> has expired.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}The request you have sent to <b>{{ recipient }}</b> has expired.{% endblocktrans %}</p>
 
 <b>{{ projects_label }}</b>
 <ul>

--- a/kobo/apps/project_ownership/templates/emails/expired_invite.txt
+++ b/kobo/apps/project_ownership/templates/emails/expired_invite.txt
@@ -4,7 +4,7 @@
 
 {% trans "Dear" %} {{ username }},
 
-{% blocktrans %}The request you have sent to {{ recipient }} has expired.{% endblocktrans %}
+{% blocktrans trimmed %}The request you have sent to {{ recipient }} has expired.{% endblocktrans %}
 
 {{ projects_label }}
 {% for transfer in transfers %}

--- a/kobo/apps/project_ownership/templates/emails/new_invite.html
+++ b/kobo/apps/project_ownership/templates/emails/new_invite.html
@@ -9,7 +9,7 @@
 
   <p>{% trans "When you accept the ownership transfer, all of the submissions, data storage, and transcription and translation usage for these projects will be transferred to you and count against your plan limits." %}</p>
 {% else %}
-  <p>{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+  <p>{% blocktrans trimmed %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
     <ul>
     {% for transfer in transfers %}
       <li><a href="{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing">{{ transfer.asset_name }}</a></li>
@@ -22,9 +22,9 @@
 
 <p>{% trans "If you are unsure, please contact the current owner." %}</p>
 
-<p>{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
 
-<p>{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
 
 <p>
 &nbsp;-&nbsp;KoboToolbox

--- a/kobo/apps/project_ownership/templates/emails/new_invite.txt
+++ b/kobo/apps/project_ownership/templates/emails/new_invite.txt
@@ -8,7 +8,7 @@
 
 {% trans "When you accept the ownership transfer, all of the submissions, data storage, and transcription and translation usage for the project will be transferred to you and count against your plan limits." %}
 {% else %}
-{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+{% blocktrans trimmed %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
     {% for transfer in transfers %}
     * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ asset_uid }}/landing]
     {% endfor %}
@@ -18,8 +18,8 @@
 
 {% trans "If you are unsure, please contact the current owner." %}
 
-{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
+{% blocktrans trimmed %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
 
-{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
+{% blocktrans trimmed %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
 
 - KoboToolbox

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.html
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.html
@@ -9,7 +9,7 @@
 
   <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
 
-  <p>{% blocktrans %}
+  <p>{% blocktrans trimmed %}
     If you accept the transfer:
     <ul>
       <li>All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits</li>
@@ -18,7 +18,7 @@
     {% endblocktrans %}
   </p>
 {% else %}
-  <p>{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+  <p>{% blocktrans trimmed %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
     <ul>
     {% for transfer in transfers %}
       <li><a href="{{ base_url }}/#/forms/{{ transfer.asset_uid }}/landing">{{ transfer.asset_name }}</a></li>
@@ -28,7 +28,7 @@
 
   <p>{% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}</p>
 
-  <p>{% blocktrans %}
+  <p>{% blocktrans trimmed %}
     If you accept the transfer:
     <ul>
       <li>All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits</li>
@@ -39,9 +39,9 @@
 
 <p>{% trans "If you are unsure, please contact the current owner." %}</p>
 
-<p>{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}</p>
 
-<p>{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
+<p>{% blocktrans trimmed %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}</p>
 
 <p>
 &nbsp;-&nbsp;KoboToolbox

--- a/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
+++ b/kobo/apps/project_ownership/templates/emails/new_invite_org.txt
@@ -8,21 +8,21 @@
 
 {% trans "Because you are part of a team, this project will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own this project, then don’t click on the link below." %}
 
-{% blocktrans %}
+{% blocktrans trimmed %}
 If you accept the transfer:
 - All submissions, data storage, and transcription/translation usage for this project will count toward the team’s plan limits
 - If you leave the team in the future, your account will still retain manage project permissions for this project
 {% endblocktrans %}
 
 {% else %}
-{% blocktrans %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
+{% blocktrans trimmed %}{{ sender_username }} ({{ sender_email }}) has requested to transfer ownership of the following projects to you:{% endblocktrans %}
     {% for transfer in transfers %}
     * {{ transfer.asset_name }} - [{{ base_url }}/#/forms/{{ asset_uid }}/landing]
     {% endfor %}
 
 {% trans "Because you are part of a team, these projects will be owned by the team, but you will retain the ability to manage project permissions. If you do not want the team to own these projects, then don’t click on the link below." %}
 
-{% blocktrans %}
+{% blocktrans trimmed %}
 If you accept the transfer:
 - All submissions, data storage, and transcription/translation usage for these projects will count toward the team’s plan limits
 {% endblocktrans %}
@@ -31,8 +31,8 @@ If you accept the transfer:
 
 {% trans "If you are unsure, please contact the current owner." %}
 
-{% blocktrans %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
+{% blocktrans trimmed %}This transfer request will expire in {{ invite_expiry }} days.{% endblocktrans %}
 
-{% blocktrans %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
+{% blocktrans trimmed %}To respond to this transfer request, please use the following link: {{ base_url }}/#/projects/home?invite={{ invite_uid }}{% endblocktrans %}
 
 - KoboToolbox


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging


### 📖 Description
Developer-only changes


### 💭 Notes
This was done with a simple find-and-replace. To test it,  I compiled the messages and ran
`find . -name django.po | xargs awk '{ if (lastline == "msgid \"\"" && $0 ~ "\"\\\\n\"") {print FILENAME, $0} {lastline=$0}}' | wc -l` and checked to make sure the output was empty.

The `awk` command looks for sections of a .po file that look like
```
msgid ""
"\n"
```
, which is what it looks like when a translation string begins with a newline char. The full command lists all po files, checks for that sequence of lines using `awk` for each one, and counts the total. On main, the count was 257. Using this branch, the count is 2. It should be 0, but for some reason `makemessages` had trouble with `zh-Hant` and `zh-Hans` so it didn't actually update those files. That doesn't matter for this PR.

### :eyes: Preview steps

1. In the kpi container run `python ./manage makemessages -a`
2. Locally, cd to the `locale` directory inside kpi
3.  run `find . -name django.po | xargs awk '{ if (lastline == "msgid \"\"" && $0 ~ "\"\\\\n\"") {print FILENAME, $0} {lastline=$0}}' | wc -l`
4. :red_circle: [on main] The result will be > 200
5. :green_circle: [on PR] The result will be 0 (or 2, if django has trouble compiling zh-Hant and zh-Hans. Not sure if that was a local issue).


