### PR TITLE
feat(massEmails): Test admin action for sending emails TASK-1732

### DIFF
--- a/kobo/apps/mass_emails/admin.py
+++ b/kobo/apps/mass_emails/admin.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin, messages
 
 from .models import EmailStatus, MassEmailConfig, MassEmailRecord
@@ -9,7 +10,13 @@ class MassEmailConfigAdmin(admin.ModelAdmin):
 
     list_display = ('name', 'date_modified')
     fields = ('name', 'subject', 'template', 'query')
-    actions = ['enqueue_mass_emails']
+    actions = ['enqueue_mass_emails', 'test_email_config']
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if settings.MASS_EMAIL_ENABLE_TEST_ACTION:
+            del actions['test_email_config']
+        return actions
 
     @admin.action(description='Add to daily send queue')
     def enqueue_mass_emails(self, request, queryset):
@@ -33,3 +40,13 @@ class MassEmailConfigAdmin(admin.ModelAdmin):
                 f'Emails for {config.name} have been scheduled for tomorrow',
                 level=messages.SUCCESS,
             )
+
+    @admin.action(
+        description='Test configuration sending first 20 enqueued email records'
+    )
+    def test_email_config(self, request, queryset):
+        sender = MassEmailSender()
+        for config in queryset:
+            if config.jobs.count() == 0:
+                enqueue_mass_email_records(config)
+            sender.send_day_emails(config_id=config.id, limit_emails=20)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -154,9 +154,15 @@ class MassEmailSender:
             plan_name = gettext('Not available')
         return plan_name
 
-    def send_day_emails(self):
+    def send_day_emails(self, config_id: int|None=None, limit_emails: int|None=None):
+        """ Send the emails for the current day. Optionally provide a configuration id and
+        a limit of emails for testing purposes
+        """
         emails_sent = 0
         for email_config in self.configs:
+            if config_id is not None and email_config.id != config_id:
+                continue
+
             limit = self.limits.get(email_config.id)
             if not limit:
                 continue
@@ -175,6 +181,8 @@ class MassEmailSender:
                 self.cache_limit_value(None, self.total_limit - 1)
                 self.send_email(email_config, record)
                 emails_sent += 1
+                if limit_emails is not None and emails_sent >= limit_emails:
+                    break
 
     def send_email(self, email_config, record):
         logging.info(f'Processing MassEmailRecord({record})')

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -154,8 +154,10 @@ class MassEmailSender:
             plan_name = gettext('Not available')
         return plan_name
 
-    def send_day_emails(self, config_id: int|None=None, limit_emails: int|None=None):
-        """ Send the emails for the current day. Optionally provide a configuration id and
+    def send_day_emails(
+        self, config_id: int | None = None, limit_emails: int | None = None
+    ):
+        """Send the emails for the current day. Optionally provide a configuration id and
         a limit of emails for testing purposes
         """
         emails_sent = 0

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -124,3 +124,14 @@ class TestCeleryTask(BaseTestCase):
             'sleep',
             'send_email',
         ]
+
+    def test_send_emails_limited(self):
+        sender = MassEmailSender()
+        config_1 = MassEmailConfig.objects.get(name='Config 1')
+        sender.send_day_emails(config_1.id, 2)
+        records = MassEmailRecord.objects.filter(email_job__email_config=config_1)
+        sent_count = sum([record.status == EmailStatus.SENT for record in records])
+        queue_count = sum([record.status == EmailStatus.ENQUEUED for record in records])
+        assert len(mail.outbox) == 2
+        assert sent_count == 2
+        assert queue_count == 1


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 📣 Summary
Adds an action to the mass email configuration admin to test configurations by sending the first 20 enqueued emails.


### 👀 Preview steps
1. Create a new mass email configuration,  use the inactive users query
2. Modify temporarily the inactive users default parameter, to 2 days instead of 365
3. Restart celery containers to re-load the code 
4. Select the created configuration, in the admin list
5. Execute action
6. Check on sent emails