### PR TITLE
feat(massEmails): adapt timeouts for condensed send mode

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -38,7 +38,7 @@ templates_placeholders = {
 PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{key_date}_emails'
 TASK_TIMEOUT = (
     5 * 60 if getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False) else 60 * 60
-)
+) # 5 minutes if condense send, otherwise 1h
 
 
 def enqueue_mass_email_records(email_config):
@@ -299,8 +299,8 @@ class MassEmailSender:
 
 
 @celery_app.task(
-    time_limit=TASK_TIMEOUT - 1, soft_time_limit=TASK_TIMEOUT - 1
-)  # 55 minutes
+    time_limit=TASK_TIMEOUT - 2, soft_time_limit=TASK_TIMEOUT - 2
+)  # subtract 2 so we don't run in to the generate_send task
 def send_emails():
     """
     Send the emails for the current day. It schedules the emails if they have not

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -38,7 +38,7 @@ templates_placeholders = {
 PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{key_date}_emails'
 TASK_TIMEOUT = (
     5 * 60 if getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False) else 60 * 60
-) # 5 minutes if condense send, otherwise 1h
+)  # 5 minutes if condense send, otherwise 1h
 
 
 def enqueue_mass_email_records(email_config):

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1420,8 +1420,8 @@ if os.environ.get('EMAIL_USE_TLS'):
     EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
 
 MAX_MASS_EMAILS_PER_DAY = 1000
-MASS_EMAIL_THROTTLE_PER_SECOND = 40
-MASS_EMAIL_SLEEP_SECONDS = 1
+MASS_EMAIL_THROTTLE_PER_SECOND = 1
+MASS_EMAIL_SLEEP_SECONDS = 310
 # change the interval between "daily" email sends for testing. this will set both
 # the frequency of the task and the expiry time of the cached email limits. should
 # only be True on small testing instances
@@ -1429,7 +1429,7 @@ MASS_EMAILS_CONDENSE_SEND = env.bool('MASS_EMAILS_CONDENSE_SEND', False)
 if MASS_EMAILS_CONDENSE_SEND:
     CELERY_BEAT_SCHEDULE['mass-emails-send'] = {
         'task': 'kobo.apps.mass_emails.tasks.send_emails',
-        'schedule': crontab(minute='2-59/5'),
+        'schedule': crontab(minute='1-59/5'),
         'options': {'queue': 'kpi_queue'},
     }
     CELERY_BEAT_SCHEDULE['mass-emails-enqueue-records'] = {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1420,8 +1420,8 @@ if os.environ.get('EMAIL_USE_TLS'):
     EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
 
 MAX_MASS_EMAILS_PER_DAY = 1000
-MASS_EMAIL_THROTTLE_PER_SECOND = 1
-MASS_EMAIL_SLEEP_SECONDS = 310
+MASS_EMAIL_THROTTLE_PER_SECOND = 40
+MASS_EMAIL_SLEEP_SECONDS = 1
 # change the interval between "daily" email sends for testing. this will set both
 # the frequency of the task and the expiry time of the cached email limits. should
 # only be True on small testing instances


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Lower the timeouts for mass email sends when in test mode.

### 💭 Notes
Update the time_limit option in the task decorator to be conditional on whether or not we're in condensed send mode. Also adds the soft_time_limit option because celery will ignore the regular time_limit if soft_time_limit is higher.


### 👀 Preview steps
If you are using kobo-compose, you may need to recreate the kpi_worker container (not just restart it).
Bug template:
1. ℹ️ have a superuser account and at least one other account
2. Update `MASS_EMAIL_THROTTLE_PER_SECOND` to 1 and `MASS_EMAIL_SLEEP_SECONDS` to 400
3. Add at least two user emails to `MASS_EMAIL_TEST_EMAILS`
4. Create a new MassEmailConfig with frequency=1 and using the test_users query. Set it to live.
5. 🟢 At the next 15 min boundary (+1 minute), the send_emails job should run. It should send one email then throw a 
TimeLimitExceeded error after 3 minutes

