### PR TITLE
fix(export): restore supplement details columns with (nested) groups

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@cc9aaf63679e9b1780dddcfc803eab367de3021e#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in


### PR DESCRIPTION
### 📣 Summary
Fixed missing supplement details columns when forms include (nested) groups.


### 📖 Description
This fix restores missing supplement details columns in exports when forms include (nested) groups. 



### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project with audio
2. submit data 
3. transcript / translate / add QA questions
4. export data
4. 🔴 [on release branch] notice that supplemental details are missing
5. 🟢 [on PR] notice that supplemental details are there

