### PR TITLE
ci(dependabot): drop major version handling and only log automerge DEV-646

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
         patterns:
           - "*"
         update-types:
-          - "patch"
           - "minor"
+          - "patch"
     # change from 10 to make it more manageable
     open-pull-requests-limit: 2

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,9 +17,9 @@ jobs:
     needs:
       - npm-test
     if: |
+      ${{ github.event.pull_request.user.login == 'dependabot[bot]' }} &&
       !failure() &&
-      needs.npm-test.result == 'success' &&
-      ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+      needs.npm-test.result == 'success'
     outputs:
       pr-url: ${{ github.event.pull_request.html_url }}
     steps:
@@ -27,14 +27,14 @@ jobs:
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v1.3.1
 
-      # Disable until I figure out what is wrong with automerges
-      # - name: Enable auto-merge for Dependabot PRs of patch and minor updates
-      #   if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
-      #   # This requires auto-merge to be enabled in GitHub repo settings
-      #   run: gh pr merge --auto --squash "$PR_URL"
-      #   env:
-      #     PR_URL: ${{github.event.pull_request.html_url}}
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs of patch and minor updates
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
+        # This requires auto-merge to be enabled in GitHub repo settings
+        # WIP: for now we only echo the command to see if the rest works correctly
+        run: echo "gh pr merge --auto --squash \"$PR_URL\""
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Approve patch and minor updates
         if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
@@ -44,23 +44,6 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Get special token that can read organization users
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.PR_MANAGEMENT_APP_ID }}
-          private-key: ${{ secrets.PR_MANAGEMENT_PRIVATE_KEY }}
-
-      - name: Comment and request review on major updates
-        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major'}}
-        run: |
-          gh pr comment $PR_URL --body "I'm **not approving** this PR because **it includes a major update of a dependency**"
-          gh pr edit $PR_URL --add-label "Front end"
-          gh pr edit $PR_URL --add-reviewer Akuukis,magicznyleszek,pauloamorimbr
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{steps.app-token.outputs.token}}
 
   on-failure:
     if: |


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Drop broken major version handling. Log automerge command instead of doing them.