### PR TITLE
perf(mongoSync): speed up mongo sync 

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -17,8 +17,6 @@ from taggit.managers import TaggableManager
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import XLSFormError
-from kobo.apps.openrosa.apps.logger.xform_instance_parser import get_abbreviated_xpath, XFormInstanceParser
-from kobo.apps.openrosa.apps.viewer.models import ParsedInstance
 from kobo.apps.openrosa.koboform.pyxform_utils import convert_csv_to_xls
 from kobo.apps.openrosa.libs.constants import (
     CAN_ADD_SUBMISSIONS,
@@ -359,6 +357,3 @@ class XForm(AbstractTimeStampedModel):
                     return convert_csv_to_xls(ff.read())
                 else:
                     return BytesIO(ff.read())
-
-
-

--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -17,6 +17,8 @@ from taggit.managers import TaggableManager
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import XLSFormError
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import get_abbreviated_xpath, XFormInstanceParser
+from kobo.apps.openrosa.apps.viewer.models import ParsedInstance
 from kobo.apps.openrosa.koboform.pyxform_utils import convert_csv_to_xls
 from kobo.apps.openrosa.libs.constants import (
     CAN_ADD_SUBMISSIONS,
@@ -357,3 +359,6 @@ class XForm(AbstractTimeStampedModel):
                     return convert_csv_to_xls(ff.read())
                 else:
                     return BytesIO(ff.read())
+
+
+

--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -167,10 +167,9 @@ class XForm(AbstractTimeStampedModel):
 
         if not use_cache:
             return DataDictionary.all_objects.get(pk=self.pk)
-
+        fields = [field.name for field in self._meta.get_fields()]
         xform_dict = deepcopy(self.__dict__)
-        xform_dict.pop('_state', None)
-        xform_dict.pop('_cached_asset', None)
+        xform_dict = { key: val for key, val in xform_dict.items() if key in fields}
         return DataDictionary(**xform_dict)
 
     def file_name(self):

--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -169,7 +169,7 @@ class XForm(AbstractTimeStampedModel):
             return DataDictionary.all_objects.get(pk=self.pk)
         fields = [field.name for field in self._meta.get_fields()]
         xform_dict = deepcopy(self.__dict__)
-        xform_dict = { key: val for key, val in xform_dict.items() if key in fields}
+        xform_dict = {key: val for key, val in xform_dict.items() if key in fields}
         return DataDictionary(**xform_dict)
 
     def file_name(self):

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -295,27 +295,28 @@ def _get_all_attributes(node):
 
 class XFormInstanceParser:
 
-    def __init__(self, xml_str, data_dictionary):
+    def __init__(self, xml_str, data_dictionary, delay_parse=False):
         self.dd = data_dictionary
         # The two following variables need to be initialized in the constructor, in case parsing fails.
         self._flat_dict = {}
         self._attributes = {}
-        try:
-            self.parse(xml_str)
-        except Exception as e:
-            logging.error(
-                f"Failed to parse instance '{xml_str}'", exc_info=True
-            )
-            # `self.parse()` has been wrapped in to try/except but it makes the
-            # exception silently ignored.
-            # `logger_tool.py::safe_create_instance()` needs the exception
-            # to return the correct HTTP code
-            six.reraise(*sys.exc_info())
+        if not delay_parse:
+            try:
+                self.parse(xml_str)
+            except Exception as e:
+                logging.error(
+                    f"Failed to parse instance '{xml_str}'", exc_info=True
+                )
+                # `self.parse()` has been wrapped in to try/except but it makes the
+                # exception silently ignored.
+                # `logger_tool.py::safe_create_instance()` needs the exception
+                # to return the correct HTTP code
+                six.reraise(*sys.exc_info())
 
-    def parse(self, xml_str):
+    def parse(self, xml_str, repeats=None):
         self._xml_obj = clean_and_parse_xml(xml_str)
         self._root_node = self._xml_obj.documentElement
-        repeats = [
+        repeats = repeats or [
             get_abbreviated_xpath(e)
             for e in self.dd.get_survey_elements_of_type('repeat')
         ]

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -300,18 +300,19 @@ class XFormInstanceParser:
         # The two following variables need to be initialized in the constructor, in case parsing fails.
         self._flat_dict = {}
         self._attributes = {}
-        if not delay_parse:
-            try:
-                self.parse(xml_str)
-            except Exception as e:
-                logging.error(
-                    f"Failed to parse instance '{xml_str}'", exc_info=True
-                )
-                # `self.parse()` has been wrapped in to try/except but it makes the
-                # exception silently ignored.
-                # `logger_tool.py::safe_create_instance()` needs the exception
-                # to return the correct HTTP code
-                six.reraise(*sys.exc_info())
+        if delay_parse:
+            return
+        try:
+            self.parse(xml_str)
+        except Exception as e:
+            logging.error(
+                f"Failed to parse instance '{xml_str}'", exc_info=True
+            )
+            # `self.parse()` has been wrapped in to try/except but it makes the
+            # exception silently ignored.
+            # `logger_tool.py::safe_create_instance()` needs the exception
+            # to return the correct HTTP code
+            six.reraise(*sys.exc_info())
 
     def parse(self, xml_str, repeats=None):
         self._xml_obj = clean_and_parse_xml(xml_str)

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -316,10 +316,11 @@ class XFormInstanceParser:
     def parse(self, xml_str, repeats=None):
         self._xml_obj = clean_and_parse_xml(xml_str)
         self._root_node = self._xml_obj.documentElement
-        repeats = repeats or [
-            get_abbreviated_xpath(e)
-            for e in self.dd.get_survey_elements_of_type('repeat')
-        ]
+        if repeats is None:
+            repeats = [
+                get_abbreviated_xpath(e)
+                for e in self.dd.get_survey_elements_of_type('repeat')
+            ]
         self._dict = _xml_node_to_dict(self._root_node, repeats)
         if self._dict is None:
             raise InstanceEmptyError

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -63,6 +63,7 @@ def update_mongo_instance(record):
         raise Exception('Submission could not be saved to Mongo') from e
     return True
 
+
 class ParsedInstance(models.Model):
     USERFORM_ID = '_userform_id'
     STATUS = '_status'

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -352,7 +352,7 @@ class ParsedInstance(models.Model):
         return MongoHelper.delete_many(query)
 
     def to_dict(self):
-        if hasattr(self, '_mongo_dict_override') and self._mongo_dict_override is not None:
+        if hasattr(self, '_mongo_dict_override'):
             return self._mongo_dict_override
         if not hasattr(self, '_dict_cache'):
             self._dict_cache = self.instance.get_dict()

--- a/kobo/apps/openrosa/apps/viewer/tests/test_remongo.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_remongo.py
@@ -1,14 +1,17 @@
 # coding: utf-8
 import os
+from unittest.mock import patch
 
 from django.conf import settings
 from django.core.management import call_command
 from django_digest.test import DigestAuth
+from mock.mock import PropertyMock
 
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.viewer.management.commands.remongo import Command
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.utils.common_tags import USERFORM_ID
+from kobo.apps.openrosa.libs.utils.logger_tools import _update_mongo_for_xform
 from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 
 
@@ -22,7 +25,7 @@ class TestRemongo(TestBase):
         settings.MONGO_DB.instances.drop()
         c = Command()
         c.handle(batchsize=3)
-        # mongo db should now have 5 records
+        # mongo db should now have 4 records
         count = settings.MONGO_DB.instances.count_documents(filter={})
         self.assertEqual(count, 4)
 
@@ -117,3 +120,21 @@ class TestRemongo(TestBase):
             {USERFORM_ID: userform_id})
         self.assertEqual(mongo_count,
                          initial_mongo_count + len(self.surveys))
+
+    def test_sync_mongo_only_parses_xform_once(self):
+        self._publish_transportation_form()
+        # submit 4 instances
+        self._make_submissions()
+        self.assertEqual(ParsedInstance.objects.count(), 4)
+        patched_data_dict = self.xform.data_dictionary(use_cache=True)
+        # get_survey is expensive, we only want to call it once per xform
+        patched_get_survey = PropertyMock(wraps=patched_data_dict.get_survey)
+
+        with patch(
+            'kobo.apps.openrosa.apps.viewer.models.data_dictionary.DataDictionary.get_survey',  # noqa: E501
+            new_callable=patched_get_survey,
+        ):
+            # calling the command directly puts us in mocking hell, so just
+            # call the important internal method
+            _update_mongo_for_xform(self.xform, only_update_missing=False)
+        patched_get_survey.assert_called_once()

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -1020,7 +1020,6 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
                 'it is empty\033[0m'.format(id_, instance.uuid)
             )
 
-
         progress = '\r%.2f %% done...' % ((float(done) / float(total)) * 100)
         sys.stdout.write(progress)
         sys.stdout.flush()

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -955,6 +955,7 @@ def _has_edit_xform_permission(
 
 
 def _update_mongo_for_xform(xform, only_update_missing=True):
+    xform.refresh_from_db(fields=xform.get_deferred_fields())
 
     instance_ids = set(
         [i.id for i in Instance.objects.only('id').filter(xform=xform)])
@@ -978,7 +979,7 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
 
     # get instances
     sys.stdout.write('Total no of instances to update: %d\n' % len(instance_ids))
-    instances = Instance.objects.only('id', 'xml').in_bulk([id_ for id_ in instance_ids])
+    instances = Instance.objects.only('id', 'xml', 'json').in_bulk([id_ for id_ in instance_ids])
     total = len(instances)
     done = 0
 
@@ -988,6 +989,7 @@ def _update_mongo_for_xform(xform, only_update_missing=True):
         parser = XFormInstanceParser(instance.xml, data_dictionary=None, delay_parse=True)
         parser.parse(instance.xml, repeats=repeat_groups)
         as_dict = parser.get_flat_dict_with_attributes()
+        breakpoint()
         try:
             (pi, created) = ParsedInstance.objects.get_or_create(instance=instance, defaults={'mongo_dict_override': as_dict})
             if not created:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Improve performance of `sync_mongo` job.


### 💭 Notes
One major inefficiency in the sync_mongo job was that every ParsedInstance needed to dict-ify itself in isolation, which requires information that can only be obtained by parsing the XForm. The ParsedInstances had no way of sharing the information from the XForm, even though it was the same every time, so the job ended up parsing the XForm again for every single ParsedInstance, which is very slow for large XForms.

This PR allows creating the dict version of a submission to be done outside the ParsedInstance.save() code, then have the ParsedInstance use the pre-made dict to create the mongo entry. This means that the code for creating the dict version can share information not available inside the ParsedInstance itself. Specifically, we can determine the repeating groups ahead of time, which is the only reason we actually need to parse the XForm.

Eventually, this could use a larger refactor to make it easier to debug. Right now, pi.save() calls a very long chain of methods that goes through Instance, XFormInstanceParser, and DataDictionary, with necessary data cached on different objects and sometimes inaccessible to the calling object. It's conceivable we could get rid of ParsedInstance, XFormInstanceParser, and DataDictionary altogether and just get the information we need from XForm and Instance objects. ParsedInstance and XFormInstanceParser are basically layers on top of Instance, and DataDictionary is basically a layer on top of XForm.

### 👀 Preview steps

On both the release branch and the PR branch:
1. ℹ️ have account and a large project with at least one repeating group (see internal [example](https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Inefficency.20of.20ParsedInstance.2Esave.28.29/near/602833))
2. Create about ~10 submissions (should be enough to see the time difference).
3. Note: if you're using the xls provided, the easiest way to make 10 submissions without having to go through a massive form is to select 'PAP type: MST'. This form has been modified from the one originally taken from prod. It may also be faster to just create one or two submissions and then use the `api/v2/assets/uid/data/id/duplicate` endpoint to copy them as what's in the submission is not terribly important
4. Run the Django IPython shell
5. `from django.core.management import call_command`
6. `time call_command('sync_mongo', '-a', '-r', <username>, <project uid>)`
7. :green_circle: the process should be much faster on the PR branch than on main
8. In the mongo container, run `mongoexport --db=formhub --collection=instances --query='{"_xform_id_string": "<uid>"}' --out=/tmp/instances.json` and copy the results locally
9. Once you have copied both .jsons locally, compare them using your favorite diff tool to make sure they are the same 


