### PR TITLE
Inject Django CSRF token in SwaggerUI template

### DIFF
--- a/kpi/static/js/swagger/swagger-ui-init.js
+++ b/kpi/static/js/swagger/swagger-ui-init.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const swaggerSettingsJson = swaggerUiDiv.dataset.swaggerSettings;
     const schemaAuthNamesJson = swaggerUiDiv.dataset.schemaAuthNames;
     const csrfHeaderName = swaggerUiDiv.dataset.csrfHeaderName;
-    const csrfToken = swaggerUiDiv.dataset.csrfToken;
+    const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;
     const schemaUrl = swaggerUiDiv.dataset.schemaUrl;
     const oauth2ConfigJson = swaggerUiDiv.dataset.oauth2Config;
 

--- a/kpi/templates/drf_spectacular/swagger_ui.html
+++ b/kpi/templates/drf_spectacular/swagger_ui.html
@@ -7,8 +7,11 @@
 {% endblock %}
 
 {% block body %}
+  {% csrf_token %}
   <div id="swagger-ui"
-       data-schema-url="{{ data_schema_url }}"></div>
+       data-schema-url="{{ data_schema_url }}"
+       data-csrf-header-name="X-CSRFToken"
+  ></div>
   <script src="{{ swagger_ui_bundle }}"></script>
   <script src="{{ swagger_ui_standalone }}"></script>
   <script src="{{ script_url }}"></script>


### PR DESCRIPTION
### 📣 Summary
Inject Django CSRF token in SwaggerUI template

### 📖 Description
Inject Django CSRF token in SwaggerUI template so user may still have the ability to use the swagger POST, PATCH and DELETE try out function.