### PR TITLE
docs(api): adding API endpoints for deployment in KPI documentation DEV-550

### DIFF
--- a/kpi/docs/api/v2/deployments/create.md
+++ b/kpi/docs/api/v2/deployments/create.md
@@ -1,0 +1,3 @@
+## Create a deployment
+
+Create a new deployment, but only if a deployment does not exist already.

--- a/kpi/docs/api/v2/deployments/create.md
+++ b/kpi/docs/api/v2/deployments/create.md
@@ -1,3 +1,3 @@
-## Create a deployment
+## (Re)Deploy a form
 
-Create a new deployment, but only if a deployment does not exist already.
+Deploy a new form or re-deploy an existing one.

--- a/kpi/docs/api/v2/deployments/list.md
+++ b/kpi/docs/api/v2/deployments/list.md
@@ -1,0 +1,1 @@
+## Retrieve the existing deployment (if any)

--- a/kpi/docs/api/v2/deployments/update.md
+++ b/kpi/docs/api/v2/deployments/update.md
@@ -1,0 +1,5 @@
+## Update the existing deployment.
+
+Update the `active` field of the existing deployment.
+
+To overwrite the entire deployment (including the form contents), use a PUT request.

--- a/kpi/docs/api/v2/deployments/update.md
+++ b/kpi/docs/api/v2/deployments/update.md
@@ -1,4 +1,4 @@
-## (un)archive the existing deployment.
+## (Un)Archive the existing deployment.
 
 Update the `active` field of the existing deployment.
 

--- a/kpi/docs/api/v2/deployments/update.md
+++ b/kpi/docs/api/v2/deployments/update.md
@@ -1,4 +1,4 @@
-## Update the existing deployment.
+## (un)archive the existing deployment.
 
 Update the `active` field of the existing deployment.
 

--- a/kpi/schema_extensions/v2/deployments/serializers.py
+++ b/kpi/schema_extensions/v2/deployments/serializers.py
@@ -3,11 +3,18 @@ from rest_framework import serializers
 from kpi.serializers.v2.asset import AssetSerializer
 from kpi.utils.schema_extensions.serializers import inline_serializer_class
 
-
 DeploymentCreateRequest = inline_serializer_class(
     name='DeploymentCreateRequest',
     fields={
         'active': serializers.BooleanField(),
+    },
+)
+
+DeploymentPatchRequest = inline_serializer_class(
+    name='DeploymentPatchRequest',
+    fields={
+        'active': serializers.BooleanField(),
+        'version_id': serializers.CharField(),
     },
 )
 
@@ -18,13 +25,5 @@ DeploymentResponse = inline_serializer_class(
         'active': serializers.BooleanField(),
         'version_id': serializers.CharField(),
         'asset': AssetSerializer(),
-    },
-)
-
-DeploymentPatchRequest = inline_serializer_class(
-    name='DeploymentPatchRequest',
-    fields={
-        'active': serializers.BooleanField(),
-        'version_id': serializers.CharField(),
     },
 )

--- a/kpi/schema_extensions/v2/deployments/serializers.py
+++ b/kpi/schema_extensions/v2/deployments/serializers.py
@@ -5,7 +5,7 @@ from kpi.utils.schema_extensions.serializers import inline_serializer_class
 
 
 DeploymentCreateRequest = inline_serializer_class(
-    name='DeploymentResponse',
+    name='DeploymentCreateRequest',
     fields={
         'active': serializers.BooleanField(),
     },
@@ -22,7 +22,7 @@ DeploymentResponse = inline_serializer_class(
 )
 
 DeploymentPatchRequest = inline_serializer_class(
-    name='DeploymentResponse',
+    name='DeploymentPatchRequest',
     fields={
         'active': serializers.BooleanField(),
         'version_id': serializers.CharField(),

--- a/kpi/schema_extensions/v2/deployments/serializers.py
+++ b/kpi/schema_extensions/v2/deployments/serializers.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers
+
+from kpi.serializers.v2.asset import AssetSerializer
+from kpi.utils.schema_extensions.serializers import inline_serializer_class
+
+
+DeploymentCreateRequest = inline_serializer_class(
+    name='DeploymentResponse',
+    fields={
+        'active': serializers.BooleanField(),
+    },
+)
+
+DeploymentResponse = inline_serializer_class(
+    name='DeploymentResponse',
+    fields={
+        'backend': serializers.CharField(),
+        'active': serializers.BooleanField(),
+        'version_id': serializers.CharField(),
+        'asset': AssetSerializer(),
+    },
+)
+
+DeploymentPatchRequest = inline_serializer_class(
+    name='DeploymentResponse',
+    fields={
+        'active': serializers.BooleanField(),
+        'version_id': serializers.CharField(),
+    },
+)

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -55,6 +55,11 @@ from kpi.schema_extensions.v2.assets.serializers import (
     AssetReportResponse,
     AssetValidContentResponse,
 )
+from kpi.schema_extensions.v2.deployments.serializers import (
+    DeploymentResponse,
+    DeploymentPatchRequest,
+    DeploymentCreateRequest,
+)
 from kpi.serializers.v2.asset import (
     AssetBulkActionsSerializer,
     AssetListSerializer,
@@ -470,19 +475,25 @@ class AssetViewSet(
     @extend_schema(
         methods=["GET"],
         description=read_md('kpi', 'deployments/list.md'),
-        responses=None,
+        responses=open_api_200_ok_response(
+            DeploymentResponse,
+        ),
     )
     @extend_schema(
         methods=["POST"],
         description=read_md('kpi', 'deployments/create.md'),
-        request=None,
-        responses=None,
+        request={'application/json': DeploymentCreateRequest},
+        responses=open_api_200_ok_response(
+            DeploymentResponse,
+        ),
     )
     @extend_schema(
         methods=["PATCH"],
         description=read_md('kpi', 'deployments/update.md'),
-        request=None,
-        responses=None
+        request={'application/json': DeploymentPatchRequest},
+        responses=open_api_200_ok_response(
+            DeploymentResponse,
+        ),
     )
     @action(detail=True,
             methods=['get', 'post', 'patch'],

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -505,12 +505,18 @@ class AssetViewSet(
             permission_classes=[PostMappedToChangePermission])
     def deployment(self, request, uid):
         """
-        A GET request retrieves the existing deployment, if any.
-        A POST request creates a new deployment, but only if a deployment does
-            not exist already.
-        A PATCH request updates the `active` field of the existing deployment.
-        A PUT request overwrites the entire deployment, including the form
-            contents, but does not change the deployment's identifier
+            ViewSet for managing the current project's deployment
+
+            Available actions:
+            - list           → GET /api/v2/assets/{uid}/deployment/
+            - create         → POST /api/v2/assets/{uid}/deployment/
+            - patch          → PATCH /api/v2/assets/{uid}/deployment/
+
+        
+            Documentation:
+            - docs/api/v2/deployments/list.md
+            - docs/api/v2/deployments/create.md
+            - docs/api/v2/deployments/patch.md
         """
         asset = self.get_object()
         serializer_context = self.get_serializer_context()

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -56,9 +56,9 @@ from kpi.schema_extensions.v2.assets.serializers import (
     AssetValidContentResponse,
 )
 from kpi.schema_extensions.v2.deployments.serializers import (
-    DeploymentResponse,
-    DeploymentPatchRequest,
     DeploymentCreateRequest,
+    DeploymentPatchRequest,
+    DeploymentResponse,
 )
 from kpi.serializers.v2.asset import (
     AssetBulkActionsSerializer,
@@ -473,7 +473,7 @@ class AssetViewSet(
         )
 
     @extend_schema(
-        methods=["GET"],
+        methods=['GET'],
         description=read_md('kpi', 'deployments/list.md'),
         responses=open_api_200_ok_response(
             DeploymentResponse,
@@ -483,18 +483,18 @@ class AssetViewSet(
         ),
     )
     @extend_schema(
-        methods=["POST"],
-        description=read_md('kpi', 'deployments/create.md'),
-        request={'application/json': DeploymentCreateRequest},
+        methods=['PATCH'],
+        description=read_md('kpi', 'deployments/update.md'),
+        request={'application/json': DeploymentPatchRequest},
         responses=open_api_200_ok_response(
             DeploymentResponse,
             raise_access_forbidden=False,
         ),
     )
     @extend_schema(
-        methods=["PATCH"],
-        description=read_md('kpi', 'deployments/update.md'),
-        request={'application/json': DeploymentPatchRequest},
+        methods=['POST'],
+        description=read_md('kpi', 'deployments/create.md'),
+        request={'application/json': DeploymentCreateRequest},
         responses=open_api_200_ok_response(
             DeploymentResponse,
             raise_access_forbidden=False,
@@ -505,18 +505,17 @@ class AssetViewSet(
             permission_classes=[PostMappedToChangePermission])
     def deployment(self, request, uid):
         """
-            ViewSet for managing the current project's deployment
+        ViewSet for managing the current project's deployment
 
-            Available actions:
-            - list           → GET /api/v2/assets/{uid}/deployment/
-            - create         → POST /api/v2/assets/{uid}/deployment/
-            - patch          → PATCH /api/v2/assets/{uid}/deployment/
+        Available actions:
+        - list           → GET /api/v2/assets/{uid}/deployment/
+        - create         → POST /api/v2/assets/{uid}/deployment/
+        - patch          → PATCH /api/v2/assets/{uid}/deployment/
 
-        
-            Documentation:
-            - docs/api/v2/deployments/list.md
-            - docs/api/v2/deployments/create.md
-            - docs/api/v2/deployments/patch.md
+        Documentation:
+        - docs/api/v2/deployments/list.md
+        - docs/api/v2/deployments/create.md
+        - docs/api/v2/deployments/patch.md
         """
         asset = self.get_object()
         serializer_context = self.get_serializer_context()

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -477,6 +477,9 @@ class AssetViewSet(
         description=read_md('kpi', 'deployments/list.md'),
         responses=open_api_200_ok_response(
             DeploymentResponse,
+            require_auth=False,
+            raise_access_forbidden=False,
+            validate_payload=False,
         ),
     )
     @extend_schema(
@@ -485,6 +488,7 @@ class AssetViewSet(
         request={'application/json': DeploymentCreateRequest},
         responses=open_api_200_ok_response(
             DeploymentResponse,
+            raise_access_forbidden=False,
         ),
     )
     @extend_schema(
@@ -493,6 +497,7 @@ class AssetViewSet(
         request={'application/json': DeploymentPatchRequest},
         responses=open_api_200_ok_response(
             DeploymentResponse,
+            raise_access_forbidden=False,
         ),
     )
     @action(detail=True,

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -387,35 +387,6 @@ class AssetViewSet(
     >
     >       curl -X GET https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/data/
 
-    ### Deployment
-
-    Retrieves the existing deployment, if any.
-    <pre class="prettyprint">
-    <b>GET</b> /api/v2/assets/{uid}/deployment/
-    </pre>
-
-    > Example
-    >
-    >       curl -X GET https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/deployment/
-
-    Creates a new deployment, but only if a deployment does not exist already.
-    <pre class="prettyprint">
-    <b>POST</b> /api/v2/assets/{uid}/deployment/
-    </pre>
-
-    > Example
-    >
-    >       curl -X POST https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/deployment/
-
-    Updates the `active` field of the existing deployment.
-    <pre class="prettyprint">
-    <b>PATCH</b> /api/v2/assets/{uid}/deployment/
-    </pre>
-
-    > Example
-    >
-    >       curl -X PATCH https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/deployment/
-
     Overwrites the entire deployment, including the form contents, but does not change the deployment's identifier
     <pre class="prettyprint">
     <b>PUT</b> /api/v2/assets/{uid}/deployment/
@@ -496,6 +467,23 @@ class AssetViewSet(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )
 
+    @extend_schema(
+        methods=["GET"],
+        description=read_md('kpi', 'deployments/list.md'),
+        responses=None,
+    )
+    @extend_schema(
+        methods=["POST"],
+        description=read_md('kpi', 'deployments/create.md'),
+        request=None,
+        responses=None,
+    )
+    @extend_schema(
+        methods=["PATCH"],
+        description=read_md('kpi', 'deployments/update.md'),
+        request=None,
+        responses=None
+    )
     @action(detail=True,
             methods=['get', 'post', 'patch'],
             permission_classes=[PostMappedToChangePermission])


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/deployment` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `deployment` endpoint. With these changes, users will be able to understand, test and use the `deployment` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `deployment` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.