### PR TITLE
feat(usageLimits): handle project ownership transfer limits DEV-441

### DIFF
--- a/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
@@ -175,7 +175,7 @@ export default function TransferProjects(props: TransferProjectsProps) {
               isFullWidth
               onClick={toggleModal}
               isDisabled={isTransferBlocked}
-              tooltip={isTransferBlocked ? t('Transfer is not allowed when limits are exceeded.') : undefined}
+              tooltip={isTransferBlocked ? t('Transfer is not allowed when current owner is over their usage limit.') : undefined}
               tooltipPosition='right'
               type='secondary'
               size='l'

--- a/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 
+import { UsageLimitTypes } from '#/account/stripe.types'
+import { useServiceUsageQuery } from '#/account/usage/useServiceUsageQuery'
 import Button from '#/components/common/button'
 import InlineMessage from '#/components/common/inlineMessage'
 import TextBox from '#/components/common/textBox'
@@ -41,6 +43,16 @@ export default function TransferProjects(props: TransferProjectsProps) {
     inviteUrl: props.asset.project_ownership ? props.asset.project_ownership.invite : null,
     submitPending: false,
   })
+
+  const { data: serviceUsageData } = useServiceUsageQuery()
+
+  const isTransferBlocked = useMemo(
+    () =>
+      !serviceUsageData ||
+      serviceUsageData.limitExceedList.includes(UsageLimitTypes.STORAGE) ||
+      serviceUsageData.limitExceedList.includes(UsageLimitTypes.SUBMISSION),
+    [serviceUsageData],
+  )
 
   const updateUsername = (newUsername: string) => {
     setTransfer({
@@ -162,6 +174,9 @@ export default function TransferProjects(props: TransferProjectsProps) {
               label={t('Transfer')}
               isFullWidth
               onClick={toggleModal}
+              isDisabled={isTransferBlocked}
+              tooltip={isTransferBlocked ? t('Transfer is not allowed when limits are exceeded.') : undefined}
+              tooltipPosition='right'
               type='secondary'
               size='l'
             />

--- a/jsapp/js/components/permissions/transferProjects/transferProjects.module.scss
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.module.scss
@@ -21,6 +21,7 @@
   gap: 12px;
 
   .transferButton {
+    min-width: 180px;
     max-width: 180px;
   }
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR blocks the transfer project ownership button if either `submission` or `storage` limits are exceeded.

### 💭 Notes
- I've opted to also add a tooltip to the button
- A small CSS adjustment was needed to avoid size changing due to the tooltip wrapper

### 👀 Preview steps
1. ℹ️ have an account and a project
2. Navigate to project Settings > Sharing view
5. 🟢 If either `submission` or `storage` limits are exceeded, the transfer button should be disabled and have a tooltip.