### PR TITLE
fix(organization): ensure members have permissions to view project forms and submit data TASK-1768

### DIFF
--- a/kobo/apps/openrosa/libs/filters.py
+++ b/kobo/apps/openrosa/libs/filters.py
@@ -27,6 +27,7 @@ class GuardianObjectPermissionsFilter(BaseFilterBackend):
         'XFormListApi': [
             'manifest',
             'list',
+            'retrieve',
         ]
     }
 

--- a/kobo/apps/openrosa/libs/filters.py
+++ b/kobo/apps/openrosa/libs/filters.py
@@ -28,6 +28,7 @@ class GuardianObjectPermissionsFilter(BaseFilterBackend):
             'manifest',
             'list',
             'retrieve',
+            'media',
         ]
     }
 

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -427,6 +427,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 validated_data['owner'] = real_owner
                 validated_data['is_excluded_from_projects_list'] = True
                 instance = super().create(validated_data)
+                # Does not assign any `*_submissions` permissions because the asset
+                # type equals 'empty'.
                 instance.assign_perm(current_owner, PERM_MANAGE_ASSET)
         else:
             validated_data['is_excluded_from_projects_list'] = False
@@ -438,6 +440,22 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context['request']
         user = request.user
 
+        perms = asset.get_perms(user)
+        if (
+            not asset.has_deployment
+            and asset.asset_type == ASSET_TYPE_SURVEY
+            and PERM_MANAGE_ASSET in perms
+            and not any([perm.endswith('_submissions') for perm in perms])
+        ):
+            # This should only occur when a member of an organization creates a project.
+            # In that case, the request user is the one who just created the project.
+            # If not, something went wrong — we raise a 500 to avoid accidentally
+            # granting full permissions to the wrong user.
+            assert user.username == asset.created_by
+            # Reset permission. Safer than adding missing permissions.
+            asset.remove_perm(user, PERM_MANAGE_ASSET)
+            asset.assign_perm(user, PERM_MANAGE_ASSET)
+
         validated_data['last_modified_by'] = user.username
         self._set_asset_ids_cache(asset)
 
@@ -446,8 +464,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             and user_has_project_view_asset_perm(asset, user, PERM_CHANGE_METADATA_ASSET)
         ):
             _validated_data = {}
-            if settings := validated_data.get('settings'):
-                _validated_data['settings'] = settings
+            if settings_ := validated_data.get('settings'):
+                _validated_data['settings'] = settings_
             if name := validated_data.get('name'):
                 _validated_data['name'] = name
             return super().update(asset, _validated_data)

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -441,27 +441,11 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         user = request.user
 
         perms = asset.get_perms(user)
-        if (
-            not asset.has_deployment
-            and asset.asset_type == ASSET_TYPE_SURVEY
-            and PERM_MANAGE_ASSET in perms
-            and not any([perm.endswith('_submissions') for perm in perms])
-        ):
-            # This should only occur when a member of an organization creates a project.
-            # In that case, the request user is the one who just created the project.
-            # If not, something went wrong — we raise a 500 to avoid accidentally
-            # granting full permissions to the wrong user.
-            assert user.username == asset.created_by
-            # Reset permission. Safer than adding missing permissions.
-            asset.remove_perm(user, PERM_MANAGE_ASSET)
-            asset.assign_perm(user, PERM_MANAGE_ASSET)
-
         validated_data['last_modified_by'] = user.username
         self._set_asset_ids_cache(asset)
 
-        if (
-            not asset.has_perm(user, PERM_CHANGE_ASSET)
-            and user_has_project_view_asset_perm(asset, user, PERM_CHANGE_METADATA_ASSET)
+        if PERM_CHANGE_ASSET not in perms and user_has_project_view_asset_perm(
+            asset, user, PERM_CHANGE_METADATA_ASSET
         ):
             _validated_data = {}
             if settings_ := validated_data.get('settings'):
@@ -483,7 +467,25 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                     'translations': str(err)
                 })
             validated_data['content'] = asset_content
-        return super().update(asset, validated_data)
+        asset = super().update(asset, validated_data)
+
+        # Restore submission related permissions to the creator of the form
+        if (
+            not asset.has_deployment
+            and asset.asset_type == ASSET_TYPE_SURVEY
+            and PERM_MANAGE_ASSET in perms
+            and not any([perm.endswith('_submissions') for perm in perms])
+        ):
+            # This should only occur when a member of an organization creates a project.
+            # In that case, the request user is the one who just created the project.
+            # If not, something went wrong — we raise a 500 to avoid accidentally
+            # granting full permissions to the wrong user.
+            assert user.username == asset.created_by
+            # Reset permission. Safer than adding missing permissions.
+            asset.remove_perm(user, PERM_MANAGE_ASSET)
+            asset.assign_perm(user, PERM_MANAGE_ASSET)
+
+        return asset
 
     def get_fields(self, *args, **kwargs):
         fields = super().get_fields(*args, **kwargs)

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -47,6 +47,10 @@ class AssetListApiTests(test_api_assets.AssetListApiTests):
     def test_asset_owner_label(self):
         pass
 
+    @unittest.skip(reason='Only needed for v2')
+    def test_creator_permissions_on_import(self):
+        pass
+
 
 class AssetVersionApiTests(test_api_assets.AssetVersionApiTests):
     URL_NAMESPACE = None


### PR DESCRIPTION
### 📣 Summary
Fixed missing permissions for organization members to view forms and submit data.


### 📖 Description
Organization members were unable to view project forms or submit data due to missing permission assignments. This fix ensures that the correct permissions are granted when a user joins an organization, so they can interact with project content as expected.


### 👀 Preview steps

See internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Enketo.20broken.20on.20Main/near/588425
