### PR TITLE
docs(api): adding API endpoints for exports in KPI documentation DEV-634

### DIFF
--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters, renderers
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -14,7 +14,17 @@ from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
 
 @extend_schema(
-    tags=['exports'],
+    tags=['Exports'],
+)
+@extend_schema_view(
+    create=extend_schema(),
+    destroy=extend_schema(),
+    list=extend_schema(),
+    partial_update=extend_schema(),
+    retrieve=extend_schema(),
+    update=extend_schema(
+        exclude=True,
+    ),
 )
 class ExportTaskViewSet(
     AssetNestedObjectViewsetMixin, NestedViewSetMixin, AuditLoggedNoUpdateModelViewSet


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/exports` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the asset_attachments endpoint. With these changes, users will be able to understand, test and use the `exports` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `exports` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.
