### PR TITLE
docs(deprecation): fix release version for `v1` deprecation

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,4 +1,4 @@
-# Endpoint deprecation as of release 2.025.30
+# Endpoint deprecation as of release 2.025.14h
 
 ⚠️ The deprecated endpoints listed below will be permanently removed with the first release of 2026, scheduled for the week of **January 19, 2026**.
 


### PR DESCRIPTION
### 📣 Summary
Change release number to accurate version for `v1` endpoints deprecation
