### PR TITLE
Public beta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,7 @@ deploy-beta:
   rules:
     - if: $CI_COMMIT_BRANCH == "public-beta" && $CI_COMMIT_REF_PROTECTED
 
+
 deploy-staging:
   stage: deploy
   image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ deploy-beta:
     name: beta
     url: https://kf.beta.kobotoolbox.org
   rules:
-    - if: $CI_COMMIT_BRANCH == "public-beta"
+    - if: $CI_COMMIT_BRANCH == "public-beta" && $CI_COMMIT_REF_PROTECTED
 
 
 deploy-staging:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,4 +61,4 @@ pages:
     paths:
       - public
   rules:
-    - if: $CI_COMMIT_BRANCH == "main" || $$CI_COMMIT_BRANCH == "storybook"
+    - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "storybook"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ deploy-beta:
     name: beta
     url: https://kf.beta.kobotoolbox.org
   rules:
-    - if: $CI_COMMIT_BRANCH == "public-beta" && $CI_COMMIT_REF_PROTECTED
+    - if: $CI_COMMIT_BRANCH == "public-beta"
 
 
 deploy-staging:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,11 +29,8 @@ deploy-beta:
   environment:
     name: beta
     url: https://kf.beta.kobotoolbox.org
-  only:
-    refs:
-      - public-beta
-    variables:
-      - $CI_COMMIT_REF_PROTECTED
+  rules:
+    - if: $CI_COMMIT_BRANCH == "public-beta" && $CI_COMMIT_REF_PROTECTED
 
 deploy-staging:
   stage: deploy
@@ -63,7 +60,5 @@ pages:
   artifacts:
     paths:
       - public
-  only:
-    refs:
-      - main
-      - storybook
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main" || $$CI_COMMIT_BRANCH == "storybook"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ build:
 deploy-beta:
   stage: deploy
   image:
-    name: alpine/helm:3.12.0
+    name: alpine/helm
     entrypoint: [""]
   script:
     - helm -n kobo-dev upgrade beta oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${CI_COMMIT_SHORT_SHA} --reuse-values


### PR DESCRIPTION
- CI Image update
- Migrate from deprecated `only` to `rules` syntax 
- Removed the `$CI_COMMIT_REF_PROTECTED` condition from the `deploy-beta` pipeline rule 