### PR TITLE
fix(assets): do not update date_modified when viewing asset page TASK-1672

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -441,10 +441,10 @@ class BaseDeploymentBackend(abc.ABC):
         updates.pop('_stored_data_key', None)
         fields_to_update = {
             '_deployment_data': UpdateJSONFieldAttributes('_deployment_data', updates),
-        '_deployment_status': self.asset.deployment_status,
+            '_deployment_status': self.asset.deployment_status,
         }
         if update_date_modified:
-            fields_to_update['date_modified']=now
+            fields_to_update['date_modified'] = now
 
         self.asset.__class__.objects.filter(id=self.asset.pk).update(**fields_to_update)
         if update_date_modified:

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -424,7 +424,7 @@ class BaseDeploymentBackend(abc.ABC):
     def rename_enketo_id_key(self, previous_owner_username: str):
         pass
 
-    def save_to_db(self, updates: dict):
+    def save_to_db(self, updates: dict, update_date_modified=True):
         """
         Persist values from deployment data into the DB.
         `updates` is a dictionary of properties to update.
@@ -439,16 +439,16 @@ class BaseDeploymentBackend(abc.ABC):
 
         # never save `_stored_data_key` attribute
         updates.pop('_stored_data_key', None)
+        fields_to_update = {
+            '_deployment_data': UpdateJSONFieldAttributes('_deployment_data', updates),
+        '_deployment_status': self.asset.deployment_status,
+        }
+        if update_date_modified:
+            fields_to_update['date_modified']=now
 
-        self.asset.__class__.objects.filter(id=self.asset.pk).update(
-            _deployment_data=UpdateJSONFieldAttributes(
-                '_deployment_data',
-                updates=updates,
-            ),
-            date_modified=now,
-            _deployment_status=self.asset.deployment_status
-        )
-        self.asset.date_modified = now
+        self.asset.__class__.objects.filter(id=self.asset.pk).update(**fields_to_update)
+        if update_date_modified:
+            self.asset.date_modified = now
 
     @abc.abstractmethod
     def set_active(self, active: bool):

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -627,7 +627,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 logging.warning(
                     f'Enketo ID has changed from {stored_enketo_id} to {enketo_id}'
                 )
-            self.save_to_db({'enketo_id': enketo_id})
+            self.save_to_db({'enketo_id': enketo_id}, update_date_modified=False)
 
         if self.xform.require_auth:
             # Unfortunately, EE creates unique ID based on OpenRosa server URL.

--- a/kpi/tests/test_deployment_backends.py
+++ b/kpi/tests/test_deployment_backends.py
@@ -125,7 +125,16 @@ class MockDeployment(TestCase):
         self.assertEqual(self.asset.deployment.get_data(new_key), new_value)
 
     def test_save_to_db_without_date_modified(self):
+        last_modified = self.asset.date_modified
         self.asset.deployment.save_to_db({'key': 'value'}, update_date_modified=False)
+        self.asset.refresh_from_db()
+        self.assertEqual(self.asset.date_modified, last_modified)
+
+    def test_save_to_db_with_date_modified(self):
+        last_modified = self.asset.date_modified
+        self.asset.deployment.save_to_db({'key': 'value'})
+        self.asset.refresh_from_db()
+        self.assertGreater(self.asset.date_modified, last_modified)
 
     def test_save_data(self):
 

--- a/kpi/tests/test_deployment_backends.py
+++ b/kpi/tests/test_deployment_backends.py
@@ -124,6 +124,9 @@ class MockDeployment(TestCase):
         self.asset.refresh_from_db()
         self.assertEqual(self.asset.deployment.get_data(new_key), new_value)
 
+    def test_save_to_db_without_date_modified(self):
+        self.asset.deployment.save_to_db({'key':'value'}, update_date_modified=False)
+
     def test_save_data(self):
 
         deployment_data = self.asset.deployment.get_data()

--- a/kpi/tests/test_deployment_backends.py
+++ b/kpi/tests/test_deployment_backends.py
@@ -125,7 +125,7 @@ class MockDeployment(TestCase):
         self.assertEqual(self.asset.deployment.get_data(new_key), new_value)
 
     def test_save_to_db_without_date_modified(self):
-        self.asset.deployment.save_to_db({'key':'value'}, update_date_modified=False)
+        self.asset.deployment.save_to_db({'key': 'value'}, update_date_modified=False)
 
     def test_save_data(self):
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug where the most recent modify date on assets was changing when the page was viewed.


### 💭 Notes
Updates the save_to_db method to take an additional parameter to include `date_modified` in the fields to update. The field defaults to True since most of the time it is called when we are actually setting a value from a user action and do want the date_modified to update. When we are just getting the enketo id, though, sets it to False.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. In the Django shell, run `my_asset.deployment.save_to_db({'enketo_id':None})` and `my_asset.refresh_from_db`
3. Look at `my_asset.date_modified` and record the value
4. Navigate to the project page for the asset
5. In the Django shell, refresh the asset and look at the date_modified
6. 🔴 [on main] The date_modified will have been updated
7. 🟢 [on PR] The date_modified will not have been updated
