### PR TITLE
fix(billing): direct storage addon holders to Stripe for upgrade DEV-275

### DIFF
--- a/jsapp/js/account/addOns/addOnList.component.tsx
+++ b/jsapp/js/account/addOns/addOnList.component.tsx
@@ -24,7 +24,6 @@ const AddOnList = (props: {
 }) => {
   const [subscribedAddOns, setSubscribedAddOns] = useState<SubscriptionInfo[]>([])
   const [subscribedPlans, setSubscribedPlans] = useState<SubscriptionInfo[]>([])
-  const [activeSubscriptions, setActiveSubscriptions] = useState<SubscriptionInfo[]>([])
   const [addOnProducts, setAddOnProducts] = useState<Product[]>([])
   const oneTimeAddOnsContext = useContext(OneTimeAddOnsContext)
   const oneTimeAddOnSubscriptions = oneTimeAddOnsContext.oneTimeAddOns
@@ -55,7 +54,6 @@ const AddOnList = (props: {
     () => {
       setSubscribedAddOns(subscriptionStore.addOnsResponse)
       setSubscribedPlans(subscriptionStore.planResponse)
-      setActiveSubscriptions(subscriptionStore.activeSubscriptions)
     },
     [],
   )
@@ -153,7 +151,6 @@ const AddOnList = (props: {
               isBusy={props.isBusy}
               setIsBusy={props.setIsBusy}
               subscribedAddOns={subscribedAddOns}
-              activeSubscriptions={activeSubscriptions}
               organization={props.organization}
             />
           )}
@@ -164,7 +161,6 @@ const AddOnList = (props: {
               isBusy={props.isBusy}
               setIsBusy={props.setIsBusy}
               subscribedAddOns={subscribedAddOns}
-              activeSubscriptions={activeSubscriptions}
               organization={props.organization}
             />
           )}

--- a/jsapp/js/account/addOns/addOnList.component.tsx
+++ b/jsapp/js/account/addOns/addOnList.component.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 
-import { OneTimeAddOnRow } from '#/account/addOns/oneTimeAddOnRow.component'
+import { AddOnProductRow } from '#/account/addOns/addOnProductRow.component'
 import type { Organization } from '#/account/organization/organizationQuery'
 import type { OneTimeAddOn, Price, Product, SubscriptionInfo } from '#/account/stripe.types'
 import { isAddonProduct } from '#/account/stripe.utils'
@@ -147,7 +147,7 @@ const AddOnList = (props: {
         </caption>
         <tbody>
           {showRecurringAddons && (
-            <OneTimeAddOnRow
+            <AddOnProductRow
               key={recurringAddOnProducts.map((product) => product.id).join('-')}
               products={recurringAddOnProducts}
               isBusy={props.isBusy}
@@ -158,7 +158,7 @@ const AddOnList = (props: {
             />
           )}
           {!!oneTimeAddOnProducts.length && (
-            <OneTimeAddOnRow
+            <AddOnProductRow
               key={oneTimeAddOnProducts.map((product) => product.id).join('-')}
               products={oneTimeAddOnProducts}
               isBusy={props.isBusy}

--- a/jsapp/js/account/addOns/addOnProductRow.component.tsx
+++ b/jsapp/js/account/addOns/addOnProductRow.component.tsx
@@ -8,7 +8,7 @@ import type { Product, SubscriptionInfo } from '#/account/stripe.types'
 import Button from '#/components/common/ButtonNew'
 import Select from '#/components/common/Select'
 
-interface addOnProductRowProps {
+interface AddOnProductRowProps {
   products: Product[]
   isBusy: boolean
   setIsBusy: (value: boolean) => void
@@ -22,7 +22,7 @@ export const AddOnProductRow = ({
   setIsBusy,
   subscribedAddOns,
   organization,
-}: addOnProductRowProps) => {
+}: AddOnProductRowProps) => {
   const [selectedProduct, setSelectedProduct] = useState(products[0])
   const [selectedPrice, setSelectedPrice] = useState<Product['prices'][0]>(selectedProduct.prices[0])
   const displayPrice = useDisplayPrice(selectedPrice)

--- a/jsapp/js/account/addOns/addOnProductRow.component.tsx
+++ b/jsapp/js/account/addOns/addOnProductRow.component.tsx
@@ -5,7 +5,6 @@ import type { Organization } from '#/account/organization/organizationQuery'
 import { useDisplayPrice } from '#/account/plans/useDisplayPrice.hook'
 import { postCheckout, postCustomerPortal } from '#/account/stripe.api'
 import type { Product, SubscriptionInfo } from '#/account/stripe.types'
-import { isChangeScheduled } from '#/account/stripe.utils'
 import Button from '#/components/common/ButtonNew'
 import Select from '#/components/common/Select'
 
@@ -13,7 +12,6 @@ interface addOnProductRowProps {
   products: Product[]
   isBusy: boolean
   setIsBusy: (value: boolean) => void
-  activeSubscriptions: SubscriptionInfo[]
   subscribedAddOns: SubscriptionInfo[]
   organization: Organization
 }
@@ -22,7 +20,6 @@ export const AddOnProductRow = ({
   products,
   isBusy,
   setIsBusy,
-  activeSubscriptions,
   subscribedAddOns,
   organization,
 }: addOnProductRowProps) => {
@@ -52,7 +49,6 @@ export const AddOnProductRow = ({
   // will only end up being true/relevant for recurring addons
   const userAlreadyHasCategoryProduct = useMemo(
     () =>
-      isChangeScheduled(selectedPrice, activeSubscriptions) ||
       subscribedAddOns.some((subscription) =>
         products.map((product) => product.id).includes(subscription.items[0].price.product.id),
       ),


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Quick fix for bug that made upgrading storage addons overly complicated. Always direct users with storage addons to Stripe account management instead of attempting to purchase new addon directly. 


### 💭 Notes
1. This is a workaround until we get a better system in place. Ideally, users with an existing storage addon should be able to select a new addon, click the button, and only be directed to Stripe to confirm change. But currently attempting to purchase a new addon results in the user being prompted by Stripe to confirm their email address, after which they are directed to Stripe account management. So we are just cutting out that email confirmation to make it a less annoying.

2. I renamed the oneTimeAddOnRow component because we use it for both recurring and one time addons.

3. I did a little refactoring to make the jsx template easier to read.

Bug template:
1. As a new user in a Stripe-enabled environment, purchase a 5gb storage addon and sync stripe
2. Navigate to addons page.
3. On `main`, observe that the button on the storage addon row says "Buy now" unless you use the select to pick your current storage plan. If you click on "Buy now" you are directed to Stripe, which asks you to confirm your email
4. On this branch, observe that the button always says "Manage" and clicking on it takes you to your Stripe account management page
5. Purchase an NLP addon
6. Notice that the behavior of the NLP addons row on the addons page is unchanged between this branch and `main`.
