### PR TITLE
ci(dependabot): dependabot workflow typo fix DEV-646

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: |
           gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
-          gh pr edit $PR_URL --add-label "Front end, automerge"
+          gh pr edit $PR_URL --add-label "Front end,automerge"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### 💭 Notes

Because of typo, workflow was looking for ` automerge` instead of `automerge` label.
