### PR TITLE
fix(attachments): set project, owner, and timestamps on attachment creation DEV-607

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_instance_creation.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_instance_creation.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import glob
 import os
 
@@ -88,6 +87,15 @@ class TestInstanceCreation(TestCase):
             postdata = create_post_data(path)
             response = self.client.post('/bob/submission', postdata)
             self.assertEqual(response.status_code, 201)
+
+        instance = Instance.objects.get(root_uuid='435f173c688e482486a48661700467gh')
+        attachment = instance.attachments.first()
+        assert attachment.media_file_basename == '1300375832136.jpg'
+        assert attachment.xform_id == instance.xform_id
+        assert attachment.user_id == instance.xform.user_id
+        assert attachment.date_created is not None
+        assert attachment.date_modified is not None
+
 
     def test_submission_for_missing_form(self):
         xml_file = open(os.path.join(

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -793,6 +793,10 @@ def save_attachments(
             hash=uploaded_file_hash,
             media_file_basename=media_file_basename,
             media_file_size=f.size,
+            xform_id=instance.xform_id,
+            user_id=instance.xform.user_id,
+            date_created=dj_timezone.now(),
+            date_modified=dj_timezone.now(),
         )
         total_bytes += f.size
         new_attachments.append(new_attachment)


### PR DESCRIPTION
### 📣 Summary
Restores the automatic population of user, form, and timestamp fields when saving new attachments.

### 📖 Description
This PR ensures that `user_id`, `xform_id`, `date_created`, and `date_modified` are correctly set when creating new Attachment entries during submission processing.

These fields are necessary for upcoming features that rely on complete metadata for each attachment.

### 💭 Notes
A previous merge inadvertently dropped this logic during a save optimization. This change reinstates the necessary field population to maintain data integrity and support future developments.

Linter fixes are pushed to #5851 

### 👀 Preview steps

1. ℹ️ have an account and a project with attachments
2. Submit data
3. From the shell, print the attachment with `vars(attachment)`
4. 🔴 [on release branch] notice `user_id`, `xform_id`, `date_created`, and `date_modified` equal `None`
5. 🟢 [on PR] notice that they are all set
