### PR TITLE
fix(projectTransfer)!: fix incorrect in-app message for project transfers

### DIFF
--- a/kobo/apps/help/serializers.py
+++ b/kobo/apps/help/serializers.py
@@ -128,9 +128,17 @@ class InAppMessageSerializer(serializers.ModelSerializer):
         except Transfer.DoesNotExist:
             return value
 
+        # If the recipient's org is an MMO, the new owner is the organization
+        recipient = transfer.invite.recipient
+        new_owner = (
+            recipient.organization.name
+            if recipient.organization.is_mmo
+            else recipient.username
+        )
+
         value = value.replace('##username##', user.username)
         value = value.replace('##project_name##', transfer.asset.name)
         value = value.replace('##previous_owner##', transfer.invite.sender.username)
-        value = value.replace('##new_owner##', transfer.invite.recipient.username)
+        value = value.replace('##new_owner##', new_owner)
 
         return value


### PR DESCRIPTION
### 📣 Summary
Corrected the in-app message to show the proper owner for project transfers.

### 📖 Description
The in-app message for project transfers previously displayed the wrong user as the new owner. This fix ensures that if the recipient's organization is a multi-member organization (MMO), the organization name is shown as the new owner, rather than the recipient's username. This change improves the clarity and accuracy of transfer notifications.

### Notes 
Backport of #5549 and supersedes it