### PR TITLE
perf(projectOwnershipTransfer): optimize database queries to retrieve project names faster in Admin UI

### DIFF
--- a/kobo/apps/project_ownership/admin.py
+++ b/kobo/apps/project_ownership/admin.py
@@ -1,13 +1,45 @@
+from collections import defaultdict
+
 from django.contrib import admin
 from django.utils.html import linebreaks
 from django.utils.safestring import mark_safe
 
-from .models import Invite
+from .models import Invite, Transfer
+from .models.invite import InviteType
 from .models.transfer import TransferStatusTypeChoices
+
+
+class InviteTypeFilter(admin.SimpleListFilter):
+    # Human-readable title which will be displayed in the
+    # right admin sidebar just above the filter options.
+    title = 'Invite type'
+
+    # Parameter for the filter that will be used in the URL query.
+    parameter_name = 'invite_type'
+
+    def lookups(self, request, model_admin):
+        return InviteType.choices
+
+    def queryset(self, request, queryset):
+        """
+        Returns the filtered queryset based on the value
+        provided in the query string and retrievable via
+        `self.value()`.
+        """
+        if self.value():
+            return queryset.filter(invite_type=self.value())
+
+        return None
 
 
 @admin.register(Invite)
 class InviteAdmin(admin.ModelAdmin):
+
+    list_filter = [InviteTypeFilter]
+    search_fields = [
+        'transfers__asset__name',
+        'transfers__asset__uid',
+    ]
 
     list_display = (
         'get_projects',
@@ -43,15 +75,26 @@ class InviteAdmin(admin.ModelAdmin):
     class Media:
         css = {'all': ('admin/css/transfers_as_inline.css',)}
 
+    def changelist_view(self, request, extra_context=None):
+        response = super().changelist_view(request, extra_context)
+
+        try:
+            cl = response.context_data['cl']  # ChangeList instance
+            self._get_cached_asset_names_by_invite(list(cl.result_list))
+        except (AttributeError, KeyError):
+            self._asset_names_by_invite = {}
+
+        return response
+
     def get_queryset(self, request):
         return Invite.all_objects.all()
 
     @admin.display(description='Projects')
     def get_projects(self, obj):
-        transfers = []
-        for transfer in obj.transfers.all():
-            transfers.append(transfer.asset.name)
-        return mark_safe(linebreaks('\n'.join(transfers)))
+
+        return mark_safe(
+           linebreaks('\n'.join(self._asset_names_by_invite.get(obj.id, [])))
+        )
 
     def get_transfers(self, obj):
         html = '<ul>'
@@ -81,3 +124,20 @@ class InviteAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def _get_cached_asset_names_by_invite(
+        self, paginated_invites: list[Invite]
+    ) -> dict[int, list[str]]:
+        invite_ids = [invite.pk for invite in paginated_invites]
+
+        rows = (
+            Transfer.objects.filter(invite_id__in=invite_ids)
+            .select_related('asset')
+            .values_list('invite_id', 'asset__name')
+        )
+
+        asset_map = defaultdict(list)
+        for invite_id, asset_name in rows:
+            asset_map[invite_id].append(asset_name or '-')
+
+        self._asset_names_by_invite = dict(asset_map)

--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -15,7 +15,8 @@ from .choices import InviteStatusChoices
 
 class InviteType(models.TextChoices):
     ORG_MEMBERSHIP = 'org-membership'
-    ORG_OWNERSHIP_TRANSFER = 'org-ownership-transfer'
+    # Not implemented yet:
+    # ORG_OWNERSHIP_TRANSFER = 'org-ownership-transfer'
     USER_OWNERSHIP_TRANSFER = 'user-ownership-transfer'
 
 


### PR DESCRIPTION
### 📣 Summary
Reduced the number of database queries and response time for listing transferred projects in Admin UI

### 📖 Description
This PR optimizes those queries, significantly reducing database load and improving UI responsiveness — especially in organizations with a large number of projects.


### 👀 Preview steps
Hard to test without a (very) large dataset
Use debug toolbar to see that the number of SQL queries decrease ( `DEBUG_TOOLBAR` env variable in `dev.py`)

snippet to create invites based on an existing one: 

```python
From the shell
i = Invite.objects.last()
transfers = list(i.transfers.all())
for j in range(20000):
     i.pk = None
     i.uid = None
     i.save()
     for t in transfers:
         t.pk = None
         t.uid = None
         t.invite = i
         t.save()
```


Bug template:
1. Open http://kf/admin/project_ownership/invite
2. Look at debug tool bar menu
4. 🔴 [on release branch] notice the number of queries is high
5. 🟢 [on PR] notice the number of queries is low

Locally with 20000, it went down from 200~ish to ~10. With production, the page load went from 78s to 1s. 