### PR TITLE
fix(projectTransfer): reset legacy project identifier to KPI identifier on transfer conflict DEV-253

### DIFF
--- a/kobo/apps/project_ownership/models/transfer.py
+++ b/kobo/apps/project_ownership/models/transfer.py
@@ -143,7 +143,7 @@ class Transfer(AbstractTimeStampedModel):
                         try:
                             xform = deployment.xform
                         except (InvalidXFormException, MissingXFormException):
-                            id_string = deployment.backend_response.get('id_string')
+                            id_string = deployment.xform_id_string
                             self.status = (
                                 TransferStatusChoices.FAILED,
                                 f'Project `{self.asset.uid}` could not be transferred '
@@ -151,33 +151,32 @@ class Transfer(AbstractTimeStampedModel):
                             )
                             return
 
-                        if XForm.objects.filter(
-                            id_string=xform.id_string,
-                            user_id=new_owner.pk,
-                        ).exists():
-                            self.status = (
-                                TransferStatusChoices.FAILED,
-                                f'Project `{self.asset.uid}` could not be transferred '
-                                f'because XForm IdString `{xform.id_string}`'
-                                f' for new owner (#{new_owner.pk}) already exists.',
-                            )
-                            return
-
                         with deployment.suspend_submissions(
                             [self.asset.owner_id, new_owner.pk]
                         ):
+                            old_id_string = None
+                            if XForm.objects.filter(
+                                id_string=xform.id_string,
+                                user_id=new_owner.pk,
+                            ).exists():
+                                old_id_string = xform.id_string
+                                deployment.reset_backend_response_id_string()
+
                             # Update counters
                             deployment.transfer_counters_ownership(new_owner)
                             previous_owner_username = self.asset.owner.username
                             self._reassign_project_permissions(
                                 update_deployment=True
                             )
-                            deployment.rename_enketo_id_key(previous_owner_username)
+                            deployment.rename_enketo_id_key(
+                                previous_owner_username, old_id_string
+                            )
 
                         self._sent_in_app_messages()
 
                     # Update `is_excluded_from_projects_list` flag
                     self._update_project_exclusion_flag()
+
             # Do not delegate anything to Celery before the transaction has
             # been validated. Otherwise, Celery could fetch outdated data.
             transaction.on_commit(lambda: self._start_async_jobs(_rewrite_mongo))

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -422,7 +422,9 @@ class BaseDeploymentBackend(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def rename_enketo_id_key(self, previous_owner_username: str):
+    def rename_enketo_id_key(
+        self, previous_owner_username: str, project_identifier: str = None
+    ):
         pass
 
     def save_to_db(self, updates: dict, update_date_modified=True):

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -872,7 +872,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             enketo_redis_client = get_redis_connection('enketo_redis_main')
             enketo_redis_client.rename(
                 src=f'or:{domain_name}/{previous_owner_username},{project_identifier}',
-                dst=f'or:{domain_name}/{self.asset.owner.username},{self.xform.id_string}',
+                dst=f'or:{domain_name}/{self.asset.owner.username},{self.xform.id_string}',  # noqa E501
             )
         except InvalidCacheBackendError:
             # TODO: This handles the case when the cache is disabled and
@@ -1320,9 +1320,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             mongo_query = {
                 '$or': [
                     {'_userform_id': f'{previous_owner_username}_{previous_id_string}'},
-                    {
-                        '_userform_id': f'{previous_owner_username}_{self.xform_id_string}'
-                    },  # noqa
+                    {'_userform_id': f'{previous_owner_username}_{self.xform_id_string}'},  # noqa E501
                 ],
             }
         else:

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -20,6 +20,7 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from django_redis import get_redis_connection
+from pyxform.builder import create_survey_from_xls
 from rest_framework import status
 
 from kobo.apps.openrosa.apps.logger.models import (
@@ -858,15 +859,20 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
         ObjectPermission.objects.filter(**filters).delete()
 
-    def rename_enketo_id_key(self, previous_owner_username: str):
+    def rename_enketo_id_key(
+        self, previous_owner_username: str, project_identifier: str = None
+    ):
         parsed_url = urlparse(settings.KOBOCAT_URL)
         domain_name = parsed_url.netloc
-        asset_uid = self.asset.uid
+
+        if not project_identifier:
+            project_identifier = self.xform.id_string
+
         try:
             enketo_redis_client = get_redis_connection('enketo_redis_main')
             enketo_redis_client.rename(
-                src=f'or:{domain_name}/{previous_owner_username},{asset_uid}',
-                dst=f'or:{domain_name}/{self.asset.owner.username},{asset_uid}',
+                src=f'or:{domain_name}/{previous_owner_username},{project_identifier}',
+                dst=f'or:{domain_name}/{self.asset.owner.username},{self.xform.id_string}',
             )
         except InvalidCacheBackendError:
             # TODO: This handles the case when the cache is disabled and
@@ -875,6 +881,32 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         except redis.exceptions.ResponseError:
             # original does not exist, weird but don't raise a 500 for that
             pass
+
+    def reset_backend_response_id_string(self):
+        xform_id = self.xform.pk
+        backend_response = self.backend_response
+        backend_response['previous_id_string'] = backend_response['id_string']
+        backend_response['id_string'] = self.asset.uid
+        self.save_to_db(
+            {'backend_response': backend_response}, update_date_modified=False
+        )
+        xlsx_io = self.asset.to_xlsx_io(
+            versioned=True,
+            append={
+                'settings': {
+                    'id_string': self.asset.uid,
+                    'form_title': self.asset.name,
+                }
+            },
+        )
+        xlsx_io.name = f'{self.asset.uid}.xlsx'
+        survey = create_survey_from_xls(xlsx_io, default_name=self.asset.uid)
+        XForm.objects.filter(pk=xform_id).update(
+            xml=survey.to_xml(), json=survey.to_json(), id_string=self.asset.uid
+        )
+        self.xform.id_string = self.asset.uid
+        self.xform.xml = survey.to_xml()
+        self.xform.json = survey.to_json()
 
     @staticmethod
     def prepare_bulk_update_response(backend_results: list[dict]) -> dict:
@@ -984,7 +1016,9 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         """
         if not self.xform.mongo_uuid:
             self.xform.mongo_uuid = KpiUidField.generate_unique_id()
-            self.xform.save(update_fields=['mongo_uuid'])
+            XForm.objects.filter(pk=self.xform_id).update(
+                mongo_uuid=self.xform.mongo_uuid
+            )
 
     def set_validation_status(
         self,
@@ -1282,8 +1316,22 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
     def transfer_submissions_ownership(self, previous_owner_username: str) -> bool:
 
+        if previous_id_string := self.backend_response.get('previous_id_string'):
+            mongo_query = {
+                '$or': [
+                    {'_userform_id': f'{previous_owner_username}_{previous_id_string}'},
+                    {
+                        '_userform_id': f'{previous_owner_username}_{self.xform_id_string}'
+                    },  # noqa
+                ],
+            }
+        else:
+            mongo_query = {
+                '_userform_id': f'{previous_owner_username}_{self.xform_id_string}'
+            }
+
         results = MongoHelper.update_many(
-            {'_userform_id': f'{previous_owner_username}_{self.xform_id_string}'},
+            mongo_query,
             {'_userform_id': self.mongo_userform_id},
         )
 


### PR DESCRIPTION
### 📣 Summary
Resolved identifier collisions when transferring projects between users with legacy id_string values.


### 📖 Description
When transferring a project, a conflict may occur if both the sender and the recipient have a project with the same legacy `id_string`, due to the uniqueness constraint of `id_string` per user.

This PR detects such collisions and resolves them by resetting the `id_string` of the project to match its unique KPI identifier (`Asset.uid`) before the transfer proceeds. This allows the receiving user to retain their version without disruption, while the legacy project adopts a safe, unique identifier.

⚠️ Note: Historical data will continue to use the original legacy id_string as the root node in their XML submissions.



### 👀 Preview steps

Bug template:
1. Modify [this line](https://github.com/kobotoolbox/kpi/blob/c7641726228cac5869c01ba14d353bd667836320/kobo/apps/openrosa/apps/logger/models/xform.py#L313) to assign a random string, e.g. `self.id_string = 'foo'`
2. Log in as userA 
3. Create a project (ProjectA) and deploy it
4. Log in as userB
5. Create a project (ProjectB) and deploy it, add submissions (with pictures - not required but better for testing). Keep note of the EnketoID
6. Validate in DB you have two XForm with same `id_string` (but different users)
7. Undo the modification applied in `#1` 
8. Transfer ProjectB to userA
9. 🔴 [on release branch] transfer should fail
10. 🟢 [on PR] 
   - **DO NOT FORGET** to restart your Celery worker containers
   - transfer should succeed
   - userA should be the owner of ProjectB 
   - userA should see the data and attachments
   - The Enketo ID should remain the same as before the transfer

11. Repeat step 2 to 8 to make sure regular projects still transfer flawlessly


