### PR TITLE
feat(massEmails): add 80% queries

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.mass_emails.user_queries import (
     get_inactive_users,
+    get_users_over_80_percent_of_storage_limit,
+    get_users_over_80_percent_of_submission_limit,
     get_users_over_90_percent_of_nlp_limits,
     get_users_over_90_percent_of_storage_limit,
     get_users_over_90_percent_of_submission_limit,
@@ -16,9 +18,11 @@ from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 
 USER_QUERIES: dict[str, Callable] = {
+    'users_above_80_percent_storage': get_users_over_80_percent_of_storage_limit,
     'users_above_90_percent_storage': get_users_over_90_percent_of_storage_limit,
     'users_above_100_percent_storage': get_users_over_100_percent_of_storage_limit,
     'users_inactive_for_365_days': get_inactive_users,
+    'users_above_80_percent_submissions': get_users_over_80_percent_of_submission_limit,
     'users_above_90_percent_submissions': get_users_over_90_percent_of_submission_limit,
     'users_above_100_percent_submissions': get_users_over_100_percent_of_submission_limit,  # noqa
     'users_above_90_percent_nlp_usage': get_users_over_90_percent_of_nlp_limits,

--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.mass_emails.user_queries import (
     get_inactive_users,
+    get_users_over_80_percent_of_nlp_limits,
     get_users_over_80_percent_of_storage_limit,
     get_users_over_80_percent_of_submission_limit,
     get_users_over_90_percent_of_nlp_limits,
@@ -25,6 +26,7 @@ USER_QUERIES: dict[str, Callable] = {
     'users_above_80_percent_submissions': get_users_over_80_percent_of_submission_limit,
     'users_above_90_percent_submissions': get_users_over_90_percent_of_submission_limit,
     'users_above_100_percent_submissions': get_users_over_100_percent_of_submission_limit,  # noqa
+    'users_above_80_percent_nlp_usage': get_users_over_80_percent_of_nlp_limits,
     'users_above_90_percent_nlp_usage': get_users_over_90_percent_of_nlp_limits,
     'users_above_100_percent_nlp_usage': get_users_over_100_percent_of_nlp_limits,
 }

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -171,6 +171,12 @@ def get_users_over_100_percent_of_submission_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(usage_types=['submission'], minimum=1)
 
 
+def get_users_over_80_percent_of_nlp_limits() -> QuerySet:
+    return get_users_within_range_of_usage_limit(
+        usage_types=['characters', 'seconds'], minimum=0.8, maximum=0.9
+    )
+
+
 def get_users_over_90_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
         usage_types=['characters', 'seconds'], minimum=0.9, maximum=1

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -139,6 +139,12 @@ def get_users_within_range_of_usage_limit(
     return User.objects.filter(id__in=user_ids)
 
 
+def get_users_over_80_percent_of_storage_limit() -> QuerySet:
+    return get_users_within_range_of_usage_limit(
+        usage_types=['storage'], minimum=0.8, maximum=0.9
+    )
+
+
 def get_users_over_90_percent_of_storage_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(
         usage_types=['storage'], minimum=0.9, maximum=1
@@ -147,6 +153,12 @@ def get_users_over_90_percent_of_storage_limit() -> QuerySet:
 
 def get_users_over_100_percent_of_storage_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(usage_types=['storage'], minimum=1)
+
+
+def get_users_over_80_percent_of_submission_limit() -> QuerySet:
+    return get_users_within_range_of_usage_limit(
+        usage_types=['submission'], minimum=0.8, maximum=0.9
+    )
 
 
 def get_users_over_90_percent_of_submission_limit() -> QuerySet:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds new queries for mass emails for finding users who are between 80% and 90% of their storage and submission limits.


### 👀 Preview steps

Bug template:
1. ℹ️ have an account and a project with an audio question
2. ℹ️ make sure Stripe is enabled and the account you're using is on the community plan
3. ℹ️ make sure NLP is enabled
4. In Django admin, update the Community product metadata with `"storage_bytes_limit": "1030700", "submission_limit": "10" , "mt_characters_limit":"10"`
5. Submit 8 submissions to the project using 
[sample-6s-14_44_13.zip](https://github.com/user-attachments/files/20102809/sample-6s-14_44_13.zip)
as the audio file
6. For one of the submissions, add a manual transcription that is 8 characters (eg "ballroom")
7. Create an automated translation to another language
8. In Django admin, create 3 new MassEmailConfigs, one using the `users_above_80_percent_storage,` one with `users_above_80_percent_submissions,` and one with `users_above_80_percent_nlp_usage`
9. Add the three emails to the daily send
10. 🟢 the user should receive all 3 emails

