### PR TITLE
ci(releases): use Github App DEV-561

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -80,7 +80,7 @@ jobs:
 
 
   merge-forward:
-    name: Merge Forward
+    name: Merge forward
     runs-on: ubuntu-24.04
     needs:
       - darker
@@ -97,24 +97,35 @@ jobs:
       needs.deploy-to-beta.result == 'success'
     steps:
       - name: Generate a token to trigger a workflow from a workflow
-        id: generate-token
+        id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.KPI_GITHUB_ACTIONS_CASCADING_TOKEN_APP_ID }}
-          private-key: ${{ secrets.KPI_GITHUB_ACTIONS_CASCADING_TOKEN_PRIVATE_KEY }}
+          app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+          private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: "0"
+
+      # https://github.com/actions/create-github-app-token?tab=readme-ov-file#configure-git-cli-for-an-apps-bot-user
+      - name: Get GitHub App user id
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      - name: Set git name and email for the bot
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Find next release branch
         id: branches
         run: ./.github/find_next_release_branch.sh
+
       - name: Merge
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "github-actions-bot@kobotoolbox.org"
           current_branch="${{ steps.branches.outputs.current_branch }}"
           next_branch="${{ steps.branches.outputs.next_branch }}"
           git checkout "${next_branch}"


### PR DESCRIPTION
### 💭 Notes

Use one Github App for all release related git actions.

See [GitHub docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow#authenticating-with-a-github-app).
