### PR TITLE
refactor(billing): standardize usage naming TASK-1827

### DIFF
--- a/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
+++ b/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
@@ -113,7 +113,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
             False,
             True,
         ),
-                (
+        (
             'asr_seconds',
             'get_nlp_usage_for_current_billing_period_by_user_id',
             False,

--- a/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
+++ b/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
@@ -9,8 +9,8 @@ from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.mass_emails.user_queries import get_users_within_range_of_usage_limit
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
-from kobo.apps.organizations.types import UsageType
 from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase
 
 
@@ -39,9 +39,9 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
         user3org = user3.organization
 
         usage_limits = {
-            user1org.id: {'storage_limit': 1000000000},
-            user2org.id: {'storage_limit': 1000000000},
-            user3org.id: {'storage_limit': 1000000000},
+            user1org.id: {'storage_bytes_limit': 1000000000},
+            user2org.id: {'storage_bytes_limit': 1000000000},
+            user3org.id: {'storage_bytes_limit': 1000000000},
         }
         storage_by_user_id = {
             user1.id: 1000000001,  # over full usage
@@ -59,7 +59,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                 return_value=storage_by_user_id,
             ):
                 results = get_users_within_range_of_usage_limit(
-                    usage_types=['storage'], minimum=minimum, maximum=maximum
+                    usage_types=[UsageType.STORAGE_BYTES], minimum=minimum, maximum=maximum
                 )
         aslist = list(results.order_by('username'))
         assert aslist == list(
@@ -78,7 +78,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
     def test_users_with_infinite_limits(self, minimum, maximum):
         user1 = User.objects.get(username='anotheruser')
         user1org = user1.organization
-        usage_limits = {user1org.id: {'storage_limit': inf}}
+        usage_limits = {user1org.id: {'storage_bytes_limit': inf}}
         storage_by_user_id = {user1.id: 1000000000}
         with patch(
             'kobo.apps.mass_emails.user_queries.get_organizations_effective_limits',
@@ -89,7 +89,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                 return_value=storage_by_user_id,
             ):
                 results = get_users_within_range_of_usage_limit(
-                    usage_types=['storage'], minimum=minimum, maximum=maximum
+                    usage_types=[UsageType.STORAGE_BYTES], minimum=minimum, maximum=maximum
                 )
 
         # result should always be empty no matter what min/max were given if user has
@@ -102,16 +102,16 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
     )
     @data(
         # usage type, usage method, include storage addons, include one-time addons
-        ('storage', 'get_storage_usage_by_user_id', True, False),
+        ('storage_bytes', 'get_storage_usage_by_user_id', True, False),
         (
             'submission',
             'get_submissions_for_current_billing_period_by_user_id',
             False,
             True,
         ),
-        ('seconds', 'get_nlp_usage_for_current_billing_period_by_user_id', False, True),
+        ('asr_seconds', 'get_nlp_usage_for_current_billing_period_by_user_id', False, True),
         (
-            'characters',
+            'mt_characters',
             'get_nlp_usage_for_current_billing_period_by_user_id',
             False,
             True,
@@ -146,7 +146,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
     )
     def test_users_in_range_of_usage_limit_only_gets_nlp_usage_once(self):
         org1 = User.objects.get(username='someuser').organization
-        usage = {org1.id: {'seconds': 10, 'characters': 20}}
+        usage = {org1.id: {UsageType.ASR_SECONDS: 10, UsageType.MT_CHARACTERS: 20}}
 
         full_usage_method_to_patch = ('kobo.apps.mass_emails.user_queries'
                                       '.get_nlp_usage_for_current_billing_period'
@@ -159,7 +159,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
         ) as patched_usage_method:
             with patch(full_limit_method_to_patch):
                 get_users_within_range_of_usage_limit(
-                    usage_types=['seconds', 'characters']
+                    usage_types=[UsageType.ASR_SECONDS, UsageType.MT_CHARACTERS]
                 )
         patched_usage_method.assert_called_once()
 
@@ -172,7 +172,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
     def test_organization_with_no_owner(self):
         no_owner = baker.make(Organization, id='org_abcd1234', mmo_override=False)
         assert no_owner.owner_user_object is None
-        usage_limits = {no_owner.id: {'storage_limit': 10}}
+        usage_limits = {no_owner.id: {'storage_bytes_limit': 10}}
         storage_by_user_id = {self.someuser.id: 1000000000}
         with patch(
             'kobo.apps.mass_emails.user_queries.get_organizations_effective_limits',
@@ -183,7 +183,7 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                 return_value=storage_by_user_id,
             ):
                 results = get_users_within_range_of_usage_limit(
-                    usage_types=['storage'], minimum=0
+                    usage_types=[UsageType.STORAGE_BYTES], minimum=0
                 )
 
         # result should be empty because the organization has no owner

--- a/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
+++ b/kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py
@@ -59,7 +59,9 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                 return_value=storage_by_user_id,
             ):
                 results = get_users_within_range_of_usage_limit(
-                    usage_types=[UsageType.STORAGE_BYTES], minimum=minimum, maximum=maximum
+                    usage_types=[UsageType.STORAGE_BYTES],
+                    minimum=minimum,
+                    maximum=maximum,
                 )
         aslist = list(results.order_by('username'))
         assert aslist == list(
@@ -89,7 +91,9 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
                 return_value=storage_by_user_id,
             ):
                 results = get_users_within_range_of_usage_limit(
-                    usage_types=[UsageType.STORAGE_BYTES], minimum=minimum, maximum=maximum
+                    usage_types=[UsageType.STORAGE_BYTES],
+                    minimum=minimum,
+                    maximum=maximum,
                 )
 
         # result should always be empty no matter what min/max were given if user has
@@ -109,7 +113,12 @@ class UsageLimitUserQueryTestCase(BaseServiceUsageTestCase):
             False,
             True,
         ),
-        ('asr_seconds', 'get_nlp_usage_for_current_billing_period_by_user_id', False, True),
+                (
+            'asr_seconds',
+            'get_nlp_usage_for_current_billing_period_by_user_id',
+            False,
+            True,
+        ),
         (
             'mt_characters',
             'get_nlp_usage_for_current_billing_period_by_user_id',

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -7,8 +7,8 @@ from django.utils.timezone import now
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models import Instance
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
-from kobo.apps.organizations.types import UsageType
 from kobo.apps.stripe.utils import get_organizations_effective_limits
 from kpi.models import Asset
 from kpi.utils.usage_calculator import (
@@ -91,19 +91,19 @@ def get_users_within_range_of_usage_limit(
         return get_nlp_usage
 
     usage_method_by_type = {
-        'submission': get_submissions_for_current_billing_period_by_user_id,
-        'storage': get_storage_usage_by_user_id,
-        'seconds': get_nlp_usage_method('seconds'),
-        'characters': get_nlp_usage_method('characters'),
+        UsageType.SUBMISSION: get_submissions_for_current_billing_period_by_user_id,
+        UsageType.STORAGE_BYTES: get_storage_usage_by_user_id,
+        UsageType.ASR_SECONDS: get_nlp_usage_method(UsageType.ASR_SECONDS),
+        UsageType.MT_CHARACTERS: get_nlp_usage_method(UsageType.MT_CHARACTERS),
     }
 
     minimum = minimum or 0
     maximum = maximum or inf
-    include_storage_addons = 'storage' in usage_types
+    include_storage_addons = UsageType.STORAGE_BYTES in usage_types
     include_onetime_addons = (
-        'submission' in usage_types
-        or 'seconds' in usage_types
-        or 'characters' in usage_types
+        UsageType.SUBMISSION in usage_types
+        or UsageType.ASR_SECONDS in usage_types
+        or UsageType.MT_CHARACTERS in usage_types
     )
     org_ids_with_no_owner = list(
         Organization.objects.filter(owner__isnull=True).values_list('pk', flat=True)
@@ -141,49 +141,49 @@ def get_users_within_range_of_usage_limit(
 
 def get_users_over_80_percent_of_storage_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['storage'], minimum=0.8, maximum=0.9
+        usage_types=[UsageType.STORAGE_BYTES], minimum=0.8, maximum=0.9
     )
 
 
 def get_users_over_90_percent_of_storage_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['storage'], minimum=0.9, maximum=1
+        usage_types=[UsageType.STORAGE_BYTES], minimum=0.9, maximum=1
     )
 
 
 def get_users_over_100_percent_of_storage_limit() -> QuerySet:
-    return get_users_within_range_of_usage_limit(usage_types=['storage'], minimum=1)
+    return get_users_within_range_of_usage_limit(usage_types=[UsageType.STORAGE_BYTES], minimum=1)
 
 
 def get_users_over_80_percent_of_submission_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['submission'], minimum=0.8, maximum=0.9
+        usage_types=[UsageType.SUBMISSION], minimum=0.8, maximum=0.9
     )
 
 
 def get_users_over_90_percent_of_submission_limit() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['submission'], minimum=0.9, maximum=1
+        usage_types=[UsageType.SUBMISSION], minimum=0.9, maximum=1
     )
 
 
 def get_users_over_100_percent_of_submission_limit() -> QuerySet:
-    return get_users_within_range_of_usage_limit(usage_types=['submission'], minimum=1)
+    return get_users_within_range_of_usage_limit(usage_types=[UsageType.SUBMISSION], minimum=1)
 
 
 def get_users_over_80_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['characters', 'seconds'], minimum=0.8, maximum=0.9
+        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS], minimum=0.8, maximum=0.9
     )
 
 
 def get_users_over_90_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['characters', 'seconds'], minimum=0.9, maximum=1
+        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS], minimum=0.9, maximum=1
     )
 
 
 def get_users_over_100_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=['characters', 'seconds'], minimum=1
+        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS], minimum=1
     )

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -152,7 +152,9 @@ def get_users_over_90_percent_of_storage_limit() -> QuerySet:
 
 
 def get_users_over_100_percent_of_storage_limit() -> QuerySet:
-    return get_users_within_range_of_usage_limit(usage_types=[UsageType.STORAGE_BYTES], minimum=1)
+    return get_users_within_range_of_usage_limit(
+        usage_types=[UsageType.STORAGE_BYTES], minimum=1
+    )
 
 
 def get_users_over_80_percent_of_submission_limit() -> QuerySet:
@@ -168,18 +170,24 @@ def get_users_over_90_percent_of_submission_limit() -> QuerySet:
 
 
 def get_users_over_100_percent_of_submission_limit() -> QuerySet:
-    return get_users_within_range_of_usage_limit(usage_types=[UsageType.SUBMISSION], minimum=1)
+    return get_users_within_range_of_usage_limit(
+        usage_types=[UsageType.SUBMISSION], minimum=1
+    )
 
 
 def get_users_over_80_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS], minimum=0.8, maximum=0.9
+        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS],
+        minimum=0.8,
+        maximum=0.9,
     )
 
 
 def get_users_over_90_percent_of_nlp_limits() -> QuerySet:
     return get_users_within_range_of_usage_limit(
-        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS], minimum=0.9, maximum=1
+        usage_types=[UsageType.MT_CHARACTERS, UsageType.ASR_SECONDS],
+        minimum=0.9,
+        maximum=1,
     )
 
 

--- a/kobo/apps/organizations/constants.py
+++ b/kobo/apps/organizations/constants.py
@@ -1,3 +1,13 @@
+from django.db import models
+
+
+class UsageType(models.TextChoices):
+    SUBMISSION = 'submission'
+    STORAGE_BYTES = 'storage_bytes'
+    MT_CHARACTERS = 'mt_characters'
+    ASR_SECONDS = 'asr_seconds'
+
+
 INVITE_OWNER_ERROR = (
     'This account is already the owner of ##organization_name##. '
     'You cannot join multiple organizations with the same account. '

--- a/kobo/apps/organizations/types.py
+++ b/kobo/apps/organizations/types.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-from typing import Literal, TypedDict
-
-UsageType = Literal['characters', 'seconds', 'submission', 'storage']
+from typing import TypedDict
 
 
 class BillingDates(TypedDict):
@@ -10,12 +8,12 @@ class BillingDates(TypedDict):
 
 
 class UsageLimits(TypedDict):
-    storage_limit: float
+    storage_bytes_limit: float
     submission_limit: float
-    seconds_limit: float
-    characters_limit: float
+    asr_seconds_limit: float
+    mt_characters_limit: float
 
 
 class NLPUsage(TypedDict):
-    seconds: int
-    characters: int
+    asr_seconds: int
+    mt_characters: int

--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -20,10 +20,3 @@ FREE_TIER_EMPTY_DISPLAY = {
 }
 
 ORGANIZATION_USAGE_MAX_CACHE_AGE = timedelta(minutes=15)
-
-USAGE_LIMIT_MAP = {
-    'characters': 'mt_characters',
-    'seconds': 'asr_seconds',
-    'storage': 'storage_bytes',
-    'submission': 'submission',
-}

--- a/kobo/apps/stripe/models.py
+++ b/kobo/apps/stripe/models.py
@@ -1,4 +1,4 @@
-from typing import List, get_args
+from typing import List
 
 from django.contrib import admin
 from django.core.exceptions import ObjectDoesNotExist

--- a/kobo/apps/stripe/tests/test_one_time_addons_api.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_api.py
@@ -6,7 +6,6 @@ from rest_framework import status
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
-from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.stripe.models import PlanAddOn
 from kobo.apps.stripe.tests.utils import _create_one_time_addon_product, _create_payment
 from kpi.tests.kpi_test_case import BaseTestCase
@@ -124,10 +123,10 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         assert response_get_list.status_code == status.HTTP_200_OK
         assert response_get_list.data['results'] == []
 
-    @data('characters', 'seconds')
+    @data('mt_characters', 'asr_seconds')
     def test_get_user_totals(self, usage_type):
         limit = 2000
-        usage_limit_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
+        usage_limit_key = f'{usage_type}_limit'
         self._create_product(
             metadata={
                 'product_type': 'addon_onetime',
@@ -170,7 +169,7 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         _create_payment(self.customer, product=addon, price=addon.default_price)
         _create_payment(self.customer, product=addon, price=addon.default_price)
         results = PlanAddOn.get_organizations_totals()
-        assert results[self.organization.id]['total_seconds_limit'] == 6000
-        assert results[self.organization.id]['total_characters_limit'] == 4000
-        assert results[second_organization.id]['total_seconds_limit'] == 3000
-        assert results[second_organization.id]['total_characters_limit'] == 2000
+        assert results[self.organization.id]['total_asr_seconds_limit'] == 6000
+        assert results[self.organization.id]['total_mt_characters_limit'] == 4000
+        assert results[second_organization.id]['total_asr_seconds_limit'] == 3000
+        assert results[second_organization.id]['total_mt_characters_limit'] == 2000

--- a/kobo/apps/stripe/tests/test_one_time_addons_api.py
+++ b/kobo/apps/stripe/tests/test_one_time_addons_api.py
@@ -5,6 +5,7 @@ from model_bakery import baker
 from rest_framework import status
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
 from kobo.apps.stripe.models import PlanAddOn
 from kobo.apps.stripe.tests.utils import _create_one_time_addon_product, _create_payment
@@ -33,7 +34,7 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         if not metadata:
             metadata = {
                 'product_type': 'addon_onetime',
-                'submission_limit': 2000,
+                f'{UsageType.SUBMISSION}_limit': 2000,
                 'valid_tags': 'all',
             }
         product = _create_one_time_addon_product(limit_metadata=metadata)
@@ -46,7 +47,7 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
             price=self.price,
             product=self.product,
             payment_status=payment_status,
-            refunded=refunded
+            refunded=refunded,
         )
         self.charge = charge
 
@@ -74,7 +75,10 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
 
     def test_no_addons_for_invalid_product_metadata(self):
         self._create_product(
-            metadata={'product_type': 'subscription', 'submission_limit': 2000}
+            metadata={
+                'product_type': 'subscription',
+                f'{UsageType.SUBMISSION}_limit': 2000,
+            }
         )
         self._create_payment()
         response = self.client.get(self.url)
@@ -144,9 +148,7 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         assert total_limit == limit * 3
         assert remaining == limit * 3
 
-        PlanAddOn.deduct_add_ons_for_organization(
-            self.organization, usage_type, limit
-        )
+        PlanAddOn.deduct_add_ons_for_organization(self.organization, usage_type, limit)
         total_limit, remaining = PlanAddOn.get_organization_totals(
             self.organization, usage_type
         )
@@ -156,9 +158,9 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
     def test_get_organizations_totals(self):
         addon = _create_one_time_addon_product(
             limit_metadata={
-                'mt_characters_limit': 2000,
+                f'{UsageType.MT_CHARACTERS}_limit': 2000,
                 'valid_tags': 'all',
-                'asr_seconds_limit': 3000,
+                f'{UsageType.ASR_SECONDS}_limit': 3000,
             }
         )
         anotheruser = User.objects.get(username='anotheruser')
@@ -169,7 +171,19 @@ class OneTimeAddOnAPITestCase(BaseTestCase):
         _create_payment(self.customer, product=addon, price=addon.default_price)
         _create_payment(self.customer, product=addon, price=addon.default_price)
         results = PlanAddOn.get_organizations_totals()
-        assert results[self.organization.id]['total_asr_seconds_limit'] == 6000
-        assert results[self.organization.id]['total_mt_characters_limit'] == 4000
-        assert results[second_organization.id]['total_asr_seconds_limit'] == 3000
-        assert results[second_organization.id]['total_mt_characters_limit'] == 2000
+        assert (
+            results[self.organization.id][f'total_{UsageType.ASR_SECONDS}_limit']
+            == 6000
+        )
+        assert (
+            results[self.organization.id][f'total_{UsageType.MT_CHARACTERS}_limit']
+            == 4000
+        )
+        assert (
+            results[second_organization.id][f'total_{UsageType.ASR_SECONDS}_limit']
+            == 3000
+        )
+        assert (
+            results[second_organization.id][f'total_{UsageType.MT_CHARACTERS}_limit']
+            == 2000
+        )

--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -14,16 +14,17 @@ from djstripe.models import (
 )
 from model_bakery import baker
 
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
 
 
 def generate_free_plan():
     product_metadata = {
         'product_type': 'plan',
-        'submission_limit': '5000',
-        'asr_seconds_limit': '600',
-        'mt_characters_limit': '6000',
-        'storage_bytes_limit': '1000',
+        f'{UsageType.SUBMISSION}_limit': '5000',
+        f'{UsageType.ASR_SECONDS}_limit': '600',
+        f'{UsageType.MT_CHARACTERS}_limit': '6000',
+        f'{UsageType.STORAGE_BYTES}_limit': '1000',
         'default_free_plan': 'true',
     }
 

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -310,9 +310,9 @@ def get_current_billing_period_dates_for_active_plans(
 
 def get_default_add_on_limits():
     return {
-        'submission_limit': 0,
-        'asr_seconds_limit': 0,
-        'mt_characters_limit': 0,
+        f'{UsageType.SUBMISSION}_limit': 0,
+        f'{UsageType.ASR_SECONDS}_limit': 0,
+        f'{UsageType.MT_CHARACTERS}_limit': 0,
     }
 
 

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -2,7 +2,7 @@ import calendar
 import functools
 from datetime import datetime
 from math import ceil, floor, inf
-from typing import Optional, get_args
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
@@ -12,9 +12,10 @@ from django.db.models import F, Max, Q, QuerySet, Window
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization, OrganizationUser
-from kobo.apps.organizations.types import BillingDates, UsageLimits, UsageType
-from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES, USAGE_LIMIT_MAP
+from kobo.apps.organizations.types import BillingDates, UsageLimits
+from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 
 def requires_stripe(func):
@@ -56,11 +57,11 @@ def requires_stripe(func):
 
 
 def _get_default_usage_limits():
-    return {f'{usage_type}_limit': inf for usage_type in get_args(UsageType)}
+    return {f'{usage_type}_limit': inf for usage_type, _ in UsageType.choices}
 
 
 def _get_limit_key(usage_type: UsageType):
-    return f'{USAGE_LIMIT_MAP[usage_type]}_limit'
+    return f'{usage_type}_limit'
 
 
 def _get_subscription_metadata_fields_for_usage_type(usage_type: UsageType):
@@ -75,8 +76,7 @@ def _get_subscription_metadata_fields_for_usage_type(usage_type: UsageType):
 def get_default_plan_name(**kwargs) -> Optional[str]:
     Product = kwargs['product_model']
     default_plan = (
-        Product
-        .objects.filter(metadata__default_free_plan='true')
+        Product.objects.filter(metadata__default_free_plan='true')
         .values('name')
         .first()
     )
@@ -325,7 +325,7 @@ def get_organization_subscription_limit(
     will fall back to infinite value if no subscription or
     default free tier plan found.
     """
-    include_storage_addons = usage_type == 'storage'
+    include_storage_addons = usage_type == UsageType.STORAGE_BYTES
     return (
         get_organizations_subscription_limits([organization], include_storage_addons)
         .get(organization.id, {})
@@ -353,10 +353,10 @@ def get_organizations_subscription_limits(
     Example result:
     { 'org1':
         {
-            'storage_limit': inf,
+            'storage_bytes_limit': inf,
             'submission_limit': 5000,
-            'characters_limit': 72000,
-            'seconds_limit': 6000,
+            'mt_characters_limit': 72000,
+            'asr_seconds_limit': 6000,
         },
         ...
     }
@@ -381,30 +381,29 @@ def get_organizations_subscription_limits(
         if row['product_type'] == 'plan':
             row_limits = {
                 f'{usage_type}_limit': row[f'{usage_type}_limit']
-                for usage_type in get_args(UsageType)
+                for usage_type, _ in UsageType.choices
             }
         elif row['product_type'] == 'addon':
-            row_limits['addon_storage_limit'] = row['storage_limit']
+            row_limits['addon_storage_limit'] = row['storage_bytes_limit']
         subscription_limits_by_org_id[row['org_id']] = row_limits
 
-    storage_limit = _get_limit_key('storage')
-    submission_limit = _get_limit_key('submission')
-    characters_limit = _get_limit_key('characters')
-    seconds_limit = _get_limit_key('seconds')
+    storage_limit = _get_limit_key(UsageType.STORAGE_BYTES)
+    submission_limit = _get_limit_key(UsageType.SUBMISSION)
+    characters_limit = _get_limit_key(UsageType.MT_CHARACTERS)
+    seconds_limit = _get_limit_key(UsageType.ASR_SECONDS)
     # Anyone who does not have a subscription is on the free tier plan by default
     default_plan = (
-        Product
-        .objects.filter(metadata__default_free_plan='true')
+        Product.objects.filter(metadata__default_free_plan='true')
         .values(
-            storage_limit=F(f'metadata__{storage_limit}'),
+            storage_bytes_limit=F(f'metadata__{storage_limit}'),
             submission_limit=F(f'metadata__{submission_limit}'),
-            characters_limit=F(f'metadata__{characters_limit}'),
-            seconds_limit=F(f'metadata__{seconds_limit}'),
+            mt_characters_limit=F(f'metadata__{characters_limit}'),
+            asr_seconds_limit=F(f'metadata__{seconds_limit}'),
         )
         .first()
     ) or {}
     default_plan_limits = {}
-    for usage_type in get_args(UsageType):
+    for usage_type, _ in UsageType.choices:
         limit_key = f'{usage_type}_limit'
         default_limit = default_plan.get(limit_key)
         if default_limit is None:
@@ -415,7 +414,7 @@ def get_organizations_subscription_limits(
     results = {}
     for org_id in all_org_ids:
         all_org_limits = {}
-        for usage_type in get_args(UsageType):
+        for usage_type, _ in UsageType.choices:
             plan_limit = subscription_limits_by_org_id.get(org_id, {}).get(
                 f'{usage_type}_limit'
             )
@@ -473,7 +472,7 @@ def get_organizations_effective_limits(
         PlanAddOn = apps.get_model('stripe', 'PlanAddOn')  # noqa
         addon_limits = PlanAddOn.get_organizations_totals(organizations=organizations)
         for org_id, limits in effective_limits.items():
-            for usage_type in get_args(UsageType):
+            for usage_type, _ in UsageType.choices:
                 addon = addon_limits.get(org_id, {}).get(f'total_{usage_type}_limit', 0)
                 limits[f'{usage_type}_limit'] += addon
     return effective_limits
@@ -492,16 +491,16 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
     Subscription = kwargs['subscription_model']
 
     price_storage_key, product_storage_key = (
-        _get_subscription_metadata_fields_for_usage_type('storage')
+        _get_subscription_metadata_fields_for_usage_type(UsageType.STORAGE_BYTES)
     )
     price_submission_key, product_submission_key = (
-        _get_subscription_metadata_fields_for_usage_type('submission')
+        _get_subscription_metadata_fields_for_usage_type(UsageType.SUBMISSION)
     )
     price_characters_key, product_characters_key = (
-        _get_subscription_metadata_fields_for_usage_type('characters')
+        _get_subscription_metadata_fields_for_usage_type(UsageType.MT_CHARACTERS)
     )
     price_seconds_key, product_seconds_key = (
-        _get_subscription_metadata_fields_for_usage_type('seconds')
+        _get_subscription_metadata_fields_for_usage_type(UsageType.ASR_SECONDS)
     )
 
     # Get organizations we care about (either those in the 'organizations' param or all)
@@ -516,12 +515,12 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
     most_recent_subs = (
         active_subscriptions.values(
             org_id=F('customer__subscriber_id'),
-            storage_limit=Coalesce(F(price_storage_key), F(product_storage_key)),
+            storage_bytes_limit=Coalesce(F(price_storage_key), F(product_storage_key)),
             submission_limit=Coalesce(
                 F(price_submission_key), F(product_submission_key)
             ),
-            seconds_limit=Coalesce(F(price_seconds_key), F(product_seconds_key)),
-            characters_limit=Coalesce(
+            asr_seconds_limit=Coalesce(F(price_seconds_key), F(product_seconds_key)),
+            mt_characters_limit=Coalesce(
                 F(price_characters_key), F(product_characters_key)
             ),
             sub_start_date=F('start_date'),
@@ -538,7 +537,7 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
                 expression=Max('sub_start_date', filter=Q(product_type='addon')),
                 partition_by=F('org_id'),
                 order_by='org_id',
-            )
+            ),
         )
         .filter(
             # most recent full plan
@@ -578,7 +577,7 @@ def determine_limit(
         limit = float(limit)
 
     # for storage, factor in addons if specified
-    if usage_type == 'storage' and include_storage_addons:
+    if usage_type == UsageType.STORAGE_BYTES and include_storage_addons:
         if addon_limit == 'unlimited':
             addon_limit = inf
         else:

--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -384,7 +384,7 @@ def get_organizations_subscription_limits(
                 for usage_type, _ in UsageType.choices
             }
         elif row['product_type'] == 'addon':
-            row_limits['addon_storage_limit'] = row['storage_bytes_limit']
+            row_limits['addon_storage_limit'] = row[f'{UsageType.STORAGE_BYTES}_limit']
         subscription_limits_by_org_id[row['org_id']] = row_limits
 
     storage_limit = _get_limit_key(UsageType.STORAGE_BYTES)

--- a/kobo/apps/subsequences/integrations/google/base.py
+++ b/kobo/apps/subsequences/integrations/google/base.py
@@ -117,7 +117,7 @@ class GoogleService(ABC):
 
     def update_counters(self, amount) -> None:
         update_nlp_counter(
-            self.counter_name,
+            self.counter_name, 
             amount,
             self.asset.owner_id,
             self.asset.id,

--- a/kobo/apps/subsequences/integrations/google/base.py
+++ b/kobo/apps/subsequences/integrations/google/base.py
@@ -117,7 +117,7 @@ class GoogleService(ABC):
 
     def update_counters(self, amount) -> None:
         update_nlp_counter(
-            self.counter_name, 
+            self.counter_name,
             amount,
             self.asset.owner_id,
             self.asset.id,

--- a/kobo/apps/trackers/tests/test_utils.py
+++ b/kobo/apps/trackers/tests/test_utils.py
@@ -8,7 +8,6 @@ from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
-from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.stripe.utils import requires_stripe
 from kobo.apps.trackers.utils import (
     get_organization_remaining_usage,
@@ -95,10 +94,10 @@ class TrackersUtilitiesTestCase(BaseTestCase):
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
     )
-    @data('characters', 'seconds')
+    @data('mt_characters', 'asr_seconds')
     def test_organization_usage_utils(self, usage_type):
         from kobo.apps.stripe.tests.utils import generate_plan_subscription
-        usage_key = f'{USAGE_LIMIT_MAP[usage_type]}_limit'
+        usage_key = f'{usage_type}_limit'
         sub_metadata = {
             usage_key: '1000',
             'product_type': 'plan',
@@ -121,14 +120,14 @@ class TrackersUtilitiesTestCase(BaseTestCase):
         assert remaining == total_limit
 
         update_nlp_counter(
-            USAGE_LIMIT_MAP[usage_type], 1000, self.someuser.id, self.asset.id
+            usage_type, 1000, self.someuser.id, self.asset.id
         )
 
         remaining = get_organization_remaining_usage(self.organization, usage_type)
         assert remaining == total_limit - 1000
 
         update_nlp_counter(
-            USAGE_LIMIT_MAP[usage_type], 1500, self.someuser.id, self.asset.id
+            usage_type, 1500, self.someuser.id, self.asset.id
         )
         remaining = get_organization_remaining_usage(self.organization, usage_type)
         assert remaining == total_limit - 2500
@@ -136,13 +135,13 @@ class TrackersUtilitiesTestCase(BaseTestCase):
     @pytest.mark.skipif(
         settings.STRIPE_ENABLED, reason='Tests non-stripe functionality'
     )
-    @data('characters', 'seconds')
+    @data('mt_characters', 'asr_seconds')
     def test_org_usage_utils_without_stripe(self, usage_type):
         remaining = get_organization_remaining_usage(self.organization, usage_type)
         assert remaining == inf
 
         update_nlp_counter(
-            USAGE_LIMIT_MAP[usage_type], 10000, self.someuser.id, self.asset.id
+            usage_type, 10000, self.someuser.id, self.asset.id
         )
 
         remaining = get_organization_remaining_usage(self.organization, usage_type)

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -52,11 +52,11 @@ def update_nlp_counter(
     # Update the total counters by the usage amount to keep them current
     deduct = settings.STRIPE_ENABLED
     kwargs = {}
-    if service.endswith('asr_seconds'):
+    if service.endswith(UsageType.ASR_SECONDS):
         kwargs['total_asr_seconds'] = F('total_asr_seconds') + amount
         if deduct and asset_id is not None:
             handle_usage_deduction(organization, UsageType.ASR_SECONDS, amount)
-    if service.endswith('mt_characters'):
+    if service.endswith(UsageType.MT_CHARACTERS):
         kwargs['total_mt_characters'] = F('total_mt_characters') + amount
         if deduct and asset_id is not None:
             handle_usage_deduction(organization, UsageType.MT_CHARACTERS, amount)

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -13,7 +13,6 @@ from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
-from kobo.apps.stripe.constants import USAGE_LIMIT_MAP
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseAssetTestCase
@@ -244,8 +243,8 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
 
         assert calculator.get_storage_usage() == 5 * self.expected_file_size()
 
-        assert calculator.get_nlp_usage_by_type(USAGE_LIMIT_MAP['characters']) == 5473
-        assert calculator.get_nlp_usage_by_type(USAGE_LIMIT_MAP['seconds']) == 4586
+        assert calculator.get_nlp_usage_by_type('mt_characters') == 5473
+        assert calculator.get_nlp_usage_by_type('asr_seconds') == 4586
 
     def test_storage_usage_all_users(self):
         asset_2 = self._create_asset(self.someuser)
@@ -400,10 +399,10 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
             return_value=mock_billing_periods,
         ):
             nlp_usage_by_user = get_nlp_usage_for_current_billing_period_by_user_id()
-        assert nlp_usage_by_user[self.someuser.id]['seconds'] == 20
-        assert nlp_usage_by_user[self.anotheruser.id]['seconds'] == 10
-        assert nlp_usage_by_user[self.someuser.id]['characters'] == 40
-        assert nlp_usage_by_user[self.anotheruser.id]['characters'] == 20
+        assert nlp_usage_by_user[self.someuser.id]['asr_seconds'] == 20
+        assert nlp_usage_by_user[self.anotheruser.id]['asr_seconds'] == 10
+        assert nlp_usage_by_user[self.someuser.id]['mt_characters'] == 40
+        assert nlp_usage_by_user[self.anotheruser.id]['mt_characters'] == 20
 
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -89,8 +89,8 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
     results = {}
     for row in nlp_tracking:
         results[row['user_id']] = {
-            'asr_seconds': row['asr_seconds_current_period'],
-            'mt_characters': row['mt_characters_current_period'],
+            UsageType.ASR_SECONDS: row['asr_seconds_current_period'],
+            UsageType.MT_CHARACTERS: row['mt_characters_current_period'],
         }
     return results
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Switches to standardized choices for referring to usage types in backend code.


### 📖 Description
For the usage limits project we will be adding a model that includes a field for storing a usage type. Usage types are very stable. There are only four choices and any future changes will only entail the addition of further choices. As such, it makes the most sense to use a character choice field for this purpose. (Note: I had considered using an Integer choice field, but because we use the string values so frequently and the table we will be adding the choice field on will not be particularly big, I decided against the added complexity).

However, in the code we currently have two almost, but not quite identical ways of writing usage types, reflected in our `USAGE_LIMIT_MAP`

```python
USAGE_LIMIT_MAP = {
    'characters': 'mt_characters',
    'seconds': 'asr_seconds',
    'storage': 'storage_bytes',
    'submission': 'submission',
}
```

Aside from saving a few keystrokes in the backend code when typing a usage type (an advantage erased by having to use this mapping across the codebase), there doesn’t seem to be any reason for this divergence. 

This PR creates a django TextChoices enum using the values from the above mapping and replaces all instances of keys from the above mapping accordingly.

### 👀 Preview steps
The affected strings are only used in internal code. The API isn't impacted. So existing unit test coverage should be sufficient here.
