### PR TITLE
fix(projectOwnership): prevent failed transfers caused by race conditions DEV-629

### DIFF
--- a/kobo/apps/organizations/admin/organization_user.py
+++ b/kobo/apps/organizations/admin/organization_user.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
+from django.db import transaction
 from django.db.models import Count
 from django.utils.safestring import mark_safe
 from django_request_cache import cache_for_request
@@ -133,36 +134,12 @@ class OrgUserResource(resources.ModelResource):
         model = OrganizationUser
 
     def after_import(self, dataset, result, **kwargs):
-        super().after_import(dataset, result, **kwargs)
-        dry_run = kwargs.get('dry_run', False)
+        with transaction.atomic():
+            super().after_import(dataset, result, **kwargs)
+            dry_run = kwargs.get('dry_run', False)
 
-        if not dry_run:
-            new_organization_user_ids = defaultdict(list)
-            for row in result.rows:
-                if row.import_type == 'error':
-                    continue
-                new_org_id = row.instance.organization.id
-                # collect all organization users who were moved to a new org
-                if row.import_type == 'new':
-                    new_organization_user_ids[new_org_id].append(row.object_id)
-                elif row.import_type == 'update':
-                    original_org_id = row.original.organization.id
-                    if original_org_id != new_org_id:
-                        new_organization_user_ids[new_org_id].append(row.object_id)
-            for org_id, new_member_ids in new_organization_user_ids.items():
-                # remove old single-user orgs
-                old_orgs = Organization.objects.filter(
-                    owner__organization_user__id__in=new_member_ids
-                ).exclude(pk=org_id)
-                mmos = [org.id for org in old_orgs if org.is_mmo]
-                old_orgs = old_orgs.exclude(pk__in=mmos)
-                old_orgs.delete()
-                # begin the asset transfer processes
-                user_ids = OrganizationUser.objects.values_list(
-                    'user_id', flat=True
-                ).filter(pk__in=new_member_ids)
-                for user_id in user_ids:
-                    transfer_member_data_ownership_to_org.delay(user_id)
+            if not dry_run:
+                transaction.on_commit(lambda: self._transfer_user_ownership(result))
 
     def before_import_row(self, row, **kwargs):
         user = User.objects.get(username=row.get('user'))
@@ -185,6 +162,35 @@ class OrgUserResource(resources.ModelResource):
             return Organization.objects.filter(pk=organization_id).first()
 
         return
+
+    @staticmethod
+    def _transfer_user_ownership(result):
+        new_organization_user_ids = defaultdict(list)
+        for row in result.rows:
+            if row.import_type == 'error':
+                continue
+            new_org_id = row.instance.organization.id
+            # collect all organization users who were moved to a new org
+            if row.import_type == 'new':
+                new_organization_user_ids[new_org_id].append(row.object_id)
+            elif row.import_type == 'update':
+                original_org_id = row.original.organization.id
+                if original_org_id != new_org_id:
+                    new_organization_user_ids[new_org_id].append(row.object_id)
+        for org_id, new_member_ids in new_organization_user_ids.items():
+            # remove old single-user orgs
+            old_orgs = Organization.objects.filter(
+                owner__organization_user__id__in=new_member_ids
+            ).exclude(pk=org_id)
+            mmos = [org.id for org in old_orgs if org.is_mmo]
+            old_orgs = old_orgs.exclude(pk__in=mmos)
+            old_orgs.delete()
+            # begin the asset transfer processes
+            user_ids = OrganizationUser.objects.values_list(
+                'user_id', flat=True
+            ).filter(pk__in=new_member_ids)
+            for user_id in user_ids:
+                transfer_member_data_ownership_to_org.delay(user_id)
 
 
 @admin.register(OrganizationUser)
@@ -226,18 +232,28 @@ class OrgUserAdmin(ImportExportModelAdmin, BaseOrganizationUserAdmin):
 
     def save_model(self, request, obj, form, change):
         previous_organization = form.cleaned_data.get('previous_organization')
-        super().save_model(request, obj, form, change)
-        if previous_organization:
-            transfer_member_data_ownership_to_org.delay(obj.user.pk)
-            message = (
-                f'User <b>{obj.user.username}</b> has been added to '
-                f'<b>{obj.organization.name}</b>, and their project transfers have '
-                f'started'
-            )
+        with transaction.atomic():
+            super().save_model(request, obj, form, change)
 
-            self.message_user(
-                request,
-                mark_safe(message),
-                messages.INFO,
-            )
-            revoke_org_asset_perms(previous_organization, [obj.user.pk])
+            if previous_organization:
+                transaction.on_commit(
+                    lambda: self._transfer_user_ownership(obj, previous_organization)
+                )
+                message = (
+                    f'User <b>{obj.user.username}</b> has been added to '
+                    f'<b>{obj.organization.name}</b>, and their project transfers have '
+                    f'started'
+                )
+                self.message_user(
+                    request,
+                    mark_safe(message),
+                    messages.INFO,
+                )
+
+    @staticmethod
+    def _transfer_user_ownership(
+        organization_user: OrganizationUser,
+        previous_organization: Organization,
+    ):
+        transfer_member_data_ownership_to_org.delay(organization_user.user.pk)
+        revoke_org_asset_perms(previous_organization, [organization_user.user.pk])

--- a/kobo/apps/organizations/tests/test_organization_user_import.py
+++ b/kobo/apps/organizations/tests/test_organization_user_import.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.admin.organization_user import OrgUserResource
 from kobo.apps.organizations.models import OrganizationOwner, OrganizationUser
+from kpi.tests.utils.transaction import immediate_on_commit
 
 
 class TestOrganizationUserImportTestCase(TestCase):
@@ -62,7 +63,8 @@ class TestOrganizationUserImportTestCase(TestCase):
     def test_add_user_to_mmo(self):
         # org_user should have a corresponding owner object
         assert self.org_user.organizationowner
-        results = self._import_organization_user(self.org_user, self.mmo)
+        with immediate_on_commit():
+            results = self._import_organization_user(self.org_user, self.mmo)
 
         assert not results.has_errors()
         assert self.org_user.user.organization == self.mmo
@@ -111,6 +113,8 @@ class TestOrganizationUserImportTestCase(TestCase):
         'kobo.apps.organizations.admin.organization_user.transfer_member_data_ownership_to_org.delay'  # noqa: E501
     )
     def test_assets_are_transferred(self, mock_task):
-        results = self._import_organization_user(self.org_user, self.mmo)
+        with immediate_on_commit():
+            results = self._import_organization_user(self.org_user, self.mmo)
+
         assert not results.has_errors()
         mock_task.assert_called_with(self.org_user.user.id)


### PR DESCRIPTION
### 📣 Summary
Ensures ownership transfer tasks don’t start before the database state is fully committed.

### 📖 Description
This fix addresses a race condition where Celery tasks for project ownership transfer are triggered too early, before the database has fully persisted the new state after a save() operation.

As a result, the task may incorrectly detect the new owner or fail altogether.

The logic now ensures that Celery only runs after the database state is consistent.

### Preview steps
See #5857

🔴 [on the release branch] In some circumstances, the projects are not correctly transferred because the recipient is either null or the previous org owner.  (You may need to repeat this step many times to get the race condition)
🟢 [on PR] The transfer should succeed every time





