### PR TITLE
fix(api): prevent 500 errors when accessing v1 API endpoints

### DIFF
--- a/kobo/apps/openrosa/apps/api/permissions.py
+++ b/kobo/apps/openrosa/apps/api/permissions.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+from copy import deepcopy
+
 from django.http import Http404
 from rest_framework.permissions import (
     SAFE_METHODS,
@@ -15,6 +16,7 @@ from kobo.apps.openrosa.libs.constants import (
     CAN_VALIDATE_XFORM,
     CAN_VIEW_XFORM,
 )
+from kpi.utils.log import logging
 
 
 class ViewDjangoObjectPermissions(DjangoObjectPermissions):
@@ -40,7 +42,7 @@ class ObjectPermissionsWithViewRestricted(DjangoObjectPermissions):
         super().__init__(*args, **kwargs)
         # Do NOT mutate `perms_map` from the parent class! Doing so will affect
         # *every* instance of `DjangoObjectPermissions` and all its subclasses
-        self.perms_map = self.perms_map.copy()
+        self.perms_map = deepcopy(self.perms_map)
         self.perms_map['GET'] = ['%(app_label)s.view_%(model_name)s']
         self.perms_map['OPTIONS'] = ['%(app_label)s.view_%(model_name)s']
         self.perms_map['HEAD'] = ['%(app_label)s.view_%(model_name)s']
@@ -109,7 +111,7 @@ class XFormDataPermissions(ObjectPermissionsWithViewRestricted):
         super().__init__(*args, **kwargs)
         # Those who can edit submissions can also delete them, following the
         # behavior of `kobo.apps.openrosa.apps.main.views.delete_data`
-        self.perms_map = self.perms_map.copy()
+        self.perms_map = deepcopy(self.perms_map)
         self.perms_map['DELETE'] = ['%(app_label)s.' + CAN_DELETE_DATA_XFORM]
 
     def has_permission(self, request, view):
@@ -234,7 +236,7 @@ class MetaDataObjectPermissions(ObjectPermissionsWithViewRestricted):
         super(MetaDataObjectPermissions, self).__init__(
             *args, **kwargs
         )
-        self.perms_map = self.perms_map.copy()
+        self.perms_map = deepcopy(self.perms_map)
         self.perms_map['POST'] = self.perms_map['PATCH']
         self.perms_map['PUT'] = self.perms_map['PATCH']
         self.perms_map['DELETE'] = self.perms_map['PATCH']
@@ -288,7 +290,7 @@ class AttachmentObjectPermissions(DjangoObjectPermissions):
     def __init__(self, *args, **kwargs):
         # The default `perms_map` does not include GET, OPTIONS, PATCH or HEAD.
         # See http://www.django-rest-framework.org/api-guide/filtering/#djangoobjectpermissionsfilter  # noqa
-        self.perms_map = DjangoObjectPermissions.perms_map.copy()
+        self.perms_map = deepcopy(DjangoObjectPermissions.perms_map)
         self.perms_map['GET'] = ['%(app_label)s.view_xform']
         self.perms_map['OPTIONS'] = ['%(app_label)s.view_xform']
         self.perms_map['HEAD'] = ['%(app_label)s.view_xform']
@@ -316,7 +318,7 @@ class NoteObjectPermissions(DjangoObjectPermissions):
     authenticated_users_only = False
 
     def __init__(self, *args, **kwargs):
-        self.perms_map = self.perms_map.copy()
+        self.perms_map = deepcopy(self.perms_map)
         self.perms_map['GET'] = ['%(app_label)s.view_xform']
         self.perms_map['OPTIONS'] = ['%(app_label)s.view_xform']
         self.perms_map['HEAD'] = ['%(app_label)s.view_xform']

--- a/kpi/permissions.py
+++ b/kpi/permissions.py
@@ -1,6 +1,6 @@
-# coding: utf-8
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Union
 
 from django.conf import settings
@@ -132,7 +132,7 @@ class AssetPermission(
     # With the default of True, anonymous requests are categorically rejected.
     authenticated_users_only = False
 
-    perms_map = permissions.DjangoObjectPermissions.perms_map.copy()
+    perms_map = deepcopy(permissions.DjangoObjectPermissions.perms_map)
     perms_map['GET'] = ['%(app_label)s.view_%(model_name)s']
     perms_map['OPTIONS'] = perms_map['GET']
     perms_map['HEAD'] = perms_map['GET']
@@ -232,7 +232,7 @@ class AssetEditorPermission(AssetNestedObjectPermission):
         - Reads need 'view_asset' permission
         - Writes need 'change_asset' permission
     """
-    perms_map = AssetNestedObjectPermission.perms_map.copy()
+    perms_map = deepcopy(AssetNestedObjectPermission.perms_map)
     perms_map['POST'] = ['%(app_label)s.change_asset']
     perms_map['PUT'] = perms_map['POST']
     perms_map['PATCH'] = perms_map['POST']
@@ -260,7 +260,7 @@ class AssetEditorSubmissionViewerPermission(AssetNestedObjectPermission):
 
 class AssetPermissionAssignmentPermission(AssetNestedObjectPermission):
 
-    perms_map = AssetNestedObjectPermission.perms_map.copy()
+    perms_map = deepcopy(AssetNestedObjectPermission.perms_map)
     # This change allows users with `view_asset` to permissions to
     # remove themselves from an asset that has been shared with them
     perms_map['DELETE'] = perms_map['GET']
@@ -275,7 +275,7 @@ class AssetSnapshotPermission(AssetPermission):
         app_label = Asset._meta.app_label
         model_name = Asset._meta.model_name
 
-        self.perms_map = self.perms_map.copy()
+        self.perms_map = deepcopy(self.perms_map)
         for action in self.perms_map.keys():
             for idx, perm in enumerate(self.perms_map[action]):
                 self.perms_map[action][idx] = perm % {
@@ -327,7 +327,7 @@ class PostMappedToChangePermission(IsOwnerOrReadOnly):
     Maps POST requests to the change_model permission instead of DRF's default
     of add_model
     """
-    perms_map = IsOwnerOrReadOnly.perms_map.copy()
+    perms_map = deepcopy(IsOwnerOrReadOnly.perms_map)
     perms_map['POST'] = ['%(app_label)s.change_%(model_name)s']
 
 

--- a/kpi/tests/test_permissions.py
+++ b/kpi/tests/test_permissions.py
@@ -3,8 +3,10 @@ import unittest
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
+from rest_framework.permissions import DjangoObjectPermissions
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.api.permissions import XFormPermissions
 from kpi.constants import (
     ASSET_TYPE_COLLECTION,
     ASSET_TYPE_SURVEY,
@@ -21,6 +23,7 @@ from kpi.constants import (
     PERM_VIEW_SUBMISSIONS,
 )
 from kpi.exceptions import BadPermissionsException
+from kpi.permissions import AssetSnapshotPermission
 from kpi.utils.object_permission import get_all_objects_for_user
 
 from ..models import ObjectPermission
@@ -907,3 +910,18 @@ class PermissionsTestCase(BasePermissionsTestCase):
             # …but they still access to someuser's org projects
             for expected_perm in expected_perms:
                 assert asset.has_perm(self.anotheruser, expected_perm)
+
+    def test_perms_map_is_not_mutated_on_inherance(self):
+        django_perm_class = DjangoObjectPermissions()
+        assert django_perm_class.perms_map['PATCH'] == [
+            '%(app_label)s.change_%(model_name)s'
+        ]
+        snap_perm_class = AssetSnapshotPermission()
+        assert snap_perm_class.perms_map['PATCH'] == ['kpi.change_asset']
+        xform_perm_class = XFormPermissions()
+        assert xform_perm_class.perms_map['PATCH'] == [
+            '%(app_label)s.change_%(model_name)s'
+        ]
+        assert django_perm_class.perms_map['PATCH'] == [
+            '%(app_label)s.change_%(model_name)s'
+        ]


### PR DESCRIPTION
### 📣 Summary
Fixed server errors caused by unexpected permission mutations in views using `DjangoModelPermissions`.

### 📖 Description
This PR resolves 500 Internal Server Errors occurring when accessing certain endpoints of the v1 API. The issue was caused by an unintended mutation of the `perms_map` attribute in classes inheriting from DjangoModelPermissions.

Since perms_map is shared across instances, modifying it dynamically introduced side effects across views and requests. This fix prevents the mutation and ensures that permission handling remains isolated and reliable across the API.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. preview the project
3. access `http://kc/api/v1/forms.json`
4. 🔴 [on release branch] receive a 500 (because of AssertionError)
5. 🟢 [on PR] everything is ok
