### PR TITLE
fix(organizations): use correct teams MMO label in invite feature TASK-1644

### DIFF
--- a/jsapp/js/account/organization/InviteModal.tsx
+++ b/jsapp/js/account/organization/InviteModal.tsx
@@ -8,9 +8,13 @@ import { OrganizationUserRole } from './organizationQuery'
 import userExistence from 'js/users/userExistence.store'
 import { useField } from '@mantine/form'
 import { checkEmailPattern, notify } from 'js/utils'
+import envStore from 'jsapp/js/envStore'
+import subscriptionStore from 'jsapp/js/account/subscriptionStore'
+import { getSimpleMMOLabel } from 'js/account/organization/organization.utils'
 
 export default function InviteModal(props: ModalProps) {
   const inviteQuery = useSendMemberInvite()
+  const mmoLabel = getSimpleMMOLabel(envStore.data, subscriptionStore.activeSubscriptions[0])
 
   const [role, setRole] = useState<string | null>(null)
 
@@ -68,8 +72,8 @@ export default function InviteModal(props: ModalProps) {
       <Stack>
         <Text>
           {t(
-            'Enter the username or email address of the person you wish to invite to your team. They will receive an invitation in their inbox.',
-          )}
+            'Enter the username or email address of the person you wish to invite to your ##TEAM_OR_ORGANIZATION##. They will receive an invitation in their inbox.',
+          ).replace('##TEAM_OR_ORGANIZATION##', mmoLabel)}
         </Text>
         <Group align={'flex-start'} w='100%' gap='xs'>
           <TextInput

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -13,7 +13,10 @@ import { Divider, Group, Stack, Text, Title, Box } from '@mantine/core'
 import InviteModal from 'js/account/organization/InviteModal'
 
 // Stores, hooks and utilities
+import envStore from 'jsapp/js/envStore'
+import subscriptionStore from 'jsapp/js/account/subscriptionStore'
 import { formatDate } from 'js/utils'
+import { getSimpleMMOLabel } from 'js/account/organization/organization.utils'
 import { OrganizationUserRole, useOrganizationQuery } from './organizationQuery'
 import useOrganizationMembersQuery from './membersQuery'
 import { useDisclosure } from '@mantine/hooks'
@@ -30,6 +33,7 @@ import InviteeActionsDropdown from './InviteeActionsDropdown'
 export default function MembersRoute() {
   const orgQuery = useOrganizationQuery()
   const [opened, { open, close }] = useDisclosure(false)
+  const mmoLabel = getSimpleMMOLabel(envStore.data, subscriptionStore.activeSubscriptions[0])
 
   /**
    * Checks whether object should be treated as organization member or invitee.
@@ -197,7 +201,11 @@ export default function MembersRoute() {
               <Title fw={600} order={5}>
                 {t('Invite members')}
               </Title>
-              <Text>{t('Invite more people to join your team or change their role permissions below.')}</Text>
+              <Text>
+                {t(
+                  'Invite more people to join your ##TEAM_OR_ORGANIZATION## or change their role permissions below.',
+                ).replace('##TEAM_OR_ORGANIZATION##', mmoLabel)}
+              </Text>
             </Stack>
 
             <Box>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes an issue where UI text did not use proper MMO label for teams/organizations on the Members page and invite initiation modal.

### 👀 Preview steps
1. As a django admin, create an MMO in Django admin panel using the MMO override
2. As MMO owner, open members page.
3. See that MMO is referred to as "team" or "organization" in invite members section and invite modal depending on the USE_TEAM_LABEL config option in constance.
4. Switch USE_TEAM_LABEL config option
5. Reload members page and see that text follows new config.