### PR TITLE
feat(longRunningMigrations): add system check to validate completion of critical long-running migrations

### DIFF
--- a/kobo/apps/long_running_migrations/app.py
+++ b/kobo/apps/long_running_migrations/app.py
@@ -1,6 +1,45 @@
 from django.apps import AppConfig
+from django.core.checks import Error, register, Tags
+from django.db import connection
+
+from .constants import MUST_COMPLETE_LONG_RUNNING_MIGRATIONS
 
 
 class LongRunningMigrationAppConfig(AppConfig):
     name = 'kobo.apps.long_running_migrations'
     verbose_name = 'Long-running migrations'
+
+
+def check_must_complete_long_running_migrations(app_configs, **kwargs):
+
+    placeholders = ', '.join(['%s'] * len(MUST_COMPLETE_LONG_RUNNING_MIGRATIONS))
+    sql = f"""
+            SELECT 1
+            FROM long_running_migrations_longrunningmigration
+            WHERE name IN ({placeholders})
+              AND status != 'completed'
+            LIMIT 1
+        """
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, MUST_COMPLETE_LONG_RUNNING_MIGRATIONS)
+        row = cursor.fetchone()
+
+    if row is None:
+        return []
+
+    return [
+        Error(
+            'Some required long-running migrations have not been completed.',
+            hint=(
+                'Run the missing long-running migrations using '
+                '`execute_long_running_migrations()` in the shell. '
+                'Note that this process may take some time to complete.'
+            ),
+            obj=None,
+            id='long_running_migrations.E001',
+        )
+    ]
+
+
+register(check_must_complete_long_running_migrations, Tags.database)

--- a/kobo/apps/long_running_migrations/constants.py
+++ b/kobo/apps/long_running_migrations/constants.py
@@ -1,0 +1,4 @@
+# Long-running migrations that must be completed before the app can start.
+MUST_COMPLETE_LONG_RUNNING_MIGRATIONS = [
+    '0007_backfill_attachment_model'
+]

--- a/kobo/apps/long_running_migrations/tests/test_checks.py
+++ b/kobo/apps/long_running_migrations/tests/test_checks.py
@@ -1,0 +1,33 @@
+from django.core.checks import run_checks
+from django.test import TestCase, override_settings
+
+from ..constants import MUST_COMPLETE_LONG_RUNNING_MIGRATIONS
+from ..models import LongRunningMigration, LongRunningMigrationStatus
+
+
+@override_settings(
+    CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}
+    }
+)
+class LongRunningMigrationSystemCheckTestCase(TestCase):
+
+    def test_system_check_fails_when_not_completed(self):
+        errors = run_checks()
+
+        assert any(
+            e.id == 'long_running_migrations.E001'
+            for e in errors
+        )
+
+    def test_system_check_passes_when_completed(self):
+        LongRunningMigration.objects.filter(
+            name__in=MUST_COMPLETE_LONG_RUNNING_MIGRATIONS
+        ).update(status=LongRunningMigrationStatus.COMPLETED)
+
+        errors = run_checks()
+
+        assert not any(
+            e.id == 'long_running_migrations.E001'
+            for e in errors
+        )


### PR DESCRIPTION
### 📣 Summary
Added a Django system check to ensure important long-running migrations have completed

### 📖 Description
This PR introduces a Django system check that validates whether specific long-running migrations—considered critical to data integrity or system functionality—have been completed. If any of these migrations are still running or incomplete, the system check will raise an error to prevent the application from starting.

This mechanism not only protects the system from running in an inconsistent state, but also serves as a useful signal for sysadmins, giving them immediate visibility into whether the database is fully up-to-date. Instead of silently failing or relying on logs, this check provides a clear and explicit message during startup, making it easier to identify and act on pending background data migrations.


### 👀 Preview steps

Bug template:
1. Go to admin > Long running migrations 
2. Update 0007... to "in_progress" (or created, does not matter)
3. 🔴 [on main] The application starts as usual
5. 🟢 [on PR] The application does not start, Django system check returns an error