### PR TITLE
fix(organization): stop duplicate project transfers when adding a member to an org from Django Admin DEV-558

### DIFF
--- a/kobo/apps/organizations/admin/organization.py
+++ b/kobo/apps/organizations/admin/organization.py
@@ -61,7 +61,6 @@ class OrgAdmin(BaseOrganizationAdmin):
                         transaction.on_commit(
                             lambda: self._transfer_user_ownership(request, new_members)
                         )
-                        self._transfer_user_ownership(request, new_members)
                         self._delete_previous_organizations(
                             new_members, organization_id
                         )

--- a/kobo/apps/organizations/tests/admin/test_organization_admin.py
+++ b/kobo/apps/organizations/tests/admin/test_organization_admin.py
@@ -5,6 +5,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
 from kpi.constants import PERM_MANAGE_ASSET
 from kpi.models.asset import Asset
+from kpi.tests.utils.transaction import immediate_on_commit
 
 
 class TestOrganizationAdminTestCase(TestCase):
@@ -88,6 +89,8 @@ class TestOrganizationAdminTestCase(TestCase):
             'admin:organizations_organization_change',
             kwargs={'object_id': self.organization.id},
         )
-        response = self.client.post(url, data=payload, follow=True)
+        with immediate_on_commit():
+            response = self.client.post(url, data=payload, follow=True)
+
         assert 'was changed successfully' in str(response.content)
         return response


### PR DESCRIPTION
### 📣 Summary
Prevents multiple transfers of the same projects when adding a user to an organization via the Django Admin.

### 📖 Description
This fix addresses an issue where adding a user to an organization from the Django Admin interface could trigger duplicate project transfers, resulting in unnecessary processing and potential inconsistencies.
