### PR TITLE
refactor(backendDeployment): remove fallback logic that retrieved the KPI project from OpenRosa counterpart

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       DATABASE_URL: postgis://kobo:kobo@localhost:5432/kpi_test
       DJANGO_LANGUAGE_CODES: "ar cs de-DE en es fr hi ku pl pt tr zh-hans"

--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -142,18 +142,13 @@ class XForm(AbstractTimeStampedModel):
                     'pk', 'name', 'uid', 'owner_id'
                 ).get(uid=self.kpi_asset_uid)
             except Asset.DoesNotExist:
-                try:
-                    asset = Asset.all_objects.only(
-                        'pk', 'name', 'uid', 'owner_id'
-                    ).get(_deployment_data__backend_response__formid=self.pk)
-                except Asset.DoesNotExist:
-                    # An `Asset` object needs to be returned to avoid 500 while
-                    # Enketo is fetching for project XML (e.g: /formList, /manifest)
-                    asset = Asset(
-                        uid=self.id_string,
-                        name=self.title,
-                        owner_id=self.user.id,
-                    )
+                # An `Asset` object needs to be returned to avoid 500 while
+                # Enketo is fetching for project XML (e.g: /formList, /manifest)
+                asset = Asset(
+                    uid=self.id_string,
+                    name=self.title,
+                    owner_id=self.user.id,
+                )
 
             setattr(self, '_cached_asset', asset)
 

--- a/kobo/apps/openrosa/apps/logger/tests/models/test_xform.py
+++ b/kobo/apps/openrosa/apps/logger/tests/models/test_xform.py
@@ -52,13 +52,7 @@ class TestXForm(TestBase):
         xform.kpi_asset_uid = None
         xform.save(update_fields=['kpi_asset_uid'])
 
-        # 2) Fallback, asset is retrieved with formid in backend response
-        # Reset internal cache of xform
-        setattr(xform, '_cache_asset', None)
-        assert xform.kpi_asset_uid is None
-        assert xform.asset.pk == asset.pk
-
-        # 3) No asset found, `xform.asset` should still be an asset
+        # 2) No asset found, `xform.asset` should still be an asset
         Asset.objects.filter(uid=asset.uid).update(_deployment_data={})
         setattr(xform, '_cache_asset', None)
         assert xform.kpi_asset_uid is None

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -273,6 +273,8 @@ class Asset(
             GinIndex(
                 F('settings__country_codes'), name='settings__country_codes_idx'
             ),
+            # ToDo remove this index. It is wrong. It should be
+            #  `_deployment_data__backend_response__formid` but not used anymore.
             BTreeIndex(
                 F('_deployment_data__formid'), name='deployment_data__formid_idx'
             ),


### PR DESCRIPTION
### 📣 Summary
Removed fallback mechanism that attempted to retrieve Asset when not explicitly linked.