### PR TITLE
feat(tag): migrate `tag` endpoints to API `v2`  DEV-800

### DIFF
--- a/kpi/serializers/v1/tag.py
+++ b/kpi/serializers/v1/tag.py
@@ -1,40 +1,14 @@
-# coding: utf-8
-from rest_framework import serializers
-from rest_framework.reverse import reverse
-from taggit.models import Tag
-
-from kpi.models import Asset, TagUid
-from kpi.utils.object_permission import get_database_user
+from kpi.serializers.v2.tag import (
+    TagSerializer as TagSerializerV2,
+    TagListSerializer as TagListSerializerV2,
+)
 
 
-class TagSerializer(serializers.ModelSerializer):
-    url = serializers.SerializerMethodField('_get_tag_url', read_only=True)
-    assets = serializers.SerializerMethodField('_get_assets', read_only=True)
-    parent = serializers.SerializerMethodField(
-        '_get_parent_url', read_only=True)
-    uid = serializers.ReadOnlyField(source='taguid.uid')
+class TagSerializer(TagSerializerV2):
 
-    class Meta:
-        model = Tag
-        fields = ('name', 'url', 'assets', 'parent', 'uid')
-
-    def _get_parent_url(self, obj):
-        return reverse('tag-list', request=self.context.get('request', None))
-
-    def _get_assets(self, obj):
-        request = self.context.get('request', None)
-        user = get_database_user(request.user)
-        return [reverse('asset-detail', args=(sa.uid,), request=request)
-                for sa in Asset.objects.filter(tags=obj, owner=user).all()]
-
-    def _get_tag_url(self, obj):
-        request = self.context.get('request', None)
-        uid = TagUid.objects.get_or_create(tag=obj)[0].uid
-        return reverse('tag-detail', args=(uid,), request=request)
+    pass
 
 
-class TagListSerializer(TagSerializer):
+class TagListSerializer(TagListSerializerV2):
 
-    class Meta:
-        model = Tag
-        fields = ('name', 'url', )
+    pass

--- a/kpi/serializers/v1/tag.py
+++ b/kpi/serializers/v1/tag.py
@@ -1,7 +1,5 @@
-from kpi.serializers.v2.tag import (
-    TagSerializer as TagSerializerV2,
-    TagListSerializer as TagListSerializerV2,
-)
+from kpi.serializers.v2.tag import TagListSerializer as TagListSerializerV2
+from kpi.serializers.v2.tag import TagSerializer as TagSerializerV2
 
 
 class TagSerializer(TagSerializerV2):

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+from rest_framework import serializers
+from rest_framework.reverse import reverse
+from taggit.models import Tag
+
+from kpi.models import Asset, TagUid
+from kpi.utils.object_permission import get_database_user
+
+
+class TagSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField('_get_tag_url', read_only=True)
+    assets = serializers.SerializerMethodField('_get_assets', read_only=True)
+    parent = serializers.SerializerMethodField(
+        '_get_parent_url', read_only=True)
+    uid = serializers.ReadOnlyField(source='taguid.uid')
+
+    class Meta:
+        model = Tag
+        fields = ('name', 'url', 'assets', 'parent', 'uid')
+
+    def _get_parent_url(self, obj):
+        return reverse('tag-list', request=self.context.get('request', None))
+
+    def _get_assets(self, obj):
+        request = self.context.get('request', None)
+        user = get_database_user(request.user)
+        return [reverse('asset-detail', args=(sa.uid,), request=request)
+                for sa in Asset.objects.filter(tags=obj, owner=user).all()]
+
+    def _get_tag_url(self, obj):
+        request = self.context.get('request', None)
+        uid = TagUid.objects.get_or_create(tag=obj)[0].uid
+        return reverse('tag-detail', args=(uid,), request=request)
+
+
+class TagListSerializer(TagSerializer):
+
+    class Meta:
+        model = Tag
+        fields = ('name', 'url', )

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -10,8 +10,7 @@ from kpi.utils.object_permission import get_database_user
 class TagSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField('_get_tag_url', read_only=True)
     assets = serializers.SerializerMethodField('_get_assets', read_only=True)
-    parent = serializers.SerializerMethodField(
-        '_get_parent_url', read_only=True)
+    parent = serializers.SerializerMethodField('_get_parent_url', read_only=True)
     uid = serializers.ReadOnlyField(source='taguid.uid')
 
     class Meta:
@@ -23,8 +22,10 @@ class TagSerializer(serializers.ModelSerializer):
 
     def _get_assets(self, obj):
         request = self.context.get('request', None)
-        return [reverse('asset-detail', args=(sa.uid,), request=request)
-                for sa in Asset.objects.values_list('uid', flat=True)]
+        return [
+            reverse('asset-detail', args=(sa.uid,), request=request)
+            for sa in Asset.objects.values_list('uid', flat=True)
+        ]
 
     def _get_tag_url(self, obj):
         request = self.context.get('request', None)
@@ -33,7 +34,9 @@ class TagSerializer(serializers.ModelSerializer):
 
 
 class TagListSerializer(TagSerializer):
-
     class Meta:
         model = Tag
-        fields = ('name', 'url', )
+        fields = (
+            'name',
+            'url',
+        )

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -18,7 +18,7 @@ class TagSerializer(serializers.ModelSerializer):
         fields = ('name', 'url', 'assets', 'parent', 'uid')
 
     def _get_parent_url(self, obj):
-        return reverse('tag-list', request=self.context.get('request', None))
+        return reverse('tags-list', request=self.context.get('request', None))
 
     def _get_assets(self, obj):
         request = self.context.get('request', None)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -4,7 +4,6 @@ from rest_framework.reverse import reverse
 from taggit.models import Tag
 
 from kpi.models import Asset, TagUid
-from kpi.utils.object_permission import get_database_user
 
 
 class TagSerializer(serializers.ModelSerializer):

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -30,7 +30,7 @@ class TagSerializer(serializers.ModelSerializer):
     def _get_tag_url(self, obj):
         request = self.context.get('request', None)
         tag_uid, _ = TagUid.objects.get_or_create(tag=obj)
-        return reverse('tag-detail', args=(tag_uid.uid,), request=request)
+        return reverse('tags-detail', args=(tag_uid.uid,), request=request)
 
 
 class TagListSerializer(TagSerializer):

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -23,9 +23,8 @@ class TagSerializer(serializers.ModelSerializer):
 
     def _get_assets(self, obj):
         request = self.context.get('request', None)
-        user = get_database_user(request.user)
         return [reverse('asset-detail', args=(sa.uid,), request=request)
-                for sa in Asset.objects.filter(tags=obj, owner=user).all()]
+                for sa in Asset.objects.values_list('uid', flat=True)]
 
     def _get_tag_url(self, obj):
         request = self.context.get('request', None)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -29,8 +29,8 @@ class TagSerializer(serializers.ModelSerializer):
 
     def _get_tag_url(self, obj):
         request = self.context.get('request', None)
-        uid = TagUid.objects.get_or_create(tag=obj)[0].uid
-        return reverse('tag-detail', args=(uid,), request=request)
+        tag_uid, _ = TagUid.objects.get_or_create(tag=obj)
+        return reverse('tag-detail', args=(tag_uid.uid,), request=request)
 
 
 class TagListSerializer(TagSerializer):

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from taggit.models import Tag
@@ -7,34 +6,33 @@ from kpi.models import Asset, TagUid
 
 
 class TagSerializer(serializers.ModelSerializer):
-    url = serializers.SerializerMethodField('_get_tag_url', read_only=True)
-    assets = serializers.SerializerMethodField('_get_assets', read_only=True)
-    parent = serializers.SerializerMethodField('_get_parent_url', read_only=True)
+    url = serializers.SerializerMethodField()
+    assets = serializers.SerializerMethodField()
+    parent = serializers.SerializerMethodField()
     uid = serializers.ReadOnlyField(source='taguid.uid')
 
     class Meta:
         model = Tag
         fields = ('name', 'url', 'assets', 'parent', 'uid')
 
-    def _get_parent_url(self, obj):
+    def get_parent(self, obj):
         return reverse('tags-list', request=self.context.get('request', None))
 
-    def _get_assets(self, obj):
+    def get_assets(self, obj):
         request = self.context.get('request', None)
         return [
-            reverse('asset-detail', args=(sa.uid,), request=request)
-            for sa in Asset.objects.values_list('uid', flat=True)
+            reverse('asset-detail', args=(asset_uid,), request=request)
+            for asset_uid in Asset.objects.values_list('uid', flat=True)
         ]
 
-    def _get_tag_url(self, obj):
+    def get_url(self, obj):
         request = self.context.get('request', None)
         tag_uid, _ = TagUid.objects.get_or_create(tag=obj)
         return reverse('tags-detail', args=(tag_uid.uid,), request=request)
 
 
 class TagListSerializer(TagSerializer):
-    class Meta:
-        model = Tag
+    class Meta(TagSerializer.Meta):
         fields = (
             'name',
             'url',

--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -1,0 +1,104 @@
+from ddt import data, ddt, unpack
+from django.urls import reverse
+from rest_framework import status
+from taggit.models import Tag
+
+from kpi.models import Asset, TagUid
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.base_test_case import BaseTestCase
+from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
+
+
+class BaseTagTestCase(BaseTestCase):
+    fixtures = ['test_data']
+
+    URL_NAMESPACE = ROUTER_URL_NAMESPACE
+
+    def setUp(self):
+        self.client.login(username='someuser', password='someuser')
+        self.asset = Asset.objects.create(
+            owner=User.objects.get(username='someuser')
+        )
+        self.tag = Tag.objects.create(
+            name='tag_creation'
+        )
+        self.asset.tags.add(self.tag)
+        self.tag_uid, _ = TagUid.objects.get_or_create(tag=self.tag)
+        self.url = reverse(self._get_endpoint('tags-list'))
+
+
+class TagListTestCase(BaseTagTestCase):
+
+    def test_only_owner_can_see_their_own(self):
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['name'] == self.tag.name
+
+    def test_user_cannot_see_others(self):
+        self.client.login(username='anotheruser', password='anotheruser')
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0
+        assert response.data['results'] == []
+
+
+@ddt
+class TagDetailTestCase(BaseTagTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse(self._get_endpoint('tags-detail'),kwargs={'taguid__uid': self.tag_uid.uid})
+
+    @data(
+        ('someuser',),
+        ('anotheruser',),
+        ('anonymous',),
+    )
+    @unpack
+    def test_nobody_can_edit(self, username):
+        if username != 'anonymous':
+            self.client.force_login(User.objects.get(username=username))
+        else:
+            self.client.logout()
+
+        response = self.client.post(self.url, data={'name': 'tag_edit'})
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @data(
+        ('someuser',),
+        ('anotheruser',),
+        ('anonymous',),
+    )
+    @unpack
+    def test_nobody_can_delete(self, username):
+        if username != 'anonymous':
+            self.client.force_login(User.objects.get(username=username))
+        else:
+            self.client.logout()
+
+        response = self.client.delete(self.url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_owner_can_see_their_own(self):
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['name'] == self.tag.name
+
+    @data(
+        ('anotheruser',),
+        ('anonymous',),
+    )
+    @unpack
+    def test_non_owner_cannot_see_tag(self, username):
+        if username != 'anonymous':
+            self.client.force_login(User.objects.get(username=username))
+        else:
+            self.client.logout()
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -3,8 +3,8 @@ from django.urls import reverse
 from rest_framework import status
 from taggit.models import Tag
 
-from kpi.models import Asset, TagUid
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.models import Asset, TagUid
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
@@ -16,12 +16,8 @@ class BaseTagTestCase(BaseTestCase):
 
     def setUp(self):
         self.client.login(username='someuser', password='someuser')
-        self.asset = Asset.objects.create(
-            owner=User.objects.get(username='someuser')
-        )
-        self.tag = Tag.objects.create(
-            name='tag_creation'
-        )
+        self.asset = Asset.objects.create(owner=User.objects.get(username='someuser'))
+        self.tag = Tag.objects.create(name='tag_creation')
         self.asset.tags.add(self.tag)
         self.tag_uid, _ = TagUid.objects.get_or_create(tag=self.tag)
         self.url = reverse(self._get_endpoint('tags-list'))
@@ -50,7 +46,9 @@ class TagDetailTestCase(BaseTagTestCase):
 
     def setUp(self):
         super().setUp()
-        self.url = reverse(self._get_endpoint('tags-detail'),kwargs={'taguid__uid': self.tag_uid.uid})
+        self.url = reverse(
+            self._get_endpoint('tags-detail'), kwargs={'taguid__uid': self.tag_uid.uid}
+        )
 
     @data(
         ('someuser',),

--- a/kpi/urls/router_api_v1.py
+++ b/kpi/urls/router_api_v1.py
@@ -53,7 +53,7 @@ router_api_v1.register(r'asset_snapshots', AssetSnapshotViewSet)
 router_api_v1.register(
     r'asset_subscriptions', UserAssetSubscriptionViewSet)
 router_api_v1.register(r'users', UserViewSet, basename='user-kpi')
-router_api_v1.register(r'tags', TagViewSet)
+router_api_v1.register(r'tags', TagViewSet, basename='tags')
 router_api_v1.register(r'permissions', ObjectPermissionViewSet)
 router_api_v1.register(r'reports', ReportsViewSet, basename='reports')
 router_api_v1.register(r'imports', ImportTaskViewSet)

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -30,6 +30,7 @@ from kpi.views.v2.import_task import ImportTaskViewSet
 from kpi.views.v2.paired_data import PairedDataViewset
 from kpi.views.v2.permission import PermissionViewSet
 from kpi.views.v2.service_usage import ServiceUsageViewSet
+from kpi.views.v2.tag import TagViewSet
 from kpi.views.v2.user import UserViewSet
 from kpi.views.v2.user_asset_subscription import UserAssetSubscriptionViewSet
 
@@ -171,7 +172,7 @@ router_api_v2.register(r'service_usage',
                        ServiceUsageViewSet, basename='service-usage')
 router_api_v2.register(r'users', UserViewSet, basename='user-kpi')
 
-
+router_api_v2.register(r'tags', TagViewSet, basename='tags')
 # Merge django apps routers with API v2 router
 # All routes are under `/api/v2/` within the same namespace.
 router_api_v2.registry.extend(project_ownership_router.registry)

--- a/kpi/views/v1/tag.py
+++ b/kpi/views/v1/tag.py
@@ -1,37 +1,10 @@
-# coding: utf-8
-from django.contrib.contenttypes.models import ContentType
-from rest_framework import viewsets
-from taggit.models import Tag
-
-from kpi.constants import PERM_VIEW_ASSET
-from kpi.filters import SearchFilter
-from kpi.models import Asset
-from kpi.utils.object_permission import (
-    get_database_user,
-    get_objects_for_user,
-)
-from kpi.serializers import TagSerializer, TagListSerializer
+from kpi.views.v2.tag import TagViewSet as TagViewSetV2
 
 
-class TagViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Tag.objects.all()
-    serializer_class = TagSerializer
-    lookup_field = 'taguid__uid'
-    filter_backends = (SearchFilter,)
+class TagViewSet(TagViewSetV2):
+    """
+    ## This document is for a deprecated version of kpi's API.
 
-    def get_queryset(self, *args, **kwargs):
-        user = get_database_user(self.request.user)
-        accessible_asset_pks = get_objects_for_user(
-            user, PERM_VIEW_ASSET, Asset
-        ).only('pk')
-        content_type = ContentType.objects.get_for_model(Asset)
-        return Tag.objects.filter(
-            taggit_taggeditem_items__content_type=content_type,
-            taggit_taggeditem_items__object_id__in=[accessible_asset_pks],
-        )
-
-    def get_serializer_class(self):
-        if self.action == 'list':
-            return TagListSerializer
-        else:
-            return TagSerializer
+    **Please upgrade to latest release `/api/v2/tags/`**
+    """
+    pass

--- a/kpi/views/v1/tag.py
+++ b/kpi/views/v1/tag.py
@@ -7,4 +7,5 @@ class TagViewSet(TagViewSetV2):
 
     **Please upgrade to latest release `/api/v2/tags/`**
     """
+
     pass

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import viewsets
+from taggit.models import Tag
+
+from kpi.constants import PERM_VIEW_ASSET
+from kpi.filters import SearchFilter
+from kpi.models import Asset
+from kpi.utils.object_permission import (
+    get_database_user,
+    get_objects_for_user,
+)
+from kpi.serializers import TagSerializer, TagListSerializer
+
+
+class TagViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Tag.objects.all()
+    serializer_class = TagSerializer
+    lookup_field = 'taguid__uid'
+    filter_backends = (SearchFilter,)
+
+    def get_queryset(self, *args, **kwargs):
+        user = get_database_user(self.request.user)
+        accessible_asset_pks = get_objects_for_user(
+            user, PERM_VIEW_ASSET, Asset
+        ).only('pk')
+        content_type = ContentType.objects.get_for_model(Asset)
+        return Tag.objects.filter(
+            taggit_taggeditem_items__content_type=content_type,
+            taggit_taggeditem_items__object_id__in=[accessible_asset_pks],
+        )
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return TagListSerializer
+        else:
+            return TagSerializer

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -10,7 +10,7 @@ from kpi.utils.object_permission import (
     get_database_user,
     get_objects_for_user,
 )
-from kpi.serializers import TagSerializer, TagListSerializer
+from kpi.serializers.v2.tag import TagSerializer, TagListSerializer
 
 
 class TagViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import viewsets
 from taggit.models import Tag

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -5,11 +5,8 @@ from taggit.models import Tag
 from kpi.constants import PERM_VIEW_ASSET
 from kpi.filters import SearchFilter
 from kpi.models import Asset
-from kpi.utils.object_permission import (
-    get_database_user,
-    get_objects_for_user,
-)
-from kpi.serializers.v2.tag import TagSerializer, TagListSerializer
+from kpi.serializers.v2.tag import TagListSerializer, TagSerializer
+from kpi.utils.object_permission import get_database_user, get_objects_for_user
 
 
 class TagViewSet(viewsets.ReadOnlyModelViewSet):
@@ -20,9 +17,9 @@ class TagViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self, *args, **kwargs):
         user = get_database_user(self.request.user)
-        accessible_asset_pks = get_objects_for_user(
-            user, PERM_VIEW_ASSET, Asset
-        ).only('pk')
+        accessible_asset_pks = get_objects_for_user(user, PERM_VIEW_ASSET, Asset).only(
+            'pk'
+        )
         content_type = ContentType.objects.get_for_model(Asset)
         return Tag.objects.filter(
             taggit_taggeditem_items__content_type=content_type,


### PR DESCRIPTION
### 📣 Summary
Migrate the `tag` endpoint from the now deprecated `/tags/` to the `/api/v2/tags/`.

### 👀 Preview steps
1. Execute the container and enter `./manage.py show_urls | grep tags`
2. Make sure the api/v1 and api/v2 appears (`tags/` and `api/v2/tags`)
3. Visit `http://kf.kobo.local/api/v2/tags/`, an api page for tag appears
4. The page at `http://kf.kobo.local/tags/` is still present and suggests the user to visit the `api/v2`
