### PR TITLE
test: add query-counting tests to critical endpoints

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -49,6 +49,24 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
         response = self.view(request)
         self.validate_openrosa_head_response(response)
 
+    def test_query_counts(self):
+        path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..',
+            'fixtures',
+            'transport_submission.json')
+        with open(path, 'rb') as f:
+            data = json.loads(f.read())
+            request = self.factory.post('/submission', data, format='json')
+            response = self.view(request)
+
+            # redo the request since it was consumed
+            request = self.factory.post('/submission', data, format='json')
+            auth = DigestAuth('bob', 'bobbob')
+            request.META.update(auth(request.META, response))
+            with self.assertNumQueries(47):
+                self.view(request)
+
     def test_post_submission_anonymous(self):
 
         self.xform.require_auth = False

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -19,6 +19,7 @@ from kpi.tests.api.v2 import test_api_assets
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.tests.utils.transaction import immediate_on_commit
+from kpi.utils.fuzzy_int import FuzzyInt
 from kpi.utils.xml import check_lxml_fromstring
 
 EMPTY_SURVEY = {'survey': [], 'schema': SCHEMA_VERSION, 'settings': {}}
@@ -56,12 +57,13 @@ class AssetListApiTests(test_api_assets.AssetListApiTests):
         # expected query counts are different in v1 and v2 so override the test here
         self.create_asset()
 
-        with self.assertNumQueries(31):
+        with self.assertNumQueries(FuzzyInt(31, 32)):
             self.client.get(self.list_url)
         # test query count does not increase with more assets
         self.create_asset()
         self.create_asset()
-        with self.assertNumQueries(31):
+        self.create_asset()
+        with self.assertNumQueries(FuzzyInt(31, 32)):
             self.client.get(self.list_url)
 
 

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -56,12 +56,12 @@ class AssetListApiTests(test_api_assets.AssetListApiTests):
         # expected query counts are different in v1 and v2 so override the test here
         self.create_asset()
 
-        with self.assertNumQueries(29):
+        with self.assertNumQueries(31):
             self.client.get(self.list_url)
         # test query count does not increase with more assets
         self.create_asset()
         self.create_asset()
-        with self.assertNumQueries(29):
+        with self.assertNumQueries(31):
             self.client.get(self.list_url)
 
 

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -4,10 +4,10 @@ import unittest
 from urllib.parse import unquote_plus
 
 from django.urls import reverse
-from formpack.utils.expand_content import SCHEMA_VERSION
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 
+from formpack.utils.expand_content import SCHEMA_VERSION
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import ASSET_TYPE_COLLECTION
 from kpi.models import Asset, SubmissionExportTask
@@ -51,6 +51,18 @@ class AssetListApiTests(test_api_assets.AssetListApiTests):
     @unittest.skip(reason='Only needed for v2')
     def test_creator_permissions_on_import(self):
         pass
+
+    def test_query_counts(self):
+        # expected query counts are different in v1 and v2 so override the test here
+        self.create_asset()
+
+        with self.assertNumQueries(29):
+            self.client.get(self.list_url)
+        # test query count does not increase with more assets
+        self.create_asset()
+        self.create_asset()
+        with self.assertNumQueries(29):
+            self.client.get(self.list_url)
 
 
 class AssetVersionApiTests(test_api_assets.AssetVersionApiTests):

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -411,18 +411,18 @@ class AssetListApiTests(BaseAssetTestCase):
     def test_query_counts(self):
         self.create_asset()
         # 45 when stripe is disabled, 46 when enabled
-        with self.assertNumQueries(FuzzyInt(45,46)):
+        with self.assertNumQueries(FuzzyInt(45, 46)):
             self.client.get(self.list_url)
         # test query count does not increase with more assets
         # add several assets so the fuzziness of the count doesn't hide an O(n) addition
         self.create_asset()
         self.create_asset()
         self.create_asset()
-        with self.assertNumQueries(FuzzyInt(45,46)):
+        with self.assertNumQueries(FuzzyInt(45, 46)):
             self.client.get(self.list_url)
 
         # test query counts with search filter
-        with self.assertNumQueries(FuzzyInt(45,46)):
+        with self.assertNumQueries(FuzzyInt(45, 46)):
             self.client.get(self.list_url, data={'q': 'asset_type:survey'})
 
 

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -407,6 +407,21 @@ class AssetListApiTests(BaseAssetTestCase):
         assert asset.has_perm(anotheruser, PERM_VALIDATE_SUBMISSIONS)
         assert asset.has_perm(anotheruser, PERM_VIEW_SUBMISSIONS)
 
+    def test_query_counts(self):
+        self.create_asset()
+
+        with self.assertNumQueries(46):
+            self.client.get(self.list_url)
+        # test query count does not increase with more assets
+        self.create_asset()
+        self.create_asset()
+        with self.assertNumQueries(46):
+            self.client.get(self.list_url)
+
+        # test query counts with search filter
+        with self.assertNumQueries(46):
+            self.client.get(self.list_url, data={'q': 'asset_type:survey'})
+
 
 class AssetProjectViewListApiTests(BaseAssetTestCase):
     fixtures = ['test_data']

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -37,6 +37,7 @@ from kpi.tests.base_test_case import (
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.tests.utils.mixins import AssetFileTestCaseMixin
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
+from kpi.utils.fuzzy_int import FuzzyInt
 from kpi.utils.hash import calculate_hash
 from kpi.utils.object_permission import get_anonymous_user
 from kpi.utils.project_views import get_region_for_view
@@ -409,17 +410,19 @@ class AssetListApiTests(BaseAssetTestCase):
 
     def test_query_counts(self):
         self.create_asset()
-
-        with self.assertNumQueries(46):
+        # 45 when stripe is disabled, 46 when enabled
+        with self.assertNumQueries(FuzzyInt(45,46)):
             self.client.get(self.list_url)
         # test query count does not increase with more assets
+        # add several assets so the fuzziness of the count doesn't hide an O(n) addition
         self.create_asset()
         self.create_asset()
-        with self.assertNumQueries(46):
+        self.create_asset()
+        with self.assertNumQueries(FuzzyInt(45,46)):
             self.client.get(self.list_url)
 
         # test query counts with search filter
-        with self.assertNumQueries(46):
+        with self.assertNumQueries(FuzzyInt(45,46)):
             self.client.get(self.list_url, data={'q': 'asset_type:survey'})
 
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Add query-counting tests to the following endpoints:

/assets - AssetViewSet (v1), tested in v1/test_api_assets.py
/api/v2/assets/*uid*/data - DataViewSet, tested in test_data_viewset.py
/api/v2/assets - AssetViewSet, tested in v2/test_api_assets.py
/assets/*uid*/submissions - SubmissionViewSet, tested in v1/test_api_submissions.py
/*username*/submission - XFormSubmissionApi, tested in test_xform_submission_api.py

Adding these tests revealed that we were in fact hitting the database once per asset to get export settings, so this PR also adds export_settings to the prefetched attributes, and replaces the serializer method field with the built-in django nested serializer.

### Preview Steps
1. Have an account and a project
2. Make sure the project has at least one select-one question
3. Add a few submissions to the project
4. Go to Data -> Downloads
5. Open Advanced Settings and check 'Save selection'
6. Export the data (you won't actually need the exported data)
7. [on main] go to `api/v2/assets` and take note of what is in the export_settings field of your project
8. [on main] go to `api/v2/assets/<asset_uid>` and similarly take note of what is in the export_settings field
9. [on branch] go to the same 2 endpoints and make sure the export_settings are the same

