### PR TITLE
fix(stripe): annotate methods requiring stripe functionality

### DIFF
--- a/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
+++ b/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
@@ -1,10 +1,13 @@
 from math import inf
+from typing import get_args
 from unittest.mock import patch
 
 from ddt import data, ddt, unpack
+from django.test import override_settings
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.mass_emails.user_queries import get_users_within_range_of_usage_limit
+from kobo.apps.organizations.types import UsageType
 from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase
 
 
@@ -144,3 +147,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                     usage_types=['seconds', 'characters']
                 )
         patched_usage_method.assert_called_once()
+
+    @override_settings(STRIPE_ENABLED=False)
+    def test_users_in_range_of_usage_limit_stripe_disabled_returns_empty(self):
+        assert list(get_users_within_range_of_usage_limit(get_args(UsageType))) == []

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -79,7 +79,6 @@ def get_users_within_range_of_usage_limit(
     # cheat so that we don't fetch information twice if we're looking for nlp usage
     def get_nlp_usage_method(nlp_usage_type):
         def get_nlp_usage():
-            nonlocal cached_nlp_usage
             if cached_nlp_usage == {}:
                 cached_nlp_usage.update(
                     get_nlp_usage_for_current_billing_period_by_user_id()

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from math import inf
 
+from django.conf import settings
 from django.db.models import Q, QuerySet
 from django.utils.timezone import now
 
@@ -70,11 +71,15 @@ def get_users_within_range_of_usage_limit(
     :param minimum: float. Minimum usage, eg 0.9 for 90% of the limit. Default 0
     :param maximum: float. Maximum usage, eg 1 for 100% of the limit. Default inf
     """
+    if not settings.STRIPE_ENABLED:
+        return User.objects.none()
+
     cached_nlp_usage = {}
 
     # cheat so that we don't fetch information twice if we're looking for nlp usage
     def get_nlp_usage_method(nlp_usage_type):
         def get_nlp_usage():
+            nonlocal cached_nlp_usage
             if cached_nlp_usage == {}:
                 cached_nlp_usage.update(
                     get_nlp_usage_for_current_billing_period_by_user_id()

--- a/kobo/apps/organizations/utils.py
+++ b/kobo/apps/organizations/utils.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from typing import Union
+from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 from django.apps import apps
+from django.conf import settings
 from django.utils import timezone
-from zoneinfo import ZoneInfo
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
@@ -20,7 +21,7 @@ def get_billing_dates(organization: Union['Organization', None]):
         first_of_this_month
         + relativedelta(months=1)
     )
-    if not organization:
+    if not organization or not settings.STRIPE_ENABLED:
         return first_of_this_month, first_of_next_month
     calculated_dates = get_current_billing_period_dates_by_org([organization]).get(
         organization.id

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -4,7 +4,6 @@ from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
 from ddt import data, ddt, unpack
-from django.test import override_settings
 from django.utils import timezone
 from djstripe.models import Customer, Price, Product
 from model_bakery import baker
@@ -96,13 +95,6 @@ class OrganizationsUtilsTestCase(BaseTestCase):
             assert all_limits[org.id]['storage_limit'] == int(
                 free_plan.metadata['storage_bytes_limit']
             )
-
-    @override_settings(STRIPE_ENABLED=False)
-    def test_get_organization_limits_stripe_disabled_returns_inf(self):
-        all_limits = get_organizations_subscription_limits()
-        for org in Organization.objects.all():
-            for usage_type in ['submission', 'storage', 'seconds', 'characters']:
-                assert all_limits[org.id][f'{usage_type}_limit'] == inf
 
     def test__prioritizes_price_metadata(self):
         product_metadata = {

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -1,3 +1,4 @@
+from math import inf
 from typing import Optional, Union
 
 from django.apps import apps
@@ -86,6 +87,8 @@ def get_organization_remaining_usage(
     """
     Get the organization remaining usage count for a given limit type
     """
+    if not settings.STRIPE_ENABLED:
+        return inf
     addon_remaining = 0
     if settings.STRIPE_ENABLED:
         PlanAddOn = apps.get_model('stripe', 'PlanAddOn')  # noqa

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -11,7 +11,10 @@ from kobo.apps.openrosa.apps.logger.models import DailyXFormSubmissionCounter, X
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.types import NLPUsage
 from kobo.apps.organizations.utils import get_billing_dates
-from kobo.apps.stripe.utils import get_current_billing_period_dates_by_org
+from kobo.apps.stripe.utils import (
+    get_current_billing_period_dates_by_org,
+    requires_stripe,
+)
 from kpi.utils.cache import CachedClass, cached_class_property
 
 
@@ -40,8 +43,8 @@ def get_submission_counts_in_date_range_by_user_id(
     )
     return {row['user_id']: row['total'] for row in all_sub_counters}
 
-
-def get_submissions_for_current_billing_period_by_user_id() -> dict[int, int]:
+@requires_stripe
+def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int, int]:
     current_billing_dates_by_org = get_current_billing_period_dates_by_org()
     owner_by_org = {
         org.id: org.owner.organization_user.user.id
@@ -87,7 +90,10 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
     return results
 
 
-def get_nlp_usage_for_current_billing_period_by_user_id() -> dict[int, NLPUsage]:
+@requires_stripe
+def get_nlp_usage_for_current_billing_period_by_user_id(
+    **kwargs,
+) -> dict[int, NLPUsage]:
     current_billing_dates_by_org = get_current_billing_period_dates_by_org()
     owner_by_org = {
         org.id: org.owner.organization_user.user.id

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -43,6 +43,7 @@ def get_submission_counts_in_date_range_by_user_id(
     )
     return {row['user_id']: row['total'] for row in all_sub_counters}
 
+
 @requires_stripe
 def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int, int]:
     current_billing_dates_by_org = get_current_billing_period_dates_by_org()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug that was preventing startup when stripe was disabled.


### 💭 Notes
Adds a `stripe_required` annotation to make it clearer which methods require stripe to be enabled. Also removes an unused method, sets billing dates to the first of the month when stripe is disabled, and moves all stripe-disabled functionality to get_organization_effective_limits, since that's the main method that other apps interact with.


### 👀 Preview steps
Build KPI with stripe disabled.