### PR TITLE
fix(storybook): make dates consistent in UniversalTable tests DEV-277

### DIFF
--- a/jsapp/js/universalTable/universalTable.mocks.tsx
+++ b/jsapp/js/universalTable/universalTable.mocks.tsx
@@ -18,6 +18,7 @@ function createUniversalTableExampleData(index: number): UniversalTableExampleDa
   const sources = ['MacOS', 'iOS', 'Windows 98', 'CrunchBang Linux', 'Firefox', 'Safari', 'Gossip']
 
   faker.seed(index)
+  faker.setDefaultRefDate('2023-01-01T00:00:00.000Z')
 
   return {
     date_created: formatDate(faker.date.recent().toString()),


### PR DESCRIPTION
### 💭 Notes
Uses `faker.setDefaultRefDate()` to ensure we have identical dates in example test data.