### PR TITLE
fix(billing): improve default free plan identification TASK-1702

### DIFF
--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -257,7 +257,9 @@ const getStripeMetadataAndFreeTierStatus = async (products: Product[]) => {
       (product) => product.metadata['default_free_plan'] === 'true'
     );
     if (!freeProduct) {
-      throw "Stripe-enabled instances must have a default free plan product configured.";
+      throw new Error(
+        'Stripe-enabled instances must have a default free plan product configured.'
+      );
     }
     metadata = {
       ...freeProduct.metadata,

--- a/jsapp/js/account/stripe.api.ts
+++ b/jsapp/js/account/stripe.api.ts
@@ -253,12 +253,12 @@ const getStripeMetadataAndFreeTierStatus = async (products: Product[]) => {
     await when(() => !!products.length);
     // the user has no subscription, so get limits from the free monthly product
     hasFreeTier = true;
-    const freeProduct = products.filter((product) =>
-      product.prices.filter(
-        (price) =>
-          price.unit_amount === 0 && price.recurring?.interval === 'month'
-      )
-    )[0];
+    const freeProduct = products.find(
+      (product) => product.metadata['default_free_plan'] === 'true'
+    );
+    if (!freeProduct) {
+      throw "Stripe-enabled instances must have a default free plan product configured.";
+    }
     metadata = {
       ...freeProduct.metadata,
       ...freeProduct.prices[0].metadata,

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -585,7 +585,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         limit = get_organization_plan_limit(self.organization, usage_type)
         assert limit == float('inf')
 
-    def test_get_addon_suscription_default_limits(self):
+    def test_get_addon_subscription_default_limits(self):
         generate_free_plan()
         product_metadata = {
             'product_type': 'addon',

--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -15,6 +15,7 @@ def generate_free_plan():
         'asr_seconds_limit': '600',
         'mt_characters_limit': '6000',
         'storage_bytes_limit': '1000000000',
+        'default_free_plan': 'true',
     }
 
     product = baker.make(Product, active=True, metadata=product_metadata)

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -65,7 +65,7 @@ def get_organization_plan_limit(
         # Anyone who does not have a subscription is on the free tier plan by default
         default_plan = (
             Product.objects.filter(
-                prices__unit_amount=0, prices__recurring__interval='month'
+                metadata__default_free_plan='true'
             )
             .values(limit=F(f'metadata__{limit_key}'))
             .first()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Uses new default_free_plan Stripe product metadata value to ensure proper identification of community plan product on backend and frontend.


### 💭 Notes
See [notion task](https://www.notion.so/kobotoolbox/Unreliable-query-filtering-for-default-community-plan-1bc7e515f65480b7b4f1e3cdfa8d5d8b?pvs=4) for context.

### 👀 Preview steps
1. With Stripe enabled, ensure that the "community" product is not the first entry in the djstripe products table. At the moment, a fresh call of `./manage.py djstripe_sync_models Price Product` will do this automatically. If you already have products in your table, just delete them and resync.
2. Create a new user and navigate to the account usage page.
3. On the 2.025.02 branch, your displayed limits will (incorrectly) match the first product returned on the list from the `/products` endpoint. On this branch, they will match the community plan limits regardless of its place in the list of products.