### PR TITLE
ci(dependabot): make it group all types of minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
       - "dependencies"
     groups:
       minor-and-patch:
-        applies-to: security-updates
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
### 💭 Notes

Previously it was grouping only security-updates.