### PR TITLE
fix(billing): remove indent of last item in nlp add-ons dropdown TASK-15

### DIFF
--- a/jsapp/js/account/addOns/addOnList.module.scss
+++ b/jsapp/js/account/addOns/addOnList.module.scss
@@ -149,10 +149,6 @@
 
   .oneTime {
     justify-content: center;
-
-    :last-child {
-      margin-left: 8px;
-    }
   }
 
   .productName {


### PR DESCRIPTION
### 👀 Preview steps

1. ℹ️ have an account and a project
2. Check out the Account Settings < Add-ons
3. 🔴 [on main] notice that when any add-on dropdown is expanded, the last item is indented
4. 🟢 [on PR] notice that when any add-on dropdown is expanded, all items are properly aligned