### PR TITLE
feat(projectHistoryLogs): add owner to deployment logs DEV-45

### DIFF
--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -505,7 +505,7 @@ class ProjectHistoryLog(AuditLog):
             'ip_address': get_client_ip(request),
             'source': get_human_readable_client_user_agent(request),
             'latest_version_uid': audit_log_info['latest_version_uid'],
-            #         'project_owner': audit_log_info['owner_username'],
+            'project_owner': audit_log_info['owner_username'],
         }
 
         # requests to archive/unarchive will only have the `active` param in the request

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -505,7 +505,7 @@ class ProjectHistoryLog(AuditLog):
             'ip_address': get_client_ip(request),
             'source': get_human_readable_client_user_agent(request),
             'latest_version_uid': audit_log_info['latest_version_uid'],
-            'project_owner': audit_log_info['owner_username'],
+            #         'project_owner': audit_log_info['owner_username'],
         }
 
         # requests to archive/unarchive will only have the `active` param in the request

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -459,6 +459,7 @@ class ProjectHistoryLog(AuditLog):
                 'ip_address': client_ip,
                 'source': source,
                 'latest_version_uid': asset.prefetched_latest_versions[0].uid,
+                'project_owner': asset.owner.username,
             }
             ProjectHistoryLog.objects.create(
                 user=request.user,
@@ -504,6 +505,7 @@ class ProjectHistoryLog(AuditLog):
             'ip_address': get_client_ip(request),
             'source': get_human_readable_client_user_agent(request),
             'latest_version_uid': audit_log_info['latest_version_uid'],
+            'project_owner': audit_log_info['owner_username'],
         }
 
         # requests to archive/unarchive will only have the `active` param in the request

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -250,7 +250,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expect_owner=True,
             expected_queries=45,
         )
-            # do it again (archive an already-archived asset)
+        # do it again (archive an already-archived asset)
         self.client.patch(
             reverse('api_v2:asset-deployment', kwargs={'uid': self.asset.uid}),
             data=request_data,

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -198,8 +198,8 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
     def test_first_time_deployment_creates_log(self):
         post_data = {
-                'active': True,
-                'backend': 'mock',
+            'active': True,
+            'backend': 'mock',
         }
         log_metadata = self._base_asset_detail_endpoint_test(
             patch=False,

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -27,7 +27,7 @@ from kpi.filters import (
     AssetOrderingFilter,
     ExcludeOrgAssetFilter,
     KpiObjectPermissionsFilter,
-    SearchFilter
+    SearchFilter,
 )
 from kpi.highlighters import highlight_xform
 from kpi.mixins.asset import AssetViewSetListMixin
@@ -485,6 +485,7 @@ class AssetViewSet(
                     'id': asset.id,
                     'latest_deployed_version_uid': asset.latest_deployed_version_uid,
                     'latest_version_uid': asset.latest_version.uid,
+                    'owner_username': asset.owner.username,
                 }
                 # TODO: Understand why this 404s when `serializer.data` is not
                 # coerced to a dict
@@ -518,6 +519,7 @@ class AssetViewSet(
                     'active': serializer.data['active'],
                     'latest_deployed_version_uid': asset.latest_deployed_version_uid,
                     'latest_version_uid': asset.latest_version.uid,
+                    'owner_username': asset.owner.username,
                 }
                 # TODO: Understand why this 404s when `serializer.data` is not
                 # coerced to a dict


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add the project owner to all project history logs dealing with deployment/archiving.


### 💭 Notes
This PR also tries to set up for easier testing in the future by conditionally adding the project owner to the method for testing basic metadata that is called in almost all of the tests.
This PR also tests the number of queries for the updated project history logs. This is to ensure we aren't accidentally adding queries to requests to get more information for the project history logs (unless it's unavoidable). Query counts do tend to vary, so if we end up constantly having to update the counts whenever we make changes we can remove it.
The query counts were based on the counts before the project owner was added.


### 👀 Preview steps

1. ℹ️ have an account
2. Create a new project
3. Deploy the project
4. Redeploy the project
5. Archive the project
6. Unarchive the project
7. Go to `api/v2/<asset_uid>/history`
8. 🟢 There should be four new project history logs, one for each action, and they should each have your username in the metadata under `product_owner.`

