### PR TITLE
fix(projectOwnershipTransfer): submissions are not transferred to new owner

### DIFF
--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -537,12 +537,14 @@ class MongoHelper:
 
         command = {
             'update': cls.COLLECTION,
-            'updates': [{
-                'q': query,
-                'u': safe_update,
-                'multi': many,
-            }],
-            'maxTimeMS': cls.get_max_time_ms()
+            'updates': [
+                {
+                    'q': query,
+                    'u': safe_update,
+                    'multi': many,
+                }
+            ],
+            'maxTimeMS': cls.get_max_time_ms(),
         }
         result = settings.MONGO_DB.command(command)
 

--- a/kpi/utils/mongo_helper.py
+++ b/kpi/utils/mongo_helper.py
@@ -458,6 +458,25 @@ class MongoHelper:
         return False
 
     @classmethod
+    def _normalize_update(cls, update: dict) -> dict:
+        """
+        Normalize a MongoDB update to ensure it uses update operators like $set.
+
+        If the update dict already uses an operator (e.g., $set, $unset), it is
+        returned as-is.
+        If not, it wraps the update inside a $set operator.
+        """
+        # Check if the first key is an operator (starts with "$")
+        first_key = next(iter(update), None)
+
+        if first_key is not None and first_key.startswith('$'):
+            # Update already uses an operator, return as-is
+            return update
+
+        # Otherwise, wrap inside $set
+        return {'$set': update}
+
+    @classmethod
     def _raw_delete(cls, query: dict, many: bool = True) -> int:
         """
         PyMongo's delete_one and delete_many methods do not support maxTimeMS queries.
@@ -514,11 +533,13 @@ class MongoHelper:
                 'modified_count': result.modified_count,
             }
 
+        safe_update = cls._normalize_update(update)
+
         command = {
             'update': cls.COLLECTION,
             'updates': [{
                 'q': query,
-                'u': update,
+                'u': safe_update,
                 'multi': many,
             }],
             'maxTimeMS': cls.get_max_time_ms()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Corrected the Mongo helper to avoid the "multi update is not supported" error when performing bulk updates.



### 📖 Description
The MongoDB helper for bulk updates (`update_many`) was incorrectly structured, leading to a "multi update is not supported" error when attempting to update multiple documents at once.

This fix ensures that the helper uses the correct command format, allowing updates to multiple records without triggering this MongoDB validation error.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project
2. add submissions 
3. transfer the project to someone else
4. 🔴 [on release branch] notice that data table is empty (for new and older owner)
    1. use the shell to see that the query did not update anything. `list(settings.MONGO_DB.instances.find({'_userform_id': '<previous_owner_username>_<xform_id_string>'}))` does return all data. (it should not) 
5. 🟢 [on PR] notice that data is there (**do not forget to restart your worker containers**)
    1. use the shell to see that the query did update the records. `list(settings.MONGO_DB.instances.find({'_userform_id': '<previous_owner_username>_<xform_id_string>'}))` returns an empty list. list(settings.MONGO_DB.instances.find({'_userform_id': '<asset.deployment.xform.mongo_uuid>'})) returns all the data
