### PR TITLE
fix(attachments): hide the "Delete media files only" button from any permission except `change_submissions` or higher

### DIFF
--- a/jsapp/js/components/submissions/tableBulkOptions.tsx
+++ b/jsapp/js/components/submissions/tableBulkOptions.tsx
@@ -267,7 +267,7 @@ class TableBulkOptions extends React.Component<TableBulkOptionsProps> {
           )}
 
         {Object.keys(this.props.selectedRows).length > 0 &&
-          (userCan(PERMISSIONS_CODENAMES.delete_submissions, this.props.asset) ||
+          (userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) ||
             userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)) &&
           this.getSelectedSubmissionsWithAttachments().length > 0 && (
             <BulkDeleteMediaFiles


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update all related docs (API, README, inline, etc.), if any
3. [x] draft PR with a title `<type>(<scope>)<!>: <title> TASK-1234`
4. [x] tag PR: at least `frontend` or `backend` unless it's global
5. [x] fill in the template below and delete template comments
6. [x] review thyself: read the diff and repro the preview as written
7. [x] open PR & confirm that CI passes
8. [x] request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

Those with `delete_submissions` permission for submissions cannot see the "Delete media files only" button in the bulk options

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

Missed a spot when writing the guards for displaying the button. Clicking it would trigger another set of guards in the actual component so the user couldn't delete attachments this way anyway.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have 3 accounts and a project with media attachment submissions
2. allow a `user_a` to have `delete_submissions` permissions
3. allow a `user_b` to have `change_submissions` permissions
4. 🔴 [on main] notice that both `user_a` and `user_b` can see "Delete media files only" button in the bulk select options'
6. 🟢 [on PR] notice `user_a` cannot see  "Delete media files only" button, but `user_b` still can
