### PR TITLE
fix(frontend): ensure country list respects RTL languages DEV-841

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import React from 'react'
+import { isRtlLang } from 'rtl-detect'
 
 import assetStore from '#/assetStore'
 import permConfig from '#/components/permissions/permConfig'
@@ -38,7 +39,6 @@ import type { IconName } from '#/k-icons'
 import sessionStore from '#/stores/session'
 import { ANON_USERNAME_URL } from '#/users/utils'
 import { currentLang } from '#/utils'
-import { isRtlLang } from 'rtl-detect'
 
 /**
  * Removes whitespace from tags. Returns list of cleaned up tags.

--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -37,7 +37,7 @@ import envStore from '#/envStore'
 import type { IconName } from '#/k-icons'
 import sessionStore from '#/stores/session'
 import { ANON_USERNAME_URL } from '#/users/utils'
-
+import { isRtlLanguage, currentLang } from '#/utils'
 /**
  * Removes whitespace from tags. Returns list of cleaned up tags.
  * NOTE: Behavior should match KpiTaggableManager.add()
@@ -143,9 +143,15 @@ export function getCountryDisplayString(asset: AssetResponse | ProjectViewAsset)
       return '-'
     }
 
-    // TODO: improve for RTL?
-    // See: https://github.com/kobotoolbox/kpi/issues/3903
-    return countries.join(', ')
+    // RTL handling
+    const isRtl = isRtlLanguage(currentLang())
+
+    if (isRtl) {
+      countries.reverse()
+    }
+
+    const separator = isRtl ? '، ' : ', '
+    return countries.join(separator)
   } else {
     return '-'
   }

--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -37,7 +37,8 @@ import envStore from '#/envStore'
 import type { IconName } from '#/k-icons'
 import sessionStore from '#/stores/session'
 import { ANON_USERNAME_URL } from '#/users/utils'
-import { currentLang, isRtlLanguage } from '#/utils'
+import { currentLang } from '#/utils'
+import { isRtlLang } from 'rtl-detect'
 
 /**
  * Removes whitespace from tags. Returns list of cleaned up tags.
@@ -145,7 +146,7 @@ export function getCountryDisplayString(asset: AssetResponse | ProjectViewAsset)
     }
 
     // RTL handling
-    const isRtl = isRtlLanguage(currentLang())
+    const isRtl = isRtlLang(currentLang())
 
     if (isRtl) {
       countries.reverse()

--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -37,7 +37,8 @@ import envStore from '#/envStore'
 import type { IconName } from '#/k-icons'
 import sessionStore from '#/stores/session'
 import { ANON_USERNAME_URL } from '#/users/utils'
-import { isRtlLanguage, currentLang } from '#/utils'
+import { currentLang, isRtlLanguage } from '#/utils'
+
 /**
  * Removes whitespace from tags. Returns list of cleaned up tags.
  * NOTE: Behavior should match KpiTaggableManager.add()

--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -150,10 +150,9 @@ export function getCountryDisplayString(asset: AssetResponse | ProjectViewAsset)
 
     if (isRtl) {
       countries.reverse()
+      return countries.join('، ')
     }
-
-    const separator = isRtl ? '، ' : ', '
-    return countries.join(separator)
+    return countries.join(', ')
   } else {
     return '-'
   }

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -17,6 +17,7 @@ import type { Json } from './components/common/common.interfaces'
 import type { MongoQuery } from './dataInterface'
 
 export const LANGUAGE_COOKIE_NAME = 'django_language'
+export const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur']
 
 const cookies = new Cookies()
 

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -17,7 +17,6 @@ import type { Json } from './components/common/common.interfaces'
 import type { MongoQuery } from './dataInterface'
 
 export const LANGUAGE_COOKIE_NAME = 'django_language'
-export const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur']
 
 const cookies = new Cookies()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "react-textarea-autosize": "^8.5.9",
         "reflux": "^6.4.1",
         "reflux-core": "^1.0.0",
-        "select2": "^3.5.2-browserify",
+        "rtl-detect": "^1.1.2",
+        "select2": "3.5.2-browserify",
         "spark-md5": "^3.0.2",
         "use-immer": "^0.10.0",
         "wretch": "^2.9.0",
@@ -139,6 +140,7 @@
         "@types/react-table": "^6.8.5",
         "@types/react-tagsinput": "^3.20.6",
         "@types/reflux": "^6.4.6",
+        "@types/rtl-detect": "^1.0.3",
         "@types/zxcvbn": "^4.4.4",
         "@vusion/webfonts-generator": "^0.8.0",
         "autoprefixer": "^10.4.19",
@@ -6810,6 +6812,13 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/rtl-detect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rtl-detect/-/rtl-detect-1.0.3.tgz",
+      "integrity": "sha512-qpstuHivwg/HoXxRrBo5/r/OVx5M2SkqJpVu2haasdLctt+jMGHWjqdbI0LL7Rk2wRmN/UHdHK4JZg9RUMcvKA==",
       "dev": true,
       "license": "MIT"
     },
@@ -22708,6 +22717,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -32374,6 +32389,12 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true
+    },
+    "@types/rtl-detect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rtl-detect/-/rtl-detect-1.0.3.tgz",
+      "integrity": "sha512-qpstuHivwg/HoXxRrBo5/r/OVx5M2SkqJpVu2haasdLctt+jMGHWjqdbI0LL7Rk2wRmN/UHdHK4JZg9RUMcvKA==",
       "dev": true
     },
     "@types/semver": {
@@ -43599,6 +43620,11 @@
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
       "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
       "dev": true
+    },
+    "rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-textarea-autosize": "^8.5.9",
     "reflux": "^6.4.1",
     "reflux-core": "^1.0.0",
+    "rtl-detect": "^1.1.2",
     "select2": "^3.5.2-browserify",
     "spark-md5": "^3.0.2",
     "use-immer": "^0.10.0",
@@ -135,6 +136,7 @@
     "@types/react-table": "^6.8.5",
     "@types/react-tagsinput": "^3.20.6",
     "@types/reflux": "^6.4.6",
+    "@types/rtl-detect": "^1.0.3",
     "@types/zxcvbn": "^4.4.4",
     "@vusion/webfonts-generator": "^0.8.0",
     "autoprefixer": "^10.4.19",
@@ -251,6 +253,8 @@
   "bugs": "https://github.com/kobotoolbox/kpi/issues",
   "homepage": "https://github.com/kobotoolbox/kpi",
   "msw": {
-    "workerDirectory": ["msw-mocks"]
+    "workerDirectory": [
+      "msw-mocks"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -253,8 +253,6 @@
   "bugs": "https://github.com/kobotoolbox/kpi/issues",
   "homepage": "https://github.com/kobotoolbox/kpi",
   "msw": {
-    "workerDirectory": [
-      "msw-mocks"
-    ]
+    "workerDirectory": ["msw-mocks"]
   }
 }


### PR DESCRIPTION
# 🗒️ Checklist
- [x] run linter locally
- [ ] update developer docs (N/A)
- [ ] for user-facing doc changes create a Zulip thread at #Kobo support docs (N/A)
- [x] draft PR with a title `fix(utils): adjust RTL country display in assetUtils.ts`
- [x] assign yourself, tag PR: `Front end`
- [x] fill in the template below and delete template comments
- [x] review thyself: read the diff carefully
- [ ] open PR & confirm CI passes, request reviewers
- [ ] delete this section before merging

## 📣 Summary
Ensure countries list is displayed in the correct direction for RTL languages.

## 📖 Description
This adjusts `getCountryDisplayString` so that when the UI language is RTL (like Arabic or Hebrew), the countries list respects the reading order, improving the UX for RTL users.

No functional changes outside the display of the countries string.

## 👷 Description for instance maintainers
No database or deployment changes. Pure frontend utility fix.

## 💭 Notes
* Couldn't fully run the local Docker frontend due to platform + Docker daemon issues on ARM Mac, but linting, unit tests, and code review of the minimal change look solid.
* Happy to adjust or add any follow-up if maintainers suggest improvements.

## 👀 Preview steps
*(didn't run full manual UI preview locally due to setup blockers — trusting maintainers to validate UI or have CI e2e handle it)*

Expected:
* **Before:** RTL users saw `Country1, Country2, Country3` always in LTR order.
* **After:** `getCountryDisplayString` respects RTL when `currentLang()` is an RTL language.
