### PR TITLE
fix(submissions): ensure atomicity of submissions TASK-1764

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -82,6 +82,7 @@ from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator, set_uui
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
+from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
@@ -138,6 +139,7 @@ def check_edit_submission_permissions(
         ))
 
 
+@kc_transaction_atomic
 def create_instance(
     username: str,
     xml_file: File,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Submissions are now properly rolled back if something goes wrong during processing.



### 📖 Description
Previously, if a submission encountered an internal error (like a server issue), it could still be partially saved in the system. This caused problems when retrying the submission, such as duplicate errors. Submissions are now fully atomic: if something fails, nothing is saved - ensuring cleaner retries and more reliable form processing.
