### PR TITLE
fix(submissions): inject rootUuid in bulk edit operations

### DIFF
--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -169,6 +169,16 @@ class BaseDeploymentBackend(abc.ABC):
             deprecated_id = get_or_create_element(
                 xml_parsed, self.SUBMISSION_DEPRECATED_UUID_XPATH
             )
+
+            # If the submission has been edited before, it will already contain
+            # a rootUuid element - otherwise create a new element
+            root_uuid = get_or_create_element(
+                xml_parsed, self.SUBMISSION_ROOT_UUID_XPATH
+            )
+
+            if not root_uuid.text:
+                root_uuid.text = instance_id.text
+
             deprecated_id.text = instance_id.text
             instance_id.text = uuid_formatted
 

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -958,6 +958,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             results.append(
                 {
                     'uuid': uuid,
+                    'root_uuid': backend_result['result'].root_uuid,
                     'status_code': status_code,
                     'message': message,
                 }

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -2384,6 +2384,26 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_200_OK
         self._check_bulk_update(response)
 
+        # Not really testing the API, but let's validate everything is in place
+        # with the ORM, i.e.: instance.xml contains a <meta/rootUuid> node that matches
+        # with instance.root_uuid
+        instances = Instance.objects.filter(
+            pk__in=self.updated_submission_data['submission_ids']
+        )
+        for instance in instances:
+            for result in response.data['results']:
+                if result['uuid'] == instance.uuid:
+                    assert instance.root_uuid == result['root_uuid']
+                    xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+                    root_uuid = xml_parsed.find(
+                        self.asset.deployment.SUBMISSION_ROOT_UUID_XPATH
+                    )
+                    assert root_uuid is not None
+                    assert result['root_uuid'] == remove_uuid_prefix(
+                        root_uuid.text
+                    )
+                    break
+
     @pytest.mark.skip(
         reason=(
             'Useless with the current implementation of'


### PR DESCRIPTION
### 📣 Summary
Ensures that bulk submission edits include the `rootUuid` to match the behavior of single edits.


### 📖 Description
This PR fixes an inconsistency between single and bulk submission edits.

Previously, only single edits injected the `rootUuid` into the submission XML, while bulk edits did not,  leading to discrepancies in how submission versions were linked and tracked.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. add a submission
3. use bulk edit modal to edit the submission
4. Go to `/api/v2/assets/<asset_uid>/data/<data_id>.xml`
5. 🔴 [on current release] notice that rootUuid is not present
6. 🟢 [on PR] notice that rootUuid is present
