### PR TITLE
chore(updateHelmRepo): Updating helm repo to use ghcr

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,8 +25,7 @@ deploy-beta:
     name: alpine/helm:3.12.0
     entrypoint: [""]
   script:
-    - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
-    - helm -n kobo-dev upgrade beta kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+    - helm -n kobo-dev upgrade beta oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
   environment:
     name: beta
     url: https://kf.beta.kobotoolbox.org
@@ -43,13 +42,12 @@ deploy-staging:
     entrypoint: [""]
   script:
     - BRANCH_TITLE=${CI_COMMIT_BRANCH#feature/}
-    - helm repo add kobo https://gitlab.com/api/v4/projects/32216873/packages/helm/stable
     - |
       if [ "$CI_COMMIT_BRANCH" = "main" ]; then
-        helm -n kobo-dev upgrade staging-main kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
-        helm -n kobo-dev upgrade staging-nobill kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+        helm -n kobo-dev upgrade staging-main oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+        helm -n kobo-dev upgrade staging-nobill oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
       else
-        helm -n kobo-dev upgrade --install $BRANCH_TITLE kobo/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+        helm -n kobo-dev upgrade --install $BRANCH_TITLE oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
       fi
   rules:
     - if: $CI_COMMIT_BRANCH =~ /^(feature\/)/ && $CI_COMMIT_REF_PROTECTED


### PR DESCRIPTION
We're migrating away from using gitlab repo for helm charts so this updates the nonprod environments to use the new ghcr repo.