### PR TITLE
fix(frontend): use kobo default line-height again DEV-22

### DIFF
--- a/jsapp/js/app.jsx
+++ b/jsapp/js/app.jsx
@@ -3,7 +3,6 @@
  */
 import '#/bemComponents' // importing it so it exists
 import '#/surveyCompanionStore' // importing it so it exists
-import '@mantine/core/styles.css'
 
 import React from 'react'
 

--- a/jsapp/js/main.js
+++ b/jsapp/js/main.js
@@ -2,7 +2,14 @@
  * The Project Management app bundle file. All the required setup is done here
  * plus it is the file that is handling the root rendering.
  */
+
+/**
+ * Import order matters, because for CSS selectors with equal specificy the last one applies.
+ * Notably, `line-length` mismatches between mantine default styles and main global scss styles.
+ * TODO: reconsile differences in the mantine config at `theme/kobo/index.ts`.
+ */
 import 'jquery-ui/ui/widgets/sortable'
+import '@mantine/core/styles.css'
 import '../scss/main.scss'
 
 import React from 'react'

--- a/jsapp/js/theme/kobo/index.ts
+++ b/jsapp/js/theme/kobo/index.ts
@@ -87,6 +87,7 @@ export const themeKobo = createTheme({
     lg: rem(16),
     xl: rem(18),
   },
+  // Kobo uses 20+ different line-heights in different units. TODO: standardize and use mantine config.
   lineHeights: {},
   headings: {
     fontWeight: '500',


### PR DESCRIPTION
### 📣 Summary

Revert broken default line-height for various elements.

### 💭 Notes

CSS import order matters, because CSS selectors with equal specificity the last one applies.
#5568 across files moved mantine default styles after kobo styles that changed the resulting CSS rules.

### 👀 Preview steps

- launch frontend
- :green_circle: notice that line-height is as expected (compare with before/after screenshots in the ticket)