### PR TITLE
fix(massEmails): read MASS_EMAIL_CONDENSE_SEND from env

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1407,7 +1407,7 @@ MASS_EMAIL_SLEEP_SECONDS = 1
 # change the interval between "daily" email sends for testing. this will set both
 # the frequency of the task and the expiry time of the cached email limits. should
 # only be True on small testing instances
-MASS_EMAILS_CONDENSE_SEND = False
+MASS_EMAILS_CONDENSE_SEND = env.bool('MASS_EMAILS_CONDENSE_SEND', False)
 if MASS_EMAILS_CONDENSE_SEND:
     CELERY_BEAT_SCHEDULE['mass-emails-send'] = {
         'task': 'kobo.apps.mass_emails.tasks.send_emails',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 👷 Description for instance maintainers
Enables Django to read the MASS_EMAIL_CONDENSE_SEND setting from the environment.


### 👀 Preview steps


1. Open a django shell
2. Run `getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False)`. It should return False.
3. Exit the shell
4. In the container, run `export MASS_EMAILS_CONDENSE_SEND=true`
5. Re-open the django shell
6. :green_circle: Run `getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False)`. It should return True.
