### PR TITLE
feat(billing): add balances to service usage api DEV-488

### DIFF
--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -139,6 +139,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         <p>Tracks the total usage of different services for each account in an organization</p>
         <p>Tracks the submissions and NLP seconds/characters for the current month/year/all time</p>
         <p>Tracks the current total storage used</p>
+        <p>Includes a detailed list of balances relative to a user's usage limits</p>
         <p>If no organization is found with the provided ID, returns the usage for the logged-in user</p>
         <strong>This endpoint is cached for an amount of time determined by ENDPOINT_CACHE_DURATION</strong>
 
@@ -160,6 +161,32 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         >           "total_submission_count": {
         >               "current_period": {integer},
         >               "all_time": {integer},
+        >           },
+        >           "balances": {
+        >               "asr_seconds": {
+        >                   "effective_limit": {integer},
+        >                   "balance_value": {integer},
+        >                   "balance_percent": {integer},
+        >                   "exceeded": {boolean},
+        >               } | {None},
+        >               "mt_characters": {
+        >                   "effective_limit": {integer},
+        >                   "balance_value": {integer},
+        >                   "balance_percent": {integer},
+        >                   "exceeded": {boolean},
+        >               } | {None},
+        >               "storage_bytes": {
+        >                   "effective_limit": {integer},
+        >                   "balance_value": {integer},
+        >                   "balance_percent": {integer},
+        >                   "exceeded": {boolean},
+        >               } | {None},
+        >               "submission": {
+        >                   "effective_limit": {integer},
+        >                   "balance_value": {integer},
+        >                   "balance_percent": {integer},
+        >                   "exceeded": {boolean},
+        >               } | {None},
         >           },
         >           "current_period_start": {string (date), ISO format},
         >           "current_period_end": {string (date), ISO format}|{None},

--- a/kpi/serializers/v2/service_usage.py
+++ b/kpi/serializers/v2/service_usage.py
@@ -86,6 +86,7 @@ class ServiceUsageSerializer(serializers.Serializer):
     total_nlp_usage = serializers.SerializerMethodField()
     total_storage_bytes = serializers.SerializerMethodField()
     total_submission_count = serializers.SerializerMethodField()
+    balances = serializers.SerializerMethodField()
     current_period_start = serializers.SerializerMethodField()
     current_period_end = serializers.SerializerMethodField()
     last_updated = serializers.SerializerMethodField()
@@ -111,3 +112,6 @@ class ServiceUsageSerializer(serializers.Serializer):
 
     def get_total_storage_bytes(self, user):
         return self.calculator.get_storage_usage()
+
+    def get_balances(self, user):
+        return self.calculator.get_usage_balances()

--- a/kpi/views/v2/service_usage.py
+++ b/kpi/views/v2/service_usage.py
@@ -39,8 +39,35 @@ class ServiceUsageViewSet(viewsets.GenericViewSet):
     >               "current_period": {integer},
     >               "all_time": {integer},
     >           },
+    >           "balances": {
+    >               "asr_seconds": {
+    >                   "effective_limit": {integer},
+    >                   "balance_value": {integer},
+    >                   "balance_percent": {integer},
+    >                   "exceeded": {boolean},
+    >               } | {None},
+    >               "mt_characters": {
+    >                   "effective_limit": {integer},
+    >                   "balance_value": {integer},
+    >                   "balance_percent": {integer},
+    >                   "exceeded": {boolean},
+    >               } | {None},
+    >               "storage_bytes": {
+    >                   "effective_limit": {integer},
+    >                   "balance_value": {integer},
+    >                   "balance_percent": {integer},
+    >                   "exceeded": {boolean},
+    >               } | {None},
+    >               "submission": {
+    >                   "effective_limit": {integer},
+    >                   "balance_value": {integer},
+    >                   "balance_percent": {integer},
+    >                   "exceeded": {boolean},
+    >               } | {None},
+    >           },
     >           "current_period_start": {string (date), ISO format},
-    >           "current_period_end": {string (date), ISO format},
+    >           "current_period_end": {string (date), ISO format}|{None},
+    >           "last_updated": {string (date), ISO format},
     >       }
 
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a field 'balances' on the service usage endpoint that indicates whether and by how much a user is over their usage limit for each usage type.


### 👀 Preview steps
1. With stripe enabled and synced, create a user
2. Create and deploy a form 
3. Create some submissions 
4. Check the response on the service usage endpoint to see that submissions balance is correctly reflected (relative to community plan).
