### PR TITLE
fix(projectOwnershipTransfer): make transfer more resilient by catching exceptions

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0003_transfer_members_data_ownership_to_org.py
+++ b/kobo/apps/long_running_migrations/jobs/0003_transfer_members_data_ownership_to_org.py
@@ -20,4 +20,6 @@ def run():
                 owner_id=OuterRef('pk')
             )
         ).exclude(pk=organization.owner_user_object.pk):
+            if not Asset.objects.filter(owner_id=user.pk).exists():
+                continue
             transfer_member_data_ownership_to_org(user.pk)

--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -10,6 +10,7 @@ from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.main.models import MetaData
 from kobo.apps.project_ownership.models import InviteStatusChoices
 from kpi.models.asset import Asset, AssetFile
+from kpi.utils.log import logging
 from .constants import ASYNC_TASK_HEARTBEAT
 from .exceptions import AsyncTaskException
 from .models.choices import TransferStatusChoices, TransferStatusTypeChoices
@@ -98,6 +99,7 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
 
     heartbeat = int(time.time())
     # Moving files is pretty slow, thus it should run in a celery task.
+    errors = False
     for attachment in attachments.iterator():
         if not (
             target_folder := get_target_folder(
@@ -111,10 +113,19 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
             # There is no way to ensure atomicity when moving the file and saving the
             # object to the database. Fingers crossed that the process doesn't get
             # interrupted between these two operations.
-            attachment.media_file.move(target_folder)
-            attachment.save(update_fields=['media_file'])
+            if attachment.media_file.move(target_folder):
+                attachment.save(update_fields=['media_file'])
+            else:
+                errors = True
+                logging.error(
+                    f'File {attachment.media_file_basename} (#{attachment.pk}) '
+                    f'could not be moved to {target_folder}'
+                )
 
             heartbeat = _update_heartbeat(heartbeat, transfer, async_task_type)
+
+    if errors:
+        raise AsyncTaskException('Some attachments could not be moved')
 
     _mark_task_as_successful(transfer, async_task_type)
 

--- a/kpi/fields/file.py
+++ b/kpi/fields/file.py
@@ -8,7 +8,7 @@ from storages.backends.s3 import ClientError, S3Storage
 
 class ExtendedFieldFile(FieldFile):
 
-    def move(self, target_folder: str):
+    def move(self, target_folder: str) -> bool:
 
         old_path = self.name
         filename = os.path.basename(old_path)


### PR DESCRIPTION
### 📣 Summary
Improved the robustness of the project ownership transfer process by catching and handling exceptions.


### 📖 Description
This update enhances the resilience of the project ownership transfer process by catching exceptions that may occur during the transfer of individual resources (e.g., assets, attachments, submissions).

Instead of failing the entire transfer due to a single error, the system now logs the exception and proceeds with the remaining steps. This ensures that most of the transfer completes successfully, reducing manual recovery efforts.


### 💭 Notes
Improvements: 
- Does not try to transfer member's project to org if user does not any
- Detects if Asset object has a valid XForm counterpart, flags the transfer as failed.
- Detects if the recipient has already a project with the same id_string (could be possible with old project)  - in `logger_xform` table, flags the transfer as failed


### 👀 Preview steps

Bug template:

**First case:**
1. ℹ️ have an account and two projects with attachments
2. Add several submissions to both
3. From the shell, load the first related asset, find its xForm (`xf = a.deployment.xform`). Delete it. If it does not work from the shell, do it directly in the PostgreSQL with psql
4. Add the user to an MMO
5. 🔴 [on release branch] notice the transfer fails abruptly, the second project is not transferred
6. 🟢 [on PR] notice that the first transfer fails gracefully, the second project is transferred

**Second case:**
1. ℹ️ have an account and one project with attachments
2. Add several submissions
3. From the shell, load the first attachment of the first submission, delete the related file from the storage
4. Transfer the project to another user
5. 🔴 [on release branch] notice the transfer fails abruptly, none of the other attachments are transferred
6. 🟢 [on PR] notice the transfer keeps going, error is logged and all other attachments are transferred