### PR TITLE
chore(frontend): .git-blame-ignore-revs for Biome DEV-269

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,7 @@ f82d494ab36f502aa35a7880b726c6df89738754
 
 # Run prettier on miniAudioPlayer
 2e65d24e8595f7732670ab7c378782fceeda27b3
+
+# Biome
+d5796bd4e412aac55c519bf629ae650ff25af4d5 # 2025-03-05 13:58:44 +0200 - style(frontend): organize imports with Biome TASK-1640 (#5568)
+06c05bb1036bf40675cb358bdba99392b390d45e # 2025-02-10 16:08:52 +0200 - style(frontend): format with Biome and enforce in CI (#5498)


### PR DESCRIPTION
### 💭 Notes

Ignore biome whitespace commits in the blame and heatmap.

Works for me in VSCode and Gitlens, note that file history still shows ignored commits and that's ok. Please report if it works on your IDE and workflow.

### 👀 Preview steps

1. open any frontend react file
2. git blame it
4. :red_circle: [on main] notice biome commits, likely on import statements
6. 🟢 [on PR] notice that those biome commits are skipped
