### PR TITLE
fix(kpi): Support geo+json mime type for form media TASK-1210

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1845,7 +1845,8 @@ SUPPORTED_MEDIA_UPLOAD_TYPES = [
     'text/csv',
     'application/xml',
     'application/zip',
-    'application/x-zip-compressed'
+    'application/x-zip-compressed',
+    'application/geo+json',
 ]
 
 LOG_DELETION_BATCH_SIZE = 1000

--- a/kpi/models/asset_file.py
+++ b/kpi/models/asset_file.py
@@ -78,6 +78,7 @@ class AssetFile(AbstractTimeStampedModel, AbstractFormMedia):
             'text/csv',
             'application/xml',
             'application/zip',
+            'application/geo+json',
         ),
         PAIRED_DATA: ('application/xml',),
         MAP_LAYER: (

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1626,7 +1626,7 @@ class AssetFileTest(AssetFileTestCaseMixin, BaseTestCase):
         json_response = response.json()
         expected_response = {
             'metadata': ['Only `image`, `audio`, `video`, `text/csv`, '
-                         '`application/xml`, `application/zip` '
+                         '`application/xml`, `application/zip`, `application/geo+json` '
                          'MIME types are allowed']
         }
         assert json_response == expected_response


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Support geojson mime type

### 👀 Preview steps
No need to preview, this is tested in unit tests