### PR TITLE
feat(projectHistoryLogs): add owner to permission logs DEV-182

### DIFF
--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -485,6 +485,7 @@ class ProjectHistoryLog(AuditLog):
                 'ip_address': get_client_ip(request),
                 'source': get_human_readable_client_user_agent(request),
                 'cloned_from': request._data[CLONE_ARG_NAME],
+                'project_owner': initial_data['asset.owner.username'],
             },
         )
 
@@ -734,6 +735,7 @@ class ProjectHistoryLog(AuditLog):
             'source': get_human_readable_client_user_agent(request),
             'asset_uid': asset_uid,
             'log_subtype': PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            'project_owner': source_data['asset.owner.username'],
         }
         # we'll be bulk creating logs instead of using .create, so we have to set
         # all fields manually

--- a/kobo/apps/audit_log/tests/test_models.py
+++ b/kobo/apps/audit_log/tests/test_models.py
@@ -655,9 +655,7 @@ class ProjectHistoryLogModelTestCase(BaseAuditLogTestCase):
         request.user = User.objects.get(username='someuser')
         request.resolver_match = Mock()
         request.resolver_match.kwargs = {'parent_lookup_asset': 'a12345'}
-        request.updated_data = {
-            'asset.id': 1,
-        }
+        request.updated_data = {'asset.id': 1, 'asset.owner.username': 'fred'}
         request.permissions_added = {
             # these permissions are not allowed for anonymous users,
             # pretend something went wrong/changed and they were assigned anyway

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1083,10 +1083,14 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             metadata__permissions__username='anotheruser'
         ).first()
         self._check_common_metadata(
-            someuser_log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            someuser_log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
         self._check_common_metadata(
-            anotheruser_log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            anotheruser_log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
         self.assertListEqual(
             someuser_log.metadata['permissions'][
@@ -1183,7 +1187,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log = ProjectHistoryLog.objects.filter(action=expected_action).first()
         self.assertEqual(log.action, expected_action)
         self._check_common_metadata(
-            log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
 
         # get the permission that was created
@@ -1201,7 +1207,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             action=expected_inverse_action
         ).first()
         self._check_common_metadata(
-            removal_log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            removal_log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
 
     # use bulk endpoint? (as opposed to -detail)
@@ -1233,7 +1241,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             action=AuditAction.MODIFY_USER_PERMISSIONS
         ).first()
         self._check_common_metadata(
-            log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
         self.assertListEqual(
             sorted(
@@ -1319,7 +1329,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             action=AuditAction.MODIFY_USER_PERMISSIONS
         ).first()
         self._check_common_metadata(
-            log.metadata, PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE
+            log.metadata,
+            PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
         # can't sort a list of strings and dicts,
         # so check length and expected entries individually
@@ -1458,6 +1470,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data={CLONE_ARG_NAME: second_asset.uid},
             expected_action=AuditAction.CLONE_PERMISSIONS,
             expected_subtype=PROJECT_HISTORY_LOG_PERMISSION_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['cloned_from'], second_asset.uid)
 

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1539,6 +1539,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data={},
             expected_action=AuditAction.ADD_SUBMISSION,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         new_submission = Instance.objects.last()
         self._check_submission_log_metadata(
@@ -1585,7 +1586,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         # check the log has the expected fields and metadata
         self.assertEqual(log.object_id, self.asset.id)
         self.assertEqual(log.action, AuditAction.MODIFY_SUBMISSION)
-        self._check_common_metadata(log.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         submitted_by = username if username is not None else 'AnonymousUser'
         self._check_submission_log_metadata(
             log.metadata, submitted_by, instance.root_uuid
@@ -1615,7 +1618,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log1 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='adminuser'
         ).first()
-        self._check_common_metadata(log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log1.action, AuditAction.MODIFY_SUBMISSION)
         self._check_submission_log_metadata(
             log1.metadata, 'adminuser', instance1.root_uuid
@@ -1624,7 +1629,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log2 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='someuser'
         ).first()
-        self._check_common_metadata(log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log2.action, AuditAction.MODIFY_SUBMISSION)
         self._check_submission_log_metadata(
             log2.metadata, 'someuser', instance2.root_uuid
@@ -1633,7 +1640,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log3 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='AnonymousUser'
         ).first()
-        self._check_common_metadata(log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log3.action, AuditAction.MODIFY_SUBMISSION)
         self._check_submission_log_metadata(
             log3.metadata, 'AnonymousUser', instance3.root_uuid
@@ -1686,7 +1695,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log1 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='adminuser'
         ).first()
-        self._check_common_metadata(log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log1.action, AuditAction.MODIFY_SUBMISSION)
         self.assertEqual(log1.metadata['submission']['status'], 'On Hold')
         self._check_submission_log_metadata(
@@ -1696,7 +1707,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log2 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='someuser'
         ).first()
-        self._check_common_metadata(log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log2.action, AuditAction.MODIFY_SUBMISSION)
         self.assertEqual(log2.metadata['submission']['status'], 'On Hold')
         self._check_submission_log_metadata(
@@ -1706,7 +1719,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log3 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='AnonymousUser'
         ).first()
-        self._check_common_metadata(log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log3.action, AuditAction.MODIFY_SUBMISSION)
         self.assertEqual(log3.metadata['submission']['status'], 'On Hold')
         self._check_submission_log_metadata(
@@ -1768,7 +1783,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
 
         self.assertEqual(log.object_id, self.asset.id)
         self.assertEqual(log.action, AuditAction.ADD_SUBMISSION)
-        self._check_common_metadata(log.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         username = 'AnonymousUser' if anonymous else self.user.username
         self._check_submission_log_metadata(log.metadata, username, inst.root_uuid)
 
@@ -1828,7 +1845,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log1 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='adminuser'
         ).first()
-        self._check_common_metadata(log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log1.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log1.action, AuditAction.DELETE_SUBMISSION)
         self._check_submission_log_metadata(
             log1.metadata, 'adminuser', instance1.root_uuid
@@ -1837,7 +1856,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log2 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='someuser'
         ).first()
-        self._check_common_metadata(log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log2.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log2.action, AuditAction.DELETE_SUBMISSION)
         self._check_submission_log_metadata(
             log2.metadata, 'someuser', instance2.root_uuid
@@ -1846,7 +1867,9 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         log3 = ProjectHistoryLog.objects.filter(
             metadata__submission__submitted_by='AnonymousUser'
         ).first()
-        self._check_common_metadata(log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE)
+        self._check_common_metadata(
+            log3.metadata, PROJECT_HISTORY_LOG_PROJECT_SUBTYPE, expect_owner=True
+        )
         self.assertEqual(log3.action, AuditAction.DELETE_SUBMISSION)
         self._check_submission_log_metadata(
             log3.metadata, 'AnonymousUser', instance3.root_uuid

--- a/kpi/views/v2/asset_permission_assignment.py
+++ b/kpi/views/v2/asset_permission_assignment.py
@@ -191,7 +191,7 @@ class AssetPermissionAssignmentViewSet(
     permission_classes = (AssetPermissionAssignmentPermission,)
     pagination_class = None
     log_type = AuditType.PROJECT_HISTORY
-    logged_fields = ['asset.id']
+    logged_fields = ['asset.id', 'asset.owner.username']
     # filter_backends = Just kidding! Look at this instead:
     #     kpi.utils.object_permission.get_user_permission_assignments_queryset
 
@@ -208,7 +208,10 @@ class AssetPermissionAssignmentViewSet(
         :param request:
         :return: JSON
         """
-        request._request.updated_data = {'asset.id': self.asset.id}
+        request._request.updated_data = {
+            'asset.id': self.asset.id,
+            'asset.owner.username': self.asset.owner.username,
+        }
         serializer = AssetBulkInsertPermissionSerializer(
             data={'assignments': request.data},
             context=self.get_serializer_context(),
@@ -226,7 +229,10 @@ class AssetPermissionAssignmentViewSet(
         source_asset_uid = self.request.data[CLONE_ARG_NAME]
         source_asset = get_object_or_404(Asset, uid=source_asset_uid)
         user = request.user
-        request._request.initial_data = {'asset.id': self.asset.id}
+        request._request.initial_data = {
+            'asset.id': self.asset.id,
+            'asset.owner.username': self.asset.owner.username,
+        }
 
         if user.has_perm(PERM_MANAGE_ASSET, self.asset) and user.has_perm(
             PERM_VIEW_ASSET, source_asset
@@ -283,7 +289,10 @@ class AssetPermissionAssignmentViewSet(
             )
         # we don't call perform_destroy, so manually attach the relevant
         # information to the request
-        request._request.initial_data = {'asset.id': self.asset.id}
+        request._request.initial_data = {
+            'asset.id': self.asset.id,
+            'asset.owner.username': self.asset.owner.username,
+        }
         codename = object_permission.permission.codename
         self.asset.remove_perm(user, codename)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add project owner to project history logs that record changes to project permissions.

### 👀 Preview steps

1. ℹ️ have account, at least 2 projects, and at least one other user
2. Go to Settings > Sharing > Add User
3. Grant some permissions to the second user
4. Select and then deselect 'Allow submissions to this form without a username and password', 'Anyone can view this form', and 'Anyone can view submissions made to this form'
5. From a terminal, run
`curl -X PATCH -H 'Authorization: Token <your token>' -H 'Content-type: application/json' localhost/api/v2/assets/<project_1_uid>/permission-assignments/clone/ -d '{"clone_from": "<project_2_uid>"}'`
6. Go to `/api/v2/assets/<project_1_uid>/history`
7. There should be 8 new project history logs (modify-user-permissions, dis/allow-anonymous-submissions, un/share-form-publicly, un/share-data-publicly, and  clone-permissions)
8. 🟢 Ensure that each log contains 'project_owner' in the metadata

