### PR TITLE
fix(organizations): keep invite acceptance loading spinner in 'accept' button TASK-1603

### DIFF
--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -88,7 +88,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string;
   let title: React.ReactNode = null
 
   // Case 1: loading data.
-  if (orgMemberInviteQuery.isLoading || awaitingDataRefresh) {
+  if (orgMemberInviteQuery.isLoading) {
     content = <LoadingSpinner />
   }
   // Case 2: failed to get the invitation data from API.
@@ -139,7 +139,8 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string;
     content = <Alert type='error'>{miscError}</Alert>
   }
   // Case 3: got the invite, its status is pending, so we display form
-  else if (orgMemberInviteQuery.data?.status === MemberInviteStatus.pending) {
+  // We also continue displaying this content while we wait for data to refresh following acceptance
+  else if (orgMemberInviteQuery.data?.status === MemberInviteStatus.pending || awaitingDataRefresh) {
     title = t('Accept invitation to join ##TEAM_OR_ORGANIZATION_NAME##').replace(
       '##TEAM_OR_ORGANIZATION_NAME##',
       orgName,
@@ -162,7 +163,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string;
             variant='light'
             size='lg'
             onClick={handleDeclineInvite}
-            loading={userResponseType === MemberInviteStatus.declined && patchMemberInvite.isPending}
+            loading={userResponseType === MemberInviteStatus.declined}
           >
             {t('Decline')}
           </Button>
@@ -171,7 +172,9 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string;
             variant='filled'
             size='lg'
             onClick={handleAcceptInvite}
-            loading={userResponseType === MemberInviteStatus.accepted && patchMemberInvite.isPending}
+            // We don't use RQ loading state here because we also want spinner to display during
+            // timeout while we give backend time for data transfer
+            loading={userResponseType === MemberInviteStatus.accepted}
           >
             {t('Accept')}
           </Button>

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -116,7 +116,6 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string, display
   return useQuery<MemberInvite, FailResponse>({
     queryFn: () => fetchGet<MemberInvite>(apiPath, fetchOptions),
     queryKey: [QueryKeys.organizationMemberInviteDetail, apiPath, fetchOptions],
-    retry: false,
   })
 }
 

--- a/jsapp/js/account/organization/membersInviteQuery.ts
+++ b/jsapp/js/account/organization/membersInviteQuery.ts
@@ -116,6 +116,7 @@ export const useOrgMemberInviteQuery = (orgId: string, inviteId: string, display
   return useQuery<MemberInvite, FailResponse>({
     queryFn: () => fetchGet<MemberInvite>(apiPath, fetchOptions),
     queryKey: [QueryKeys.organizationMemberInviteDetail, apiPath, fetchOptions],
+    retry: false,
   })
 }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Uses the 'accept' button to display loading state both while PATCH request is pending and during timeout for org data refresh.


### 👀 Preview steps
1. As an MMO admin/owner, invite second user to org
2. As second user, navigate to emailed invite link
3. Accept the invite (you may want to throttle your connection in the network tab to make the process easier to see)
4. On main, the 'accept' button loading spinner will spin until the PATCH request is completed, then the modal content will be replaced by a loading spinner while we wait one second for the backend data transfer to get started
5. On this branch, the 'accept' button loading spinner will stay throughout the entire process