### PR TITLE
chore(removingAttachments): remove feature flag TASK-1838

### DIFF
--- a/jsapp/js/attachments/AttachmentActionsDropdown.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.tsx
@@ -6,7 +6,6 @@ import Icon from '#/components/common/icon'
 import { userHasPermForSubmission } from '#/components/permissions/utils'
 import { QuestionTypeName } from '#/constants'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { notify } from '#/utils'
 import styles from './AttachmentActionsDropdown.module.scss'
 import { useRemoveAttachment } from './attachmentsQuery'
@@ -31,7 +30,6 @@ export default function AttachmentActionsDropdown(props: AttachmentActionsDropdo
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false)
   const [isDeletePending, setIsDeletePending] = useState<boolean>(false)
   const removeAttachmentMutation = useRemoveAttachment(props.asset.uid)
-  const isFeatureEnabled = useFeatureFlag(FeatureFlag.removingAttachmentsEnabled)
 
   const attachment = props.submissionData._attachments.find((item) => item.uid === props.attachmentUid)
   if (!attachment) {
@@ -87,7 +85,7 @@ export default function AttachmentActionsDropdown(props: AttachmentActionsDropdo
           <Menu.Item component='a' href={attachment!.download_url} leftSection={<Icon name='download' />}>
             {t('Download')}
           </Menu.Item>
-          {isFeatureEnabled && userCanChangeSubmission && (
+          {userCanChangeSubmission && (
             <>
               <Menu.Divider />
               <Menu.Item

--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -6,7 +6,6 @@ import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
 import { userHasPermForSubmission } from '#/components/permissions/utils'
 import { getMediaCount } from '#/components/submissions/submissionUtils'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { notify, removeDefaultUuidPrefix } from '#/utils'
 import { useRemoveBulkAttachments } from './attachmentsQuery'
 
@@ -18,17 +17,11 @@ interface BulkDeleteMediaFilesProps {
 }
 
 export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
-  const isFeatureEnabled = useFeatureFlag(FeatureFlag.removingAttachmentsEnabled)
-
   const [opened, { open, close }] = useDisclosure(false)
   const [isDeletePending, setIsDeletePending] = useState(false)
   const [warningAcknowledged, setWarningAcknowledged] = useState(false)
 
   const removeBulkAttachments = useRemoveBulkAttachments(props.asset.uid)
-
-  if (!isFeatureEnabled) {
-    return null
-  }
 
   // Filter submissions based on partial permissions
   const filteredSubmissions = props.selectedSubmissions.filter((submission) =>

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -3,8 +3,7 @@
  * For our sanity, use camel case and match key with value.
  */
 export enum FeatureFlag {
-  // exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
-  removingAttachmentsEnabled = 'removingAttachmentsEnabled', //Comment out when we have active FFs
+  exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
 }
 
 /**


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

After removing feature flag, the feauture is easliy accessible.

### 👀 Preview steps

Case A: testing steps for Submission Modal:
1. ℹ️ Have a project with `audio`, `file`, `image`, and `video` question
2. Make a submission that has responses to all the questions
   - go to Project > Form and use "Open" button in the "Collect data" section
3. Go to Project > Data > Table
4. Open submission ("eye" icon button)
5. 🟢 Notice that each question response has now "…" button on the right side
   - Using "Download" button (link) should work for each of question type
   - Using "Delete" button should do this for each question type:
      1. a success notification appears
      2. "…" modal is closed
      3. Data Table underneath modal fetches new data
      4. deleted attachment now appear as deleted
6. 🟢 Notice that when attachment is deleted the "…" button is not rendered

Case B: testing steps for Table Media Preview modal (`file`, `image`, and `video` questions):
1. Go through steps 1-3 of Case A
2. 🟢 Notice in the table that cell now has a file name and an icon button (previously it was just the file name for `file` and just icon for the other two)
3. Open a modal (icon button in the cell)
4. 🟢 Notice in the modal that we now have "…" button in top right instead of "Download" button
   - Using "Download" button (link) should work
   - Using "Delete" button should do this for each question type:
      1. a success notification appears
      2. "…" modal is closed
      3. Data Table fetches new data
      4. deleted attachment now appear as deleted
5. 🟢 Notice that for `file` type the file name and mimetype are being displayed as modal content

Case C: testing steps for NLP View:
1. Go through steps 1-3 of Case A
2. For `audio` question response use "Open" button
3. 🟢 Notice that in the right side the audio player now has "…" button
   - Using "Download" button (link) should work
   - Using "Delete" button should do this:
      1. a success notification appears
      2. "…" modal is closed
      3. new submission data is fetched
      4. deleted attachment now appear as deleted
      
Case D: testing steps for bulk delete:
1. Go through steps 1-3 of Case A
2. 