### PR TITLE
feat(attachments): Update formpack export to handle deleted attachments TASK-575

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@efddba5933955bc00dda538b305fd93a1482aa1d#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@efddba5933955bc00dda538b305fd93a1482aa1d#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@8735cd8a37bf9f7753be952f30e8d32b0475c338#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@0bca3fa59a580eaba10fcb427b0c5dc1b8dd7d69#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@efddba5933955bc00dda538b305fd93a1482aa1d#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -1195,15 +1195,9 @@ class MockDataExports(MockDataExportsBase):
         media_url = submission['_attachments'][0]['download_url']
         expected_data = {
             asset_name: [
-                [
-                    'Submit an image',
-                    'Submit an image_is_deleted',
-                    'Submit an image_URL',
-                    '_uuid'
-                ],
+                ['Submit an image', 'Submit an image_URL', '_uuid'],
                 [
                     'audio_conversion_test_image.jpg',
-                    False,
                     media_url,
                     'f80be949-89b5-4af1-a42d-7d292b2bc0cd',
                 ],

--- a/kpi/tests/test_mock_data_exports.py
+++ b/kpi/tests/test_mock_data_exports.py
@@ -1195,9 +1195,15 @@ class MockDataExports(MockDataExportsBase):
         media_url = submission['_attachments'][0]['download_url']
         expected_data = {
             asset_name: [
-                ['Submit an image', 'Submit an image_URL', '_uuid'],
+                [
+                    'Submit an image',
+                    'Submit an image_is_deleted',
+                    'Submit an image_URL',
+                    '_uuid'
+                ],
                 [
                     'audio_conversion_test_image.jpg',
+                    False,
                     media_url,
                     'f80be949-89b5-4af1-a42d-7d292b2bc0cd',
                 ],


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure KPI installs the latest formpack version to support new export features for deleted media attachments.



### 📖 Description
This PR updates the formpack dependency hash in `requirements.in`, `requirements.txt`, and `dev_requirements.txt` to use the commit from [formpack#335](https://github.com/kobotoolbox/formpack/pull/335). That PR introduces support for displaying deleted attachments more clearly in exports:

- Replaces `{field}_URL` with the text `Deleted` when the attachment is marked as deleted and `include_media_url=True`.

These changes ensure that exports generated by KPI reflect deleted attachments more transparently for end users.
