### PR TITLE
fix(frontend): don't install playwright in dockerfile DEV-276

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ ENV PATH=$PATH:${KPI_NODE_PATH}/.bin
 # Build client code. #
 ######################
 
-RUN npm run build
+RUN npm run build:app
 
 ###########################
 # Organize static assets. #


### PR DESCRIPTION
### 📣 Summary

Reverse an accidental increase in docker file by 1.5GB.


### 👀 Preview steps

Bug template:
1. ℹ️ 
2. build docker file
3. 🔴 [on main] layer "npm run build" is 1.5GB
4. 🟢 [on PR] layer "npm run build" is 16 MB
