### PR TITLE
fix:(reports): Fix infinite reloading failed report DEV-265

### DIFF
--- a/jsapp/js/components/reports/reports.tsx
+++ b/jsapp/js/components/reports/reports.tsx
@@ -180,7 +180,7 @@ export default class Reports extends React.Component<ReportsProps, ReportsState>
                 ),
               )
 
-              // reset default report groupBy if it fails and notify user
+              // reset default report groupBy if it fails
               reportStyles.default.groupDataBy = undefined
               this.setState({ reportStyles: reportStyles }, () => {
                 // Retry loading report data without groupBy

--- a/jsapp/js/components/reports/reports.tsx
+++ b/jsapp/js/components/reports/reports.tsx
@@ -114,7 +114,7 @@ export default class Reports extends React.Component<ReportsProps, ReportsState>
       let groupBy = ''
       // The code below is overriding the `ReportStyles` we got from endpoint in
       // `AssetResponse`, we clone it here to avoid mutation.
-      const reportStyles: AssetResponseReportStyles = clonedeep(asset.report_styles)
+      const reportStyles: AssetResponseReportStyles = this.state.reportStyles || clonedeep(asset.report_styles)
       const reportCustom = asset.report_custom
 
       if (this.state.currentCustomReport?.reportStyle?.groupDataBy) {
@@ -173,16 +173,19 @@ export default class Reports extends React.Component<ReportsProps, ReportsState>
               !this.state.currentCustomReport &&
               reportStyles.default?.groupDataBy !== undefined
             ) {
-              // reset default report groupBy if it fails and notify user
-              reportStyles.default.groupDataBy = ''
-              this.setState({ reportStyles: reportStyles })
               notify.error(
                 t('Could not load grouped results via "##". Will attempt to load the ungrouped report.').replace(
                   '##',
                   groupBy,
                 ),
               )
-              this.loadReportData()
+
+              // reset default report groupBy if it fails and notify user
+              reportStyles.default.groupDataBy = undefined
+              this.setState({ reportStyles: reportStyles }, () => {
+                // Retry loading report data without groupBy
+                this.loadReportData()
+              })
             } else {
               this.setState({
                 error: err,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR fixes a bug where under a certain condition loading a report containing a Group By configured fails and the app tries to reload it infinitely.

### 👀 Preview steps
Bug template:

1. Have at least 1 select one type question in the form
2. Have a number input in the form
3. Generate multiple submissions
4. Generate report
5. Setup a Group By for the report (in report settings)
6. Report will display normally
7. Open the data and bulk edit the submissions to insert an invalid value into the number field
8. Try to load the report
9. Error should happen
