### PR TITLE
fix(mongo): Update MongoDB utilities to handle documents using the new `_user_formid` value

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/instance.py
+++ b/kobo/apps/openrosa/apps/logger/models/instance.py
@@ -5,9 +5,9 @@ import reversion
 from django.apps import apps
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GeometryCollection, Point
+from django.db.models import UniqueConstraint
 from django.utils import timezone
 from django.utils.encoding import smart_str
-from django.db.models import UniqueConstraint
 from jsonfield import JSONField
 from taggit.managers import TaggableManager
 
@@ -39,6 +39,7 @@ from kobo.apps.openrosa.libs.utils.common_tags import (
     XFORM_ID_STRING,
 )
 from kobo.apps.openrosa.libs.utils.model_tools import set_uuid
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kpi.models.abstract_models import AbstractTimeStampedModel
 
 
@@ -289,9 +290,7 @@ class Instance(AbstractTimeStampedModel):
         data = {
             UUID: self.uuid,
             ID: self.id,
-            self.USERFORM_ID: '%s_%s' % (
-                self.user.username,
-                self.xform.id_string),
+            self.USERFORM_ID: get_mongo_userform_id(self.xform, self.user.username),
             ATTACHMENTS: [a.media_file.name for a in
                           self.attachments.all()],
             self.STATUS: self.status,

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -26,6 +26,7 @@ from kobo.apps.openrosa.libs.utils.common_tags import (
 )
 from kobo.apps.openrosa.libs.utils.decorators import apply_form_field_names
 from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kobo.celery import celery_app
 from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
@@ -91,15 +92,7 @@ class ParsedInstance(models.Model):
                 id_string=id_string, user__username=username
             )
 
-        userform_id = (
-            xform.mongo_uuid
-            if xform.mongo_uuid
-            else f'{username}_{id_string}'
-        )
-
-        return {
-            cls.USERFORM_ID: userform_id
-        }
+        return {cls.USERFORM_ID: get_mongo_userform_id(xform, username)}
 
     @classmethod
     @apply_form_field_names

--- a/kobo/apps/openrosa/libs/serializers/data_serializer.py
+++ b/kobo/apps/openrosa/libs/serializers/data_serializer.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import json
 
 from django.utils.translation import gettext as t
@@ -7,6 +6,7 @@ from rest_framework.exceptions import ParseError
 
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kpi.utils.mongo_helper import MongoHelper
 
 
@@ -33,10 +33,7 @@ class DataListSerializer(serializers.Serializer):
             return super().to_representation(obj)
 
         query_params = (request and request.query_params) or {}
-        query = {
-            ParsedInstance.USERFORM_ID:
-            '%s_%s' % (obj.user.username, obj.id_string)
-        }
+        query = {ParsedInstance.USERFORM_ID: get_mongo_userform_id(obj)}
         limit = query_params.get('limit', False)
         start = query_params.get('start', False)
         count = query_params.get('count', False)
@@ -44,8 +41,9 @@ class DataListSerializer(serializers.Serializer):
         try:
             query.update(json.loads(query_params.get('query', '{}')))
         except ValueError:
-            raise ParseError(t("Invalid query: %(query)s"
-                             % {'query': query_params.get('query')}))
+            raise ParseError(
+                t('Invalid query: %(query)s' % {'query': query_params.get('query')})
+            )
 
         query_kwargs = {
             'query': json.dumps(query),
@@ -85,8 +83,7 @@ class DataInstanceSerializer(serializers.Serializer):
         request = self.context.get('request')
         query_params = (request and request.query_params) or {}
         query = {
-            ParsedInstance.USERFORM_ID:
-            '%s_%s' % (obj.xform.user.username, obj.xform.id_string),
+            ParsedInstance.USERFORM_ID: get_mongo_userform_id(obj.xform),
             '_id': obj.pk
         }
         query_kwargs = {

--- a/kobo/apps/openrosa/libs/utils/export_tools.py
+++ b/kobo/apps/openrosa/libs/utils/export_tools.py
@@ -684,8 +684,8 @@ def increment_index_in_filename(filename):
 
 
 def generate_attachments_zip_export(
-        export_type, extension, username, id_string, export_id=None,
-        filter_query=None):
+    export_type, extension, username, id_string, export_id=None, filter_query=None
+):
     xform = XForm.objects.get(user__username=username, id_string=id_string)
     attachments = Attachment.objects.filter(instance__xform=xform)
     basename = '%s_%s' % (id_string, datetime.now().strftime('%Y_%m_%d_%H_%M_%S'))

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -10,19 +10,18 @@ import traceback
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
+from wsgiref.util import FileWrapper
+from xml.dom import Node
 from xml.etree import ElementTree as ET
 from xml.parsers.expat import ExpatError
 from zoneinfo import ZoneInfo
-
-from wsgiref.util import FileWrapper
-from xml.dom import Node
 
 from dict2xml import dict2xml
 from django.conf import settings
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.files.base import File
 from django.core.mail import mail_admins
-from django.db import connection, IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
 from django.db.models import Q
 from django.http import (
     Http404,
@@ -41,10 +40,15 @@ from rest_framework.exceptions import NotAuthenticated
 
 from kobo.apps.openrosa.apps.logger.exceptions import (
     AccountInactiveError,
+    ConflictingSubmissionUUIDError,
+    DuplicateInstanceError,
     DuplicateUUIDError,
     FormInactiveError,
+    InstanceEmptyError,
     InstanceIdMissingError,
-    TemporarilyUnavailableError, ConflictingSubmissionUUIDError,
+    InstanceInvalidUserError,
+    InstanceMultipleNodeError,
+    TemporarilyUnavailableError,
 )
 from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, XForm
 from kobo.apps.openrosa.apps.logger.models.attachment import (
@@ -62,12 +66,6 @@ from kobo.apps.openrosa.apps.logger.signals import (
     update_xform_monthly_counter,
     update_xform_submission_count,
 )
-from kobo.apps.openrosa.apps.logger.exceptions import (
-    DuplicateInstanceError,
-    InstanceEmptyError,
-    InstanceInvalidUserError,
-    InstanceMultipleNodeError,
-)
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     clean_and_parse_xml,
     get_deprecated_uuid_from_xml,
@@ -79,6 +77,7 @@ from kobo.apps.openrosa.apps.viewer.models.data_dictionary import DataDictionary
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.utils import common_tags
 from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator, set_uuid
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
@@ -480,9 +479,8 @@ def mongo_sync_status(remongo=False, update_all=False, user=None, xform=None):
     report_string = ''
     for xform in queryset_iterator(qs, 100):
         # get the count
-        user = xform.user
         instance_count = Instance.objects.filter(xform=xform).count()
-        userform_id = '%s_%s' % (user.username, xform.id_string)
+        userform_id = get_mongo_userform_id(xform)
         mongo_count = mongo_instances.count_documents(
             {common_tags.USERFORM_ID: userform_id},
             maxTimeMS=MongoHelper.get_max_time_ms()
@@ -493,7 +491,7 @@ def mongo_sync_status(remongo=False, update_all=False, user=None, xform=None):
                 'user: %s, id_string: %s\nInstance count: %d\t'
                 'Mongo count: %d\n---------------------------------'
                 '-----\n'
-                % (user.username, xform.id_string, instance_count, mongo_count)
+                % (xform.user.username, xform.id_string, instance_count, mongo_count)
             )
             report_string += line
             found += 1
@@ -961,9 +959,8 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
     instance_ids = set(
         [i.id for i in Instance.objects.only('id').filter(xform=xform)])
     sys.stdout.write('Total no of instances: %d\n' % len(instance_ids))
-    mongo_ids = set()
-    user = xform.user
-    userform_id = '%s_%s' % (user.username, xform.id_string)
+    userform_id = get_mongo_userform_id(xform)
+
     if only_update_missing:
         sys.stdout.write('Only updating missing mongo instances\n')
         mongo_ids = set(

--- a/kobo/apps/openrosa/libs/utils/viewer_tools.py
+++ b/kobo/apps/openrosa/libs/utils/viewer_tools.py
@@ -1,13 +1,11 @@
-# coding: utf-8
-import os
 import logging
+import os
 import traceback
-import requests
 import zipfile
 from datetime import datetime
-
 from tempfile import NamedTemporaryFile
 
+import requests
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.core.files.uploadedfile import InMemoryUploadedFile
@@ -19,7 +17,7 @@ from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
 
-SLASH = "/"
+SLASH = '/'
 
 
 class MyError(Exception):
@@ -34,6 +32,16 @@ def format_date_for_mongo(x):
     return datetime.strptime(x, '%y_%m_%d_%H_%M_%S').strftime(
         '%Y-%m-%dT%H:%M:%S'
     )
+
+
+def get_mongo_userform_id(xform: 'logger.XForm', username: str = None) -> str:
+    # Auto-detect the username from the XForm if it is not provided.
+    # Avoids an additional query on the User model when the username is already
+    # available.
+    if not username:
+        username = xform.user.username
+
+    return xform.mongo_uuid or f'{username}_{xform.id_string}'
 
 
 def get_optimized_image_path(path: str, suffix: str) -> str:
@@ -60,9 +68,11 @@ def image_urls_dict(instance):
 def report_exception(subject, info, exc_info=None):
     if exc_info:
         cls, err = exc_info[:2]
-        info += t("Exception in request: %(class)s: %(error)s") \
-            % {'class': cls.__name__, 'error': err}
-        info += "".join(traceback.format_exception(*exc_info))
+        info += t('Exception in request: %(class)s: %(error)s') % {
+            'class': cls.__name__,
+            'error': err,
+        }
+        info += ''.join(traceback.format_exception(*exc_info))
 
     if settings.DEBUG:
         print(subject, flush=True)
@@ -223,7 +233,7 @@ def create_attachments_zipfile(attachments, output_file=None):
                         )
                 except Exception as e:
                     report_exception(
-                        "Error adding file \"{}\" to archive.".format(
+                        'Error adding file "{}" to archive.'.format(
                             attachment.media_file.name
                         ),
                         e,

--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -4,14 +4,11 @@ from copy import deepcopy
 
 from django.utils.translation import gettext as t
 from rest_framework import serializers
-from formpack import FormPack
 
+from formpack import FormPack
 from kpi.utils.bugfix import repair_file_column_content_and_save
 from kpi.utils.log import logging
-from .constants import (
-    FUZZY_VERSION_ID_KEY,
-    INFERRED_VERSION_ID_KEY,
-)
+from .constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY
 
 
 def build_formpack(asset, submission_stream=None, use_all_form_versions=True):
@@ -100,10 +97,6 @@ def build_formpack(asset, submission_stream=None, use_all_form_versions=True):
         return submission
 
     if submission_stream is None:
-        _userform_id = asset.deployment.mongo_userform_id
-        if not _userform_id.startswith(asset.owner.username):
-            raise Exception('asset has unexpected `mongo_userform_id`')
-
         submission_stream = asset.deployment.get_submissions(user=asset.owner)
 
     submission_stream = (
@@ -137,15 +130,13 @@ def data_by_identifiers(asset, field_names=None, submission_stream=None,
     if field_names is None:
         field_names = fields_by_name.keys()
     if split_by and (split_by not in fields_by_name):
-        raise serializers.ValidationError({
-            'split_by': t("`{}` not found.").format(split_by)
-        })
+        raise serializers.ValidationError(
+            {'split_by': t('`{}` not found.').format(split_by)}
+        )
     if split_by and (fields_by_name[split_by].data_type != 'select_one'):
-        raise serializers.ValidationError({
-            'split_by':
-                t("`{}` is not a select one question.").format(
-                    split_by)
-        })
+        raise serializers.ValidationError(
+            {'split_by': t('`{}` is not a select one question.').format(split_by)}
+        )
     if report_styles is None:
         report_styles = asset.report_styles
     specified_styles = report_styles.get('specified', {})

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -38,6 +38,7 @@ from kobo.apps.openrosa.apps.logger.utils.instance import (
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kobo.apps.openrosa.apps.main.models import MetaData, UserProfile
 from kobo.apps.openrosa.libs.utils.logger_tools import create_instance, publish_xls_form
+from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kobo.apps.subsequences.utils import stream_with_extras
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.constants import (
@@ -69,7 +70,6 @@ from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
-
 from ..exceptions import BadFormatException
 from .base_backend import BaseDeploymentBackend
 from .kc_access.utils import assign_applicable_kc_permissions, kc_transaction_atomic
@@ -747,10 +747,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
     @property
     def mongo_userform_id(self):
-        return (
-            self.xform.mongo_uuid
-            or f'{self.asset.owner.username}_{self.xform_id_string}'
-        )
+        return get_mongo_userform_id(self.xform, self.asset.owner.username)
 
     @staticmethod
     def nlp_tracking_data(


### PR DESCRIPTION
### 📣 Summary
Updated the MongoDB management commands to correctly handle documents using the new `_user_formid` based on the mongo_uuid field of the project.


### 📖 Description
The MongDB utilities, used to restore MongoDB collections from PostgreSQL, was previously ignoring documents that used the new `_user_formid` value, which is based on the project's `mongo_uuid field.

This update ensures that documents saved with the new user_formid format are properly detected and synchronized, avoiding missing submissions during the restoration process.


### 👀 Preview steps

Bug template:
1. create project
2. add submissions
3. Transfer the project to someone
4. delete one MongoDB document from the  shell (i.e.: `settings.MONGO_DB.instances.delete_one({'_id': 'submission_id'})`
5. run `./manage.py sync_mongo --remongo username xform_id_string`
6. Ensure the documents are restored with correct value for `_userform_id` (should be equal to `xform.mongo_uuid`) 

