### PR TITLE
feat(attachment): expose attachment unique identifier in data endpoint

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_attachment_viewset.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_attachment_viewset.py
@@ -303,7 +303,7 @@ class TestAttachmentViewSet(TestAbstractViewSet):
             'IMG_2235.JPG'
         )
 
-        # Edit are only allowed with service account
+        # Edits are only allowed with service account
         with open(media_file_path, 'rb') as media_file:
             self._make_submission(
                 xml_path,
@@ -351,7 +351,8 @@ class TestAttachmentViewSet(TestAbstractViewSet):
             'xform': self.xform.pk,
             'instance': instance.pk,
             'mimetype': attachment.mimetype,
-            'filename': attachment.media_file.name
+            'filename': attachment.media_file.name,
+            'uid': attachment.uid,
         }
         request = self.factory.get('/', **self.extra)
         response = self.list_view(request, pk=attachment.pk)
@@ -370,7 +371,8 @@ class TestAttachmentViewSet(TestAbstractViewSet):
             'xform': expected['xform'],
             'instance': expected['instance'],
             'mimetype': expected['mimetype'],
-            'filename': expected['filename']
+            'filename': expected['filename'],
+            'uid': attachment.uid,
         }
 
         instance_response = self.client.get(

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_data_viewset.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_data_viewset.py
@@ -329,6 +329,7 @@ class TestDataViewSet(TestBase):
                                'instance': self.attachment.instance.pk,
                                'filename': self.attachment.media_file.name,
                                'id': self.attachment.pk,
+                               'uid': self.attachment.uid,
                                'xform': self.xform.id}
                               ],
             '_geolocation': [None, None],

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -456,6 +456,7 @@ def _get_attachments_from_instance(instance):
         attachment['instance'] = a.instance.pk
         attachment['xform'] = instance.xform.id
         attachment['id'] = a.id
+        attachment['uid'] = a.uid
         attachments.append(attachment)
 
     return attachments


### PR DESCRIPTION
### 📣 Summary
Added the unique identifier (uid) of attachments to the data API response.

### Description
This update adds the unique identifier (uid) of each attachment to the data endpoint response. While it doesn’t change existing functionality, it provides the necessary metadata for future developments.

### Preview steps 

1. in release branch, create a project with attachments
2. submit data 
3. from the shell, look at the Mongo document of your submission just posted with `settings.MONGO_DB.instances.find_one({'_id': <submission_id>}) 
4. No `uid` key should be present
5. checkout the PR branch
6. submit data 
7. follow the same instructions as 3). `uid` key should be present. 
