### PR TITLE
refactor(removingAttachments): better success and error handling in bulkDeleteAttachments

### DIFF
--- a/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
+++ b/jsapp/js/attachments/BulkDeleteMediaFiles.tsx
@@ -1,11 +1,13 @@
 import { Anchor, Box, Button, Checkbox, FocusTrap, Group, Modal, Stack, Text } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { useState } from 'react'
+import { actions } from '#/actions'
+import { handleApiFail } from '#/api'
 import Alert from '#/components/common/alert'
 import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
 import { userHasPermForSubmission } from '#/components/permissions/utils'
 import { getMediaCount } from '#/components/submissions/submissionUtils'
-import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
+import type { AssetResponse, FailResponse, SubmissionResponse } from '#/dataInterface'
 import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { notify, removeDefaultUuidPrefix } from '#/utils'
 import { useRemoveBulkAttachments } from './attachmentsQuery'
@@ -43,6 +45,8 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
 
     try {
       await removeBulkAttachments.mutateAsync(selectedRootUuids)
+      // Prompt table to refresh submission list
+      actions.resources.refreshTableSubmissions()
       handleCloseModal()
       notify(
         t('Media files from ##number_of_selected_submissions## submission(s) have been deleted').replace(
@@ -51,7 +55,7 @@ export default function BulkDeleteMediaFiles(props: BulkDeleteMediaFilesProps) {
         ),
       )
     } catch (error) {
-      notify(t('An error occurred while removing the attachments'), 'error')
+      handleApiFail(error as FailResponse)
     } finally {
       setIsDeletePending(false)
     }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Uses our `handleApiFail` instead of simple notification. Also added refreshing of Data Table that was missing here.