### PR TITLE
feature(attachments): make bulk delete attachments account for partial permissions TASK-559

### DIFF
--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -68,36 +68,46 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
 
       <Modal opened={opened} onClose={handleCloseModal} title={t('Delete media files')} size={'md'}>
         <FocusTrap.InitialFocus />
-        <Stack>
-          <Checkbox
-            label={
-              <Text>
-                {t('You are about to permanently remove the following media files from the selected submissions:')}
-                <br />
-                {getMediaCount(filteredSubmissions)}
-              </Text>
-            }
-            onClick={() => setWarningAcknowledged(!warningAcknowledged)}
-            checked={warningAcknowledged}
-          />
-          <Alert iconName='warning' type='error'>
-            {t('Careful - it is not possible to recover deleted media files')}
-          </Alert>
-          <Group justify='flex-end'>
-            <Button variant='light' size='lg' onClick={close} disabled={isDeletePending}>
-              {t('Cancel')}
-            </Button>
 
-            <Button
-              disabled={!warningAcknowledged || isDeletePending}
-              variant='danger'
-              size='lg'
-              onClick={handleConfirmDelete}
-            >
-              {t('Delete')}
-            </Button>
-          </Group>
-        </Stack>
+        {filteredSubmissions.length === 0 && (
+          // This can only happen if the user has permissions to view (but not delete) certain submissions
+          <Stack>
+            <Text>{t('You do not have permissions to delete the selected submissions.')}</Text>
+          </Stack>
+        )}
+
+        {filteredSubmissions.length > 0 && (
+          <Stack>
+            <Checkbox
+              label={
+                <Text>
+                  {t('You are about to permanently remove the following media files from the selected submissions:')}
+                  <br />
+                  {getMediaCount(filteredSubmissions)}
+                </Text>
+              }
+              onClick={() => setWarningAcknowledged(!warningAcknowledged)}
+              checked={warningAcknowledged}
+            />
+            <Alert iconName='warning' type='error'>
+              {t('Careful - it is not possible to recover deleted media files')}
+            </Alert>
+            <Group justify='flex-end'>
+              <Button variant='light' size='lg' onClick={close} disabled={isDeletePending}>
+                {t('Cancel')}
+              </Button>
+
+              <Button
+                disabled={!warningAcknowledged || isDeletePending}
+                variant='danger'
+                size='lg'
+                onClick={handleConfirmDelete}
+              >
+                {t('Delete')}
+              </Button>
+            </Group>
+          </Stack>
+        )}
       </Modal>
     </Box>
   )

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks'
 import { useState } from 'react'
 import Alert from '#/components/common/alert'
 import { getMediaCount } from '#/components/submissions/submissionUtils'
-import type { SubmissionResponse } from '#/dataInterface'
+import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
 import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { notify } from '#/utils'
 import { useRemoveBulkAttachments } from './attachmentsQuery'
@@ -11,7 +11,7 @@ import { useRemoveBulkAttachments } from './attachmentsQuery'
 interface BulkDeleteMediaFilesProps {
   // An array of all selected submissions with a valid set of attachments to be deleted
   selectedSubmissions: SubmissionResponse[]
-  assetUid: string
+  asset: AssetResponse
   onDeleted: () => void
 }
 
@@ -22,7 +22,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
   const [isDeletePending, setIsDeletePending] = useState(false)
   const [warningAcknowledged, setWarningAcknowledged] = useState(false)
 
-  const removeBulkAttachments = useRemoveBulkAttachments(props.assetUid)
+  const removeBulkAttachments = useRemoveBulkAttachments(props.asset.uid)
 
   if (!isFeatureEnabled) {
     return null
@@ -67,7 +67,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
               <Text>
                 {t('You are about to permanently remove the following media files from the selected submissions:')}
                 <br />
-                {getMediaCount(props.selectedSubmissions)}
+                {getMediaCount(props.selectedSubmissions, props.asset)}
               </Text>
             }
             onClick={() => setWarningAcknowledged(!warningAcknowledged)}

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -2,6 +2,8 @@ import { Anchor, Box, Button, Checkbox, FocusTrap, Group, Modal, Stack, Text } f
 import { useDisclosure } from '@mantine/hooks'
 import { useState } from 'react'
 import Alert from '#/components/common/alert'
+import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
+import { userHasPermForSubmission } from '#/components/permissions/utils'
 import { getMediaCount } from '#/components/submissions/submissionUtils'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
 import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
@@ -28,6 +30,11 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
     return null
   }
 
+  // Filter submissions based on partial permissions
+  const filteredSubmissions = props.selectedSubmissions.filter((submission) =>
+    userHasPermForSubmission(PERMISSIONS_CODENAMES.delete_submissions, props.asset, submission),
+  )
+
   const handleConfirmDelete = async () => {
     const selectedIds = props.selectedSubmissions.map((submission) => submission._id)
     setIsDeletePending(true)
@@ -38,7 +45,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
       notify(
         t('Media files from ##number_of_selected_submissions## submission(s) have been deleted').replace(
           '##number_of_selected_submissions##',
-          props.selectedSubmissions.length.toString(),
+          filteredSubmissions.length.toString(),
         ),
       )
     } catch (error) {
@@ -67,7 +74,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
               <Text>
                 {t('You are about to permanently remove the following media files from the selected submissions:')}
                 <br />
-                {getMediaCount(props.selectedSubmissions, props.asset)}
+                {getMediaCount(filteredSubmissions)}
               </Text>
             }
             onClick={() => setWarningAcknowledged(!warningAcknowledged)}

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -72,7 +72,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
         {filteredSubmissions.length === 0 && (
           // This can only happen if the user has permissions to view (but not delete) certain submissions
           <Stack>
-            <Text>{t('You do not have permissions to delete the selected submissions.')}</Text>
+            <Text>{t('You do not have sufficient permissions to delete attachments from the selected submissions.')}</Text>
           </Stack>
         )}
 

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -32,7 +32,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
 
   // Filter submissions based on partial permissions
   const filteredSubmissions = props.selectedSubmissions.filter((submission) =>
-    userHasPermForSubmission(PERMISSIONS_CODENAMES.delete_submissions, props.asset, submission),
+    userHasPermForSubmission(PERMISSIONS_CODENAMES.change_submissions, props.asset, submission),
   )
 
   const handleConfirmDelete = async () => {

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -72,7 +72,9 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
         {filteredSubmissions.length === 0 && (
           // This can only happen if the user has permissions to view (but not delete) certain submissions
           <Stack>
-            <Text>{t('You do not have sufficient permissions to delete attachments from the selected submissions.')}</Text>
+            <Text>
+              {t('You do not have sufficient permissions to delete attachments from the selected submissions.')}
+            </Text>
           </Stack>
         )}
 

--- a/jsapp/js/components/submissions/submissionUtils.tsx
+++ b/jsapp/js/components/submissions/submissionUtils.tsx
@@ -844,19 +844,13 @@ export function shouldProcessingBeAccessible(
 // Counts the number of each attachment type for the given array of submissions
 // Returns semi-colon seperated string in the form of `<number_of_attachments> <attachment_type>;` ending with a period
 // for each attachment type present
-export function getMediaCount(selectedSubmissions: SubmissionResponse[], asset: AssetResponse) {
-  // Filter submissions based on partial permissions
-  const filteredSubmissions = selectedSubmissions.filter((submission) =>
-    userHasPermForSubmission(PERMISSIONS_CODENAMES.delete_submissions, asset, submission),
-  )
-  console.log('what', filteredSubmissions)
-
+export function getMediaCount(selectedSubmissions: SubmissionResponse[]) {
   let totalImages = 0
   let totalVideos = 0
   let totalFiles = 0
   let totalAudios = 0
 
-  filteredSubmissions.forEach((submission) => {
+  selectedSubmissions.forEach((submission) => {
     submission._attachments.forEach((attachment) => {
       const mimetype = attachment.mimetype
       if (mimetype.includes('image/')) {

--- a/jsapp/js/components/submissions/submissionUtils.tsx
+++ b/jsapp/js/components/submissions/submissionUtils.tsx
@@ -29,6 +29,8 @@ import type {
   SurveyChoice,
   SurveyRow,
 } from '#/dataInterface'
+import { PERMISSIONS_CODENAMES } from '../permissions/permConstants'
+import { userHasPermForSubmission } from '../permissions/utils'
 
 export enum DisplayGroupTypeName {
   group_root = 'group_root',
@@ -840,15 +842,21 @@ export function shouldProcessingBeAccessible(
 }
 
 // Counts the number of each attachment type for the given array of submissions
-// Returns semi-colon seperated string in the form of `<number_of_attachments> <attachment_type>;` followed by a period
+// Returns semi-colon seperated string in the form of `<number_of_attachments> <attachment_type>;` ending with a period
 // for each attachment type present
-export function getMediaCount(selectedSubmissions: SubmissionResponse[]) {
+export function getMediaCount(selectedSubmissions: SubmissionResponse[], asset: AssetResponse) {
+  // Filter submissions based on partial permissions
+  const filteredSubmissions = selectedSubmissions.filter((submission) =>
+    userHasPermForSubmission(PERMISSIONS_CODENAMES.delete_submissions, asset, submission),
+  )
+  console.log('what', filteredSubmissions)
+
   let totalImages = 0
   let totalVideos = 0
   let totalFiles = 0
   let totalAudios = 0
 
-  selectedSubmissions.forEach((submission) => {
+  filteredSubmissions.forEach((submission) => {
     submission._attachments.forEach((attachment) => {
       const mimetype = attachment.mimetype
       if (mimetype.includes('image/')) {

--- a/jsapp/js/components/submissions/submissionUtils.tsx
+++ b/jsapp/js/components/submissions/submissionUtils.tsx
@@ -29,8 +29,6 @@ import type {
   SurveyChoice,
   SurveyRow,
 } from '#/dataInterface'
-import { PERMISSIONS_CODENAMES } from '../permissions/permConstants'
-import { userHasPermForSubmission } from '../permissions/utils'
 
 export enum DisplayGroupTypeName {
   group_root = 'group_root',

--- a/jsapp/js/components/submissions/tableBulkOptions.tsx
+++ b/jsapp/js/components/submissions/tableBulkOptions.tsx
@@ -268,7 +268,7 @@ class TableBulkOptions extends React.Component<TableBulkOptionsProps> {
 
         {Object.keys(this.props.selectedRows).length > 0 &&
           (userCan(PERMISSIONS_CODENAMES.delete_submissions, this.props.asset) ||
-            userCanPartially(PERMISSIONS_CODENAMES.delete_submissions, this.props.asset)) &&
+            userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)) &&
           this.getSelectedSubmissionsWithAttachments().length > 0 && (
             <BulkDeleteMediaFiles
               selectedSubmissions={this.getSelectedSubmissionsWithAttachments()}

--- a/jsapp/js/components/submissions/tableBulkOptions.tsx
+++ b/jsapp/js/components/submissions/tableBulkOptions.tsx
@@ -272,7 +272,7 @@ class TableBulkOptions extends React.Component<TableBulkOptionsProps> {
           this.getSelectedSubmissionsWithAttachments().length > 0 && (
             <BulkDeleteMediaFiles
               selectedSubmissions={this.getSelectedSubmissionsWithAttachments()}
-              assetUid={this.props.asset.uid}
+              asset={this.props.asset}
               onDeleted={this.handleDeletedAttachment}
             />
           )}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Displays the correct number of attachments/submissions in the UI when bulk deleting based on current user permissions.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->
Feature/no-change template:
1.  Have a form with submissions and `removingAttachmentsEnabled` flag enabled
2. Give partial delete permissions to another user somehow. The way I did it was:
    1. Have 2 accounts
    2. Submit data logged in on both accounts (so there are submissions from multiple accounts)
    3. Give one user permission to view submissions from both account
    4. Give the same user in step above permission to only delete from one account, let's call this the Test User.
6. As the Test User, select all submissions and click "Delete media files only"
8. 🟢 notice that the number of attachments counted in the modal correctly matches those that come from the submission(s) Test User can delete
9. 🟢notice that after a successful "delete" the notify displays the correct number of submissions that Test User can delete
