### PR TITLE
fix(massEmails): make get_plan_name ordering more deterministic TASK-1836

### DIFF
--- a/kobo/apps/stripe/utils.py
+++ b/kobo/apps/stripe/utils.py
@@ -618,7 +618,13 @@ def get_plan_name(org_user: OrganizationUser, **kwargs) -> str | None:
     for subscription in subscriptions:
         unique_plans.add(subscription.plan)
 
-    plan_name = ' and '.join([plan.product.name for plan in unique_plans])
+    # Make sure plans come before addons
+    plan_list = sorted(
+        unique_plans,
+        key=lambda plan: plan.product.metadata.get('product_type', '') == 'plan',
+        reverse=True,
+    )
+    plan_name = ' and '.join([plan.product.name for plan in plan_list])
     if plan_name is None or plan_name == '':
         plan_name = get_default_plan_name()
     return plan_name


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure `get_plan_name()` util function returns plans before addons.

### 💭 Notes
Previously non-deterministic ordering was causing a unit test to fail occasionally.


### 👀 Preview steps
On `main` the `test_get_plan_name` unit test fails about 1/10 times. So if you run `pytest  --reuse-db kobo/apps/stripe/tests/test_stripe_utils.py` 20 times you should see the improvement on this branch.
