### PR TITLE
feat(organizations): remove org invite button feature flag TASK-1599

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -24,7 +24,6 @@ import type { UniversalTableColumn } from 'jsapp/js/universalTable/universalTabl
 
 // Styles
 import styles from './membersRoute.module.scss'
-import { FeatureFlag, useFeatureFlag } from 'jsapp/js/featureFlags'
 import ActionIcon from 'jsapp/js/components/common/ActionIcon'
 import InviteeActionsDropdown from './InviteeActionsDropdown'
 
@@ -45,8 +44,6 @@ export default function MembersRoute() {
   if (!orgQuery.data) {
     return <LoadingSpinner />
   }
-
-  const isInviteOrgMembersEnabled = useFeatureFlag(FeatureFlag.orgMemberInvitesEnabled)
 
   const columns: Array<UniversalTableColumn<OrganizationMemberListItem>> = [
     {
@@ -191,7 +188,7 @@ export default function MembersRoute() {
         <h2 className={styles.headerText}>{t('Members')}</h2>
       </header>
 
-      {isInviteOrgMembersEnabled && !(orgQuery.data.request_user_role === 'member') && (
+      {!(orgQuery.data.request_user_role === 'member') && (
         <Box>
           <Divider />
           <Group w='100%' justify='space-between'>

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -3,8 +3,7 @@
  * For our sanity, use camel case and match key with value.
  */
 export enum FeatureFlag {
-  //exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
-  orgMemberInvitesEnabled = 'orgMemberInvitesEnabled',
+  exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
 }
 
 /**


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Removes feature flag that was hiding org invite button on the members page.


### 👀 Preview steps
1. View members page as an MMO owner/admin
2. Observe that invite button is visible without feature flag param (or ff in local storage)