### PR TITLE
fix(longRunningMigration): do not block fresh installs with system checks DEV-272

### DIFF
--- a/kobo/apps/long_running_migrations/app.py
+++ b/kobo/apps/long_running_migrations/app.py
@@ -12,33 +12,72 @@ class LongRunningMigrationAppConfig(AppConfig):
 
 
 def check_must_complete_long_running_migrations(app_configs, **kwargs):
+    """
+    System check to ensure that required long-running migrations have been completed.
+
+    This check is triggered at startup (e.g., by uWSGI workers) to avoid proceeding
+    with an incomplete database state. It verifies that specific long-running migrations
+    (listed in `MUST_COMPLETE_LONG_RUNNING_MIGRATIONS`) are marked as completed in the
+    database.
+
+    - If the database or required tables do not exist yet, the check is skipped.
+    - If none of the required migrations are marked as incomplete, the check passes.
+    - If the database is freshly installed (i.e., empty `kpi_asset`), it marks the
+      required migrations as completed automatically to avoid blocking startup.
+    - Otherwise, it raises an `Error` to prompt the user to complete those migrations
+      manually.
+    """
 
     try:
         existing_tables = connection.introspection.table_names()
     except (OperationalError, ProgrammingError):
-        # DB does not exist yet
+        # Database hasn't been created yet
         return []
 
     if 'long_running_migrations_longrunningmigration' not in existing_tables:
-        # Migrations have not run yet
+        # Migration tracking table does not exist yet
         return []
 
     placeholders = ', '.join(['%s'] * len(MUST_COMPLETE_LONG_RUNNING_MIGRATIONS))
+
+    # 1) Check if any of the required long-running migrations are still incomplete
     sql = f"""
-            SELECT 1
-            FROM long_running_migrations_longrunningmigration
-            WHERE name IN ({placeholders})
-              AND status != 'completed'
-            LIMIT 1
-        """
+        SELECT 1
+        FROM long_running_migrations_longrunningmigration
+        WHERE name IN ({placeholders})
+          AND status != 'completed'
+        LIMIT 1
+    """
 
     with connection.cursor() as cursor:
         cursor.execute(sql, MUST_COMPLETE_LONG_RUNNING_MIGRATIONS)
         row = cursor.fetchone()
 
     if row is None:
+        # All required migrations have been completed, there is nothing to do
         return []
+    else:
+        # 2) If some migrations are pending, check whether this is a fresh install
+        #    We use the absence of `kpi_asset` records as an indicator
+        sql = 'SELECT 1 FROM kpi_asset LIMIT 1'
 
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            row = cursor.fetchone()
+
+            if row is None:
+                # 3) No assets found. Assume fresh install, mark pending migrations
+                #    as completed
+                sql = f"""
+                    UPDATE long_running_migrations_longrunningmigration
+                    SET status = 'completed'
+                    WHERE name IN ({placeholders}) AND status = 'created'
+                """
+                cursor.execute(sql, MUST_COMPLETE_LONG_RUNNING_MIGRATIONS)
+                return []
+
+    # 4) At this point, required migrations are missing and the DB is not empty.
+    #    Raise an error
     long_running_migrations_list = (
         '\n * ' + '\n  * '.join(MUST_COMPLETE_LONG_RUNNING_MIGRATIONS) + '\n'
     )

--- a/kobo/apps/long_running_migrations/tests/test_checks.py
+++ b/kobo/apps/long_running_migrations/tests/test_checks.py
@@ -1,6 +1,8 @@
 from django.core.checks import run_checks
 from django.test import TestCase, override_settings
 
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.models import Asset
 from ..constants import MUST_COMPLETE_LONG_RUNNING_MIGRATIONS
 from ..models import LongRunningMigration, LongRunningMigrationStatus
 
@@ -13,6 +15,10 @@ from ..models import LongRunningMigration, LongRunningMigrationStatus
 class LongRunningMigrationSystemCheckTestCase(TestCase):
 
     def test_system_check_fails_when_not_completed(self):
+        # Create at least one asset to fake existing install
+        someuser = User.objects.create_user(username='someuser', password='someuser')
+        Asset.objects.create(owner=someuser, name='foo')
+
         errors = run_checks()
 
         assert any(
@@ -21,10 +27,23 @@ class LongRunningMigrationSystemCheckTestCase(TestCase):
         )
 
     def test_system_check_passes_when_completed(self):
+        # Create at least one asset to fake existing install
+        someuser = User.objects.create_user(username='someuser', password='someuser')
+        Asset.objects.create(owner=someuser, name='foo')
+
+        # Fake migrations have run
         LongRunningMigration.objects.filter(
             name__in=MUST_COMPLETE_LONG_RUNNING_MIGRATIONS
         ).update(status=LongRunningMigrationStatus.COMPLETED)
 
+        errors = run_checks()
+
+        assert not any(
+            e.id == 'long_running_migrations.E001'
+            for e in errors
+        )
+
+    def test_system_check_passes_on_fresh_installs(self):
         errors = run_checks()
 
         assert not any(


### PR DESCRIPTION
### 📣 Summary
Prevented system checks from raising errors on fresh installs when long-running migrations haven't been executed.

### 📖 Description
System checks for long-running migrations were incorrectly raising errors even on fresh installs, where no data exists and migrations are not required. This caused unnecessary blocking during setup or deployment of a new environment.

### 👀 Preview steps

1. Create a fresh install with kobo-install
2. 🔴 [on main] notice that the KPI container will crash on its first attempt to connect to the database
3. Stop containers
4. Delete kobo-docker, kobo-env folders
5. In KPI folder, checkout this branch
6. run kobo-install setup again (`--setup`)
7. starts containers if they are not started yet
7. 🟢 [on PR] notice that the KPI container starts and kobo-install displays the message "Postgres is up and running"
