### PR TITLE
fix(billing): expand add-on section to full page width TASK-14

### DIFF
--- a/jsapp/js/account/addOns/addOnList.module.scss
+++ b/jsapp/js/account/addOns/addOnList.module.scss
@@ -17,8 +17,6 @@
   table-layout: fixed;
   border-collapse: collapse;
   border-spacing: 0;
-  width: 100%;
-  max-width: plan.$plans-page-max-width;
 
   tr {
     border-top: 1px solid colors.$kobo-light-storm;
@@ -99,7 +97,8 @@
   width: 200px;
 }
 
-.mobileView {
+.mobileView,
+.purchase{
   display: flex;
   vertical-align: center;
   flex: 1;
@@ -124,9 +123,13 @@
   .productName {
     display: table-cell;
     width: 40%;
+    margin-right: 12px;
   }
 
-  .fullScreen,
+  .fullScreen {
+    display: table-cell;
+  }
+
   .price {
     display: table-cell;
     width: 30%;
@@ -137,13 +140,7 @@
   }
 
   .oneTimePrice,
-  .buy {
-    display: table-cell;
-    vertical-align: middle;
-    justify-content: center;
-  }
-
-  .oneTimePrice {
+  .buyContainer {
     width: 50%;
   }
 
@@ -155,13 +152,16 @@
     }
   }
 
-  .productName {
-    margin-right: 12px;
-  }
-
   .buy {
     width: 140px;
     padding-left: 20px;
+    float: right;
+  }
+
+  .purchase {
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }
 

--- a/jsapp/js/account/addOns/oneTimeAddOnRow.component.tsx
+++ b/jsapp/js/account/addOns/oneTimeAddOnRow.component.tsx
@@ -96,31 +96,33 @@ export const OneTimeAddOnRow = ({
   }
 
   const priceTableCells = (
-    <>
+    <div className={styles.purchase}>
       <div className={styles.oneTimePrice}>
         {selectedPrice.recurring?.interval === 'year' ? selectedPrice.human_readable_price : displayPrice}
       </div>
-      <div className={styles.buy}>
-        {isSubscribedAddOnPrice && (
-          <BillingButton
-            size={'m'}
-            label={t('Manage')}
-            isDisabled={Boolean(selectedPrice) && isBusy}
-            onClick={onClickManage}
-            isFullWidth
-          />
-        )}
-        {!isSubscribedAddOnPrice && (
-          <BillingButton
-            size={'m'}
-            label={t('Buy now')}
-            isDisabled={Boolean(selectedPrice) && isBusy}
-            onClick={onClickBuy}
-            isFullWidth
-          />
-        )}
+      <div className={styles.buyContainer}>
+        <div className={styles.buy}>
+          {isSubscribedAddOnPrice && (
+            <BillingButton
+              size={'m'}
+              label={t('Manage')}
+              isDisabled={Boolean(selectedPrice) && isBusy}
+              onClick={onClickManage}
+              isFullWidth
+            />
+          )}
+          {!isSubscribedAddOnPrice && (
+            <BillingButton
+              size={'m'}
+              label={t('Buy now')}
+              isDisabled={Boolean(selectedPrice) && isBusy}
+              onClick={onClickBuy}
+              isFullWidth
+            />
+          )}
+        </div>
       </div>
-    </>
+    </div>
   )
 
   return (


### PR DESCRIPTION
### 👀 Preview steps

1. ℹ️ have an account and a project
2. Navigate to the Account Settings < **Add-ons** page
4. 🔴 [on main] notice that the Available Add-ons section doesn't expand to the full width of the page
5. 🟢 [on PR] notice that the Available Add-ons section expands to the full width of the page and is responsive to different screen widths 
