### PR TITLE
fix(openRosa): list anonymous projects manageable by user

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/fixtures/formList_with_version.xml
+++ b/kobo/apps/openrosa/apps/api/tests/fixtures/formList_with_version.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><majorMinorVersion>%(version)s</majorMinorVersion><version>%(version)s</version><hash>md5:%(hash)s</hash><descriptionText>transportation_2011_07_25</descriptionText><downloadUrl>http://testserver/bob/forms/%(pk)s/form.xml</downloadUrl><manifestUrl>http://testserver/bob/xformsManifest/%(pk)s</manifestUrl></xform></xforms>

--- a/kobo/apps/openrosa/apps/api/tests/fixtures/formList_with_version.xml
+++ b/kobo/apps/openrosa/apps/api/tests/fixtures/formList_with_version.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xforms xmlns="http://openrosa.org/xforms/xformsList"><xform><formID>transportation_2011_07_25</formID><name>transportation_2011_07_25</name><majorMinorVersion>%(version)s</majorMinorVersion><version>%(version)s</version><hash>md5:%(hash)s</hash><descriptionText>transportation_2011_07_25</descriptionText><downloadUrl>http://testserver/bob/forms/%(pk)s/form.xml</downloadUrl><manifestUrl>http://testserver/bob/xformsManifest/%(pk)s</manifestUrl></xform></xforms>

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_user.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_user.py
@@ -252,6 +252,7 @@ class TestUserViewSet(TestAbstractViewSet):
 
         # Need to deactivate auth on XForm when using OpenRosa endpoints with username
         from kpi.models import Asset
+
         dummy_asset = Asset.objects.create(
             owner=self.user, asset_type=ASSET_TYPE_SURVEY, content={}
         )

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_user.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_user.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
+from kpi.constants import ASSET_TYPE_SURVEY
 from .test_abstract_viewset import TestAbstractViewSet
 
 
@@ -250,7 +251,14 @@ class TestUserViewSet(TestAbstractViewSet):
         assert response.status_code == status.HTTP_200_OK
 
         # Need to deactivate auth on XForm when using OpenRosa endpoints with username
-        XForm.objects.filter(pk=xform_id).update(require_auth=False)
+        from kpi.models import Asset
+        dummy_asset = Asset.objects.create(
+            owner=self.user, asset_type=ASSET_TYPE_SURVEY, content={}
+        )
+        XForm.objects.filter(pk=xform_id).update(
+            require_auth=False,
+            kpi_asset_uid=dummy_asset.uid,
+        )
         response = self.client.get(
             reverse('manifest-url', kwargs={'pk': xform_id, 'username': 'bob'}),
             **headers,

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_list_api.py
@@ -1,7 +1,5 @@
-import json
 import os
 import re
-from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -19,9 +17,8 @@ from kobo.apps.openrosa.apps.logger.models.xform import XForm
 from kobo.apps.openrosa.libs.constants import CAN_ADD_SUBMISSIONS, CAN_VIEW_XFORM
 from kobo.apps.openrosa.libs.utils.guardian import assign_perm
 from kobo.apps.organizations.models import Organization
-from kpi.constants import PERM_MANAGE_ASSET, PERM_ADD_SUBMISSIONS
-from kpi.models import Asset, ImportTask
-from kpi.utils.strings import to_str
+from kpi.constants import PERM_ADD_SUBMISSIONS, PERM_MANAGE_ASSET
+from kpi.models import Asset
 
 
 class TestXFormListApiBase(TestAbstractViewSet):
@@ -131,13 +128,9 @@ class TestXFormListApiWithoutAuthRequired(TestXFormListApiBase):
             content = response.render().content
             self.assertEqual(content.decode(), form_list_xml % data)
             self.assertTrue(response.has_header('X-OpenRosa-Version'))
-            self.assertTrue(
-                response.has_header('X-OpenRosa-Accept-Content-Length')
-            )
+            self.assertTrue(response.has_header('X-OpenRosa-Accept-Content-Length'))
             self.assertTrue(response.has_header('Date'))
-            self.assertEqual(
-                response['Content-Type'], 'text/xml; charset=utf-8'
-            )
+            self.assertEqual(response['Content-Type'], 'text/xml; charset=utf-8')
 
     def test_get_xform_list_as_owner(self):
 
@@ -168,13 +161,9 @@ class TestXFormListApiWithoutAuthRequired(TestXFormListApiBase):
             content = response.render().content
             self.assertEqual(content.decode(), form_list_xml % data)
             self.assertTrue(response.has_header('X-OpenRosa-Version'))
-            self.assertTrue(
-                response.has_header('X-OpenRosa-Accept-Content-Length')
-            )
+            self.assertTrue(response.has_header('X-OpenRosa-Accept-Content-Length'))
             self.assertTrue(response.has_header('Date'))
-            self.assertEqual(
-                response['Content-Type'], 'text/xml; charset=utf-8'
-            )
+            self.assertEqual(response['Content-Type'], 'text/xml; charset=utf-8')
 
     def test_retrieve_xform_manifest_as_owner(self):
 
@@ -245,9 +234,7 @@ class TestXFormListApiWithoutAuthRequired(TestXFormListApiBase):
 
         manager = User.objects.create_user(username='manager', password='manager')
         asset = Asset.objects.create(
-            content={
-                'survey': [{'type': 'text', 'label': 'q1'}]
-            },
+            content={'survey': [{'type': 'text', 'label': 'q1'}]},
             owner=self.user,
         )
         asset.deploy(active=True, backend='mock')
@@ -341,7 +328,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
             form_list_xml = f.read().strip()
             data = {'hash': self.xform.md5_hash, 'pk': self.xform.pk}
             content = response.render().content
-            self.assertEqual(content .decode(), form_list_xml % data)
+            self.assertEqual(content.decode(), form_list_xml % data)
             self.assertTrue(response.has_header('X-OpenRosa-Version'))
             self.assertTrue(
                 response.has_header('X-OpenRosa-Accept-Content-Length'))
@@ -362,7 +349,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
 
         xml = '<?xml version="1.0" encoding="utf-8"?>\n<xforms '
         xml += 'xmlns="http://openrosa.org/xforms/xformsList"></xforms>'
-        content = response.render().content .decode()
+        content = response.render().content.decode()
         self.assertEqual(content, xml)
         self.assertTrue(response.has_header('X-OpenRosa-Version'))
         self.assertTrue(
@@ -396,7 +383,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
         request.META.update(auth(request.META, response))
         response = self.view(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.render().content .decode()
+        content = response.render().content.decode()
         self.assertNotIn(self.xform.id_string, content)
         self.assertEqual(
             content, '<?xml version="1.0" encoding="utf-8"?>\n<xforms '
@@ -427,7 +414,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
         request.META.update(auth(request.META, response))
         response = self.view(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.render().content .decode()
+        content = response.render().content.decode()
         self.assertNotIn(self.xform.id_string, content)
         self.assertEqual(
             content, '<?xml version="1.0" encoding="utf-8"?>\n<xforms '
@@ -470,7 +457,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
             form_list_xml = f.read().strip()
             data = {'hash': self.xform.md5_hash, 'pk': self.xform.pk}
             content = response.render().content
-            self.assertEqual(content .decode(), form_list_xml % data)
+            self.assertEqual(content.decode(), form_list_xml % data)
             self.assertTrue(response.has_header('X-OpenRosa-Version'))
             self.assertTrue(
                 response.has_header('X-OpenRosa-Accept-Content-Length'))
@@ -510,7 +497,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
         with open(path) as f:
             form_list_xml = f.read().strip()
             data = {'hash': self.xform.md5_hash, 'pk': self.xform.pk}
-            content = response.render().content .decode()
+            content = response.render().content.decode()
             self.assertEqual(content, form_list_xml % data)
 
     def test_retrieve_xform_xml(self):
@@ -539,7 +526,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
         with open(path) as f:
             form_xml = f.read().strip()
             data = {'form_uuid': self.xform.uuid}
-            content = response.render().content .decode().strip()
+            content = response.render().content.decode().strip()
             self.assertEqual(content, form_xml % data)
 
     def test_retrieve_xform_manifest(self):
@@ -573,7 +560,7 @@ class TestXFormListApiWithAuthRequired(TestXFormListApiBase):
             'pk': self.metadata.pk,
             'xform': self.xform.pk,
         }
-        content = response.render().content .decode().strip()
+        content = response.render().content.decode().strip()
         self.assertEqual(content, manifest_xml % data)
         self.assertTrue(response.has_header('X-OpenRosa-Version'))
         self.assertTrue(
@@ -731,7 +718,7 @@ class TestXFormListAsOrgAdminApiBase(TestXFormListApiBase):
         with open(path) as f:
             form_list_xml = f.read().strip()
             data = {'hash': self.xform.md5_hash, 'pk': self.xform.pk}
-            content = response.render().content .decode()
+            content = response.render().content.decode()
             self.assertEqual(content, form_list_xml % data)
 
     def test_retrieve_xform_xml(self):
@@ -759,7 +746,7 @@ class TestXFormListAsOrgAdminApiBase(TestXFormListApiBase):
         with open(path) as f:
             form_xml = f.read().strip()
             data = {'form_uuid': self.xform.uuid}
-            content = response.render().content .decode().strip()
+            content = response.render().content.decode().strip()
             self.assertEqual(content, form_xml % data)
 
     def test_retrieve_xform_manifest(self):
@@ -791,7 +778,7 @@ class TestXFormListAsOrgAdminApiBase(TestXFormListApiBase):
             'pk': self.metadata.pk,
             'xform': self.xform.pk,
         }
-        content = response.render().content .decode().strip()
+        content = response.render().content.decode().strip()
         self.assertEqual(content, manifest_xml % data)
         self.assertTrue(response.has_header('X-OpenRosa-Version'))
         self.assertTrue(response.has_header('X-OpenRosa-Accept-Content-Length'))

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
@@ -103,17 +103,16 @@ class XFormListApi(OpenRosaReadOnlyModelViewSet):
             # No need to filter by asset_type or archive status (and trigger additional
             # joins), since OpenRosa only handles surveys and already excludes archived
             # forms.
-            asset_uids = list(ObjectPermission.objects.values_list(
-                'asset__uid', flat=True
-            ).filter(
-                permission__codename=PERM_MANAGE_ASSET,
-                deny=False,
-                user_id=openrosa_user.pk,
-            ))
+            asset_uids = list(
+                ObjectPermission.objects.values_list('asset__uid', flat=True).filter(
+                    permission__codename=PERM_MANAGE_ASSET,
+                    deny=False,
+                    user_id=openrosa_user.pk,
+                )
+            )
 
             queryset = queryset.filter(
-                Q(user__username=username.lower())
-                | Q(kpi_asset_uid__in=asset_uids),
+                Q(user__username=username.lower()) | Q(kpi_asset_uid__in=asset_uids),
                 require_auth=False,
             )
 


### PR DESCRIPTION
### 📣 Summary
Fixed logic to return projects that allow anonymous submissions and are manageable by the user.

### 📖 Description
Previously, the OpenRosa API used the project owner's account to list all projects that allowed anonymous submissions. After account unification into organizations, this resulted in a list that was too large to handle, causing 502/504 errors in KoboCollect and making devices difficult to maintain since they required manual reconfiguration.

With this PR:
- Only projects that allow anonymous submissions and that the user has manage_asset permission on are returned.
- The behavior remains transparent for users — devices do not need to be reconfigured.

### Preview steps

1. ℹ️ have account (`user_a`) and a few projects
2. Activate Allow submissions for anonymous for all of them
3. Add this account to a MMO
4. Go to http://kf.kobo.local/user_a/formList
4. 🔴 [on release branch] Response is empty
6. 🟢 [on this PR] Projects should be listed
