### PR TITLE
chore(attachments): use `SKIP_HEAVY_MIGRATIONS` for new column index creation

### DIFF
--- a/kobo/apps/openrosa/apps/logger/migrations/0043_add_new_columns_to_attachment.py
+++ b/kobo/apps/openrosa/apps/logger/migrations/0043_add_new_columns_to_attachment.py
@@ -6,6 +6,125 @@ from django.db import migrations, models
 
 import kpi.fields.kpi_uid
 
+def manually_create_indexes_instructions(apps, schema_editor):
+    print(
+        """
+        ⚠️ ATTENTION ⚠️
+        Run the SQL queries below in PostgreSQL directly:
+
+            ```sql
+            --
+            -- Rename fields
+            --
+            ALTER TABLE "logger_attachment" RENAME COLUMN "xform" TO "xform_id";
+            ALTER TABLE "logger_attachment" RENAME COLUMN "user" TO "user_id";
+
+            --
+            -- Add index on field delete_status on attachment
+            --
+            CREATE INDEX CONCURRENTLY "logger_attachment_delete_status_19ec7f2f" ON "logger_attachment" ("delete_status");
+
+            --
+            -- Add unique index on field uid on attachment
+            --
+            CREATE UNIQUE INDEX CONCURRENTLY "unique_att_uid" ON "logger_attachment" ("uid");
+            ALTER TABLE "logger_attachment" ADD CONSTRAINT "logger_attachment_uid_99ff28ae_uniq" UNIQUE USING INDEX "unique_att_uid";
+
+            --
+            -- Add foreign key on field user_id on attachment
+            --
+            CREATE INDEX CONCURRENTLY "logger_attachment_user_id_4fde878d" ON "logger_attachment" ("user_id");
+            ALTER TABLE "logger_attachment" ADD CONSTRAINT "logger_attachment_user_id_4fde878d_fk_auth_user_id" FOREIGN KEY ("user_id") REFERENCES "auth_user" ("id") DEFERRABLE INITIALLY DEFERRED;
+
+            --
+            -- Add foreign key on field xform_id on attachment
+            --
+            CREATE INDEX CONCURRENTLY "logger_attachment_xform_id_22b4fd1f" ON "logger_attachment" ("xform_id");
+            ALTER TABLE "logger_attachment" ADD CONSTRAINT "logger_attachment_xform_id_22b4fd1f_fk_logger_xform_id" FOREIGN KEY ("xform_id") REFERENCES "logger_xform" ("id") DEFERRABLE INITIALLY DEFERRED;
+            ```
+
+        """
+    )
+
+
+def manually_drop_indexes_instructions(apps, schema_editor):
+    print(
+        """
+        ⚠️ ATTENTION ⚠️
+        Run the SQL queries below in PostgreSQL directly:
+
+            ```sql
+            ALTER TABLE "logger_attachment" DROP CONSTRAINT "logger_attachment_uid_99ff28ae_uniq";
+            ALTER TABLE "logger_attachment" DROP CONSTRAINT "logger_attachment_user_id_4fde878d_fk_auth_user_id";
+            ALTER TABLE "logger_attachment" DROP CONSTRAINT "logger_attachment_xform_id_22b4fd1f_fk_logger_xform_id";
+            DROP INDEX CONCURRENTLY IF EXISTS "logger_attachment_user_id_4fde878d";
+            DROP INDEX CONCURRENTLY IF EXISTS "logger_attachment_xform_id_22b4fd1f";
+            DROP INDEX CONCURRENTLY IF EXISTS "logger_attachment_delete_status_19ec7f2f";
+            ALTER TABLE "logger_attachment" RENAME COLUMN "xform_id" TO "xform";
+            ALTER TABLE "logger_attachment" RENAME COLUMN "user_id" TO "user";
+            ```
+
+        """
+    )
+
+
+def get_conditional_operations():
+
+    if settings.SKIP_HEAVY_MIGRATIONS:
+        return [
+            migrations.RunPython(
+                manually_create_indexes_instructions,
+                manually_drop_indexes_instructions,
+            )
+        ]
+    else:
+        # Add indexes with DJANGO
+        return [
+            migrations.AlterField(
+                model_name='attachment',
+                name='delete_status',
+                field=models.CharField(
+                    choices=[
+                        ('deleted', 'Deleted'),
+                        ('soft-deleted', 'Soft Deleted'),
+                        ('pending-delete', 'Pending Delete'),
+                    ],
+                    db_index=True,
+                    max_length=20,
+                    null=True,
+                ),
+            ),
+            migrations.AlterField(
+                model_name='attachment',
+                name='uid',
+                field=kpi.fields.kpi_uid.KpiUidField(
+                    _null=True, null=True, uid_prefix='att'
+                ),
+            ),
+            migrations.AlterField(
+                model_name='attachment',
+                name='user',
+                field=models.ForeignKey(
+                    blank=True,
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='attachments',
+                    to=settings.AUTH_USER_MODEL,
+                ),
+            ),
+            migrations.AlterField(
+                model_name='attachment',
+                name='xform',
+                field=models.ForeignKey(
+                    blank=True,
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='attachments',
+                    to='logger.xform',
+                ),
+            ),
+        ]
+
 
 class Migration(migrations.Migration):
 
@@ -18,24 +137,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attachment',
             name='user',
-            field=models.ForeignKey(
-                blank=True,
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name='attachments',
-                to=settings.AUTH_USER_MODEL,
-            ),
+            field=models.IntegerField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name='attachment',
             name='xform',
-            field=models.ForeignKey(
-                blank=True,
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name='attachments',
-                to='logger.xform',
-            ),
+            field=models.IntegerField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name='attachment',
@@ -50,9 +157,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attachment',
             name='uid',
-            field=kpi.fields.kpi_uid.KpiUidField(
-                _null=True, null=True, uid_prefix='att'
-            ),
+            field=models.CharField(blank=True, null=True, max_length=24)
         ),
         migrations.AddField(
             model_name='attachment',
@@ -63,9 +168,9 @@ class Migration(migrations.Migration):
                     ('soft-deleted', 'Soft Deleted'),
                     ('pending-delete', 'Pending Delete'),
                 ],
-                db_index=True,
                 max_length=20,
                 null=True,
             ),
         ),
+        *get_conditional_operations(),
     ]


### PR DESCRIPTION
### 📣 Summary
Adds support for skipping heavy index creation on large databases using the `SKIP_HEAVY_MIGRATIONS` flag.



### 📖 Description
This PR wraps the index creation for new attachment-related columns in a conditional check using the `SKIP_HEAVY_MIGRATIONS` setting.

This allows deploys on large databases to skip time-consuming index creation steps during the main release migration process.
Indexes can then be applied separately in a controlled environment, reducing downtime and improving deployment reliability.