### PR TITLE
test(billing): fix incorrect billing cycle end date when testing previous month

### DIFF
--- a/kobo/apps/stripe/tests/test_organization_usage.py
+++ b/kobo/apps/stripe/tests/test_organization_usage.py
@@ -311,6 +311,9 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
                 current_billing_period_end.year,
                 current_billing_period_end.month,
             )[1]
+            if last_day_of_billing_period > canceled_at.day:
+                last_day_of_billing_period = canceled_at.day
+
             current_billing_period_end = current_billing_period_end.replace(
                 day=last_day_of_billing_period
             )


### PR DESCRIPTION
### 📣 Summary
Corrected a test case where the billing cycle end date for the previous month was miscalculated.

