### PR TITLE
fix(dataTable): prevent 500 error when opening data table view DEV-695

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -666,20 +666,13 @@ class Asset(
         # return deployed versions first
         versions = self.asset_versions.filter(deployed=True).order_by('-date_modified')
         xpaths = set()
-        for i, version in enumerate(versions):
-            # insert the xpaths if this is the latest deployed version
-            insert_xpath = i == 0
+        for version in versions:
+            if xpaths_from_version := self.get_attachment_xpaths_from_version(version):
+                xpaths.update(xpaths_from_version)
 
-            xpaths.update(
-                self.get_attachment_xpaths_from_version(
-                    version, insert_xpath=insert_xpath
-                )
-            )
         return list(xpaths)
 
-    def get_attachment_xpaths_from_version(
-        self, version=None, insert_xpath=False
-    ) -> Optional[list]:
+    def get_attachment_xpaths_from_version(self, version=None) -> Optional[list]:
 
         if version:
             content = version.to_formpack_schema()['content']
@@ -703,11 +696,15 @@ class Asset(
                 except KeyError:
                     return None
                 xpaths.append(xpath)
+
             return xpaths
+
         if xpaths := _get_xpaths(survey):
             return xpaths
-        if insert_xpath:
-            self._insert_xpath(content)
+
+        # Inject missing `$xpath` properties
+        self._insert_xpath(content)
+
         return _get_xpaths(survey)
 
     def get_filters_for_partial_perm(

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -10,8 +10,8 @@ from django.test import TestCase
 from model_bakery import baker
 
 from kpi.constants import ATTACHMENT_QUESTION_TYPES
-from kpi.utils.sluggify import sluggify_label
 from kpi.models import Asset
+from kpi.utils.sluggify import sluggify_label
 
 
 def test_expand_twice():
@@ -914,9 +914,7 @@ class TestAssetContent(TestCase):
         # Simulate versions created before the NLP feature, which lack the `$xpath`
         # property
         first_version = (
-            asset.asset_versions.filter(deployed=True)
-            .order_by('date_modified')
-            .first()
+            asset.asset_versions.filter(deployed=True).order_by('date_modified').first()
         )
         first_version_survey = first_version.version_content['survey']
         for question in first_version_survey:

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import inspect
 import json
 import string
@@ -10,8 +9,9 @@ from django.conf import settings
 from django.test import TestCase
 from model_bakery import baker
 
-from kpi.models import Asset
+from kpi.constants import ATTACHMENT_QUESTION_TYPES
 from kpi.utils.sluggify import sluggify_label
+from kpi.models import Asset
 
 
 def test_expand_twice():
@@ -879,9 +879,7 @@ class TestAssetContent(TestCase):
                 'survey': [
                     {
                         'type': 'image',
-                        '$kuid': 'ff2tv42',
                         'label': ['Image'],
-                        '$xpath': 'Image',
                         'required': False,
                         'name': 'Image',
                     }
@@ -895,22 +893,43 @@ class TestAssetContent(TestCase):
                 {
                     'name': 'group_kq1rd43',
                     'type': 'begin_group',
-                    '$kuid': 'wu8pl89',
                     'label': ['Group'],
-                    '$xpath': 'group_kq1rd43',
                 },
                 {
                     'type': 'image',
-                    '$kuid': 'ff2tv42',
                     'label': ['Image'],
-                    '$xpath': 'group_kq1rd43/Image',
                     'required': False,
                     'name': 'Image',
                 },
-                {'type': 'end_group', '$kuid': '/wu8pl89'},
+                {'type': 'end_group'},
             ],
         }
         asset.save()
         asset.deploy(backend='mock')
+        xpaths = asset.get_all_attachment_xpaths()
+        assert sorted(xpaths) == ['Image', 'group_kq1rd43/Image']
+
+        assert asset.asset_versions.filter(deployed=True).count() == 2
+
+        # Simulate versions created before the NLP feature, which lack the `$xpath`
+        # property
+        first_version = (
+            asset.asset_versions.filter(deployed=True)
+            .order_by('date_modified')
+            .first()
+        )
+        first_version_survey = first_version.version_content['survey']
+        for question in first_version_survey:
+            if question['type'] not in ATTACHMENT_QUESTION_TYPES:
+                continue
+            try:
+                del question['$xpath']
+            except KeyError:
+                pass
+
+        first_version.version_content['survey'] = first_version_survey
+        first_version.save(update_fields=['version_content'])
+
+        # Validate XPaths can still be retrieved even on old versions
         xpaths = asset.get_all_attachment_xpaths()
         assert sorted(xpaths) == ['Image', 'group_kq1rd43/Image']


### PR DESCRIPTION
### 📣 Summary
Prevent a 500 error when opening data table view when the project contains versions created before the NLP feature.

### 📖 Description
This PR resolves a 500 Internal Server Error that could occur when opening the data table view for projects with old versions.
The issue was caused by a TypeError when the system attempted to access a `$xpath` property that doesn’t exist on versions created/deployed before the introduction of the NLP feature.


### 👀 Preview steps

1. Follow steps from #5862 up to step 4
2. From the shell (or from the DB directly with pgAdmin, psql or dbeaver) remove the `$xpath` property from `version_content` field for every question in the first version of your project.
3. Go to DATA > Table
4. 🔴 [on current release] Receive a 500 (look at the Python console, it prints `TypeError: 'NoneType' object is not iterable`
5. 🟢 [on PR] The data appears as expected


### Related issues
kpi#5862