### PR TITLE
fix(organization): assign invitations to members correctly TASK-1600

### DIFF
--- a/kobo/apps/organizations/serializers.py
+++ b/kobo/apps/organizations/serializers.py
@@ -79,6 +79,7 @@ class OrganizationUserSerializer(serializers.ModelSerializer):
         ]
 
     def get_url(self, obj):
+
         request = self.context.get('request')
         return reverse(
             'organization-members-detail',
@@ -93,14 +94,21 @@ class OrganizationUserSerializer(serializers.ModelSerializer):
         """
         Get the latest invite for the user if it exists
         """
-        invite = OrganizationInvitation.objects.filter(
-            invitee=obj.user
-        ).order_by('-created').first()
+        try:
+            invites_per_member = self.context['invites_per_member']
+        except KeyError:
+            invite = OrganizationInvitation.objects.filter(
+                organization=obj.organization,
+                invitee=obj.user
+            ).order_by('-created').first()
+        else:
+            invite = invites_per_member.get(obj.user_id)
 
         if invite:
             return OrgMembershipInviteSerializer(
                 invite, context=self.context
             ).data
+
         return {}
 
     def to_representation(self, instance):

--- a/kobo/apps/organizations/tests/test_organization_invitations.py
+++ b/kobo/apps/organizations/tests/test_organization_invitations.py
@@ -60,11 +60,11 @@ class BaseOrganizationInviteTestCase(BaseOrganizationAssetApiTestCase):
             'invitees': ['bob', 'unregistereduser@example.com']
         }
 
-    def _create_invite(self, user):
+    def _create_invite(self, invited_by):
         """
         Helper method to create invitations
         """
-        self.client.force_login(user)
+        self.client.force_login(invited_by)
         return self.client.post(self.list_url, data=self.invitation_data)
 
     def _update_invite(self, user, guid, status):


### PR DESCRIPTION
### 📣 Summary
Fixed an issue where invitations were not properly assigned to the correct organization members and ensured that invitations reflect the intended recipient and organization.


### 📖 Description
An issue caused invitations to be incorrectly assigned, leading to inconsistencies in organization membership management. This fix ensures that invitations are correctly linked to the intended recipients, preventing access errors or misdirected invitations.


### 💭 Notes
`invite` property queryset has been optimized to avoid one query per member from the list endpoint.



### 👀 Preview steps

Bug template:
1. Create two MMO
2. From the owner account, invite the owner of the second
4. 🔴 [on main] notice that in the account of the 2nd owner, the organization member table shows the owner as invited
5. 🟢 [on PR] notice that in the account of the 2nd owner, the organization member table shows the owner as the owner and active
