### PR TITLE
fix(projectTransfer)!: fix asset visibility issue when user joins another organization

### DIFF
--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -159,7 +159,9 @@ class ExcludeOrgAssetFilter(filters.BaseFilterBackend):
         user = get_database_user(request.user)
         organization = user.organization
         if organization and organization.is_owner(user) and organization.is_mmo:
-            return queryset.exclude(is_excluded_from_projects_list=True)
+            return queryset.exclude(
+                is_excluded_from_projects_list=True, owner_id=user.pk
+            )
         return queryset
 
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensures that assets shared with an organization owner remain visible even after the asset owner joins a different organization.

### 📖 Description
Previously, when an external user shared an asset with an organization owner and later joined a different organization, the asset became invisible to the original organization. This fix ensures that the asset remains visible in both organizations, maintaining expected access permissions. A test case has been added to verify this behavior.