### PR TITLE
fix(massEmails): throttle mass email send

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -176,7 +176,6 @@ class MassEmailSender:
                 self.send_email(email_config, record)
                 emails_sent += 1
 
-
     def send_email(self, email_config, record):
         logging.info(f'Processing MassEmailRecord({record})')
         org_user = record.user.organization.organization_users.get(user=record.user)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -170,7 +170,7 @@ class MassEmailSender:
             batch_size = settings.MASS_EMAIL_THROTTLE_PER_SECOND
             for record in records:
                 if emails_sent > 0 and emails_sent % batch_size == 0:
-                    sleep(5)
+                    sleep(settings.MASS_EMAIL_SLEEP_SECONDS)
                 self.cache_limit_value(email_config, self.limits[email_config.id] - 1)
                 self.cache_limit_value(None, self.total_limit - 1)
                 self.send_email(email_config, record)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime, time, timedelta
 from math import ceil
+from time import sleep
 from typing import Optional
 
 from constance import config
@@ -154,6 +155,7 @@ class MassEmailSender:
         return plan_name
 
     def send_day_emails(self):
+        emails_sent = 0
         for email_config in self.configs:
             limit = self.limits.get(email_config.id)
             if not limit:
@@ -165,10 +167,15 @@ class MassEmailSender:
             logging.info(
                 f'Processing {limit} records for MassEmailConfig({email_config})'
             )
+            batch_size = settings.MASS_EMAIL_THROTTLE_PER_SECOND
             for record in records:
+                if emails_sent > 0 and emails_sent % batch_size == 0:
+                    sleep(5)
                 self.cache_limit_value(email_config, self.limits[email_config.id] - 1)
                 self.cache_limit_value(None, self.total_limit - 1)
                 self.send_email(email_config, record)
+                emails_sent += 1
+
 
     def send_email(self, email_config, record):
         logging.info(f'Processing MassEmailRecord({record})')

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -99,3 +99,28 @@ class TestCeleryTask(BaseTestCase):
         sender = MassEmailSender()
         plan_name = sender.get_plan_name(org_user)
         assert plan_name == 'Not available'
+
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=2)
+    def test_send_is_throttled(self):
+        calls = []
+        with patch(
+            'kobo.apps.mass_emails.tasks.sleep',
+            side_effect=lambda *x: calls.append('sleep'),
+        ):
+            with patch.object(
+                MassEmailSender,
+                'send_email',
+                side_effect=lambda *x: calls.append('send_email'),
+            ):
+                sender = MassEmailSender()
+                sender.limits = {self.configs[0].id: 3, self.configs[1].id: 2}
+                sender.send_day_emails()
+        assert calls == [
+            'send_email',
+            'send_email',
+            'sleep',
+            'send_email',
+            'send_email',
+            'sleep',
+            'send_email',
+        ]

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1402,6 +1402,7 @@ if os.environ.get('EMAIL_USE_TLS'):
     EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
 
 MAX_MASS_EMAILS_PER_DAY = 1000
+MASS_EMAIL_THROTTLE_PER_SECOND = 40
 
 """ AWS configuration (email and storage) """
 if env.str('AWS_ACCESS_KEY_ID', False):

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1403,6 +1403,7 @@ if os.environ.get('EMAIL_USE_TLS'):
 
 MAX_MASS_EMAILS_PER_DAY = 1000
 MASS_EMAIL_THROTTLE_PER_SECOND = 40
+MASS_EMAIL_SLEEP_SECONDS = 5
 
 """ AWS configuration (email and storage) """
 if env.str('AWS_ACCESS_KEY_ID', False):

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1403,7 +1403,7 @@ if os.environ.get('EMAIL_USE_TLS'):
 
 MAX_MASS_EMAILS_PER_DAY = 1000
 MASS_EMAIL_THROTTLE_PER_SECOND = 40
-MASS_EMAIL_SLEEP_SECONDS = 5
+MASS_EMAIL_SLEEP_SECONDS = 1
 
 """ AWS configuration (email and storage) """
 if env.str('AWS_ACCESS_KEY_ID', False):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Limit the rate of emails sent per second to avoid hitting SES limits.


### 👀 Preview steps

1. ℹ️ have at least 2 users
2. In your settings, set `MASS_EMAIL_THROTTLE_PER_SECOND` to 1
3. Update the `get_inactive_users` query to use a timedelta of 0
4. Create a MassEmailConfig that uses the inactive users query
5. Clear the redis cache and reschedule the the mass-email cron as necessary so you don't have to wait for the send. `redis-cli KEYS "*mass_emails*" | xargs redis-cli DEL` will clear the relevant keys  when run in the redis container
6. Open the kpi_worker logs
7. Add the new config to the daily send
8. 🟢 Monitor the sends in the kpi worker logs. There should be about 5 seconds between `Processing MassEmailRecord(id)` logs

