### PR TITLE
perf(tasks): reduce the number of stuck tasks restarted to ease DB load

### DIFF
--- a/kobo/apps/trash_bin/tasks.py
+++ b/kobo/apps/trash_bin/tasks.py
@@ -302,20 +302,24 @@ def task_restarter():
         seconds=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT + 60 * 5
     )
 
-    stuck_account_ids = AccountTrash.objects.values_list(
-        'pk', flat=True
-    ).filter(
-        status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
-        date_modified__lte=stuck_threshold,
+    stuck_account_ids = (
+        AccountTrash.objects.values_list('pk', flat=True)
+        .filter(
+            status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
+            date_modified__lte=stuck_threshold,
+        )
+        .order_by('date_modified')[:settings.MAX_RESTARTED_TASKS]
     )
     for stuck_account_id in stuck_account_ids:
         empty_account.delay(stuck_account_id, force=True)
 
-    stuck_project_ids = ProjectTrash.objects.values_list(
-        'pk', flat=True
-    ).filter(
-        status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
-        date_modified__lte=stuck_threshold,
+    stuck_project_ids = (
+        ProjectTrash.objects.values_list('pk', flat=True)
+        .filter(
+            status__in=[TrashStatus.PENDING, TrashStatus.IN_PROGRESS],
+            date_modified__lte=stuck_threshold,
+        )
+        .order_by('date_modified')[:settings.MAX_RESTARTED_TASKS]
     )
     for stuck_project_id in stuck_project_ids:
         empty_project.delay(stuck_project_id, force=True)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1203,10 +1203,10 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/30'),
         'options': {'queue': 'kpi_low_priority_queue'},
     },
-    # Schedule every 10 minutes
+    # Schedule every 30 minutes
     'trash-bin-task-restarter': {
         'task': 'kobo.apps.trash_bin.tasks.task_restarter',
-        'schedule': crontab(minute='*/10'),
+        'schedule': crontab(minute='*/30'),
         'options': {'queue': 'kpi_low_priority_queue'}
     },
     'perform-maintenance': {
@@ -1224,10 +1224,10 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(hour=0, minute=0),
         'options': {'queue': 'kobocat_queue'}
     },
-    # Schedule every 10 minutes
+    # Schedule every 30 minutes
     'project-ownership-task-restarter': {
         'task': 'kobo.apps.project_ownership.tasks.task_restarter',
-        'schedule': crontab(minute='*/10'),
+        'schedule': crontab(minute='*/30'),
         'options': {'queue': 'kpi_low_priority_queue'}
     },
     # Schedule every 30 minutes
@@ -1861,3 +1861,6 @@ LOG_DELETION_BATCH_SIZE = 1000
 USER_ASSET_ORG_TRANSFER_BATCH_SIZE = 1000
 SUBMISSION_DELETION_BATCH_SIZE = 1000
 LONG_RUNNING_MIGRATION_BATCH_SIZE = 2000
+
+# Number of stuck tasks should be restarted at a time
+MAX_RESTARTED_TASKS = 100


### PR DESCRIPTION
### 📣 Summary
Limited the number of stuck tasks restarted at once to reduce pressure on the database.


### 📖 Description
This update improves the performance of the task restarter by reducing the number of stuck or incomplete tasks restarted in a single run. Restarting too many tasks at once could result in a burst of activity and high load on the database, potentially slowing down the system.

The new behavior introduces a more gradual, controlled approach to restarting tasks, ensuring smoother system operation while still addressing unfinished work in a timely manner.
