### PR TITLE
docs(api): fix schema errors DEV-643

### DIFF
--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -93,7 +93,7 @@ class AssetPagination(Paginated):
                                 'type': 'array',
                                 'items': {
                                     'type': 'string',
-                                }
+                                },
                             },
                             'example': [['FRA', 'France']]
                         },
@@ -103,7 +103,7 @@ class AssetPagination(Paginated):
                                 'type': 'array',
                                 'items': {
                                     'type': 'string',
-                                }
+                                },
                             },
                             'example': [['Public Administration', 'Public Administration']]
                         },

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -84,22 +84,32 @@ class AssetPagination(Paginated):
                     'properties': {
                         'languages': {
                             'type': 'array',
-                            'item': {'type': 'string'},
+                            'items': {'type': 'string'},
                             'example': ['English (en)']
                         },
                         'countries': {
                             'type': 'array',
-                            'item': {'type': 'array'},
+                            'items': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                }
+                            },
                             'example': [['FRA', 'France']]
                         },
                         'sectors': {
                             'type': 'array',
-                            'item': {'type': 'array'},
+                            'items': {
+                                'type': 'array',
+                                'items': {
+                                    'type': 'string',
+                                }
+                            },
                             'example': [['Public Administration', 'Public Administration']]
                         },
                         'organizations': {
                             'type': 'array',
-                            'item': {'type': 'string'},
+                            'items': {'type': 'string'},
                             'example': ['Kobotoolbox']
                         }
                     }

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -83,19 +83,23 @@ class AssetPagination(Paginated):
                     'type': 'object',
                     'properties': {
                         'languages': {
-                            'type': 'list',
+                            'type': 'array',
+                            'item': {'type': 'string'},
                             'example': ['English (en)']
                         },
                         'countries': {
-                            'type': 'list',
+                            'type': 'array',
+                            'item': {'type': 'array'},
                             'example': [['FRA', 'France']]
                         },
                         'sectors': {
-                            'type': 'list',
+                            'type': 'array',
+                            'item': {'type': 'array'},
                             'example': [['Public Administration', 'Public Administration']]
                         },
                         'organizations': {
-                            'type': 'list',
+                            'type': 'array',
+                            'item': {'type': 'string'},
                             'example': ['Kobotoolbox']
                         }
                     }

--- a/kpi/schema_extensions/v2/asset_snapshots/extensions.py
+++ b/kpi/schema_extensions/v2/asset_snapshots/extensions.py
@@ -19,12 +19,14 @@ class AssetSnapshotCreateRequestSerializerExtension(OpenApiSerializerExtension):
         return {
             'oneOf': [
                 build_object_type(
+                    required=['asset', 'details'],
                     properties={
                         'asset': ASSET_URL_SCHEMA,
                         'details': ASSET_SNAPSHOT_DETAILS_SCHEMA,
                     }
                 ),
                 build_object_type(
+                    required=['source', 'details'],
                     properties={
                         'source': ASSET_SNAPSHOT_SOURCE_SCHEMA,
                         'details': ASSET_SNAPSHOT_DETAILS_SCHEMA,

--- a/kpi/schema_extensions/v2/assets/extensions.py
+++ b/kpi/schema_extensions/v2/assets/extensions.py
@@ -621,7 +621,7 @@ class ValidContentDataFieldExtension(OpenApiSerializerFieldExtension):
                 ),
                 'translations': build_array_type(
                     schema=build_basic_type(OpenApiTypes.STR)
-                ),  # noqa
+                ),
             }
         )
 

--- a/kpi/schema_extensions/v2/assets/extensions.py
+++ b/kpi/schema_extensions/v2/assets/extensions.py
@@ -29,7 +29,7 @@ class AccessTypeFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kpi.schema_extensions.v2.assets.fields.AccessTypeField'
 
     def map_serializer_field(self, auto_schema, direction):
-        return build_array_type(schema={})
+        return build_array_type(schema=build_basic_type(OpenApiTypes.STR))
 
 
 class AdvancedFeatureFieldExtension(OpenApiSerializerFieldExtension):
@@ -60,7 +60,9 @@ class AnalysisFormJsonExtension(OpenApiSerializerFieldExtension):
         return build_object_type(
             properties={
                 'engines': build_object_type(properties={}),
-                'additional_fields': build_array_type(schema={}),
+                'additional_fields': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),  # noqa
             }
         )
 
@@ -72,7 +74,7 @@ class AssetCloneFieldExtension(OpenApiSerializerFieldExtension):
         return ASSET_CLONE_FROM
 
 
-class AssetCreateRequestSerializerExtension(OpenApiSerializerFieldExtension):
+class AssetCreateRequestSerializerExtension(OpenApiSerializerExtension):
 
     target_class = 'kpi.schema_extensions.v2.assets.serializers.AssetCreateRequest'
 
@@ -81,6 +83,11 @@ class AssetCreateRequestSerializerExtension(OpenApiSerializerFieldExtension):
         return {
             'oneOf': [
                 build_object_type(
+                    required=[
+                        'name',
+                        'clone_from',
+                        'asset_type',
+                    ],
                     properties={
                         'name': ASSET_NAME,
                         'clone_from': ASSET_CLONE_FROM,
@@ -88,6 +95,11 @@ class AssetCreateRequestSerializerExtension(OpenApiSerializerFieldExtension):
                     }
                 ),
                 build_object_type(
+                    required=[
+                        'name',
+                        'settings',
+                        'asset_type',
+                    ],
                     properties={
                         'name': ASSET_NAME,
                         'settings': ASSET_SETTINGS,
@@ -107,12 +119,14 @@ class AssetPatchRequestSerializerExtension(OpenApiSerializerExtension):
         return {
             'oneOf': [
                 build_object_type(
+                    required=['content', 'name'],
                     properties={
                         'content': ASSET_CONTENT,
                         'name': ASSET_NAME,
                     }
                 ),
                 build_object_type(
+                    required=['enabled', 'fields'],
                     properties={
                         'enabled': ASSET_ENABLED,
                         'fields': ASSET_FIELDS,
@@ -188,12 +202,14 @@ class BulkPayloadSerializerExtension(OpenApiSerializerExtension):
         return {
             'oneOf': [
                 build_object_type(
+                    required=['asset_uids', 'action'],
                     properties={
                         'asset_uids': BULK_ASSET_UIDS,
                         'action': BULK_ACTION,
                     }
                 ),
                 build_object_type(
+                    required=['confirm', 'action'],
                     properties={
                         'confirm': BULK_CONFIRM,
                         'action': BULK_ACTION,
@@ -237,8 +253,12 @@ class ContentFieldExtension(OpenApiSerializerFieldExtension):
                 'schema': build_basic_type(OpenApiTypes.STR),
                 'survey': build_array_type(schema=build_object_type(properties={})),
                 'settings': build_object_type(properties={}),
-                'translated': build_array_type(schema={}),
-                'translations': build_array_type(schema={}),
+                'translated': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),
+                'translations': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),  # noqa
             }
         )
 
@@ -372,7 +392,7 @@ class FileListFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kpi.schema_extensions.v2.assets.fields.FileListField'
 
     def map_serializer_field(self, auto_schema, direction):
-        return build_array_type(schema={})
+        return build_array_type(schema=build_basic_type(OpenApiTypes.STR))
 
 
 class HasDeploymentFieldExtension(OpenApiSerializerFieldExtension):
@@ -411,7 +431,7 @@ class MetadataListFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return build_array_type(
-            schema={},
+            schema=build_basic_type(OpenApiTypes.STR),
         )
 
 
@@ -420,7 +440,7 @@ class MetadataSectorFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return build_array_type(
-            schema=build_array_type(schema={}),
+            schema=build_array_type(schema=build_basic_type(OpenApiTypes.STR)),
         )
 
 
@@ -444,7 +464,7 @@ class PermissionsFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kpi.schema_extensions.v2.assets.fields.PermissionsField'
 
     def map_serializer_field(self, auto_schema, direction):
-        return build_array_type(schema={})
+        return build_array_type(schema=build_basic_type(OpenApiTypes.STR))
 
 
 class ReportCustomFieldExtension(OpenApiSerializerFieldExtension):
@@ -521,11 +541,13 @@ class SettingsFieldExtension(OpenApiSerializerFieldExtension):
         return build_object_type(
             properties={
                 'sector': build_object_type(properties={}),
-                'country': build_array_type(schema={}),
+                'country': build_array_type(schema=build_basic_type(OpenApiTypes.STR)),
                 'description': build_basic_type(OpenApiTypes.STR),
                 'collects_pii': build_basic_type(OpenApiTypes.STR),
                 'organization': build_basic_type(OpenApiTypes.STR),
-                'country_codes': build_array_type(schema={}),
+                'country_codes': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),  # noqa
                 'operational_purpose': build_basic_type(OpenApiTypes.STR),
             }
         )
@@ -545,11 +567,13 @@ class SummaryFieldExtension(OpenApiSerializerFieldExtension):
         return build_object_type(
             properties={
                 'geo': build_basic_type(OpenApiTypes.BOOL),
-                'labels': build_array_type(schema={}),
-                'columns': build_array_type(schema={}),
+                'labels': build_array_type(schema=build_basic_type(OpenApiTypes.STR)),
+                'columns': build_array_type(schema=build_basic_type(OpenApiTypes.STR)),
                 'lock_all': build_basic_type(OpenApiTypes.BOOL),
                 'lock_any': build_basic_type(OpenApiTypes.BOOL),
-                'languages': build_array_type(schema={}),
+                'languages': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),
                 'row_count': build_basic_type(OpenApiTypes.INT),
                 'name_quality': build_object_type(properties={}),
                 'default_translation': build_basic_type(OpenApiTypes.STR),
@@ -583,8 +607,12 @@ class ValidContentDataFieldExtension(OpenApiSerializerFieldExtension):
                     )
                 ),
                 'settings': build_object_type(properties={}),
-                'translated': build_array_type(schema={}),
-                'translations': build_array_type(schema={}),
+                'translated': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),
+                'translations': build_array_type(
+                    schema=build_basic_type(OpenApiTypes.STR)
+                ),  # noqa
             }
         )
 

--- a/kpi/schema_extensions/v2/assets/extensions.py
+++ b/kpi/schema_extensions/v2/assets/extensions.py
@@ -62,7 +62,7 @@ class AnalysisFormJsonExtension(OpenApiSerializerFieldExtension):
                 'engines': build_object_type(properties={}),
                 'additional_fields': build_array_type(
                     schema=build_basic_type(OpenApiTypes.STR)
-                ),  # noqa
+                ),
             }
         )
 
@@ -556,7 +556,7 @@ class SettingsFieldExtension(OpenApiSerializerFieldExtension):
                 'organization': build_basic_type(OpenApiTypes.STR),
                 'country_codes': build_array_type(
                     schema=build_basic_type(OpenApiTypes.STR)
-                ),  # noqa
+                ),
                 'operational_purpose': build_basic_type(OpenApiTypes.STR),
             }
         )

--- a/kpi/schema_extensions/v2/assets/extensions.py
+++ b/kpi/schema_extensions/v2/assets/extensions.py
@@ -258,7 +258,7 @@ class ContentFieldExtension(OpenApiSerializerFieldExtension):
                 ),
                 'translations': build_array_type(
                     schema=build_basic_type(OpenApiTypes.STR)
-                ),  # noqa
+                ),
             }
         )
 

--- a/kpi/schema_extensions/v2/assets/extensions.py
+++ b/kpi/schema_extensions/v2/assets/extensions.py
@@ -274,6 +274,15 @@ class CountDailySubmissionResponseFieldExtension(OpenApiSerializerFieldExtension
         )
 
 
+class CountriesFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.assets.fields.CountriesField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_array_type(
+            schema=build_array_type(schema=build_basic_type(OpenApiTypes.STR)),
+        )
+
+
 class DataFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kpi.schema_extensions.v2.assets.fields.DataURLField'
 

--- a/kpi/schema_extensions/v2/assets/fields.py
+++ b/kpi/schema_extensions/v2/assets/fields.py
@@ -73,6 +73,10 @@ class CountDailySubmissionResponseField(serializers.JSONField):
     pass
 
 
+class CountriesField(serializers.ListField):
+    pass
+
+
 class DataSharingField(WritableJSONField):
     pass
 

--- a/kpi/schema_extensions/v2/assets/schema.py
+++ b/kpi/schema_extensions/v2/assets/schema.py
@@ -17,7 +17,7 @@ ASSET_CONTENT = build_basic_type(OpenApiTypes.STR)
 
 ASSET_ENABLED = build_basic_type(OpenApiTypes.BOOL)
 
-ASSET_FIELDS = build_array_type({'type': 'string'})
+ASSET_FIELDS = build_array_type(schema=build_basic_type(OpenApiTypes.STR))
 
 ASSET_SETTINGS = build_object_type(
     properties={

--- a/kpi/schema_extensions/v2/assets/serializers.py
+++ b/kpi/schema_extensions/v2/assets/serializers.py
@@ -9,6 +9,7 @@ from .fields import (
     BulkAssetUidsField,
     ContentDataField,
     CountDailySubmissionResponseField,
+    CountriesField,
     MetadataListField,
     MetadataSectorField,
     ReportListField,
@@ -88,7 +89,7 @@ AssetMetadataResponse = inline_serializer_class(
     name='AssetMetadataResponse',
     fields={
         'languages': MetadataListField(),
-        'countries': MetadataSectorField(),
+        'countries': CountriesField(),
         'sectors': MetadataSectorField(),
         'organizations': MetadataListField(),
     },

--- a/kpi/schema_extensions/v2/assets/serializers.py
+++ b/kpi/schema_extensions/v2/assets/serializers.py
@@ -88,7 +88,7 @@ AssetMetadataResponse = inline_serializer_class(
     name='AssetMetadataResponse',
     fields={
         'languages': MetadataListField(),
-        'countries': MetadataListField(),
+        'countries': MetadataSectorField(),
         'sectors': MetadataSectorField(),
         'organizations': MetadataListField(),
     },

--- a/kpi/schema_extensions/v2/openrosa/schema.py
+++ b/kpi/schema_extensions/v2/openrosa/schema.py
@@ -16,13 +16,11 @@ XFORM_SCHEMA = build_object_type(
                             properties={
                                 'instanceUuid': build_object_type(
                                     properties={
-                                        'fieldName': build_basic_type(
-                                            OpenApiTypes.NONE
-                                        ),
+                                        'fieldName': build_basic_type(OpenApiTypes.STR),
                                         'meta': build_object_type(
                                             properties={
                                                 'instanceID': build_basic_type(
-                                                    OpenApiTypes.NONE
+                                                    OpenApiTypes.STR
                                                 ),
                                             }
                                         ),

--- a/kpi/utils/schema_extensions/response.py
+++ b/kpi/utils/schema_extensions/response.py
@@ -12,6 +12,10 @@ class ErrorDetailSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
+class ErrorObjectSerializer(serializers.Serializer):
+    detail = serializers.JSONField()
+
+
 # Returns an OpenApiResponse with the given serializer and a 200 http code
 def open_api_200_ok_response(
     given_serializer: Optional[Serializer] = None,
@@ -160,7 +164,6 @@ def open_api_error_responses(
     if raise_not_found:
         if media_type == 'text/html':
             response[status.HTTP_404_NOT_FOUND] = OpenApiResponse(
-                response=ErrorDetailSerializer(),
                 examples=[
                     OpenApiExample(
                         name='Not Found',
@@ -186,11 +189,11 @@ def open_api_error_responses(
             'validations_errors', {'field_name': ['Error message']}
         )
         response[status.HTTP_400_BAD_REQUEST] = OpenApiResponse(
-            response=ErrorDetailSerializer(),
+            response=ErrorObjectSerializer(),
             examples=[
                 OpenApiExample(
                     name='Bad request',
-                    value=validation_errors,
+                    value={'detail': validation_errors},
                     response_only=True,
                 )
             ],

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -43,7 +43,9 @@ from kpi.permissions import (
     get_perm_name,
 )
 from kpi.renderers import AssetJsonRenderer, SSJsonRenderer, XFormRenderer, XlsRenderer
+from kpi.schema_extensions.v2.assets.schema import ASSET_CLONE_FROM
 from kpi.schema_extensions.v2.assets.serializers import (
+    AssetBulkRequest,
     AssetBulkResponse,
     AssetContentResponse,
     AssetCreateRequest,
@@ -127,7 +129,7 @@ class AssetSchema(AutoSchema):
                 'UsingSource': {
                     'value': {
                         'name': generate_example_from_schema(ASSET_NAME),
-                        'clone_from': 'akJTPb4JLVFqXMqYhKiPXZ',
+                        'clone_from': generate_example_from_schema(ASSET_CLONE_FROM),
                         'asset_type': generate_example_from_schema(ASSET_TYPE),
                     },
                     'summary': 'Cloning an asset',
@@ -181,6 +183,7 @@ class AssetSchema(AutoSchema):
 @extend_schema_view(
     bulk=extend_schema(
         description=read_md('kpi', 'assets/bulk.md'),
+        request={'application/json': AssetBulkRequest},
         responses=open_api_200_ok_response(
             AssetBulkResponse(),
             require_auth=False,


### PR DESCRIPTION
### 📣 Summary
Fixed schema fail validations that were raising.

### 👀 Preview steps
Go to  `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. Check in the assets `bulk` and `patch` payload, when clicking on `schema`, that the notion of `oneOf` is visible with the different options. Also make sure when typing `http://kf.kobo.local/api/v2/assets.json?metadata=on` that all fields are presents.