### PR TITLE
feat(datatable): handle deleted audio attachment TASK-566

### DIFF
--- a/jsapp/js/components/submissions/audioCell.tsx
+++ b/jsapp/js/components/submissions/audioCell.tsx
@@ -2,6 +2,7 @@ import './audioCell.scss'
 
 import React from 'react'
 
+import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
 import Button from '#/components/common/button'
 import Icon from '#/components/common/icon'
@@ -27,15 +28,15 @@ interface AudioCellProps {
 export default function AudioCell(props: AudioCellProps) {
   return (
     <bem.AudioCell>
-      {typeof props.mediaAttachment === 'string' && (
+      {typeof props.mediaAttachment === 'string' ? (
         <span data-tip={props.mediaAttachment}>
           <Icon name='alert' color='mid-red' size='s' />
         </span>
-      )}
-
-      {typeof props.mediaAttachment === 'object' && props.mediaAttachment?.download_url && (
+      ) : props.mediaAttachment?.is_deleted ? (
+        <DeletedAttachment />
+      ) : props.mediaAttachment?.download_url ? (
         <MiniAudioPlayer mediaURL={props.mediaAttachment?.download_url} />
-      )}
+      ) : null}
 
       <Button
         type='primary'


### PR DESCRIPTION
### 📣 Summary

In forms data table, display deleted audiofiles as deleted. The button for NLP is still there to access transcripts.


### 👀 Preview steps

1. ℹ️ have an account and a project with a audio question type
2. submit the form with an audio
3. open data table
4. add debug code in `audioCell.tsx`
   ```ts
    +   ;(props.mediaAttachment as SubmissionAttachment).download_url = 'http://kalvis.lv/404'
     ```
5. 🔴 notice that audioplayer errors like in the  "before" screenshot
3. add debug code in `audioCell.tsx`
   ```ts
    +   ;(props.mediaAttachment as SubmissionAttachment).is_deleted = true
     ```
4. 🔴 [on main] same as before
6. 🟢 [on PR] notice that audiofile is displayed as deleted like in the  "after" screenshot

| | |
|---|---|
| Before |![image](https://github.com/user-attachments/assets/813a4a80-4ea7-4f3c-b8b8-ba1883e6f451)|
| After | ![image](https://github.com/user-attachments/assets/f8a2a839-e03f-4333-ad19-f98977bffbb3)| 
