### PR TITLE
fix(stripe): only import Product when stripe is enabled

### DIFF
--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -1,5 +1,6 @@
 import timeit
 from datetime import datetime, timedelta
+from math import inf
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -559,6 +560,12 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         )
         for org in other_orgs:
             assert all_limits[org.id] == 6000
+
+    @override_settings(STRIPE_ENABLED=False)
+    def test_get_organization_plan_limits_stripe_disabled_returns_inf(self):
+        all_limits = get_organization_plan_limits('submission')
+        for org in Organization.objects.all():
+            assert all_limits[org.id] == inf
 
     def test_get_organization_plan_limits_prioritizes_price_metadata(self):
         product_metadata = {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Return all limits as infinite when Stripe is not enabled.


### 📖 Description
Fixes a bug that was preventing kpi from starting up when Stripe was not enabled.


### 💭 Notes
Any import of modules from `djstripe` needs to be conditional on Stripe being enabled.
