### PR TITLE
fix(languageSelector): force refresh languages list after clearing the searchbox DEV-183

### DIFF
--- a/jsapp/js/components/languages/languageSelector.tsx
+++ b/jsapp/js/components/languages/languageSelector.tsx
@@ -189,12 +189,12 @@ class LanguageSelector extends React.Component<LanguageSelectorProps, LanguageSe
   }
 
   clearSearchPhrase() {
-    this.setSearchPhrase('')
+    this.setSearchPhrase('', true)
   }
 
-  setSearchPhrase(searchPhrase: string) {
+  setSearchPhrase(searchPhrase: string, forceFetch?: boolean) {
     this.setState({ searchPhrase: searchPhrase })
-    if (searchPhrase.length >= MINIMUM_SEARCH_LENGTH) {
+    if (forceFetch || searchPhrase.length >= MINIMUM_SEARCH_LENGTH) {
       this.fetchLanguagesDebounced()
     }
   }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 👀 Preview steps

Steps:

1. Have a project with `audio` question and a submission
2. Go to Project → Data → Table
3. Use "Open" button for the `audio` question response to open NLP View
4. Click "Begin" to start creating transcript
5. Type "swed" in the search box
6. 🟢 Notice the results are only one item: "Swedish"
7. Use "x" button in the searchbox to clear results
8. 🟢 Notice the searchbox is cleared
9. 🔴 Notice the list is not refreshed on kf.beta
10. 🟢 Notice the list is properly refreshed on PR branch
