### PR TITLE
fix(billing): direct storage addon holders to Stripe for upgrade DEV-275

### DIFF
--- a/jsapp/js/account/addOns/addOnList.component.tsx
+++ b/jsapp/js/account/addOns/addOnList.component.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 
-import { OneTimeAddOnRow } from '#/account/addOns/oneTimeAddOnRow.component'
+import { AddOnProductRow } from '#/account/addOns/addOnProductRow.component'
 import type { Organization } from '#/account/organization/organizationQuery'
 import type { OneTimeAddOn, Price, Product, SubscriptionInfo } from '#/account/stripe.types'
 import { isAddonProduct } from '#/account/stripe.utils'
@@ -24,7 +24,6 @@ const AddOnList = (props: {
 }) => {
   const [subscribedAddOns, setSubscribedAddOns] = useState<SubscriptionInfo[]>([])
   const [subscribedPlans, setSubscribedPlans] = useState<SubscriptionInfo[]>([])
-  const [activeSubscriptions, setActiveSubscriptions] = useState<SubscriptionInfo[]>([])
   const [addOnProducts, setAddOnProducts] = useState<Product[]>([])
   const oneTimeAddOnsContext = useContext(OneTimeAddOnsContext)
   const oneTimeAddOnSubscriptions = oneTimeAddOnsContext.oneTimeAddOns
@@ -55,7 +54,6 @@ const AddOnList = (props: {
     () => {
       setSubscribedAddOns(subscriptionStore.addOnsResponse)
       setSubscribedPlans(subscriptionStore.planResponse)
-      setActiveSubscriptions(subscriptionStore.activeSubscriptions)
     },
     [],
   )
@@ -147,24 +145,22 @@ const AddOnList = (props: {
         </caption>
         <tbody>
           {showRecurringAddons && (
-            <OneTimeAddOnRow
+            <AddOnProductRow
               key={recurringAddOnProducts.map((product) => product.id).join('-')}
               products={recurringAddOnProducts}
               isBusy={props.isBusy}
               setIsBusy={props.setIsBusy}
               subscribedAddOns={subscribedAddOns}
-              activeSubscriptions={activeSubscriptions}
               organization={props.organization}
             />
           )}
           {!!oneTimeAddOnProducts.length && (
-            <OneTimeAddOnRow
+            <AddOnProductRow
               key={oneTimeAddOnProducts.map((product) => product.id).join('-')}
               products={oneTimeAddOnProducts}
               isBusy={props.isBusy}
               setIsBusy={props.setIsBusy}
               subscribedAddOns={subscribedAddOns}
-              activeSubscriptions={activeSubscriptions}
               organization={props.organization}
             />
           )}

--- a/jsapp/js/account/addOns/addOnProductRow.component.tsx
+++ b/jsapp/js/account/addOns/addOnProductRow.component.tsx
@@ -5,8 +5,8 @@ import type { Organization } from '#/account/organization/organizationQuery'
 import { useDisplayPrice } from '#/account/plans/useDisplayPrice.hook'
 import { postCheckout, postCustomerPortal } from '#/account/stripe.api'
 import type { Product, SubscriptionInfo } from '#/account/stripe.types'
+import KoboSelect3 from '#/components/special/koboAccessibleSelect'
 import Button from '#/components/common/ButtonNew'
-import { Select } from '#/components/common/Select'
 
 interface AddOnProductRowProps {
   products: Product[]
@@ -112,22 +112,20 @@ export const AddOnProductRow = ({
       </td>
       <td className={styles.price}>
         <div className={styles.oneTime}>
-          <Select
-            size='sm'
-            className={styles.selectProducts}
+          <KoboSelect3
+            size={'fit'}
             name='products'
-            data={products.map((product) => {
+            options={products.map((product) => {
               return { value: product.id, label: product.name }
             })}
-            onChange={(productId: string | null) => onChangeProduct(productId)}
+            onChange={(productId) => onChangeProduct(productId as string)}
             value={selectedProduct.id}
           />
           {displayName === 'File Storage' && (
-            <Select
-              size='sm'
-              className={styles.selectPrices}
-              name='prices'
-              data={priceOptions}
+            <KoboSelect3
+              size={'fit'}
+              name={t('prices')}
+              options={priceOptions}
               onChange={onChangePrice}
               value={selectedPrice.id}
             />

--- a/jsapp/js/account/addOns/addOnProductRow.component.tsx
+++ b/jsapp/js/account/addOns/addOnProductRow.component.tsx
@@ -2,30 +2,27 @@ import React, { useMemo, useState } from 'react'
 
 import styles from '#/account/addOns/addOnList.module.scss'
 import type { Organization } from '#/account/organization/organizationQuery'
-import BillingButton from '#/account/plans/billingButton.component'
 import { useDisplayPrice } from '#/account/plans/useDisplayPrice.hook'
 import { postCheckout, postCustomerPortal } from '#/account/stripe.api'
 import type { Product, SubscriptionInfo } from '#/account/stripe.types'
-import { isChangeScheduled } from '#/account/stripe.utils'
-import KoboSelect3 from '#/components/special/koboAccessibleSelect'
+import Button from '#/components/common/ButtonNew'
+import { Select } from '#/components/common/Select'
 
-interface OneTimeAddOnRowProps {
+interface AddOnProductRowProps {
   products: Product[]
   isBusy: boolean
   setIsBusy: (value: boolean) => void
-  activeSubscriptions: SubscriptionInfo[]
   subscribedAddOns: SubscriptionInfo[]
   organization: Organization
 }
 
-export const OneTimeAddOnRow = ({
+export const AddOnProductRow = ({
   products,
   isBusy,
   setIsBusy,
-  activeSubscriptions,
   subscribedAddOns,
   organization,
-}: OneTimeAddOnRowProps) => {
+}: AddOnProductRowProps) => {
   const [selectedProduct, setSelectedProduct] = useState(products[0])
   const [selectedPrice, setSelectedPrice] = useState<Product['prices'][0]>(selectedProduct.prices[0])
   const displayPrice = useDisplayPrice(selectedPrice)
@@ -48,15 +45,18 @@ export const OneTimeAddOnRow = ({
     description = t('Get up to 50GB of media storage on a KoboToolbox public server.')
   }
 
-  const isSubscribedAddOnPrice = useMemo(
+  // In practice, this variable and related onSubmit behavior
+  // will only end up being true/relevant for recurring addons
+  const userAlreadyHasCategoryProduct = useMemo(
     () =>
-      isChangeScheduled(selectedPrice, activeSubscriptions) ||
-      subscribedAddOns.some((subscription) => subscription.items[0].price.id === selectedPrice.id),
+      subscribedAddOns.some((subscription) =>
+        products.map((product) => product.id).includes(subscription.items[0].price.product.id),
+      ),
     [subscribedAddOns, selectedPrice],
   )
 
-  const onChangeProduct = (productId: string) => {
-    const product = products.find((product) => product.id === productId)
+  const onChangeProduct = (productId: string | null) => {
+    const product = products.find((item) => item.id === productId)
     if (product) {
       setSelectedProduct(product)
       setSelectedPrice(product.prices[0])
@@ -72,28 +72,20 @@ export const OneTimeAddOnRow = ({
     }
   }
 
-  // TODO: Merge functionality of onClickBuy and onClickManage so we can unduplicate
-  // the billing button in priceTableCells
-  const onClickBuy = () => {
+  const onSubmit = () => {
     if (isBusy || !selectedPrice) {
       return
     }
     setIsBusy(true)
-    if (selectedPrice) {
+    if (userAlreadyHasCategoryProduct) {
+      postCustomerPortal(organization.id)
+        .then((response) => window.location.assign(response.url))
+        .catch(() => setIsBusy(false))
+    } else {
       postCheckout(selectedPrice.id, organization.id)
         .then((response) => window.location.assign(response.url))
         .catch(() => setIsBusy(false))
     }
-  }
-
-  const onClickManage = () => {
-    if (isBusy || !selectedPrice) {
-      return
-    }
-    setIsBusy(true)
-    postCustomerPortal(organization.id)
-      .then((response) => window.location.assign(response.url))
-      .catch(() => setIsBusy(false))
   }
 
   const priceTableCells = (
@@ -103,24 +95,9 @@ export const OneTimeAddOnRow = ({
       </div>
       <div className={styles.buyContainer}>
         <div className={styles.buy}>
-          {isSubscribedAddOnPrice && (
-            <BillingButton
-              size={'m'}
-              label={t('Manage')}
-              isDisabled={Boolean(selectedPrice) && isBusy}
-              onClick={onClickManage}
-              isFullWidth
-            />
-          )}
-          {!isSubscribedAddOnPrice && (
-            <BillingButton
-              size={'m'}
-              label={t('Buy now')}
-              isDisabled={Boolean(selectedPrice) && isBusy}
-              onClick={onClickBuy}
-              isFullWidth
-            />
-          )}
+          <Button size={'lg'} disabled={Boolean(selectedPrice) && isBusy} onClick={onSubmit}>
+            {userAlreadyHasCategoryProduct ? t('Manage') : t('Buy now')}
+          </Button>
         </div>
       </div>
     </div>
@@ -135,20 +112,22 @@ export const OneTimeAddOnRow = ({
       </td>
       <td className={styles.price}>
         <div className={styles.oneTime}>
-          <KoboSelect3
-            size={'fit'}
+          <Select
+            size='sm'
+            className={styles.selectProducts}
             name='products'
-            options={products.map((product) => {
+            data={products.map((product) => {
               return { value: product.id, label: product.name }
             })}
-            onChange={(productId) => onChangeProduct(productId as string)}
+            onChange={(productId: string | null) => onChangeProduct(productId)}
             value={selectedProduct.id}
           />
           {displayName === 'File Storage' && (
-            <KoboSelect3
-              size={'fit'}
-              name={t('prices')}
-              options={priceOptions}
+            <Select
+              size='sm'
+              className={styles.selectPrices}
+              name='prices'
+              data={priceOptions}
               onChange={onChangePrice}
               value={selectedPrice.id}
             />

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -1,8 +1,8 @@
 import type React from 'react'
-import {Suspense, useEffect, useState} from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import sessionStore from '#/stores/session'
 import LoadingSpinner from '../components/common/loadingSpinner'
-import {redirectToLogin} from './routerUtils'
+import { redirectToLogin } from './routerUtils'
 import { RequireOrg } from './RequireOrg'
 
 interface Props {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Quick fix for bug that made upgrading storage addons overly complicated. Always direct users with storage addons to Stripe account management instead of attempting to purchase new addon directly. 


### 💭 Notes
1. This is a workaround until we get a better system in place. Ideally, users with an existing storage addon should be able to select a new addon, click the button, and only be directed to Stripe to confirm change. But currently attempting to purchase a new addon results in the user being prompted by Stripe to confirm their email address, after which they are directed to Stripe account management. So we are just cutting out that email confirmation to make it a less annoying.

2. I renamed the oneTimeAddOnRow component because we use it for both recurring and one time addons.

3. I did a little refactoring to make the jsx template easier to read.

Bug template:
1. As a new user in a Stripe-enabled environment, purchase a 5gb storage addon and sync stripe
2. Navigate to addons page.
3. On `release/2.025.10`, observe that the button on the storage addon row says "Buy now" unless you use the select to pick your current storage plan. If you click on "Buy now" you are directed to Stripe, which asks you to confirm your email
4. On this branch, observe that the button always says "Manage" and clicking on it takes you to your Stripe account management page
5. Purchase an NLP addon
6. Notice that the behavior of the NLP addons row on the addons page is unchanged between this branch and `release/2.025.10`.
