### PR TITLE
feat(projectHistoryLogs): add project owner to related viewsets

### DIFF
--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -937,12 +937,14 @@ class ProjectHistoryLog(AuditLog):
             # request failed, don't try to log
             return
         object_id = source_data.pop('object_id')
+        owner = source_data.pop('asset.owner.username')
 
         metadata = {
             'asset_uid': asset_uid,
             'log_subtype': PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
             'ip_address': get_client_ip(request),
             'source': get_human_readable_client_user_agent(request),
+            'project_owner': owner,
         }
         if label:
             metadata.update({label: source_data})

--- a/kobo/apps/audit_log/tests/test_models.py
+++ b/kobo/apps/audit_log/tests/test_models.py
@@ -465,6 +465,7 @@ class ProjectHistoryLogModelTestCase(BaseAuditLogTestCase):
             'object_id': 1,
             'field_1': 'a',
             'field_2': 'b',
+            'asset.owner.username': 'fred',
         }
         ProjectHistoryLog._related_request_base(
             request,
@@ -494,6 +495,7 @@ class ProjectHistoryLogModelTestCase(BaseAuditLogTestCase):
             'object_id': 1,
             'field_1': 'a',
             'field_2': 'b',
+            'asset.owner.username': 'fred',
         }
         ProjectHistoryLog._related_request_base(
             request,
@@ -522,11 +524,13 @@ class ProjectHistoryLogModelTestCase(BaseAuditLogTestCase):
             'object_id': 1,
             'field_1': 'a',
             'field_2': 'b',
+            'asset.owner.username': 'fred',
         }
         request.updated_data = {
             'object_id': 1,
             'field_1': 'new_field1',
             'field_2': 'new_field2',
+            'asset.owner.username': 'fred',
         }
         ProjectHistoryLog._related_request_base(
             request,

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -639,6 +639,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data=request_data,
             expected_action=AuditAction.REGISTER_SERVICE,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         new_hook = Hook.objects.get(name='test')
         self.assertEqual(log_metadata['hook']['uid'], new_hook.uid)
@@ -669,6 +670,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data=request_data,
             expected_action=AuditAction.MODIFY_SERVICE,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['hook']['uid'], new_hook.uid)
         self.assertEqual(log_metadata['hook']['active'], False)
@@ -697,6 +699,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data=request_data,
             expected_action=AuditAction.DELETE_SERVICE,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['hook']['uid'], new_hook.uid)
         self.assertEqual(log_metadata['hook']['active'], True)
@@ -726,6 +729,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data=request_data,
             expected_action=AuditAction.CONNECT_PROJECT,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['paired-data']['source_name'], source.name)
         self.assertEqual(log_metadata['paired-data']['source_uid'], source.uid)
@@ -760,6 +764,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.DISCONNECT_PROJECT,
             request_data=None,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['paired-data']['source_name'], source.name)
         self.assertEqual(log_metadata['paired-data']['source_uid'], source.uid)
@@ -793,6 +798,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.MODIFY_IMPORTED_FIELDS,
             request_data={'fields': ['q2']},
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['paired-data']['source_name'], source.name)
         self.assertEqual(log_metadata['paired-data']['source_uid'], source.uid)
@@ -821,6 +827,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             request_data=request_data,
             expected_action=AuditAction.ADD_MEDIA,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         file = AssetFile.objects.filter(asset=self.asset).first()
         self.assertEqual(log_metadata['asset-file']['uid'], file.uid)
@@ -850,6 +857,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.DELETE_MEDIA,
             request_data=None,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
         self.assertEqual(log_metadata['asset-file']['uid'], media.uid)
         self.assertEqual(log_metadata['asset-file']['filename'], media.filename)
@@ -972,6 +980,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             expected_action=AuditAction.EXPORT,
             request_data=request_data,
             expected_subtype=PROJECT_HISTORY_LOG_PROJECT_SUBTYPE,
+            expect_owner=True,
         )
 
     def test_export_v1_creates_log(self):

--- a/kobo/apps/hook/views/v2/hook.py
+++ b/kobo/apps/hook/views/v2/hook.py
@@ -159,7 +159,13 @@ class HookViewSet(
     serializer_class = HookSerializer
     permission_classes = (AssetEditorSubmissionViewerPermission,)
     log_type = AuditType.PROJECT_HISTORY
-    logged_fields = ['endpoint', 'active', 'uid', ('object_id', 'asset.id')]
+    logged_fields = [
+        'endpoint',
+        'active',
+        'uid',
+        ('object_id', 'asset.id'),
+        'asset.owner.username',
+    ]
 
     def get_queryset(self):
         queryset = self.model.objects.filter(asset__uid=self.asset.uid)

--- a/kpi/views/v2/asset_file.py
+++ b/kpi/views/v2/asset_file.py
@@ -137,6 +137,7 @@ class AssetFileViewSet(
         'md5_hash',
         'download_url',
         ('object_id', 'asset.id'),
+        'asset.owner.username',
     ]
 
     def get_queryset(self):

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -161,7 +161,7 @@ class ExportTaskViewSet(
         'uid__icontains',
     ]
     log_type = AuditType.PROJECT_HISTORY
-    logged_fields = [('object_id', 'asset.id')]
+    logged_fields = [('object_id', 'asset.id'), 'asset.owner.username']
 
     def get_queryset(self):
         user = get_database_user(self.request.user)

--- a/kpi/views/v2/paired_data.py
+++ b/kpi/views/v2/paired_data.py
@@ -183,6 +183,7 @@ class PairedDataViewset(
         ('object_id', 'asset.id'),
         'fields',
         ('source_uid', 'source.uid'),
+        'asset.owner.username',
     ]
 
     @action(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add project owner to project history logs for adding/removing media, exporting data, importing fields from other projects, and modifying REST services.


### 💭 Notes
Though the endpoints are very different, it makes sense to do this in one PR because they all go through the `_related_request_base` method and require the exact same change in the viewset.


### 👀 Preview steps

1. ℹ️ have account and at least 2 projects
2. Submit some data to one of the projects
3. Export data from the project
4. Go to Settings > Media. Add and remove an image from the project.
5. Make sure the second project has data sharing enabled.
6. Go to Settings > Connect Project
7. Import fields from the second project, change the imported fields, then remove the import.
8. Go to Settings > REST Services
9. Add a new REST service, change its name, then remove it
10. Go to `api/v2/assets/*uid*/history`
11. 🟢 There should be 9 new project history logs (add/delete-media, dis/connect-project, modify-imported-fields, register/delete-service, modify-service, and export). Each should have the project_owner in the metadata.

