### PR TITLE
fix(table): show hard coded error message for `500`'s

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -113,6 +113,8 @@ interface DataTableState {
   pageSize: number
   currentPage: number
   error: string | boolean
+  errorNumber: number | null
+  errorStatus: string | null
   showLabels: boolean
   translationIndex: number
   showGroupName: boolean
@@ -161,6 +163,8 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
       pageSize: 30,
       currentPage: 0,
       error: false,
+      errorNumber: null,
+      errorStatus: null,
       showLabels: true,
       translationIndex: 0,
       showGroupName: true,
@@ -330,8 +334,31 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
       handleApiFail(error)
     }
 
-    if (error?.status && error.statusText) {
-      this.setState({ error: `${error.status} ${error.statusText}` })
+    if (error?.status) {
+      this.setState({ errorNumber: error.status })
+
+      // 500's from the backend gives us an html responseText, so we show a hard coded string during render instead
+      if (error.status !== 500 && error?.responseText) {
+        let displayedError
+
+        try {
+          displayedError = JSON.parse(error.responseText)
+        } catch {
+          displayedError = error.responseText
+        }
+
+        if (displayedError.detail) {
+          this.setState({ error: displayedError.detail, loading: false })
+        } else {
+          this.setState({ error: displayedError, loading: false })
+        }
+      } else if (error.status !== 500 && !error?.responseText) {
+        this.setState({ error: t('Error: could not load data.'), loading: false })
+      }
+    }
+
+    if (error?.statusText) {
+      this.setState({ errorStatus: error.statusText })
     }
   }
 
@@ -1320,7 +1347,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
   }
 
   render() {
-    if (this.state.error && typeof this.state.error === 'string') {
+    if (this.state.errorNumber && this.state.errorNumber === 500) {
       const supportMessage = t(
         'Please try again later, or [contact the support team](##SUPPORT_URL##) if this happens repeatedly.',
       ).replace('##SUPPORT_URL##', envStore.data.support_url)
@@ -1335,11 +1362,19 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
                 </div>
                 <br />
                 <div>
-                  {t('Response details:')} {this.state.error}
+                  {t('Response details:')} {`${this.state.errorNumber} ${this.state.errorStatus}`}
                 </div>
               </div>
             }
           />
+        </bem.FormView>
+      )
+    }
+
+    if (this.state.error && typeof this.state.error === 'string') {
+      return (
+        <bem.FormView m='ui-panel'>
+          <CenteredMessage message={this.state.error} />
         </bem.FormView>
       )
     }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a regression introduced in #5903 where the error message intended for `500`'s was displaying for empty forms, undeployed forms, and/or deployed forms with no data. Reverts the behaviour to show the response text in these cases

### 👀 Preview steps

1. ℹ️ have an account and 2 projects
2. leave both projects empty
3. deploy one project
4. check the data table for both projects
6. 🔴 [on main] notice that the "Oops!" message exists for both these projects
7. 🟢 [on PR] notice that the error messages are correct and relevant to the issue (not deployed, or no submissions)
8. add `1/0` to line 444 on `data.py`
9. 🟢 notice that the data table still does not show an a mess of html
10. remove the `1/0` in `data.py`
11. submit some data in a form, or navigate to a form with data
9. 🟢 notice that the data table displays as expected