### PR TITLE
fix(trashBin): Ensure the project is fully restored from the trash

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -115,7 +115,7 @@ class XForm(AbstractTimeStampedModel):
     @property
     def asset(self):
         """
-        Retrieve related asset object easily from XForm instance.
+        Retrieve the related asset object easily from XForm instance.
 
         Useful to display form disclaimer in Enketo.
         See kpi.utils.xml.XMLFormWithDisclaimer for more details.
@@ -126,16 +126,22 @@ class XForm(AbstractTimeStampedModel):
             # uses an Asset object only to narrow down a query with a filter,
             # thus uses only asset PK
             try:
-                asset = Asset.objects.only('pk').get(uid=self.kpi_asset_uid)
+                asset = Asset.all_objects.only(
+                    'pk', 'name', 'uid', 'owner_id'
+                ).get(uid=self.kpi_asset_uid)
             except Asset.DoesNotExist:
                 try:
-                    asset = Asset.objects.only('pk').get(
-                        _deployment_data__formid=self.pk
-                    )
+                    asset = Asset.all_objects.only(
+                        'pk', 'name', 'uid', 'owner_id'
+                    ).get(_deployment_data__formid=self.pk)
                 except Asset.DoesNotExist:
                     # An `Asset` object needs to be returned to avoid 500 while
                     # Enketo is fetching for project XML (e.g: /formList, /manifest)
-                    asset = Asset(uid=self.id_string)
+                    asset = Asset(
+                        uid=self.id_string,
+                        name=self.title,
+                        owner_id=self.user.id,
+                    )
 
             setattr(self, '_cache_asset', asset)
 

--- a/kobo/apps/trash_bin/models/project.py
+++ b/kobo/apps/trash_bin/models/project.py
@@ -85,10 +85,9 @@ class ProjectTrash(BaseTrash):
                         ).values_list('invite_id', flat=True)
                     ).update(status=InviteStatusChoices.CANCELLED)
 
-                if not settings.TESTING:
-                    kc_updated = XForm.objects.filter(**kc_filter_params).update(
-                        **kc_update_params
-                    )
-                    assert updated >= kc_updated
+                kc_updated = XForm.all_objects.filter(**kc_filter_params).update(
+                    **kc_update_params
+                )
+                assert updated >= kc_updated
 
         return queryset, updated

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -656,6 +656,12 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             fields=['_id'],
             skip_count=True,
         )
+
+        if settings.TESTING:
+            # `all_submissions` is a list in testing environment,
+            # but a generator on production.
+            all_submissions = iter(all_submissions)
+
         try:
             next(all_submissions)
         except StopIteration:
@@ -1212,7 +1218,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
         pk = self.backend_response['formid']
         xform = (
-            XForm.objects.filter(pk=pk)
+            XForm.all_objects.filter(pk=pk)
             .only(
                 'user__username',
                 'id_string',


### PR DESCRIPTION
### 📣 Summary
Fixed an issue where projects were not being completely restored from the trash.


### 📖 Description
A bug prevented projects from being fully restored after being moved to the trash, leading to missing or incomplete data upon recovery. 

### 💭 Notes
Some unittests were apparently missing for this part, this PR adds two new tests. Moreover, part of kpi#5514 has been backported to this release. 


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. delete the project
3. go the admin interface and put back the project from the trash bin
4. 🔴 [on release branch] (from the shell) notice asset.deployment.xform.pending_delete still equals True
5. 🟢 [on PR] (from the shell) notice asset.deployment.xform.pending_delete now equals False
