### PR TITLE
fix(attachments): ignore old MongoDB attachment format when backfilling new attributes

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0009_backfill_attachment_model.py
+++ b/kobo/apps/long_running_migrations/jobs/0009_backfill_attachment_model.py
@@ -112,6 +112,12 @@ def update_mongo(attachment_ids_per_instance: dict):
 
         for attachment in doc['_attachments']:
 
+            try:
+                attachment['id']
+            except (TypeError, KeyError):
+                # Ignore attachments that don't conform to the expected structure
+                continue
+
             if (
                 'uid' not in attachment
                 and attachment['id'] in attachment_ids_per_instance[doc['_id']]


### PR DESCRIPTION
### 📣 Summary
Avoids processing outdated MongoDB attachment documents during the backfilling of new attributes.


### 📖 Description
This change prevents errors during long-running migrations by skipping legacy-formatted attachment documents in MongoDB.

These documents don't match the expected structure for the new attributes being added (e.g., `uid`, `media_base_name`, etc.).
