### PR TITLE
fix(massEmails): handle organizations with no owners

### DIFF
--- a/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
+++ b/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
@@ -156,6 +156,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
 
     def test_organization_with_no_owner(self):
         no_owner = baker.make(Organization, id='org_abcd1234', mmo_override=False)
+        assert no_owner.owner_user_object is None
         usage_limits = {no_owner.id: {'storage_limit': 10}}
         storage_by_user_id = {self.someuser.id: 1000000000}
         with patch(

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -105,10 +105,21 @@ def get_users_within_range_of_usage_limit(
         or 'seconds' in usage_types
         or 'characters' in usage_types
     )
+    org_ids_with_no_owner = list(
+        Organization.objects.filter(owner__isnull=True).values_list('pk', flat=True)
+    )
     limits_by_org = get_organizations_effective_limits(
         include_storage_addons=include_storage_addons,
         include_onetime_addons=include_onetime_addons,
     )
+
+    # filter out any organization with no owner
+    limits_by_org = {
+        org_id: limits
+        for org_id, limits in limits_by_org.items()
+        if org_id not in org_ids_with_no_owner
+    }
+
     owner_by_org = {
         org.id: org.owner_user_object.pk
         for org in Organization.objects.filter(owner__isnull=False)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes an error that was causing 500s when attempting to trigger mass emails with usage queries.



### 📖 Description
Removes organizations with no owner when determining which organizations may be over their limits since there is no one to email.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. ℹ️ make sure stripe is enabled
3. In the terminal, create a new organization with just `Organization.objects.create()`
4. In admin, create a new Mass Email Config with query `users_above_90_percent_storage`
5. Add the email to the daily send
6. 🔴 [on main] a KeyError/500 error is triggered
7. 🟢 [on PR] the email is successfully added to the send
