### PR TITLE
feat(organization): allow organization ownership transfer from Admin UI

### DIFF
--- a/kobo/apps/organizations/admin/organization_owner.py
+++ b/kobo/apps/organizations/admin/organization_owner.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from organizations.base_admin import BaseOrganizationOwnerAdmin, BaseOwnerInline
 
-from ..models import OrganizationOwner
+from ..models import OrganizationOwner, OrganizationUser
 
 
 class OwnerInline(BaseOwnerInline):
@@ -21,4 +21,15 @@ class OwnerInline(BaseOwnerInline):
 
 @admin.register(OrganizationOwner)
 class OrgOwnerAdmin(BaseOrganizationOwnerAdmin):
+    search_fields = [
+        'organization_user__user__username',
+        'organization_user__organization__id',
+        'organization_user__organization__name',
+    ]
     autocomplete_fields = ['organization_user', 'organization']
+
+    def get_readonly_fields(self, request, obj=None):
+
+        if obj is not None and obj.pk:
+            return ['organization']
+        return []

--- a/kobo/apps/organizations/admin/organization_owner.py
+++ b/kobo/apps/organizations/admin/organization_owner.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.db import transaction
 from organizations.base_admin import BaseOrganizationOwnerAdmin, BaseOwnerInline
 
@@ -50,4 +50,10 @@ class OrgOwnerAdmin(BaseOrganizationOwnerAdmin):
                     lambda: transfer_member_data_ownership_to_org.delay(
                         old_user_id
                     )
+                )
+
+                self.message_user(
+                    request,
+                    'The organization ownership transfer is in progress',
+                    messages.INFO,
                 )

--- a/kobo/apps/organizations/admin/organization_owner.py
+++ b/kobo/apps/organizations/admin/organization_owner.py
@@ -30,6 +30,9 @@ class OrgOwnerAdmin(BaseOrganizationOwnerAdmin):
     ]
     autocomplete_fields = ['organization_user', 'organization']
 
+    class Media:
+        js = ['admin/js/organization_user_autocomplete.js']
+
     def get_readonly_fields(self, request, obj=None):
 
         if obj is not None and obj.pk:

--- a/kobo/apps/organizations/static/admin/js/organization_user_autocomplete.js
+++ b/kobo/apps/organizations/static/admin/js/organization_user_autocomplete.js
@@ -1,0 +1,22 @@
+window.alert('added');
+
+document.addEventListener('DOMContentLoaded', function () {
+  const orgLink = document.querySelector('.field-organization .readonly a');
+
+  if (orgLink) {
+    const orgUrl = new URL(orgLink.href, window.location.origin);
+    const pathParts = orgUrl.pathname.split('/');
+    const orgId = pathParts[pathParts.length - 3];
+    const userField = document.querySelector('#id_organization_user');
+
+    if (userField) {
+      userField.addEventListener('focus', function () {
+        const baseUrl = userField.dataset.autocompleteUrl;
+        const newUrl = new URL(baseUrl, window.location.origin);
+        newUrl.searchParams.set('organization_id', orgId);
+
+        userField.dataset.autocompleteUrl = newUrl.toString();
+      });
+    }
+  }
+});


### PR DESCRIPTION
### 📣 Summary
Added functionality to transfer organization ownership directly from the Django Admin UI.


### 📖 Description
Organization ownership can now be transferred directly from the Django Admin UI to members of the same organization. When an ownership transfer is initiated, all projects belonging to the organization are asynchronously transferred to the new owner using Celery.
Previous owner keeps explicit `manage_asset` permission on every project and their role is demoted to `admin`.

### 👀 Preview steps

1. Go to Admin UI > Organizations › Organization owners
2. Select a multi-member organization
3. Choose a new owner among choices in the list of organization users
4. Wait for a moment
4. From the shell, see that previous owner does not have any assets anymore
5. From the shell, see that new owner owns all the org assets