### PR TITLE
fix(table): Improve the table error message DEV-692

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -1321,7 +1321,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
   render() {
     if (this.state.error && typeof this.state.error === 'string') {
-      const supportMessage = `Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.`
+      const supportMessage = t('Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.')
       return (
         <bem.FormView m='ui-panel'>
           <CenteredMessage
@@ -1330,7 +1330,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
                 <h2>{t('Oops! Something went wrong on our end.')}</h2>
                   <div>
                     <Markdown>
-                      {t(supportMessage).replace(
+                      {supportMessage.replace(
                       '##SUPPORT_URL##',
                       envStore.data.support_url)}
                     </Markdown>

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -93,10 +93,10 @@ import envStore from '#/envStore'
 import pageState from '#/pageState.store'
 import type { PageStateStoreState } from '#/pageState.store'
 import { stores } from '#/stores'
-import { replaceBracketsWithLink } from '#/textUtils'
 import { formatTimeDateShort, removeDefaultUuidPrefix } from '#/utils'
 import AudioCell from './audioCell'
 import MediaCell from './mediaCell'
+import Markdown from 'react-markdown'
 
 const DEFAULT_PAGE_SIZE = 30
 
@@ -1321,19 +1321,20 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
   render() {
     if (this.state.error && typeof this.state.error === 'string') {
+      const supportMessage = `Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.`
       return (
         <bem.FormView m='ui-panel'>
           <CenteredMessage
             message={
               <div>
                 <h2>{t('Oops! Something went wrong on our end.')}</h2>
-                <div>
-                  Please try again later, or{' '}
-                  <a href={envStore.data.support_url} target='_blank'>
-                    contact the support team
-                  </a>{' '}
-                  if this happens repeatedly.
-                </div>
+                  <div>
+                    <Markdown>
+                      {t(supportMessage).replace(
+                      '##SUPPORT_URL##',
+                      envStore.data.support_url)}
+                    </Markdown>
+                  </div>
                 <br />
                 <div>
                   {t('Response details:')} {this.state.error}

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import clonedeep from 'lodash.clonedeep'
 import isEqual from 'lodash.isequal'
 import { DebounceInput } from 'react-debounce-input'
+import Markdown from 'react-markdown'
 import ReactTable from 'react-table'
 import type { CellInfo } from 'react-table'
 import { actions } from '#/actions'
@@ -96,7 +97,6 @@ import { stores } from '#/stores'
 import { formatTimeDateShort, removeDefaultUuidPrefix } from '#/utils'
 import AudioCell from './audioCell'
 import MediaCell from './mediaCell'
-import Markdown from 'react-markdown'
 
 const DEFAULT_PAGE_SIZE = 30
 
@@ -1321,20 +1321,18 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
   render() {
     if (this.state.error && typeof this.state.error === 'string') {
-      const supportMessage = t('Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.')
+      const supportMessage = t(
+        'Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.',
+      ).replace('##SUPPORT_URL##', envStore.data.support_url)
       return (
         <bem.FormView m='ui-panel'>
           <CenteredMessage
             message={
               <div>
                 <h2>{t('Oops! Something went wrong on our end.')}</h2>
-                  <div>
-                    <Markdown>
-                      {supportMessage.replace(
-                      '##SUPPORT_URL##',
-                      envStore.data.support_url)}
-                    </Markdown>
-                  </div>
+                <div>
+                  <Markdown>{supportMessage}</Markdown>
+                </div>
                 <br />
                 <div>
                   {t('Response details:')} {this.state.error}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Stops the table view from spitting out raw html when an error occurs. Replaces it with a more user friendly error

### 💭 Notes
Utilizes `handleApiFail` to display a helpful toast with the specific error "plucked" out. Changes the error handling JSX code in the table without getting too complicated and editing other files.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. submit some data
3. go to `data.py` and under the `def list ...` line add `1/0` to throw an error
4. navigate to the data tab
5. 🔴 [on release] notice that the error message is raw html
6. 🟢 [on PR] notice that the error message is more user friendly 
