### PR TITLE
feat(nlp): handle deleted audiofile TASK-566

### DIFF
--- a/jsapp/js/components/processing/sidebar/sidebarSubmissionMedia.module.scss
+++ b/jsapp/js/components/processing/sidebar/sidebarSubmissionMedia.module.scss
@@ -1,15 +1,19 @@
 @use 'scss/colors';
 
 .mediaWrapper {
+  border-radius: var(--mantine-radius-default);
+  background-color: var(--mantine-color-white);
+
+  &.mediaWrapperDeleted {
+    padding: 14px;
+  }
+
   &.mediaWrapperAudio {
-    background-color: colors.$kobo-white;
-    border-radius: 6px;
     // right padding is for the audio player to appear centered
     padding: 20px #{20px + 12px} 14px 20px;
   }
 
   &.mediaWrapperVideo {
-    border-radius: 6px;
     overflow: hidden;
   }
 }

--- a/jsapp/js/components/processing/sidebar/sidebarSubmissionMedia.tsx
+++ b/jsapp/js/components/processing/sidebar/sidebarSubmissionMedia.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react'
+
+import cx from 'classnames'
 import AttachmentActionsDropdown from '#/attachments/AttachmentActionsDropdown'
+import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import AudioPlayer from '#/components/common/audioPlayer'
 import singleProcessingStore from '#/components/processing/singleProcessingStore'
 import { getAttachmentForProcessing } from '#/components/processing/transcript/transcript.utils'
@@ -23,6 +26,13 @@ export default function SidebarSubmissionMedia(props: SidebarSubmissionMediaProp
   const attachment = getAttachmentForProcessing(props.asset.content)
   if (typeof attachment === 'string') {
     return null
+  }
+  if (attachment.is_deleted) {
+    return (
+      <section className={cx([styles.mediaWrapper, styles.mediaWrapperDeleted])} key='deleted'>
+        <DeletedAttachment />
+      </section>
+    )
   }
 
   switch (store.currentQuestionType) {


### PR DESCRIPTION
### 📣 Summary

In NLP, display deleted audiofiles as deleted.




### 💭 Notes

Used Mantine components and styles as much as possible.



### 👀 Preview steps

1. ℹ️ have an account and a project with a audio question type
2. submit the form with an audio
3. open NLP from data table
4. add debug code in `sidebarSubmissionMedia.tsx`
   ```ts
    +   attachment.download_url = 'http://kalvis.lv/404'
    +   attachment.download_large_url = 'http://kalvis.lv/404'
    +   attachment.download_medium_url = 'http://kalvis.lv/404'
    +   attachment.download_small_url = 'http://kalvis.lv/404'
     ```
5. :yellow_circle: notice the error, like in the "before" screenshot
3. add debug code in `sidebarSubmissionMedia.tsx`
   ```ts
    +   attachment.is_deleted = true
     ```
4. 🔴 [on main] as above
6. 🟢 [on PR] notice the "Deleted", like in the "after" screenshot

| | |
|---|---|
| Before |![image](https://github.com/user-attachments/assets/403c61c1-7455-49a6-a107-ebf107ce40c8)|
| After | ![image](https://github.com/user-attachments/assets/e873f2b6-8709-4bd3-a95e-70fd2079fa5d)| 
