### PR TITLE
docs(api): removing openRosa endpoints from schema DEV-782

### DIFF
--- a/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
@@ -74,6 +74,7 @@ class DoXmlFormUpload:
     def publish(self):
         return publish_xml_form(self.xml_file, self.user)
 
+
 @extend_schema(
     tags=['OpenRosa'],
     exclude=True,

--- a/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/briefcase_api.py
@@ -5,6 +5,7 @@ from django.core.files import File
 from django.core.validators import ValidationError
 from django.http import Http404
 from django.utils.translation import gettext as t
+from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, mixins, permissions, status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -73,7 +74,10 @@ class DoXmlFormUpload:
     def publish(self):
         return publish_xml_form(self.xml_file, self.user)
 
-
+@extend_schema(
+    tags=['OpenRosa'],
+    exclude=True,
+)
 class BriefcaseApi(
     OpenRosaHeadersMixin,
     mixins.CreateModelMixin,

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, status
 from rest_framework.decorators import action
 from rest_framework.request import Request
@@ -30,7 +31,10 @@ from kpi.constants import PERM_MANAGE_ASSET
 from kpi.models.object_permission import ObjectPermission
 from ..utils.rest_framework.viewsets import OpenRosaReadOnlyModelViewSet
 
-
+@extend_schema(
+    tags=['OpenRosa'],
+    exclude=True,
+)
 class XFormListApi(OpenRosaReadOnlyModelViewSet):
 
     content_negotiation_class = MediaFileContentNegotiation

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_list_api.py
@@ -31,6 +31,7 @@ from kpi.constants import PERM_MANAGE_ASSET
 from kpi.models.object_permission import ObjectPermission
 from ..utils.rest_framework.viewsets import OpenRosaReadOnlyModelViewSet
 
+
 @extend_schema(
     tags=['OpenRosa'],
     exclude=True,

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
@@ -3,6 +3,7 @@ import re
 
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as t
+from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, permissions, status
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
@@ -63,7 +64,10 @@ def create_instance_from_json(username, request):
     xml_file = io.StringIO(xml_string)
     return safe_create_instance(username, xml_file, [], None, request=request)
 
-
+@extend_schema(
+    tags=['OpenRosa'],
+    exclude=True,
+)
 class XFormSubmissionApi(
     OpenRosaHeadersMixin,
     mixins.CreateModelMixin,

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
@@ -64,6 +64,7 @@ def create_instance_from_json(username, request):
     xml_file = io.StringIO(xml_string)
     return safe_create_instance(username, xml_file, [], None, request=request)
 
+
 @extend_schema(
     tags=['OpenRosa'],
     exclude=True,

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -171,6 +171,7 @@ class AssetSnapshotSchema(AutoSchema):
             error_media_type='text/html',
         ),
         tags=['OpenRosa'],
+        exclude=True,
     ),
     manifest=extend_schema(
         description=read_md('kpi', 'openrosa/manifest.md'),
@@ -183,6 +184,7 @@ class AssetSnapshotSchema(AutoSchema):
             error_media_type='text/html',
         ),
         tags=['OpenRosa'],
+        exclude=True,
     ),
     submission=extend_schema(
         description=read_md('kpi', 'openrosa/submission.md'),
@@ -195,6 +197,7 @@ class AssetSnapshotSchema(AutoSchema):
             raise_not_found=False,
         ),
         tags=['OpenRosa'],
+        exclude=True,
     ),
     preview=extend_schema(
         description=read_md('kpi', 'asset_snapshots/preview.md'),


### PR DESCRIPTION
### 📣 Summary
Removed the OpenRosa endpoints from appearing the schema.

### 📖 Description
Removed the OpenRosa endpoints from appearing in the `/api/v2/docs/` schema since they will be moved to their own docs later on.

### 💭 Notes

The endpoints have been 'removed' by simply excluding them from the current schema. Unfortunately I cannot remove them with the pre-processing hooks as we still want them in the schema for later on when we will be documenting their own docs (probably using a post-processing hook to separate the schema). 