### PR TITLE
Revert "chore(deps): bump @tanstack/react-query from 5.50.1 to 5.83.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@mapbox/leaflet-omnivore": "^0.3.4",
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/react": "^7.61.0",
-        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-query": "^5.49.2",
         "@tanstack/react-table": "^8.20.5",
         "alertifyjs": "^1.14.0",
         "backbone": "^1.4.0",
@@ -5516,9 +5516,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
-      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.50.1.tgz",
+      "integrity": "sha512-lpfhKPrJlyV2DSVcQb/HuozH3Av3kws4ge22agx+lNGpFkS4vLZ7St0l3GLwlAD+bqB+qXGex3JdRKUNtMviEQ==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -5535,18 +5535,18 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
-      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.50.1.tgz",
+      "integrity": "sha512-s0DW3rVBDPReDDovUjVqItVa3R2nPfUANK9nqGvarO2DwTiY9U4EBTsqizMxItRCoGgK5apeM7D3mxlHrSKpdQ==",
       "dependencies": {
-        "@tanstack/query-core": "5.83.0"
+        "@tanstack/query-core": "5.50.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
+        "react": "^18.0.0"
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
@@ -30954,9 +30954,9 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
-      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA=="
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.50.1.tgz",
+      "integrity": "sha512-lpfhKPrJlyV2DSVcQb/HuozH3Av3kws4ge22agx+lNGpFkS4vLZ7St0l3GLwlAD+bqB+qXGex3JdRKUNtMviEQ=="
     },
     "@tanstack/query-devtools": {
       "version": "5.50.1",
@@ -30965,11 +30965,11 @@
       "dev": true
     },
     "@tanstack/react-query": {
-      "version": "5.83.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
-      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.50.1.tgz",
+      "integrity": "sha512-s0DW3rVBDPReDDovUjVqItVa3R2nPfUANK9nqGvarO2DwTiY9U4EBTsqizMxItRCoGgK5apeM7D3mxlHrSKpdQ==",
       "requires": {
-        "@tanstack/query-core": "5.83.0"
+        "@tanstack/query-core": "5.50.1"
       }
     },
     "@tanstack/react-query-devtools": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mapbox/leaflet-omnivore": "^0.3.4",
     "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/react": "^7.61.0",
-    "@tanstack/react-query": "^5.83.0",
+    "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-table": "^8.20.5",
     "alertifyjs": "^1.14.0",
     "backbone": "^1.4.0",


### PR DESCRIPTION
Reverts kobotoolbox/kpi#5953