### PR TITLE
fix(attachments): "Could not find image" in data table after form edits DEV-632

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -835,8 +835,12 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
             if (Object.keys(TABLE_MEDIA_TYPES).includes(q.type)) {
               let mediaAttachment = null
 
-              if (q.type !== QUESTION_TYPES.text.id && q.$xpath !== undefined) {
-                mediaAttachment = getMediaAttachment(row.original, row.value, q.$xpath)
+              if (q.type !== QUESTION_TYPES.text.id && row.original._attachments[0]) {
+                mediaAttachment = getMediaAttachment(
+                  row.original,
+                  row.value,
+                  row.original._attachments[0].question_xpath,
+                )
               }
 
               if (q.type === QUESTION_TYPES.audio.id || q.type === QUESTION_TYPES['background-audio'].id) {


### PR DESCRIPTION
### 🗒️ Checklist

1. [X] run linter locally
2. [X] update developer docs (API, README, inline, etc.), if any
3. [X] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [X] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [X] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [X] fill in the template below and delete template comments
7. [X] review thyself: read the diff and repro the preview as written
8. [X] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure images on the data table which were submitted from older versions of a survey can always be accessed. 

### 💭 Notes
Frontend fix for #5862 

### 👀 Preview steps
1. ℹ️ have an account and a project
2. Create a project with an attachment question
3. Add a submission with an attachment
4. Edit the project to move the attachment question to a group
5. Add a new submission under the new version
8. 🔴 [on main] Data table will have an error in the first submission
9. 🟢 [on PR] Data table will not have an error and all the images are accessible
