### PR TITLE
ci(chromatic): fix failing nightly builds DEV-590

### DIFF
--- a/jsapp/js/attachments/AttachmentActionsDropdown.stories.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof AttachmentActionsDropdown> = {
           padding: '20px',
           lineHeight: '50px',
           textAlign: 'justify',
-          fontSize: '50px',
+          fontSize: '32px',
           color: 'lightcoral',
           background: 'radial-gradient(circle, pink, blanchedalmond, thistle, pink, lavender, lavenderblush)',
           display: 'inline-block',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Chromatic build was failing because we use an external image in one of the stories, and that external site was being flaky. I added a CSS fake image instead to make things consistent.

### 👀 Preview steps

1. start storybook `npm run storybook`
2. go to `AttachmentActionsDropdown` story
3. 🟢 notice that there is a fake image with gradient and some quote
