### PR TITLE
style(frontend): enable passing Biome linter rules

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm install
 
       # Check for Biome formatting errors
-      - name: Check Biome formatting
+      - name: Check Biome formatting, import order and linter
         run: npm run lint:biome
 
       # Check for TypeScript errors

--- a/CODING_STYLE_FE.md
+++ b/CODING_STYLE_FE.md
@@ -7,11 +7,15 @@ Coding Style Guidelines for Frontend
 Automatic Linting Rules
 ---------------------------------------
 
-Kobotoolbox uses [Biome](https://biomejs.dev/) mainly for formatting, and [ESLint](https://typescript-eslint.io/) exclusively for linting.
-- formatting: consistent whitespaces and other style of code.
-- linting: identifying bugs and anti-patterns.
 
-Kobotoolbox has plans to adopt [oxlint](https://oxc.rs/docs/guide/usage/linter.html) in the future. It's an upcoming performant competitor to ESlint, but isn't type-aware yet and thus limited in it's capacity.
+Kobotoolbox uses automated tools to assist developers in three ways:
+- formatting: enforce consistent code style.
+- organize imports: enforce consistent import statement order sorted by "distance" and natural ordering.
+- linting: enforce fixing common errors and writing modern code.
+
+Kobotoolbox uses the fast [Biome](https://biomejs.dev/) for all three, although it's linter is not type-aware. and [ESLint](https://typescript-eslint.io/) for linting only. There are plans to adopt [oxlint](https://oxc.rs/docs/guide/usage/linter.html) in the future, it's an upcoming performant competitor to ESlint, but isn't type-aware yet and thus limited in it's capacity.
+
+Kobotoolbox is in progress of gradually adopting Biome. Please find TODOs in [`./biome.jsonc`](./biome.jsonc).
 
 
 

--- a/CODING_STYLE_FE.md
+++ b/CODING_STYLE_FE.md
@@ -13,7 +13,7 @@ Kobotoolbox uses automated tools to assist developers in three ways:
 - organize imports: enforce consistent import statement order sorted by "distance" and natural ordering.
 - linting: enforce fixing common errors and writing modern code.
 
-Kobotoolbox uses the fast [Biome](https://biomejs.dev/) for all three, although it's linter is not type-aware. and [ESLint](https://typescript-eslint.io/) for linting only. There are plans to adopt [oxlint](https://oxc.rs/docs/guide/usage/linter.html) in the future, it's an upcoming performant competitor to ESlint, but isn't type-aware yet and thus limited in it's capacity.
+Kobotoolbox uses the fast [Biome](https://biomejs.dev/) for all three, although it's linter is not type-aware, and [ESLint](https://typescript-eslint.io/) for linting only. There are plans to adopt [oxlint](https://oxc.rs/docs/guide/usage/linter.html) in the future, it's an upcoming performant competitor to ESlint, but isn't type-aware yet and thus limited in it's capacity.
 
 Kobotoolbox is in progress of gradually adopting Biome. Please find TODOs in [`./biome.jsonc`](./biome.jsonc).
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -44,9 +44,93 @@
     "enabled": true
   },
   "linter": {
-    "enabled": false, // TODO: for later.
+    "enabled": true,
     "rules": {
-      "recommended": false // Workaround: see https://github.com/biomejs/biome-vscode/issues/491#issuecomment-2643675948
+      "recommended": true,
+      // Note: amount of cases are written as of May 7, 2025, commit 87af38ed5.
+      "correctness": {
+        "noEmptyPattern": "off", // Recommended rule. TODO: review 5 cases and enable.
+        "noInnerDeclarations": "off", // Recommended rule. TODO: review 22 cases and enable.
+        "noInvalidUseBeforeDeclaration": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "noSwitchDeclarations": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "noUnsafeOptionalChaining": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "useExhaustiveDependencies": "off", // Recommended rule. TODO: review 101 cases and enable.
+        "useJsxKeyInIterable": "off" // Recommended rule. TODO: review 17 cases and enable.
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off", // Recommended rule. TODO: review 40 cases and enable.
+        "noAssignInExpressions": "off", // Recommended rule. TODO: review 4 cases and enable.
+        "noConfusingVoidType": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "noControlCharactersInRegex": "off", // Recommended rule. TODO: review 4 cases and enable.
+        "noDoubleEquals": "off", // Recommended rule. TODO: review 14 cases and enable.
+        "noEmptyInterface": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "noExplicitAny": "off", // Recommended rule. TODO: review 129 cases and enable.
+        "noImplicitAnyLet": "off", // Recommended rule. TODO: review 42 cases and enable.
+        "noMisleadingCharacterClass": "off", // Recommended rule. TODO: review 1 case and enable.
+        "noPrototypeBuiltins": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "noRedeclare": "off", // Recommended rule. TODO: review 1 case and enable.
+        "noRedundantUseStrict": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "noShadowRestrictedNames": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "useIsArray": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "useValidTypeof": "off" // Recommended rule. TODO: review 3 cases and enable.
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "off" // Recommended rule. TODO: review 11 cases and enable.
+      },
+      "complexity": {
+        "noBannedTypes": "off", // Recommended rule. TODO: review 144 cases and enable.
+        "noExtraBooleanCast": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "noForEach": "off", // Recommended rule. TODO: review 217 cases and enable.
+        "noUselessConstructor": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "noUselessFragments": "off", // Recommended rule. TODO: review 4 cases and enable.
+        "noUselessSwitchCase": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "noUselessTernary": "off", // Recommended rule. TODO: review 4 cases and enable.
+        "noUselessThisAlias": "off", // Recommended rule. TODO: review 7 cases and enable.
+        "useArrowFunction": "off", // Recommended rule. TODO: review 245 cases and enable.
+        "useLiteralKeys": "off", // Recommended rule. TODO: review 28 cases and enable.
+        "useOptionalChain": "off", // Recommended rule. TODO: review 36 cases and enable.
+        "useRegexLiterals": "off" // Recommended rule. TODO: review 1 cases and enable.
+      },
+      "performance": {
+        "noAccumulatingSpread": "off", // Recommended rule. TODO: review 7 cases and enable.
+        "noDelete": "off" // Recommended rule. TODO: review 17 cases and enable.
+      },
+      "a11y": {
+        "noBlankTarget": "off", // Not a problem for modern browsers; see 2021 update, see https://mathiasbynens.github.io/rel-noopener/#recommendations.
+        "noLabelWithoutControl": "off", // Recommended rule. TODO: review 63 cases and enable.
+        "noNoninteractiveTabindex": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "noPositiveTabindex": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "noSvgWithoutTitle": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "useAltText": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "useAriaPropsForRole": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "useButtonType": "off", // Recommended rule. TODO: review 31 cases and enable.
+        "useFocusableInteractive": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "useIframeTitle": "off", // Recommended rule. TODO: review 4 cases and enable.
+        "useKeyWithClickEvents": "off", // Recommended rule. TODO: review 24 cases and enable.
+        "useKeyWithMouseEvents": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "useMediaCaption": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "useSemanticElements": "off", // Recommended rule. TODO: review 5 cases and enable.
+        "useValidAnchor": "off" // Recommended rule. TODO: review 4 cases and enable.
+      },
+      "style": {
+        "noArguments": "off", // Recommended rule. TODO: review 6 cases and enable.
+        "noCommaOperator": "off", // Recommended rule. TODO: review 7 cases and enable.
+        "noInferrableTypes": "off", // Recommended rule. TODO: review 5 cases and enable.
+        "noNonNullAssertion": "off", // Recommended rule. TODO: review 50 cases and enable.
+        "noParameterAssign": "off", // Recommended rule. TODO: review 31 cases and enable.
+        "noUnusedTemplateLiteral": "off", // Recommended rule. TODO: review 5 cases and enable.
+        "noUselessElse": "off", // Recommended rule. TODO: review 167 cases and enable.
+        "noVar": "off", // Recommended rule. TODO: review 234 cases and enable.
+        "useConst": "off", // Recommended rule. TODO: review 108 cases and enable.
+        "useDefaultParameterLast": "off", // Recommended rule. TODO: review 1 cases and enable.
+        "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "useImportType": "off", // Recommended rule. TODO: review 64 cases and enable.
+        "useNodejsImportProtocol": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "useNumberNamespace": "off", // Recommended rule. TODO: review 35 cases and enable.
+        "useShorthandFunctionType": "off", // Recommended rule. TODO: review 9 cases and enable.
+        "useSingleVarDeclarator": "off", // Recommended rule. TODO: review 35 cases and enable.
+        "useTemplate": "off" // Recommended rule. TODO: review 103 cases and enable.
+      }
     }
   }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -87,6 +87,7 @@
         "noUselessTernary": "off", // Recommended rule. TODO: review 4 cases and enable.
         "noUselessThisAlias": "off", // Recommended rule. TODO: review 7 cases and enable.
         "useArrowFunction": "off", // Recommended rule. TODO: review 245 cases and enable.
+        "noUselessUndefinedInitialization": "error", // Enable all safely fixable rules.
         "useLiteralKeys": "off", // Recommended rule. TODO: review 28 cases and enable.
         "useOptionalChain": "off", // Recommended rule. TODO: review 36 cases and enable.
         "useRegexLiterals": "off" // Recommended rule. TODO: review 1 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -123,6 +123,7 @@
         "noUnusedTemplateLiteral": "off", // Recommended rule. TODO: review 5 cases and enable.
         "noUselessElse": "off", // Recommended rule. TODO: review 167 cases and enable.
         "noVar": "off", // Recommended rule. TODO: review 234 cases and enable.
+        "noYodaExpression": "error", // Enable all safely fixable rules.
         "useConst": "off", // Recommended rule. TODO: review 108 cases and enable.
         "useDefaultParameterLast": "off", // Recommended rule. TODO: review 1 cases and enable.
         "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -130,6 +130,7 @@
         "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.
         "useExportType": "error", // Enable all safely fixable rules.
         "useImportType": "off", // Recommended rule. TODO: review 64 cases and enable.
+        "useNamingConvention": "off", // TODO: Enable all safely fixable rules.
         "useNodeAssertStrict": "error", // Enable all safely fixable rules.
         "useNodejsImportProtocol": "off", // Recommended rule. TODO: review 3 cases and enable.
         "useNumberNamespace": "off", // Recommended rule. TODO: review 35 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -128,6 +128,7 @@
         "useConst": "off", // Recommended rule. TODO: review 108 cases and enable.
         "useDefaultParameterLast": "off", // Recommended rule. TODO: review 1 cases and enable.
         "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.
+        "useExportType": "error", // Enable all safely fixable rules.
         "useImportType": "off", // Recommended rule. TODO: review 64 cases and enable.
         "useNodejsImportProtocol": "off", // Recommended rule. TODO: review 3 cases and enable.
         "useNumberNamespace": "off", // Recommended rule. TODO: review 35 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -66,7 +66,6 @@
         "noEmptyInterface": "off", // Recommended rule. TODO: review 1 cases and enable.
         "noExplicitAny": "off", // Recommended rule. TODO: review 129 cases and enable.
         "noImplicitAnyLet": "off", // Recommended rule. TODO: review 42 cases and enable.
-        "noMisleadingCharacterClass": "off", // Recommended rule. TODO: review 1 case and enable.
         "noPrototypeBuiltins": "off", // Recommended rule. TODO: review 3 cases and enable.
         "noRedeclare": "off", // Recommended rule. TODO: review 1 case and enable.
         "noRedundantUseStrict": "off", // Recommended rule. TODO: review 2 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -130,6 +130,7 @@
         "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.
         "useExportType": "error", // Enable all safely fixable rules.
         "useImportType": "off", // Recommended rule. TODO: review 64 cases and enable.
+        "useNodeAssertStrict": "error", // Enable all safely fixable rules.
         "useNodejsImportProtocol": "off", // Recommended rule. TODO: review 3 cases and enable.
         "useNumberNamespace": "off", // Recommended rule. TODO: review 35 cases and enable.
         "useShorthandFunctionType": "off", // Recommended rule. TODO: review 9 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -115,6 +115,7 @@
       },
       "style": {
         "noArguments": "off", // Recommended rule. TODO: review 6 cases and enable.
+        "noImplicitBoolean": "off", // Enable all safely fixable rules, except this for a cleaner look.
         "noCommaOperator": "off", // Recommended rule. TODO: review 7 cases and enable.
         "noInferrableTypes": "off", // Recommended rule. TODO: review 5 cases and enable.
         "noNonNullAssertion": "off", // Recommended rule. TODO: review 50 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -124,6 +124,7 @@
         "noUselessElse": "off", // Recommended rule. TODO: review 167 cases and enable.
         "noVar": "off", // Recommended rule. TODO: review 234 cases and enable.
         "noYodaExpression": "error", // Enable all safely fixable rules.
+        "useAsConstAssertion": "error", // Enable all safely fixable rules.
         "useConst": "off", // Recommended rule. TODO: review 108 cases and enable.
         "useDefaultParameterLast": "off", // Recommended rule. TODO: review 1 cases and enable.
         "useEnumInitializers": "off", // Recommended rule. TODO: review 2 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -69,7 +69,6 @@
         "noPrototypeBuiltins": "off", // Recommended rule. TODO: review 3 cases and enable.
         "noReactSpecificProps": "off", // We use React.
         "noRedeclare": "off", // Recommended rule. TODO: review 1 case and enable.
-        "noRedundantUseStrict": "off", // Recommended rule. TODO: review 2 cases and enable.
         "noShadowRestrictedNames": "off", // Recommended rule. TODO: review 2 cases and enable.
         "useIsArray": "off", // Recommended rule. TODO: review 3 cases and enable.
         "useValidTypeof": "off" // Recommended rule. TODO: review 3 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -67,6 +67,7 @@
         "noExplicitAny": "off", // Recommended rule. TODO: review 129 cases and enable.
         "noImplicitAnyLet": "off", // Recommended rule. TODO: review 42 cases and enable.
         "noPrototypeBuiltins": "off", // Recommended rule. TODO: review 3 cases and enable.
+        "noReactSpecificProps": "off", // We use React.
         "noRedeclare": "off", // Recommended rule. TODO: review 1 case and enable.
         "noRedundantUseStrict": "off", // Recommended rule. TODO: review 2 cases and enable.
         "noShadowRestrictedNames": "off", // Recommended rule. TODO: review 2 cases and enable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -130,7 +130,8 @@
         "useNumberNamespace": "off", // Recommended rule. TODO: review 35 cases and enable.
         "useShorthandFunctionType": "off", // Recommended rule. TODO: review 9 cases and enable.
         "useSingleVarDeclarator": "off", // Recommended rule. TODO: review 35 cases and enable.
-        "useTemplate": "off" // Recommended rule. TODO: review 103 cases and enable.
+        "useTemplate": "off", // Recommended rule. TODO: review 103 cases and enable.
+        "useWhile": "error" // Enable all safely fixable rules.
       }
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -253,7 +253,6 @@ const biomeConfig = {
   },
   rules: {
     // new in eslint v8, See https://typescript-eslint.io/blog/announcing-typescript-eslint-v8/#replacement-of-ban-types
-    '@typescript-eslint/no-restricted-types': 'off',
     '@typescript-eslint/no-empty-object-type': 'off',
     '@typescript-eslint/no-unsafe-function-type': 'off',
     '@typescript-eslint/no-wrapper-object-types': 'off',

--- a/jsapp/js/components/special/koboAccessibleSelect.tsx
+++ b/jsapp/js/components/special/koboAccessibleSelect.tsx
@@ -78,6 +78,7 @@ export default function KoboSelect3(props: KoboSelect3Props) {
   }
   // Comparison helpers, for letter matching
   const closestAscii = (str: string) => {
+    // biome-ignore lint/suspicious/noMisleadingCharacterClass: TODO: investigate, test, and solve or explain.
     const combining = /[\u0300-\u036F]/g
     return str.normalize('NFKD').replace(combining, '')
   }

--- a/jsapp/xlform/src/validator.backbone.adaptors.js
+++ b/jsapp/xlform/src/validator.backbone.adaptors.js
@@ -1,7 +1,6 @@
 /* global _ */
 /* global Backbone */
 /* global viewUtils */
-'use strict'
 
 _.extend(Backbone.Validation.validators, {
   invalidChars: function (value, attr, customValue) {

--- a/jsapp/xlform/src/view.utils.validator.js
+++ b/jsapp/xlform/src/view.utils.validator.js
@@ -1,5 +1,4 @@
 /* global viewUtils */
-'use strict'
 
 /*
     Options:

--- a/kpi.code-workspace
+++ b/kpi.code-workspace
@@ -43,35 +43,35 @@
     "[javascript]": {
       "editor.defaultFormatter": "biomejs.biome",
       "editor.codeActionsOnSave": {
-        "quickfix.biome": "explicit",
+        "source.fixAll.biome": "explicit",
         "source.organizeImports.biome": "explicit"
       }
     },
     "[javascriptreact]": {
       "editor.defaultFormatter": "biomejs.biome",
       "editor.codeActionsOnSave": {
-        "quickfix.biome": "explicit",
+        "source.fixAll.biome": "explicit",
         "source.organizeImports.biome": "explicit"
       }
     },
     "[typescript]": {
       "editor.defaultFormatter": "biomejs.biome",
       "editor.codeActionsOnSave": {
-        "quickfix.biome": "explicit",
+        "source.fixAll.biome": "explicit",
         "source.organizeImports.biome": "explicit"
       }
     },
     "[typescriptreact]": {
       "editor.defaultFormatter": "biomejs.biome",
       "editor.codeActionsOnSave": {
-        "quickfix.biome": "explicit",
+        "source.fixAll.biome": "explicit",
         "source.organizeImports.biome": "explicit"
       }
     },
     "[json]": {
       "editor.defaultFormatter": "biomejs.biome",
       "editor.codeActionsOnSave": {
-        "quickfix.biome": "explicit"
+        "source.fixAll.biome": "explicit"
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "test": "jest --config ./jsapp/jest/unit.config.ts",
     "test-watch": "jest --config ./jsapp/jest/unit.config.ts --watch",
     "lint": "npm run lint:biome && npm run lint:eslint && npm run lint:types && npm run lint:css && npm run lint:coffee",
-    "lint:biome": "biome format",
+    "lint:biome": "biome check",
     "lint:eslint": "eslint 'jsapp/js/'",
     "lint:eslint-summary": "npm run lint -- --ext .js,.jsx,.ts,.tsx --format compact | grep '(@' | grep ' - ' | sed -r 's/.* (\\w+ -) .*(\\(@.*)$/\\1 \\2/' | sort | uniq -c | sort -nr",
     "lint:types": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
### 💭 Notes

Use Biome linter, enable all recommended rules that are passing out-of-box and explicitly disable those that are failing.

### 👀 Preview steps

Users:
- Nothing changes. No production code was changed, so it's safe not to test.

Developers:
- open any ts/js file.
- write a problem that's covered by recommended rules but we don't have already and so isn't disabled for now. E.g.
    ```ts
    const a = 1
    a = 2
    ```
- :green_circle: in VSCode, notice a linter problem
- :green_circle: notice that `npm run lint:biome` errors
- :green_circle: in VSCode, notice an auto-fix on save