### PR TITLE
refactor(storybook): reorganize stories DEV-50

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -30,7 +30,10 @@ export const decorators = [
 
 export const parameters = {
   options: {
-    storySort: (a, b) => (a.title === b.title ? 0 : a.title.localeCompare(b.title, undefined, { numeric: true })),
+    storySort: {
+      method: 'alphabetical',
+      order: ['Design system', 'Design system old', 'Components', '*'],
+    },
   },
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/jsapp/js/attachments/AttachmentActionsDropdown.stories.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.stories.tsx
@@ -9,7 +9,7 @@ const mockSubmission = assetWithImageSubmission
 const mockAttachmentId = assetWithImageSubmission._attachments[0].id
 
 const meta: Meta<typeof AttachmentActionsDropdown> = {
-  title: 'Attachments/AttachmentActionsDropdown',
+  title: 'Components/AttachmentActionsDropdown',
   component: AttachmentActionsDropdown,
   argTypes: {
     asset: { control: 'object' },

--- a/jsapp/js/attachments/deletedAttachment.stories.tsx
+++ b/jsapp/js/attachments/deletedAttachment.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import DeletedAttachment from './deletedAttachment.component'
 
 const meta: Meta<typeof DeletedAttachment> = {
-  title: 'Attachments/DeletedAttachment',
+  title: 'Components/DeletedAttachment',
   component: DeletedAttachment,
 }
 

--- a/jsapp/js/components/common/Select.stories.tsx
+++ b/jsapp/js/components/common/Select.stories.tsx
@@ -37,7 +37,7 @@ const largeData = [
  * See detailed uses in [Mantine's Select page](https://mantine.dev/core/select/)
  */
 const meta: Meta<typeof Select> = {
-  title: 'Common/Select',
+  title: 'Design system/Select',
   component: Select,
   decorators: [
     (Story) => (

--- a/jsapp/js/components/common/SimpleTable.stories.tsx
+++ b/jsapp/js/components/common/SimpleTable.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import SimpleTable from './SimpleTable'
 
 const meta: Meta<React.ComponentProps<typeof SimpleTable>> = {
-  title: 'common/SimpleTable',
+  title: 'Design system/SimpleTable',
   component: SimpleTable,
   argTypes: {},
   args: {},

--- a/jsapp/js/components/common/actionIcon.stories.tsx
+++ b/jsapp/js/components/common/actionIcon.stories.tsx
@@ -17,7 +17,7 @@ const actionIconVariants: Array<ActionIconProps['variant']> = [
 const actionIconSizes: Array<ActionIconProps['size']> = ['sm', 'md', 'lg']
 
 export default {
-  title: 'common/Action Icon',
+  title: 'Design system/ActionIcon',
   component: ActionIcon,
   argTypes: {
     variant: {

--- a/jsapp/js/components/common/alert.stories.tsx
+++ b/jsapp/js/components/common/alert.stories.tsx
@@ -1,6 +1,6 @@
 import Alert from './alert'
 
-export default { title: 'common/Alert' }
+export default { title: 'Design system/Alert' }
 
 export function Demo() {
   const message =

--- a/jsapp/js/components/common/ariaText.stories.tsx
+++ b/jsapp/js/components/common/ariaText.stories.tsx
@@ -5,7 +5,7 @@ import AriaText from '#/components/common/ariaText'
 
 export default {
   component: AriaText,
-  title: 'Common/Aria Text',
+  title: 'Design system old/AriaText',
   tags: ['autodocs'],
 }
 

--- a/jsapp/js/components/common/avatar.stories.tsx
+++ b/jsapp/js/components/common/avatar.stories.tsx
@@ -5,7 +5,7 @@ import type { AvatarSize } from './avatar'
 const avatarSizes: AvatarSize[] = ['s', 'm']
 
 const meta: Meta<typeof Avatar> = {
-  title: 'common/Avatar',
+  title: 'Design system old/Avatar',
   component: Avatar,
   argTypes: {
     size: {

--- a/jsapp/js/components/common/badge.stories.tsx
+++ b/jsapp/js/components/common/badge.stories.tsx
@@ -7,7 +7,7 @@ const badgeColors: BadgeColor[] = ['light-storm', 'light-amber', 'light-blue', '
 const badgeSizes: BadgeSize[] = ['s', 'm', 'l']
 
 const meta: Meta<typeof Badge> = {
-  title: 'common/Badge',
+  title: 'Design system old/Badge',
   component: Badge,
   argTypes: {
     color: {

--- a/jsapp/js/components/common/button.stories.tsx
+++ b/jsapp/js/components/common/button.stories.tsx
@@ -44,7 +44,7 @@ const tooltipPositions: Array<NonNullable<TooltipProps['position']>> = [
 ] as const
 
 const meta: Meta<typeof Button> = {
-  title: 'common/Button',
+  title: 'Design system/Button',
   component: Button,
   argTypes: {
     variant: {

--- a/jsapp/js/components/common/checkbox.stories.tsx
+++ b/jsapp/js/components/common/checkbox.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import Checkbox from './checkbox'
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'common/Checkbox',
+  title: 'Design system old/Checkbox',
   component: Checkbox,
   argTypes: {
     label: { type: 'string' },

--- a/jsapp/js/components/common/diffValue.stories.tsx
+++ b/jsapp/js/components/common/diffValue.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj } from '@storybook/react'
 import DiffValue from '#/components/common/diffValue.component'
 
 export default {
-  title: 'Design system/DiffValue',
+  title: 'Design system old/DiffValue',
   component: DiffValue,
 }
 

--- a/jsapp/js/components/common/diffValue.stories.tsx
+++ b/jsapp/js/components/common/diffValue.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj } from '@storybook/react'
 import DiffValue from '#/components/common/diffValue.component'
 
 export default {
-  title: 'Common/Diff Value',
+  title: 'Design system/DiffValue',
   component: DiffValue,
 }
 

--- a/jsapp/js/components/common/dropdownmenu.stories.tsx
+++ b/jsapp/js/components/common/dropdownmenu.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Menu } from '@mantine/core'
 import Button from './ButtonNew'
 
-export default { title: 'common/Dropdown Menu' }
+export default { title: 'Design system/DropdownMenu' }
 
 export function dropdownMenu() {
   return (

--- a/jsapp/js/components/common/icon.stories.tsx
+++ b/jsapp/js/components/common/icon.stories.tsx
@@ -6,7 +6,7 @@ import type { IconColor } from './icon'
 const iconColors: Array<IconColor | undefined> = [undefined, 'mid-red', 'storm', 'teal', 'amber', 'blue']
 
 const meta: Meta<typeof Icon> = {
-  title: 'common/Icon',
+  title: 'Design system/Icon',
   component: Icon,
   argTypes: {
     color: {

--- a/jsapp/js/components/common/icon.stories.tsx
+++ b/jsapp/js/components/common/icon.stories.tsx
@@ -6,7 +6,7 @@ import type { IconColor } from './icon'
 const iconColors: Array<IconColor | undefined> = [undefined, 'mid-red', 'storm', 'teal', 'amber', 'blue']
 
 const meta: Meta<typeof Icon> = {
-  title: 'Design system/Icon',
+  title: 'Design system old/Icon',
   component: Icon,
   argTypes: {
     color: {

--- a/jsapp/js/components/common/inlineMessage.stories.tsx
+++ b/jsapp/js/components/common/inlineMessage.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import InlineMessage from '#/components/common/inlineMessage'
 
 const meta: Meta<typeof InlineMessage> = {
-  title: 'commonDeprecated/Inline Message',
+  title: 'Design system old/InlineMessage',
   component: InlineMessage,
   argTypes: {},
 }

--- a/jsapp/js/components/common/koboDropdown.stories.tsx
+++ b/jsapp/js/components/common/koboDropdown.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import KoboDropdown from '#/components/common/koboDropdown'
 
 const meta: Meta<typeof KoboDropdown> = {
-  title: 'common/KoboDropdown',
+  title: 'Design system old/KoboDropdown',
   component: KoboDropdown,
   argTypes: {
     placement: {

--- a/jsapp/js/components/common/koboRange.stories.tsx
+++ b/jsapp/js/components/common/koboRange.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import KoboRange, { KoboRangeColors } from '#/components/common/koboRange'
 
 const meta: Meta<typeof KoboRange> = {
-  title: 'common/KoboRange',
+  title: 'Design system old/KoboRange',
   component: KoboRange,
   argTypes: {
     color: {

--- a/jsapp/js/components/common/koboSelect.stories.tsx
+++ b/jsapp/js/components/common/koboSelect.stories.tsx
@@ -3,7 +3,7 @@ import KoboSelect from '#/components/common/koboSelect'
 import { IconNames } from '#/k-icons'
 
 const meta: Meta<typeof KoboSelect> = {
-  title: 'commonDeprecated/KoboSelect',
+  title: 'Design system old/KoboSelect',
   component: KoboSelect,
   argTypes: {
     selectedOption: {

--- a/jsapp/js/components/common/loader.stories.tsx
+++ b/jsapp/js/components/common/loader.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react'
  * Mantine [Loader](https://mantine.dev/core/loader/) component stories.
  */
 const meta: Meta<typeof Loader> = {
-  title: 'Common/Loader',
+  title: 'Design system/Loader',
   component: Loader,
   decorators: [
     (Story) => (

--- a/jsapp/js/components/common/loadingOverlay.stories.tsx
+++ b/jsapp/js/components/common/loadingOverlay.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react'
  * Component used to display an overlay  over the sibling content containing the Loader component
  */
 const meta: Meta<typeof LoadingOverlay> = {
-  title: 'Common/LoadingOverlay',
+  title: 'Design system/LoadingOverlay',
   component: LoadingOverlay,
   decorators: [
     (Story) => (

--- a/jsapp/js/components/common/loadingSpinner.stories.tsx
+++ b/jsapp/js/components/common/loadingSpinner.stories.tsx
@@ -5,7 +5,7 @@ import type { LoadingSpinnerType } from './loadingSpinner'
 const spinnerTypes: LoadingSpinnerType[] = ['regular', 'big']
 
 const meta: Meta<typeof LoadingSpinner> = {
-  title: 'common/LoadingSpinner',
+  title: 'Design system old/LoadingSpinner',
   component: LoadingSpinner,
   argTypes: {
     type: {

--- a/jsapp/js/components/common/miniAudioPlayer.stories.tsx
+++ b/jsapp/js/components/common/miniAudioPlayer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import MiniAudioPlayer from './miniAudioPlayer'
 
 const meta: Meta<typeof MiniAudioPlayer> = {
-  title: 'common/MiniAudioPlayer',
+  title: 'Design system old/MiniAudioPlayer',
   component: MiniAudioPlayer,
   argTypes: {},
 }

--- a/jsapp/js/components/common/modal.stories.tsx
+++ b/jsapp/js/components/common/modal.stories.tsx
@@ -26,7 +26,7 @@ const RenderModal = ({ ...args }: ModalProps) => {
  * Mantine [Modal](https://mantine.dev/core/modal/) component stories.
  */
 const meta: Meta<typeof Modal> = {
-  title: 'Common/Modal',
+  title: 'Design system old/Modal',
   component: Modal,
   render: RenderModal,
   argTypes: {

--- a/jsapp/js/components/common/multiCheckbox.stories.tsx
+++ b/jsapp/js/components/common/multiCheckbox.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import MultiCheckbox from './multiCheckbox'
 
 const meta: Meta<typeof MultiCheckbox> = {
-  title: 'common/MultiCheckbox',
+  title: 'Design system old/MultiCheckbox',
   component: MultiCheckbox,
   argTypes: {},
   args: {},

--- a/jsapp/js/components/common/radio.stories.tsx
+++ b/jsapp/js/components/common/radio.stories.tsx
@@ -24,7 +24,7 @@ const defaultOptions: RadioOption[] = [
 ]
 
 const meta: Meta<typeof Radio> = {
-  title: 'common/Radio',
+  title: 'Design system old/Radio',
   component: Radio,
   argTypes: {},
 }

--- a/jsapp/js/components/common/tabs.stories.tsx
+++ b/jsapp/js/components/common/tabs.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import Tabs from './tabs'
 
 const meta: Meta<typeof Tabs> = {
-  title: 'Common/Tabs',
+  title: 'Design system old/Tabs',
   component: Tabs,
   argTypes: {
     tabs: {

--- a/jsapp/js/components/common/textBox.stories.tsx
+++ b/jsapp/js/components/common/textBox.stories.tsx
@@ -7,7 +7,7 @@ const textBoxTypes: TextBoxType[] = ['email', 'number', 'password', 'text-multil
 const textBoxSizes: TextBoxSize[] = ['s', 'm', 'l']
 
 const meta: Meta<typeof TextBox> = {
-  title: 'commonDeprecated/TextBox',
+  title: 'Design system old/TextBox',
   component: TextBox,
   argTypes: {
     type: {

--- a/jsapp/js/components/common/textInput.stories.tsx
+++ b/jsapp/js/components/common/textInput.stories.tsx
@@ -5,7 +5,7 @@ import Icon from './icon'
 const inputSizes: Array<TextInputProps['size']> = ['sm', 'md', 'lg']
 
 export default {
-  title: 'common/TextInput',
+  title: 'Design system old/TextInput',
   component: TextInput,
   argTypes: {
     label: {

--- a/jsapp/js/components/common/tooltip.stories.tsx
+++ b/jsapp/js/components/common/tooltip.stories.tsx
@@ -5,7 +5,7 @@ import Tooltip from './tooltip'
 const tooltipPositions: TooltipAlignment[] = ['right', 'left', 'center']
 
 const meta: Meta<typeof Tooltip> = {
-  title: 'Design system/Tooltip',
+  title: 'Design system old/Tooltip',
   component: Tooltip,
   argTypes: {
     text: {

--- a/jsapp/js/components/common/tooltip.stories.tsx
+++ b/jsapp/js/components/common/tooltip.stories.tsx
@@ -5,7 +5,7 @@ import Tooltip from './tooltip'
 const tooltipPositions: TooltipAlignment[] = ['right', 'left', 'center']
 
 const meta: Meta<typeof Tooltip> = {
-  title: 'Common/Tooltip',
+  title: 'Design system/Tooltip',
   component: Tooltip,
   argTypes: {
     text: {

--- a/jsapp/js/components/exportToEmailButton/exportToEmailButton.stories.tsx
+++ b/jsapp/js/components/exportToEmailButton/exportToEmailButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import ExportToEmailButton from './exportToEmailButton.component'
 
 export default {
-  title: 'misc/ExportToEmailButton',
+  title: 'Components/ExportToEmailButton',
   component: ExportToEmailButton,
   argTypes: {
     label: {

--- a/jsapp/js/components/languages/languageSelector.stories.tsx
+++ b/jsapp/js/components/languages/languageSelector.stories.tsx
@@ -3,7 +3,7 @@ import LanguageSelector from './languageSelector'
 
 // TODO: somehow mock the `languagesStore` here, so that there are means to play with this properly :)
 const meta: Meta<typeof LanguageSelector> = {
-  title: 'common/LanguageSelector',
+  title: 'Components/LanguageSelector',
   component: LanguageSelector,
   argTypes: {},
 }

--- a/jsapp/js/components/languages/regionSelector.stories.tsx
+++ b/jsapp/js/components/languages/regionSelector.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import RegionSelector from './regionSelector'
 
 const meta: Meta<typeof RegionSelector> = {
-  title: 'common/RegionSelector',
+  title: 'Components/RegionSelector',
   component: RegionSelector,
   argTypes: {
     rootLanguage: { control: 'text' },

--- a/jsapp/js/components/modals/koboModal.stories.tsx
+++ b/jsapp/js/components/modals/koboModal.stories.tsx
@@ -6,7 +6,7 @@ import KoboModalFooter from './koboModalFooter'
 import KoboModalHeader from './koboModalHeader'
 
 const meta: Meta<typeof KoboModal> = {
-  title: 'commonDeprecated/KoboModal',
+  title: 'Design system old/KoboModal',
   component: KoboModal,
   argTypes: {
     isOpen: { control: 'boolean' },

--- a/jsapp/js/components/modals/koboPrompt.stories.tsx
+++ b/jsapp/js/components/modals/koboPrompt.stories.tsx
@@ -3,7 +3,7 @@ import { IconNames } from '#/k-icons'
 import KoboPrompt from './koboPrompt'
 
 const meta: Meta<typeof KoboPrompt> = {
-  title: 'common/KoboPrompt',
+  title: 'Design system old/KoboPrompt',
   component: KoboPrompt,
   argTypes: {
     titleIcon: {

--- a/jsapp/js/universalTable/universalTable.stories.tsx
+++ b/jsapp/js/universalTable/universalTable.stories.tsx
@@ -95,7 +95,7 @@ function getMockDataItem(): MockDataItem {
 }
 
 const meta: Meta<UniversalTablePropsAndCustomArgs> = {
-  title: 'misc/UniversalTable',
+  title: 'Components/UniversalTable',
   component: UniversalTable,
   argTypes: {
     hasColumnsPinnedLeft: {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Moved stories around (in Storybook context, not moving the files):
- all Mantine powered common components are in "Design system/"
- all common components that have no Mantine uquivalents are in "Design system/" (e.g. `DiffValue`, `Icon`, `Tooltip`)
- all other common components are in "Design system old/" (so the deprecated ones, and the ones that have Mantine equivalents, but we haven't migrated them yet)
- some stories are on "Components/" - for components that are more feature related

### 👀 Preview steps

Testing:
1. ℹ️ run storybook
2. verify in sidebar that each story is where it makes the most sense