### PR TITLE
refactor(submissions): optimize `clean_duplicated_submissions` command with batching and project scoping

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
@@ -84,6 +84,7 @@ def _process_instances_batch(
                 call_command(
                     'clean_duplicated_submissions',
                     xform=xform.id_string,
+                    verbosity=2,
                 )
             except Exception as e:
                 logging.error(f'Failed to clean duplicated submissions: {str(e)}')

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -1,3 +1,4 @@
+import pytest
 from django.conf import settings
 from django.urls import reverse
 from rest_framework import status

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -1,4 +1,3 @@
-import pytest
 from django.conf import settings
 from django.urls import reverse
 from rest_framework import status


### PR DESCRIPTION
### 📣 Summary
Refactored the `clean_duplicated_submissions` management command to process instances in smaller batches and grouped instances by project to ensure UUID uniqueness is enforced per project, not globally.


### 📖 Description
The `clean_duplicated_submissions` command has been refactored to address performance and correctness issues on large datasets. Previously, it attempted to load and process all submissions at once, which could cause out-of-memory (OOM) errors. It also enforced submission uuid uniqueness globally, instead of per project, which is incorrect.