### PR TITLE
fix(projectTransfer): fix project ownership transfer does not transfer thumbnails DEV-139

### DIFF
--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -3,6 +3,7 @@ import time
 from typing import Literal, Optional, Union
 
 from django.apps import apps
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
@@ -101,6 +102,7 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
     # Moving files is pretty slow, thus it should run in a celery task.
     errors = False
     for attachment in attachments.iterator():
+        media_file_path = attachment.media_file.path
         if not (
             target_folder := get_target_folder(
                 transfer.invite.sender.username,
@@ -114,6 +116,7 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
             # object to the database. Fingers crossed that the process doesn't get
             # interrupted between these two operations.
             if attachment.media_file.move(target_folder):
+                _delete_thumbnails(media_file_path)
                 attachment.save(update_fields=['media_file'])
             else:
                 errors = True
@@ -238,6 +241,31 @@ def _mark_task_as_successful(
     TransferStatus.update_status(
         transfer.pk, TransferStatusChoices.SUCCESS, async_task_type
     )
+
+
+def _delete_thumbnails(media_file_path: str):
+    """
+    Delete generated thumbnail files (large, medium, small) that correspond to
+    an original attachment.
+
+    Thumbnails are not stored in the database and are generated on the fly
+    when a user previews an image. Since they will be regenerated for the new
+    owner after transfer, we safely delete them from the old owner's folder
+    after moving the original attachment.
+    """
+    if not media_file_path:
+        return
+
+    dir_name = os.path.dirname(media_file_path)
+    base, ext = os.path.splitext(os.path.basename(media_file_path))
+
+    for size_key in settings.THUMB_CONF.keys():
+        thumb_path = os.path.join(dir_name, f'{base}-{size_key}{ext}')
+        if os.path.exists(thumb_path):
+            try:
+                os.remove(thumb_path)
+            except Exception as e:
+                logging.warning(f'Could not delete thumbnail: {thumb_path} ({e})')
 
 
 def _update_heartbeat(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Safe cleanup of old image thumbnails when transferring project ownership, ensuring no leftover images from previous owner.


### 📖 Description
When a project is transferred from one user to another, any thumbnails (small, medium, large) generated by the previous owner are now properly deleted. Since these thumbnails are generated on the fly when an image is previewed, it’s safe to delete them during transfer. This avoids orphaned files and ensures the new project owner sees freshly generated image previews.
