### PR TITLE
fix(permissions): update team members row with changes from sharing modal DEV-281

### DIFF
--- a/jsapp/js/components/formSummary/formSummary.js
+++ b/jsapp/js/components/formSummary/formSummary.js
@@ -29,21 +29,27 @@ class FormSummary extends React.Component {
 
   unlisteners = []
 
+  // Copying how sharingForm.component.tsx does their listeners
   componentDidMount() {
     this.unlisteners.push(
       actions.permissions.bulkSetAssetPermissions.completed.listen(this.onAssetPermissionsUpdated.bind(this)),
+      // This is the call to listen to for the permissions list as a response after removing a user's permissions
       actions.permissions.getAssetPermissions.completed.listen(this.onAssetPermissionsUpdated.bind(this)),
     )
-  }
-
-  onAssetPermissionsUpdated(permissions) {
-    this.setState({ permissions: permissions })
   }
 
   componentWillUnmount() {
     this.unlisteners.forEach((clb) => {
       clb()
     })
+  }
+
+  onAssetPermissionsUpdated(permissionsResponse) {
+    // HACK-FIX: "update" the state's permissions with the response from adding/removing all permissions from a user
+    //
+    // TODO: Replacing our permissions api logic with react query is the best solution, but in the meantime the
+    // "Team members" component should updated based on changes made in the sharing modal
+    this.setState({ permissions: permissionsResponse })
   }
 
   renderQuickLinks() {

--- a/jsapp/js/components/formSummary/formSummary.js
+++ b/jsapp/js/components/formSummary/formSummary.js
@@ -7,6 +7,7 @@ import DocumentTitle from 'react-document-title'
 import reactMixin from 'react-mixin'
 import { Link, NavLink } from 'react-router-dom'
 import Reflux from 'reflux'
+import { actions } from '#/actions'
 import bem from '#/bem'
 import Avatar from '#/components/common/avatar'
 import Icon from '#/components/common/icon'
@@ -24,6 +25,25 @@ class FormSummary extends React.Component {
     super(props)
     this.state = {}
     autoBind(this)
+  }
+
+  unlisteners = []
+
+  componentDidMount() {
+    this.unlisteners.push(
+      actions.permissions.bulkSetAssetPermissions.completed.listen(this.onAssetPermissionsUpdated.bind(this)),
+      actions.permissions.getAssetPermissions.completed.listen(this.onAssetPermissionsUpdated.bind(this)),
+    )
+  }
+
+  onAssetPermissionsUpdated(permissions) {
+    this.setState({ permissions: permissions })
+  }
+
+  componentWillUnmount() {
+    this.unlisteners.forEach((clb) => {
+      clb()
+    })
   }
 
   renderQuickLinks() {

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -106,6 +106,7 @@ export default class SharingForm extends React.Component<SharingFormProps, Shari
     const publicPerms = permissionAssignments.filter((assignment) => assignment.user === ANON_USERNAME_URL)
     const nonOwnerPerms = parseUserWithPermsList(parsedPerms).filter((perm) => perm.user !== ownerUrl)
 
+    console.log('the get')
     this.setState({
       permissions: parsedPerms,
       nonOwnerPerms: nonOwnerPerms,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

When making changes to a project's permissions, if a user is added or removed it will reflect immidately in the "Team members" component in the "Summary" page.

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

(from the linear task)
Discovered that:
- `store.allAssets.byUid[...]` returns the `assetResponse` but it's permissions are not updated
- `actions.permissions.removeAssetPermissions` did listen correctly to a deleted permission but returned only `assetUid` and not     list of permissions
    - listening on `actions.permissions.getAssetPermissions` returns the updated permission list after deleting a user's permissions

Opted for hacky fix because it took .5 hours to draft and refactoring to react query would require increasing scope significantly

### 👀 Preview steps
1. Have multiple accounts
1. Create a project and give another user some permissions for this project
1. Navigate to the "Summary" tab
1. 🟢 notice that the "Team members" row is correctly displaying only the owner and the added user
1. Open the share modal and remove the added user's permissions
1. [on main] 🔴notice that "Team members" still displays both users
1. [on PR] 🟢 notice that "Team members" updates accordingly to changes made in sharing modal
