### PR TITLE
docs(api): adding API endpoints for email in KPI documentation DEV-831

### DIFF
--- a/kobo/apps/accounts/docs/api/v2/email/create.md
+++ b/kobo/apps/accounts/docs/api/v2/email/create.md
@@ -1,0 +1,4 @@
+## Set a new email
+
+The new email will be unverified and replace existing unverified, non-primary emails.
+New email is not usable until verified.

--- a/kobo/apps/accounts/docs/api/v2/email/list.md
+++ b/kobo/apps/accounts/docs/api/v2/email/list.md
@@ -1,0 +1,1 @@
+## View current user's email

--- a/kobo/apps/accounts/extend_schemas/api/v2/email/serializers.py
+++ b/kobo/apps/accounts/extend_schemas/api/v2/email/serializers.py
@@ -5,6 +5,6 @@ from kpi.utils.schema_extensions.serializers import inline_serializer_class
 EmailRequestPayload = inline_serializer_class(
     name='EmailRequestPayload',
     fields={
-        "email": serializers.EmailField(),
+        'email': serializers.EmailField(),
     },
 )

--- a/kobo/apps/accounts/extend_schemas/api/v2/email/serializers.py
+++ b/kobo/apps/accounts/extend_schemas/api/v2/email/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from kpi.utils.schema_extensions.serializers import inline_serializer_class
+
+EmailRequestPayload = inline_serializer_class(
+    name='EmailRequestPayload',
+    fields={
+        "email": serializers.EmailField(),
+    },
+)

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -2,7 +2,6 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
-from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -11,7 +11,7 @@ from kpi.utils.schema_extensions.markdown import read_md
 from kpi.utils.schema_extensions.response import open_api_200_ok_response, \
     open_api_201_created_response
 from kpi.versioning import APIV2Versioning
-from .extend_schemas.api.v2.emails.serializers import EmailRequestPayload
+from .extend_schemas.api.v2.email.serializers import EmailRequestPayload
 from .mixins import MultipleFieldLookupMixin
 from .serializers import EmailAddressSerializer, SocialAccountSerializer
 
@@ -21,7 +21,7 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
 )
 @extend_schema_view(
     list=extend_schema(
-        description=read_md('accounts', 'emails/list.md'),
+        description=read_md('accounts', 'email/list.md'),
         responses=open_api_200_ok_response(
             EmailAddressSerializer,
             raise_not_found=False,
@@ -30,7 +30,7 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
         )
     ),
     create=extend_schema(
-        description=read_md('accounts', 'emails/create.md'),
+        description=read_md('accounts', 'email/create.md'),
         request={'application/json': EmailRequestPayload},
         responses=open_api_201_created_response(
             EmailAddressSerializer,

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -1,14 +1,36 @@
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from kpi.permissions import IsAuthenticated
+from kpi.utils.schema_extensions.response import open_api_200_ok_response, \
+    open_api_201_created_response
 from kpi.versioning import APIV2Versioning
 from .mixins import MultipleFieldLookupMixin
 from .serializers import EmailAddressSerializer, SocialAccountSerializer
 
 
+@extend_schema(
+    tags=['Me'],
+)
+@extend_schema_view(
+    list=extend_schema(
+        description='list',
+        responses=open_api_200_ok_response(
+            EmailAddressSerializer,
+        )
+    ),
+    create=extend_schema(
+        description='create',
+        responses=open_api_201_created_response(
+            EmailAddressSerializer,
+        )
+    )
+)
 class EmailAddressViewSet(
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -29,6 +51,9 @@ class EmailAddressViewSet(
     serializer_class = EmailAddressSerializer
     permission_classes = (IsAuthenticated,)
     versioning_class = APIV2Versioning
+    renderer_classes = [
+        JSONRenderer,
+    ]
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -24,6 +24,9 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
         description=read_md('accounts', 'emails/list.md'),
         responses=open_api_200_ok_response(
             EmailAddressSerializer,
+            raise_not_found=False,
+            raise_access_forbidden=False,
+            validate_payload=False,
         )
     ),
     create=extend_schema(
@@ -31,6 +34,8 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
         request={'application/json': EmailRequestPayload},
         responses=open_api_201_created_response(
             EmailAddressSerializer,
+            raise_not_found=False,
+            raise_access_forbidden=False,
         )
     )
 )

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -7,6 +7,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from kpi.permissions import IsAuthenticated
+from kpi.utils.schema_extensions.markdown import read_md
 from kpi.utils.schema_extensions.response import open_api_200_ok_response, \
     open_api_201_created_response
 from kpi.versioning import APIV2Versioning
@@ -20,13 +21,13 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
 )
 @extend_schema_view(
     list=extend_schema(
-        description='list',
+        description=read_md('accounts', 'emails/list.md'),
         responses=open_api_200_ok_response(
             EmailAddressSerializer,
         )
     ),
     create=extend_schema(
-        description='create',
+        description=read_md('accounts', 'emails/create.md'),
         request={'application/json': EmailRequestPayload},
         responses=open_api_201_created_response(
             EmailAddressSerializer,
@@ -39,14 +40,15 @@ class EmailAddressViewSet(
     viewsets.GenericViewSet,
 ):
     """
-    View and change email. Allow only 1 primary/confirmed email.
+    Viewset for managing current user email address
 
-    Set a new email: POST a new email address. The new email will be unverified
-    and replace existing unverfied, non-primary emails. New email is not usable
-    until verified.
+    Available actions:
+    - list           → GET       /me/
+    - create         → CREATE    /me/
 
-    Delete unconfirmed email: DELETE with no body will delete any existing
-    non-primary/non-verified emails.
+    Documentation:
+    - docs/api/v2/me/list.md
+    - docs/api/v2/me/create.md
     """
 
     queryset = EmailAddress.objects.all()

--- a/kobo/apps/accounts/views.py
+++ b/kobo/apps/accounts/views.py
@@ -10,6 +10,7 @@ from kpi.permissions import IsAuthenticated
 from kpi.utils.schema_extensions.response import open_api_200_ok_response, \
     open_api_201_created_response
 from kpi.versioning import APIV2Versioning
+from .extend_schemas.api.v2.emails.serializers import EmailRequestPayload
 from .mixins import MultipleFieldLookupMixin
 from .serializers import EmailAddressSerializer, SocialAccountSerializer
 
@@ -26,6 +27,7 @@ from .serializers import EmailAddressSerializer, SocialAccountSerializer
     ),
     create=extend_schema(
         description='create',
+        request={'application/json': EmailRequestPayload},
         responses=open_api_201_created_response(
             EmailAddressSerializer,
         )


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/email` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `email` endpoint. With these changes, users will be able to understand, test and use the `email` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `email` endpoint, scroll down to the `Me` category or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.