### PR TITLE
fix(massEmails): make sure sends are not interrupted when configs change TASK-1835

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -305,18 +305,17 @@ def send_emails():
     cache_key = PROCESSED_EMAILS_CACHE_KEY.format(key_date=cache_key_date)
     cached_data = cache.get(cache_key, [])
     processed_configs = set(cached_data)
-    all_active_email_ids = MassEmailConfig.objects.filter(live=True).values_list(
-        'id', flat=True
-    )
+    all_active_email_ids = MassEmailConfig.objects.filter(
+        live=True, date_created__lt=cache_key_date
+    ).values_list('id', flat=True)
 
-    if set(all_active_email_ids) != processed_configs:
+    if not set(all_active_email_ids) <= processed_configs:
         logging.info(
             'Skipping send emails task because we have not yet generated send lists'
         )
         return
     sender = MassEmailSender()
     sender.send_day_emails()
-
 
 def get_users_for_config(email_config):
     """
@@ -330,16 +329,13 @@ def get_users_for_config(email_config):
     users = USER_QUERIES.get(email_config.query, lambda: [])()
     if email_config.frequency == -1:
         return users
+    day_boundary = MassEmailSender.get_cache_key_date(now)
 
-    today_midnight = now.replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
-    cutoff_date = today_midnight - timedelta(days=email_config.frequency-1)
+    cutoff_date = day_boundary - timedelta(days=email_config.frequency - 1)
     if getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False):
         # if we're condensing sends, pretend 15 minutes is a day
-        date_boundary = MassEmailSender.get_cache_key_date(now)
         delta = (email_config.frequency-1)*15
-        cutoff_date = date_boundary - timedelta(minutes=delta)
+        cutoff_date = day_boundary - timedelta(minutes=delta)
 
     recent_recipients = set(
         MassEmailRecord.objects.filter(


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->



### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->



### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->



### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->



### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Bug template:
1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere BUT it should be here
5. 🟢 [on PR] notice that this is here

Feature/no-change template:
1. ℹ️ have account and a project
2. do this
3. do that
4. 🟢 notice that this is there
5. do that another thing
6. 🟢 notice that this changed like that
