### PR TITLE
fix(projectTransfer)!: fix incorrect in-app message for project transfers

### DIFF
--- a/kobo/apps/help/serializers.py
+++ b/kobo/apps/help/serializers.py
@@ -128,9 +128,17 @@ class InAppMessageSerializer(serializers.ModelSerializer):
         except Transfer.DoesNotExist:
             return value
 
+        # If the recipient's org is an MMO, the new owner is the organization
+        recipient = transfer.invite.recipient
+        new_owner = (
+            recipient.organization.name
+            if recipient.organization.is_mmo
+            else recipient.username
+        )
+
         value = value.replace('##username##', user.username)
         value = value.replace('##project_name##', transfer.asset.name)
         value = value.replace('##previous_owner##', transfer.invite.sender.username)
-        value = value.replace('##new_owner##', transfer.invite.recipient.username)
+        value = value.replace('##new_owner##', new_owner)
 
         return value


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Corrected the in-app message to show the proper owner for project transfers.

### 📖 Description
The in-app message for project transfers previously displayed the wrong user as the new owner. This fix ensures that if the recipient's organization is a multi-member organization (MMO), the organization name is shown as the new owner, rather than the recipient's username. This change improves the clarity and accuracy of transfer notifications.