### PR TITLE
fix(djangoAdmin): make search functional again in admin interface

### DIFF
--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -247,7 +247,10 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
         )
 
     def get_search_results(self, request, queryset, search_term):
-        if request.path != '/admin/auth/user/':
+
+        user_change_list_url = reverse('admin:kobo_auth_user_changelist')
+
+        if request.path != user_change_list_url:
             queryset = self._filter_queryset(request, queryset)
 
             # If search comes from autocomplete field, use parent class method

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -16,6 +16,7 @@ from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import set_meta
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
+from kpi.utils.mongo_helper import MongoHelper
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
### 📣 Summary
Fixed a regression that broke search functionality in the Django Admin interface.


### 📖 Description
The Django Admin search had stopped working due to a conditional check that restricted search activation to URLs matching the user list endpoint. However, following the merge of OpenRosa into KPI, the admin URL structure changed, making the condition obsolete.

This fix updates the condition to correctly detect the context for enabling search, restoring the functionality.

### 👀 Preview steps

Bug template:
1. Go to admin users list
2. Make a search (e.g. `last_login__gte:2025-05-01`)
3. 🔴 [on release branch] notice that it returns 0 results
5. 🟢 [on PR] notice that its returns n results
