### PR TITLE
fix(PyMongo): enforce maxTimeMS using low-level command to ensure query timeout

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -139,7 +139,7 @@ class Command(BaseCommand):
 
             instance_queryset.delete()
 
-            settings.MONGO_DB.instances.delete_many(
+            MongoHelper.delete_many(
                 {'_id': {'$in': duplicated_instance_ids}}
             )
             if self._verbosity > 1:

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -54,10 +54,10 @@ def datetime_from_str(text):
 @celery_app.task
 def update_mongo_instance(record):
     # since our dict always has an id, save will always result in an upsert op
-    # - so we dont need to worry whether its an edit or not
-    # https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.replace_one
+    # - so we do not need to worry whether it is an edit or not
+    # https://www.mongodb.com/docs/manual/reference/method/db.collection.replaceOne/
     try:
-        xform_instances.replace_one({'_id': record['_id']}, record, upsert=True)
+        MongoHelper.replace_one(record)
     except PyMongoError as e:
         raise Exception('Submission could not be saved to Mongo') from e
     return True
@@ -345,14 +345,11 @@ class ParsedInstance(models.Model):
 
     @staticmethod
     def bulk_update_validation_statuses(query, validation_status):
-        return xform_instances.update_many(
-            query,
-            {'$set': {VALIDATION_STATUS: validation_status}},
-        )
+        return MongoHelper.update_many(query, {VALIDATION_STATUS: validation_status})
 
     @staticmethod
     def bulk_delete(query):
-        return xform_instances.delete_many(query)
+        return MongoHelper.delete_many(query)
 
     def to_dict(self):
         if not hasattr(self, '_dict_cache'):

--- a/kobo/apps/openrosa/apps/viewer/signals.py
+++ b/kobo/apps/openrosa/apps/viewer/signals.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
 
@@ -13,6 +12,7 @@ from kobo.apps.openrosa.libs.utils.guardian import (
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
+from kpi.utils.mongo_helper import MongoHelper
 
 
 @receiver(post_delete, sender=Export)
@@ -32,4 +32,4 @@ def set_object_permissions(sender, instance=None, created=False, **kwargs):
 @receiver(pre_delete, sender=ParsedInstance)
 def remove_from_mongo(sender, **kwargs):
     instance_id = kwargs.get('instance').instance.id
-    settings.MONGO_DB.instances.delete_one({'_id': instance_id})
+    MongoHelper.delete_one({'_id': instance_id})

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -977,7 +977,7 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
         instance_ids = instance_ids.difference(mongo_ids)
     else:
         # clear mongo records
-        mongo_instances.delete_many({common_tags.USERFORM_ID: userform_id})
+        MongoHelper.delete_many({common_tags.USERFORM_ID: userform_id})
 
     # get instances
     sys.stdout.write('Total no of instances to update: %d\n' % len(instance_ids))

--- a/kobo/apps/trash_bin/utils.py
+++ b/kobo/apps/trash_bin/utils.py
@@ -329,7 +329,13 @@ def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: 'kpi.As
         # already deleted
         xform_id_string = asset.deployment.backend_response['id_string']
         xform_uuid = asset.deployment.backend_response['uuid']
-        deleted_orphans = MongoHelper.delete(xform_id_string, xform_uuid)
+        mongo_query = {
+            '$or': [
+                {'_xform_id_string': xform_id_string},
+                {'formhub/uuid': xform_uuid},
+            ],
+        }
+        deleted_orphans = MongoHelper.delete_many(mongo_query)
         logging.warning(f'TrashBin: {deleted_orphans} deleted MongoDB orphans')
 
         return

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -545,7 +545,8 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                             'count': {'$sum': 1},
                         }
                     },
-                ]
+                ],
+                maxTimeMS=MongoHelper.get_max_time_ms(),
             )
             return {doc['_id']: doc['count'] for doc in documents}
 
@@ -1284,14 +1285,14 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
     def transfer_submissions_ownership(self, previous_owner_username: str) -> bool:
 
-        results = settings.MONGO_DB.instances.update_many(
+        results = MongoHelper.update_many(
             {'_userform_id': f'{previous_owner_username}_{self.xform_id_string}'},
-            {'$set': {'_userform_id': self.mongo_userform_id}},
+            {'_userform_id': self.mongo_userform_id},
         )
 
-        return results.matched_count == 0 or (
-            results.matched_count > 0
-            and results.matched_count == results.modified_count
+        return results['matched_count'] == 0 or (
+            results['matched_count'] > 0
+            and results['matched_count'] == results['modified_count']
         )
 
     def transfer_counters_ownership(self, new_owner: 'kobo_auth.User'):

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -89,15 +89,12 @@ class MongoHelper:
         return key
 
     @classmethod
-    def delete(cls, xform_id_string: str, xform_uuid: str) -> int:
-        query = {
-            '$or': [
-                {'_xform_id_string': xform_id_string},
-                {'formhub/uuid': xform_uuid},
-            ],
-        }
-        mongo_query = settings.MONGO_DB.instances.delete_many(query)
-        return mongo_query.deleted_count
+    def delete_one(cls, query: dict) -> int:
+        return cls._raw_delete(query, many=False)
+
+    @classmethod
+    def delete_many(cls, query: dict) -> int:
+        return cls._raw_delete(query, many=True)
 
     @classmethod
     def encode(cls, key: str) -> str:
@@ -183,6 +180,34 @@ class MongoHelper:
         return key not in cls.KEY_WHITELIST and (
             key.startswith('$') or key.count('.') > 0
         )
+
+    @classmethod
+    def replace_one(cls, document: dict) -> int:
+        """
+        PyMongo's update_one and update_many methods do not support maxTimeMS queries.
+        Use low-level command instead.
+
+        Unfortunately, MockMongo (in the testing environment) does not support `command`
+        yet.
+        """
+
+        if settings.TESTING:
+            result = settings.MONGO_DB.instances.replace_one(
+                {'_id': document['_id']}, document, upsert=True
+            )
+            return result.modified_count
+
+        command = {
+            'update': 'formhub',
+            'updates': [{
+                'q': {'_id': document['_id']},
+                'u': document,
+                'upsert': True
+            }],
+            'maxTimeMS': cls.get_max_time_ms()
+        }
+        result = settings.MONGO_DB.command(command)
+        return result.get('nModified', 0)
 
     @classmethod
     def to_readable_dict(cls, d: dict) -> dict:
@@ -285,6 +310,14 @@ class MongoHelper:
                 d[cls.encode(key)] = value
 
         return d
+
+    @classmethod
+    def update_one(cls, query: dict, update: dict) -> dict[str, int]:
+        return cls._raw_update(query, update, many=False)
+
+    @classmethod
+    def update_many(cls, query: dict, update: dict) -> dict[str, int]:
+        return cls._raw_update(query, update, many=True)
 
     @classmethod
     def get_permission_filters_query(
@@ -413,3 +446,76 @@ class MongoHelper:
             if key.startswith('{}.'.format(reserved_attribute)):
                 return True
         return False
+
+    @classmethod
+    def _raw_delete(cls, query: dict, many: bool = True) -> int:
+        """
+        PyMongo's delete_one and delete_many methods do not support maxTimeMS queries.
+        Use low-level command instead.
+
+        Unfortunately, MockMongo (in the testing environment) does not support `command`
+        yet.
+        """
+        if settings.TESTING:
+            if many:
+                result = settings.MONGO_DB.instances.delete_many(query)
+            else:
+                result = settings.MONGO_DB.instances.delete_one(query)
+
+            return result.deleted_count
+
+        command = {
+            'delete': 'formhub',
+            'deletes': [
+                {
+                    'q': query,
+                    'limit': 0 if many else 1,
+                }
+            ],
+            'maxTimeMS': cls.get_max_time_ms(),
+        }
+
+        result = settings.MONGO_DB.command(command)
+        return result.get('n', 0)
+
+    @classmethod
+    def _raw_update(
+        cls, query: dict, update: dict, many: bool = True
+    ) -> dict[str, int]:
+        """
+        PyMongo's update_one and update_many methods do not support maxTimeMS queries.
+        Use low-level command instead.
+
+        Unfortunately, MockMongo (in the testing environment) does not support `command`
+        yet.
+        """
+        if settings.TESTING:
+            if many:
+                result = settings.MONGO_DB.instances.update_many(
+                    query, {'$set': update}
+                )
+            else:
+                result = settings.MONGO_DB.instances.update_one(
+                    query, {'$set': update}
+                )
+
+            return {
+                'matched_count': result.matched_count,
+                'modified_count': result.modified_count,
+            }
+
+        command = {
+            'update': 'formhub',
+            'updates': [{
+                'q': query,
+                'u': update,
+                'multi': many,
+            }],
+            'maxTimeMS': cls.get_max_time_ms()
+        }
+        result = settings.MONGO_DB.command(command)
+
+        return {
+            'matched_count': result.get('n', 0),
+            'modified_count': result.get('nModified', 0),
+        }


### PR DESCRIPTION
### 📣 Summary
Enforced maxTimeMS on MongoDB queries by using the low-level `command()` API.


### 📖 Description
PyMongo does not always forward the `maxTimeMS` parameter to MongoDB in certain high-level query operations, which can result in long-running queries blocking resources indefinitely.

To address this, this PR enforces the use of maxTimeMS by leveraging MongoDB’s low-level `command()` interface, ensuring that the timeout is always respected regardless of the type of operation or query abstraction used.


### Notes
Unfortunately, MockMongo does not support `command()` yet and raise `NotImplementedError`. 