### PR TITLE
fix(abstractTimestampedModel): restore `date_modified` saving behavior

### DIFF
--- a/kobo/apps/accounts/mfa/models.py
+++ b/kobo/apps/accounts/mfa/models.py
@@ -60,7 +60,12 @@ class MfaMethod(TrenchMFAMethod, AbstractTimeStampedModel):
         if update_fields:
             update_fields += ['date_disabled']
 
-        super().save(force_insert, force_update, using, update_fields)
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
 
         """
         Update user's profile in KoBoCAT database.

--- a/kobo/apps/accounts/mfa/signals.py
+++ b/kobo/apps/accounts/mfa/signals.py
@@ -25,4 +25,4 @@ def deactivate_mfa_method_for_user(**kwargs):
         pass
     else:
         mfa_method.is_active = False
-        mfa_method.save(update_fields=['is_active'])
+        mfa_method.save(update_fields=['is_active', 'date_modified'])

--- a/kobo/apps/long_running_migrations/models.py
+++ b/kobo/apps/long_running_migrations/models.py
@@ -58,7 +58,7 @@ class LongRunningMigration(AbstractTimeStampedModel):
 
         self.status = LongRunningMigrationStatus.IN_PROGRESS
         self.attempts += 1
-        self.save(update_fields=['status', 'attempts'])
+        self.save(update_fields=['status', 'attempts', 'date_modified'])
 
         try:
             module.run()
@@ -66,11 +66,11 @@ class LongRunningMigration(AbstractTimeStampedModel):
             # Log the error and update the status to 'failed'
             logging.error(f'LongRunningMigration.execute(): {str(e)}')
             self.status = LongRunningMigrationStatus.FAILED
-            self.save(update_fields=['status'])
+            self.save(update_fields=['status', 'date_modified'])
             return
 
         self.status = LongRunningMigrationStatus.COMPLETED
-        self.save(update_fields=['status'])
+        self.save(update_fields=['status', 'date_modified'])
 
     def save(self, **kwargs):
 

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -33,7 +33,7 @@ def add_validation_status_to_instance(
         validation_status = get_validation_status(validation_status_uid, username)
         if validation_status:
             instance.validation_status = validation_status
-            instance.save(update_fields=['validation_status'])
+            instance.save(update_fields=['validation_status', 'date_modified'])
             success = instance.parsed_instance.update_mongo(asynchronous=False)
 
     return success
@@ -108,7 +108,7 @@ def get_validation_status(validation_status_uid: str, username: str) -> dict:
 
 def remove_validation_status_from_instance(instance: Instance) -> bool:
     instance.validation_status = {}
-    instance.save(update_fields=['validation_status'])
+    instance.save(update_fields=['validation_status', 'date_modified'])
     return instance.parsed_instance.update_mongo(asynchronous=False)
 
 

--- a/kobo/apps/project_ownership/models/transfer.py
+++ b/kobo/apps/project_ownership/models/transfer.py
@@ -103,7 +103,6 @@ class Transfer(AbstractTimeStampedModel):
 
             global_status.save()
 
-            self.date_modified = timezone.now()
             self.save(update_fields=['date_modified'])
             self._update_invite_status()
 
@@ -327,7 +326,6 @@ class Transfer(AbstractTimeStampedModel):
             invite.status = InviteStatusChoices.COMPLETE
 
         if previous_status != invite.status:
-            invite.date_modified = timezone.now()
             invite.save(update_fields=['status', 'date_modified'])
             if invite.status == InviteStatusChoices.FAILED:
                 send_email_to_admins.delay(invite.uid)

--- a/kobo/apps/trash_bin/tasks.py
+++ b/kobo/apps/trash_bin/tasks.py
@@ -81,7 +81,7 @@ def empty_account(account_trash_id: int, force: bool = False):
 
         account_trash.status = TrashStatus.IN_PROGRESS
         account_trash.metadata['failure_error'] = ''
-        account_trash.save(update_fields=['metadata', 'status'])
+        account_trash.save(update_fields=['metadata', 'status', 'date_modified'])
 
     # Delete children first…
     for asset in assets.filter(parent__isnull=False):
@@ -198,7 +198,7 @@ def empty_project(project_trash_id: int, force: bool = False):
             return
 
         project_trash.status = TrashStatus.IN_PROGRESS
-        project_trash.save(update_fields=['status'])
+        project_trash.save(update_fields=['status', 'date_modified'])
 
     delete_asset(project_trash.request_author, project_trash.asset)
     PeriodicTask.objects.get(pk=project_trash.periodic_task_id).delete()
@@ -219,7 +219,7 @@ def empty_account_failure(sender=None, **kwargs):
         )
         account_trash.metadata['failure_error'] = str(exception)
         account_trash.status = TrashStatus.FAILED
-        account_trash.save(update_fields=['status', 'metadata'])
+        account_trash.save(update_fields=['status', 'metadata', 'date_modified'])
 
 
 @task_retry.connect(sender=empty_account)
@@ -232,7 +232,7 @@ def empty_account_retry(sender=None, **kwargs):
         )
         account_trash.metadata['failure_error'] = str(exception)
         account_trash.status = TrashStatus.RETRY
-        account_trash.save(update_fields=['status', 'metadata'])
+        account_trash.save(update_fields=['status', 'metadata', 'date_modified'])
 
 
 @task_failure.connect(sender=empty_project)
@@ -246,7 +246,7 @@ def empty_project_failure(sender=None, **kwargs):
         )
         project_trash.metadata['failure_error'] = str(exception)
         project_trash.status = TrashStatus.FAILED
-        project_trash.save(update_fields=['status', 'metadata'])
+        project_trash.save(update_fields=['status', 'metadata', 'date_modified'])
 
 
 @task_retry.connect(sender=empty_project)
@@ -259,7 +259,7 @@ def empty_project_retry(sender=None, **kwargs):
         )
         project_trash.metadata['failure_error'] = str(exception)
         project_trash.status = TrashStatus.RETRY
-        project_trash.save(update_fields=['status', 'metadata'])
+        project_trash.save(update_fields=['status', 'metadata', 'date_modified'])
 
 
 @celery_app.task

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -145,7 +145,9 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         self._xform = publish_xls_form(xlsx_file, self.asset.owner)
         self._xform.downloadable = active
         self._xform.kpi_asset_uid = self.asset.uid
-        self._xform.save(update_fields=['downloadable', 'kpi_asset_uid'])
+        self._xform.save(
+            update_fields=['downloadable', 'kpi_asset_uid', 'date_modified']
+        )
 
         self.store_data(
             {

--- a/kpi/models/abstract_models.py
+++ b/kpi/models/abstract_models.py
@@ -23,8 +23,6 @@ class AbstractTimeStampedModel(models.Model):
 
     def save(self, *args, **kwargs):
         update_fields = kwargs.get('update_fields', None)
-        if update_fields is None or 'date_modified' not in update_fields:
+        if update_fields is None or 'date_modified' in update_fields:
             self.date_modified = timezone.now()
-            if update_fields:
-                update_fields.append('date_modified')
         super().save(*args, **kwargs)

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -135,8 +135,11 @@ class AssetWithoutPendingDeletedManager(models.Manager):
         # (and the default Django create() does not allow that)
         created = self.model(**kwargs)
         self._for_write = True
-        created.save(force_insert=True, using=self.db,
-                     update_parent_languages=update_parent_languages)
+        created.save(
+            force_insert=True,
+            using=self.db,
+            update_parent_languages=update_parent_languages,
+        )
 
         if tag_string:
             created.tag_string = tag_string

--- a/kpi/models/asset_file.py
+++ b/kpi/models/asset_file.py
@@ -205,14 +205,24 @@ class AssetFile(AbstractTimeStampedModel, AbstractFormMedia):
         self.set_mimetype()
         return self.metadata['mimetype']
 
-    def save(self, force_insert=False, force_update=False, using=None,
-             update_fields=None):
+    def save(
+        self,
+        force_insert=False,
+        force_update=False,
+        using=None,
+        update_fields=None,
+    ):
         if self.pk is None:
             self.set_filename()
             self.set_md5_hash()
             self.set_mimetype()
 
-        return super().save(force_insert, force_update, using, update_fields)
+        return super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
 
     def set_filename(self):
         if not self.metadata.get('filename'):

--- a/kpi/tests/test_abstract_timestamped_model.py
+++ b/kpi/tests/test_abstract_timestamped_model.py
@@ -1,0 +1,51 @@
+from django.apps import apps
+from django.db import models, connection
+from django.test import TestCase
+
+from kpi.models.abstract_models import AbstractTimeStampedModel
+
+
+class DummyModel(AbstractTimeStampedModel):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = 'dummy_tests'
+
+
+class AbstractTimestampedModelTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        if not apps.is_installed('dummy_tests'):
+            apps.all_models['dummy_tests'] = {}
+        apps.all_models['dummy_tests']['dummymodel'] = DummyModel
+        apps.clear_cache()
+        with connection.schema_editor() as schema_editor:
+            schema_editor.create_model(DummyModel)
+
+    @classmethod
+    def tearDownClass(cls):
+        with connection.schema_editor() as schema_editor:
+            schema_editor.delete_model(DummyModel)
+        super().tearDownClass()
+
+    def test_date_modified(self):
+        obj = DummyModel.objects.create(name='Test')
+        date_modified = obj.date_modified
+
+        # `update_fields` is not specified, `date_modified` should be modified
+        obj.save()
+        assert obj.date_modified != date_modified
+        assert obj.date_modified > date_modified
+        date_modified = obj.date_modified
+
+        # `update_fields` is specified without `date_modified`.
+        # `date_modified` should NOT be modified.
+        obj.save(update_fields=['name'])
+        assert obj.date_modified == date_modified
+
+        # `update_fields` is specified with `date_modified`.
+        # `date_modified` should be modified.
+        obj.save(update_fields=['name', 'date_modified'])
+        assert obj.date_modified != date_modified
+        assert obj.date_modified > date_modified


### PR DESCRIPTION
### 📣 Summary
Restored the intended behavior of automatically saving modification timestamps.


### 💭 Notes
When `date_modified` needs to be updated, either call `.save()` without the `update_fields` parameter or explicitly include `date_modified` in `update_fields`. Otherwise, the modification timestamp will not be updated.


### 👀 Preview steps

1. From the shell, retrieve an object which inherit from `AbstractTimestampedModel`
2. Try to update only one field of the object with `.save(update_fields=['field_name'])`
3. On release branch, `date_modified` has changed
4. On this PR, `date_modified` has not
