### PR TITLE
feat(gallery): handle deleted attachments TASK-566

### DIFF
--- a/jsapp/js/components/formGallery/formGallery.component.scss
+++ b/jsapp/js/components/formGallery/formGallery.component.scss
@@ -1,5 +1,6 @@
 @use 'scss/colors';
 @use 'scss/breakpoints';
+@use 'scss/mixins';
 
 .gallery {
   background-color: colors.$kobo-white;
@@ -47,10 +48,17 @@
   margin-right: 5px;
 }
 
-.gallery-grid {
+.gallery__grid {
   display: flex;
   flex-wrap: wrap;
   gap: 3px;
+}
+
+.gallery-grid-deleted-attachment {
+  min-width: 100px;
+  min-height: 100px;
+  border-radius: var(--mantine-radius-md);
+  background-color: var(--mantine-color-gray-filled);
 }
 
 @include breakpoints.breakpoint(mediumAndUp) {

--- a/jsapp/js/components/formGallery/formGallery.component.tsx
+++ b/jsapp/js/components/formGallery/formGallery.component.tsx
@@ -2,8 +2,10 @@ import './formGallery.component.scss'
 
 import React, { useEffect, useMemo, useReducer } from 'react'
 
+import { Center } from '@mantine/core'
 import ReactSelect from 'react-select'
 import { getFlatQuestionsList } from '#/assetUtils'
+import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
 import Button from '#/components/common/button'
 import type { AssetResponse, PaginatedResponse, SubmissionResponse } from '#/dataInterface'
@@ -117,11 +119,17 @@ export default function FormGallery(props: FormGalleryProps) {
           </bem.GalleryFiltersDates>
         </bem.GalleryFilters>
         <bem.GalleryGrid>
-          {attachments.map((attachment) => (
-            <a key={attachment.id} href={attachment.download_url} target='_blank'>
-              <img src={attachment.download_small_url} alt={attachment.filename} width='150' loading='lazy' />
-            </a>
-          ))}
+          {attachments.map((attachment) =>
+            attachment.is_deleted ? (
+              <Center key={attachment.id} title={attachment.filename} className='gallery-grid-deleted-attachment'>
+                <DeletedAttachment />
+              </Center>
+            ) : (
+              <a key={attachment.id} href={attachment.download_url} target='_blank'>
+                <img src={attachment.download_url} alt={attachment.filename} width='150' loading='lazy' />
+              </a>
+            ),
+          )}
         </bem.GalleryGrid>
         {showLoadMore && (
           <bem.GalleryFooter>


### PR DESCRIPTION
### 📣 Summary

In gallery, display deleted attachments as deleted. Also, show the filename on hover. 


### 💭 Notes

Used Mantine components and styles as much as possible.


### 👀 Preview steps

1. ℹ️ have an account and a project with a file question type
2. submit the form with an picture
3. add debug code to `useEffect` in `formGallery.component.tsx`
   ```ts
        for (const submission of resp.results) {
          for (const attachment of submission._attachments) {
            attachment.download_url = 'http://kalvis.lv/404'
            attachment.download_large_url = 'http://kalvis.lv/404'
            attachment.download_medium_url = 'http://kalvis.lv/404'
            attachment.download_small_url = 'http://kalvis.lv/404'
            attachment.is_deleted = true
          }
        }
     ```
5. 🔴 [on main] notice ugly filenames
6. 🟢 [on PR] notice beautiful deleted placeholders as above

| | |
|---|---|
| Before | ![image](https://github.com/user-attachments/assets/15cc1702-1aa4-48dc-b7c7-b659a4a6353d) |
| After | ![image](https://github.com/user-attachments/assets/9872cc29-294f-4ce8-a2ee-02ca72ff79cb) | 
