### PR TITLE
fix(submissions): reject submissions with identical basename

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -702,15 +702,19 @@ def save_attachments(
         attachment_filename = generate_attachment_filename(
             instance, os.path.basename(f.name)
         )
+        media_file_basename = os.path.basename(attachment_filename)
+
+        # The basename of a (non-deleted) attachment must be unique per instance.
         existing_attachment = Attachment.objects.filter(
             instance=instance,
-            media_file=attachment_filename,
-            mimetype=f.content_type,
+            media_file_basename=media_file_basename,
         ).first()
+
         if existing_attachment:
             # We already have this attachment!
             continue
         f.seek(0)
+
         # This is a new attachment; save it!
         new_attachment = Attachment(
             instance=instance, media_file=f, mimetype=f.content_type


### PR DESCRIPTION
### 📣 Summary
Prevented multiple submissions with the same basename from being accepted.


### 📖 Description
This fix ensures that identical submissions, those with the same XML content and the same `meta/instanceID`,  are properly rejected if they are submitted again using the same basename. The response will be **202 - Duplicated submission**.

Previously, a submission could be accepted multiple times under the same basename if it was retried, leading to inconsistent states and potential storage issues.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:

[duplicate_files.zip](https://github.com/user-attachments/files/20393778/duplicate_files.zip)

1. Extract the ZIP file somewhere
2. Import the XLSX found in the zip file above
3. In `submission.xml`:
  - Update the root node to match the asset `uid` 
  - Update the `__version__`  to match the asset version `uid` 
4. Run the script 
5. Change your token in `duplication_submissions.py`
6. Update the [code here](https://github.com/kobotoolbox/kpi/blob/602b716ef45d28ad16d2f2eaf20f61235071920b/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py#L46) 
```python 
def create_instance_from_xml(username, request):
    xml_file_list = request.FILES.pop('xml_submission_file', [])
    xml_file = xml_file_list[0] if len(xml_file_list) else None
    media_files = request.FILES.values()

    if request.query_params.get('simulate_delay') == '1':
        import time
        time.sleep(3)

    return safe_create_instance(username, xml_file, media_files, None, request=request)
```
7. Run the script (make sure to have `requests` installed first).
8. 🔴 [on main] notice both submissions are accepted with a 201
   - Go to the table view, see there is only one submission but the image is not accessible (see an exclamation mark)
   - Do not delete the submission
9. Checkout this branch and run the script again
10. 🟢 [on PR], both submissions are accepted with a 202
   - Go to the table view, see there is only one submission and the image is now accessible
11. Delete the submission, replay 9 and 10
  -  Submission with no delay is accepted with 201
  - Submission with delay is accepted with 202  - Duplicated Submission
  - Go to the table view, see there is only one submission and the image is accessible


