### PR TITLE
fix(NLP): missing suggested language in language selector DEV-17

### DIFF
--- a/jsapp/js/components/languages/languageSelector.tsx
+++ b/jsapp/js/components/languages/languageSelector.tsx
@@ -179,22 +179,18 @@ class LanguageSelector extends React.Component<
   async fetchSuggestedLanguages() {
     this.setState({ suggestedLanguages: undefined });
     if (this.props.suggestedLanguages) {
-      try {
-        const languages = await Promise.all(
-          this.props.suggestedLanguages.map(async (languageCode) => {
-            try {
-              return await languagesStore.getLanguage(languageCode);
-            } catch (error) {
-              console.error(`Language ${languageCode} not found 2`);
-              return null;
-            }
-          })
-        );
-        const suggestedLanguages = languages.filter((language) => language !== null);
-        this.setState({ suggestedLanguages });
-      } catch (error) {
-        console.error('Error fetching suggested languages', error);
-      }
+      const languages = await Promise.all(
+        this.props.suggestedLanguages.map(async (languageCode) => {
+          try {
+            return await languagesStore.getLanguage(languageCode);
+          } catch (error) {
+            console.error(`Language ${languageCode} not found 2`);
+            return null;
+          }
+        })
+      );
+      const suggestedLanguages = languages.filter((language) => language !== null);
+      this.setState({ suggestedLanguages });
     }
   }
 

--- a/jsapp/js/components/languages/languageSelector.tsx
+++ b/jsapp/js/components/languages/languageSelector.tsx
@@ -190,8 +190,8 @@ class LanguageSelector extends React.Component<
             }
           })
         );
-        const validLanguages = languages.filter((language) => language !== null);
-        this.setState({ suggestedLanguages: validLanguages });
+        const suggestedLanguages = languages.filter((language) => language !== null);
+        this.setState({ suggestedLanguages });
       } catch (error) {
         console.error('Error fetching suggested languages', error);
       }

--- a/jsapp/js/components/languages/languageSelector.tsx
+++ b/jsapp/js/components/languages/languageSelector.tsx
@@ -176,27 +176,25 @@ class LanguageSelector extends React.Component<
     }
   }
 
-  fetchSuggestedLanguages() {
-    this.setState({suggestedLanguages: undefined});
+  async fetchSuggestedLanguages() {
+    this.setState({ suggestedLanguages: undefined });
     if (this.props.suggestedLanguages) {
-      this.props.suggestedLanguages.forEach(async (languageCode) => {
-        try {
-          const language = await languagesStore.getLanguage(languageCode);
-          // Just a safe check if suggested languages list didn't change while we
-          // waited for the response.
-          const isAlreadyAdded = Boolean(this.state.suggestedLanguages?.find((stateLanguage) => stateLanguage.code === language.code));
-          if (
-            this.props.suggestedLanguages?.includes(language.code) &&
-            !isAlreadyAdded
-          ) {
-            const newLanguages = this.state.suggestedLanguages || [];
-            newLanguages.push(language);
-            this.setState({suggestedLanguages: newLanguages});
-          }
-        } catch (error) {
-          console.error(`Language ${languageCode} not found 2`);
-        }
-      });
+      try {
+        const languages = await Promise.all(
+          this.props.suggestedLanguages.map(async (languageCode) => {
+            try {
+              return await languagesStore.getLanguage(languageCode);
+            } catch (error) {
+              console.error(`Language ${languageCode} not found 2`);
+              return null;
+            }
+          })
+        );
+        const validLanguages = languages.filter((language) => language !== null);
+        this.setState({ suggestedLanguages: validLanguages });
+      } catch (error) {
+        console.error('Error fetching suggested languages', error);
+      }
     }
   }
 
@@ -254,7 +252,7 @@ class LanguageSelector extends React.Component<
 
   /**
    * We need to filter out some languages from the list, so we use this neat
-   * little alias to `this.store.suggestedLanguages`.
+   * little alias to `this.state.suggestedLanguages`.
    */
   get suggestedLanguages() {
     return this.state.suggestedLanguages?.filter((language) =>


### PR DESCRIPTION
### 💭 Notes
Loop of asynchronous calls was bad. I made Promise.all that fixes the problem. 

### 👀 Preview steps
I can reproduce this on kf.main but I believe this is on production too.

1. Create a form with one audio question
2. Create two submissions (each with one audio file)
3. From the data table, click Open for the first submission.
4. Create a manual transcription in English. Save it.
5. Delete the transcript.
6. Go to the second submission (from the data table or by just clicking the up/down button from the same screen).
7. Create a manual transcription in Spanish. Save it.
8. Go back to the first subscription. Try to create a new transcript in English.

Expected behavior: The top of the language list shows English in the first position.

Instead: English is not displayed at all (and can't be found by searching either). Spanish is displayed in first position.