### PR TITLE
fix(permissions): hide `discover_asset` in the UI DEV-257

### DIFF
--- a/jsapp/js/components/permissions/userPermissionRow.component.tsx
+++ b/jsapp/js/components/permissions/userPermissionRow.component.tsx
@@ -16,6 +16,7 @@ import permConfig from './permConfig'
 import type { AssignablePermsMap } from './sharingForm.component'
 import UserAssetPermsEditor from './userAssetPermsEditor.component'
 import { getFriendlyPermName, getPermLabel } from './utils'
+import {PERMISSIONS_CODENAMES} from './permConstants'
 
 interface UserPermissionRowProps {
   assetUid: string
@@ -100,6 +101,12 @@ export default class UserPermissionRow extends React.Component<UserPermissionRow
     return (
       <bem.UserRow__perms>
         {permissions.map((perm) => {
+          // UI already shows if a collection is discoverable, and we should not explcitly assign this permission, so
+          // we display nothing if we run into it
+          if (perm.permission.includes(PERMISSIONS_CODENAMES.discover_asset)) {
+            return null
+          }
+
           const permLabel = getPermLabel(perm)
 
           const friendlyPermName = getFriendlyPermName(perm)

--- a/jsapp/js/components/permissions/userPermissionRow.component.tsx
+++ b/jsapp/js/components/permissions/userPermissionRow.component.tsx
@@ -13,10 +13,10 @@ import sessionStore from '#/stores/session'
 import { escapeHtml } from '#/utils'
 import { permissionsActions } from '../../actions/permissions'
 import permConfig from './permConfig'
+import { PERMISSIONS_CODENAMES } from './permConstants'
 import type { AssignablePermsMap } from './sharingForm.component'
 import UserAssetPermsEditor from './userAssetPermsEditor.component'
 import { getFriendlyPermName, getPermLabel } from './utils'
-import {PERMISSIONS_CODENAMES} from './permConstants'
 
 interface UserPermissionRowProps {
   assetUid: string


### PR DESCRIPTION
### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Fixes bug that displayed ??? in the collection sharing modal when giving a user Manage project permissions.

### 💭 Notes
Sharing modal was confused and displayed ??? for the `discover_asset` permission for collections. There are enough indicators for if a collection is public so we don't display anything for this permission.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. ℹ️ Create a collection
2. Share collection to another user
3. Give that user "Manage project" permissions
5. 🔴 [on main] notice that in the permissions row there is a ??? permission among the other assigned ones
6. 🟢 [on PR] notice that ??? is gone
