### PR TITLE
fix(billing): plan page always redirecting to settings (BACKPORT #5440)

### DIFF
--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -223,13 +223,6 @@ export default function Plan(props: PlanProps) {
     [searchParams, shouldRevalidate]
   );
 
-  // if the user is not the owner of their org, send them back to the settings page
-  useEffect(() => {
-    if (!orgQuery.data?.is_owner) {
-      navigate(ACCOUNT_ROUTES.ACCOUNT_SETTINGS);
-    }
-  }, [orgQuery.data]);
-
   // Re-fetch data from API and re-enable buttons if displaying from back/forward cache
   useEffect(() => {
     const handlePersisted = (event: PageTransitionEvent) => {


### PR DESCRIPTION
### 📣 Summary
Fixes a bug that was causing the plans page to always redirect current user to account settings page.

### 💭 Notes
This is a backport of #5440 and supersedes it.
