### PR TITLE
 refactor(coffeeScript): fix DS0002 in view.rowDetail.SkipLogic.coffee DEV-795

### DIFF
--- a/jsapp/xlform/src/view.rowDetail.SkipLogic.coffee
+++ b/jsapp/xlform/src/view.rowDetail.SkipLogic.coffee
@@ -39,7 +39,7 @@ module.exports = do ->
 
       @
 
-    addCriterion: (evt) =>
+    addCriterion: (evt) ->
       @facade.view_factory.survey.trigger('change')
       @facade.add_empty()
 
@@ -140,8 +140,12 @@ module.exports = do ->
       super(element)
       return
 
-    constructor: (@question_picker_view, @operator_picker_view, @response_value_view, @presenter) ->
+    constructor: (question_picker_view, operator_picker_view, response_value_view, presenter) ->
       super()
+      @question_picker_view = question_picker_view
+      @operator_picker_view = operator_picker_view
+      @response_value_view = response_value_view
+      @presenter = presenter
 
   ###----------------------------------------------------------------------------------------------------------###
   #-- View.RowDetail.SkipLogic.QuestionPickerView.coffee
@@ -237,8 +241,9 @@ module.exports = do ->
       chosen_element.text(abbreviated_label)
       return
 
-    constructor: (@operators) ->
+    constructor: (operators) ->
       super()
+      @operators = operators
 
   ###----------------------------------------------------------------------------------------------------------###
   #-- View.RowDetail.SkipLogic.ResponseViews.coffee
@@ -267,24 +272,24 @@ module.exports = do ->
       super()
       @setElement('<div class="skiplogic__responseval-wrapper">' + @$el + '<div></div></div>')
       @$error_message = @$('div')
-      @model.bind 'validated:invalid', @show_invalid_view
-      @model.bind 'validated:valid', @clear_invalid_view
+      @model.bind 'validated:invalid', @show_invalid_view.bind(@)
+      @model.bind 'validated:valid', @clear_invalid_view.bind(@)
       @$input = @$el.find('input')
       return @
 
-    show_invalid_view: (model, errors) =>
+    show_invalid_view: (model, errors) ->
       if @$input.val()
         @$el.addClass('textbox--invalid')
         @$error_message.html(errors.value)
         @$input.focus()
-    clear_invalid_view: (model, errors) =>
+    clear_invalid_view: (model, errors) ->
       @$el.removeClass('textbox--invalid')
       @$error_message.html('')
 
     bind_event: (handler) ->
       @$input.on 'change', handler
 
-    val: (value) =>
+    val: (value) ->
       if value?
         @$input.val(value)
       else
@@ -311,11 +316,13 @@ module.exports = do ->
       @model.off 'change:cid', handle_model_cid_change
       @model.on 'change:cid', handle_model_cid_change
 
-    constructor: (@responses, @model) ->
-      super(_.map @responses.models, (response) ->
+    constructor: (responses, model) ->
+      super(_.map responses.models, (response) ->
         text: response.get('label')
         value: response.cid
       )
+      @responses = responses
+      @model = model
 
   ###----------------------------------------------------------------------------------------------------------###
   #-- Factories.RowDetail.SkipLogic.coffee


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

For the decaffeination project adjusted code in `view.rowDetail.SkipLogic.coffee` to no longer produce DS0002 warning. Also did some cleanups while there.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. go to Project page and choose "Edit form"
3. inside Form Builder use different functionalities
4. 🟢 notice that everything still works as previously
