### PR TITLE
fix(NLP): correct paths for grouped questions

### DIFF
--- a/jsapp/js/components/submissions/submissionUtils.ts
+++ b/jsapp/js/components/submissions/submissionUtils.ts
@@ -14,6 +14,7 @@ import {
   GROUP_TYPES_BEGIN,
   QUESTION_TYPES,
   CHOICE_LISTS,
+  SUPPLEMENTAL_DETAILS_PROP,
 } from 'js/constants';
 import type {AnyRowTypeName} from 'js/constants';
 import type {
@@ -668,14 +669,12 @@ export function getSupplementalDetailsContent(
   submission: SubmissionResponse,
   path: string
 ): string | null {
-  let pathArray;
   const pathParts = getSupplementalPathParts(path);
+  let pathArray = [SUPPLEMENTAL_DETAILS_PROP, pathParts.sourceRowPath];
 
   if (pathParts.type === 'transcript') {
-    pathArray = path.split('/');
     // There is always one transcript, not nested in language code object, thus
     // we don't need the language code in the last element of the path.
-    pathArray.pop();
     pathArray.push('transcript');
     const transcriptObj = get(submission, pathArray, '');
     if (
@@ -687,10 +686,8 @@ export function getSupplementalDetailsContent(
   }
 
   if (pathParts.type === 'translation') {
-    pathArray = path.split('/');
     // The last element is `translation_<language code>`, but we don't want
     // the underscore to be there.
-    pathArray.pop();
     pathArray.push('translation');
     pathArray.push(pathParts.languageCode || '??');
 
@@ -705,9 +702,7 @@ export function getSupplementalDetailsContent(
   }
 
   if (pathParts.type === 'qual') {
-    pathArray = path.split('/');
     // The last element is some random uuid, but we look for `qual`.
-    pathArray.pop();
     pathArray.push('qual');
     const qualResponses: SubmissionAnalysisResponse[] = get(submission, pathArray, []);
     const foundResponse = qualResponses.find(


### PR DESCRIPTION
### 📣 Summary
Resolves a problem where transcripts, translations, and qualitative analysis responses were missing from the data table view and single submission modal for grouped questions


### 👷 Description for instance maintainers
Assumptions in the construction of `_supplementalDetails` paths relied on the old dash-delimited `qpath`s and broke for slash-delimited XPaths. See also #5616 for similar backend fix; internal discussion: https://chat.kobotoolbox.org/#narrow/stream/6-Kobo-Support/topic/Qualitative.20Analysis.20Feature/near/578393.


### 👀 Preview steps
1. Create a survey with an audio question inside a group
2. Collect an audio response
3. Add a transcript, translation, and qualitative analysis question + response
4. See the NLP & QA data saved properly and visible in the single processing view
5. 🔴 [on release branch] Notice that none of the NLP or QA data appear in the data table or single submission modal
6. 🟢 [on PR] All data appears correctly