### PR TITLE
fix(organizations): adjust loading process for invite responses TASK-1602

### DIFF
--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 // Partial components
 import Alert from 'js/components/common/alert'
 import { Modal, Button, Stack, Text, Group, FocusTrap } from '@mantine/core'

--- a/jsapp/js/projects/universalProjectsRoute.tsx
+++ b/jsapp/js/projects/universalProjectsRoute.tsx
@@ -171,7 +171,9 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
 
         <ProjectsTable
           assets={customView.assets}
-          isLoading={!customView.isFirstLoadComplete}
+          // refreshing session will result in refreshing table, so while that is pending
+          // we want to show a loading spinner
+          isLoading={!customView.isFirstLoadComplete || session.isPending}
           highlightedFields={getFilteredFieldsNames()}
           visibleFields={getTableVisibleFields()}
           orderableFields={props.defaultOrderableFields}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Introduces a delay in refreshing user data after an MMO invitation is accepted to allow for initial backend project transfers and separates the loading state of the accept/decline buttons.

### 💭 Notes
Combines work for both [TASK-1602](https://www.notion.so/kobotoolbox/Add-delay-in-refreshing-data-after-invite-acceptance-19f7e515f654809a916fecf0b43908b8?pvs=4) and [TASK-1603](https://www.notion.so/kobotoolbox/Display-spinner-on-one-button-in-invite-moda-1a07e515f65480ac8373f2095ba9f2b6?pvs=4). The impacted code is closely related and it will be quicker to preview/test both at the same time.


### 👀 Preview steps
1. As an MMO owner/admin invite a new member to organization
2. As invitee, navigate to emailed invitation link
3. Decline invite (you might want to throttle your network connection in devtools first for easier observation)
4. Observe that only the "decline" button loading spinner is activated

5. As an MMO owner/admin invite a new member to organization
6. As invitee, create an empty project ("invitee's project")
7. navigate to emailed invitation link
8. Accept invite (you might want to throttle your network connection in devtools first for easier observation)
9. Observe that only the "Accept" button loading spinner is activated
10. Observe that once invitation patch has been successful, the modal displays a loading spinner for 1 second before disappearing, following which session and project list data are refreshed (with a loading spinner on the data table) and "invitee's project" is now shown to belong to MMO