### PR TITLE
fix(tests): Use `reverse()` instead of hardcoded url in unit tests

### DIFF
--- a/kobo/apps/subsequences/tests/test_proj_advanced_features.py
+++ b/kobo/apps/subsequences/tests/test_proj_advanced_features.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 from model_bakery import baker
 from rest_framework import status
@@ -115,5 +116,6 @@ class ProjectAdvancedFeaturesTestCase(TestCase):
         asset.save()
 
         self.client.force_login(asset.owner)
-        resp = self.client.get(f'/api/v2/assets/{asset.uid}/')
-        assert resp.status_code == status.HTTP_200_OK
+        asset_detail_url = reverse('asset-detail', kwargs={'uid': asset.uid})
+        response = self.client.get(asset_detail_url)
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Replaced hardcoded URL in unit test with `reverse()` to ensure better maintainability and consistency with URL routing.



### 📖 Description
This change updates a test case to use Django's `reverse()` function instead of hardcoding the API URL.
