### PR TITLE
fix(massEmails): do not enqueue new records mid-day

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -373,10 +373,11 @@ def generate_mass_email_user_lists():
         date_created__lt=cache_key_date, live=True
     )
 
-    for email_config in email_configs:
-        if email_config.id in processed_configs:
-            continue
+    if len(processed_configs) > 1:
+        logging.info('Already generated sends lists for today.')
+        return
 
+    for email_config in email_configs:
         email_records = MassEmailRecord.objects.filter(
             email_job__email_config=email_config,
         )

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -435,43 +435,6 @@ class GenerateDailyEmailUserListTaskTestCase(BaseMassEmailsTestCase):
         self.assertEqual(email_records.count(), total_records)
         self.assertIn(email_config.id, cache.get(self.cache_key))
 
-    def test_task_skips_already_processed_configs_using_cache(self):
-        """
-        Test that `generate_mass_email_user_lists` uses the cached config IDs
-        to skip already processed email configs
-        """
-        email_config1 = self._create_email_config('Test A')
-        generate_mass_email_user_lists()
-
-        self.assertIn(email_config1.id, cache.get(self.cache_key))
-        config1_records = MassEmailRecord.objects.filter(
-            email_job__email_config=email_config1, status=EmailStatus.ENQUEUED
-        )
-        self.assertEqual(config1_records.count(), 2)
-
-        # Delete the records to simulate reprocessing of the config
-        config1_records.delete()
-        self.assertEqual(
-            MassEmailRecord.objects.filter(
-                email_job__email_config=email_config1
-            ).count(), 0
-        )
-
-        email_config2 = self._create_email_config('Test B')
-        generate_mass_email_user_lists()
-
-        self.assertIn(email_config2.id, cache.get(self.cache_key))
-        records = MassEmailRecord.objects.filter(
-            email_job__email_config=email_config2, status=EmailStatus.ENQUEUED
-        )
-        self.assertEqual(records.count(), 2)
-
-        # Confirm email_config1 was skipped and no new records were created
-        config1_reprocessed_records = MassEmailRecord.objects.filter(
-            email_job__email_config=email_config1
-        )
-        self.assertEqual(config1_reprocessed_records.count(), 0)
-
     def test_cache_expiry(self):
         """
         Test that the cache expires after 24 hours


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update all related docs (API, README, inline, etc.), if any
3. [ ] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [ ] tag PR: at least `frontend` or `backend` unless it's global
5. [ ] fill in the template below and delete template comments
6. [ ] review thyself: read the diff and repro the preview as written
7. [ ] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Because we add all the processed configs to the cache at the end of the process, we do not actually gain anything by rechecking each configuration each time. There can never be a case where we have only put some of the configurations we need in the cache. If an existing email configuration that was not previously live is set to live in the middle of the day, its records should not be enqueued until the next day.

Bug template:
1. ℹ️ have some live MassEmailConfigs
2. Wait for the send lists to generate at the 15m boundary
3. In 5 minutes, when the job runs again, there should be a message in the logs "Already generated sends lists for today."

