### PR TITLE
fix(organizations: remove invite params on accept/decline TASK-1582

### DIFF
--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -24,7 +24,7 @@ import { endpoints } from 'jsapp/js/api.endpoints'
  *
  * Note: this is for a user that is NOT a part of an organization (and thus has no access to it).
  */
-export default function OrgInviteModal(props: { orgId: string; inviteId: string }) {
+export default function OrgInviteModal(props: { orgId: string; inviteId: string; onUserResponse: () => void }) {
   const inviteUrl = endpoints.ORG_MEMBER_INVITE_DETAIL_URL.replace(':organization_id', props.orgId).replace(
     ':invite_id',
     props.inviteId,
@@ -46,6 +46,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
     try {
       await patchMemberInvite.mutateAsync({ status: MemberInviteStatus.declined })
       setIsModalOpen(false)
+      props.onUserResponse()
       notify(t('Invitation successfully declined'))
     } catch (error) {
       setMiscError(t('Unknown error while trying to update an invitation'))
@@ -56,6 +57,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string 
     try {
       await patchMemberInvite.mutateAsync({ status: MemberInviteStatus.accepted })
       setIsModalOpen(false)
+      props.onUserResponse()
       notify(t('Invitation successfully accepted'))
     } catch (error) {
       setMiscError(t('Unknown error while trying to update an invitation'))

--- a/jsapp/js/account/organization/invites/OrgInviteModalWrapper.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModalWrapper.tsx
@@ -3,7 +3,7 @@ import OrgInviteModal from './OrgInviteModal'
 
 /**
  * This is a wrapper for conditionally rendering the OrgInviteModal component. It looks for a particular pair of
- * search parameters and, if an invitation is deleted or accepted, removes those params.
+ * search parameters to pass to the modal. Also, if an invitation is deleted or accepted, it removes those params.
  */
 export default function OrgInviteModalWrapper() {
   const [searchParams, setSearchParams] = useSearchParams()

--- a/jsapp/js/account/organization/invites/OrgInviteModalWrapper.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModalWrapper.tsx
@@ -1,21 +1,25 @@
-import { useLocation } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import OrgInviteModal from './OrgInviteModal'
 
 /**
- * This is a wrapper for conditionally rendering the OrgInviteModal component. It simply looks for particular pair of
- * search parameters.
+ * This is a wrapper for conditionally rendering the OrgInviteModal component. It looks for a particular pair of
+ * search parameters and, if an invitation is deleted or accepted, removes those params.
  */
 export default function OrgInviteModalWrapper() {
-  // Get values from URL params
-  const location = useLocation()
-  const searchParams = new URLSearchParams(location.search)
+  const [searchParams, setSearchParams] = useSearchParams()
   const inviteId = searchParams.get('organization_invite')
   const orgId = searchParams.get('organization_id')
+
+  function handleUserResponse() {
+    searchParams.delete('organization_invite')
+    searchParams.delete('organization_id')
+    setSearchParams(searchParams)
+  }
 
   // Avoid rendering anything if there is no invite in the URL
   if (!inviteId || !orgId) {
     return null
   }
 
-  return <OrgInviteModal orgId={orgId} inviteId={inviteId} />
+  return <OrgInviteModal orgId={orgId} inviteId={inviteId} onUserResponse={handleUserResponse} />
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Remove relevant search params when a user accepts or declines an MMO invite


### 👀 Preview steps
1.As an MMO owner/admin, invite a new MMO member
2. Sign out as owner/admin, use invite link from resulting email and sign in as new member
3. decline or accept invite
4. observe that the invitation search params have been removed