### PR TITLE
fix(removingAttachments): add missing trailing slash in attachment bulk url

### DIFF
--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -1,7 +1,7 @@
 export const endpoints = {
   ENVIRONMENT: '/environment/',
   /** Note: currently this endpoint only handles DELETE. Pass `{submission_root_uuids: string[]}` as payload. */
-  ATTACHMENT_BULK_URL: '/api/v2/assets/:asset_uid/attachments/bulk',
+  ATTACHMENT_BULK_URL: '/api/v2/assets/:asset_uid/attachments/bulk/',
   /** Note: currently this endpoint only handles DELETE */
   ATTACHMENT_DETAIL_URL: '/api/v2/assets/:asset_uid/attachments/:attachment_uid/',
   ASSET_HISTORY: '/api/v2/assets/:asset_uid/history/',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Pointed out at https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Remove.20attachments.20without.20deleting.20submissions.20.28PROJ-100.29/near/630287