### PR TITLE
feat(massEmails): Celery task for sending emails TASK-1692

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -35,6 +35,7 @@ templates_placeholders = {
 
 PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{today}_emails'
 
+
 def enqueue_mass_email_records(email_config):
     """
     Creates a email job and enqueues email records for users based on query

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -99,7 +99,7 @@ class MassEmailSender:
                 'jobs__records',
                 filter=Q(jobs__records__status=EmailStatus.ENQUEUED),
             )
-        )
+        ).filter(enqueued_records_count__gt=0)
         logging.info(f'Found {self.total_records} enqueued records')
         self.get_day_limits()
 

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -33,6 +33,7 @@ templates_placeholders = {
     '##date_created##': 'date_created',
 }
 
+PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{today}_emails'
 
 def enqueue_mass_email_records(email_config):
     """
@@ -237,7 +238,7 @@ def _send_emails():
     """
     today = timezone.now().date()
     sender = MassEmailSender()
-    cache_key = f'mass_emails_{today}_emails'
+    cache_key = PROCESSED_EMAILS_CACHE_KEY.format(today=today)
     cached_data = cache.get(cache_key, [])
     processed_configs = set(cached_data)
     config_ids = {email_config.id for email_config in sender.configs}
@@ -289,7 +290,7 @@ def generate_mass_email_user_lists():
     #       email sending tasks.
 
     today = timezone.now().date()
-    cache_key = f'mass_emails_{today}_emails'
+    cache_key = PROCESSED_EMAILS_CACHE_KEY.format(today=today)
     cached_data = cache.get(cache_key, [])
     processed_configs = set(cached_data)
     email_configs = MassEmailConfig.objects.filter(

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -21,13 +21,76 @@ from ..tasks import (
 )
 
 
+def test_template_render(self):
+    data = {
+        'username': 'Test Username',
+        'full_name': 'Test Full Name',
+        'plan_name': 'Test Plan Name',
+    }
+    template = """
+    Username: ##username##
+    Full name: ##full_name##
+    Plan name: ##plan_name##
+    """
+    rendered = render_template(template, data)
+    assert 'Username: Test Username' in rendered
+    assert 'Full name: Test Full Name' in rendered
+    assert 'Plan name: Test Plan Name' in rendered
+
+
+class BaseMassEmailsTestCase(BaseTestCase):
+    def setUp(self):
+        self.user1 = User.objects.create(
+            username='user1', last_login=timezone.now() - timedelta(days=400), email='user1@test.com',
+        )
+        self.user2 = User.objects.create(
+            username='user2', last_login=timezone.now() - timedelta(days=400), email='user2@test.com',
+        )
+        self.user3 = User.objects.create(
+            username='user3', last_login=timezone.now() - timedelta(days=7), email='user3@test.com',
+        )
+        self.cache_key = f'mass_emails_{timezone.now().date()}_emails'
+        cache.delete(self.cache_key)
+
+    def _create_email_config(self, name, template=None, frequency=-1):
+        """
+        Helper function to create a MassEmailConfig
+        """
+        return MassEmailConfig.objects.create(
+            name=name,
+            subject='Test Subject',
+            template=template if template else 'Test Template',
+            live=True,
+            query='users_inactive_for_365_days',
+            frequency=frequency,
+            date_created=timezone.now() - timedelta(days=1),
+        )
+
+    def _create_email_record(self, user, email_config, status, days_ago=0, job=None):
+        """
+        Helper function to create a MassEmailRecord
+        """
+        if job is None:
+            job = MassEmailJob.objects.create(email_config=email_config)
+        record = MassEmailRecord.objects.create(
+            user=user,
+            email_job=job,
+            status=status,
+            date_created=timezone.now() - timedelta(days=days_ago),
+        )
+
+        # Update date_modified to simulate record creation in the past
+        MassEmailRecord.objects.filter(id=record.id).update(
+            date_modified=timezone.now() - timedelta(days=days_ago)
+        )
+
+
 @ddt
-class TestCeleryTask(BaseTestCase):
+class TestMassEmailSender(BaseMassEmailsTestCase):
     fixtures = ['test_data']
 
     def setUp(self):
         super().setUp()
-        cache.clear()
         self.template = """
         Username: ##username##
         Full name: ##full_name##
@@ -35,25 +98,21 @@ class TestCeleryTask(BaseTestCase):
         """
         self.configs = []
         self.jobs = []
-        self.user1 = User.objects.get(username='someuser')
-        self.user2 = User.objects.get(username='anotheruser')
-        self.user3 = User.objects.get(username='adminuser')
+        cache.clear()
 
         for i in range(0, 100):
-            config = MassEmailConfig.objects.create(
-                name=f'Config {i}', subject=f'Subject {i}', template=self.template
-            )
+            config = self._create_email_config(name=f'Config {i}', template=self.template)
             job = MassEmailJob.objects.create(email_config=config)
             self.configs.append(config)
             self.jobs.append(job)
-            MassEmailRecord.objects.create(
-                user=self.user1, email_job=job, status=EmailStatus.ENQUEUED
+            self._create_email_record(
+                user=self.user1, email_config=config, job=job, status=EmailStatus.ENQUEUED
             )
-            MassEmailRecord.objects.create(
-                user=self.user2, email_job=job, status=EmailStatus.ENQUEUED
+            self._create_email_record(
+                user=self.user2, email_config=config, job=job, status=EmailStatus.ENQUEUED
             )
-            MassEmailRecord.objects.create(
-                user=self.user3, email_job=job, status=EmailStatus.ENQUEUED
+            self._create_email_record(
+                user=self.user3, email_config=config, job=job, status=EmailStatus.ENQUEUED
             )
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=310)
@@ -74,31 +133,22 @@ class TestCeleryTask(BaseTestCase):
     @patch('django.utils.timezone.now')
     def test_send_emails_limits(self, now_mock):
         now_mock.return_value = datetime(2025, 1, 1, 0, 0, 0, 0, pytz.UTC)
-        send_emails()
+        sender = MassEmailSender()
+        sender.send_day_emails()
         assert len(mail.outbox) == 10
         now_mock.return_value = datetime(2025, 1, 2, 0, 0, 0, 0, pytz.UTC)
-        send_emails()
+        sender = MassEmailSender()
+        sender.send_day_emails()
         assert len(mail.outbox) == 20
         # Calling send_emails on the same day:
-        send_emails()
+        sender = MassEmailSender()
+        sender.send_day_emails()
         assert len(mail.outbox) == 20
 
-        # Test if limits end up witht he correct value
+        # Test if limits end up with the correct value
         sender = MassEmailSender()
         assert sum([0 if lim is None else lim for lim in sender.limits.values()]) == 0
         assert sender.total_limit == 0
-
-    def test_template_render(self):
-        data = {
-            'username': 'Test Username',
-            'full_name': 'Test Full Name',
-            'plan_name': 'Test Plan Name',
-        }
-
-        rendered = render_template(self.template, data)
-        assert 'Username: Test Username' in rendered
-        assert 'Full name: Test Full Name' in rendered
-        assert 'Plan name: Test Plan Name' in rendered
 
     @override_settings(STRIPE_ENABLED=False)
     def test_get_plan_name_stripe_disabled(self):
@@ -148,51 +198,16 @@ class TestCeleryTask(BaseTestCase):
         assert sender.get_cache_key_date(send_date=current_time) == expected_time
 
 
-@ddt
-class GenerateDailyEmailUserListTaskTestCase(BaseTestCase):
+class TestSendRecurringEmails(BaseMassEmailsTestCase):
     def setUp(self):
-        self.user1 = User.objects.create(
-            username='user1', last_login=timezone.now() - timedelta(days=400)
-        )
-        self.user2 = User.objects.create(
-            username='user2', last_login=timezone.now() - timedelta(days=400)
-        )
-        self.user3 = User.objects.create(
-            username='user3', last_login=timezone.now() - timedelta(days=7)
-        )
-        self.cache_key = f'mass_emails_{timezone.now().date()}_emails'
-        cache.delete(self.cache_key)
+        super().setUp()
 
-    def _create_email_config(self, name, frequency=-1):
-        """
-        Helper function to create a MassEmailConfig
-        """
-        return MassEmailConfig.objects.create(
-            name=name,
-            subject='Test Subject',
-            template='Test Template',
-            live=True,
-            query='users_inactive_for_365_days',
-            frequency=frequency,
-            date_created=timezone.now() - timedelta(days=1),
-        )
+    def test_send_recurring_emails(self):
+        pass
 
-    def _create_email_record(self, user, email_config, status, days_ago=0):
-        """
-        Helper function to create a MassEmailRecord
-        """
-        record = MassEmailRecord.objects.create(
-            user=user,
-            email_job=MassEmailJob.objects.create(email_config=email_config),
-            status=status,
-            date_created=timezone.now() - timedelta(days=days_ago),
-        )
 
-        # Update date_modified to simulate record creation in the past
-        MassEmailRecord.objects.filter(id=record.id).update(
-            date_modified=timezone.now() - timedelta(days=days_ago)
-        )
-
+@ddt
+class GenerateDailyEmailUserListTaskTestCase(BaseMassEmailsTestCase):
     @data(
         (EmailStatus.ENQUEUED, 1),
         (EmailStatus.SENT, 0),

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -21,7 +21,7 @@ from ..tasks import (
 )
 
 
-def test_template_render(self):
+def test_template_render():
     data = {
         'username': 'Test Username',
         'full_name': 'Test Full Name',
@@ -213,7 +213,6 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
             year=2025, month=1, day=1, hour=1, minute=expected_minute
         )
         assert sender.get_cache_key_date(send_date=current_time) == expected_time
-
 
     def test_send_recurring_emails_exits_when_incomplete_init(self):
         _send_emails()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a new task to sync with the recurring emails feature. For now this task is not enabled but it will replace the old task in the near future.


### 👀 Preview steps
For now unit tests cover the functionality, though the task can be executed manually. These steps may be followed:

1. Set the django emails backend setting to file backend or console backend in order to be able to debug
2. Set up one or more mass email configs
3. You can use the inactive user query, and change temporarily the inactive days parameter so that the users email records list is not empty
4. Enter to the manage.py shell and import the tasks generate_mass_email_user_lists and _send_emails 
5. Execute generate_mass_email_user_lists manually and then _send_emails 
6. Review that the emails were sent