### PR TITLE
feat(trashBin): add object owner filters to `ProjectTrash` and `AttachmentTrash` admin views DEV-241

### DIFF
--- a/kobo/apps/trash_bin/admin.py
+++ b/kobo/apps/trash_bin/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin, messages
 from django.db.models import F
 
 from kpi.models import Asset
+from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.viewer.models import ParsedInstance
 
@@ -13,6 +14,49 @@ from .models.project import ProjectTrash
 from .mixins.admin import TrashMixin
 from .tasks import empty_account, empty_attachment, empty_project
 from .utils import put_back
+
+
+class AttachmentOwnerListFilter(admin.SimpleListFilter):
+    # Human-readable title which will be displayed in the
+    # right admin sidebar just above the filter options.
+    title = 'Attachment Owner'
+
+    # Parameter for the filter that will be used in the URL query.
+    parameter_name = 'attachment_owner'
+
+    def lookups(self, request, model_admin):
+        attachment_ids = (
+            model_admin.model.objects.values_list('attachment_id', flat=True)
+        )
+        attachment_owners = (
+            Attachment.all_objects.filter(pk__in=list(attachment_ids))
+            .select_related('user')
+            .values_list('user__pk', 'user__username')
+            .distinct()
+        )
+        return list(attachment_owners)
+
+    def queryset(self, request, queryset):
+        if self.value():
+            attachment_ids = Attachment.all_objects.filter(
+                user__pk=self.value()
+            ).values_list('pk', flat=True)
+            return queryset.filter(attachment_id__in=list(attachment_ids))
+        return queryset
+
+
+class ProjectOwnerListFilter(admin.SimpleListFilter):
+    title = 'Project Owner'
+    parameter_name = 'project_owner'
+
+    def lookups(self, request, model_admin):
+        users = User.objects.filter(assets__trash__isnull=False).distinct()
+        return [(user.pk, user.username) for user in users]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(asset__owner__pk=self.value())
+        return queryset
 
 
 class StatusListFilter(admin.SimpleListFilter):
@@ -97,7 +141,7 @@ class ProjectTrashAdmin(TrashMixin, admin.ModelAdmin):
         'get_start_time',
         'get_failure_error',
     ]
-    list_filter = [StatusListFilter]
+    list_filter = [ProjectOwnerListFilter, StatusListFilter]
     search_fields = ['asset__name', 'asset__uid', 'request_author__username']
     ordering = ['-date_created', 'asset__name']
     actions = ['empty_trash', 'put_back']
@@ -165,7 +209,7 @@ class AttachmentTrashAdmin(TrashMixin, admin.ModelAdmin):
         'get_start_time',
         'get_failure_error',
     ]
-    list_filter = [StatusListFilter]
+    list_filter = [AttachmentOwnerListFilter, StatusListFilter]
     search_fields = ['attachment_id', 'request_author__username']
     ordering = ['-date_created']
     actions = ['empty_trash', 'put_back']


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Admins can now filter trashed projects and attachments by the object owner, making it easier to locate and manage soft-deleted content.


### 📖 Description
This update improves the admin interface for the trash bin by adding filters for project and attachment owners. When viewing trashed projects or attachments, admins can now narrow down the list based on the user who originally owned them.
This enhancement improves usability, especially on instances with large volumes of deleted items, by making it faster and easier to find relevant records.


### 👀 Preview steps

1. ℹ️ Soft-delete some projects and attachments owned by different users.
2. In the Django admin, go to the trash bin views for `ProjectTrash` and `AttachmentTrash`.
3. 🔴 [on main] No filters are available to filter records by owner.
4. 🟢 [on PR] New filters (`Project Owner` and `Attachment Owner`) appear in the right-hand filter panel.
5.  Use these filters to confirm that only records belonging to the selected user are shown.
