### PR TITLE
ci(releases): use Github App for cascading merges DEV-561

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -96,10 +96,18 @@ jobs:
       (needs.changelog.result == 'skipped' || needs.changelog.result == 'success') &&
       needs.deploy-to-beta.result == 'success'
     steps:
+      - name: Generate a token to trigger a workflow from a workflow
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.KPI_GITHUB_ACTIONS_CASCADING_TOKEN_APP_ID }}
+          private-key: ${{ secrets.KPI_GITHUB_ACTIONS_CASCADING_TOKEN_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CI_RELEASE_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: "0"
+
       - name: Find next release branch
         id: branches
         run: ./.github/find_next_release_branch.sh

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -98,6 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.CI_RELEASE_PAT }}
           fetch-depth: "0"
       - name: Find next release branch
         id: branches


### PR DESCRIPTION
### 💭 Notes

See Github docs [here](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow).