### PR TITLE
refactor(trashBin): group tasks by object type for better organization

### DIFF
--- a/kobo/apps/trash_bin/tasks/__init__.py
+++ b/kobo/apps/trash_bin/tasks/__init__.py
@@ -6,8 +6,8 @@ from django.utils import timezone
 from django_celery_beat.models import ClockedSchedule, PeriodicTask
 
 from kobo.celery import celery_app
-from .project import empty_project
 from .account import empty_account
+from .project import empty_project
 from ..constants import DELETE_PROJECT_STR_PREFIX, DELETE_USER_STR_PREFIX
 from ..models import TrashStatus
 from ..models.account import AccountTrash
@@ -22,26 +22,22 @@ def garbage_collector():
         with transaction.atomic():
             # Remove orphan periodic tasks
             PeriodicTask.objects.exclude(
-                pk__in=AccountTrash.objects.values_list(
-                    'periodic_task_id', flat=True
-                ),
+                pk__in=AccountTrash.objects.values_list('periodic_task_id', flat=True),
             ).filter(
                 name__startswith=DELETE_USER_STR_PREFIX, clocked__isnull=False
             ).delete()
 
             PeriodicTask.objects.exclude(
-                pk__in=ProjectTrash.objects.values_list(
-                    'periodic_task_id', flat=True
-                ),
+                pk__in=ProjectTrash.objects.values_list('periodic_task_id', flat=True),
             ).filter(
                 name__startswith=DELETE_PROJECT_STR_PREFIX, clocked__isnull=False
             ).delete()
 
             # Then, remove clocked schedules
             ClockedSchedule.objects.exclude(
-                pk__in=PeriodicTask.objects.filter(
-                    clocked__isnull=False
-                ).values_list('clocked_id', flat=True),
+                pk__in=PeriodicTask.objects.filter(clocked__isnull=False).values_list(
+                    'clocked_id', flat=True
+                ),
             ).delete()
 
 
@@ -55,18 +51,14 @@ def task_restarter():
         seconds=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT + 60 * 5
     )
 
-    stuck_account_ids = AccountTrash.objects.values_list(
-        'pk', flat=True
-    ).filter(
+    stuck_account_ids = AccountTrash.objects.values_list('pk', flat=True).filter(
         status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
         date_modified__lte=stuck_threshold,
     )
     for stuck_account_id in stuck_account_ids:
         empty_account.delay(stuck_account_id, force=True)
 
-    stuck_project_ids = ProjectTrash.objects.values_list(
-        'pk', flat=True
-    ).filter(
+    stuck_project_ids = ProjectTrash.objects.values_list('pk', flat=True).filter(
         status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
         date_modified__lte=stuck_threshold,
     )

--- a/kobo/apps/trash_bin/tasks/__init__.py
+++ b/kobo/apps/trash_bin/tasks/__init__.py
@@ -1,0 +1,74 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+from django_celery_beat.models import ClockedSchedule, PeriodicTask
+
+from kobo.celery import celery_app
+from .project import empty_project
+from .account import empty_account
+from ..constants import DELETE_PROJECT_STR_PREFIX, DELETE_USER_STR_PREFIX
+from ..models import TrashStatus
+from ..models.account import AccountTrash
+from ..models.project import ProjectTrash
+from ..utils import temporarily_disconnect_signals
+
+
+@celery_app.task
+def garbage_collector():
+
+    with temporarily_disconnect_signals(delete=True):
+        with transaction.atomic():
+            # Remove orphan periodic tasks
+            PeriodicTask.objects.exclude(
+                pk__in=AccountTrash.objects.values_list(
+                    'periodic_task_id', flat=True
+                ),
+            ).filter(
+                name__startswith=DELETE_USER_STR_PREFIX, clocked__isnull=False
+            ).delete()
+
+            PeriodicTask.objects.exclude(
+                pk__in=ProjectTrash.objects.values_list(
+                    'periodic_task_id', flat=True
+                ),
+            ).filter(
+                name__startswith=DELETE_PROJECT_STR_PREFIX, clocked__isnull=False
+            ).delete()
+
+            # Then, remove clocked schedules
+            ClockedSchedule.objects.exclude(
+                pk__in=PeriodicTask.objects.filter(
+                    clocked__isnull=False
+                ).values_list('clocked_id', flat=True),
+            ).delete()
+
+
+@celery_app.task
+def task_restarter():
+    """
+    This task restarts previous tasks which have been stopped accidentally,
+    e.g.: docker container/k8s pod restart or OOM killed.
+    """
+    stuck_threshold = timezone.now() - timedelta(
+        seconds=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT + 60 * 5
+    )
+
+    stuck_account_ids = AccountTrash.objects.values_list(
+        'pk', flat=True
+    ).filter(
+        status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
+        date_modified__lte=stuck_threshold,
+    )
+    for stuck_account_id in stuck_account_ids:
+        empty_account.delay(stuck_account_id, force=True)
+
+    stuck_project_ids = ProjectTrash.objects.values_list(
+        'pk', flat=True
+    ).filter(
+        status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
+        date_modified__lte=stuck_threshold,
+    )
+    for stuck_project_id in stuck_project_ids:
+        empty_project.delay(stuck_project_id, force=True)

--- a/kobo/apps/trash_bin/tasks/account.py
+++ b/kobo/apps/trash_bin/tasks/account.py
@@ -4,7 +4,6 @@ from celery.signals import task_failure, task_retry
 from django.conf import settings
 
 from kobo.celery import celery_app
-from kpi.exceptions import KobocatCommunicationError
 from ..exceptions import TrashTaskInProgressError
 from ..models.account import AccountTrash
 from ..utils import (
@@ -19,7 +18,6 @@ from ..utils.account import validate_pre_deletion
 @celery_app.task(
     autoretry_for=(
         TrashTaskInProgressError,
-        KobocatCommunicationError,
     ),
     retry_backoff=60,
     retry_backoff_max=600,

--- a/kobo/apps/trash_bin/tasks/account.py
+++ b/kobo/apps/trash_bin/tasks/account.py
@@ -16,9 +16,7 @@ from ..utils.account import validate_pre_deletion
 
 
 @celery_app.task(
-    autoretry_for=(
-        TrashTaskInProgressError,
-    ),
+    autoretry_for=(TrashTaskInProgressError,),
     retry_backoff=60,
     retry_backoff_max=600,
     max_retries=5,

--- a/kobo/apps/trash_bin/tasks/account.py
+++ b/kobo/apps/trash_bin/tasks/account.py
@@ -2,31 +2,18 @@ import logging
 
 from celery.signals import task_failure, task_retry
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.db import transaction
-from django.db.models.signals import post_delete
-from django.utils import timezone
-from django_celery_beat.models import PeriodicTask
-from requests.exceptions import HTTPError
 
-from kobo.apps.audit_log.audit_actions import AuditAction
-from kobo.apps.audit_log.models import AuditLog, AuditType
-from kobo.apps.trackers.models import NLPUsageCounter
 from kobo.celery import celery_app
-from kpi.deployment_backends.kc_access.utils import delete_kc_user
 from kpi.exceptions import KobocatCommunicationError
-from kpi.models.asset import Asset
-from kpi.utils.storage import rmdir
 from ..exceptions import TrashTaskInProgressError
-from ..models import TrashStatus
 from ..models.account import AccountTrash
-from ..models.project import ProjectTrash
 from ..utils import (
-    delete_asset,
-    replace_user_with_placeholder,
+    delete_account,
+    process_deletion,
     trash_bin_task_failure,
     trash_bin_task_retry,
 )
+from ..utils.account import validate_pre_deletion
 
 
 @celery_app.task(
@@ -43,129 +30,20 @@ from ..utils import (
     time_limit=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT,
 )
 def empty_account(account_trash_id: int, force: bool = False):
-    with transaction.atomic():
-        account_trash = AccountTrash.objects.select_for_update().get(
-            pk=account_trash_id
-        )
-        if not force and account_trash.status == TrashStatus.IN_PROGRESS:
-            logging.warning(
-                f'User {account_trash.user.username} deletion is already '
-                f'in progress'
-            )
-            return
-
-        assets = (
-            Asset.all_objects.filter(owner=account_trash.user)
-            .only(
-                'uid',
-                '_deployment_data',
-                'owner',
-                'name',
-                'asset_type',
-                'advanced_features',
-            )
-            .select_related('owner')
-        )
-
-        # Ensure there are no running other project trash tasks related to this
-        # account
-        if ProjectTrash.objects.filter(
-            asset__in=assets, status=TrashStatus.IN_PROGRESS
-        ).exists():
-            # Let them finish and retry later
-            raise TrashTaskInProgressError
-
-        account_trash.status = TrashStatus.IN_PROGRESS
-        account_trash.metadata['failure_error'] = ''
-        account_trash.save(update_fields=['metadata', 'status', 'date_modified'])
-
-    # Delete children first…
-    for asset in assets.filter(parent__isnull=False):
-        delete_asset(account_trash.request_author, asset)
-
-    # …then parents
-    for asset in assets.filter(parent__isnull=True):
-        delete_asset(account_trash.request_author, asset)
-
-    user = account_trash.user
-    user_id = user.pk
-    date_removal_requested = user.extra_details.date_removal_requested
-    try:
-        # We need to deactivate this post_delete signal because it's triggered
-        # on `User` delete cascade and fails to insert into DB within a transaction.
-        # The post_delete signal occurs before user is deleted, therefore still
-        # has a reference of it when the whole transaction is committed.
-        # It fails with an IntegrityError.
-        post_delete.disconnect(
-            NLPUsageCounter.update_catch_all_counters_on_delete,
-            sender=NLPUsageCounter,
-            dispatch_uid='update_catch_all_monthly_xform_submission_counters',
-        )
-        with transaction.atomic():
-            audit_log_params = {
-                'app_label': get_user_model()._meta.app_label,
-                'model_name': get_user_model()._meta.model_name,
-                'object_id': user_id,
-                'user': account_trash.request_author,
-                'user_uid': account_trash.request_author.extra_details.uid,
-                'metadata': {
-                    'username': user.username,
-                },
-                'log_type': AuditType.USER_MANAGEMENT
-            }
-
-            if account_trash.retain_placeholder:
-                audit_log_params['action'] = AuditAction.REMOVE
-                placeholder_user = replace_user_with_placeholder(user)
-                # Retain removal date information
-                extra_details = placeholder_user.extra_details
-                extra_details.date_removal_requested = date_removal_requested
-                extra_details.date_removed = timezone.now()
-                extra_details.save(
-                    update_fields=['date_removal_requested', 'date_removed']
-                )
-            else:
-                audit_log_params['action'] = AuditAction.DELETE
-                user.delete()
-
-            AuditLog.objects.create(**audit_log_params)
-
-            try:
-                delete_kc_user(user.username)
-            except HTTPError as e:
-                error = str(e)
-                if error.startswith(
-                    (
-                        '502',
-                        '504',
-                    )
-                ):
-                    raise KobocatCommunicationError
-                if error.startswith(('401',)):
-                    # When users are deleted in a huge batch, there may be a
-                    # race condition that causes the service account token to
-                    # be expired, making auth against KoBoCAT fail.
-                    raise KobocatCommunicationError(
-                        'Could not authenticate with KoBoCAT'
-                    )
-                if not error.startswith('404'):
-                    raise e
-
-            if user.username:
-                rmdir(f'{user.username}/')
-
-    finally:
-        post_delete.connect(
-            NLPUsageCounter.update_catch_all_counters_on_delete,
-            sender=NLPUsageCounter,
-            dispatch_uid='update_catch_all_monthly_xform_submission_counters',
-        )
-
-    # Delete related periodic task
-    PeriodicTask.objects.get(pk=account_trash.periodic_task_id).delete()
-    logging.info(
-        f'User {user.username} (#{user_id}) has been successfully deleted!'
+    account_trash, success = process_deletion(
+        AccountTrash,
+        account_trash_id,
+        deletion_callback=delete_account,
+        pre_deletion_callback=validate_pre_deletion,
+        force=force,
     )
+    user = account_trash.user
+    if not success:
+        logging.warning(f'User {user.username} deletion is already in progress')
+    else:
+        logging.info(
+            f'User {user.username} (#{user.pk}) has been successfully deleted!'
+        )
 
 
 @task_failure.connect(sender=empty_account)

--- a/kobo/apps/trash_bin/tasks/account.py
+++ b/kobo/apps/trash_bin/tasks/account.py
@@ -35,10 +35,10 @@ def empty_account(account_trash_id: int, force: bool = False):
     )
     user = account_trash.user
     if not success:
-        logging.warning(f'User {user.username} deletion is already in progress')
+        logging.warning(f'User `{user.username}` deletion is already in progress')
     else:
         logging.info(
-            f'User {user.username} (#{user.pk}) has been successfully deleted!'
+            f'User `{user.username}` has been successfully deleted!'
         )
 
 

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -33,10 +33,10 @@ def empty_project(project_trash_id: int, force: bool = False):
     )
     asset = project_trash.asset
     if not success:
-        logging.warning(f'Project {asset.name} deletion is already in progress')
+        logging.warning(f'Project `{asset.name}` (#{asset.uid}) deletion is already in progress')
     else:
         logging.info(
-            f'Project {asset.name} (#{asset.uid}) has been successfully deleted!'
+            f'Project `{asset.name}` (#{asset.uid}) has been successfully deleted!'
         )
 
 

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -31,12 +31,12 @@ def empty_project(project_trash_id: int, force: bool = False):
         deletion_callback=_deletion_callback,
         force=force,
     )
-    asset = project_trash.asset.name
+    asset = project_trash.asset
     if not success:
-        logging.warning(f'Project {asset.name} deletion is already ' f'in progress')
+        logging.warning(f'Project {asset.name} deletion is already in progress')
     else:
         logging.info(
-            f'Project {asset.name} (#{asset.uid}) has ' f'been successfully deleted!'
+            f'Project {asset.name} (#{asset.uid}) has been successfully deleted!'
         )
 
 

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -59,4 +59,10 @@ def empty_project_retry(sender=None, **kwargs):
 
 
 def _deletion_callback(project_trash: ProjectTrash):
+    """
+    Deletion callback for a project trash object.
+
+    This wrapper extracts the necessary arguments from the trash object
+    and delegates the deletion to the actual `delete_asset()` function.
+    """
     delete_asset(project_trash.request_author, project_trash.asset)

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -1,0 +1,79 @@
+import logging
+
+from celery.signals import task_failure, task_retry
+from django.conf import settings
+from django.db import transaction
+from django_celery_beat.models import (
+    PeriodicTask,
+)
+
+from kobo.celery import celery_app
+from kpi.exceptions import KobocatCommunicationError
+from ..exceptions import TrashTaskInProgressError
+from ..models import TrashStatus
+from ..models.account import AccountTrash
+from ..models.project import ProjectTrash
+from ..utils import delete_asset
+
+
+@celery_app.task(
+    autoretry_for=(
+        TrashTaskInProgressError,
+        KobocatCommunicationError,
+    ),
+    retry_backoff=60,
+    retry_backoff_max=600,
+    max_retries=5,
+    retry_jitter=False,
+    queue='kpi_low_priority_queue',
+    soft_time_limit=settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT,
+    time_limit=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT,
+)
+def empty_project(project_trash_id: int, force: bool = False):
+    with transaction.atomic():
+        project_trash = ProjectTrash.objects.select_for_update().get(
+            pk=project_trash_id
+        )
+        if not force and project_trash.status == TrashStatus.IN_PROGRESS:
+            logging.warning(
+                f'Project {project_trash.asset.name} deletion is already '
+                f'in progress'
+            )
+            return
+
+        project_trash.status = TrashStatus.IN_PROGRESS
+        project_trash.save(update_fields=['status', 'date_modified'])
+
+    delete_asset(project_trash.request_author, project_trash.asset)
+    PeriodicTask.objects.get(pk=project_trash.periodic_task_id).delete()
+    logging.info(
+        f'Project {project_trash.asset.name} (#{project_trash.asset.uid}) has '
+        f'been successfully deleted!'
+    )
+
+
+@task_failure.connect(sender=empty_project)
+def empty_project_failure(sender=None, **kwargs):
+
+    exception = kwargs['exception']
+    project_trash_id = kwargs['args'][0]
+    with transaction.atomic():
+        project_trash = ProjectTrash.objects.select_for_update().get(
+            pk=project_trash_id
+        )
+        project_trash.metadata['failure_error'] = str(exception)
+        project_trash.status = TrashStatus.FAILED
+        project_trash.save(update_fields=['status', 'metadata', 'date_modified'])
+
+
+@task_retry.connect(sender=empty_project)
+def empty_project_retry(sender=None, **kwargs):
+    project_trash_id = kwargs['request'].get('args')[0]
+    exception = str(kwargs['reason'])
+    with transaction.atomic():
+        project_trash = AccountTrash.objects.select_for_update().get(
+            pk=project_trash_id
+        )
+        project_trash.metadata['failure_error'] = str(exception)
+        project_trash.status = TrashStatus.RETRY
+        project_trash.save(update_fields=['status', 'metadata', 'date_modified'])

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -33,7 +33,10 @@ def empty_project(project_trash_id: int, force: bool = False):
     )
     asset = project_trash.asset
     if not success:
-        logging.warning(f'Project `{asset.name}` (#{asset.uid}) deletion is already in progress')
+        logging.warning(
+            f'Project `{asset.name}` (#{asset.uid}) deletion is '
+            f'already in progress'
+        )
     else:
         logging.info(
             f'Project `{asset.name}` (#{asset.uid}) has been successfully deleted!'

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -6,13 +6,16 @@ from django.conf import settings
 from kobo.celery import celery_app
 from ..exceptions import TrashTaskInProgressError
 from ..models.project import ProjectTrash
-from ..utils import delete_asset, process_deletion, trash_bin_task_failure, trash_bin_task_retry
+from ..utils import (
+    delete_asset,
+    process_deletion,
+    trash_bin_task_failure,
+    trash_bin_task_retry,
+)
 
 
 @celery_app.task(
-    autoretry_for=(
-        TrashTaskInProgressError,
-    ),
+    autoretry_for=(TrashTaskInProgressError,),
     retry_backoff=60,
     retry_backoff_max=600,
     max_retries=5,
@@ -30,14 +33,10 @@ def empty_project(project_trash_id: int, force: bool = False):
     )
     asset = project_trash.asset.name
     if not success:
-        logging.warning(
-            f'Project {asset.name} deletion is already '
-            f'in progress'
-        )
+        logging.warning(f'Project {asset.name} deletion is already ' f'in progress')
     else:
         logging.info(
-            f'Project {asset.name} (#{asset.uid}) has '
-            f'been successfully deleted!'
+            f'Project {asset.name} (#{asset.uid}) has ' f'been successfully deleted!'
         )
 
 

--- a/kobo/apps/trash_bin/tasks/project.py
+++ b/kobo/apps/trash_bin/tasks/project.py
@@ -2,15 +2,9 @@ import logging
 
 from celery.signals import task_failure, task_retry
 from django.conf import settings
-from django.db import transaction
-from django_celery_beat.models import (
-    PeriodicTask,
-)
 
 from kobo.celery import celery_app
-from kpi.exceptions import KobocatCommunicationError
 from ..exceptions import TrashTaskInProgressError
-from ..models import TrashStatus
 from ..models.project import ProjectTrash
 from ..utils import delete_asset, process_deletion, trash_bin_task_failure, trash_bin_task_retry
 
@@ -18,7 +12,6 @@ from ..utils import delete_asset, process_deletion, trash_bin_task_failure, tras
 @celery_app.task(
     autoretry_for=(
         TrashTaskInProgressError,
-        KobocatCommunicationError,
     ),
     retry_backoff=60,
     retry_backoff_max=600,

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -56,11 +56,7 @@ class AccountTrashTestCase(TestCase):
             retain_placeholder=False,
         )
         account_trash = AccountTrash.objects.get(user=someuser)
-        with patch(
-            'kobo.apps.trash_bin.tasks.account.delete_kc_user'
-        ) as mock_delete_kc_user:
-            mock_delete_kc_user.return_value = True
-            empty_account.apply([account_trash.pk])
+        empty_account.apply([account_trash.pk])
 
         assert not get_user_model().objects.filter(pk=someuser_id).exists()
         assert not Asset.objects.filter(owner_id=someuser_id).exists()
@@ -182,11 +178,7 @@ class AccountTrashTestCase(TestCase):
             retain_placeholder=True,
         )
         account_trash = AccountTrash.objects.get(user=someuser)
-        with patch(
-            'kobo.apps.trash_bin.tasks.account.delete_kc_user'
-        ) as mock_delete_kc_user:
-            mock_delete_kc_user.return_value = True
-            empty_account.apply([account_trash.pk])
+        empty_account.apply([account_trash.pk])
         after = now() + timedelta(days=grace_period)
 
         someuser.refresh_from_db()

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -56,7 +56,9 @@ class AccountTrashTestCase(TestCase):
             retain_placeholder=False,
         )
         account_trash = AccountTrash.objects.get(user=someuser)
-        with patch('kobo.apps.trash_bin.tasks.delete_kc_user') as mock_delete_kc_user:
+        with patch(
+            'kobo.apps.trash_bin.tasks.account.delete_kc_user'
+        ) as mock_delete_kc_user:
             mock_delete_kc_user.return_value = True
             empty_account.apply([account_trash.pk])
 
@@ -180,7 +182,9 @@ class AccountTrashTestCase(TestCase):
             retain_placeholder=True,
         )
         account_trash = AccountTrash.objects.get(user=someuser)
-        with patch('kobo.apps.trash_bin.tasks.delete_kc_user') as mock_delete_kc_user:
+        with patch(
+            'kobo.apps.trash_bin.tasks.account.delete_kc_user'
+        ) as mock_delete_kc_user:
             mock_delete_kc_user.return_value = True
             empty_account.apply([account_trash.pk])
         after = now() + timedelta(days=grace_period)

--- a/kobo/apps/trash_bin/type_aliases.py
+++ b/kobo/apps/trash_bin/type_aliases.py
@@ -8,12 +8,13 @@ ObjectIdentifiers: TypeAlias = list[str | int]
 # Return type: a Django QuerySet and an integer (e.g., number of updated records)
 UpdatedQuerySetAndCount: TypeAlias = tuple[models.QuerySet, int]
 
-# Represents a class reference to a trash model, such as AccountTrash or ProjectTrash.
+# Represents a class reference to a trash model (anyone which extends BaseTrash).
 # This is used when working with the model itself (e.g., for .objects operations).
 TrashBinModel: TypeAlias = Union['trash_bin.AccountTrash', 'trash_bin.ProjectTrash']
 
-# Represents an instance of a trash model (e.g., an AccountTrash or ProjectTrash object).
-# Shares the same underlying types as TrashBinModel, but this alias clarifies that we expect an instance.
+# Represents an instance of a trash model (anyone which extends BaseTrash).
+# Shares the same underlying types as TrashBinModel, but this alias clarifies that we
+# expect an instance.
 TrashBinModelInstance: TypeAlias = TrashBinModel
 
 # A callback function that takes a TrashBinModelInstance and returns nothing.

--- a/kobo/apps/trash_bin/type_aliases.py
+++ b/kobo/apps/trash_bin/type_aliases.py
@@ -8,8 +8,14 @@ ObjectIdentifiers: TypeAlias = list[str | int]
 # Return type: a Django QuerySet and an integer (e.g., number of updated records)
 UpdatedQuerySetAndCount: TypeAlias = tuple[models.QuerySet, int]
 
-TrashModels: TypeAlias = Union['trash_bin.AccountTrash', 'trash_bin.ProjectTrash']
+# Represents a class reference to a trash model, such as AccountTrash or ProjectTrash.
+# This is used when working with the model itself (e.g., for .objects operations).
+TrashBinModel: TypeAlias = Union['trash_bin.AccountTrash', 'trash_bin.ProjectTrash']
 
-TrashModelInstance: TypeAlias = TrashModels
+# Represents an instance of a trash model (e.g., an AccountTrash or ProjectTrash object).
+# Shares the same underlying types as TrashBinModel, but this alias clarifies that we expect an instance.
+TrashBinModelInstance: TypeAlias = TrashBinModel
 
-DeletionCallback: TypeAlias = Callable[[TrashModels], None]
+# A callback function that takes a TrashBinModelInstance and returns nothing.
+# Used to define pre-deletion or deletion logic for a specific object.
+DeletionCallback: TypeAlias = Callable[[TrashBinModel], None]

--- a/kobo/apps/trash_bin/type_aliases.py
+++ b/kobo/apps/trash_bin/type_aliases.py
@@ -1,8 +1,13 @@
-from typing import TypeAlias
+from typing import TypeAlias, Union
+
 from django.db import models
+
 
 # A list of object identifiers
 ObjectIdentifiers: TypeAlias = list[str | int]
 
 # Return type: a Django QuerySet and an integer (e.g., number of updated records)
 UpdatedQuerySetAndCount: TypeAlias = tuple[models.QuerySet, int]
+
+
+TrashModels: TypeAlias = Union['trash_bin.AccountTrash', 'trash_bin.ProjectTrash']

--- a/kobo/apps/trash_bin/type_aliases.py
+++ b/kobo/apps/trash_bin/type_aliases.py
@@ -1,7 +1,6 @@
-from typing import TypeAlias, Union
+from typing import Callable, TypeAlias, Union
 
 from django.db import models
-
 
 # A list of object identifiers
 ObjectIdentifiers: TypeAlias = list[str | int]
@@ -9,5 +8,8 @@ ObjectIdentifiers: TypeAlias = list[str | int]
 # Return type: a Django QuerySet and an integer (e.g., number of updated records)
 UpdatedQuerySetAndCount: TypeAlias = tuple[models.QuerySet, int]
 
-
 TrashModels: TypeAlias = Union['trash_bin.AccountTrash', 'trash_bin.ProjectTrash']
+
+TrashModelInstance: TypeAlias = TrashModels
+
+DeletionCallback: TypeAlias = Callable[[TrashModels], None]

--- a/kobo/apps/trash_bin/utils.py
+++ b/kobo/apps/trash_bin/utils.py
@@ -166,12 +166,13 @@ def move_to_trash(
         clocked = ClockedSchedule.objects.create(clocked_time=clocked_time)
         trash_model.objects.bulk_create(trash_objects)
         try:
+            python_file = task.replace('empty_', '')
             periodic_tasks = PeriodicTask.objects.bulk_create(
                 [
                     PeriodicTask(
                         clocked=clocked,
                         name=task_name_placeholder.format(**ato.metadata),
-                        task=f'kobo.apps.trash_bin.tasks.{task}',
+                        task=f'kobo.apps.trash_bin.tasks.{python_file}.{task}',
                         args=json.dumps([ato.id]),
                         one_off=True,
                         enabled=not empty_manually,

--- a/kobo/apps/trash_bin/utils/__init__.py
+++ b/kobo/apps/trash_bin/utils/__init__.py
@@ -1,0 +1,10 @@
+from .account import replace_user_with_placeholder
+from .project import delete_asset
+from .trash import move_to_trash, put_back, temporarily_disconnect_signals
+
+__all__ = [
+    'delete_asset',
+    'move_to_trash',
+    'put_back',
+    'replace_user_with_placeholder',
+]

--- a/kobo/apps/trash_bin/utils/__init__.py
+++ b/kobo/apps/trash_bin/utils/__init__.py
@@ -1,10 +1,14 @@
 from .account import replace_user_with_placeholder
 from .project import delete_asset
-from .trash import move_to_trash, put_back, temporarily_disconnect_signals
+from .signals import temporarily_disconnect_signals
+from .trash import move_to_trash, put_back, trash_bin_task_failure, trash_bin_task_retry
 
 __all__ = [
     'delete_asset',
     'move_to_trash',
     'put_back',
     'replace_user_with_placeholder',
+    'temporarily_disconnect_signals',
+    'trash_bin_task_failure',
+    'trash_bin_task_retry',
 ]

--- a/kobo/apps/trash_bin/utils/__init__.py
+++ b/kobo/apps/trash_bin/utils/__init__.py
@@ -1,11 +1,19 @@
-from .account import replace_user_with_placeholder
+from .account import delete_account, replace_user_with_placeholder
 from .project import delete_asset
 from .signals import temporarily_disconnect_signals
-from .trash import move_to_trash, put_back, trash_bin_task_failure, trash_bin_task_retry
+from .trash import (
+    move_to_trash,
+    process_deletion,
+    put_back,
+    trash_bin_task_failure,
+    trash_bin_task_retry,
+)
 
 __all__ = [
+    'delete_account',
     'delete_asset',
     'move_to_trash',
+    'process_deletion',
     'put_back',
     'replace_user_with_placeholder',
     'temporarily_disconnect_signals',

--- a/kobo/apps/trash_bin/utils/__init__.py
+++ b/kobo/apps/trash_bin/utils/__init__.py
@@ -1,4 +1,4 @@
-from .account import delete_account, replace_user_with_placeholder
+from .account import delete_account
 from .project import delete_asset
 from .signals import temporarily_disconnect_signals
 from .trash import (
@@ -15,7 +15,6 @@ __all__ = [
     'move_to_trash',
     'process_deletion',
     'put_back',
-    'replace_user_with_placeholder',
     'temporarily_disconnect_signals',
     'trash_bin_task_failure',
     'trash_bin_task_retry',

--- a/kobo/apps/trash_bin/utils/account.py
+++ b/kobo/apps/trash_bin/utils/account.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db import models, transaction
+
+from kobo.apps.audit_log.models import AuditLog
+
+
+def replace_user_with_placeholder(
+    user: settings.AUTH_USER_MODEL, retain_audit_logs: bool = True
+) -> settings.AUTH_USER_MODEL:
+    """
+    Replace a user with an inactive placeholder, which prevents others from
+    registering a new account with the same username. The placeholder uses the
+    same primary key as the original user, and certain other fields are
+    retained.
+    """
+    FIELDS_TO_RETAIN = ('username', 'last_login', 'date_joined')
+
+    placeholder_user = get_user_model()()
+    placeholder_user.pk = user.pk
+    placeholder_user.is_active = False
+    placeholder_user.password = 'REMOVED USER'  # cannot match any hashed value
+    for field in FIELDS_TO_RETAIN:
+        setattr(placeholder_user, field, getattr(user, field))
+
+    if not retain_audit_logs:
+        user.delete()
+        placeholder_user.save()
+        return placeholder_user
+
+    audit_log_user_field = AuditLog._meta.get_field('user').remote_field
+    original_audit_log_delete_handler = audit_log_user_field.on_delete
+    with transaction.atomic():
+        try:
+            # prevent the delete() call from touching the audit logs
+            audit_log_user_field.on_delete = models.DO_NOTHING
+            # …and cause a FK violation!
+            user.delete()
+            # then resolve the violation by creating the placeholder with the
+            # same PK as the original user
+            placeholder_user.save()
+        finally:
+            audit_log_user_field.on_delete = original_audit_log_delete_handler
+
+    return placeholder_user

--- a/kobo/apps/trash_bin/utils/account.py
+++ b/kobo/apps/trash_bin/utils/account.py
@@ -2,9 +2,122 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db import models, transaction
+from django.db import models
+from django.db import transaction
+from django.db.models.signals import post_delete
+from django.utils import timezone
+from requests.exceptions import HTTPError
 
-from kobo.apps.audit_log.models import AuditLog
+from kobo.apps.audit_log.audit_actions import AuditAction
+from kobo.apps.audit_log.models import AuditLog, AuditType
+from kobo.apps.trackers.models import NLPUsageCounter
+from kpi.deployment_backends.kc_access.utils import delete_kc_user
+from kpi.exceptions import KobocatCommunicationError
+from kpi.models.asset import Asset
+from kpi.utils.storage import rmdir
+from ..exceptions import TrashTaskInProgressError
+from ..models import TrashStatus
+from ..models.account import AccountTrash
+from ..models.project import ProjectTrash
+from ..utils.project import delete_asset
+
+
+def delete_account(account_trash: AccountTrash):
+
+    assets = (
+        Asset.all_objects.filter(owner=account_trash.user)
+        .only(
+            'uid',
+            '_deployment_data',
+            'owner',
+            'name',
+            'asset_type',
+            'advanced_features',
+        )
+        .select_related('owner')
+    )
+
+    # Delete children first…
+    for asset in assets.filter(parent__isnull=False):
+        delete_asset(account_trash.request_author, asset)
+
+    # …then parents
+    for asset in assets.filter(parent__isnull=True):
+        delete_asset(account_trash.request_author, asset)
+
+    user = account_trash.user
+    user_id = user.pk
+    date_removal_requested = user.extra_details.date_removal_requested
+    try:
+        # We need to deactivate this post_delete signal because it's triggered
+        # on `User` delete cascade and fails to insert into DB within a transaction.
+        # The post_delete signal occurs before user is deleted, therefore still
+        # has a reference of it when the whole transaction is committed.
+        # It fails with an IntegrityError.
+        post_delete.disconnect(
+            NLPUsageCounter.update_catch_all_counters_on_delete,
+            sender=NLPUsageCounter,
+            dispatch_uid='update_catch_all_monthly_xform_submission_counters',
+        )
+        with transaction.atomic():
+            audit_log_params = {
+                'app_label': get_user_model()._meta.app_label,
+                'model_name': get_user_model()._meta.model_name,
+                'object_id': user_id,
+                'user': account_trash.request_author,
+                'user_uid': account_trash.request_author.extra_details.uid,
+                'metadata': {
+                    'username': user.username,
+                },
+                'log_type': AuditType.USER_MANAGEMENT
+            }
+
+            if account_trash.retain_placeholder:
+                audit_log_params['action'] = AuditAction.REMOVE
+                placeholder_user = replace_user_with_placeholder(user)
+                # Retain removal date information
+                extra_details = placeholder_user.extra_details
+                extra_details.date_removal_requested = date_removal_requested
+                extra_details.date_removed = timezone.now()
+                extra_details.save(
+                    update_fields=['date_removal_requested', 'date_removed']
+                )
+            else:
+                audit_log_params['action'] = AuditAction.DELETE
+                user.delete()
+
+            AuditLog.objects.create(**audit_log_params)
+
+            try:
+                delete_kc_user(user.username)
+            except HTTPError as e:
+                error = str(e)
+                if error.startswith(
+                    (
+                        '502',
+                        '504',
+                    )
+                ):
+                    raise KobocatCommunicationError
+                if error.startswith(('401',)):
+                    # When users are deleted in a huge batch, there may be a
+                    # race condition that causes the service account token to
+                    # be expired, making auth against KoBoCAT fail.
+                    raise KobocatCommunicationError(
+                        'Could not authenticate with KoBoCAT'
+                    )
+                if not error.startswith('404'):
+                    raise e
+
+            if user.username:
+                rmdir(f'{user.username}/')
+
+    finally:
+        post_delete.connect(
+            NLPUsageCounter.update_catch_all_counters_on_delete,
+            sender=NLPUsageCounter,
+            dispatch_uid='update_catch_all_monthly_xform_submission_counters',
+        )
 
 
 def replace_user_with_placeholder(
@@ -45,3 +158,26 @@ def replace_user_with_placeholder(
             audit_log_user_field.on_delete = original_audit_log_delete_handler
 
     return placeholder_user
+
+
+def validate_pre_deletion(account_trash: AccountTrash):
+    assets = (
+        Asset.all_objects.filter(owner=account_trash.user)
+        .only(
+            'uid',
+            '_deployment_data',
+            'owner',
+            'name',
+            'asset_type',
+            'advanced_features',
+        )
+        .select_related('owner')
+    )
+
+    # Ensure there are no running other project trash tasks related to this
+    # account
+    if ProjectTrash.objects.filter(
+        asset__in=assets, status=TrashStatus.IN_PROGRESS
+    ).exists():
+        # Let them finish and retry later
+        raise TrashTaskInProgressError

--- a/kobo/apps/trash_bin/utils/account.py
+++ b/kobo/apps/trash_bin/utils/account.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.db import models
-from django.db import transaction
+from django.db import models, transaction
 from django.db.models.signals import post_delete
 from django.utils import timezone
 
@@ -81,7 +80,7 @@ def delete_account(account_trash: AccountTrash):
                     'metadata': {
                         'username': user.username,
                     },
-                    'log_type': AuditType.USER_MANAGEMENT
+                    'log_type': AuditType.USER_MANAGEMENT,
                 }
 
                 if account_trash.retain_placeholder:

--- a/kobo/apps/trash_bin/utils/project.py
+++ b/kobo/apps/trash_bin/utils/project.py
@@ -7,7 +7,7 @@ from django.db.models import F, Q
 from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import AuditLog, AuditType
 from kpi.exceptions import InvalidXFormException, MissingXFormException
-from kpi.models import Asset, SubmissionExportTask, ImportTask
+from kpi.models import Asset, ImportTask, SubmissionExportTask
 from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.storage import rmdir
@@ -93,7 +93,7 @@ def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: Asset):
             if not (
                 submissions := queryset_or_false.annotate(
                     _id=F('pk'), _uuid=F('uuid')
-                ).values('_id', '_uuid')[:settings.SUBMISSION_DELETION_BATCH_SIZE]
+                ).values('_id', '_uuid')[: settings.SUBMISSION_DELETION_BATCH_SIZE]
             ):
                 break
 

--- a/kobo/apps/trash_bin/utils/project.py
+++ b/kobo/apps/trash_bin/utils/project.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.db import transaction
+from django.db.models import F, Q
+
+from kobo.apps.audit_log.audit_actions import AuditAction
+from kobo.apps.audit_log.models import AuditLog, AuditType
+from kpi.exceptions import InvalidXFormException, MissingXFormException
+from kpi.models import Asset, SubmissionExportTask, ImportTask
+from kpi.utils.log import logging
+from kpi.utils.mongo_helper import MongoHelper
+from kpi.utils.storage import rmdir
+
+
+def delete_asset(request_author: settings.AUTH_USER_MODEL, asset: Asset):
+
+    asset_id = asset.pk
+    asset_uid = asset.uid
+    host = settings.KOBOFORM_URL
+    owner_username = asset.owner.username
+    project_exports = []
+
+    if asset.has_deployment:
+        _delete_submissions(request_author, asset)
+        asset.deployment.delete()
+        project_exports = SubmissionExportTask.objects.filter(
+            Q(data__source=f'{host}/api/v2/assets/{asset.uid}/')
+            | Q(data__source=f'{host}/assets/{asset.uid}/')
+        )
+
+    with transaction.atomic():
+        # Delete imports
+        ImportTask.objects.filter(
+            Q(data__destination=f'{host}/api/v2/assets/{asset.uid}/')
+            | Q(data__destination=f'{host}/assets/{asset.uid}/')
+        ).delete()
+        # Delete exports (and related files on storage)
+        for export in project_exports:
+            export.delete()
+
+        asset.delete()
+        AuditLog.objects.create(
+            app_label=asset._meta.app_label,
+            model_name=asset._meta.model_name,
+            object_id=asset_id,
+            user=request_author,
+            action=AuditAction.DELETE,
+            metadata={
+                'asset_uid': asset_uid,
+                'asset_name': asset.name,
+            },
+            log_type=AuditType.ASSET_MANAGEMENT,
+        )
+
+    # Delete media files left on storage
+    if asset_uid:
+        rmdir(f'{owner_username}/asset_files/{asset_uid}')
+
+
+def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: Asset):
+
+    # Test if XForm is still valid
+    try:
+        asset.deployment.xform
+    except (MissingXFormException, InvalidXFormException):
+        # Submissions are lingering in MongoDB but XForm has been
+        # already deleted
+        xform_id_string = asset.deployment.backend_response['id_string']
+        xform_uuid = asset.deployment.backend_response['uuid']
+        deleted_orphans = MongoHelper.delete(xform_id_string, xform_uuid)
+        logging.warning(f'TrashBin: {deleted_orphans} deleted MongoDB orphans')
+
+        return
+
+    while True:
+        audit_logs = []
+        submissions = list(
+            asset.deployment.get_submissions(
+                asset.owner,
+                fields=['_id', '_uuid'],
+                limit=settings.SUBMISSION_DELETION_BATCH_SIZE,
+            )
+        )
+        if not submissions:
+            if not (
+                queryset_or_false := asset.deployment.get_orphan_postgres_submissions()
+            ):
+                break
+
+            # Make submissions an iterable, similar to the output of
+            # `deployment.get_submissions()`.
+            if not (
+                submissions := queryset_or_false.annotate(
+                    _id=F('pk'), _uuid=F('uuid')
+                ).values('_id', '_uuid')[:settings.SUBMISSION_DELETION_BATCH_SIZE]
+            ):
+                break
+
+        submission_ids = []
+        for submission in submissions:
+            audit_logs.append(
+                AuditLog(
+                    app_label='logger',
+                    model_name='instance',
+                    object_id=submission['_id'],
+                    user=request_author,
+                    user_uid=request_author.extra_details.uid,
+                    metadata={
+                        'asset_uid': asset.uid,
+                        'uuid': submission['_uuid'],
+                    },
+                    action=AuditAction.DELETE,
+                    log_type=AuditType.SUBMISSION_MANAGEMENT,
+                )
+            )
+
+            submission_ids.append(submission['_id'])
+
+        asset.deployment.delete_submissions(
+            {'submission_ids': submission_ids, 'query': ''}, request_author
+        )
+
+        if audit_logs:
+            AuditLog.objects.bulk_create(audit_logs)

--- a/kobo/apps/trash_bin/utils/signals.py
+++ b/kobo/apps/trash_bin/utils/signals.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
+from django_celery_beat.models import (
+    ClockedSchedule,
+    PeriodicTask,
+    PeriodicTasks,
+)
+
+
+@contextmanager
+def temporarily_disconnect_signals(save=False, delete=False):
+    """
+    Temporarily disconnects `PeriodicTasks` signals to prevent accumulating
+    update queries for Celery Beat while bulk operations are in progress.
+
+    See https://django-celery-beat.readthedocs.io/en/stable/reference/django-celery-beat.models.html#django_celery_beat.models.PeriodicTasks  # noqa: E501
+    """
+
+    try:
+        if delete:
+            pre_delete.disconnect(PeriodicTasks.changed, sender=PeriodicTask)
+            post_delete.disconnect(PeriodicTasks.update_changed, sender=ClockedSchedule)
+        if save:
+            pre_save.disconnect(PeriodicTasks.changed, sender=PeriodicTask)
+            post_save.disconnect(PeriodicTasks.update_changed, sender=ClockedSchedule)
+        yield
+    finally:
+        if delete:
+            post_delete.connect(PeriodicTasks.update_changed, sender=ClockedSchedule)
+            pre_delete.connect(PeriodicTasks.changed, sender=PeriodicTask)
+        if save:
+            pre_save.connect(PeriodicTasks.changed, sender=PeriodicTask)
+            post_save.connect(PeriodicTasks.update_changed, sender=ClockedSchedule)
+
+    # Force celery beat scheduler to refresh
+    PeriodicTasks.update_changed()

--- a/kobo/apps/trash_bin/utils/signals.py
+++ b/kobo/apps/trash_bin/utils/signals.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
-from django_celery_beat.models import (
-    ClockedSchedule,
-    PeriodicTask,
-    PeriodicTasks,
-)
+from django_celery_beat.models import ClockedSchedule, PeriodicTask, PeriodicTasks
 
 
 @contextmanager

--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -32,6 +32,7 @@ from kobo.apps.trash_bin.models.attachment import AttachmentTrash
 from kobo.apps.trash_bin.models.project import ProjectTrash
 from kobo.apps.openrosa.apps.logger.models import Attachment
 from ..type_aliases import TrashModels
+from ..utils import temporarily_disconnect_signals
 
 
 @transaction.atomic

--- a/kpi/deployment_backends/kc_access/utils.py
+++ b/kpi/deployment_backends/kc_access/utils.py
@@ -327,6 +327,9 @@ def reset_kc_permissions(
 
 
 def delete_kc_user(username: str):
+    if settings.TESTING:
+        return
+
     with use_db(settings.OPENROSA_DB_ALIAS):
         # Do not use `.using()` here because it does not bubble down to the
         # Collector.


### PR DESCRIPTION
### 📣 Summary
Split trash bin tasks into separate files based on the object they operate on.



### 📖 Description
Previously, all trash bin–related tasks were located in a single tasks.py file, regardless of the object type (e.g., projects, accounts). This refactor organizes tasks by grouping them into separate files according to the object they manage.

This restructuring sets the stage for integrating attachment-related tasks cleanly and consistently.


### 👀 Preview steps
There are no really preview steps, except the fact the reviewer needs to validate that deleting a project or an account still works. 
It's recommended to set `ACCOUNT_TRASH_GRACE_PERIOD` and `PROJECT_TRASH_GRACE_PERIOD` to 0 to fire celery tasks immediately. 

