### PR TITLE
fix(submissions): fix media question parsing bug causing silent data loss with appearance attribute

### DIFF
--- a/kobo/apps/openrosa/apps/main/tests/fixtures/signature/project_with_ref_after.xml
+++ b/kobo/apps/openrosa/apps/main/tests/fixtures/signature/project_with_ref_after.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:ev="http://www.w3.org/2001/xml-events"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms"
+        xmlns:odk="http://www.opendatakit.org/xforms">
+  <h:head>
+    <h:title>Project with 2 attachments</h:title>
+    <model odk:xforms-version="1.0.0">
+      <instance>
+        <project_with_ref_after id="project_with_ref_after" version="1 (2025-04-30 20:19:50)">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <start/>
+          <end/>
+          <image/>
+          <signature/>
+          <__version__/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </project_with_ref_after>
+      </instance>
+
+      <bind nodeset="/project_with_ref_after/start" jr:preload="timestamp" type="dateTime" jr:preloadParams="start"/>
+
+      <bind nodeset="/project_with_ref_after/end" jr:preload="timestamp" type="dateTime" jr:preloadParams="end"/>
+
+      <bind nodeset="/project_with_ref_after/image" type="binary" required="false()"/>
+
+      <bind nodeset="/project_with_ref_after/signature" type="binary" required="false()" orx:max-pixels="1024"/>
+
+      <bind nodeset="/project_with_ref_after/__version__" type="string" calculate="\'vugu7d2UrKF8UNcnBkF2Gv\'"/>
+
+      <bind nodeset="/project_with_ref_after/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+
+      <bind nodeset="/project_with_ref_after/formhub/uuid" type="string" calculate="\'6ec7e72ee2944696bbca46b677db03b2\'"/>
+
+    </model>
+
+  </h:head>
+
+  <h:body>
+    <upload mediatype="image/*" ref="/project_with_ref_after/image">
+      <label>image</label>
+    </upload>
+
+    <upload
+      mediatype="image/*"
+      appearance="signature"
+      ref="/project_with_ref_after/signature"
+    >
+      <label>signature</label>
+    </upload>
+
+  </h:body>
+
+</h:html>

--- a/kobo/apps/openrosa/apps/main/tests/fixtures/signature/project_with_ref_before.xml
+++ b/kobo/apps/openrosa/apps/main/tests/fixtures/signature/project_with_ref_before.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:ev="http://www.w3.org/2001/xml-events"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms"
+        xmlns:odk="http://www.opendatakit.org/xforms">
+  <h:head>
+    <h:title>Project with 2 attachments</h:title>
+    <model odk:xforms-version="1.0.0">
+      <instance>
+        <project_with_ref_before id="project_with_ref_before" version="1 (2025-04-30 20:19:50)">
+          <formhub>
+            <uuid/>
+          </formhub>
+          <start/>
+          <end/>
+          <image/>
+          <signature/>
+          <__version__/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </project_with_ref_before>
+      </instance>
+
+      <bind nodeset="/project_with_ref_before/start" jr:preload="timestamp" type="dateTime" jr:preloadParams="start"/>
+
+      <bind nodeset="/project_with_ref_before/end" jr:preload="timestamp" type="dateTime" jr:preloadParams="end"/>
+
+      <bind nodeset="/project_with_ref_before/image" type="binary" required="false()"/>
+
+      <bind nodeset="/project_with_ref_before/signature" type="binary" required="false()" orx:max-pixels="1024"/>
+
+      <bind nodeset="/project_with_ref_before/__version__" type="string" calculate="\'vugu7d2UrKF8UNcnBkF2Gv\'"/>
+
+      <bind nodeset="/project_with_ref_before/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
+
+      <bind nodeset="/project_with_ref_before/formhub/uuid" type="string" calculate="\'6ec7e72ee2944696bbca46b677db03b2\'"/>
+
+    </model>
+
+  </h:head>
+
+  <h:body>
+    <upload ref="/project_with_ref_before/image" mediatype="image/*">
+      <label>image</label>
+    </upload>
+
+    <upload
+      ref="/project_with_ref_before/signature"
+      mediatype="image/*"
+      appearance="signature"
+    >
+      <label>signature</label>
+    </upload>
+
+  </h:body>
+
+</h:html>


### PR DESCRIPTION
### 📣 Summary
Fixes a bug where media questions (e.g., images) could be silently ignored if their XML attributes were not in a specific order.

### 📖 Description
The previous logic assumed that the `ref` attribute would always appear immediately after the `mediatype` attribute in media upload questions. This assumption caused issues when the attribute order varied. For example, if `appearance` appeared between `mediatype` and `ref`, the parser would fail to detect the ref attribute, resulting in valid media questions being missed and their data silently dropped. This fix makes the parsing logic more flexible by detecting both attributes within the same node regardless of order, preventing silent data loss.

### Notes
Supersedes #5726 

### 👀 Preview steps
1. Add two image questions:
- Leave the first as-is.
- Set the second’s appearance to signature.
2. Deploy the form.
3. Open in Enketo, attach an image to the first, draw a signature for the second.
4. Submit, then check the data table in KPI. Both images should be present.
5. 🔴 [on `release/2.025.02`] notice that the first question's image is present, but the signature is missing
6. 🟢 [on PR] both images should be present.
