### PR TITLE
fix(submission): prevent "Failed to duplicate submission" when duplicating a previously edited submission DEV-677

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -202,6 +202,7 @@ def create_instance(
     # get root uuid
     root_uuid, fallback_on_uuid = get_root_uuid_from_xml(xml)
     new_uuid = root_uuid if fallback_on_uuid else get_uuid_from_xml(xml)
+
     if not new_uuid:
         raise InstanceIdMissingError
 

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -302,6 +302,20 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         # silently
         xml_parsed.find(self.SUBMISSION_CURRENT_UUID_XPATH).text = uuid_formatted
 
+        # Remove references to the source
+        meta_node = xml_parsed.find('meta')
+        root_uuid_node = meta_node.find(
+            self.SUBMISSION_ROOT_UUID_XPATH.replace('meta/', '')
+        )
+        if root_uuid_node is not None:
+            meta_node.remove(root_uuid_node)
+
+        deprecated_uuid_node = meta_node.find(
+            self.SUBMISSION_DEPRECATED_UUID_XPATH.replace('meta/', '')
+        )
+        if deprecated_uuid_node is not None:
+            meta_node.remove(deprecated_uuid_node)
+
         # create_instance uses `username` argument to identify the XForm object
         # (when nothing else worked). `_submitted_by` is populated by `request.user`
         instance = create_instance(

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1901,49 +1901,6 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         assert 'deprecatedID' in instance.xml
         self._simulate_edit_submission(instance)
 
-    def _simulate_edit_submission(self, instance: Instance):
-        # Simulate editing the submission:
-        # - fetch the original XML
-        # - generate a new snapshot
-        # - inject rootUuid and deprecatedID in XML
-        submission_xml = instance.xml
-        submission_json = self.asset.deployment.get_submission(
-            instance.pk, self.asset.owner, format_type='json'
-        )
-        xml_parsed = fromstring_preserve_root_xmlns(submission_xml)
-        xml_root_node_name = xml_parsed.tag
-
-        last_deployed_version = self.asset.deployed_versions.first()
-
-        snapshot = self.asset.snapshot(
-            regenerate=True,
-            root_node_name=xml_root_node_name,
-            version_uid=last_deployed_version.uid,
-            submission_uuid=remove_uuid_prefix(submission_json['meta/rootUuid']),
-        )
-
-        edit_submission_xml(
-            xml_parsed, 'meta/deprecatedID', submission_json['meta/instanceID']
-        )
-        edit_submission_xml(
-            xml_parsed, 'meta/rootUuid', submission_json['meta/rootUuid']
-        )
-        new_submission_uuid = str(uuid.uuid4())
-        edit_submission_xml(xml_parsed, 'meta/instanceID', new_submission_uuid)
-        edited_submission = xml_tostring(xml_parsed)
-
-        # Submit the edited XML
-        url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
-            args=(snapshot.uid,),
-        )
-
-        data = {'xml_submission_file': ContentFile(edited_submission)}
-        response = self.client.post(url, data)
-
-        # The submission edit should succeed and create a new Instance
-        assert response.status_code == status.HTTP_201_CREATED
-
 
 class SubmissionViewApiTests(SubmissionViewTestCaseMixin, BaseSubmissionTestCase):
 
@@ -2170,7 +2127,9 @@ class SubmissionDuplicateWithXMLNamespaceApiTests(SubmissionDuplicateBaseApiTest
         self._check_duplicate(response)
 
 
-class SubmissionDuplicateApiTests(SubmissionDuplicateBaseApiTests):
+class SubmissionDuplicateApiTests(
+    SubmissionEditTestCaseMixin, SubmissionDuplicateBaseApiTests
+):
 
     def setUp(self):
         super().setUp()
@@ -2341,6 +2300,39 @@ class SubmissionDuplicateApiTests(SubmissionDuplicateBaseApiTests):
             duplicated_extra.content['q1']['transcript']['value']
             == dummy_extra['q1']['transcript']['value']
         )
+
+    def test_duplicate_edited_submission(self):
+        """
+        someuser is the owner of the project.
+        someuser is allowed to duplicate their own data
+        """
+        deployment = self.asset.deployment
+        instance = Instance.objects.get(root_uuid=self.submission['_uuid'])
+        self._simulate_edit_submission(instance)
+
+        submission = deployment.get_submission(instance.pk, self.asset.owner)
+        assert deployment.SUBMISSION_DEPRECATED_UUID_XPATH in submission
+
+        response = self.client.post(self.submission_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_201_CREATED
+        self._check_duplicate(response)
+
+        duplicated_instance = Instance.objects.get(
+            root_uuid=remove_uuid_prefix(
+                response.data[deployment.SUBMISSION_ROOT_UUID_XPATH]
+            )
+        )
+        # `rootUuid` should be present in MongoDB but different from the source, but
+        # should not be present in the duplicated submission XML
+        assert (
+            submission[deployment.SUBMISSION_ROOT_UUID_XPATH]
+            != response.data[deployment.SUBMISSION_ROOT_UUID_XPATH]
+        )
+        assert 'rootUuid' not in duplicated_instance.xml
+        # `deprecatedID` should not be present in MongoDB, neither in the duplicated
+        # submission XML
+        assert deployment.SUBMISSION_DEPRECATED_UUID_XPATH not in response.data
+        assert 'deprecatedID' not in duplicated_instance.xml
 
 
 class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):


### PR DESCRIPTION
### 📣 Summary
Fixes an error that occurred when duplicating submissions that had already been edited.

### 📖 Description
This PR resolves an issue where attempting to duplicate a submission that had already been edited resulted in the error "Failed to duplicate submission".

### 💭 Notes
`meta/deprecatedID` and `meta/rootUuid` were also duplicated. When the new submission was saved, it raised a 409 because the rootUuid was already used by another instance (the source). 


### 👀 Preview steps

1. Create a simple form with only 1 question
2. Deploy the project
3. Make a submission (Sub1) for the project
4. Go to DATA>Table View and then duplicate the submission (Sub1)
5. Again, go to DATA>Table View and then edit the submission (Sub1)
6. Duplicate the edited submission (Sub1)
7. 🔴 [on release branch] You will see the Failed to duplicate submission error message (Error 409)
8. 🟢 [on PR] Submission is duplicated (validated from the shell or API that "meta/deprecatedID" is not present in the XML of the duplicated submission
 