### PR TITLE
feat(attachments): Add Celery task to process users exceeding storage limit DEV-239

### DIFF
--- a/kobo/apps/trash_bin/tasks/attachment.py
+++ b/kobo/apps/trash_bin/tasks/attachment.py
@@ -2,11 +2,15 @@ import logging
 
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from celery.signals import task_failure, task_retry
+from constance import config
 from django.conf import settings
+if settings.STRIPE_ENABLED:
+    from kobo.apps.stripe.models import ExceededLimitCounter
 
 from kobo.celery import celery_app
 from ..exceptions import TrashTaskInProgressError
 from ..models.attachment import AttachmentTrash
+from ...organizations.constants import UsageType
 from ..utils import process_deletion, trash_bin_task_failure, trash_bin_task_retry
 from ..utils.attachment import delete_attachment
 
@@ -53,3 +57,28 @@ def empty_attachment_failure(sender=None, **kwargs):
 @task_retry.connect(sender=empty_attachment)
 def empty_attachment_retry(sender=None, **kwargs):
     trash_bin_task_retry(AttachmentTrash, **kwargs)
+
+
+# @celery_app.task
+def schedule_auto_attachment_cleanup_for_users():
+    """
+    Identifies users exceeding storage limits beyond the grace period and
+    schedules a cleanup task for each.
+
+    Runs only if AUTO_DELETE_ATTACHMENTS and Stripe billing is enabled.
+    """
+    if not config.AUTO_DELETE_ATTACHMENTS or not settings.STRIPE_ENABLED:
+        return
+
+    exceeded_counters = ExceededLimitCounter.objects.filter(
+        limit_type=UsageType.STORAGE_BYTES,
+        days__gte=config.STORAGE_OVERAGE_ATTACHMENT_DELETION_GRACE_PERIOD
+    ).select_related('user')
+
+    for counter in exceeded_counters:
+        auto_delete_excess_attachments(counter.user.pk)
+
+
+def auto_delete_excess_attachments(user_id: int):
+    # ToDo: Implement the logic to auto-delete excess attachments for the user.
+    pass

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -458,6 +458,16 @@ CONSTANCE_CONFIG = {
         'them and before automatically hard-deleting them by the system',
         'positive_int',
     ),
+    'AUTO_DELETE_ATTACHMENTS': (
+        False,
+        'Enable automatic deletion of attachments for users who have exceeded '
+        'their storage limits.'
+    ),
+    'STORAGE_OVERAGE_ATTACHMENT_DELETION_GRACE_PERIOD': (
+        90,
+        'Number of days to keep attachments after the user has exceeded their '
+        'storage limits.'
+    ),
     # Toggle for ZXCVBN
     'ENABLE_PASSWORD_ENTROPY_METER': (
         True,
@@ -757,7 +767,9 @@ CONSTANCE_CONFIG_FIELDSETS = {
     'Trash bin': (
         'ACCOUNT_TRASH_GRACE_PERIOD',
         'ATTACHMENT_TRASH_GRACE_PERIOD',
+        'AUTO_DELETE_ATTACHMENTS',
         'PROJECT_TRASH_GRACE_PERIOD',
+        'STORAGE_OVERAGE_ATTACHMENT_DELETION_GRACE_PERIOD',
     ),
     'Regular maintenance settings': (
         'ASSET_SNAPSHOT_DAYS_RETENTION',
@@ -1279,6 +1291,13 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/30'),
         'options': {'queue': 'kpi_low_priority_queue'}
     },
+    # Schedule every 30 minutes
+    # ToDo: Uncomment when the task for auto-cleanup of attachments is ready (DEV-240)
+    # 'attachment-cleanup-for-users-exceeding-limits': {
+    #     'task': 'kobo.apps.trash_bin.tasks.attachment.schedule_auto_attachment_cleanup_for_users',  # noqa
+    #     'schedule': crontab(minute='*/1'),
+    #     'options': {'queue': 'kpi_low_priority_queue'}
+    # },
     # Schedule every day at midnight UTC
     'project-ownership-garbage-collector': {
         'task': 'kobo.apps.project_ownership.tasks.garbage_collector',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a new celery task that identifies users who have exceeded their storage limits for a configurable number of days and dispatches a cleanup task for each. This prepares the foundation for automated enforcement of storage quotas via attachment deletion.


### 📖 Description
This PR introduces a Celery task (`dispatch_attachment_cleanup_for_users_exceeding_limits`) that:

- Runs periodically via Celery Beat (every 30 mins, currently commented out in `CELERY_BEAT_SCHEDULE`)
- Filters users from the `ExceededLimitCounter` model who have exceeded their storage quota for more than `STORAGE_OVERAGE_ATTACHMENT_DELETION_GRACE_PERIOD` days (default: 90)
- For each qualifying user, dispatches a cleanup task (`auto_delete_excess_attachments(user_id)`), currently a placeholder.

Additional Constance settings added:

- `AUTO_DELETE_ATTACHMENTS`: Global toggle for enabling/disabling the auto deletion (default: False)
- `STORAGE_OVERAGE_ATTACHMENT_DELETION_GRACE_PERIOD`: Grace period before triggering cleanup for over-quota users

Notes for reviewers:

- Task is not yet active: The beat schedule is commented out in settings and will be enabled once the attachment deletion logic is implemented in `auto_delete_excess_attachments()`
- Unit tests will be added along with the implementation of `auto_delete_excess_attachments`, when the full deletion pipeline is built. 
- The `ExceededLimitCounter` model is currently not updated automatically. Integration with periodic quota tracking will be handled later in the billing project.