### PR TITLE
fix(submissions): prevent the management command to crash when fixing rootUuid conflicts DEV-650 (backport of #5971)

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -91,11 +91,16 @@ class Command(BaseCommand):
                     instance.root_uuid = (
                         f'CONFLICT-{now}-{xform_id_string}-{old_uuid}'
                     )
-                    instance.xml = set_meta(
-                        instance.xml,
-                        'rootUuid',
-                        add_uuid_prefix(instance.root_uuid),
-                    )
+                    try:
+                        instance.xml = set_meta(
+                            instance.xml,
+                            'rootUuid',
+                            add_uuid_prefix(instance.root_uuid),
+                        )
+                    except ValueError:
+                        # instance has never been edited
+                        pass
+
                     instance.xml_hash = instance.get_hash(instance.xml)
                     if self._verbosity >= 2:
                         self.stdout.write(


### PR DESCRIPTION
### 📣 Summary
Fixes a crash in the `clean_duplicated_submissions_root_uuid` command when processing submissions without a `meta/rootUuid`.

### 📖 Description
This PR resolves an issue where the `clean_duplicated_submissions_root_uuid` management command would crash if it encountered a submission that had never been edited and whose XML lacked a `meta/rootUuid` node.

### Notes 
Backport of #5971 