### PR TITLE
feat(massEmails): prioritize recurring sends over one-time TASK-1697

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from enum import Enum
 
 from django.db import models
 
@@ -33,6 +34,7 @@ USER_QUERIES: dict[str, Callable] = {
     'test_users': get_all_test_users,
 }
 USER_QUERY_CHOICES = [(name, name.lower()) for name in USER_QUERIES.keys()]
+EmailType = Enum('EmailType', ['RECURRING', 'ONE_TIME'])
 
 
 class EmailStatus(models.TextChoices):
@@ -61,6 +63,12 @@ class MassEmailConfig(AbstractTimeStampedModel):
 
     def __str__(self):
         return self.name
+
+    @property
+    def type(self):
+        if self.frequency == -1:
+            return EmailType.ONE_TIME
+        return EmailType.RECURRING
 
 
 class MassEmailJob(AbstractTimeStampedModel):

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, time, timedelta
+from enum import Enum
 from math import ceil
 from time import sleep
 from typing import Optional
@@ -14,6 +15,7 @@ from django.utils.translation import gettext
 from kobo.apps.mass_emails.models import (
     USER_QUERIES,
     EmailStatus,
+    EmailType,
     MassEmailConfig,
     MassEmailJob,
     MassEmailRecord,
@@ -128,6 +130,32 @@ class MassEmailSender:
 
         cache.set(cache_key, limit, TTL)
 
+    def get_config_limit(
+        self,
+        email_config: MassEmailConfig,
+        current_total: int,
+        total_records_by_type: dict[Enum, int],
+        limit_by_type: dict[Enum, int],
+    ) -> int:
+        """
+        Determine the number of emails to be sent for the given config
+
+        :param email_config: MassEmailConfig
+        :param current_total: Total limits already calculated (for both types)
+        :param total_records_by_type: Total enqueued records for all sends
+        :param limit_by_type: Send limits for recurring and one-time sends
+        """
+        email_type = email_config.type
+        total_records = total_records_by_type[email_type]
+        limit = limit_by_type[email_type]
+        if total_records_by_type[email_type] < limit_by_type[email_type]:
+            return email_config.enqueued_records_count
+        config_limit = ceil(email_config.enqueued_records_count / total_records * limit)
+
+        if current_total + config_limit > settings.MAX_MASS_EMAILS_PER_DAY:
+            config_limit = settings.MAX_MASS_EMAILS_PER_DAY - current_total
+        return config_limit
+
     def get_day_limits(self):
         MAX_EMAILS = settings.MAX_MASS_EMAILS_PER_DAY
         self.limits = {}
@@ -139,6 +167,8 @@ class MassEmailSender:
                 self.limits[email_config.id] = stored_limit
         else:
             logging.info('Setting up MassEmailConfig limits for the current day')
+            # if the total number of emails to be sent is < MAX allowed, just
+            # send all emails
             if self.total_records < MAX_EMAILS:
                 for email_config in self.configs:
                     self.cache_limit_value(
@@ -146,19 +176,62 @@ class MassEmailSender:
                     )
                 self.cache_limit_value(None, self.total_records)
             else:
+                # divide configs into daily sends and one-time sends
+                recurring_emails = [
+                    email_config
+                    for email_config in self.configs
+                    if email_config.frequency > -1
+                ]
+                total_recurring_records = sum(
+                    email_config.enqueued_records_count
+                    for email_config in recurring_emails
+                )
+                one_time_sends = [
+                    email_config
+                    for email_config in self.configs
+                    if email_config.frequency == -1
+                ]
+                total_one_time_records = sum(
+                    email_config.enqueued_records_count
+                    for email_config in one_time_sends
+                )
+                total_records_by_type = {
+                    EmailType.RECURRING: total_recurring_records,
+                    EmailType.ONE_TIME: total_one_time_records,
+                }
+                max_available_by_type = {
+                    EmailType.RECURRING: MAX_EMAILS,
+                    EmailType.ONE_TIME: max(MAX_EMAILS - total_recurring_records, 0),
+                }
+
                 day_limit = 0
-                for email_config in self.configs:
+                # recurring sends get priority. limits are allotted proportionally
+                # with the total number of recurring emails to be sent
+                for email_config in recurring_emails:
                     if day_limit >= MAX_EMAILS:
                         break
-                    config_limit = ceil(
-                        email_config.enqueued_records_count
-                        / self.total_records
-                        * MAX_EMAILS
+                    config_limit = self.get_config_limit(
+                        email_config,
+                        day_limit,
+                        total_records_by_type,
+                        max_available_by_type,
                     )
-                    if day_limit + config_limit > MAX_EMAILS:
-                        config_limit = MAX_EMAILS - day_limit
                     self.cache_limit_value(email_config, config_limit)
                     day_limit += config_limit
+                # if there is still capacity, divide the remaining number of emails
+                # allowed among the one-time sends using the same system
+                if day_limit < MAX_EMAILS:
+                    for email_config in one_time_sends:
+                        if day_limit >= MAX_EMAILS:
+                            break
+                        config_limit = self.get_config_limit(
+                            email_config,
+                            day_limit,
+                            total_records_by_type,
+                            max_available_by_type,
+                        )
+                        self.cache_limit_value(email_config, config_limit)
+                        day_limit += config_limit
                 self.cache_limit_value(None, MAX_EMAILS)
 
     def get_plan_name(self, org_user: OrganizationUser) -> str:

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -1,3 +1,4 @@
+import random
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -11,6 +12,8 @@ from django.db import IntegrityError
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
+from model_bakery import baker
+from model_bakery.recipe import seq
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.tests.base_test_case import BaseTestCase
@@ -92,6 +95,17 @@ class BaseMassEmailsTestCase(BaseTestCase):
             date_modified=timezone.now() - timedelta(days=days_ago)
         )
 
+    def _enqueue_records_for_config(self, email_config, count):
+        job = MassEmailJob.objects.create(email_config=email_config)
+        users = User.objects.all()
+        for i in range(count):
+            self._create_email_record(
+                email_config=email_config,
+                user=users[i],
+                status=EmailStatus.ENQUEUED,
+                job=job,
+            )
+
 
 @ddt
 class TestMassEmailSender(BaseMassEmailsTestCase):
@@ -108,6 +122,7 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         self.jobs = []
         cache.clear()
 
+    def _setup_common_test_data(self):
         for i in range(0, 100):
             config = self._create_email_config(
                 name=f'Config {i}', template=self.template
@@ -136,6 +151,7 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=310)
     def test_daily_limits_less_than_max(self):
+        self._setup_common_test_data()
         sender = MassEmailSender()
         assert sender.total_limit == 300
         assert len(sender.limits) == 100
@@ -143,19 +159,30 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=180)
     def test_daily_limits_more_than_max(self):
+        self._setup_common_test_data()
         sender = MassEmailSender()
         assert sender.total_limit == 180
         assert sum(sender.limits.values()) == 180
         assert list(sender.limits.values())[0] == 2
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=10)
-    @patch('django.utils.timezone.now')
-    def test_send_emails_limits(self, now_mock):
-        now_mock.return_value = datetime(2025, 1, 1, 0, 0, 0, 0, pytz.UTC)
+    def test_send_emails_limits(self):
+        self._setup_common_test_data()
+        now_mock = patch(
+            'django.utils.timezone.now',
+            return_value=datetime(2025, 1, 1, 0, 0, 0, 0, pytz.UTC),
+        )
+        now_mock.start()
         sender = MassEmailSender()
         sender.send_day_emails()
+        now_mock.stop()
+
         assert len(mail.outbox) == 10
-        now_mock.return_value = datetime(2025, 1, 2, 0, 0, 0, 0, pytz.UTC)
+        now_mock = patch(
+            'django.utils.timezone.now',
+            return_value=datetime(2025, 1, 2, 0, 0, 0, 0, pytz.UTC),
+        )
+        now_mock.start()
         sender = MassEmailSender()
         sender.send_day_emails()
         assert len(mail.outbox) == 20
@@ -168,6 +195,7 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         sender = MassEmailSender()
         assert sum([0 if lim is None else lim for lim in sender.limits.values()]) == 0
         assert sender.total_limit == 0
+        now_mock.stop()
 
     @pytest.mark.skipif(settings.STRIPE_ENABLED, reason='Test non-stripe functionality')
     def test_get_plan_name_stripe_disabled(self):
@@ -178,6 +206,7 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
 
     @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=2)
     def test_send_is_throttled(self):
+        self._setup_common_test_data()
         calls = []
         with patch(
             'kobo.apps.mass_emails.tasks.sleep',
@@ -217,14 +246,63 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         assert sender.get_cache_key_date(send_date=current_time) == expected_time
 
     def test_send_recurring_emails_exits_when_incomplete_init(self):
+        self._setup_common_test_data()
         _send_emails()
         assert len(mail.outbox) == 0
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=100)
     def test_send_recurring_emails_when_initialized(self):
+        self._setup_common_test_data()
         generate_mass_email_user_lists()
         _send_emails()
         assert len(mail.outbox) == 100
+
+    @data(
+        # max emails per day, expected limits for one-time emails 1 and 2
+        (20, 2, 8),
+        (15, 1, 4),
+        (40, 5, 20),
+        (10, 0, 0),
+    )
+    @unpack
+    def test_one_time_emails_deprioritized(
+        self, max_per_day, expected_limit_1, expected_limit_2
+    ):
+        # make sure we have at least 20 users
+        total_users = User.objects.count()
+        if total_users < 20:
+            remaining = 20 - total_users
+            baker.make(User, username=seq('User'), _quantity=remaining)
+
+        # create 1 recurring email (ie frequency > -1) with 10 enqueued records
+        recurring_config = self._create_email_config(
+            name='Recurring config',
+            template=self.template,
+            frequency=random.randint(0, 10),
+        )
+        self._enqueue_records_for_config(email_config=recurring_config, count=10)
+
+        # create 1 one-time email to send to 5 users
+        recurring_config_1 = self._create_email_config(
+            name='One-time config 5 enqueued', template=self.template, frequency=-1
+        )
+        self._enqueue_records_for_config(email_config=recurring_config_1, count=5)
+
+        # create 1 one-time email to send to 20 users
+        recurring_config_2 = self._create_email_config(
+            name='One-time config 20 enqueued', template=self.template, frequency=-1
+        )
+        self._enqueue_records_for_config(email_config=recurring_config_2, count=20)
+
+        with override_settings(MAX_MASS_EMAILS_PER_DAY=max_per_day):
+            sender = MassEmailSender()
+
+        # all max_per_day options are > 10,
+        # so the recurring emails should send all its emails
+        assert sender.limits[recurring_config.id] == 10
+
+        assert sender.limits.get(recurring_config_1.id, 0) == expected_limit_1
+        assert sender.limits.get(recurring_config_2.id, 0) == expected_limit_2
 
 
 @ddt


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Allocates send capacity to recurring emails first, then allocates whatever is left to the one-time emails.

### 📖 Description
Previously, send capacity was allotted to each email E by calculating (# of enqueued E records/total enqueued records)*total send capacity. In order to ensure recurring emails go out regardless of any large one-time sends that may be pending, we are dividing emails into "one-time" and "recurring" categories. For a recurring email R, the send capacity is now (# of enqueued R records/total enqueued recurring records)*total send capacity. After the send capacity for each recurring email is calculated, any remaining capacity is allocated among the one-time sends using the same calculation.


### 👀 Preview steps

Feature/no-change template:
1. ℹ️ Have at least 3 accounts
2. In Constance, set MASS_EMAIL_TEST_EMAILS to include all 3 emails
3. Lower the MAX_MASS_EMAILS_PER_DAY setting to 5
4. Create 3 new MassEmailConfigs, all of which use the test_users query
5. In a django shell, set one of the email configs to have a frequency of 1 (the other 2 will default to -1)
6. Add all three emails to the daily send
7. 🟢 When the daily email send occurs, the email with the frequency of 1 should send to all 3 test users. The other 2 should send to only one user each.

