### PR TITLE
fix(billing): billing period detection for end-of-month cancellations

### DIFF
--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -1,3 +1,4 @@
+import calendar
 from datetime import datetime
 from typing import Union
 
@@ -21,6 +22,8 @@ def get_billing_dates(organization: Union['Organization', None]):
         + relativedelta(months=1)
     )
 
+    # @TODO Validate if the condition is still needed, organization is always
+    #   present now.
     # If no organization, just use the calendar month
     if not organization:
         return first_of_this_month, first_of_next_month
@@ -37,13 +40,43 @@ def get_billing_dates(organization: Union['Organization', None]):
             tzinfo=ZoneInfo('UTC')
         )
         period_end = canceled_subscription_anchor
+
+        # The goal below is to mimic Stripe's logic
+
+        # > A monthly subscription with a billing cycle anchor date of January 31
+        # > bills the last day of the month closest to the anchor date, so February 28
+        # > (or February 29 in a leap year), then March 31, April 30, and so on.
+
+        # Example: If a user cancels their plan on October 31,
+        # the billing periods should be structured as follows:
+
+        # | Month of Consultation | Billing Period   |
+        # |-----------------------|------------------|
+        # | November              | Oct 31 - Nov 30  |
+        # | December              | Nov 30 - Dec 31  |
+        # | January               | Dec 31 - Jan 31  |
+        # | February              | Jan 31 - Feb 28  |
+        # | March                 | Feb 28 - Mar 31  |
+        # | April                 | Mar 31 - Apr 30  |
+        # | May                   | Apr 30 - May 31  |
+        # etc...
+
+        cpt = 1
         while period_end < now:
-            period_end += relativedelta(months=1)
-        # Avoid pushing billing cycle back to before cancelation date
-        period_start = max(
-            period_end - relativedelta(months=1),
-            canceled_subscription_anchor,
+            period_end = canceled_subscription_anchor + relativedelta(months=cpt)
+            cpt += 1
+
+        previous_month = period_end - relativedelta(months=1)
+        last_day_of_previous_month = calendar.monthrange(
+            previous_month.year, previous_month.month
+        )[1]
+        adjusted_start_day = min(
+            canceled_subscription_anchor.day, last_day_of_previous_month
         )
+        period_start = previous_month.replace(day=adjusted_start_day)
+
+        # Avoid pushing billing cycle back to before cancelation date
+        period_start = max(period_start, canceled_subscription_anchor)
         return period_start, period_end
 
     if not billing_details.get('billing_cycle_anchor'):

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -157,6 +157,7 @@ class OrganizationServiceUsageAPIMultiUserTestCase(BaseServiceUsageTestCase):
             self.expected_file_size() * self.expected_submissions_multi
         )
 
+
 @ddt
 class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
     org_id = 'orgAKWMFskafsngf'
@@ -345,6 +346,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
         assert current_period_end.day == 30
 
     @data(
+        # regular year
         ('2024-11-15', '2024-10-31', '2024-11-30'),
         ('2024-12-15', '2024-11-30', '2024-12-31'),
         ('2025-01-15', '2024-12-31', '2025-01-31'),
@@ -358,6 +360,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
         ('2025-09-15', '2025-08-31', '2025-09-30'),
         ('2025-10-15', '2025-09-30', '2025-10-31'),
         ('2025-11-15', '2025-10-31', '2025-11-30'),
+        # leap year, edge case with February
         ('2028-02-15', '2028-01-31', '2028-02-29'),
         ('2028-03-15', '2028-02-29', '2028-03-31'),
     )


### PR DESCRIPTION
### 📣 Summary
Fixed an issue where the billing period was incorrectly detected for end-of-month cancellations.

### 📖 Description
The billing period detection logic has been updated to align with Stripe's methodology for handling end-of-month cancellations. Previously, the system did not fully follow Stripe's approach when determining the final billing period, which could lead to inconsistencies in how the cancellation date was interpreted.

### 💭 Notes
Backport of #5524 and supersedes it.
@jamesrkiger already reviewed #5524 and approved it.

