### PR TITLE
fix(attachments): display attachment dropdown additionally to media in single submission modal

### DIFF
--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -225,9 +225,6 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       )
     }
 
-    if (typeof attachment.download_url !== 'string') {
-    }
-
     return (
       <>
         {type === QUESTION_TYPES.audio.id && (

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -215,27 +215,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     // In the case that an attachment is missing, don't crash the page
     if (typeof attachment !== 'object') return attachment
 
-    if (type === QUESTION_TYPES.audio.id) {
-      return (
-        <Group>
-          {attachment?.is_deleted ? (
-            <DeletedAttachment />
-          ) : attachment?.download_url ? (
-            <AudioPlayer mediaURL={attachment?.download_url} />
-          ) : null}
-
-          {shouldProcessingBeAccessible(this.props.submissionData, attachment) && (
-            <Button
-              type='primary'
-              size='s'
-              endIcon='arrow-up-right'
-              label={t('Open')}
-              onClick={this.openProcessing.bind(this, name)}
-            />
-          )}
-        </Group>
-      )
-    }
+    if (!attachment || typeof attachment.download_url !== 'string') return null
 
     if (attachment.is_deleted) {
       return (
@@ -245,40 +225,53 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       )
     }
 
-    if (type === QUESTION_TYPES.image.id) {
-      return (
-        <a href={attachment.download_url} target='_blank'>
-          <img src={attachment.download_medium_url} />
-        </a>
-      )
+    if (typeof attachment.download_url !== 'string') {
     }
 
-    if (type === QUESTION_TYPES.video.id) {
-      return <video src={attachment.download_url} controls />
-    }
+    return (
+      <>
+        {type === QUESTION_TYPES.audio.id && (
+          <Group>
+            <AudioPlayer mediaURL={attachment?.download_url} />
 
-    if (type === QUESTION_TYPES.file.id) {
-      return (
-        <a href={attachment.download_url} target='_blank'>
-          {filename}
-        </a>
-      )
-    }
+            {shouldProcessingBeAccessible(this.props.submissionData, attachment) && (
+              <Button
+                type='primary'
+                size='s'
+                endIcon='arrow-up-right'
+                label={t('Open')}
+                onClick={this.openProcessing.bind(this, name)}
+              />
+            )}
+          </Group>
+        )}
 
-    if (type !== null) {
-      return (
-        <AttachmentActionsDropdown
-          asset={this.props.asset}
-          submissionData={this.props.submissionData}
-          attachmentUid={attachment.uid}
-          onDeleted={() => {
-            this.props.onAttachmentDeleted(attachment.uid)
-          }}
-        />
-      )
-    }
+        {type === QUESTION_TYPES.image.id && (
+          <a href={attachment.download_url} target='_blank'>
+            <img src={attachment.download_medium_url} />
+          </a>
+        )}
 
-    return null
+        {type === QUESTION_TYPES.video.id && <video src={attachment.download_url} controls />}
+
+        {type === QUESTION_TYPES.file.id && (
+          <a href={attachment.download_url} target='_blank'>
+            {filename}
+          </a>
+        )}
+
+        {type !== null && (
+          <AttachmentActionsDropdown
+            asset={this.props.asset}
+            submissionData={this.props.submissionData}
+            attachmentUid={attachment.uid}
+            onDeleted={() => {
+              this.props.onAttachmentDeleted(attachment.uid)
+            }}
+          />
+        )}
+      </>
+    )
   }
 
   renderMetaResponse(dataName: MetaQuestionTypeName | string, label: string) {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Fixes bug where attachment dropdown did not display beside their respective attachments.

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

Went back to the "old" method to display different media types. Didn't have issues with this in the past so seemed logical.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. Enable the `removingAttachmentsEnabled` feature flag
2. Have a form with media questions and submissions
3. Open a single submission modal
4. 🔴 [on main] notice that the attachment dropdown does **not** display next to media
5. 🟢 [on PR] notice that attachment dropdown does display next to media
