### PR TITLE
feat(projectHistoryLogs): change code to codename for partial perms D…

### DIFF
--- a/kobo/apps/audit_log/signals.py
+++ b/kobo/apps/audit_log/signals.py
@@ -67,7 +67,7 @@ def add_assigned_partial_perms(sender, instance, user, perms, **kwargs):
     request = _initialize_request()
     if not request or instance.asset_type != ASSET_TYPE_SURVEY:
         return
-    perms_as_list_of_dicts = [{'code': k, 'filters': v} for k, v in perms.items()]
+    perms_as_list_of_dicts = [{'codename': k, 'filters': v} for k, v in perms.items()]
     # partial permissions are replaced rather than added
     request.partial_permissions_added[user.username] = perms_as_list_of_dicts
 

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1312,17 +1312,23 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         # inherited partial permissions
         self.assertIn(
             {
-                'code': PERM_CHANGE_SUBMISSIONS,
+                'codename': PERM_CHANGE_SUBMISSIONS,
                 'filters': [{'_submitted_by': 'someuser'}],
             },
             added,
         )
         self.assertIn(
-            {'code': PERM_VIEW_SUBMISSIONS, 'filters': [{'_submitted_by': 'someuser'}]},
+            {
+                'codename': PERM_VIEW_SUBMISSIONS,
+                'filters': [{'_submitted_by': 'someuser'}],
+            },
             added,
         )
         self.assertIn(
-            {'code': PERM_ADD_SUBMISSIONS, 'filters': [{'_submitted_by': 'someuser'}]},
+            {
+                'codename': PERM_ADD_SUBMISSIONS,
+                'filters': [{'_submitted_by': 'someuser'}],
+            },
             added,
         )
 

--- a/kobo/apps/audit_log/tests/test_signals.py
+++ b/kobo/apps/audit_log/tests/test_signals.py
@@ -218,7 +218,7 @@ class ProjectHistoryLogsSignalsTestCase(BaseTestCase):
             {
                 'anotheruser': [
                     {
-                        'code': PERM_VIEW_SUBMISSIONS,
+                        'codename': PERM_VIEW_SUBMISSIONS,
                         'filters': [{'_submitted_by': 'someuser'}],
                     }
                 ]


### PR DESCRIPTION
Port of  DEV-218 (#5715)

### 📣 Summary
Change the key from 'code' to 'codename' for consistency when creating PH logs for partial permission changes.


### 💭 Notes
The PH log table is huge and updating it is a pain, so this will only change data going forward. Nothing on the front end relies on the structure of the metadata field so the inconsistency shouldn't break anything.


### 👀 Preview steps
1. ℹ️ have account and a project, and at least one other user
2. Go to Project > Settings > Sharing
3. Grant the second user permission to view only submissions from a specific user
4. Go to `/api/v2/assets/<uid>/history`
5. 🟢 There should be a new `modify-user-permissions` PH log with 
```
                "permissions": {
                    "added": [
                        "view_asset",
                        "partial_submissions",
                        {
                            "filters": [
                                {
                                    "_submitted_by": "<user>"
                                }
                            ],
                            "codename": "view_submissions"
                        }
                    ],
                    "removed": [],
                    "username": "<user>"
                },
```
in the metadata

