### PR TITLE
feat(api): extend `/api/v2/users/`view to include more user stats DEV-232

### DIFF
--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -137,6 +137,14 @@ class FastAssetPagination(Paginated):
         return super().get_count(queryset)
 
 
+class LimitStartPagination(LimitOffsetPagination):
+    """
+    A pagination class that supports '?limit=<count>&start=<offset>' query parameters.
+    """
+
+    offset_query_param = 'start'
+
+
 class TinyPaginated(PageNumberPagination):
     """
     Same as Paginated with a small page size

--- a/kpi/serializers/v2/user.py
+++ b/kpi/serializers/v2/user.py
@@ -1,14 +1,22 @@
+import datetime
+import logging
 from zoneinfo import ZoneInfo
 
+import constance
+from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django_request_cache import cache_for_request
 from rest_framework import serializers
 from rest_framework.relations import HyperlinkedIdentityField
 
+from kobo.apps.accounts.serializers import SocialAccountSerializer
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import ASSET_TYPE_COLLECTION, PERM_DISCOVER_ASSET
 from kpi.models.asset import Asset, UserAssetSubscription
 from kpi.models.object_permission import ObjectPermission
+from kpi.serializers.v2.service_usage import ServiceUsageSerializer
+from kpi.utils.gravatar_url import gravatar_url
+from kpi.utils.object_permission import get_database_user
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -58,26 +66,181 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class UserListSerializer(UserSerializer):
+    extra_details_uid = serializers.SerializerMethodField()
+    is_staff = serializers.BooleanField(read_only=True)
+    last_login = serializers.SerializerMethodField()
+    validated_email = serializers.SerializerMethodField()
+    validated_password = serializers.SerializerMethodField()
+    mfa_is_active = serializers.SerializerMethodField()
+    sso_is_active = serializers.SerializerMethodField()
+    accepted_tos = serializers.SerializerMethodField()
+    projects_url = serializers.SerializerMethodField()
+    gravatar = serializers.SerializerMethodField()
+    social_accounts = SocialAccountSerializer(
+        source='socialaccount_set', many=True, read_only=True
+    )
+    organizations = serializers.SerializerMethodField()
     metadata = serializers.SerializerMethodField()
+    subscriptions = serializers.SerializerMethodField()
+    current_service_usage = serializers.SerializerMethodField()
     asset_count = serializers.SerializerMethodField()
+    deployed_asset_count = serializers.SerializerMethodField()
+    server_time = serializers.SerializerMethodField()
+    git_rev = serializers.SerializerMethodField()
 
     class Meta(UserSerializer.Meta):
         fields = (
-            'id',
+            'extra_details_uid',
             'username',
+            'first_name',
+            'last_name',
+            'email',
             'is_superuser',
+            'is_staff',
+            'is_active',
             'date_joined',
             'last_login',
-            'is_active',
-            'email',
-            'asset_count',
+            'validated_email',
+            'validated_password',
+            'mfa_is_active',
+            'sso_is_active',
+            'accepted_tos',
+            'url',
+            'projects_url',
+            'gravatar',
+            'social_accounts',
+            'organizations',
             'metadata',
+            'subscriptions',
+            'current_service_usage',
+            'asset_count',
+            'deployed_asset_count',
+            'public_collection_subscribers_count',
+            'public_collections_count',
+            'server_time',
+            'git_rev',
         )
+
+    def get_accepted_tos(self, obj) -> bool:
+        """
+        Verifies user acceptance of terms of service (tos) by checking that the tos
+        endpoint was called and stored the current time in the `private_data` property
+        """
+        try:
+            user_extra_details = obj.extra_details
+        except obj.extra_details.RelatedObjectDoesNotExist:
+            return False
+        accepted_tos = 'last_tos_accept_time' in user_extra_details.private_data.keys()
+        return accepted_tos
 
     def get_asset_count(self, user):
         return user.assets.count()
+
+    def get_current_service_usage(self, user):
+        # Cannot access service usage for anonymous users
+        if user.username == 'AnonymousUser':
+            return None
+
+        serializer = ServiceUsageSerializer(
+            instance=get_database_user(user), context=self.context
+        )
+        return serializer.data
+
+    def get_deployed_asset_count(self, user) -> int:
+        return user.assets.filter(_deployment_status='deployed').count()
+
+    def get_extra_details_uid(self, user):
+        if hasattr(user, 'extra_details'):
+            return user.extra_details.uid
+        return None
+
+    def get_git_rev(self, obj):
+        request = self.context.get('request', False)
+        if constance.config.EXPOSE_GIT_REV or (request and request.user.is_superuser):
+            return settings.GIT_REV
+        else:
+            return False
+
+    def get_gravatar(self, obj):
+        return gravatar_url(obj.email)
+
+    def get_last_login(self, obj):
+        if obj.last_login is not None:
+            return obj.last_login.astimezone(ZoneInfo('UTC')).strftime(
+                '%Y-%m-%dT%H:%M:%SZ'
+            )
+        return None
 
     def get_metadata(self, user):
         if not hasattr(user, 'extra_details'):
             return {}
         return user.extra_details.data
+
+    def get_mfa_is_active(self, user):
+        if hasattr(user, 'mfa_methods'):
+            return user.mfa_methods.filter(is_active=True).exists()
+        return False
+
+    def get_organizations(self, user):
+        if not user.organization:
+            return None
+        else:
+            return {
+                'organization_name': user.organization.name,
+                'organization_uid': (
+                    str(user.organization.id) if user.organization.id else None
+                ),
+                'role': user.organization.get_user_role(user),
+            }
+
+    def get_projects_url(self, obj):
+        return '/'.join((settings.KOBOCAT_URL, obj.username))
+
+    def get_server_time(self, obj):
+        return datetime.datetime.now(tz=ZoneInfo('UTC')).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    def get_sso_is_active(self, user):
+        return SocialAccount.objects.filter(user=user).exists()
+
+    def get_subscriptions(self, user):
+        if not settings.STRIPE_ENABLED:
+            return None
+        try:
+            subscriptions_queryset = (
+                user.organizations_organizationuser.all()
+                .select_related('organization')
+                .prefetch_related('organization__djstripe_customers__subscriptions')
+                .values_list(
+                    'organization__djstripe_customers__subscriptions', flat=True
+                )
+            )
+            all_subscriptions = {
+                sub for sub in subscriptions_queryset if sub is not None
+            }
+
+        except Exception as e:
+            logging.error(f"Error fetching subscriptions for user {user.id}: {e}")
+            return []
+
+        from djstripe.models import Subscription
+
+        actual_subscriptions = Subscription.objects.filter(
+            pk__in=list(all_subscriptions)
+        )
+        from kobo.apps.stripe.serializers import SubscriptionSerializer
+
+        return SubscriptionSerializer(
+            actual_subscriptions, many=True, context=self.context
+        ).data
+
+    def get_validated_email(self, obj):
+        try:
+            return obj.emailaddress_set.filter(primary=True, verified=True).exists()
+        except Exception as e:
+            logging.error(f"Error checking validated email for user {obj.id}: {e}")
+        return False
+
+    def get_validated_password(self, user):
+        if hasattr(user, 'extra_details'):
+            return user.extra_details.validated_password
+        return None

--- a/kpi/tests/api/v2/test_api_users.py
+++ b/kpi/tests/api/v2/test_api_users.py
@@ -2,6 +2,7 @@
 from django.urls import reverse
 from rest_framework import status
 
+from kobo.apps.kobo_auth.shortcuts import User
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
@@ -18,13 +19,15 @@ class UserListTests(BaseTestCase):
         """
         a superuser can query the entire user list and search
         """
-        url = reverse(self._get_endpoint('user-kpi-list'))
-        response = self.client.get(url, format='json')
+        response = self.client.get(self._get_list_url(), format='json')
         assert response.status_code == status.HTTP_200_OK
+        self.assertIn('count', response.data)
+        self.assertIn('results', response.data)
+        self.assertGreater(len(response.data['results']), 0)
 
         # test filtering by username
         q = '?q=adminuser'
-        response = self.client.get(url + q, format='json')
+        response = self.client.get(self._get_list_url() + q, format='json')
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['username'] == 'adminuser'
@@ -35,8 +38,7 @@ class UserListTests(BaseTestCase):
         """
         self.client.logout()
         self.client.login(username='someuser')
-        url = reverse(self._get_endpoint('user-kpi-list'))
-        response = self.client.get(url, format='json')
+        response = self.client.get(self._get_list_url(), format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_user_list_forbidden_anonymous_user(self):
@@ -44,8 +46,7 @@ class UserListTests(BaseTestCase):
         an anonymous user cannot query the entire user list
         """
         self.client.logout()
-        url = reverse(self._get_endpoint('user-kpi-list'))
-        response = self.client.get(url, format='json')
+        response = self.client.get(self._get_list_url(), format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_user_page_succeeds(self):
@@ -53,8 +54,7 @@ class UserListTests(BaseTestCase):
         we can retrieve user details
         """
         username = 'adminuser'
-        url = reverse(self._get_endpoint('user-kpi-detail'), args=[username])
-        response = self.client.get(url, format='json')
+        response = self.client.get(self._get_detail_url(username), format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('username', response.data)
         self.assertEqual(response.data['username'], username)
@@ -64,6 +64,95 @@ class UserListTests(BaseTestCase):
         verify that a 404 is returned when trying to retrieve details for an
         invalid user
         """
-        url = reverse(self._get_endpoint('user-kpi-detail'), args=['nonexistentuser'])
-        response = self.client.get(url, format='json')
+        response = self.client.get(
+            self._get_detail_url('nonexistentuser'), format='json'
+        )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_user_list_pagination_limit(self):
+        """
+        Test that pagination works with the 'limit' parameter.
+        """
+        url = self._get_list_url()
+        response = self.client.get(f'{url}?limit=1', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertIsNotNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
+
+        response = self.client.get(f'{url}?limit=100', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], len(response.data['results']))
+        self.assertIsNone(response.data['next'])
+        self.assertIsNone(response.data['previous'])
+
+    def test_user_list_pagination_start(self):
+        """
+        Test that pagination works with the 'start' parameter.
+        """
+        # Create more users to ensure pagination has enough data
+        for i in range(5):
+            User.objects.create_user(
+                username=f'paginateduser{i}',
+                email=f'paginated{i}@example.com',
+                password='pass',
+            )
+
+        url = self._get_list_url()
+        response = self.client.get(f'{url}?start=1&limit=1', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        # Verify the user is not the first one
+        first_user_in_fixture = User.objects.order_by('id').first()
+        self.assertNotEqual(
+            response.data['results'][0]['username'], first_user_in_fixture.username
+        )
+
+    def test_user_list_serializer_fields(self):
+        """
+        Verify that the UserListSerializer returns all expected fields
+        """
+        url = self._get_list_url()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        first_user_data = response.data['results'][0]
+
+        expected_fields = [
+            'extra_details_uid',
+            'username',
+            'first_name',
+            'last_name',
+            'email',
+            'is_superuser',
+            'is_staff',
+            'is_active',
+            'date_joined',
+            'last_login',
+            'validated_email',
+            'validated_password',
+            'mfa_is_active',
+            'sso_is_active',
+            'accepted_tos',
+            'url',
+            'projects_url',
+            'gravatar',
+            'social_accounts',
+            'organizations',
+            'metadata',
+            'subscriptions',
+            'current_service_usage',
+            'asset_count',
+            'deployed_asset_count',
+            'public_collection_subscribers_count',
+            'public_collections_count',
+            'server_time',
+            'git_rev',
+        ]
+        for field in expected_fields:
+            self.assertIn(field, first_user_data)
+
+    def _get_detail_url(self, username):
+        return reverse(self._get_endpoint('user-kpi-detail'), args=[username])
+
+    def _get_list_url(self):
+        return reverse(self._get_endpoint('user-kpi-list'))

--- a/kpi/views/v2/user.py
+++ b/kpi/views/v2/user.py
@@ -1,11 +1,11 @@
 from rest_framework import exceptions, mixins, renderers, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.filters import SearchFilter
+from kpi.paginators import LimitStartPagination
 from kpi.permissions import IsAuthenticated
 from kpi.serializers.v2.user import UserListSerializer, UserSerializer
 from kpi.tasks import sync_kobocat_xforms
@@ -13,15 +13,175 @@ from kpi.tasks import sync_kobocat_xforms
 
 class UserViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin):
     """
-    This viewset provides only the `detail` action; `list` is *not* provided to
-    avoid disclosing every username in the database
+    This endpoint allows interaction with user profiles. It provides
+    read access to individual user details and, for superusers, a list of all
+    users.
+
+    ---
+
+    ### List Users
+
+    Only available to superusers.
+
+    <pre class="prettyprint">
+    <b>GET</b> /users/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi]/api/v2/users/
+
+    > Response 200
+
+    >       {
+    >           "count": int,
+    >           "next": string,
+    >           "previous": string,
+    >           "results": [
+    >               {
+    >                   "extra_details_uid": string,
+    >                   "username": string,
+    >                   "first_name": string,
+    >                   "last_name": string,
+    >                   "email": string,
+    >                   "is_superuser": boolean,
+    >                   "is_staff": boolean,
+    >                   "is_active": boolean,
+    >                   "date_joined": "YYYY-MM-DDTHH:MM:SSZ",
+    >                   "last_login": "YYYY-MM-DDTHH:MM:SSZ",
+    >                   "validated_email": boolean,
+    >                   "validated_password": boolean,
+    >                   "mfa_is_active": boolean,
+    >                   "sso_is_active": boolean,
+    >                   "accepted_tos": boolean,
+    >                   "url": "https://[kpi]/users/user1/",
+    >                   "projects_url": "https://[kobocat]/user1",
+    >                   "gravatar": url,
+    >                   "social_accounts": [
+    >                       {
+    >                           "provider": string,
+    >                           "uid": string,
+    >                           "last_login": "YYYY-MM-DDTHH:MM:SSZ",
+    >                           "date_joined": "YYYY-MM-DDTHH:MM:SSZ",
+    >                           "email": string,
+    >                           "username": string
+    >                       }
+    >                   ],
+    >                   "organizations": {
+    >                       "organization_name": string,
+    >                       "organization_uid": string,
+    >                       "role": string
+    >                   },
+    >                   "metadata": {
+    >                       "bio": string,
+    >                       "city": string,
+    >                       "name": string,
+    >                       "gender": string,
+    >                       "sector": string,
+    >                       "country": string,
+    >                       "twitter": string,
+    >                       "linkedin": string,
+    >                       "instagram": string,
+    >                       "organization": string,
+    >                       "require_auth": string,
+    >                       "last_ui_language": string,
+    >                       "organization_type": string,
+    >                       "organization_website": string,
+    >                       "newsletter_subscription": string
+    >                   },
+    >                   "subscriptions": [],
+    >                   "current_service_usage": {
+    >                       "total_nlp_usage": {
+    >                           "asr_seconds_current_period": integer,
+    >                           "asr_seconds_all_time": integer,
+    >                           "mt_characters_current_period": integer,
+    >                           "mt_characters_all_time": integer,
+    >                       },
+    >                       "total_storage_bytes": integer,
+    >                       "total_submission_count": {
+    >                           "current_period": integer,
+    >                           "all_time": integer,
+    >                       },
+    >                       "balances": {
+    >                           "asr_seconds": {
+    >                               "effective_limit": integer,
+    >                               "balance_value": integer,
+    >                               "balance_percent": integer,
+    >                               "exceeded": boolean,
+    >                           },
+    >                           "mt_characters": {
+    >                               "effective_limit": integer,
+    >                               "balance_value": integer,
+    >                               "balance_percent": integer,
+    >                               "exceeded": boolean,
+    >                           },
+    >                           "storage_bytes": {
+    >                               "effective_limit": integer,
+    >                               "balance_value": integer,
+    >                               "balance_percent": integer,
+    >                               "exceeded": boolean,
+    >                           },
+    >                           "submission": {
+    >                               "effective_limit": integer,
+    >                               "balance_value": integer,
+    >                               "balance_percent": integer,
+    >                               "exceeded": boolean,
+    >                           }
+    >                       },
+    >                       "current_period_start": YYYY-MM-DDTHH:MM:SSZ,
+    >                       "current_period_end": YYYY-MM-DDTHH:MM:SSZ,
+    >                       "last_updated": YYYY-MM-DDTHH:MM:SSZ
+    >                   }
+    >                   "asset_count": integer,
+    >                   "deployed_asset_count": integer,
+    >                   "public_collection_subscribers_count": integer,
+    >                   "public_collections_count": integer,
+    >                   "server_time": "YYYY-MM-DDTHH:MM:SSZ",
+    >                   "git_rev": {
+    >                       "short": boolean,
+    >                       "long": boolean,
+    >                       "branch": boolean,
+    >                       "tag": boolean
+    >                   }
+    >               }
+    >           ]
+    >       }
+
+    This endpoint is paginated and accepts these parameters:
+
+    - `start`: The initial index from which to return the users
+    - `limit`: Number of users to return per page
+
+    ---
+
+    ### Retrieve User Details
+
+    <pre class="prettyprint">
+    <b>GET</b> /users/{username}/
+    </pre>
+
+    > Example
+    >
+    >       curl -X GET https://[kpi]/api/v2/users/user1/
+
+    > Response 200
+
+    >       {
+    >           "url": "https://[kpi]/users/user1/",
+    >           "username": string,
+    >           "date_joined": YYYY-MM-DDTHH:MM:SSZ,
+    >           "public_collection_subscribers_count": int,
+    >           "public_collections_count": int
+    >       }
+
+    ### Current User Endpoint
     """
 
     queryset = User.objects.all()
     filter_backends = (SearchFilter,)
     serializer_class = UserSerializer
     lookup_field = 'username'
-    pagination_class = LimitOffsetPagination
+    pagination_class = LimitStartPagination
     permission_classes = (IsAuthenticated,)
     search_default_field_lookups = [
         'username__icontains',


### PR DESCRIPTION
### 🗒️ Checklist

1. [X] run linter locally
2. [X] update developer docs (API, README, inline, etc.), if any
3. [X] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [X] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [X] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [X] fill in the template below and delete template comments
7. [X] review thyself: read the diff and repro the preview as written
8. [X] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Allow superusers to access more user details and current usage through the paginated `/api/v2/users/` endpoint

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have a superuser account and multiple users
2. Login as the superuser
3. navigate to `/api/v2/users/`
5. 🟢 [on PR] notice that you have access to all of the user data like their organizations, subscriptions, current service usage, and more
7. 🟢 notice that the endpoint supports pagination, ex: try `?limit=10&start=5`
8. Verify that all the fields are displaying the correct data. Ex: If the user has SSO activated on their account, make sure that `sso_is_active` is true. 
9. Login as normal user
10. 🟢 notice that only superusers can access the endpoint 
