### PR TITLE
fix(organizations): always use username for organization slug DEV-626

### DIFF
--- a/kobo/apps/kobo_auth/models.py
+++ b/kobo/apps/kobo_auth/models.py
@@ -65,7 +65,7 @@ class User(AbstractUser):
             return organization
 
         return create_organization(
-            self, f'{self.username}’s organization'
+            self, f'{self.username}\'s organization'
         )
 
     def sync_to_openrosa_db(self):

--- a/kobo/apps/kobo_auth/models.py
+++ b/kobo/apps/kobo_auth/models.py
@@ -65,7 +65,7 @@ class User(AbstractUser):
             return organization
 
         return create_organization(
-            self, f'{self.username}\'s organization'
+            self, f"{self.username}'s organization"
         )
 
     def sync_to_openrosa_db(self):

--- a/kobo/apps/kobo_auth/models.py
+++ b/kobo/apps/kobo_auth/models.py
@@ -64,13 +64,8 @@ class User(AbstractUser):
         ):
             return organization
 
-        try:
-            organization_name = self.extra_details.data['organization'].strip()
-        except (KeyError, AttributeError):
-            organization_name = None
-
         return create_organization(
-            self, organization_name or f'{self.username}’s organization'
+            self, f'{self.username}’s organization'
         )
 
     def sync_to_openrosa_db(self):

--- a/kobo/apps/organizations/tests/test_organizations.py
+++ b/kobo/apps/organizations/tests/test_organizations.py
@@ -68,12 +68,12 @@ class OrganizationTestCase(TestCase):
         # someuser is the owner
 
         # Empty the name
-        assert self.organization.name == 'someuser’s organization'
+        assert self.organization.name == "someuser's organization"
         someuser_extra_details = self.someuser.extra_details
         someuser_extra_details.data['organization'] = ''
         someuser_extra_details.save()
         self.organization.refresh_from_db()
-        assert self.organization.name == 'someuser’s organization'
+        assert self.organization.name == "someuser's organization"
 
         # Update org settings
         someuser_extra_details = self.someuser.extra_details
@@ -82,7 +82,7 @@ class OrganizationTestCase(TestCase):
         someuser_extra_details.data['organization_type'] = 'commercial'
         someuser_extra_details.save()
         self.organization.refresh_from_db()
-        assert self.organization.name == 'someuser’s organization'
+        assert self.organization.name == "someuser's organization"
         assert self.organization.website == 'https://someuser.org/'
         assert self.organization.organization_type == 'non-profit'
 
@@ -94,7 +94,7 @@ class OrganizationTestCase(TestCase):
         someuser_extra_details.data['organization_type'] = 'none'
         anotheruser_extra_details.save()
         self.organization.refresh_from_db()
-        assert self.organization.name == 'someuser’s organization'
+        assert self.organization.name == "someuser's organization"
         assert self.organization.website == 'https://someuser.org/'
         assert self.organization.organization_type == 'non-profit'
 
@@ -105,7 +105,7 @@ class OrganizationTestCase(TestCase):
         assert organization.is_mmo is False
         assert organization.website == ''
         assert organization.organization_type == 'none'
-        assert organization.name == 'anotheruser’s organization'
+        assert organization.name == "anotheruser's organization"
 
         anotheruser_extra_details = self.anotheruser.extra_details
         anotheruser_extra_details.data['organization'] = 'AnotherUser Enterprises'


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug wherein if too many users had the same organization name in their extra details, eventually some would not be able to log in.


### 💭 Notes
Always use the user's username to generate the organization slug because it is guaranteed to be unique, so there is no risk of `RuntimeError: max slug attempts for <name> exceeded (100)`


### 👀 Preview steps

1. Open a Django shell
2. Create 110 users with `'organization': 'same_name'` in their `extra_details.data` dictionary. It will be easiest if you use some common prefix for the username
3. Delete any organizations that were created (`Organization.objects.filter(name__startswith=<username_prefix>.delete()`)
4. Run:
```
for user in User.objects.filter(extra_details__data__organization='same_name'):
      print(user.organization.slug)
```
5. 🔴 [on release] After the first hundred users you will get `RuntimeError: max slug attempts for <name> exceeded (100)`
6. 🟢 [on PR] No error and the organization slugs will match the usernames

