### PR TITLE
fix(notifications): use toast instead of alertify

### DIFF
--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -4,7 +4,7 @@ import ButtonNew from 'jsapp/js/components/common/ButtonNew'
 import type { ReactNode } from 'react'
 import type { MemberInvite } from './membersInviteQuery'
 import { MemberInviteStatus, usePatchMemberInvite, useRemoveMemberInvite } from './membersInviteQuery'
-import { notify } from 'alertifyjs'
+import { notify } from 'js/utils'
 
 /**
  * A dropdown with all actions that can be taken towards an organization invitee.

--- a/jsapp/js/account/organization/MemberRemoveModal.tsx
+++ b/jsapp/js/account/organization/MemberRemoveModal.tsx
@@ -11,7 +11,7 @@ import { getSimpleMMOLabel } from './organization.utils'
 import envStore from 'jsapp/js/envStore'
 import subscriptionStore from 'jsapp/js/account/subscriptionStore'
 import { useRemoveOrganizationMember } from './membersQuery'
-import { notify } from 'alertifyjs'
+import { notify } from 'js/utils'
 
 interface MemberRemoveModalProps {
   username: string

--- a/jsapp/js/actions/mfaActions.ts
+++ b/jsapp/js/actions/mfaActions.ts
@@ -1,5 +1,5 @@
 import Reflux from 'reflux'
-import { notify } from 'alertifyjs'
+import { notify } from 'js/utils'
 import { ROOT_URL } from 'js/constants'
 import { hasActiveSubscription } from 'js/account/stripe.utils'
 import { when } from 'mobx'

--- a/jsapp/js/alertify.ts
+++ b/jsapp/js/alertify.ts
@@ -29,6 +29,7 @@ interface MultiConfirmButtonCloseEvent {
 }
 
 /**
+ * @deprecated don't use alertifyjs
  * Use this custom alertify modal to display multiple buttons with different
  * callbacks.
  */
@@ -148,6 +149,7 @@ export function multiConfirm(confirmId: string, title: string, message: string, 
 }
 
 /**
+ * @deprecated don't use alertifyjs
  * A DRY dialog wrapper for `alertifyjs` that will display a simple confirmation
  * for destroying something. The fallback text is for deleting stuff, as most
  * common case.
@@ -183,6 +185,7 @@ export function destroyConfirm(
 }
 
 /**
+ * @deprecated don't use alertifyjs
  * Useful to pass a complex JSX message into alertify (which accepts only
  * strings).
  */

--- a/jsapp/js/components/processing/processingActions.ts
+++ b/jsapp/js/components/processing/processingActions.ts
@@ -6,7 +6,7 @@
  */
 
 import Reflux from 'reflux'
-import { notify } from 'alertifyjs'
+import { notify } from 'js/utils'
 import clonedeep from 'lodash.clonedeep'
 import { actions } from 'js/actions'
 import { getAssetAdvancedFeatures, getAssetProcessingUrl } from 'js/assetUtils'

--- a/jsapp/js/global.d.ts
+++ b/jsapp/js/global.d.ts
@@ -175,6 +175,7 @@ interface AlertifyJsModule {
   /** Alias to `setting`, please do not use. */
   get: Function
   /**
+   * @deprecated Use `notify` function from our utils file, i.e. `import { notify } from 'js/utils'`.
    * Creates a new notification message.
    * If a type is passed, a class name "ajs-{type}" will be added.
    * This allows for custom look and feel for various types of notifications.

--- a/jsapp/js/global.d.ts
+++ b/jsapp/js/global.d.ts
@@ -233,6 +233,9 @@ interface AlertifyJsModule {
   [id: string]: any
 }
 declare module 'alertifyjs' {
+  /**
+   * @deprecated Use `notify` function from our utils file, i.e. `import { notify } from 'js/utils'`.
+   */
   const alertifyjsmodule: AlertifyJsModule = {}
   export = alertifyjsmodule
 }


### PR DESCRIPTION
### 💭 Notes
Mistakingly `import { notify } from 'alertifyjs'` was being used instead of `import { notify } from 'js/utils'`. I've added some deprecation tags to alertify related code. Note that our notify (it uses `react-hot-toast`) might get deprecated soon too - in favor of Mantine's notifications system.


### 👀 Preview steps

Bug template:
1. ℹ️ have two accounts: "joe" and "bo"; "joe" is org owner, "bo" is not
2. send invite from "joe" to "bo" for joining joe's organization
3. remove invitation
9. 🔴 [on main] notice that the notification appears in bottom right corner and it looks different
10. 🟢 [on PR] notice that the notification appears in top center and it looks as it should :)