### PR TITLE
fix(removingAttachments): don't disable automatic translation button DEV-588

### DIFF
--- a/jsapp/js/components/processing/translations/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/translations/stepConfig.component.tsx
@@ -14,7 +14,6 @@ import TransxAutomaticButton from '#/components/processing/transxAutomaticButton
 import { useExceedingLimits } from '#/components/usageLimits/useExceedingLimits.hook'
 import envStore from '#/envStore'
 import NlpUsageLimitBlockModal from '../nlpUsageLimitBlockModal/nlpUsageLimitBlockModal.component'
-import { getAttachmentForProcessing } from '../transcript/transcript.utils'
 
 export default function StepConfig() {
   const [usage] = useContext(UsageContext)
@@ -87,7 +86,6 @@ export default function StepConfig() {
 
   const draft = singleProcessingStore.getTranslationDraft()
   const isAutoEnabled = envStore.data.asr_mt_features_enabled
-  const attachment = getAttachmentForProcessing()
 
   return (
     <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
@@ -122,7 +120,6 @@ export default function StepConfig() {
             onClick={onAutomaticButtonClick}
             selectedLanguage={draft?.languageCode}
             type='translation'
-            disabled={typeof attachment === 'string' || attachment.is_deleted}
           />
           <NlpUsageLimitBlockModal
             isModalOpen={isLimitBlockModalOpen}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Don't disable automatic translation for deleted attachments.

### 💭 Notes

This was a mistake introduced in #5629. We added disabling of automatic transcript button (correct) and then did the same thing for automatic translation (incorrect).

### 👀 Preview steps

Testing:
1. ℹ️ Have NLP features set up (see https://www.notion.so/kobotoolbox/Setting-up-NLP-and-Languages-bb607e3fed114993bb14338fe56c6ed4?pvs=4)
2. ℹ️ Have account and a project with `audio` question
3. ℹ️ Make a submission
4. Go to Project → Data → Table and use "Open" button for the audio question response (to open NLP view)
5. Create a transcript
6. On the right side use "…" button next to audio player and choose "Delete" option
7. Open "Translations" tab and start creating translation ("Begin" button, then choose some language)
8. 🔴 on `main` notice that the "Automatic" button is disabled (bug)
9. 🟢 on the PR branch notice that "Automatic" button is enabled correctly
