### PR TITLE
fix(massEmails): Use default plan name in templates TASK-1712

### DIFF
--- a/kobo/apps/stripe/tests/test_utils.py
+++ b/kobo/apps/stripe/tests/test_utils.py
@@ -16,7 +16,7 @@ class UtilsTestCase(BaseTestCase):
             name='Test Community Plan',
         )
         product.save()
-        price = baker.make(
+        baker.make(
             Price,
             active=True,
             id='price_1LsSOSAR39rDI89svTKog9Hq',

--- a/kobo/apps/stripe/tests/test_utils.py
+++ b/kobo/apps/stripe/tests/test_utils.py
@@ -1,4 +1,4 @@
-from djstripe.models import Product, Price
+from djstripe.models import Price, Product
 from model_bakery import baker
 
 from kobo.apps.stripe.utils import get_default_plan_name
@@ -7,6 +7,8 @@ from kpi.tests.kpi_test_case import BaseTestCase
 
 class UtilsTestCase(BaseTestCase):
     def test_get_default_plan_name(self):
+        assert get_default_plan_name() is None
+
         product = baker.prepare(
             Product,
             metadata={'product_type': 'plan', 'default_free_plan': 'true'},

--- a/kobo/apps/stripe/tests/test_utils.py
+++ b/kobo/apps/stripe/tests/test_utils.py
@@ -1,0 +1,25 @@
+from djstripe.models import Product, Price
+from model_bakery import baker
+
+from kobo.apps.stripe.utils import get_default_plan_name
+from kpi.tests.kpi_test_case import BaseTestCase
+
+
+class UtilsTestCase(BaseTestCase):
+    def test_get_default_plan_name(self):
+        product = baker.prepare(
+            Product,
+            metadata={'product_type': 'plan', 'default_free_plan': 'true'},
+            active=True,
+            name='Test Community Plan',
+        )
+        product.save()
+        price = baker.make(
+            Price,
+            active=True,
+            id='price_1LsSOSAR39rDI89svTKog9Hq',
+            product=product,
+            metadata={'max_purchase_quantity': '3'},
+        )
+
+        assert get_default_plan_name() == product.name

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -1,6 +1,7 @@
 import calendar
 from datetime import datetime
 from math import ceil, floor, inf
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
@@ -8,6 +9,7 @@ from django.conf import settings
 from django.db.models import F, Max, Q, Window
 from django.db.models.functions import Coalesce
 from django.utils import timezone
+from djstripe.models import Product
 
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.types import UsageType
@@ -173,6 +175,14 @@ def get_organization_plan_limits(
         return limit
 
     return {org.id: get_limit(org) for org in orgs}
+
+
+def get_default_plan_name() -> Optional[str]:
+    default_plan = (
+        Product.objects.filter(metadata__default_free_plan='true').values('').first()
+    )
+    if default_plan is not None:
+        return default_plan.name
 
 
 def get_organization_plan_limit(

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -106,6 +106,16 @@ def get_billing_dates_for_orgs_with_canceled_subscriptions(
     return result
 
 
+def get_default_plan_name() -> Optional[str]:
+    default_plan = (
+        Product.objects.filter(metadata__default_free_plan='true')
+        .values('name')
+        .first()
+    )
+    if default_plan is not None:
+        return default_plan['name']
+
+
 def get_organization_plan_limits(
     usage_type: UsageType, organizations: list[Organization] = None
 ):
@@ -175,14 +185,6 @@ def get_organization_plan_limits(
         return limit
 
     return {org.id: get_limit(org) for org in orgs}
-
-
-def get_default_plan_name() -> Optional[str]:
-    default_plan = (
-        Product.objects.filter(metadata__default_free_plan='true').values('').first()
-    )
-    if default_plan is not None:
-        return default_plan.name
 
 
 def get_organization_plan_limit(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging


### 📣 Summary
Use the default plan name provided by the stripe product model in the mas emails templates. A new utility function was added to the stripe app in order to provide this name easily.


### 👀 Preview steps
1. Create a mass email config in the Django admin.
2. Include the plan type placeholder in the mass email configuration template 
3. Make sure that the email backend is configured to something that can be debugged, such as console or file backend
```
EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
```
4. Execute the send_emails task through console
```
./manage.py shell_plus

from kobo.apps.mass_email.tasks import send_emails
send_emails()
```
5. Check the generated emails have the correct free plan name