### PR TITLE
fix(storybook): handle the new '#' path alias

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -34,11 +34,9 @@ module.exports = {
       resolve: {
         extensions: ['.jsx', '.js', '.coffee', '.ts', '.tsx', '.scss'],
         alias: {
-          app: path.join(__dirname, '../app'),
-          jsapp: path.join(__dirname, '../jsapp'),
+          '#': path.join(__dirname, '../jsapp/js'),
           js: path.join(__dirname, '../jsapp/js'),
           scss: path.join(__dirname, '../jsapp/scss'),
-          utils: path.join(__dirname, '../jsapp/js/utils'),
         },
       },
     })

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import 'jsapp/scss/main.scss'
+import 'scss/main.scss'
 import '#/bemComponents'
 import '@mantine/core/styles.css'
 


### PR DESCRIPTION
### 💭 Notes

Storybook was broken since d5796bd4e, this fixes it.

### 👀 Preview steps

- run `npm run storybook`
- :green_circle: storybook doesn't crash