### PR TITLE
chore(vscode): exclude compiled js from search

### DIFF
--- a/kpi.code-workspace
+++ b/kpi.code-workspace
@@ -29,6 +29,11 @@
     ]
   },
   "settings": {
+    "search.exclude": {
+      "**/node_modules": true,
+      "jsapp/compiled": true
+    },
+
     // Black
     "[python]": {
       "editor.defaultFormatter": "ms-python.black-formatter"


### PR DESCRIPTION
### 💭 Notes

In VSCode workspace, exclude compiled code from search to reduce noise in results.