### PR TITLE
feat(organizations): show subscription plan in organization view TASK-1605

### DIFF
--- a/kobo/apps/organizations/admin/organization.py
+++ b/kobo/apps/organizations/admin/organization.py
@@ -17,8 +17,8 @@ from .organization_user import OrgUserInline, max_users_for_edit_mode
 class OrgAdmin(BaseOrganizationAdmin):
     inlines = [OwnerInline, OrgUserInline]
     view_on_site = False
-    readonly_fields = ['id']
-    fields = ['id', 'name', 'mmo_override']
+    readonly_fields = ['id', 'subscription_plan']
+    fields = ['id', 'name', 'mmo_override', 'subscription_plan']
     search_fields = ['name']
 
     # parent overrides

--- a/kobo/apps/organizations/admin/organization.py
+++ b/kobo/apps/organizations/admin/organization.py
@@ -1,8 +1,11 @@
+from django.conf import settings
 from django.contrib import admin, messages
 from django.db.models import Count
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from organizations.base_admin import BaseOrganizationAdmin
+if settings.STRIPE_ENABLED:
+    from djstripe.models import Price
 
 from kobo.apps.kobo_auth.shortcuts import User
 
@@ -67,6 +70,14 @@ class OrgAdmin(BaseOrganizationAdmin):
 
                 if deleted_user_ids:
                     revoke_org_asset_perms(form.instance, deleted_user_ids)
+
+    def subscription_plan(self, obj):
+        sub_details = obj.active_subscription_billing_details()
+        if sub_details:
+            price = Price.objects.get(id=sub_details['price_id'])
+            return price
+
+        return None
 
     def _delete_previous_organizations(
         self, new_members: 'QuerySet', organization_id: int

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -6,8 +6,6 @@ from django.contrib import admin
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import F
-from django.utils.translation import gettext_lazy as t
-from django.utils.translation import override
 from django_request_cache import cache_for_request
 from django.utils.translation import gettext_lazy as t
 
@@ -27,8 +25,6 @@ from organizations.abstract import (
 from organizations.utils import create_organization as create_organization_base
 
 from kpi.fields import KpiUidField
-from kpi.utils.mailer import EmailMessage, Mailer
-from kpi.utils.placeholders import replace_placeholders
 
 from .constants import (
     ORG_ADMIN_ROLE,

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -243,6 +243,7 @@ class Organization(AbstractOrganization):
 
         return None
 
+
 class OrganizationUser(AbstractOrganizationUser):
 
     def __str__(self):

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -2,7 +2,6 @@ from functools import partial
 from typing import Literal
 
 from django.conf import settings
-from django.contrib import admin
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import F
@@ -234,16 +233,6 @@ class Organization(AbstractOrganization):
             return self.owner.organization_user.user
         except ObjectDoesNotExist:
             return
-
-    @admin.display(description='Subscription Plan')
-    def subscription_plan(self):
-        obj = self
-        sub_details = obj.active_subscription_billing_details()
-        if sub_details:
-            price = Price.objects.get(id=sub_details['price_id'])
-            return price
-
-        return None
 
 
 class OrganizationUser(AbstractOrganizationUser):

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -233,6 +233,15 @@ class Organization(AbstractOrganization):
         except ObjectDoesNotExist:
             return
 
+    @admin.display(description='Subscription Plan')
+    def subscription_plan(self):
+        obj = self
+        sub_details = obj.active_subscription_billing_details()
+        if sub_details:
+            price = Price.objects.get(id=sub_details['price_id'])
+            return price
+
+        return None
 
 class OrganizationUser(AbstractOrganizationUser):
 

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -60,16 +60,6 @@ class Organization(AbstractOrganization):
         choices=OrganizationType.choices,
     )
 
-    @admin.display(description='Subscription Plan')
-    def subscription_plan(self):
-        obj = self
-        sub_details = obj.active_subscription_billing_details()
-        if sub_details:
-            price = Price.objects.get(id=sub_details['price_id'])
-            return price
-
-        return None
-
     def add_user(self, user, is_admin=False):
         if not self.is_mmo and self.users.all().count():
             raise NotMultiMemberOrganizationException

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -9,7 +9,7 @@ from django_request_cache import cache_for_request
 from django.utils.translation import gettext_lazy as t
 
 if settings.STRIPE_ENABLED:
-    from djstripe.models import Customer, Price, Subscription
+    from djstripe.models import Customer, Subscription
 
     from kobo.apps.stripe.constants import (
         ACTIVE_STRIPE_STATUSES,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Show the organization subscription plan summary in the organizations admin edit view.


### 👀 Preview steps
1. Enable stripe (see in Notion how to set it up)
2. Get a user
3. Make a paid plan purchase 
4. Go to the django admin, Organizations, and select the organization from the user you used for the test
5. Check that the Subscription Plan read only field has the correct information