### PR TITLE
docs(api): removed unnecessary markdown documentations TASK-1724

### DIFF
--- a/kpi/docs/api/v2/asset_snapshots/list.md
+++ b/kpi/docs/api/v2/asset_snapshots/list.md
@@ -1,9 +1,1 @@
 ## List all snapshots for every asset of a user
-
-This endpoint can be paginated with `offset` and `limit` parameters, e.g.:
-
-```shell
-curl -X GET https://kf.kobotoolbox.org/api/v2/asset_snapshots/?offset=100&limit=50
-```
-
-will return entries 100-149

--- a/kpi/docs/api/v2/asset_subscriptions/list.md
+++ b/kpi/docs/api/v2/asset_subscriptions/list.md
@@ -1,9 +1,1 @@
 ## List all asset subscriptions of a user
-
-This endpoint can be paginated with `offset` and `limit` parameters, e.g.:
-
-```shell
-curl -X GET https://kf.kobotoolbox.org/api/v2/asset_subscriptions/?offset=100&limit=50
-```
-
-will return entries 100-149


### PR DESCRIPTION
### 📣 Summary
Removed unnecessary curl documentation from markdown files.