### PR TITLE
fix(attachments): fix attachment deletion for edited submissions TASK-1841

### DIFF
--- a/kpi/serializers/v2/attachment_delete.py
+++ b/kpi/serializers/v2/attachment_delete.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.utils.translation import gettext as t
 from rest_framework import serializers
 
@@ -54,9 +55,12 @@ class AttachmentDeleteSerializer(serializers.Serializer):
             attachment_uids = [self.validated_data['attachment_uid']]
             field = 'attachment_uid'
         else:
+            uuids = self.validated_data['submission_root_uuids']
             attachments = Attachment.objects.filter(
-                xform_id=deployment.xform_id,
-                instance__uuid__in=self.validated_data['submission_root_uuids'],
+                Q(xform_id=deployment.xform_id) & (
+                    Q(instance__root_uuid__in=uuids) |
+                    (Q(instance__uuid__in=uuids) & Q(instance__root_uuid__isnull=True))
+                )
             )
             attachment_uids = list(attachments.values_list('uid', flat=True))
             field = 'submission_root_uuids'

--- a/kpi/tests/api/v2/test_api_attachments_delete_viewset.py
+++ b/kpi/tests/api/v2/test_api_attachments_delete_viewset.py
@@ -300,6 +300,53 @@ class AttachmentDeleteApiTests(BaseAssetTestCase):
         assert AttachmentTrash.objects.count() == initial_trash_count + 6
         assert not Attachment.objects.filter(uid__in=self.attachment_uids).exists()
 
+    def test_bulk_delete_attachments_when_submission_is_edited(self):
+        """
+        Test bulk deletion of attachments for a submission that has been edited
+        """
+        self.client.login(username='someuser', password='someuser')
+        edited_submission = {
+            '__version__': self.asset.latest_deployed_version.uid,
+            'meta': {
+                'instanceID': 'uuid:test_edited_uuid',
+                'rootUuid': 'uuid:test_uuid1',
+                'deprecatedID': 'uuid:test_uuid1',
+            },
+            'q1': 'audio_conversion_test_clip.3gp',
+            'q2': 'audio_conversion_test_image.jpg',
+            '_attachments': [
+                {
+                    'filename': (
+                        f'{self.asset.owner.username}'
+                        '/audio_conversion_test_clip.3gp'
+                    ),
+                    'mimetype': 'video/3gpp',
+                },
+                {
+                    'filename': (
+                        f'{self.asset.owner.username}'
+                        '/audio_conversion_test_image.jpg'
+                    ),
+                    'mimetype': 'image/jpeg',
+                },
+            ],
+            '_submitted_by': self.asset.owner.username,
+        }
+        self.asset.deployment.mock_submissions([edited_submission], create_uuids=False)
+
+        initial_trash_count = AttachmentTrash.objects.count()
+        response = self.client.delete(
+            self.bulk_delete_url,
+            data=json.dumps({'submission_root_uuids': [self.submission_root_uuid_1]}),
+            content_type='application/json',
+        )
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.data == {'message': '2 attachments deleted'}
+        assert AttachmentTrash.objects.count() == initial_trash_count + 2
+        assert not Attachment.objects.filter(
+            uid__in=[self.attachment_uid_1, self.attachment_uid_2]
+        ).exists()
+
     def test_bulk_delete_attachments_from_other_project_are_ignored(self):
         initial_trash_count = AttachmentTrash.objects.count()
         submission_root_uuids = list(self.submission_root_uuids)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes an issue where attachments could not be deleted from edited submissions due to incorrect handling of submission UUIDs.

### 📖 Description
This fix updates the attachment deletion logic to correctly filter using `root_uuid` for edited submissions. Previously, the API returned a 400 error when edited submissions were included, treating their root UUIDs as invalid. The updated query ensures attachments from both original and edited submissions can be deleted successfully.