### PR TITLE
fix(accountSettings): ensure correct help article URL for non-KoboToolbox instances DEV-713

### DIFF
--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -116,6 +116,11 @@ const AccountSettings = () => {
 
   const accountName = currentLoggedAccount?.username || ''
 
+  const helpArticleUrl =
+    envStore.data.support_url && envStore.data.support_url.includes('support.kobotoolbox.org')
+      ? envStore.data.support_url + HELP_ARTICLE_ANON_SUBMISSIONS_URL
+      : envStore.data.support_url
+
   return (
     <bem.AccountSettings onSubmit={updateProfile}>
       <bem.AccountSettings__actions>
@@ -150,7 +155,7 @@ const AccountSettings = () => {
                     'This privacy feature is now a per-project setting. New projects will require authentication by default.',
                   )}
                   &nbsp;
-                  <a href={envStore.data.support_url + HELP_ARTICLE_ANON_SUBMISSIONS_URL} target='_blank'>
+                  <a href={helpArticleUrl} target='_blank'>
                     {t('Learn more about these changes here.')}
                   </a>
                 </>


### PR DESCRIPTION
### 📣 Summary
The "Learn more about these changes here" link in account settings is broken on KoboToolbox instances using a custom support URL

### 👀 Preview steps
<img width="1392" height="787" alt="Screenshot 2025-07-22 at 3 09 11 PM" src="https://github.com/user-attachments/assets/a67c8bb3-76ce-40f1-b9e8-cae3c22d2fed" />

The red underlined link is the one affected by this bug. 


1. ℹ️ have an account and a project
2. Navigate to the Django Admin > Constance > Config
3. Change the support url to something that does **not** include `support.kobotoolbox.org`
4. Navigate to the `/#/account/settings` page and click on the "Learn more about these changes here" link
5. 🔴 [on main] notice that you get a 404 not found error and the support url that you added has `/managing_permissions.html` appended to the end of it
6. 🟢 [on PR] notice that the support url navigates correctly to the support url you changed and it has not been modified
