### PR TITLE
feat(user): include uid in /me endpoint DEV-234

### DIFF
--- a/kobo/apps/long_running_migrations/app.py
+++ b/kobo/apps/long_running_migrations/app.py
@@ -99,4 +99,4 @@ def check_must_complete_long_running_migrations(app_configs, **kwargs):
     ]
 
 
-#register(check_must_complete_long_running_migrations, Tags.database)
+register(check_must_complete_long_running_migrations, Tags.database)

--- a/kobo/apps/long_running_migrations/app.py
+++ b/kobo/apps/long_running_migrations/app.py
@@ -99,4 +99,4 @@ def check_must_complete_long_running_migrations(app_configs, **kwargs):
     ]
 
 
-register(check_must_complete_long_running_migrations, Tags.database)
+#register(check_must_complete_long_running_migrations, Tags.database)

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -18,6 +18,7 @@ from kobo.apps.constance_backends.utils import to_python_object
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.fields import WritableJSONField
 from kpi.utils.gravatar_url import gravatar_url
+from kpi.utils.log import logging
 from kpi.utils.object_permission import get_database_user
 
 
@@ -37,6 +38,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     validated_password = serializers.SerializerMethodField()
     accepted_tos = serializers.SerializerMethodField()
     organization = serializers.SerializerMethodField()
+    extra_details__uid = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -58,6 +60,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             'validated_password',
             'accepted_tos',
             'organization',
+            'extra_details__uid',
         )
         read_only_fields = (
             'email',
@@ -131,6 +134,9 @@ class CurrentUserSerializer(serializers.ModelSerializer):
             return True
 
         return extra_details.validated_password
+
+    def get_extra_details__uid(self, obj):
+        return obj.extra_details.uid
 
     def to_representation(self, obj):
         if obj.is_anonymous:

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -18,7 +18,6 @@ from kobo.apps.constance_backends.utils import to_python_object
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.fields import WritableJSONField
 from kpi.utils.gravatar_url import gravatar_url
-from kpi.utils.log import logging
 from kpi.utils.object_permission import get_database_user
 
 

--- a/kpi/tests/api/test_api_current_user.py
+++ b/kpi/tests/api/test_api_current_user.py
@@ -200,3 +200,13 @@ class CurrentUserTestCase(BaseTestCase):
             'last_login': None,
             'extra_details__uid': self.user.extra_details.uid,
         }
+
+    def test_cannot_update_uid(self):
+        self.client.force_authenticate(self.user)
+        uid = self.user.extra_details.uid
+        response = self.client.patch(
+            self.url, data={'extra_details__uid': 'u12345'}, format='json'
+        )
+        assert response.status_code == status.HTTP_200_OK
+        self.user.refresh_from_db()
+        assert self.user.extra_details.uid == uid

--- a/kpi/tests/api/test_api_current_user.py
+++ b/kpi/tests/api/test_api_current_user.py
@@ -1,12 +1,16 @@
 from datetime import datetime
 
 from constance.test import override_config
-from django.urls import reverse
+from django.conf import settings
+from django.test import RequestFactory
 from django.utils import timezone
+from freezegun import freeze_time
 from rest_framework import status
+from rest_framework.reverse import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.tests.base_test_case import BaseTestCase
+from kpi.utils.gravatar_url import gravatar_url
 
 
 class CurrentUserTestCase(BaseTestCase):
@@ -159,3 +163,40 @@ class CurrentUserTestCase(BaseTestCase):
             self.user.refresh_from_db()
             # Validate the flag kept the original value
             assert getattr(self.user, flag, False) is False
+
+    def test_expected_result(self):
+        request = RequestFactory().get('/')
+        self.client.force_authenticate(self.user)
+        time = timezone.now()
+        with freeze_time(time):
+            response = self.client.get(self.url)
+        assert response.data == {
+            'username': self.user.username,
+            'first_name': self.user.first_name,
+            'last_name': self.user.last_name,
+            'email': self.user.email,
+            'server_time': time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'date_joined': self.user.date_joined.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'projects_url': '/'.join((settings.KOBOCAT_URL, self.user.username)),
+            'gravatar': gravatar_url(self.user.email),
+            'extra_details': {
+                'organization': '',
+                'name': '',
+                'require_auth': True,
+            },
+            'git_rev': False,
+            'social_accounts': [],
+            'validated_password': True,
+            'accepted_tos': False,
+            'organization': {
+                'url': reverse(
+                    'api_v2:organizations-detail',
+                    kwargs={'id': self.user.organization.id},
+                    request=request,
+                ),
+                'name': self.user.organization.name,
+                'uid': self.user.organization.id,
+            },
+            'last_login': None,
+            'extra_details__uid': self.user.extra_details.uid,
+        }

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -2,7 +2,7 @@ from constance import config
 from django.db import transaction
 from django.utils.timezone import now
 from django.utils.translation import gettext as t
-from rest_framework import status, viewsets, permissions
+from rest_framework import permissions, status, viewsets
 from rest_framework.response import Response
 
 from kobo.apps.kobo_auth.shortcuts import User
@@ -58,7 +58,8 @@ class CurrentUserViewSet(viewsets.ModelViewSet):
     >               "url": string,
     >               "name": string,
     >               "uid": string,
-    >           }
+    >           },
+    >           "extra_details__uid": string,
     >       }
 
     Update account details


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add user uid to the current user endpoint.


### 💭 Notes
Adds the uid from extra_details into the /me response. We can't nest it under the existing extra_details field because that is a writeable JSON used for updating extra_details.data. In an ideal world we would have the extra_details field return a dictionary with both the uid and the data JSON and only make the data part writeable, but  that would require a new version of the API since it would break existing contracts. 

### 👀 Preview steps

1. ℹ️ have an account
2. Go to `/me`
3. 🟢 Notice your uid is returned in the response under `extra_details__uid`
