### PR TITLE
fix(frontend): printing styles DEV-375

### DIFF
--- a/jsapp/js/attachments/AttachmentActionsDropdown.module.scss
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.module.scss
@@ -1,3 +1,9 @@
 .attachmentActionsDropdown {
   align-self: flex-start;
 }
+
+@media print {
+  .attachmentActionsDropdown {
+    display: none;
+  }
+}

--- a/jsapp/js/components/activity/FormActivity.module.scss
+++ b/jsapp/js/components/activity/FormActivity.module.scss
@@ -54,3 +54,10 @@
 .detailsModalContent pre {
   margin: 0;
 }
+
+@media print {
+  .mainContainer,
+  .tableContainer {
+    overflow: visible;
+  }
+}

--- a/jsapp/js/components/submissions/RepeatGroupCell.module.scss
+++ b/jsapp/js/components/submissions/RepeatGroupCell.module.scss
@@ -11,3 +11,10 @@
     display: inline;
   }
 }
+
+@media print {
+  .repeatGroupCell {
+    // Avoid trimming data from cells
+    @include mixins.undoTextEllipsis;
+  }
+}

--- a/jsapp/js/components/submissions/RepeatGroupCell.tsx
+++ b/jsapp/js/components/submissions/RepeatGroupCell.tsx
@@ -17,10 +17,10 @@ export default function RepeatGroupCell(props: RepeatGroupCellProps) {
   return (
     <div className={styles.repeatGroupCell} dir='auto'>
       {repeatGroupAnswers.map((answer, i) => (
-        <>
+        <span key={i}>
           {i > 0 && ', '}
           {answer}
-        </>
+        </span>
       ))}
     </div>
   )

--- a/jsapp/js/components/submissions/submissionDataTable.scss
+++ b/jsapp/js/components/submissions/submissionDataTable.scss
@@ -127,3 +127,12 @@ $submission-data-table-space: 12px;
   display: inline-block;
   font-style: italic;
 }
+
+@media print {
+  .submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-file,
+  .submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-audio,
+  .submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-image,
+  .submission-data-table__column.submission-data-table__column--data.submission-data-table__column--type-video {
+    flex-wrap: wrap;
+  }
+}

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -225,14 +225,19 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       )
     }
 
+    const attachmentShortFilename = attachment.filename.split('/').pop()
+
     return (
       <>
         {type === QUESTION_TYPES.audio.id && (
           <Group>
             <AudioPlayer mediaURL={attachment?.download_url} />
 
+            <span className='print-only'>{ attachmentShortFilename }</span>
+
             {shouldProcessingBeAccessible(this.props.submissionData, attachment) && (
               <Button
+                className='hide-on-print'
                 type='primary'
                 size='s'
                 endIcon='arrow-up-right'
@@ -244,12 +249,20 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
         )}
 
         {type === QUESTION_TYPES.image.id && (
-          <a href={attachment.download_url} target='_blank'>
-            <img src={attachment.download_medium_url} />
-          </a>
+          <>
+            <a href={attachment.download_url} target='_blank'>
+              <img src={attachment.download_medium_url} />
+            </a>
+            <span className='print-only'>{ attachmentShortFilename }</span>
+          </>
         )}
 
-        {type === QUESTION_TYPES.video.id && <video src={attachment.download_url} controls />}
+        {type === QUESTION_TYPES.video.id &&
+          <>
+            <video src={attachment.download_url} controls />
+            <span className='print-only'>{ attachmentShortFilename }</span>
+          </>
+        }
 
         {type === QUESTION_TYPES.file.id && (
           <a href={attachment.download_url} target='_blank'>

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -233,7 +233,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
           <Group>
             <AudioPlayer mediaURL={attachment?.download_url} />
 
-            <span className='print-only'>{ attachmentShortFilename }</span>
+            <span className='print-only'>{attachmentShortFilename}</span>
 
             {shouldProcessingBeAccessible(this.props.submissionData, attachment) && (
               <Button
@@ -253,16 +253,16 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
             <a href={attachment.download_url} target='_blank'>
               <img src={attachment.download_medium_url} />
             </a>
-            <span className='print-only'>{ attachmentShortFilename }</span>
+            <span className='print-only'>{attachmentShortFilename}</span>
           </>
         )}
 
-        {type === QUESTION_TYPES.video.id &&
+        {type === QUESTION_TYPES.video.id && (
           <>
             <video src={attachment.download_url} controls />
-            <span className='print-only'>{ attachmentShortFilename }</span>
+            <span className='print-only'>{attachmentShortFilename}</span>
           </>
-        }
+        )}
 
         {type === QUESTION_TYPES.file.id && (
           <a href={attachment.download_url} target='_blank'>

--- a/jsapp/js/components/submissions/submissionModal.scss
+++ b/jsapp/js/components/submissions/submissionModal.scss
@@ -88,3 +88,29 @@
     color: colors.$kobo-blue;
   }
 }
+
+@media print {
+  .submission-modal-dropdowns,
+  .submission-modal-buttons,
+  .modal__x {
+    display: none;
+  }
+
+  .modal__body,
+  .modal__title {
+    padding: 10px;
+  }
+
+  .modal__header {
+    min-height: auto;
+  }
+
+  .modal,
+  .modal__content {
+    overflow: visible;
+  }
+
+  .submission-data-table__row.submission-data-table__row--column-names {
+    border: colors.$kobo-gray-300 1px solid;
+  }
+}

--- a/jsapp/js/components/submissions/table.scss
+++ b/jsapp/js/components/submissions/table.scss
@@ -511,16 +511,31 @@ $s-data-table-font: 13px;
 }
 
 @media print {
-  .form-view--table .rt-table {
-    overflow: visible !important;
+  .form-view.form-view--table {
+    padding: 0;
+  }
+
+  .form-view--table .ReactTable {
+    height: auto;
+  }
+
+  .form-view__group--table-header {
+    display: none !important;
   }
 
   .form-view--table .ReactTable .rt-tr-group {
     max-height: 100%;
   }
 
+  .form-view--table .rt-table,
+  .form-view--table .ReactTable .rt-tbody,
+  .form-view--table .ReactTable .rt-thead,
   .form-view--table .ReactTable .rt-td {
-    overflow: visible;
+    overflow: visible !important;
+  }
+
+  .form-view.form-view--table .ReactTable .rt-tbody .rt-td {
+    height: auto;
   }
 
   // Avoid trimming data from cells

--- a/jsapp/js/components/submissions/table.scss
+++ b/jsapp/js/components/submissions/table.scss
@@ -509,3 +509,22 @@ $s-data-table-font: 13px;
     margin-bottom: 20px;
   }
 }
+
+@media print {
+  .form-view--table .rt-table {
+    overflow: visible !important;
+  }
+
+  .form-view--table .ReactTable .rt-tr-group {
+    max-height: 100%;
+  }
+
+  .form-view--table .ReactTable .rt-td {
+    overflow: visible;
+  }
+
+  // Avoid trimming data from cells
+  .form-view--table .ReactTable .rt-td .trimmed-text {
+    @include mixins.undoTextEllipsis;
+  }
+}

--- a/jsapp/scss/libs/_print.scss
+++ b/jsapp/scss/libs/_print.scss
@@ -121,3 +121,9 @@
     display: none;
   }
 }
+
+@media print {
+  .hide-on-print {
+    display: none !important;
+  }
+}

--- a/jsapp/scss/libs/_print.scss
+++ b/jsapp/scss/libs/_print.scss
@@ -8,9 +8,13 @@
   body .mdl-wrapper,
   body .mdl-layout,
   body .mdl-layout__content,
-  body .mdl-layout__content > div {
-    height: auto !important;
-    overflow: visible;
+  body .form-view,
+  body .report-view {
+    height: 100% !important;
+    width: 100% !important;
+    overflow: visible !important;
+    background: transparent !important;
+    margin: 0 !important;
   }
 
   body .mdl-layout {
@@ -22,69 +26,66 @@
   body .mdl-layout__content {
     // Fixes Firefox one-page print bug
     display: block;
-    margin-left: 0;
   }
 
-  .k-drawer,
- .mdl-layout__header {
+  // Hide content if modal is open
+  body .modal__backdrop ~ .mdl-layout__content {
     display: none;
   }
 
-  .k-drawer + .mdl-layout__content {
-    margin: 0;
-  }
-
-  .form-view__reportButtons {
+  body .k-drawer,
+  body .mdl-layout__header,
+  body .header-stretch-bg {
     display: none;
   }
 
-  .report-view__chart {
+  body .form-view__reportButtons {
+    display: none;
+  }
+
+  body .report-view__chart {
     padding-left: 0;
     padding-right: 0;
   }
 
-  a[href]::after,
- abbr[title]::after {
+  body a[href]::after,
+  body abbr[title]::after {
     content: '';
   }
 
-  .form-view__row {
+  body .form-view__row {
     display: block;
   }
 
-  .form-view__cell {
+  body .form-view__cell {
     width: auto;
   }
 
-  .report-view__chart {
+  body .report-view__chart {
     page-break-inside: avoid;
   }
 
-  .report-view__itemContent table {
+  body .report-view__itemContent table {
     margin-left: 0%;
     width: 100%;
     page-break-inside: avoid;
   }
 
-  .report-view__item {
+  body .report-view__item {
     break-inside: avoid;
   }
 
   // Fix Chrome printing headers overlap bug
-  thead {
+  body thead {
     display: table-row-group;
   }
 
-  .form-view__sidetabs,
-  .form-view__toptabs {
+  body .form-view__sidetabs,
+  body .form-view__toptabs {
     display: none;
   }
 
-  .form-view__sidetabs + .report-view {
-    width: 100%;
-  }
-
-  .modal__backdrop {
+  body .modal__backdrop {
     position: static;
 
     .modal {
@@ -101,11 +102,11 @@
     }
   }
 
-  .form-view.form-view--fullscreen {
+  body .form-view.form-view--fullscreen {
     position: static;
   }
 
-  .page-wrapper {
+  body .page-wrapper {
     &.page-wrapper--is-modal-visible.page-wrapper--is-modal-submission {
       .form-view.form-view--table {
         // hide table, when displaying submission modal and user is printing

--- a/jsapp/scss/mixins.scss
+++ b/jsapp/scss/mixins.scss
@@ -39,6 +39,12 @@
   text-overflow: ellipsis;
 }
 
+@mixin undoTextEllipsis() {
+  overflow: visible;
+  white-space: wrap;
+  overflow-wrap: break-word;
+}
+
 // Use this for dropdowns and menus
 @mixin floatingRoundedBox() {
   background-color: colors.$kobo-white;


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fix issues with styles while printing.

### 📖 Description

Now all Project related routes should be printable without data being cropped out. The only issue still prevaling is printing horizontally huge tables from  Project → Data. In such case it is advised to change the amount of columns being displayed before printing and using landscape orientation of paper.

### 💭 Notes

Changes here:
- Multiple different `@media print` fixes, mainly bringing back previous styles that were not being used anymore due to specificity change (during Mantine introduction?)
- Added some styles that undo text trimming - to ensure whole data is being displayed in table cell
- Added missing `key` in `RepeatGroupCell.tsx`

### 👀 Preview steps

1. ℹ️ have an account and a project with multiple submissions, ideally with many columns
2. go through Project routes, on each checking out print styles
3. 🔴 [on main] notice that many print styles don't work
4. 🟢 [on PR] notice that styles are better

Also ensure the issue steps described in https://linear.app/kobotoolbox/issue/DEV-375/issue-printing-a-submission are fixed now.
