### PR TITLE
feat(permissions): Remove perm from kc only DEV-231

### DIFF
--- a/kobo/apps/openrosa/apps/main/migrations/0019_remove_PERM_FROM_KC_ONLY.py
+++ b/kobo/apps/openrosa/apps/main/migrations/0019_remove_PERM_FROM_KC_ONLY.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from kpi.models.object_permission import ObjectPermission
+
+PERM_FROM_KC_ONLY = 'from_kc_only'
+
+
+def noop(apps, schema_editor):
+    # Irreversible operation
+    pass
+
+
+def remove_kc_only_perm(apps, schema_editor):
+    deleted = ObjectPermission.objects.filter(
+        permission__codename=PERM_FROM_KC_ONLY
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0018_increase_metadata_data_file_max_length'),
+    ]
+
+    operations = [migrations.RunPython(remove_kc_only_perm, noop)]

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -431,15 +431,6 @@ class BaseDeploymentBackend(abc.ABC):
     def redeploy(self, active: bool = None):
         pass
 
-    def remove_from_kc_only_flag(self, *args, **kwargs):
-        # TODO: This exists only to support KoBoCAT (see #1161) and should be
-        # removed, along with all places where it is called, once we remove
-        # KoBoCAT's ability to assign permissions (kobotoolbox/kobocat#642)
-
-        # Do nothing, without complaint, so that callers don't have to worry
-        # about whether the back end is KoBoCAT or something else
-        pass
-
     @abc.abstractmethod
     def rename_enketo_id_key(
         self, previous_owner_username: str, project_identifier: str = None

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -69,7 +69,6 @@ from kpi.exceptions import (
 from kpi.fields import KpiUidField
 from kpi.interfaces.sync_backend_media import SyncBackendMediaInterface
 from kpi.models.asset_file import AssetFile
-from kpi.models.object_permission import ObjectPermission
 from kpi.models.paired_data import PairedData
 from kpi.utils.files import ExtendedContentFile
 from kpi.utils.log import logging

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -51,7 +51,6 @@ from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.constants import (
     PERM_CHANGE_SUBMISSIONS,
     PERM_DELETE_SUBMISSIONS,
-    PERM_FROM_KC_ONLY,
     PERM_PARTIAL_SUBMISSIONS,
     PERM_VALIDATE_SUBMISSIONS,
     PERM_VIEW_SUBMISSIONS,
@@ -917,39 +916,6 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 'version': self.asset.version_id,
             }
         )
-
-    def remove_from_kc_only_flag(
-        self, specific_user: Union[int, settings.AUTH_USER_MODEL] = None
-    ):
-        """
-        Removes `from_kc_only` flag for ALL USERS unless `specific_user` is
-        provided
-
-        Args:
-            specific_user (int, User): User object or pk
-        """
-        # This flag lets us know that permission assignments in KPI exist
-        # only because they were copied from KoBoCAT (by `sync_from_kobocat`).
-        # As soon as permissions are assigned through KPI, this flag must be
-        # removed
-        #
-        # This method is here instead of `ObjectPermissionMixin` because
-        # it's specific to KoBoCat as backend.
-
-        # TODO: Remove this method after kobotoolbox/kobocat#642
-
-        filters = {
-            'permission__codename': PERM_FROM_KC_ONLY,
-            'asset_id': self.asset.id,
-        }
-        if specific_user is not None:
-            try:
-                user_id = specific_user.pk
-            except AttributeError:
-                user_id = specific_user
-            filters['user_id'] = user_id
-
-        ObjectPermission.objects.filter(**filters).delete()
 
     def rename_enketo_id_key(
         self, previous_owner_username: str, project_identifier: str = None

--- a/kpi/mixins/object_permission.py
+++ b/kpi/mixins/object_permission.py
@@ -17,7 +17,6 @@ from kobo.apps.project_views.models.project_view import ProjectView
 from kpi.constants import (
     ASSET_TYPE_SURVEY,
     ASSET_TYPES_WITH_CHILDREN,
-    PERM_FROM_KC_ONLY,
     PREFIX_PARTIAL_PERMS,
 )
 from kpi.deployment_backends.kc_access.utils import (
@@ -951,8 +950,6 @@ class ObjectPermissionViewSetMixin:
         object_permissions = ObjectPermission.objects.filter(
             asset_id__in=asset_ids,
             deny=False,
-        ).exclude(
-            permission__codename=PERM_FROM_KC_ONLY
         ).select_related(
             'user', 'permission'
         ).order_by(

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -49,7 +49,6 @@ from kpi.constants import (
     PERM_DELETE_ASSET,
     PERM_DELETE_SUBMISSIONS,
     PERM_DISCOVER_ASSET,
-    PERM_FROM_KC_ONLY,
     PERM_MANAGE_ASSET,
     PERM_PARTIAL_SUBMISSIONS,
     PERM_VALIDATE_SUBMISSIONS,
@@ -319,10 +318,6 @@ class Asset(
             (PERM_CHANGE_SUBMISSIONS, t('Can modify submitted data for asset')),
             (PERM_DELETE_SUBMISSIONS, t('Can delete submitted data for asset')),
             (PERM_VALIDATE_SUBMISSIONS, t('Can validate submitted data asset')),
-            # TEMPORARY Issue #1161: A flag to indicate that permissions came
-            # solely from `sync_kobocat_xforms` and not from any user
-            # interaction with KPI
-            (PERM_FROM_KC_ONLY, 'INTERNAL USE ONLY; DO NOT ASSIGN')
         )
 
         # Since Django 2.1, 4 permissions are added for each registered model:

--- a/kpi/serializers/v1/object_permission.py
+++ b/kpi/serializers/v1/object_permission.py
@@ -53,12 +53,6 @@ class ObjectPermissionSerializer(serializers.ModelSerializer):
         asset = validated_data['content_object']
         user = validated_data['user']
         perm = validated_data['permission'].codename
-        # TODO: Remove after kobotoolbox/kobocat#642
-        # I'm looking forward to the merge conflict this creates, aren't you?
-        if getattr(asset, 'has_deployment', False):
-            asset.deployment.remove_from_kc_only_flag(
-                specific_user=user
-            )
         return asset.assign_perm(user, perm)
 
 

--- a/kpi/utils/object_permission.py
+++ b/kpi/utils/object_permission.py
@@ -247,11 +247,12 @@ def get_user_permission_assignments_queryset(affected_object, user):
     # `affected_object.permissions` is a `GenericRelation(ObjectPermission)`
     # Don't Prefetch `content_object`.
     # See `AssetPermissionAssignmentSerializer.to_representation()`
-    queryset = affected_object.permissions.filter(deny=False).select_related(
-        'permission', 'user'
-    ).order_by(
-        'user__username', 'permission__codename'
-    ).all()
+    queryset = (
+        affected_object.permissions.filter(deny=False)
+        .select_related('permission', 'user')
+        .order_by('user__username', 'permission__codename')
+        .all()
+    )
 
     # Filtering is done in `get_queryset` instead of FilteredBackend class
     # because it's specific to `ObjectPermission`.

--- a/kpi/utils/object_permission.py
+++ b/kpi/utils/object_permission.py
@@ -13,7 +13,7 @@ from django_request_cache import cache_for_request
 from rest_framework import serializers
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kpi.constants import PERM_FROM_KC_ONLY, PERM_MANAGE_ASSET, PERM_VIEW_ASSET
+from kpi.constants import PERM_MANAGE_ASSET, PERM_VIEW_ASSET
 from kpi.utils.permissions import is_user_anonymous
 
 
@@ -251,7 +251,7 @@ def get_user_permission_assignments_queryset(affected_object, user):
         'permission', 'user'
     ).order_by(
         'user__username', 'permission__codename'
-    ).exclude(permission__codename=PERM_FROM_KC_ONLY).all()
+    ).all()
 
     # Filtering is done in `get_queryset` instead of FilteredBackend class
     # because it's specific to `ObjectPermission`.


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Deletes all references to PERM_FROM_KC_ONLY constant in the codebase. Also includes a migration script that removes all of the occurrences in the ObjectPermission table

### 👀 Preview steps
No need to test, this should covered in the unit tests. The whole permissions project should go through QA, though