### PR TITLE
feat(permissions): incomplete permission removal with “Removed shared project”  TASK-1494

### DIFF
--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -120,6 +120,16 @@ class AssetPermissionAssignmentViewSet(
     >
     >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/
 
+    **Remove all permission assignments**
+
+    <pre class="prettyprint">
+    <b>DELETE</b> /api/v2/assets/<code>{uid}</code>/permission-assignments/{permission_uid}/delete-all/
+    </pre>
+
+    > Example
+    >
+    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/delete-all/
+
 
     **Assign all permissions at once**
 
@@ -229,6 +239,7 @@ class AssetPermissionAssignmentViewSet(
     @action(
         detail=True,
         methods=['DELETE'],
+        url_path='delete-all',
     )
     def delete_all(self, request, *args, **kwargs):
         object_permission = self.get_object()

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -118,7 +118,7 @@ class AssetPermissionAssignmentViewSet(
 
     > Example
     >
-    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/
+    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/  # noqa: E501
 
     **Remove all permission assignments**
 
@@ -128,7 +128,7 @@ class AssetPermissionAssignmentViewSet(
 
     > Example
     >
-    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/delete-all/
+    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/permission-assignments/pG6AeSjCwNtpWazQAX76Ap/delete-all/  # noqa: E501
 
 
     **Assign all permissions at once**

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -15,7 +15,12 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from kobo.apps.audit_log.base_views import AuditLoggedViewSet
 from kobo.apps.audit_log.models import AuditType
-from kpi.constants import CLONE_ARG_NAME, PERM_MANAGE_ASSET, PERM_VIEW_ASSET
+from kpi.constants import (
+    CLONE_ARG_NAME,
+    PERM_ADD_SUBMISSIONS,
+    PERM_MANAGE_ASSET,
+    PERM_VIEW_ASSET,
+)
 from kpi.models.asset import Asset
 from kpi.models.object_permission import ObjectPermission
 from kpi.permissions import AssetPermissionAssignmentPermission
@@ -220,6 +225,18 @@ class AssetPermissionAssignmentViewSet(
         # returns asset permissions. Users who can change permissions can
         # see all permissions.
         return self.list(request, *args, **kwargs)
+
+    @action(
+        detail=True,
+        methods=['DELETE'],
+    )
+    def delete_all(self, request, *args, **kwargs):
+        object_permission = self.get_object()
+        user = object_permission.user
+        response = self.destroy(request, *args, **kwargs)
+        if response.status_code == status.HTTP_204_NO_CONTENT:
+            self.asset.remove_perm(user, PERM_ADD_SUBMISSIONS)
+        return response
 
     def destroy(self, request, *args, **kwargs):
         object_permission = self.get_object()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add a new endpoint to delete all the permissions for a user by deleting any one of the user permissions

### 👀 Preview steps

1. Login as a user (user A)
2. Create or use an existing project to share it with another user (user B)
3. Log in as user B and go to the project page, 
4. Go to the "Form" tab, and in the three dots button, in the top right corner, click on the option "Remove shared project"
5. Log out
6. Log in as user A and check the project sharing settings, the user B should not appear anymore.