### PR TITLE
perf(attachments): Improve bulk update attachments storage counters DEV-351

### DIFF
--- a/kobo/apps/trash_bin/models/attachment.py
+++ b/kobo/apps/trash_bin/models/attachment.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from django.db import models, transaction
+from django.db import models
 from django.db.utils import IntegrityError
 from django.utils import timezone
 

--- a/kobo/apps/trash_bin/models/attachment.py
+++ b/kobo/apps/trash_bin/models/attachment.py
@@ -11,6 +11,7 @@ from kobo.apps.openrosa.apps.logger.models.attachment import (
 from kobo.apps.openrosa.apps.logger.utils.attachment import (
     bulk_update_attachment_storage_counters
 )
+from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 from kpi.fields import KpiUidField
 from . import BaseTrash
 from ..type_aliases import UpdatedQuerySetAndCount
@@ -76,7 +77,7 @@ class AttachmentTrash(BaseTrash):
             delete_status=current_delete_status
         )
 
-        with transaction.atomic():
+        with kc_transaction_atomic():
             bulk_update_attachment_storage_counters(queryset, subtract=subtract)
             updated = queryset.update(
                 delete_status=new_delete_status,

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -472,8 +472,8 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
 
     def test_storage_updates_on_project_trash_and_restore(self):
         """
-        Test that attachment storage counters in XForm and UserProfile are
-        cleared on trash, and restored properly on untrash
+        Test that attachment storage counter in UserProfile is cleared on trash,
+        and restored properly on untrash. Counter on xform remains unchanged.
         """
         asset, xform, instance, user_profile, attachment = (
             self._create_test_asset_and_submission(
@@ -501,7 +501,7 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
         )
         xform.refresh_from_db()
         user_profile.refresh_from_db()
-        self.assertEqual(xform.attachment_storage_bytes, 0)
+        self.assertGreater(xform.attachment_storage_bytes, 0)
         self.assertEqual(user_profile.attachment_storage_bytes, 0)
 
         # Restore the project

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -537,7 +537,7 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
         )
         xform.refresh_from_db()
         user_profile.refresh_from_db()
-        self.assertGreater(xform.attachment_storage_bytes, 0)
+        self.assertEqual(xform.attachment_storage_bytes, xform_storage_init)
         self.assertEqual(user_profile.attachment_storage_bytes, 0)
 
         # Restore the project
@@ -554,7 +554,7 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
         )
         xform.refresh_from_db()
         user_profile.refresh_from_db()
-        self.assertGreater(xform.attachment_storage_bytes, 0)
+        self.assertEqual(xform.attachment_storage_bytes, xform_storage_init)
         self.assertGreater(user_profile.attachment_storage_bytes, 0)
         self.assertEqual(xform_storage_init, xform.attachment_storage_bytes)
         self.assertEqual(user_storage_init, user_profile.attachment_storage_bytes)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [ ] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Improved performance of storage counter updates when bulk trashing or restoring attachments and projects.

### 📖 Description
- Refactors the logic for updating attachment storage counters on user profiles and xforms during bulk trash or restore operations.
- With this PR, when a XForm is trashed or restored, only the `UserProfile` storage counter will be updated. The XForm’s storage value remains unchanged because trashed forms are excluded from queries and considered deleted along with their attachments.

