### PR TITLE
fix(storage): Use correct database when no options are passed to update_attachment_storage_bytes command

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/update_attachment_storage_bytes.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/update_attachment_storage_bytes.py
@@ -193,7 +193,7 @@ class Command(BaseCommand):
             subquery = UserProfile.objects.values_list('user_id', flat=True).filter(
                 metadata__attachments_counting_status='complete'
             )
-            users = users.exclude(pk__in=subquery)
+            users = users.using(settings.OPENROSA_DB_ALIAS).exclude(pk__in=subquery)
 
         if self._sync:
             subquery = list(profile_queryset.values_list('user_id', flat=True))


### PR DESCRIPTION
### 📣 Summary
Ensured the `update_attachment_storage_bytes` management command uses the appropriate database when no options are provided.


### 👀 Preview steps

Bug template:
1. Use the management command without options
4. 🔴 [on release] Management command crashes
5. 🟢 [on PR] Management command runs
