### PR TITLE
docs(api): adding API endpoints for versions in KPI documentation DEV-536

### DIFF
--- a/kpi/views/v2/asset_version.py
+++ b/kpi/views/v2/asset_version.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import viewsets
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -13,7 +13,19 @@ from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
 
 @extend_schema(
-    tags=['versions'],
+    tags=['Versions'],
+)
+@extend_schema_view(
+    create=extend_schema(),
+    destroy=extend_schema(),
+    list=extend_schema(),
+    update=extend_schema(
+        exclude=True,
+    ),
+    retrieve=extend_schema(),
+    partial_update=extend_schema(
+        exclude=True,
+    ),
 )
 class AssetVersionViewSet(AssetNestedObjectViewsetMixin,
                           NestedViewSetMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/versions` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `versions` endpoint. With these changes, users will be able to understand, test and use the `versions` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `versions` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.