### PR TITLE
fix(frontend): improve paddings on Project Landing Page TASK-1565

### DIFF
--- a/jsapp/js/components/formLanding/formLanding.js
+++ b/jsapp/js/components/formLanding/formLanding.js
@@ -28,6 +28,7 @@ import AnonymousSubmission from 'js/components/anonymousSubmission.component'
 import NewFeatureDialog from 'js/components/newFeatureDialog.component'
 import pageState from 'js/pageState.store'
 import Button from 'js/components/common/button'
+import { Stack } from '@mantine/core'
 
 const DVCOUNT_LIMIT_MINIMUM = 20
 const ANON_CAN_ADD_PERM_URL = permConfig.getPermissionByCodename(PERMISSIONS_CODENAMES.add_submissions).url
@@ -308,7 +309,7 @@ class FormLanding extends React.Component {
             <bem.FormView__cell className='collect-header-actions'>{this.renderCollectLink()}</bem.FormView__cell>
           </bem.FormView__cell>
 
-          <bem.FormView__cell m={['small-padding', 'collect-meta']}>
+          <Stack pb='md' pl='md' pr='md' className='collect-meta-description'>
             {chosenMethod !== COLLECTION_METHODS.android.id && COLLECTION_METHODS[chosenMethod].desc}
 
             {chosenMethod === COLLECTION_METHODS.iframe_url.id && (
@@ -341,7 +342,7 @@ class FormLanding extends React.Component {
                 <li>{t('Open "Enter Data."')}</li>
               </ol>
             )}
-          </bem.FormView__cell>
+          </Stack>
 
           {userCan('change_asset', this.state) && (
             <bem.FormView__cell m={['padding', 'anonymous-submissions', 'bordertop']}>
@@ -634,13 +635,13 @@ class FormLanding extends React.Component {
             </bem.FormView__cell>
             <bem.FormView__cell m='box'>
               {this.isFormRedeploymentNeeded() && (
-                <bem.FormView__cell>
+                <Stack pt='md' pl='md' pr='md'>
                   <InlineMessage
                     icon='alert'
                     type='warning'
                     message={t('If you want to make these changes public, you must deploy this form.')}
                   />
-                </bem.FormView__cell>
+                </Stack>
               )}
               {this.renderFormInfo(userCanEdit)}
               {this.renderLanguages(userCanEdit)}

--- a/jsapp/js/components/formLanding/formLanding.js
+++ b/jsapp/js/components/formLanding/formLanding.js
@@ -309,7 +309,7 @@ class FormLanding extends React.Component {
             <bem.FormView__cell className='collect-header-actions'>{this.renderCollectLink()}</bem.FormView__cell>
           </bem.FormView__cell>
 
-          <Stack pb='md' pl='md' pr='md' className='collect-meta-description'>
+          <Stack pb='lg' pl='lg' pr='lg' className='collect-meta-description'>
             {chosenMethod !== COLLECTION_METHODS.android.id && COLLECTION_METHODS[chosenMethod].desc}
 
             {chosenMethod === COLLECTION_METHODS.iframe_url.id && (
@@ -635,7 +635,7 @@ class FormLanding extends React.Component {
             </bem.FormView__cell>
             <bem.FormView__cell m='box'>
               {this.isFormRedeploymentNeeded() && (
-                <Stack pt='md' pl='md' pr='md'>
+                <Stack pt='lg' pl='lg' pr='lg'>
                   <InlineMessage
                     icon='alert'
                     type='warning'

--- a/jsapp/js/components/library/assetContentSummary.tsx
+++ b/jsapp/js/components/library/assetContentSummary.tsx
@@ -28,7 +28,7 @@ export default class AssetContentSummary extends React.Component<AssetContentSum
   }
 
   renderQuestion(question: FlatQuestion, itemIndex: number) {
-    const modifiers = ['columns', 'padding-small']
+    const modifiers = ['columns', 'padding']
     if (itemIndex !== 0) {
       modifiers.push('bordertop')
     }
@@ -72,7 +72,7 @@ export default class AssetContentSummary extends React.Component<AssetContentSum
 
     if (items.length === 0) {
       return (
-        <bem.FormView__cell m={['box', 'padding-small']}>
+        <bem.FormView__cell m={['box', 'padding']}>
           {t('This ##asset_type## is empty.').replace('##asset_type##', this.props.asset.asset_type)}
         </bem.FormView__cell>
       )

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -273,7 +273,7 @@ $side-tabs-width-mobile: 70px;
   }
 
   &.form-view__cell--padding {
-    padding: var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-lg);
   }
 
   &.form-view__cell--full-width {
@@ -298,7 +298,7 @@ $side-tabs-width-mobile: 70px;
   }
 
   &.form-view__cell--first {
-    padding-bottom: var(--mantine-spacing-md);
+    padding-bottom: var(--mantine-spacing-lg);
     position: relative;
 
     .form-view__group {

--- a/jsapp/scss/components/_kobo.form-view.scss
+++ b/jsapp/scss/components/_kobo.form-view.scss
@@ -200,12 +200,6 @@ $side-tabs-width-mobile: 70px;
   }
 }
 
-.form-view__row--history {
-  .form-view__cell--history-table {
-    margin-bottom: 20px;
-  }
-}
-
 .form-view__cell-label {
   font-size: 12px;
   opacity: 0.6;
@@ -279,15 +273,7 @@ $side-tabs-width-mobile: 70px;
   }
 
   &.form-view__cell--padding {
-    padding: 20px;
-  }
-
-  &.form-view__cell--small-padding {
-    padding: 10px 20px 20px;
-  }
-
-  &.form-view__cell--padding-small {
-    padding: 10px 20px;
+    padding: var(--mantine-spacing-md);
   }
 
   &.form-view__cell--full-width {
@@ -312,7 +298,7 @@ $side-tabs-width-mobile: 70px;
   }
 
   &.form-view__cell--first {
-    padding-bottom: 20px;
+    padding-bottom: var(--mantine-spacing-md);
     position: relative;
 
     .form-view__group {
@@ -566,13 +552,17 @@ $side-tabs-width-mobile: 70px;
   gap: 10px;
 }
 
-.form-view__cell--collect-meta {
-  pre {
-    display: block;
-    margin: 10px 0;
-    padding: 10px;
+.collect-meta-description {
+  pre,
+  code {
     border: 1px solid colors.$kobo-gray-300;
     background: colors.$kobo-gray-200;
+  }
+
+  pre {
+    display: block;
+    margin: 0;
+    padding: 10px;
     font-size: 13px;
     white-space: normal;
   }
@@ -581,7 +571,7 @@ $side-tabs-width-mobile: 70px;
     margin: 0;
     padding: 0;
     margin-left: 15px;
-    margin-bottom: 25px;
+    margin-bottom: 0;
 
     li {
       margin-bottom: 5px;
@@ -597,14 +587,8 @@ $side-tabs-width-mobile: 70px;
 
   code {
     padding: 4px;
-    border: 1px solid colors.$kobo-gray-300;
-    background: colors.$kobo-gray-200;
     margin-left: 5px;
     margin-right: 5px;
-  }
-
-  .form-view__cell {
-    margin-top: 25px;
   }
 }
 


### PR DESCRIPTION
### 💭 Notes

As we want to go forward with Mantine, I've used `Stack` to fix the missing paddings.

The route already was using a "system" for paddings in the shape of `form-view__cell--paddings` class name. I've modified it to use the same size of paddings as the `Stack` (I went with `lg`, which is 20px - same as previous paddings).

I also simplified some styles by removing one shots `form-view__cell--small-paddings` and `form-view__cell--paddings-small` :heart:

### 👀 Preview steps

Reproduction:
1. ℹ️ have account and a project
2. deploy project
3. edit form
4. go to Project Landing Page (`/#/forms/<uid>/landing`)
5. 🟢 notice that there is an alert "If you want to make these changes(…)"
6. 🟢 notice alert has paddings around it (not on bottom), which is not present on `main`
7. 🟢 notice the paddings of all other sections here match the paddings around the alert
