### PR TITLE
docs(api): adding API endpoints for paired-data in KPI documentation DEV-534

### DIFF
--- a/kpi/docs/api/v2/paired_data/create.md
+++ b/kpi/docs/api/v2/paired_data/create.md
@@ -1,0 +1,35 @@
+    ### Create a connection between two projects
+
+    <pre class="prettyprint">
+    <b>POST</b> /api/v2/assets/<code>{asset_uid}</code>/paired-data/
+    </pre>
+
+    > Example
+    >
+    >       curl -X POST https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/
+
+    > **Payload**
+    >
+    >        {
+    >           "source": "https://[kpi]/api/v2/assets/aFDZxidYs5X5oJjm2Tmdf5/",
+    >           "filename": "external-data.xml",
+    >           "fields": [],
+    >        }
+    >
+    >
+    > Response
+    >
+    >       HTTP 201 Created
+    >       {
+    >           "source": "https://[kpi]/api/v2/assets/aFDZxidYs5X5oJjm2Tmdf5/",
+    >           "fields": [],
+    >           "filename": "external-data.xml",
+    >           "url": "https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/"
+    >       }
+    >
+
+    * `fields`: Optional. List of questions whose responses will be retrieved
+        from the source data. If missing or empty, all responses will be
+        retrieved. Questions must be identified by full group path separated by
+        slashes, e.g. `group/subgroup/question_name`.
+    * `filename`: Must be unique among all asset files. Only accepts letters, numbers and '-'.

--- a/kpi/docs/api/v2/paired_data/delete.md
+++ b/kpi/docs/api/v2/paired_data/delete.md
@@ -1,0 +1,19 @@
+
+    ### Remove a connection between two projects
+
+    <pre class="prettyprint">
+    <b>DELETE</b> /api/v2/assets/<code>{asset_uid}</code>/paired-data/{paired_data_uid}/
+    </pre>
+
+    > Example
+    >
+    >       curl -X DELETE https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/
+    >
+    > Response
+    >
+    >       HTTP 204 No Content
+    >
+    >
+
+
+    ### CURRENT ENDPOINT

--- a/kpi/docs/api/v2/paired_data/external.md
+++ b/kpi/docs/api/v2/paired_data/external.md
@@ -1,0 +1,4 @@
+        Returns an XML which contains data submitted to paired asset
+        Creates the endpoints
+        - /api/v2/assets/<parent_lookup_asset>/paired-data/<paired_data_uid>/external/
+        - /api/v2/assets/<parent_lookup_asset>/paired-data/<paired_data_uid>/external.xml/

--- a/kpi/docs/api/v2/paired_data/list.md
+++ b/kpi/docs/api/v2/paired_data/list.md
@@ -1,0 +1,34 @@
+## List of paired project endpoints
+
+    ### Retrieve all paired projects
+
+    <pre class="prettyprint">
+    <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/paired-data/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/
+
+    > Response
+    >
+    >       HTTP 200 OK
+    >       {
+    >           "count": 1,
+    >           "next": null,
+    >           "previous": null,
+    >           "results": [
+    >               {
+    >                   "source": "https://[kpi]/api/v2/assets/aFDZxidYs5X5oJjm2Tmdf5/",
+    >                   "fields": [],
+    >                   "filename": "external-data.xml",
+    >                   "url": "https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/"
+    >               }
+    >           ]
+    >       }
+    >
+
+    This endpoint is paginated and accepts these parameters:
+
+    - `offset`: The initial index from which to return the results
+    - `limit`: Number of results to return per page

--- a/kpi/docs/api/v2/paired_data/retrieve.md
+++ b/kpi/docs/api/v2/paired_data/retrieve.md
@@ -1,0 +1,20 @@
+    ### Retrieve a connection between two projects
+
+    <pre class="prettyprint">
+    <b>GET</b> /api/v2/assets/<code>{asset_uid}</code>/paired-data/{paired_data_uid}/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/
+    >
+    > Response
+    >
+    >       HTTP 200 Ok
+    >       {
+    >           "source": "https://[kpi]/api/v2/assets/aFDZxidYs5X5oJjm2Tmdf5/",
+    >           "fields": [],
+    >           "filename": "external-data.xml",
+    >           "url": "https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/"
+    >       }
+    >

--- a/kpi/docs/api/v2/paired_data/update.md
+++ b/kpi/docs/api/v2/paired_data/update.md
@@ -1,0 +1,30 @@
+    ### Update a connection between two projects
+
+    <pre class="prettyprint">
+    <b>PATCH</b> /api/v2/assets/<code>{asset_uid}</code>/paired-data/{paired_data_uid}/
+    </pre>
+
+    > Example
+    >
+    >       curl -X PATCH https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/
+    >
+    > **Payload**
+    >
+    >        {
+    >           "filename": "data-external.xml",
+    >           "fields": ['group/question_1']",
+    >        }
+    >
+
+    _Notes: `source` cannot be changed_
+
+    > Response
+    >
+    >       HTTP 200 Ok
+    >       {
+    >           "source": "https://[kpi]/api/v2/assets/aFDZxidYs5X5oJjm2Tmdf5/",
+    >           "fields": ['group/question_1'],
+    >           "filename": "data-external.xml",
+    >           "url": "https://[kpi]/api/v2/assets/aSAvYreNzVEkrWg5Gdcvg/paired-data/pdFQheFF4cWbtcinRUqc64q/"
+    >       }
+    >


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/paired-data` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `paired-data` endpoint. With these changes, users will be able to understand, test and use the `paired-data` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `paired-data` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.