### PR TITLE
update .gitlab-ci.yml to use shared job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,13 @@ stages:
   - build
   - test
   - deploy
+  - update_token
 
 include:
   - template: SAST.gitlab-ci.yml
+  - project: 'kobo_toolbox/shared_ci_project'
+    ref: 'main'
+    file: '.shared-iat-rotation.gitlab-ci.yml'
 
 build:
   image: docker
@@ -19,6 +23,9 @@ build:
     - docker build --cache-from $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME_SANITIZED
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule"
+
 deploy-beta:
   stage: deploy
   image:
@@ -30,11 +37,8 @@ deploy-beta:
   environment:
     name: beta
     url: https://kf.beta.kobotoolbox.org
-  only:
-    refs:
-      - public-beta
-    variables:
-      - $CI_COMMIT_REF_PROTECTED
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_REF_NAME == "public-beta" && $CI_COMMIT_REF_PROTECTED
 
 deploy-staging:
   stage: deploy
@@ -52,8 +56,8 @@ deploy-staging:
         helm -n kobo-dev upgrade --install $BRANCH_TITLE kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
       fi
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^(feature\/)/ && $CI_COMMIT_REF_PROTECTED
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_BRANCH =~ /^(feature\/)/ && $CI_COMMIT_REF_PROTECTED
+    - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_BRANCH == "main"
 
 pages:
   stage: deploy
@@ -65,7 +69,5 @@ pages:
   artifacts:
     paths:
       - public
-  only:
-    refs:
-      - main
-      - storybook
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule" && $CI_COMMIT_BRANCH =~ /(main|storybook)/


### PR DESCRIPTION
### Add GitHub Mirror Token Rotation Job
This PR adds automated GitHub token rotation for our Gitlab repository mirrors by including a shared CI job from our central CI repository.
### Changes
- Included the shared IAT (Installation Access Token) rotation job from `kobo_toolbox/shared_ci_project` in Gitlab.
- Added the `update_token` stage to the Gitlab CI pipeline.
- Updated job rules to ensure regular jobs only run on pushes/PRs and not on schedules.
- The token rotation job only runs when triggered by a schedule


