### PR TITLE
feat(projectHistoryLogs): add project owner to submission logs DEV-29

### DIFF
--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -627,6 +627,7 @@ class ProjectHistoryLog(AuditLog):
                 'log_subtype': PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
                 'ip_address': get_client_ip(request),
                 'source': get_human_readable_client_user_agent(request),
+                'project_owner': request.asset.owner.username,
                 'submission': {
                     'submitted_by': instance.username,
                     'root_uuid': instance.root_uuid,
@@ -665,6 +666,7 @@ class ProjectHistoryLog(AuditLog):
                 'log_subtype': PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
                 'ip_address': get_client_ip(request),
                 'source': get_human_readable_client_user_agent(request),
+                'project_owner': request.asset.owner.username,
                 'submission': {
                     'submitted_by': username,
                     'root_uuid': instance.root_uuid,

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -105,6 +105,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
     ):
         self.assertEqual(metadata['submission']['submitted_by'], expected_username)
         self.assertEqual(metadata['submission']['root_uuid'], expected_root_uuid)
+        self.assertEqual(metadata['project_owner'], self.asset.owner.username)
 
     def _base_asset_detail_endpoint_test(
         self, patch, url_name, request_data, expected_action, use_v2=True


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add asset owner to project history logs for submission-related actions.


### 👀 Preview steps

1. ℹ️ have account and a project
2. Enable anonymous submissions to the project
3. Add a submission
4. Navigate to `api/v2/assets/<uid>/history`
5. 🟢 There should be a new project history log with `project_owner: <username>` in the metadata

