### PR TITLE
fix(organization)!: revoke asset permissions before removing a member from the organization TASK-1560

### DIFF
--- a/kobo/apps/organizations/tests/test_organization_members_api.py
+++ b/kobo/apps/organizations/tests/test_organization_members_api.py
@@ -6,6 +6,8 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.tests.test_organizations_api import (
     BaseOrganizationAssetApiTestCase
 )
+from kpi.constants import PERM_MANAGE_ASSET
+from kpi.models import Asset
 from kpi.urls.router_api_v2 import URL_NAMESPACE
 
 
@@ -21,6 +23,10 @@ class OrganizationMemberAPITestCase(BaseOrganizationAssetApiTestCase):
         self.member_user = self.alice
         self.admin_user = self.anotheruser
         self.external_user = self.bob
+
+        # Create an asset owned by the organization member
+        asset_response = self._create_asset_by_alice()
+        self.asset = Asset.objects.get(uid=asset_response.data['uid'])
 
         self.list_url = reverse(
             self._get_endpoint('organization-members-list'),
@@ -102,6 +108,8 @@ class OrganizationMemberAPITestCase(BaseOrganizationAssetApiTestCase):
         else:
             user = getattr(self, f'{user_role}_user')
             self.client.force_login(user)
+
+        assert self.asset.has_perm(self.member_user, PERM_MANAGE_ASSET)
         response = self.client.delete(self.detail_url(self.member_user))
         self.assertEqual(response.status_code, expected_status)
         if expected_status == status.HTTP_204_NO_CONTENT:
@@ -111,6 +119,9 @@ class OrganizationMemberAPITestCase(BaseOrganizationAssetApiTestCase):
             self.assertFalse(
                 User.objects.filter(username=f'{user_role}_user').exists()
             )
+
+            # Confirm asset permissions are revoked
+            assert not self.asset.get_perms(self.member_user)
 
     @data(
         ('owner', status.HTTP_405_METHOD_NOT_ALLOWED),


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Revoke organization asset permissions before removing a member from the organization to ensure proper access control.


### 📖 Description
When a member is deleted from an organization via the `/members` DELETE API, their associated permissions on organizational assets are now revoked before the deletion takes place. This prevents orphaned permissions and ensures that removed users no longer have access to organization resources.



### 👀 Preview steps
1. Ensure you have a user account and an asset.
2. As an organization owner, send an invitation to that user to join the organization.
3. Once the user joins, confirm that the asset is now owned by the organization.
4. As an organization owner, remove the user from the organization via the /members DELETE API.
5. Verify that the removed user no longer has access to the asset.
