### PR TITLE
feat(billing): ensure accurate usage limit reporting DEV-444

### DIFF
--- a/dependencies/pip/dev_requirements.in
+++ b/dependencies/pip/dev_requirements.in
@@ -13,6 +13,7 @@ pytest-cov
 pytest-django
 pytest-env
 pytest-xdist
+fakeredis
 freezegun
 
 # KoboCAT

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -270,6 +270,8 @@ executing==2.0.1
     # via stack-data
 fabric==3.2.2
     # via -r dependencies/pip/dev_requirements.in
+fakeredis==2.30.1
+    # via -r dependencies/pip/dev_requirements.in
 flake8==7.1.1
     # via
     #   -r dependencies/pip/dev_requirements.in
@@ -547,6 +549,7 @@ redis==5.0.3
     #   celery
     #   django-redis
     #   django-redis-sessions
+    #   fakeredis
 referencing==0.34.0
     # via
     #   jsonschema
@@ -597,6 +600,8 @@ six==1.16.0
     #   python-dateutil
 smsapi-client==2.9.5
     # via django-trench
+sortedcontainers==2.4.0
+    # via fakeredis
 sqlparse==0.4.4
     # via
     #   -r dependencies/pip/requirements.in
@@ -640,6 +645,7 @@ typing-extensions==4.10.0
     #   azure-core
     #   azure-storage-blob
     #   black
+    #   fakeredis
     #   ipython
     #   jwcrypto
     #   psycopg

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -64,7 +64,12 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
             request = self.factory.post('/submission', data, format='json')
             auth = DigestAuth('bob', 'bobbob')
             request.META.update(auth(request.META, response))
-            with self.assertNumQueries(FuzzyInt(43, 47)):
+            expected_queries = FuzzyInt(43, 47)
+            # In stripe-enabled environments usage limit enforcement
+            # requires additional queries
+            if settings.STRIPE_ENABLED:
+                expected_queries = FuzzyInt(69, 73)
+            with self.assertNumQueries(expected_queries):
                 self.view(request)
 
     def test_post_submission_anonymous(self):

--- a/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
@@ -150,4 +150,3 @@ class TestSimpleSubmission(TestCase):
             self._submit_simple_yes()
             patched.assert_any_call(self.user, UsageType.SUBMISSION)
             patched.assert_any_call(self.user, UsageType.STORAGE_BYTES)
-

--- a/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
@@ -144,7 +144,7 @@ class TestSimpleSubmission(TestCase):
     )
     def test_check_exceeded_limit_on_submission(self):
         with patch(
-            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            'kobo.apps.stripe.utils.limit_enforcement.check_exceeded_limit',
             return_value=None,
         ) as patched:
             self._submit_simple_yes()

--- a/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
@@ -1,10 +1,10 @@
 import uuid
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
 from django.test import RequestFactory, TestCase
 from pyxform import SurveyElementBuilder
-from unittest.mock import patch
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import DuplicateInstanceError

--- a/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_simple_submission.py
@@ -1,7 +1,10 @@
 import uuid
 
+import pytest
+from django.conf import settings
 from django.test import RequestFactory, TestCase
 from pyxform import SurveyElementBuilder
+from unittest.mock import patch
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import DuplicateInstanceError
@@ -11,6 +14,7 @@ from kobo.apps.openrosa.libs.utils.logger_tools import (
     create_instance,
     safe_create_instance,
 )
+from kobo.apps.organizations.constants import UsageType
 
 
 class TempFileProxy:
@@ -134,3 +138,16 @@ class TestSimpleSubmission(TestCase):
         # An `ExpatError` is raised instead
         text = 'Improperly formatted XML'
         self.assertContains(error, text, status_code=400)
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
+    def test_check_exceeded_limit_on_submission(self):
+        with patch(
+            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            return_value=None,
+        ) as patched:
+            self._submit_simple_yes()
+            patched.assert_any_call(self.user, UsageType.SUBMISSION)
+            patched.assert_any_call(self.user, UsageType.STORAGE_BYTES)
+

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -89,6 +89,8 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
+if settings.STRIPE_ENABLED:
+    from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
@@ -300,10 +302,6 @@ def create_instance(
                 )
 
             if settings.STRIPE_ENABLED:
-                from kobo.apps.stripe.utils.limit_enforcement import (
-                    check_exceeded_limit,
-                )
-
                 check_exceeded_limit(xform.user, UsageType.SUBMISSION)
                 check_exceeded_limit(xform.user, UsageType.STORAGE_BYTES)
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -89,8 +89,6 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
-if settings.STRIPE_ENABLED:
-    from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
@@ -302,6 +300,10 @@ def create_instance(
                 )
 
             if settings.STRIPE_ENABLED:
+                from kobo.apps.stripe.utils.limit_enforcement import (
+                    check_exceeded_limit,
+                )
+
                 check_exceeded_limit(xform.user, UsageType.SUBMISSION)
                 check_exceeded_limit(xform.user, UsageType.STORAGE_BYTES)
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -89,7 +89,6 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
-
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
 OPEN_ROSA_VERSION = '1.0'
@@ -303,6 +302,7 @@ def create_instance(
                 from kobo.apps.stripe.utils.limit_enforcement import (
                     check_exceeded_limit,
                 )
+
                 check_exceeded_limit(xform.user, UsageType.SUBMISSION)
                 check_exceeded_limit(xform.user, UsageType.STORAGE_BYTES)
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -98,9 +98,8 @@ OPEN_ROSA_VERSION = '1.0'
 DEFAULT_CONTENT_TYPE = 'text/xml; charset=utf-8'
 DEFAULT_CONTENT_LENGTH = settings.OPENROSA_DEFAULT_CONTENT_LENGTH
 
-uuid_regex = re.compile(
-    r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>', re.DOTALL
-)
+uuid_regex = re.compile(r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>',
+                        re.DOTALL)
 
 mongo_instances = settings.MONGO_DB.instances
 
@@ -140,12 +139,10 @@ def check_edit_submission_permissions(
     if request.user.is_anonymous:
         raise UnauthenticatedEditAttempt
     if not _has_edit_xform_permission(request, xform):
-        raise PermissionDenied(
-            t(
-                'Forbidden attempt to edit a submission. To make a new submission, '
-                'Remove `deprecatedID` from the submission XML and try again.'
-            )
-        )
+        raise PermissionDenied(t(
+            'Forbidden attempt to edit a submission. To make a new submission, '
+            'Remove `deprecatedID` from the submission XML and try again.'
+        ))
 
 
 def create_instance(
@@ -1113,7 +1110,6 @@ class UnauthenticatedEditAttempt(Exception):
     which passes through unmolested to `XFormSubmissionApi.create()`, which
     then returns the appropriate 401 response.
     """
-
     pass
 
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -80,6 +80,7 @@ from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.utils import common_tags
 from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator, set_uuid
 from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
+from kobo.apps.organizations.constants import UsageType
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
@@ -88,14 +89,18 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
+if settings.STRIPE_ENABLED:
+    from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
+
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
 OPEN_ROSA_VERSION = '1.0'
 DEFAULT_CONTENT_TYPE = 'text/xml; charset=utf-8'
 DEFAULT_CONTENT_LENGTH = settings.OPENROSA_DEFAULT_CONTENT_LENGTH
 
-uuid_regex = re.compile(r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>',
-                        re.DOTALL)
+uuid_regex = re.compile(
+    r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>', re.DOTALL
+)
 
 mongo_instances = settings.MONGO_DB.instances
 
@@ -135,10 +140,12 @@ def check_edit_submission_permissions(
     if request.user.is_anonymous:
         raise UnauthenticatedEditAttempt
     if not _has_edit_xform_permission(request, xform):
-        raise PermissionDenied(t(
-            'Forbidden attempt to edit a submission. To make a new submission, '
-            'Remove `deprecatedID` from the submission XML and try again.'
-        ))
+        raise PermissionDenied(
+            t(
+                'Forbidden attempt to edit a submission. To make a new submission, '
+                'Remove `deprecatedID` from the submission XML and try again.'
+            )
+        )
 
 
 def create_instance(
@@ -296,6 +303,10 @@ def create_instance(
                     created=True,
                     xform=instance.xform,
                 )
+
+            if settings.STRIPE_ENABLED:
+                check_exceeded_limit(xform.user, UsageType.SUBMISSION)
+                check_exceeded_limit(xform.user, UsageType.STORAGE_BYTES)
 
             return instance
 
@@ -1102,6 +1113,7 @@ class UnauthenticatedEditAttempt(Exception):
     which passes through unmolested to `XFormSubmissionApi.create()`, which
     then returns the appropriate 401 response.
     """
+
     pass
 
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -89,8 +89,6 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 
-if settings.STRIPE_ENABLED:
-    from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
@@ -302,6 +300,9 @@ def create_instance(
                 )
 
             if settings.STRIPE_ENABLED:
+                from kobo.apps.stripe.utils.limit_enforcement import (
+                    check_exceeded_limit,
+                )
                 check_exceeded_limit(xform.user, UsageType.SUBMISSION)
                 check_exceeded_limit(xform.user, UsageType.STORAGE_BYTES)
 

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -39,9 +39,6 @@ from kobo.apps.stripe.utils.subscription_limits import (
     get_paid_subscription_limits,
     get_plan_name,
 )
-from kobo.apps.openrosa.apps.logger.tests.test_simple_submission import (
-    TestSimpleSubmission,
-)
 from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.tests.kpi_test_case import BaseTestCase
 from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -3,14 +3,14 @@ from math import inf
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-from fakeredis import FakeConnection
-from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 from ddt import data, ddt, unpack
 from django.conf import settings
 from django.test import override_settings
 from django.utils import timezone
 from djstripe.models import Customer, Price, Product
+from fakeredis import FakeConnection
+from freezegun import freeze_time
 from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
@@ -30,6 +30,7 @@ from kobo.apps.stripe.utils.billing_dates import (
     get_current_billing_period_dates_by_org,
     get_current_billing_period_dates_for_active_plans,
 )
+from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kobo.apps.stripe.utils.subscription_limits import (
     determine_limit,
     get_default_plan_name,
@@ -39,7 +40,6 @@ from kobo.apps.stripe.utils.subscription_limits import (
     get_paid_subscription_limits,
     get_plan_name,
 )
-from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.tests.kpi_test_case import BaseTestCase
 from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase
 

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -1,9 +1,14 @@
 from datetime import datetime, timedelta
 from math import inf
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+from fakeredis import FakeConnection
+from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 from ddt import data, ddt, unpack
+from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 from djstripe.models import Customer, Price, Product
 from model_bakery import baker
@@ -12,6 +17,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.utils import get_billing_dates
+from kobo.apps.stripe.models import ExceededLimitCounter
 from kobo.apps.stripe.tests.utils import (
     _create_one_time_addon_product,
     _create_payment,
@@ -33,7 +39,12 @@ from kobo.apps.stripe.utils.subscription_limits import (
     get_paid_subscription_limits,
     get_plan_name,
 )
+from kobo.apps.openrosa.apps.logger.tests.test_simple_submission import (
+    TestSimpleSubmission,
+)
+from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.tests.kpi_test_case import BaseTestCase
+from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase
 
 
 @ddt
@@ -581,3 +592,108 @@ class OrganizationsUtilsTestCase(BaseTestCase):
         )
 
         assert get_default_plan_name() == product.name
+
+
+class ExceededLimitsTestCase(BaseServiceUsageTestCase):
+    def setUp(self):
+        super().setUp()
+        self._create_and_set_asset()
+        product_metadata = {
+            f'{UsageType.MT_CHARACTERS}_limit': '1',
+            f'{UsageType.ASR_SECONDS}_limit': '1',
+            f'{UsageType.SUBMISSION}_limit': '1',
+            f'{UsageType.STORAGE_BYTES}_limit': '1',
+            'product_type': 'plan',
+            'plan_type': 'enterprise',
+        }
+        generate_plan_subscription(self.organization, metadata=product_metadata)
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.organization = cls.anotheruser.organization
+        cls.organization.mmo_override = True
+        cls.organization.save(update_fields=['mmo_override'])
+        cls.organization.add_user(user=cls.someuser, is_admin=True)
+
+    def test_check_exceeded_limit_adds_counters(self):
+        # We want to test this function directly here, so we patch it out when
+        # it is called on submission to avoid cache restrictions
+        with patch(
+            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            return_value=None,
+        ):
+            self.add_submissions(count=2, asset=self.asset, username='someuser')
+        self.add_nlp_trackers()
+        for usage_type, _ in UsageType.choices:
+            check_exceeded_limit(self.someuser, usage_type)
+            assert (
+                ExceededLimitCounter.objects.filter(
+                    user_id=self.anotheruser.id, limit_type=usage_type
+                ).count()
+                == 1
+            )
+
+    def test_check_exceeded_limit_updates_counters(self):
+        today = timezone.now()
+        for usage_type, _ in UsageType.choices:
+            baker.make(
+                ExceededLimitCounter,
+                user=self.anotheruser,
+                days=1,
+                date_created=today - relativedelta(days=1),
+                date_modified=today - relativedelta(days=1),
+                limit_type=usage_type,
+            )
+        # We want to test this function directly here, so we patch it out when
+        # is called on submission to avoid cache restrictions
+        with patch(
+            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            return_value=None,
+        ):
+            self.add_submissions(count=2, asset=self.asset, username='someuser')
+        self.add_nlp_trackers()
+        for usage_type, _ in UsageType.choices:
+            check_exceeded_limit(self.someuser, usage_type)
+            counter = ExceededLimitCounter.objects.get(
+                user_id=self.anotheruser.id, limit_type=usage_type
+            )
+            assert counter.days == 2
+
+    # Use fakeredis for testing cache expiration with freezegun
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django_redis.cache.RedisCache',
+                'LOCATION': 'redis://',
+                'OPTIONS': {
+                    'CONNECTION_POOL_KWARGS': {'connection_class': FakeConnection},
+                },
+            }
+        }
+    )
+    def test_check_exceeded_limit_cache_restriction(self):
+        mock_balances = {
+            UsageType.ASR_SECONDS: None,
+            UsageType.MT_CHARACTERS: None,
+            UsageType.STORAGE_BYTES: None,
+            UsageType.SUBMISSION: None,
+        }
+        with freeze_time(timezone.now()) as frozen_time:
+            with patch(
+                'kpi.utils.usage_calculator.ServiceUsageCalculator.get_usage_balances',
+                return_value=mock_balances,
+            ) as patched:
+                check_exceeded_limit(self.someuser, UsageType.SUBMISSION)
+                # Second call within cache_ttl should not check balances
+                check_exceeded_limit(self.someuser, UsageType.SUBMISSION)
+                patched.assert_called_once()
+
+            # Subsequent call after cache_ttl should check balances
+            frozen_time.tick(timedelta(seconds=settings.ENDPOINT_CACHE_DURATION + 1))
+            with patch(
+                'kpi.utils.usage_calculator.ServiceUsageCalculator.get_usage_balances',
+                return_value=mock_balances,
+            ) as patched:
+                check_exceeded_limit(self.someuser, UsageType.SUBMISSION)
+                patched.assert_called_once()

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -617,7 +617,7 @@ class ExceededLimitsTestCase(BaseServiceUsageTestCase):
         # We want to test this function directly here, so we patch it out when
         # it is called on submission to avoid cache restrictions
         with patch(
-            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            'kobo.apps.stripe.utils.limit_enforcement.check_exceeded_limit',
             return_value=None,
         ):
             self.add_submissions(count=2, asset=self.asset, username='someuser')
@@ -645,7 +645,7 @@ class ExceededLimitsTestCase(BaseServiceUsageTestCase):
         # We want to test this function directly here, so we patch it out when
         # is called on submission to avoid cache restrictions
         with patch(
-            'kobo.apps.openrosa.libs.utils.logger_tools.check_exceeded_limit',
+            'kobo.apps.stripe.utils.limit_enforcement.check_exceeded_limit',
             return_value=None,
         ):
             self.add_submissions(count=2, asset=self.asset, username='someuser')

--- a/kobo/apps/stripe/utils/import_management.py
+++ b/kobo/apps/stripe/utils/import_management.py
@@ -29,12 +29,14 @@ def requires_stripe(func):
             )
 
             PlanAddOn = apps.get_model('stripe', 'PlanAddOn')
+            ExceededLimitCounter = apps.get_model('stripe', 'ExceededLimitCounter')
 
             kwargs['product_model'] = Product
             kwargs['subscription_model'] = Subscription
             kwargs['price_model'] = Price
             kwargs['charge_model'] = Charge
             kwargs['payment_intent_model'] = PaymentIntent
+            kwargs['exceeded_limit_counter_model'] = ExceededLimitCounter
             kwargs['plan_add_on_model'] = PlanAddOn
 
             return func(*args, **kwargs)

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
-from kobo.apps.stripe.utils.import_management import requires_stripe
 from kobo.apps.organizations.constants import UsageType
+from kobo.apps.stripe.utils.import_management import requires_stripe
 from kpi.utils.usage_calculator import ServiceUsageCalculator
 
 

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -9,6 +9,12 @@ from kpi.utils.usage_calculator import ServiceUsageCalculator
 
 @requires_stripe
 def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
+    """
+    Checks whether user's org has exceeded its limits for a given
+    usage type and updates ExceededLimitCounters accordingly. Uses
+    cached key to avoid running checks more than once within
+    the ENDPOINT_CACHE_DURATION
+    """
     org = user.organization
     if org.is_mmo:
         user = org.owner_user_object
@@ -19,7 +25,11 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
         return
 
     ExceededLimitCounter = kwargs['exceeded_limit_counter_model']
-    calculator = ServiceUsageCalculator(user, True)
+
+    # We disable usage calculator cache so we can get the most recent
+    # usage when this function is called after submissions or NLP
+    # actions
+    calculator = ServiceUsageCalculator(user, disable_cache=True)
     balances = calculator.get_usage_balances()
 
     balance = balances[usage_type]

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -14,7 +14,6 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
         user = org.owner_user_object
 
     cache_key = f'{user.id}_checked_exceeded_{usage_type}_limit'
-    print(cache_key)
 
     if cache.get(cache_key, None):
         return
@@ -24,12 +23,11 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
     balances = calculator.get_usage_balances()
 
     balance = balances[usage_type]
-    # import pdb;pdb.set_trace()
     if balance and balance['exceeded']:
         counter, created = ExceededLimitCounter.objects.get_or_create(
             user=user,
             limit_type=usage_type,
-            defaults={'days': 1},  # Default value if a new counter is created
+            defaults={'days': 1},
         )
 
         if not created and counter.date_modified.date() < timezone.now().date():

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+
+from kobo.apps.stripe.utils.import_management import requires_stripe
+from kobo.apps.organizations.constants import UsageType
+from kpi.utils.usage_calculator import ServiceUsageCalculator
+
+
+@requires_stripe
+def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
+    org = user.organization
+    if org.is_mmo:
+        user = org.owner_user_object
+
+    cache_key = f'{user.id}_checked_exceeded_{usage_type}_limit'
+    print(cache_key)
+
+    if cache.get(cache_key, None):
+        print("cached?")
+        return
+
+    ExceededLimitCounter = kwargs['exceeded_limit_counter_model']
+    calculator = ServiceUsageCalculator(user, True)
+    balances = calculator.get_usage_balances()
+
+    balance = balances[usage_type]
+    # import pdb;pdb.set_trace()
+    if balance and balance['exceeded']:
+        counter, created = ExceededLimitCounter.objects.get_or_create(
+            user=user,
+            limit_type=usage_type,
+            defaults={'days': 1},  # Default value if a new counter is created
+        )
+
+        if not created and counter.date_modified.date() < timezone.now().date():
+            delta = timezone.now().date() - counter.date_modified.date()
+            counter.days += delta.days
+            counter.save()
+
+    cache.set(cache_key, True, settings.ENDPOINT_CACHE_DURATION)

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -17,7 +17,6 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
     print(cache_key)
 
     if cache.get(cache_key, None):
-        print("cached?")
         return
 
     ExceededLimitCounter = kwargs['exceeded_limit_counter_model']

--- a/kobo/apps/trackers/tests/test_trackers.py
+++ b/kobo/apps/trackers/tests/test_trackers.py
@@ -1,8 +1,8 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
-from unittest.mock import patch
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.constants import UsageType

--- a/kobo/apps/trackers/tests/test_trackers.py
+++ b/kobo/apps/trackers/tests/test_trackers.py
@@ -1,6 +1,11 @@
 from datetime import datetime
 
+import pytest
+from django.conf import settings
+from unittest.mock import patch
+
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.organizations.constants import UsageType
 from kobo.apps.trackers.models import NLPUsageCounter
 from kobo.apps.trackers.utils import update_nlp_counter
 from kpi.models.asset import Asset
@@ -96,3 +101,22 @@ class TrackersTestCases(KpiTestCase):
         )
         assert tracker_two_services.counters[new_service] == initial_amount
         assert tracker_two_services.counters[service] == expected_amount
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
+    def test_check_exceed_limit_on_update_nlp_counters(self):
+        asset = self._create_asset()
+        with patch(
+            'kobo.apps.trackers.utils.check_exceeded_limit',
+            return_value=None,
+        ) as patched:
+            update_nlp_counter(UsageType.ASR_SECONDS, 1, self.user.id, asset.id)
+            patched.assert_called_once_with(self.user, UsageType.ASR_SECONDS)
+
+        with patch(
+            'kobo.apps.trackers.utils.check_exceeded_limit',
+            return_value=None,
+        ) as patched:
+            update_nlp_counter(UsageType.MT_CHARACTERS, 1, self.user.id, asset.id)
+            patched.assert_called_once_with(self.user, UsageType.MT_CHARACTERS)

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -10,10 +10,10 @@ from django_request_cache import cache_for_request
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.organizations.models import Organization
 from kobo.apps.stripe.utils.import_management import requires_stripe
+from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kobo.apps.stripe.utils.subscription_limits import (
     get_organization_subscription_limit,
 )
-from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.utils.django_orm_helper import IncrementValue
 from kpi.utils.usage_calculator import ServiceUsageCalculator
 

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -54,15 +54,15 @@ def update_nlp_counter(
         counter_id = counter.pk
 
     # Update the total counters by the usage amount to keep them current
-    deduct = settings.STRIPE_ENABLED
+    stripe_enabled = settings.STRIPE_ENABLED
     kwargs = {}
     if service.endswith(UsageType.ASR_SECONDS):
         kwargs['total_asr_seconds'] = F('total_asr_seconds') + amount
-        if deduct and asset_id is not None:
+        if stripe_enabled and asset_id is not None:
             handle_usage_deduction(organization, UsageType.ASR_SECONDS, amount)
     if service.endswith(UsageType.MT_CHARACTERS):
         kwargs['total_mt_characters'] = F('total_mt_characters') + amount
-        if deduct and asset_id is not None:
+        if stripe_enabled and asset_id is not None:
             handle_usage_deduction(organization, UsageType.MT_CHARACTERS, amount)
 
     NLPUsageCounter.objects.filter(pk=counter_id).update(
@@ -70,7 +70,7 @@ def update_nlp_counter(
         **kwargs,
     )
 
-    if not deduct:
+    if not stripe_enabled:
         return
 
     if service.endswith(UsageType.ASR_SECONDS):

--- a/kobo/apps/trackers/utils.py
+++ b/kobo/apps/trackers/utils.py
@@ -13,6 +13,7 @@ from kobo.apps.stripe.utils.import_management import requires_stripe
 from kobo.apps.stripe.utils.subscription_limits import (
     get_organization_subscription_limit,
 )
+from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.utils.django_orm_helper import IncrementValue
 from kpi.utils.usage_calculator import ServiceUsageCalculator
 
@@ -68,6 +69,14 @@ def update_nlp_counter(
         counters=IncrementValue('counters', keyname=service, increment=amount),
         **kwargs,
     )
+
+    if not deduct:
+        return
+
+    if service.endswith(UsageType.ASR_SECONDS):
+        check_exceeded_limit(organization.owner_user_object, UsageType.ASR_SECONDS)
+    if service.endswith(UsageType.MT_CHARACTERS):
+        check_exceeded_limit(organization.owner_user_object, UsageType.MT_CHARACTERS)
 
 
 @cache_for_request


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a `check_limit_exceeded()` util to update ExceededLimitCounters after submissions are submitted or nlp counters are updated.

### 💭 Notes
Function uses cache to ensure it only runs at most once for a given limit type in the settings.ENDPOINT_CACHE_DURATION window.

However, when it does run it adds a significant number of queries to an xform submission request. 

PR includes addition of fakeredis package to dev dependencies for testing cache expiration with freezegun.

### 👀 Preview steps
Focus should be on unit tests for the time being, but if you'd like to see it in action the easiest way is through NLP features

1. With a user on a community plan (with Stripe enabled and synched), create a project and submit an audio file
2. Manually copy in a long text over 6,000 characters as a transcript 
3. Translate it into another language
4. Check django shell to see that ExceededLimitCounter has been added

Can also be tested with submissions by manually setting the default free community plan product "submission_limit" in django admin to a small number.