### PR TITLE
fix(avatar): avoid initials shrinking

### DIFF
--- a/jsapp/js/components/common/avatar.module.scss
+++ b/jsapp/js/components/common/avatar.module.scss
@@ -10,6 +10,7 @@ $avatar-size-m: 32px;
 
   .initials {
     width: $size;
+    min-width: $size; // Avoids the initials to shrink (was happening in some cases)
     height: $size;
     border-radius: $size;
     line-height: $size;


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
In some cases avatar initials were shrinking, causing them to not be a circle anymore.