### PR TITLE
fix(invites): display invite accepted banner for users who join another organization TASK-1601

### DIFF
--- a/jsapp/js/hooks/useSafeUsernameStorageKey.ts
+++ b/jsapp/js/hooks/useSafeUsernameStorageKey.ts
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react'
 
 /**
- * A hook for generating a key for `localStorage`/`sessionStorage` that includes encrypted username.
+ * A hook for generating a key for `localStorage`/`sessionStorage` that includes encrypted username and a prefix. You
+ * can pass `undefined` as prefix if it's not ready yet.
  */
-export function useSafeUsernameStorageKey(prefix: string, username: string) {
+export function useSafeUsernameStorageKey(prefix: string | undefined, username: string) {
   const [key, setKey] = useState<string | undefined>()
 
   // When this component is mounted, create the localStorage key we'll use
   useEffect(() => {
+    if (!prefix) {
+      return
+    }
     ;(async () => {
       if (crypto.subtle) {
         // Let's avoid leaving behind an easily-accessible list of all users
@@ -24,7 +28,7 @@ export function useSafeUsernameStorageKey(prefix: string, username: string) {
         setKey(`${prefix}-FOR DEVELOPMENT ONLY-${username}`)
       }
     })()
-  }, [])
+  }, [prefix, username])
 
   return key
 }

--- a/jsapp/js/projects/universalProjectsRoute.tsx
+++ b/jsapp/js/projects/universalProjectsRoute.tsx
@@ -26,6 +26,7 @@ import { dropImportXLSForms } from 'js/dropzone.utils'
 import { handleApiFail, fetchPostUrl } from 'js/api'
 import projectViewsStore from './projectViews/projectViewsStore'
 import { useSession } from 'jsapp/js/stores/useSession'
+import { useOrganizationQuery } from '../account/organization/organizationQuery'
 
 // Constants and types
 import type { ProjectsFilterDefinition, ProjectFieldName } from './projectViews/constants'
@@ -56,6 +57,7 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
   const [customView] = useState(customViewStore)
   const [selectedRows, setSelectedRows] = useState<string[]>([])
   const session = useSession()
+  const orgQuery = useOrganizationQuery()
 
   useEffect(() => {
     customView.setUp(props.viewUid, props.baseUrl, props.defaultVisibleFields, props.includeTypeFilter)
@@ -121,7 +123,9 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
 
         <OrgInviteModalWrapper />
 
-        {session.currentLoggedAccount && <OrgInviteAcceptedBanner username={session.currentLoggedAccount.username} />}
+        {session.currentLoggedAccount && orgQuery.data && (
+          <OrgInviteAcceptedBanner username={session.currentLoggedAccount.username} organization={orgQuery.data} />
+        )}
 
         <LimitNotifications useModal />
 


### PR DESCRIPTION
### 💭 Notes
Include organization id in the local storage key for banner dismissal. Also move `orgQuery` outside of `OrgInviteAcceptedBanner` to make it simpler to get organization id 👌

### 👀 Preview steps

Bug template:
1. ℹ️ have three accounts: "joe", "moe" and "bo"; "joe" and "moe" each are org owners, "bo" is not
2. send invite from "joe" to "bo" for joining joe's organization
3. accept invite as "bo"
4. 🟢 as "bo" notice that the invite accepted banner shows up (on top of `/#/projects/home` route)
5. dismiss the banner with "x" button (a localStorage item will be added)
6. as "joe" then remove "bo" from organization
7. send invite from "moe" to "bo" for joining moe's organization
8. accept invite as "bo"
9. 🔴 [on main] as "bo" notice that the banner doesn't appear
10. 🟢 [on PR] as "bo" notice that the banner does appear