### PR TITLE
fix(longRunningMigration): fix crash in long-running migration when multiple submissions share the same UUID

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -181,11 +181,12 @@ class Command(BaseCommand):
                 instance.xml, 'instanceID', instance.uuid
             )
             instance.xml_hash = instance.get_hash(instance.xml)
+            instance._populate_root_uuid()  # noqa
             instances_to_update.append(instance)
 
             # Save the parsed instance to sync MongoDB
             parsed_instance = instance.parsed_instance
-            parsed_instance.save()
+            parsed_instance.update_mongo(asynchronous=False)
 
         Instance.objects.bulk_update(
             instances_to_update, ['uuid', 'xml', 'xml_hash']


### PR DESCRIPTION
### 📣 Summary
Fixed a bug that caused the root UUID long-running migration to crash when duplicate submission UUIDs were encountered.


### 📖 Description
The long-running migration responsible for backfilling the root_uuid field crashed when two or more submissions within the same project shared the same uuid. This fix ensures that the migration can handle such cases safely without interrupting the overall process.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. submit data (at least 2 submissions)
3. update the XML, `uuid` of 2 submissions, set their `root_uuid` to null (directly in the database)
4. reset long running migration 0005 to "created"
5. from the shell run `execute_long_running_migrations()` 
4. 🔴 [on main] long running migration 0005 crashes
5. 🟢 [on PR] long running migration 0005 runs and fields are updated
