### PR TITLE
fix(massEmails): no error on empty test user list DEV-562

### DIFF
--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -201,4 +201,6 @@ def get_users_over_100_percent_of_nlp_limits() -> QuerySet:
 def get_all_test_users() -> QuerySet:
     # for testing only
     test_emails = config.MASS_EMAIL_TEST_EMAILS.split('\n')
+    # remove empty strings
+    test_emails = [email for email in test_emails if len(email) > 0]
     return User.objects.filter(email__in=test_emails)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Do not attempt to send emails when the test email configuration is empty.



### 📖 Description
Fixes an error wherein if the `MASS_EMAIL_TEST_EMAILS` configuration in Constance was empty, any email using the `test_users` query would throw errors, which could kill the whole process and prevent other emails from sending.


### 👀 Preview steps
Remember to restart the kpi_worker after switching branches

1. In Constance, reset `MASS_EMAIL_TEST_EMAILS` to default
2. Create a MassEmailConfig that uses the `test_users` query and set it to live
3.  🔴 [on main] At one minute after the next 15 m boundary the send process will fail
4. 🟢 [on PR] No errors in kpi_worker

