### PR TITLE
fix(urlPattern): prevent `drf-spectacular` URL route misinterpretation with complex regex

### DIFF
--- a/kobo/apps/accounts/mixins.py
+++ b/kobo/apps/accounts/mixins.py
@@ -4,8 +4,14 @@ from django.shortcuts import get_object_or_404
 # https://www.django-rest-framework.org/api-guide/generic-views/#creating-custom-mixins
 class MultipleFieldLookupMixin:
     """
-    Apply this mixin to any view or viewset to get multiple field filtering
-    based on a `lookup_fields` attribute, instead of the default single field filtering.
+    Apply this mixin to any view or viewset to enable multi-field lookups
+    based on a `lookup_fields` attribute, instead of the default single-field lookup
+    (`lookup_field`).
+
+    ⚠️ Warning:
+    Make sure to declare the route using `.as_view()` so that `lookup_value_regex` is
+    properly applied. Avoid using DRF's automatic routers, which rely on the default
+    `lookup_field = 'pk'`.
     """
 
     def get_object(self):

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -25,7 +25,7 @@ class AccountsEmailTestCase(APITestCase):
         account = baker.make('socialaccount.SocialAccount', user=self.user)
         url = reverse(
             'socialaccount-detail',
-            kwargs={'pk': f'{account.provider}/{account.uid}'},
+            kwargs={'provider': account.provider, 'uid': account.uid},
         )
         res = self.client.delete(url)
         self.assertEqual(res.status_code, 204)

--- a/kobo/apps/accounts/urls.py
+++ b/kobo/apps/accounts/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 from rest_framework import routers
 
 from .views import EmailAddressViewSet, SocialAccountViewSet
@@ -7,9 +7,19 @@ from .tos import TOSView
 
 router = routers.SimpleRouter()
 router.register(r'emails', EmailAddressViewSet)
-router.register(r'social-accounts', SocialAccountViewSet)
+
+socialaccount_list = SocialAccountViewSet.as_view({'get': 'list'})
+socialaccount_detail = SocialAccountViewSet.as_view(
+    {'get': 'retrieve', 'delete': 'destroy'}
+)
 
 urlpatterns = [
     path('me/', include(router.urls)),
+    path('me/social-accounts/', socialaccount_list, name='socialaccount-list'),
+    re_path(
+        rf'^me/social-accounts/{SocialAccountViewSet.lookup_value_regex}/$',
+        socialaccount_detail,
+        name='socialaccount-detail',
+    ),
     path('me/tos/', TOSView.as_view(), name='tos'),
 ]

--- a/kobo/apps/accounts/urls.py
+++ b/kobo/apps/accounts/urls.py
@@ -1,9 +1,8 @@
 from django.urls import include, path, re_path
 from rest_framework import routers
 
-from .views import EmailAddressViewSet, SocialAccountViewSet
 from .tos import TOSView
-
+from .views import EmailAddressViewSet, SocialAccountViewSet
 
 router = routers.SimpleRouter()
 router.register(r'emails', EmailAddressViewSet)

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -4,6 +4,7 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.response import Response
 
 from kpi.permissions import IsAuthenticated
+from kpi.versioning import APIV2Versioning
 from .mixins import MultipleFieldLookupMixin
 from .serializers import EmailAddressSerializer, SocialAccountSerializer
 
@@ -27,6 +28,7 @@ class EmailAddressViewSet(
     queryset = EmailAddress.objects.all()
     serializer_class = EmailAddressSerializer
     permission_classes = (IsAuthenticated,)
+    versioning_class = APIV2Versioning
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
@@ -45,11 +47,12 @@ class SocialAccountViewSet(
     mixins.DestroyModelMixin,
     viewsets.GenericViewSet,
 ):
-    lookup_value_regex = r"(?P<provider>[^/.]+)/(?P<uid>[-\w]+)"
+    lookup_value_regex = r'(?P<provider>[^/.]+)/(?P<uid>[-\w]+)'
     lookup_fields = ['provider', 'uid']
     queryset = SocialAccount.objects.all()
     serializer_class = SocialAccountSerializer
     permission_classes = (IsAuthenticated,)
+    versioning_class = APIV2Versioning
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)

--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -399,7 +399,7 @@ class ProjectHistoryLog(AuditLog):
             'submission-bulk': cls._create_from_submission_request,
             'submission-validation-statuses': cls._create_from_submission_request,
             'submission-validation-status': cls._create_from_submission_request,
-            'assetsnapshot-submission-alias': cls._create_from_submission_request,
+            'assetsnapshot-submission-openrosa': cls._create_from_submission_request,
             'submissions': cls._create_from_submission_request,
             'submissions-list': cls._create_from_submission_request,
             'submission-detail': cls._create_from_submission_request,

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1614,7 +1614,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         edit_submission_xml(xml_parsed, 'Q1', 'new answer')
         edited_submission = xml_tostring(xml_parsed)
         url = reverse(
-            self._get_endpoint('api_v2:assetsnapshot-submission-alias'),
+            self._get_endpoint('api_v2:assetsnapshot-submission-openrosa'),
             args=(self.asset.snapshot().uid,),
         )
         data = {

--- a/kpi/schema_extensions/v2/openrosa/extensions.py
+++ b/kpi/schema_extensions/v2/openrosa/extensions.py
@@ -37,7 +37,7 @@ class OpenRosaManifestURLFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return build_url_type(
-            'api_v2:assetsnapshot-manifest-alias',
+            'api_v2:assetsnapshot-manifest-openrosa',
             uid='sEMPghTguZsxj4rn4s9dvS',
         )
 
@@ -66,7 +66,7 @@ class OpenRosaXFormFieldExtension(OpenApiSerializerFieldExtension):
                     uid='sEMPghTguZsxj4rn4s9dvS',
                 ),
                 'manifestUrl': build_url_type(
-                    'api_v2:assetsnapshot-manifest-alias',
+                    'api_v2:assetsnapshot-manifest-openrosa',
                     uid='sEMPghTguZsxj4rn4s9dvS',
                 ),
             }

--- a/kpi/tests/api/v1/test_api_asset_snapshots.py
+++ b/kpi/tests/api/v1/test_api_asset_snapshots.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+import pytest
+
 # importing module instead of the class, avoid running the tests twice
 from kpi.tests.api.v2 import test_api_asset_snapshots
 
@@ -7,3 +8,6 @@ class TestAssetSnapshotList(test_api_asset_snapshots.TestAssetSnapshotList):
 
     URL_NAMESPACE = None
 
+    @pytest.mark.skip(reason='Only usable in v2')
+    def test_head_requests_return_empty_responses(self):
+        pass

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -194,6 +194,9 @@ class SubmissionEditApiTests(test_api_submissions.SubmissionEditApiTests):
     def test_edit_submission_twice(self):
         pass
 
+    @pytest.mark.skip(reason='Only usable in v2')
+    def test_get_multiple_edit_links_and_attempt_submit_edits(self):
+        pass
 
 class SubmissionValidationStatusApiTests(test_api_submissions.SubmissionValidationStatusApiTests):  # noqa: E501
 

--- a/kpi/tests/api/v1/test_api_submissions.py
+++ b/kpi/tests/api/v1/test_api_submissions.py
@@ -198,6 +198,9 @@ class SubmissionEditApiTests(test_api_submissions.SubmissionEditApiTests):
     def test_get_multiple_edit_links_and_attempt_submit_edits(self):
         pass
 
-class SubmissionValidationStatusApiTests(test_api_submissions.SubmissionValidationStatusApiTests):  # noqa: E501
+
+class SubmissionValidationStatusApiTests(
+    test_api_submissions.SubmissionValidationStatusApiTests
+):
 
     URL_NAMESPACE = None

--- a/kpi/tests/api/v2/test_api_asset_snapshots.py
+++ b/kpi/tests/api/v2/test_api_asset_snapshots.py
@@ -159,9 +159,9 @@ class TestAssetSnapshotList(AssetSnapshotBase):
         with 204 status codes and the appropriate headers set
         """
         VIEW_NAMES_TO_TEST = [
-            'assetsnapshot-form-list',
-            'assetsnapshot-manifest',
-            'assetsnapshot-submission',
+            'assetsnapshot-form-list-openrosa',
+            'assetsnapshot-manifest-openrosa',
+            'assetsnapshot-submission-openrosa',
         ]
         creation_response = self._create_asset_snapshot_from_asset()
         snapshot_uid = creation_response.data['uid']

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1417,7 +1417,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
 
     def test_edit_submission_with_digest_credentials(self):
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=(self.asset.snapshot().uid,),
         )
         self.client.logout()
@@ -1452,7 +1452,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
 
     def test_edit_submission_with_authenticated_session_but_no_digest(self):
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=(self.asset.snapshot().uid,),
         )
         self.login_as_other_user('anotheruser', 'anotheruser')
@@ -1500,7 +1500,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
             )
             self.client.get(edit_url, {'format': 'json'})
             url = reverse(
-                self._get_endpoint('assetsnapshot-submission'),
+                self._get_endpoint('assetsnapshot-submission-openrosa'),
                 args=(self.asset.snapshot().uid,),
             )
             submission_urls.append(url)
@@ -1748,7 +1748,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
     def test_edit_submission_snapshot_missing(self):
         # use non-existent snapshot id
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=('12345',),
         )
         client = DigestClient()
@@ -1758,7 +1758,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
     def test_edit_submission_snapshot_missing_unauthenticated(self):
         # use non-existent snapshot id
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=('12345',),
         )
         self.client.logout()
@@ -1795,7 +1795,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         edited_submission = xml_tostring(xml_parsed)
 
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=(self.asset.snapshot().uid,),
         )
         self.client.logout()
@@ -1906,7 +1906,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         # Enketo splits large submissions into chunks (max 10 MB per request).
         # Here we simulate that by sending one attachment per request.
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=(snapshot.uid,),
         )
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1199,20 +1199,30 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
 
         self._add_submissions()
         self.submission = self.submissions_submitted_by_someuser[0]
-        self.submission_url_legacy = reverse(
+
+        # Several URLs share the same viewname 'submission-enketo-edit' because
+        # of aliases. Django returns the last match - which is "/enketo/edit/"
+        self.submission_url = reverse(
             self._get_endpoint('submission-enketo-edit'),
             kwargs={
                 'parent_lookup_asset': self.asset.uid,
                 'pk': self.submission['_id'],
             },
         )
-        self.submission_url = self.submission_url_legacy.replace(
-            'edit', 'enketo/edit'
+        self.submission_url_legacy = reverse(
+            self._get_endpoint('submission-enketo-edit-legacy'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': self.submission['_id'],
+            },
         )
-        self.submission_redirect_url = self.submission_url_legacy.replace(
-            'edit', 'enketo/redirect/edit'
+        self.submission_redirect_url = reverse(
+            self._get_endpoint('submission-enketo-edit-redirect'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': self.submission['_id'],
+            },
         )
-        assert 'redirect' in self.submission_redirect_url
 
     @responses.activate
     def test_get_legacy_edit_link_submission_as_owner(self):
@@ -1263,9 +1273,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
             content_type='application/json',
         )
 
-        response = self.client.get(
-            self.submission_redirect_url, {'format': 'json'}
-        )
+        response = self.client.get(self.submission_redirect_url, {'format': 'json'})
         assert response.status_code == status.HTTP_302_FOUND
         assert (
             response.url
@@ -1961,10 +1969,12 @@ class SubmissionViewApiTests(SubmissionViewTestCaseMixin, BaseSubmissionTestCase
                 'pk': self.submission['_id'],
             },
         )
-        self.submission_view_redirect_url = (
-            self.submission_view_link_url.replace(
-                '/enketo/view/', '/enketo/redirect/view/'
-            )
+        self.submission_view_redirect_url = reverse(
+            self._get_endpoint('submission-enketo-view-redirect'),
+            kwargs={
+                'parent_lookup_asset': self.asset.uid,
+                'pk': self.submission['_id'],
+            },
         )
         assert 'redirect' in self.submission_view_redirect_url
 

--- a/kpi/tests/utils/mixins.py
+++ b/kpi/tests/utils/mixins.py
@@ -9,13 +9,11 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import remove_uuid_prefix
 from kpi.models.asset_file import AssetFile
 from kpi.tests.utils.mock import (
     enketo_edit_instance_response,
     enketo_view_instance_response,
-)
-from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
-    remove_uuid_prefix,
 )
 from kpi.utils.xml import (
     edit_submission_xml,

--- a/kpi/tests/utils/mixins.py
+++ b/kpi/tests/utils/mixins.py
@@ -244,7 +244,7 @@ class SubmissionEditTestCaseMixin:
 
         # Submit the edited XML
         url = reverse(
-            self._get_endpoint('assetsnapshot-submission-alias'),
+            self._get_endpoint('assetsnapshot-submission-openrosa'),
             args=(snapshot.uid,),
         )
 

--- a/kpi/tests/utils/mixins.py
+++ b/kpi/tests/utils/mixins.py
@@ -195,15 +195,12 @@ class SubmissionEditTestCaseMixin:
             content_type='application/json',
         )
 
-        submission_edit_link_url_legacy = reverse(
+        submission_edit_link_url = reverse(
             self._get_endpoint('submission-enketo-edit'),
             kwargs={
                 'parent_lookup_asset': self.asset.uid,
                 'pk': self.submission['_id'],
             },
-        )
-        submission_edit_link_url = submission_edit_link_url_legacy.replace(
-            'edit', 'enketo/edit'
         )
 
         response = self.client.get(submission_edit_link_url, {'format': 'json'})

--- a/kpi/urls/__init__.py
+++ b/kpi/urls/__init__.py
@@ -4,18 +4,14 @@ from django.urls import include, path, re_path
 from django.views.i18n import JavaScriptCatalog
 
 from hub.models import ConfigurationFile
-from kpi.views import (
-    authorized_application_authenticate_user,
-    home,
-    modern_browsers,
-)
+from kpi.views import authorized_application_authenticate_user, home, modern_browsers
 from kpi.views.current_user import CurrentUserViewSet
 from kpi.views.environment import EnvironmentView
 from kpi.views.token import TokenView
-from .router_api_v1 import urls_patterns as router_api_v1_urls
-from .router_api_v2 import urls_patterns as router_api_v2_urls, URL_NAMESPACE
 from ..views.v2.logout import logout_from_all_devices
-
+from .router_api_v1 import urls_patterns as router_api_v1_urls
+from .router_api_v2 import URL_NAMESPACE
+from .router_api_v2 import urls_patterns as router_api_v2_urls
 
 # TODO: Give other apps their own `urls.py` files instead of importing their
 # views directly! See

--- a/kpi/urls/__init__.py
+++ b/kpi/urls/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import private_storage.urls
 from django.conf import settings
 from django.urls import include, path, re_path
@@ -14,7 +13,7 @@ from kpi.views.current_user import CurrentUserViewSet
 from kpi.views.environment import EnvironmentView
 from kpi.views.token import TokenView
 from .router_api_v1 import router_api_v1
-from .router_api_v2 import router_api_v2, URL_NAMESPACE
+from .router_api_v2 import urls_patterns as router_api_v2_urls, URL_NAMESPACE
 from ..views.v2.logout import logout_from_all_devices
 
 
@@ -32,7 +31,7 @@ urlpatterns = [
         'delete': 'destroy',
     }), name='currentuser-detail'),
     re_path(r'^', include(router_api_v1.urls)),
-    re_path(r'^api/v2/', include((router_api_v2.urls, URL_NAMESPACE))),
+    re_path(r'^api/v2/', include((router_api_v2_urls, URL_NAMESPACE))),
     path('', include('kobo.apps.accounts.urls')),
     path('', include('kobo.apps.service_health.urls')),
     re_path(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),

--- a/kpi/urls/__init__.py
+++ b/kpi/urls/__init__.py
@@ -12,7 +12,7 @@ from kpi.views import (
 from kpi.views.current_user import CurrentUserViewSet
 from kpi.views.environment import EnvironmentView
 from kpi.views.token import TokenView
-from .router_api_v1 import router_api_v1
+from .router_api_v1 import urls_patterns as router_api_v1_urls
 from .router_api_v2 import urls_patterns as router_api_v2_urls, URL_NAMESPACE
 from ..views.v2.logout import logout_from_all_devices
 
@@ -30,7 +30,7 @@ urlpatterns = [
         'patch': 'partial_update',
         'delete': 'destroy',
     }), name='currentuser-detail'),
-    re_path(r'^', include(router_api_v1.urls)),
+    re_path(r'^', include(router_api_v1_urls)),
     re_path(r'^api/v2/', include((router_api_v2_urls, URL_NAMESPACE))),
     path('', include('kobo.apps.accounts.urls')),
     path('', include('kobo.apps.service_health.urls')),

--- a/kpi/urls/router_api_v1.py
+++ b/kpi/urls/router_api_v1.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+from django.urls import path
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
 from kobo.apps.hook.views.v1.hook import HookViewSet
@@ -64,3 +64,26 @@ router_api_v1.register(r'sitewide_messages', SitewideMessageViewSet)
 router_api_v1.register(r'authorized_application/users',
                        AuthorizedApplicationUserViewSet,
                        basename='authorized_applications')
+
+
+# Create aliases here instead of using complex regex patterns in the `url_path`
+# parameter of the @action decorator. DRF and drf-spectacular struggle to interpret
+# them correctly, often resulting in broken routes and schema generation errors.
+enketo_url_aliases = [
+    path(
+        'assets/<parent_lookup_asset>/submissions/<pk>/edit/',
+        SubmissionViewSet.as_view({'get': 'enketo_edit'}),
+        name='submission-enketo-edit-legacy',
+    ),
+    path(
+        'assets/<parent_lookup_asset>/submissions/<pk>/enketo/redirect/edit/',
+        SubmissionViewSet.as_view({'get': 'enketo_edit'}),
+        name='submission-enketo-edit-redirect',
+    ),
+    path(
+        'assets/<parent_lookup_asset>/submissions/<pk>/enketo/redirect/view/',
+        SubmissionViewSet.as_view({'get': 'enketo_view'}),
+        name='submission-enketo-view-redirect',
+    ),
+]
+urls_patterns = router_api_v1.urls + enketo_url_aliases

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-from django.urls import path
+from django.urls import path, re_path
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
 from kobo.apps.audit_log.urls import router as audit_log_router
@@ -193,3 +191,27 @@ router_api_v2.registry.extend(audit_log_router.registry)
 # router_api_v2.register(r'authorized_application/users',
 #                        AuthorizedApplicationUserViewSet,
 #                        basename='authorized_applications')
+
+
+# Create aliases here instead of using complex regex patterns in the `url_path`
+# parameter of the @action decorator. DRF and drf-spectacular struggle to interpret
+# them correctly, often resulting in broken routes and schema generation errors.
+enketo_url_aliases = [
+    path(
+        'assets/<parent_lookup_asset>/data/<pk>/edit/',
+        DataViewSet.as_view({'get': 'enketo_edit'}),
+        name='submission-enketo-edit',
+    ),
+    path(
+        'assets/<parent_lookup_asset>/data/<pk>/enketo/redirect/edit/',
+        DataViewSet.as_view({'get': 'enketo_edit'}),
+        name='submission-enketo-edit',
+    ),
+    path(
+        'assets/<parent_lookup_asset>/data/<pk>/enketo/redirect/view/',
+        DataViewSet.as_view({'get': 'enketo_view'}),
+        name='submission-enketo-view',
+    ),
+]
+
+urls_patterns = router_api_v2.urls + enketo_url_aliases

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -33,7 +33,7 @@ from kpi.views.v2.user import UserViewSet
 from kpi.views.v2.user_asset_subscription import UserAssetSubscriptionViewSet
 
 
-class ExtendedDefaultRouterWithPathAliases(ExtendedDefaultRouter):
+class OpenRosaCompatibleExtendedRouter(ExtendedDefaultRouter):
     """
     Historically, all of this application's endpoints have used trailing
     slashes (the DRF default). Requests missing their trailing slashes have
@@ -54,6 +54,11 @@ class ExtendedDefaultRouterWithPathAliases(ExtendedDefaultRouter):
             'assetsnapshot-manifest': 'asset_snapshots/<uid>/manifest',
             'assetsnapshot-submission': 'asset_snapshots/<uid>/submission',
         }
+
+        # Remove the original urls matching the names
+        original_urls = [url for url in urls if url.name not in names_to_alias_paths]
+
+        # Add only alias versions
         alias_urls = []
         for url in urls:
             if url.name in names_to_alias_paths:
@@ -61,15 +66,15 @@ class ExtendedDefaultRouterWithPathAliases(ExtendedDefaultRouter):
                 # only consider the first match
                 del names_to_alias_paths[url.name]
                 alias_urls.append(
-                    path(alias_paths, url.callback, name=f'{url.name}-alias')
+                    path(alias_paths, url.callback, name=f'{url.name}-openrosa')
                 )
-        urls.extend(alias_urls)
-        return urls
+        original_urls.extend(alias_urls)
+        return original_urls
 
 
 URL_NAMESPACE = 'api_v2'
 
-router_api_v2 = ExtendedDefaultRouterWithPathAliases()
+router_api_v2 = OpenRosaCompatibleExtendedRouter()
 asset_routes = router_api_v2.register(r'assets', AssetViewSet, basename='asset')
 
 asset_routes.register(r'counts',

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
 from kobo.apps.audit_log.urls import router as audit_log_router
@@ -200,17 +200,17 @@ enketo_url_aliases = [
     path(
         'assets/<parent_lookup_asset>/data/<pk>/edit/',
         DataViewSet.as_view({'get': 'enketo_edit'}),
-        name='submission-enketo-edit',
+        name='submission-enketo-edit-legacy',
     ),
     path(
         'assets/<parent_lookup_asset>/data/<pk>/enketo/redirect/edit/',
         DataViewSet.as_view({'get': 'enketo_edit'}),
-        name='submission-enketo-edit',
+        name='submission-enketo-edit-redirect',
     ),
     path(
         'assets/<parent_lookup_asset>/data/<pk>/enketo/redirect/view/',
         DataViewSet.as_view({'get': 'enketo_view'}),
-        name='submission-enketo-view',
+        name='submission-enketo-view-redirect',
     ),
 ]
 

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -21,7 +21,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'assetsnapshot-detail': '/api/v2/asset_snapshots/{uid}/',
         'assetsnapshot-preview': '/api/v2/asset_snapshots/{uid}/preview/',
         'assetsnapshot-xml-with-disclaimer': '/api/v2/asset_snapshots/{uid}/xml_with_disclaimer/',  # noqa
-        'assetsnapshot-manifest-alias': '/api/v2/asset_snapshots/{uid}/manifest/',
+        'assetsnapshot-manifest-openrosa': '/api/v2/asset_snapshots/{uid}/manifest/',
         'userassetsubscription-detail': '/api/v2/asset_subscription/{uid}/',
         'asset-version-detail': '/api/v2/assets/{parent_lookup_asset}/versions/{uid}/',
         'asset-xform': '/api/v2/assets/{uid}/xform/',

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -9,8 +9,10 @@ from rest_framework.response import Response
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.trash_bin.utils import move_to_trash
-from kpi.schema_extensions.v2.me.serializers import CurrentUserDeleteRequest, \
-    MeListResponse
+from kpi.schema_extensions.v2.me.serializers import (
+    CurrentUserDeleteRequest,
+    MeListResponse,
+)
 from kpi.serializers import CurrentUserSerializer
 from kpi.utils.schema_extensions.markdown import read_md
 from kpi.utils.schema_extensions.response import (

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -83,7 +83,7 @@ thumbnail_suffixes_pattern = 'original|' + '|'.join(
             raise_access_forbidden=False,
             validate_payload=False,
         ),
-        operation_id='attachment-thumbnail'
+        operation_id='attachment-thumbnail',
     ),
 )
 class AttachmentViewSet(

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from typing import Optional, Union
 
 from django.conf import settings
@@ -84,6 +83,7 @@ thumbnail_suffixes_pattern = 'original|' + '|'.join(
             raise_access_forbidden=False,
             validate_payload=False,
         ),
+        operation_id='attachment-thumbnail'
     ),
 )
 class AttachmentViewSet(
@@ -130,7 +130,7 @@ class AttachmentViewSet(
     @action(
         detail=True,
         methods=['GET'],
-        url_path=f'(?P<suffix>({thumbnail_suffixes_pattern}))'
+        url_path=f'(?P<suffix>({thumbnail_suffixes_pattern}))',
     )
     def thumb(self, request, pk, suffix, *args, **kwargs):
         if suffix != 'original':

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -289,7 +289,7 @@ class DataViewSet(
         methods=['GET'],
         renderer_classes=[renderers.JSONRenderer],
         permission_classes=[EditLinkSubmissionPermission],
-        url_path='((enketo/)|(enketo/redirect/))?edit',
+        url_path='enketo/edit',
     )
     def enketo_edit(self, request, pk, *args, **kwargs):
         submission_id = positive_int(pk)
@@ -308,7 +308,7 @@ class DataViewSet(
         methods=['GET'],
         renderer_classes=[renderers.JSONRenderer],
         permission_classes=[ViewSubmissionPermission],
-        url_path='enketo/(redirect/)?view',
+        url_path='enketo/view',
     )
     def enketo_view(self, request, pk, *args, **kwargs):
         submission_id = positive_int(pk)


### PR DESCRIPTION
### 📣 Summary
Fix route detection issues in schema generation when using complex regex patterns

### 📖 Description
DRF and drf-spectacular can misinterpret complex `url_path` regex patterns in `@action` decorators, leading to broken or incorrect routes in the generated OpenAPI schema.

This fix ensures that such routes are now correctly handled by simplifying or avoiding regex in `url_path`, and instead using clearer route definitions or aliases when needed.


### 👀 Preview steps

1. Go to `/api/v2/docs/`
2. Look at the console
3. 🔴 [on base branch] notice `Error: namespace versioning path resolution failed` and `Warning: operationId {url} has collisions`
4. 🟢 [on PR] notice that there no more errors or Warning for `api/v2` endpoints.
