### PR TITLE
fix(submissions): avoid 400 error when editing submissions missing `root_uuid`

### DIFF
--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.files import File
 from django.core.files.base import ContentFile
-from django.db.models import F, Sum
+from django.db.models import F, Q, Sum
 from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -341,9 +341,11 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 t('Your submission XML is missing critical elements.')
             )
 
+        sanitized_root_uuid = remove_uuid_prefix(root_uuid)
         try:
             instance = Instance.objects.get(
-                root_uuid=remove_uuid_prefix(root_uuid),
+                Q(root_uuid=sanitized_root_uuid)
+                | Q(uuid=sanitized_root_uuid, root_uuid__isnull=True),
                 xform__uuid=xform_uuid,
                 xform__kpi_asset_uid=self.asset.uid,
             )

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -186,6 +186,10 @@ class SubmissionEditApiTests(test_api_submissions.SubmissionEditApiTests):
     def test_edit_submission_with_large_uploads(self):
         pass
 
+    @pytest.mark.skip(reason='Only usable in v2')
+    def test_edit_submission_without_root_uuid(self):
+        pass
+
 
 class SubmissionValidationStatusApiTests(test_api_submissions.SubmissionValidationStatusApiTests):  # noqa: E501
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1878,6 +1878,62 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
                     else status.HTTP_202_ACCEPTED
                 )
 
+    def test_edit_submission_without_root_uuid(self):
+        # Old submissions may have `root_uuid = None` because this is a relatively new
+        # feature. Only recent submissions have their `root_uuid` set at the time of
+        # saving.
+        # For legacy data, we must fall back to `uuid` when `root_uuid` is null,
+        # until long-running migration 0005 has completed and populated missing values.
+
+        root_uuid = remove_uuid_prefix(self.submission['_uuid'])
+
+        instance = Instance.objects.get(root_uuid=root_uuid)
+
+        # Simulate a legacy submission by clearing the root_uuid
+        Instance.objects.filter(pk=instance.pk).update(root_uuid=None)
+
+        # Simulate editing the submission:
+        # - fetch the original XML
+        # - generate a new snapshot
+        # - inject rootUuid and deprecatedID in XML
+        submission_xml = instance.xml
+        submission_json = self.asset.deployment.get_submission(
+            instance.pk, self.asset.owner, format_type='json'
+        )
+        xml_parsed = fromstring_preserve_root_xmlns(submission_xml)
+        xml_root_node_name = xml_parsed.tag
+
+        last_deployed_version = self.asset.deployed_versions.first()
+
+        snapshot = self.asset.snapshot(
+            regenerate=True,
+            root_node_name=xml_root_node_name,
+            version_uid=last_deployed_version.uid,
+            submission_uuid=remove_uuid_prefix(submission_json['meta/rootUuid']),
+        )
+
+        edit_submission_xml(
+            xml_parsed, 'meta/deprecatedID', submission_json['meta/instanceID']
+        )
+        edit_submission_xml(
+            xml_parsed, 'meta/rootUuid', submission_json['meta/rootUuid']
+        )
+        new_submission_uuid = str(uuid.uuid4())
+        edit_submission_xml(xml_parsed, 'meta/instanceID', new_submission_uuid)
+        edited_submission = xml_tostring(xml_parsed)
+
+        # Submit the edited XML
+        url = reverse(
+            self._get_endpoint('assetsnapshot-submission-alias'),
+            args=(snapshot.uid,),
+        )
+
+        data = {'xml_submission_file': ContentFile(edited_submission)}
+        response = self.client.post(url, data)
+
+        # The submission edit should succeed and create a new Instance
+        assert response.status_code == status.HTTP_201_CREATED
+
 
 class SubmissionViewApiTests(SubmissionViewTestCaseMixin, BaseSubmissionTestCase):
 


### PR DESCRIPTION
### 📣 Summary
Ensures the correct submission is returned even when `root_uuid` is missing, by falling back to `uuid`


### 📖 Description
This patch introduces a fallback mechanism to retrieve edited submissions using `uuid` when `root_uuid` is not available.

1. ℹ️ have an account and a project
2. submit data
3. from the shell, set `root_uuid` to `null` for the submission you just added
4. edit the data 
4. 🔴 [on release branch] receive a 400
5. 🟢 [on PR] edit works
