### PR TITLE
fix(nlp): handle old qpaths that point at deleted questions DEV-194

### DIFF
--- a/kobo/apps/subsequences/tests/test_proj_advanced_features.py
+++ b/kobo/apps/subsequences/tests/test_proj_advanced_features.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 from model_bakery import baker
+from rest_framework import status
 
 from kpi.models import Asset
 
@@ -89,3 +90,30 @@ class ProjectAdvancedFeaturesTestCase(TestCase):
         addl_fields = _afj['additional_fields']
         assert len(addl_fields) == 2
         assert len(engines) == 1
+
+    def test_qpath_to_xpath_with_renamed_question(self):
+        """
+        Test that the analysis form JSON can handle a question that has been
+        renamed or deleted from the survey, but is still referenced in advanced
+        features or known columns.
+
+        This ensures that the asset endpoint does not return a 500 error when
+        processing legacy qpaths that no longer exist in the survey definition.
+        """
+        asset = self.sample_asset(advanced_features={
+            'translation': {
+                'values': ['q1'],
+                'languages': ['en', 'fr']
+            },
+        })
+
+        # Simulate known_cols with a legacy (renamed or deleted) question
+        asset.known_cols = [
+            'group_ia0id17-q1:translation:en',
+            'group_ia0id17-q1:translation:fr'
+        ]
+        asset.save()
+
+        self.client.force_login(asset.owner)
+        resp = self.client.get(f'/api/v2/assets/{asset.uid}/')
+        assert resp.status_code == status.HTTP_200_OK

--- a/kobo/apps/subsequences/utils/deprecation.py
+++ b/kobo/apps/subsequences/utils/deprecation.py
@@ -79,6 +79,14 @@ def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
         if '$qpath' in row and '$xpath' in row and row['$qpath'] == qpath:
             return row['$xpath']
 
+    # If the `qpath` refers to a question that was renamed or deleted, it may
+    # no longer match any XPath in the form. In such cases, where it's still
+    # present in known_cols, skip this field by returning an empty string
+    dashed_qpath = qpath.replace('/', '-')
+    for known_col in asset.known_cols:
+        if known_col.startswith(dashed_qpath):
+            return ''
+
     # Could not find it from the survey, let's try to detect it automatically
     xpaths = asset.get_attachment_xpaths(deployed=True)
     for xpath in xpaths:


### PR DESCRIPTION
### 📣 Summary
Allow users to access their project data even when older analysis features refer to questions that have since been removed from the project.

backport of #5754