### PR TITLE
fix(permissions): uncheckable permission checkboxes DEV-266

### DIFF
--- a/jsapp/js/components/permissions/userAssetPermsEditor.component.tsx
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.component.tsx
@@ -196,7 +196,7 @@ export default class UserAssetPermsEditor extends React.Component<
     // Merge built form data with existing state (with defaults) and then apply
     // validity rules (handles disabling and checking/unchecking properties
     // based on implied/contradictory rules from `permConfig`).
-    this.state = applyValidityRules(Object.assign(this.state, formData))
+    this.state = applyValidityRules(Object.assign(this.state, formData), this.props.assignablePerms)
   }
 
   componentDidMount() {
@@ -237,7 +237,7 @@ export default class UserAssetPermsEditor extends React.Component<
   onCheckboxChange(checkboxName: CheckboxNameAll, isChecked: boolean) {
     let output = clonedeep(this.state)
     output = Object.assign(output, { [checkboxName]: isChecked })
-    this.setState(applyValidityRules(output))
+    this.setState(applyValidityRules(output, this.props.assignablePerms))
   }
 
   /**

--- a/jsapp/js/components/permissions/userAssetPermsEditor.tests.ts
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.tests.ts
@@ -1,6 +1,7 @@
 import constants from '#/constants'
 import permConfig from './permConfig'
 import { endpoints } from './permParser.mocks'
+import type { AssignablePermsMap } from './sharingForm.component'
 import {
   applyValidityRules,
   getFormData,
@@ -63,6 +64,8 @@ const EMPTY_EDITOR_STATE = {
   submissionsDeletePartialByResponsesValue: '',
 }
 
+let testAssignablePerms: AssignablePermsMap = new Map()
+
 describe('userAssetPermsEditor utils tests', () => {
   beforeEach(() => {
     // bootstraping
@@ -71,15 +74,23 @@ describe('userAssetPermsEditor utils tests', () => {
   })
 
   describe('applyValidityRules', () => {
+    beforeEach(() => {
+      // For the sake of the tests, we assume all permissions are assignable
+      testAssignablePerms = new Map(permConfig.permissions.map((perm) => [perm.url, perm.name]))
+    })
+
     it('should check and disable all implied checkboxes', () => {
       // We test here form with a single `formManage` checkbox enabled - it has
       // almost all permissions in the implied list, so a lot of checkboxes need
       // to be checked, and even more need to be disabled. This is a good test
       // to check if most of the cases will work correctly.
-      const outcome = applyValidityRules({
-        ...EMPTY_EDITOR_STATE,
-        formManage: true,
-      })
+      const outcome = applyValidityRules(
+        {
+          ...EMPTY_EDITOR_STATE,
+          formManage: true,
+        },
+        testAssignablePerms,
+      )
       chai.expect(outcome).to.deep.equal({
         ...EMPTY_EDITOR_STATE,
         formView: true,
@@ -110,14 +121,17 @@ describe('userAssetPermsEditor utils tests', () => {
     })
 
     it('should cleanup partial properties of unchecked checkbox', () => {
-      const outcome = applyValidityRules({
-        ...EMPTY_EDITOR_STATE,
-        submissionsViewPartialByUsers: false,
-        submissionsViewPartialByUsersList: ['joe', 'josh'],
-        submissionsViewPartialByResponses: false,
-        submissionsViewPartialByResponsesQuestion: 'Where_are_you_from',
-        submissionsViewPartialByResponsesValue: 'North',
-      })
+      const outcome = applyValidityRules(
+        {
+          ...EMPTY_EDITOR_STATE,
+          submissionsViewPartialByUsers: false,
+          submissionsViewPartialByUsersList: ['joe', 'josh'],
+          submissionsViewPartialByResponses: false,
+          submissionsViewPartialByResponsesQuestion: 'Where_are_you_from',
+          submissionsViewPartialByResponsesValue: 'North',
+        },
+        testAssignablePerms,
+      )
 
       chai.expect(outcome).to.deep.equal({
         ...EMPTY_EDITOR_STATE,
@@ -130,11 +144,14 @@ describe('userAssetPermsEditor utils tests', () => {
     })
 
     it('should disable and uncheck "parent" checkbox if its partial counterpart is checked', () => {
-      const outcome = applyValidityRules({
-        ...EMPTY_EDITOR_STATE,
-        submissionsViewPartialByUsers: true,
-        submissionsViewPartialByUsersList: ['joe', 'josh'],
-      })
+      const outcome = applyValidityRules(
+        {
+          ...EMPTY_EDITOR_STATE,
+          submissionsViewPartialByUsers: true,
+          submissionsViewPartialByUsersList: ['joe', 'josh'],
+        },
+        testAssignablePerms,
+      )
 
       chai.expect(outcome).to.deep.equal({
         ...EMPTY_EDITOR_STATE,
@@ -219,7 +236,7 @@ describe('userAssetPermsEditor utils tests', () => {
         submissionsDelete: true,
       }
 
-      const testAssignablePerms = new Map([
+      testAssignablePerms = new Map([
         ['/api/v2/permissions/add_submissions/', 'Add submissions'],
         ['/api/v2/permissions/view_submissions/', 'View submissions'],
       ])

--- a/jsapp/js/components/permissions/userAssetPermsEditor.utils.ts
+++ b/jsapp/js/components/permissions/userAssetPermsEditor.utils.ts
@@ -105,7 +105,7 @@ function applyValidityRulesForCheckbox(checkboxName: CheckboxNameAll, stateObj: 
  *
  * Returns updated state object
  */
-export function applyValidityRules(stateObj: UserAssetPermsEditorState) {
+export function applyValidityRules(stateObj: UserAssetPermsEditorState, assignablePerms: AssignablePermsMap) {
   // Step 1: Avoid mutation
   let output = clonedeep(stateObj)
 
@@ -119,7 +119,15 @@ export function applyValidityRules(stateObj: UserAssetPermsEditorState) {
 
   // Step 3: Apply permissions configuration rules to checkboxes
   for (const [, checkboxName] of Object.entries(CHECKBOX_NAMES)) {
-    output = applyValidityRulesForCheckbox(checkboxName, output)
+    if (isAssignable(CHECKBOX_PERM_PAIRS[checkboxName], assignablePerms)) {
+      // Apply validity rules only for assignable permissions. We don't touch the rest, because they are not present
+      // in the UI, and changing them could lead to bugs (e.g. if a checkbox is disabled, because it's blocked by
+      // an implied permission that is not being displayed).
+      output = applyValidityRulesForCheckbox(checkboxName, output)
+    } else {
+      // If the checkbox is not assignable, let's make sure it's not checked
+      output = Object.assign(output, { [checkboxName]: false })
+    }
   }
 
   // Step 4: For each unchecked partial checkbox, clean up the data of related


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

After selecting "Manage collection" permission in Library's Sharing Form, User can unselect all checkboxes (one at a time) beck into initial empty state.

### 💭 Notes

`applyValidityRules` requires additional argument `assignablePerms`. We use it to ensure that the rules are being applied based on permissions that are currently being displayed/used in the UI. Nn Library we are displaying only 3 permissions, but the code was applying rules based on all 16 of them causing the bug.


### 👀 Preview steps

Bug template:
1. Go to "My Library"
2. Have a collection, block, or template
3. Use "Share" button (appears on the right on hover)
4. In "Sharing Permissions" modal use "Add user" button
5. In the form that appears check "Manage…" checkbox
6. 🟢 Notice that "View…" and "Edit…" are checked and disabled (this is correct)
7. Uncheck "Manage…" checkbox
8. 🟢 Notice that "View…" checkbox is checked and disabled, and "Edit…" checkbox is checked and (now) enabled
9. Uncheck "Edit…" checkbox
10. 🔴 (on main) Notice that "View…" checkbox is still checked and disabled → it should be checked and enabled
11. 🟢 (on PR) Notice that "View…" checkbox is still checked, but not disabled