### PR TITLE
fix(mongoSync): do not double-save new parsed instances

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -983,21 +983,22 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
     done = 0
     for id_, instance in instances.items():
         (pi, created) = ParsedInstance.objects.get_or_create(instance=instance)
-        try:
-            save_success = pi.save(asynchronous=False)
-        except InstanceEmptyError:
-            print(
-                '\033[91m[WARNING] - Skipping Instance #{}/uuid:{} because '
-                'it is empty\033[0m'.format(id_, instance.uuid)
-            )
-        else:
-            if not save_success:
+        if not created:
+            try:
+                save_success = pi.save(asynchronous=False)
+            except InstanceEmptyError:
                 print(
-                    '\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save '
-                    'the parsed instance\033[0m'.format(id_, instance.uuid)
+                    '\033[91m[WARNING] - Skipping Instance #{}/uuid:{} because '
+                    'it is empty\033[0m'.format(id_, instance.uuid)
                 )
             else:
-                done += 1
+                if not save_success:
+                    print(
+                        '\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save '
+                        'the parsed instance\033[0m'.format(id_, instance.uuid)
+                    )
+                else:
+                    done += 1
 
         progress = '\r%.2f %% done...' % ((float(done) / float(total)) * 100)
         sys.stdout.write(progress)

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -983,22 +983,24 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
     done = 0
     for id_, instance in instances.items():
         (pi, created) = ParsedInstance.objects.get_or_create(instance=instance)
-        if not created:
-            try:
-                save_success = pi.save(asynchronous=False)
-            except InstanceEmptyError:
+        if created:
+            done += 1
+            continue
+        try:
+            save_success = pi.save(asynchronous=False)
+        except InstanceEmptyError:
+            print(
+                '\033[91m[WARNING] - Skipping Instance #{}/uuid:{} because '
+                'it is empty\033[0m'.format(id_, instance.uuid)
+            )
+        else:
+            if not save_success:
                 print(
-                    '\033[91m[WARNING] - Skipping Instance #{}/uuid:{} because '
-                    'it is empty\033[0m'.format(id_, instance.uuid)
+                    '\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save '
+                    'the parsed instance\033[0m'.format(id_, instance.uuid)
                 )
             else:
-                if not save_success:
-                    print(
-                        '\033[91m[ERROR] - Instance #{}/uuid:{} - Could not save '
-                        'the parsed instance\033[0m'.format(id_, instance.uuid)
-                    )
-                else:
-                    done += 1
+                done += 1
 
         progress = '\r%.2f %% done...' % ((float(done) / float(total)) * 100)
         sys.stdout.write(progress)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging



### 💭 Notes
Dev-only change. Since `get_or_create` calls `save()` when new ParsedInstances are created, it is redundant to call `save()` again afterwards if a new object was created, so this PR updates the process to only call `save()` if dealing with an existing record.


### 👀 Preview steps

1. ℹ️ have an account and a project
2. Make sure the project has submissions
3. In a kpi python shell, run `ParsedInstance.objects.filter(instance__xform__id_string=<xform id>).delete()` 
4. In the kpi container, run `./manage.py sync_mongo -a -r`
5. In a mongosh shell, run `use formhub,` then `db.instances.find({'_xform_id_string': <xform id>})` 
6. 🟢 all submissions should be present in mongo

