### PR TITLE
chore(submissions): populate `media_base_name field` in MongoDB documents during attachment backfill

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0009_backfill_attachment_model.py
+++ b/kobo/apps/long_running_migrations/jobs/0009_backfill_attachment_model.py
@@ -35,7 +35,10 @@ def run():
 
                 if not attachment.uid:
                     attachment.uid = KpiUidField.generate_unique_id('att')
-                attachment_ids_per_instance[instance.pk][attachment.pk] = attachment.uid
+                attachment_ids_per_instance[instance.pk][attachment.pk] = {
+                    'uid': attachment.uid,
+                    'media_file_basename': attachment.media_file_basename,
+                }
 
                 if not attachment.date_created:
                     attachment.date_created = instance.date_created
@@ -115,7 +118,10 @@ def update_mongo(attachment_ids_per_instance: dict):
             ):
                 attachment['uid'] = attachment_ids_per_instance[doc['_id']][
                     attachment['id']
-                ]
+                ]['uid']
+                attachment['media_file_basename'] = attachment_ids_per_instance[
+                    doc['_id']
+                ][attachment['id']]['media_file_basename']
                 updated_attachments.append(attachment)
 
         if updated_attachments:

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_attachment_viewset.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_attachment_viewset.py
@@ -352,6 +352,7 @@ class TestAttachmentViewSet(TestAbstractViewSet):
             'instance': instance.pk,
             'mimetype': attachment.mimetype,
             'filename': attachment.media_file.name,
+            'media_file_basename': attachment.media_file_basename,
             'uid': attachment.uid,
         }
         request = self.factory.get('/', **self.extra)
@@ -372,6 +373,7 @@ class TestAttachmentViewSet(TestAbstractViewSet):
             'instance': expected['instance'],
             'mimetype': expected['mimetype'],
             'filename': expected['filename'],
+            'media_file_basename': attachment.media_file_basename,
             'uid': attachment.uid,
         }
 

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_briefcase_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_briefcase_api.py
@@ -1,18 +1,18 @@
 # coding: utf-8
 import os
 
-from django.urls import reverse
 from django.test import override_settings
+from django.urls import reverse
 from django_digest.test import DigestAuth
 from rest_framework.test import APIRequestFactory
 
-from kobo.apps.openrosa.apps.api.tests.viewsets.test_abstract_viewset import TestAbstractViewSet
+from kobo.apps.openrosa.apps.api.tests.viewsets.test_abstract_viewset import (
+    TestAbstractViewSet,
+)
 from kobo.apps.openrosa.apps.api.viewsets.briefcase_api import BriefcaseApi
 from kobo.apps.openrosa.apps.api.viewsets.xform_submission_api import XFormSubmissionApi
-from kobo.apps.openrosa.apps.logger.models import Instance
-from kobo.apps.openrosa.apps.logger.models import XForm
+from kobo.apps.openrosa.apps.logger.models import Instance, XForm
 from kobo.apps.openrosa.libs.utils.storage import rmdir
-
 
 NUM_INSTANCES = 4
 
@@ -173,7 +173,7 @@ class TestBriefcaseAPI(TestAbstractViewSet):
         self.assertEqual(instances.count(), NUM_INSTANCES)
 
         last_index = instances[:2][1].pk
-        last_expected_submission_list = ""
+        last_expected_submission_list = ''
         for index in range(1, 5):
             auth = DigestAuth(self.login_username, self.login_password)
             request = self.factory.get(
@@ -354,8 +354,7 @@ class TestBriefcaseAPI(TestAbstractViewSet):
             request.META.update(auth(request.META, response))
             response = view(request)
             self.assertEqual(XForm.objects.count(), count + 1)
-            self.assertContains(
-                response, "successfully published.", status_code=201)
+            self.assertContains(response, 'successfully published.', status_code=201)
 
     def _publish_xml_form(self, auth=None):
         view = BriefcaseApi.as_view({'post': 'create'})
@@ -376,8 +375,7 @@ class TestBriefcaseAPI(TestAbstractViewSet):
             request.META.update(auth(request.META, response))
             response = view(request)
             self.assertEqual(XForm.objects.count(), count + 1)
-            self.assertContains(
-                response, "successfully published.", status_code=201)
+            self.assertContains(response, 'successfully published.', status_code=201)
         self.xform = XForm.objects.order_by('pk').reverse()[0]
 
     def test_form_upload(self):
@@ -424,7 +422,7 @@ class TestBriefcaseAPI(TestAbstractViewSet):
     def test_submission_with_instance_id_on_root_node(self):
         view = XFormSubmissionApi.as_view({'post': 'create'})
         self._publish_xml_form()
-        message = "Successful submission."
+        message = 'Successful submission.'
         instanceId = '5b2cc313-fc09-437e-8149-fcd32f695d41'
         self.assertRaises(
             Instance.DoesNotExist, Instance.objects.get, uuid=instanceId)

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_data_viewset.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_data_viewset.py
@@ -321,23 +321,26 @@ class TestDataViewSet(TestBase):
         dataid = self.xform.instances.all().order_by('id')[0].pk
 
         data = {
-            '_attachments': [{'download_url': self.attachment.secure_url(),
-                               'download_small_url': self.attachment.secure_url('small'),
-                               'download_medium_url': self.attachment.secure_url('medium'),
-                               'download_large_url': self.attachment.secure_url('large'),
-                               'mimetype': self.attachment.mimetype,
-                               'instance': self.attachment.instance.pk,
-                               'filename': self.attachment.media_file.name,
-                               'id': self.attachment.pk,
-                               'uid': self.attachment.uid,
-                               'xform': self.xform.id}
-                              ],
+            '_attachments': [
+                {
+                    'download_url': self.attachment.secure_url(),
+                    'download_small_url': self.attachment.secure_url('small'),
+                    'download_medium_url': self.attachment.secure_url('medium'),
+                    'download_large_url': self.attachment.secure_url('large'),
+                    'mimetype': self.attachment.mimetype,
+                    'instance': self.attachment.instance.pk,
+                    'filename': self.attachment.media_file.name,
+                    'media_file_basename': self.attachment.media_file_basename,
+                    'id': self.attachment.pk,
+                    'uid': self.attachment.uid,
+                    'xform': self.xform.id,
+                }
+            ],
             '_geolocation': [None, None],
             '_xform_id_string': 'transportation_2011_07_25',
-            'transport/available_transportation_types_to_referral_facility':
-            'none',
+            'transport/available_transportation_types_to_referral_facility': 'none',
             '_status': 'submitted_via_web',
-            '_id': dataid
+            '_id': dataid,
         }
         response_first_element = sorted(response.data, key=lambda x: x['_id'])[0]
         self.assertEqual(dict(response_first_element, **data),

--- a/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
@@ -5,14 +5,14 @@ from django.core.files import File
 from django.core.validators import ValidationError
 from django.http import Http404
 from django.utils.translation import gettext as t
-from rest_framework import exceptions, mixins, status, permissions
+from rest_framework import exceptions, mixins, permissions, status
+from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
-from rest_framework.decorators import action
 
-from kobo.apps.openrosa.apps.api.tools import get_media_file_response
 from kobo.apps.openrosa.apps.api.permissions import ViewDjangoObjectPermissions
+from kobo.apps.openrosa.apps.api.tools import get_media_file_response
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
@@ -20,12 +20,14 @@ from kobo.apps.openrosa.apps.main.models.meta_data import MetaData
 from kobo.apps.openrosa.libs import filters
 from kobo.apps.openrosa.libs.mixins.openrosa_headers_mixin import OpenRosaHeadersMixin
 from kobo.apps.openrosa.libs.renderers.renderers import TemplateXMLRenderer
-from kobo.apps.openrosa.libs.serializers.xform_serializer import XFormListSerializer
-from kobo.apps.openrosa.libs.serializers.xform_serializer import XFormManifestSerializer
+from kobo.apps.openrosa.libs.serializers.xform_serializer import (
+    XFormListSerializer,
+    XFormManifestSerializer,
+)
 from kobo.apps.openrosa.libs.utils.logger_tools import (
+    get_instance_or_404,
     publish_form,
     publish_xml_form,
-    get_instance_or_404,
 )
 from kpi.authentication import DigestAuthentication
 from ..utils.rest_framework.viewsets import OpenRosaGenericViewSet
@@ -36,13 +38,13 @@ def _extract_uuid(text):
         form_id_parts = text.split('/')
 
         if form_id_parts.__len__() < 2:
-            raise ValidationError(t("Invalid formId %s." % text))
+            raise ValidationError(t('Invalid formId %s.' % text))
 
         text = form_id_parts[1]
-        text = text[text.find("@key="):-1].replace("@key=", "")
+        text = text[text.find('@key=') : -1].replace('@key=', '')
 
-        if text.startswith("uuid:"):
-            text = text.replace("uuid:", "")
+        if text.startswith('uuid:'):
+            text = text.replace('uuid:', '')
 
     return text
 
@@ -190,13 +192,12 @@ class BriefcaseApi(
             dd = publish_form(do_form_upload.publish)
 
             if isinstance(dd, XForm):
-                data['message'] = t(
-                    "%s successfully published." % dd.id_string)
+                data['message'] = t('%s successfully published.' % dd.id_string)
             else:
                 data['message'] = dd['text']
                 response_status = status.HTTP_400_BAD_REQUEST
         else:
-            data['message'] = t("Missing xml file.")
+            data['message'] = t('Missing xml file.')
             response_status = status.HTTP_400_BAD_REQUEST
 
         return Response(data, status=response_status,
@@ -240,9 +241,7 @@ class BriefcaseApi(
         data = {
             'submission_data': submission_xml_root_node.toxml(),
             'media_files': self._get_attachments_with_md5hash(instance),
-            'host': request.build_absolute_uri().replace(
-                request.get_full_path(), ''
-            )
+            'host': request.build_absolute_uri().replace(request.get_full_path(), ''),
         }
         return Response(
             data,

--- a/kobo/apps/openrosa/apps/logger/migrations/0043_add_new_columns_to_attachment.py
+++ b/kobo/apps/openrosa/apps/logger/migrations/0043_add_new_columns_to_attachment.py
@@ -10,7 +10,7 @@ import kpi.fields.kpi_uid
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('logger', '0041_add_root_uuid_field_to_instance'),
+        ('logger', '0042_add_field_hash_to_attachment'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
+++ b/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
@@ -108,10 +108,10 @@ class TestAttachment(TestBase):
             self.surveys[0],
             self.media_file,
         )
-        attachment = Attachment.objects.create(
-            instance=instance,
-            media_file=File(open(media_file, 'rb'), media_file),
-        )
+        with open(media_file, 'rb') as f:
+            attachment = Attachment.objects.create(
+                instance=instance, media_file=ContentFile(f.read(), name=media_file)
+            )
 
         attachment.refresh_from_db()
         self.assertEqual(attachment.user_id, user.id)

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
@@ -3,18 +3,18 @@ import re
 from unittest.mock import patch
 
 from django.http import Http404
-from django_digest.test import DigestAuth
 from django_digest.test import Client as DigestClient
+from django_digest.test import DigestAuth
 from rest_framework import status
 
-from kobo.apps.openrosa.libs.utils.guardian import assign_perm
-from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
-from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
-from kobo.apps.openrosa.apps.logger.models import Instance, Attachment
+from kobo.apps.openrosa.apps.logger.models import Attachment, Instance
 from kobo.apps.openrosa.apps.logger.models.instance import InstanceHistory
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import clean_and_parse_xml
+from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
+from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.utils.common_tags import GEOLOCATION
+from kobo.apps.openrosa.libs.utils.guardian import assign_perm
 
 
 class TestFormSubmission(TestBase):
@@ -26,7 +26,7 @@ class TestFormSubmission(TestBase):
         TestBase.setUp(self)
         xls_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/tutorial.xls"
+            '../fixtures/tutorial/tutorial.xls',
         )
         self._publish_xls_file_and_set_xform(xls_file_path)
 
@@ -51,7 +51,7 @@ class TestFormSubmission(TestBase):
 
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml"
+            '../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml',
         )
         with self.assertRaises(OSError):
             self._make_submission(xml_submission_file_path)
@@ -72,7 +72,7 @@ class TestFormSubmission(TestBase):
 
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml"
+            '../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml',
         )
         with self.assertRaises(OSError):
             self._make_submission(xml_submission_file_path)
@@ -90,7 +90,7 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml"
+            '../fixtures/tutorial/instances/tutorial_2012-06-27_11-27-53.xml',
         )
 
         # Anonymous should authenticate when submit data to `/<username>/submission`
@@ -162,8 +162,8 @@ class TestFormSubmission(TestBase):
     def test_form_post_to_missing_form(self):
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/tutorial/instances/"
-            "tutorial_invalid_id_string_2012-06-27_11-27-53.xml"
+            '../fixtures/tutorial/instances/'
+            'tutorial_invalid_id_string_2012-06-27_11-27-53.xml',
         )
         self._make_submission(
             path=xml_submission_file_path, assert_success=False
@@ -176,13 +176,13 @@ class TestFormSubmission(TestBase):
         """
         xls_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/test_forms/survey_names/survey_names.xls"
+            '../fixtures/test_forms/survey_names/survey_names.xls',
         )
         self._publish_xls_file(xls_file_path)
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../fixtures/test_forms/survey_names/instances/"
-            "survey_names_2012-08-17_11-24-53.xml"
+            '../fixtures/test_forms/survey_names/instances/'
+            'survey_names_2012-08-17_11-24-53.xml',
         )
 
         self._make_submission(xml_submission_file_path)
@@ -195,8 +195,11 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_unicode_submission.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_unicode_submission.xml',
         )
 
         # create a new user
@@ -215,8 +218,11 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
 
         self._make_submission(xml_submission_file_path)
@@ -230,13 +236,19 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         duplicate_xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_same_instanceID.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_same_instanceID.xml',
         )
 
         pre_count = Instance.objects.count()
@@ -339,9 +351,7 @@ class TestFormSubmission(TestBase):
 
         # Test duplicate submission with the same attachment. No attachments added
         with open(media_file_path1, 'rb') as media_file:
-            self._make_submission(
-                xml_submission_file_path, media_file=media_file
-            )
+            self._make_submission(xml_submission_file_path, media_file=media_file)
         self.assertEqual(self.response.status_code, status.HTTP_202_ACCEPTED)
         self.assertEqual(Instance.objects.count(), initial_instance_count + 1)
         # Validate the attachment is still the same
@@ -448,8 +458,11 @@ class TestFormSubmission(TestBase):
     def test_owner_can_edit_submissions(self):
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         num_instances_history = InstanceHistory.objects.count()
         num_instances = Instance.objects.count()
@@ -477,8 +490,11 @@ class TestFormSubmission(TestBase):
         # edited submission
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         self._make_submission(xml_submission_file_path)
         self.assertEqual(self.response.status_code, 201)
@@ -493,10 +509,10 @@ class TestFormSubmission(TestBase):
         query_args['count'] = False
         cursor = ParsedInstance.query_mongo(**query_args)
         record = cursor[0]
-        with open(xml_submission_file_path, "r") as f:
+        with open(xml_submission_file_path, 'r') as f:
             xml_str = f.read()
         xml_str = clean_and_parse_xml(xml_str).toxml()
-        edited_name = re.match(r"^.+?<name>(.+?)</name>", xml_str).groups()[0]
+        edited_name = re.match(r'^.+?<name>(.+?)</name>', xml_str).groups()[0]
         self.assertEqual(record['name'], edited_name)
 
     def test_submission_w_mismatched_uuid(self):
@@ -507,8 +523,11 @@ class TestFormSubmission(TestBase):
         # submit instance with uuid that would not match the forms
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_xform_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_xform_uuid.xml',
         )
 
         self._make_submission(xml_submission_file_path)
@@ -521,8 +540,11 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_xform_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_xform_uuid.xml',
         )
         with self.assertRaises(Http404):
             self._make_submission(path=xml_submission_file_path, username='')
@@ -532,8 +554,11 @@ class TestFormSubmission(TestBase):
         """
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_bad_id_string.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_bad_id_string.xml',
         )
         self._make_submission(
             path=xml_submission_file_path, assert_success=False
@@ -551,8 +576,11 @@ class TestFormSubmission(TestBase):
         }
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
 
         self._make_submission(xml_submission_file_path)
@@ -564,8 +592,11 @@ class TestFormSubmission(TestBase):
         # submit the edited instance
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         self._make_submission(xml_submission_file_path)
         self.assertEqual(self.response.status_code, 201)
@@ -573,7 +604,7 @@ class TestFormSubmission(TestBase):
         self.assertEqual(len(records), 1)
         cached_geopoint = records[0][GEOLOCATION]
         # the cached geopoint should equal the gps field
-        gps = records[0]['gps'].split(" ")
+        gps = records[0]['gps'].split(' ')
         self.assertEqual(float(gps[0]), float(cached_geopoint[0]))
         self.assertEqual(float(gps[1]), float(cached_geopoint[1]))
 
@@ -615,8 +646,11 @@ class TestFormSubmission(TestBase):
     def test_anonymous_cannot_edit_submissions(self):
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         # make first submission
         self._make_submission(xml_submission_file_path)
@@ -629,8 +663,11 @@ class TestFormSubmission(TestBase):
         # attempt an edit
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         # …without "Require authentication to see form and submit data"
         self.xform.require_auth = False
@@ -671,8 +708,11 @@ class TestFormSubmission(TestBase):
 
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         # make first submission
         self._make_submission(xml_submission_file_path)
@@ -691,8 +731,11 @@ class TestFormSubmission(TestBase):
         # attempt an edit
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         self._make_submission(xml_submission_file_path, auth=auth)
         self.assertEqual(self.response.status_code, 201)
@@ -708,8 +751,11 @@ class TestFormSubmission(TestBase):
 
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         # make first submission
         self._make_submission(xml_submission_file_path)
@@ -728,8 +774,11 @@ class TestFormSubmission(TestBase):
         # attempt an edit
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         self._make_submission(xml_submission_file_path, auth=auth)
         self.assertEqual(self.response.status_code, 201)
@@ -744,8 +793,11 @@ class TestFormSubmission(TestBase):
     def test_unauthorized_cannot_edit_submissions(self):
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid.xml',
         )
         # make first submission
         self._make_submission(xml_submission_file_path)
@@ -764,8 +816,11 @@ class TestFormSubmission(TestBase):
         # attempt an edit
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "fixtures", "tutorial", "instances",
-            "tutorial_2012-06-27_11-27-53_w_uuid_edited.xml"
+            '..',
+            'fixtures',
+            'tutorial',
+            'instances',
+            'tutorial_2012-06-27_11-27-53_w_uuid_edited.xml',
         )
         # …without "Require authentication to see form and submit data"
         self.xform.require_auth = False

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -453,6 +453,7 @@ def _get_attachments_from_instance(instance):
             attachment['download_{}_url'.format(suffix)] = a.secure_url(suffix)
         attachment['mimetype'] = a.mimetype
         attachment['filename'] = a.media_file.name
+        attachment['media_file_basename'] = a.media_file_basename
         attachment['instance'] = a.instance.pk
         attachment['xform'] = instance.xform.id
         attachment['id'] = a.id

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -34,6 +34,8 @@ from django.utils import timezone as dj_timezone
 from django.utils.encoding import DjangoUnicodeDecodeError, smart_str
 from django.utils.translation import gettext as t
 from modilabs.utils.subprocess_timeout import ProcessTimedOut
+from pyxform.errors import PyXFormError
+from pyxform.xform2json import create_survey_element_from_xml
 from rest_framework.exceptions import NotAuthenticated
 
 from kobo.apps.openrosa.apps.logger.exceptions import (
@@ -84,8 +86,6 @@ from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
-from pyxform.errors import PyXFormError
-from pyxform.xform2json import create_survey_element_from_xml
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'

--- a/kpi/utils/hash.py
+++ b/kpi/utils/hash.py
@@ -1,6 +1,6 @@
-import time
 import hashlib
-from typing import Union, BinaryIO, Optional
+import time
+from typing import BinaryIO, Optional, Union
 
 import requests
 from django.conf import settings


### PR DESCRIPTION
### 📣 Summary
Backfills the `media_base_name` field in MongoDB when rewriting attachments during long-running migration to support future optimizations.



### 📖 Description
This PR ensures that the `media_base_name` field is populated in MongoDB submission documents as part of the long-running migration that rewrites attachment metadata.

This field will be used in upcoming releases to optimize media file handling and lookup logic.
Populating it now ensures forward compatibility.


