### PR TITLE
feat(datatable): handle deleted file attachment TASK-566

### DIFF
--- a/jsapp/js/attachments/deletedAttachment.component.tsx
+++ b/jsapp/js/attachments/deletedAttachment.component.tsx
@@ -1,15 +1,18 @@
 import { Center } from '@mantine/core'
+import type { CenterProps, ElementProps } from '@mantine/core'
+
+interface DeletedAttachment extends CenterProps, ElementProps<'div', keyof CenterProps> {}
 
 /**
  * Use this in a place that you would normally render attachment things (player,
  * image, etc.), but the attachment is deleted now. We have this silly component
  * so the things are consistent.
  */
-export default function DeletedAttachment() {
+export default function DeletedAttachment(props: DeletedAttachment) {
   return (
     // We include the `deletedAttachment` class name so it's easier to style
     // this for parent component.
-    <Center className='deletedAttachment' c='gray.3' fz='md' fs='italic'>
+    <Center className='deletedAttachment' c='gray.3' fz='md' fs='italic' {...props}>
       {t('Deleted')}
     </Center>
   )

--- a/jsapp/js/components/submissions/mediaCell.tsx
+++ b/jsapp/js/components/submissions/mediaCell.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import autoBind from 'react-autobind'
 import { actions } from '#/actions'
 import AttachmentActionsDropdown from '#/attachments/AttachmentActionsDropdown'
+import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
 import Button from '#/components/common/button'
 import Icon from '#/components/common/icon'
@@ -147,6 +148,11 @@ class MediaCell extends React.Component<MediaCellProps, {}> {
           </bem.MediaCellIconWrapper>
         </bem.MediaCell>
       )
+    }
+    ;(this.props.mediaAttachment as SubmissionAttachment).download_url = 'http://kalvis.lv/404'
+    ;(this.props.mediaAttachment as SubmissionAttachment).is_deleted = true
+    if (this.props.mediaAttachment.is_deleted) {
+      return <DeletedAttachment title={this.props.mediaAttachment.filename} />
     }
 
     return (

--- a/jsapp/js/components/submissions/mediaCell.tsx
+++ b/jsapp/js/components/submissions/mediaCell.tsx
@@ -149,8 +149,6 @@ class MediaCell extends React.Component<MediaCellProps, {}> {
         </bem.MediaCell>
       )
     }
-    ;(this.props.mediaAttachment as SubmissionAttachment).download_url = 'http://kalvis.lv/404'
-    ;(this.props.mediaAttachment as SubmissionAttachment).is_deleted = true
     if (this.props.mediaAttachment.is_deleted) {
       return <DeletedAttachment title={this.props.mediaAttachment.filename} />
     }


### PR DESCRIPTION
### 📣 Summary

In forms data table, display deleted files as deleted. Hover on it to see the original path.


### 👀 Preview steps

1. ℹ️ have an account and a project with a audio question type
2. submit the form with an audio
3. open data table
4. add debug code in `mediaCell.tsx`
   ```ts
    +   ;(props.mediaAttachment as SubmissionAttachment).download_url = 'http://kalvis.lv/404'
     ```
5. 🔴 notice that opening deleted file shows only it's path, like in the "before" screenshot
3. add debug code in `mediaCell.tsx`
   ```ts
    +   ;(props.mediaAttachment as SubmissionAttachment).is_deleted = true
     ```
4. 🔴 [on main] same as before
6. 🟢 [on PR] notice that file is displayed as deleted like in the  "after" screenshot
