### PR TITLE
fix(billing): filter for plans when querying active subscription details DEV-206

### DIFF
--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -83,7 +83,7 @@ class Organization(AbstractOrganization):
             Organization.objects.prefetch_related('djstripe_customers')
             .filter(
                 djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-                djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',
+                djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
                 djstripe_customers__subscriber=self.id,
             )
             .order_by('-djstripe_customers__subscriptions__start_date')

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -202,19 +202,19 @@ class Organization(AbstractOrganization):
         if self.mmo_override:
             return True
 
-        if settings.STRIPE_ENABLED:
-            return (
-                Organization.objects.prefetch_related('djstripe_customers')
-                .filter(
-                    djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,  # noqa
-                    djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
-                    djstripe_customers__subscriptions__items__price__product__metadata__mmo_enabled='true',  # noqa
-                    djstripe_customers__subscriber=self.id,
-                )
-                .exists()
-            )
+        if not settings.STRIPE_ENABLED:
+            False
 
-        return False
+        return (
+            Organization.objects.prefetch_related('djstripe_customers')
+            .filter(
+                djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
+                djstripe_customers__subscriptions__items__price__product__metadata__mmo_enabled='true',  # noqa
+                djstripe_customers__subscriber=self.id,
+            )
+            .exists()
+        )
 
     @cache_for_request
     def is_admin_only(self, user: 'User') -> bool:

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -203,7 +203,7 @@ class Organization(AbstractOrganization):
             return True
 
         if not settings.STRIPE_ENABLED:
-            False
+            return False
 
         return (
             Organization.objects.prefetch_related('djstripe_customers')

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -206,7 +206,7 @@ class Organization(AbstractOrganization):
             return (
                 Organization.objects.prefetch_related('djstripe_customers')
                 .filter(
-                    djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                    djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,  # noqa
                     djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
                     djstripe_customers__subscriptions__items__price__product__metadata__mmo_enabled='true',  # noqa
                     djstripe_customers__subscriber=self.id,

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -83,6 +83,7 @@ class Organization(AbstractOrganization):
             Organization.objects.prefetch_related('djstripe_customers')
             .filter(
                 djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',
                 djstripe_customers__subscriber=self.id,
             )
             .order_by('-djstripe_customers__subscriptions__start_date')

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -50,7 +50,7 @@ class Organization(AbstractOrganization):
     id = KpiUidField(uid_prefix='org', primary_key=True)
     mmo_override = models.BooleanField(
         default=False,
-        verbose_name='Make organization multi-member (necessary for adding users)',
+        verbose_name='Make organization multi-member (necessary for adding users)'
     )
     website = models.CharField(default='', max_length=255)
     organization_type = models.CharField(
@@ -212,12 +212,6 @@ class Organization(AbstractOrganization):
             )
             .exists()
         )
-
-        # if billing_details := self.active_subscription_billing_details():
-        #     if product_metadata := billing_details.get('product_metadata'):
-        #         return product_metadata.get('mmo_enabled') == 'true'
-
-        # return False
 
     @cache_for_request
     def is_admin_only(self, user: 'User') -> bool:

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -202,16 +202,19 @@ class Organization(AbstractOrganization):
         if self.mmo_override:
             return True
 
-        return (
-            Organization.objects.prefetch_related('djstripe_customers')
-            .filter(
-                djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
-                djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
-                djstripe_customers__subscriptions__items__price__product__metadata__mmo_enabled='true',  # noqa
-                djstripe_customers__subscriber=self.id,
+        if settings.STRIPE_ENABLED:
+            return (
+                Organization.objects.prefetch_related('djstripe_customers')
+                .filter(
+                    djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
+                    djstripe_customers__subscriptions__items__price__product__metadata__product_type='plan',  # noqa
+                    djstripe_customers__subscriptions__items__price__product__metadata__mmo_enabled='true',  # noqa
+                    djstripe_customers__subscriber=self.id,
+                )
+                .exists()
             )
-            .exists()
-        )
+
+        return False
 
     @cache_for_request
     def is_admin_only(self, user: 'User') -> bool:

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -12,7 +12,6 @@ from rest_framework import status
 
 from kobo.apps.hook.utils.tests.mixins import HookTestCaseMixin
 from kobo.apps.kobo_auth.shortcuts import User
-from kobo.apps.organizations.models import Organization
 from kpi.constants import PERM_ADD_SUBMISSIONS, PERM_MANAGE_ASSET, PERM_VIEW_ASSET
 from kpi.models.asset import Asset
 from kpi.tests.base_test_case import BaseAssetTestCase, BaseTestCase

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import responses
 from ddt import data, ddt, unpack
 from django.contrib.auth.models import Permission
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import parse_http_date
@@ -120,6 +121,7 @@ class OrganizationApiTestCase(BaseTestCase):
     @patch(
         'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
+    @override_settings(STRIPE_ENABLED=True)
     def test_api_response_includes_is_mmo_with_subscription(
         self, mock_query
     ):
@@ -137,6 +139,7 @@ class OrganizationApiTestCase(BaseTestCase):
     @patch(
         'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
+    @override_settings(STRIPE_ENABLED=True)
     def test_api_response_includes_is_mmo_with_no_override_and_no_subscription(
         self, mock_query
     ):
@@ -153,6 +156,7 @@ class OrganizationApiTestCase(BaseTestCase):
     @patch(
         'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
+    @override_settings(STRIPE_ENABLED=True)
     def test_api_response_includes_is_mmo_with_override_and_subscription(
         self, mock_query
     ):

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -118,52 +118,49 @@ class OrganizationApiTestCase(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['is_mmo'], True)
 
-    @patch.object(
-        Organization,
-        'active_subscription_billing_details',
-        return_value=MMO_SUBSCRIPTION_DETAILS,
+    @patch(
+        'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
     def test_api_response_includes_is_mmo_with_subscription(
-        self, mock_active_subscription
+        self, mock_query
     ):
         """
         Test that is_mmo is True when there is an active MMO subscription.
         """
         self._insert_data(mmo_override=False)
+        mock_query.return_value.filter.return_value.exists.return_value = True
         response = self.client.get(self.url_detail)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['is_mmo'], True)
 
-    @patch.object(
-        Organization,
-        'active_subscription_billing_details',
-        return_value=None
+    @patch(
+        'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
     def test_api_response_includes_is_mmo_with_no_override_and_no_subscription(
-        self, mock_active_subscription
+        self, mock_query
     ):
         """
         Test that is_mmo is False when neither mmo_override nor active
         subscription is present.
         """
         self._insert_data(mmo_override=False)
+        mock_query.return_value.filter.return_value.exists.return_value = False
         response = self.client.get(self.url_detail)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['is_mmo'], False)
 
-    @patch.object(
-        Organization,
-        'active_subscription_billing_details',
-        return_value=MMO_SUBSCRIPTION_DETAILS,
+    @patch(
+        'kobo.apps.organizations.models.Organization.objects.prefetch_related'
     )
     def test_api_response_includes_is_mmo_with_override_and_subscription(
-        self, mock_active_subscription
+        self, mock_query
     ):
         """
         Test that is_mmo is True when both mmo_override and active
         MMO subscription is present.
         """
         self._insert_data(mmo_override=True)
+        mock_query.return_value.filter.return_value.exists.return_value = True
         response = self.client.get(self.url_detail)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['is_mmo'], True)

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -127,6 +127,8 @@ class OrganizationApiTestCase(BaseTestCase):
         Test that is_mmo is True when there is an active MMO subscription.
         """
         self._insert_data(mmo_override=False)
+        # Patch query in is_mmo method that checks whether org has an active
+        # subscription with a product_type of 'plan'.
         mock_query.return_value.filter.return_value.exists.return_value = True
         response = self.client.get(self.url_detail)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -635,3 +635,8 @@ class OrganizationsModelIntegrationTestCase(BaseTestCase):
         product_metadata['mmo_enabled'] = 'true'
         generate_plan_subscription(self.organization, metadata=product_metadata)
         assert self.organization.is_mmo is True
+
+        # Ensure non-plan subscriptions are ignored
+        addon_metadata = {'product_type': 'addon'}
+        generate_plan_subscription(self.organization, metadata=addon_metadata)
+        assert self.organization.is_mmo is True

--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -633,10 +633,17 @@ class OrganizationsModelIntegrationTestCase(BaseTestCase):
         subscription.save()
 
         product_metadata['mmo_enabled'] = 'true'
-        generate_plan_subscription(self.organization, metadata=product_metadata)
+        mmo_subscription = generate_plan_subscription(
+            self.organization, metadata=product_metadata
+        )
         assert self.organization.is_mmo is True
 
         # Ensure non-plan subscriptions are ignored
         addon_metadata = {'product_type': 'addon'}
         generate_plan_subscription(self.organization, metadata=addon_metadata)
         assert self.organization.is_mmo is True
+
+        # ensure inactive mmo-enabled subscriptions are ignored
+        mmo_subscription.status = 'canceled'
+        mmo_subscription.save()
+        assert self.organization.is_mmo is False


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes method for querying an organization's relevant subscription to ensure that only subscription plans are queried.

### 💭 Notes
The original error we ran into was that organizations with an MMO-enabled subscription **and** an SSO addon (with `'product_type': 'addon'` in product metadata) are not being recognized as MMOs in our code. This is because the `active_subscription_billing_details` Organization method does not distinguish between 'addon' and 'plan' subscriptions. However, because the billing code as of release `2.025.02` uses `active_subscription_billing_details` for determining billing dates, I have chosen to leave that method untouched and instead run a similar, but fixed, query directly in the `is_mmo` method.

### 👀 Preview steps
I leave it to the reviewer to determine whether an actual test is worth the effort. Ping me for help with step 2 if you decide to go for it.
1. In a stripe-enabled (and synced) environment with a new user/org, navigate to http://kf.kobo.local/#/account/plan?type=custom_teams and sign up for the Teams Unlimited plan. 
2. Add a recurring addon for SSO (this has to be done on the Stripe platform, as it is not a public-facing option)
3. Sync subscriptions with Stripe
4. Navigate to http://kf.kobo.local/#/account/
5. 🔴 [on `release/2.025.02`] Notice that the UI does not reflect MMO status (no org name in header, no "organization" section in sidenav)
6. 🟢 [on PR] notice that MMO status is reflected
