### PR TITLE
fix(termsOfService):  add new `/api/v2/terms-of-service` endpoint to replace deprecated `sitewidemessage` API DEV-807

### DIFF
--- a/jsapp/js/tos/tosForm.component.tsx
+++ b/jsapp/js/tos/tosForm.component.tsx
@@ -19,7 +19,7 @@ const TOS_SLUG_TRANSLATED = `${TOS_SLUG}_<language>`
 
 const ME_ENDPOINT = '/me/'
 const TOS_ACCEPT_ENDPOINT = '/me/tos/'
-const SITEWIDE_MESSAGES_ENDPOINT = '/sitewide_messages/'
+const TOS_MESSAGES_ENDPOINT = '/api/v2/terms-of-service/'
 
 interface MePatchFailResponse {
   responseJSON: {
@@ -28,12 +28,13 @@ interface MePatchFailResponse {
 }
 
 interface SitewideMessage {
+  url: string
   slug: string
   /** HTML or Markdown code. For TOS Announcement this will definitely be HTML. */
   body: string
 }
 
-type SitewideMessagesResponse = PaginatedResponse<SitewideMessage>
+type SitewideMessagesResponse = SitewideMessage[]
 
 /**
  * This form displays a TOS announcement message together with user metadata
@@ -59,13 +60,13 @@ export default function TOSForm() {
   useEffect(() => {
     const getTOS = async () => {
       try {
-        const response = await fetchGet<SitewideMessagesResponse>(SITEWIDE_MESSAGES_ENDPOINT)
+        const response = await fetchGet<SitewideMessagesResponse>(TOS_MESSAGES_ENDPOINT)
 
         // First we try to find and set the translated TOS message, if not present
         // we go with fallback. Otherwise we will display an error.
         const translatedSlug = TOS_SLUG_TRANSLATED.replace('<language>', currentLang())
-        const translatedMessage = response.results.find((item) => item.slug === translatedSlug)
-        const fallbackMessage = response.results.find((item) => item.slug === TOS_SLUG)
+        const translatedMessage = response.find((item) => item.slug === translatedSlug)
+        const fallbackMessage = response.find((item) => item.slug === TOS_SLUG)
         if (translatedMessage) {
           setAnnouncementMessage(translatedMessage.body)
         } else if (fallbackMessage) {

--- a/kpi/serializers/v2/tos.py
+++ b/kpi/serializers/v2/tos.py
@@ -1,0 +1,26 @@
+from rest_framework import serializers
+from rest_framework.relations import HyperlinkedIdentityField
+
+from hub.models import SitewideMessage
+
+
+class TermsOfServiceSerializer(serializers.ModelSerializer):
+
+    url = HyperlinkedIdentityField(
+        lookup_field='slug',
+        view_name='terms-of-service-detail'
+    )
+
+    class Meta:
+        model = SitewideMessage
+        fields = (
+            'url',
+            'slug',
+            'body',
+        )
+
+        read_only_fields = (
+            'url',
+            'slug',
+            'body',
+        )

--- a/kpi/tests/api/test_api_environment.py
+++ b/kpi/tests/api/test_api_environment.py
@@ -345,12 +345,17 @@ class EnvironmentTests(BaseTestCase):
         self.assertNotContains(response, 'app.name')
 
     def test_tos_sitewide_message(self):
-        # Check that fixtures properly stores terms of service
+        """
+        Check that fixtures properly stores terms of service
+        """
+
+        # Validate environment
         response = self.client.get(self.url, format='json')
         assert response.status_code == status.HTTP_200_OK
         assert not response.data['terms_of_service__sitewidemessage__exists']
 
-        # Create SitewideMessage object and check that it properly updates terms of service
+        # Create SitewideMessage object and check that it properly updates terms
+        # of service
         SitewideMessage.objects.create(
             slug='terms_of_service',
             body='tos agreement',

--- a/kpi/tests/api/v2/test_api_tos.py
+++ b/kpi/tests/api/v2/test_api_tos.py
@@ -31,7 +31,6 @@ class TermsOfServiceAPITestCase(BaseTestCase):
             ]
         )
 
-
     @data(
         ('adminuser', status.HTTP_200_OK),
         ('someuser', status.HTTP_200_OK),

--- a/kpi/tests/api/v2/test_api_tos.py
+++ b/kpi/tests/api/v2/test_api_tos.py
@@ -1,0 +1,108 @@
+from ddt import data, ddt, unpack
+from django.urls import reverse
+from rest_framework import status
+
+from hub.models import SitewideMessage
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.base_test_case import BaseTestCase
+from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
+
+
+@ddt
+class TermsOfServiceAPITestCase(BaseTestCase):
+
+    URL_NAMESPACE = ROUTER_URL_NAMESPACE
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.list_url = reverse(self._get_endpoint('terms-of-service-list'))
+        self.detail_url = reverse(
+            self._get_endpoint('terms-of-service-detail'),
+            kwargs={'slug': 'terms_of_service'},
+        )
+        SitewideMessage.objects.bulk_create(
+            [
+                SitewideMessage(
+                    slug='terms_of_service', body='Default terms of service'
+                ),
+                SitewideMessage(
+                    slug='terms_of_service_fr', body="Conditions d'utilisation"
+                ),
+            ]
+        )
+
+
+    @data(
+        ('adminuser', status.HTTP_200_OK),
+        ('someuser', status.HTTP_200_OK),
+        ('anonymous', status.HTTP_401_UNAUTHORIZED),
+    )
+    @unpack
+    def test_list_access(self, username, status_code):
+        if username != 'anonymous':
+            self.client.force_login(user=User.objects.get(username=username))
+
+        response = self.client.get(self.list_url)
+        assert response.status_code == status_code
+        if status_code == status.HTTP_200_OK:
+            response_slugs = [message['slug'] for message in response.data]
+            assert response_slugs == ['terms_of_service', 'terms_of_service_fr']
+
+    @data(
+        ('adminuser', status.HTTP_200_OK),
+        ('someuser', status.HTTP_200_OK),
+        ('anonymous', status.HTTP_401_UNAUTHORIZED),
+    )
+    @unpack
+    def test_detail_access(self, username, status_code):
+        if username != 'anonymous':
+            self.client.force_login(user=User.objects.get(username=username))
+        response = self.client.get(self.detail_url)
+        assert response.status_code == status_code
+        if status_code == status.HTTP_200_OK:
+            assert response.data == {
+                'url': self.absolute_reverse(
+                    self._get_endpoint('terms-of-service-detail'),
+                    kwargs={'slug': 'terms_of_service'}
+                ),
+                'slug': 'terms_of_service',
+                'body': 'Default terms of service',
+            }
+
+    @data(
+        ('adminuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('someuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('anonymous', status.HTTP_401_UNAUTHORIZED),
+    )
+    @unpack
+    def test_cannot_create(self, username, status_code):
+        if username != 'anonymous':
+            self.client.force_login(user=User.objects.get(username=username))
+        response = self.client.post(
+            self.list_url, data={'slug': 'foo', 'body': 'bar'}
+        )
+        assert response.status_code == status_code
+
+    @data(
+        ('adminuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('someuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('anonymous', status.HTTP_401_UNAUTHORIZED),
+    )
+    @unpack
+    def test_cannot_update(self, username, status_code):
+        if username != 'anonymous':
+            self.client.force_login(user=User.objects.get(username=username))
+        response = self.client.post(self.detail_url, data={'body': 'bar'})
+        assert response.status_code == status_code
+
+    @data(
+        ('adminuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('someuser', status.HTTP_405_METHOD_NOT_ALLOWED),
+        ('anonymous', status.HTTP_401_UNAUTHORIZED),
+    )
+    @unpack
+    def test_cannot_delete(self, username, status_code):
+        if username != 'anonymous':
+            self.client.force_login(user=User.objects.get(username=username))
+        response = self.client.delete(self.detail_url)
+        assert response.status_code == status_code

--- a/kpi/urls/router_api_v2.py
+++ b/kpi/urls/router_api_v2.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from django.urls import path
 from rest_framework_extensions.routers import ExtendedDefaultRouter
 
@@ -32,6 +30,7 @@ from kpi.views.v2.paired_data import PairedDataViewset
 from kpi.views.v2.permission import PermissionViewSet
 from kpi.views.v2.service_usage import ServiceUsageViewSet
 from kpi.views.v2.tag import TagViewSet
+from kpi.views.v2.tos import TermsOfServiceViewSet
 from kpi.views.v2.user import UserViewSet
 from kpi.views.v2.user_asset_subscription import UserAssetSubscriptionViewSet
 
@@ -174,6 +173,10 @@ router_api_v2.register(r'service_usage',
 router_api_v2.register(r'users', UserViewSet, basename='user-kpi')
 
 router_api_v2.register(r'tags', TagViewSet, basename='tags')
+router_api_v2.register(
+    r'terms-of-service', TermsOfServiceViewSet, basename='terms-of-service'
+)
+
 # Merge django apps routers with API v2 router
 # All routes are under `/api/v2/` within the same namespace.
 router_api_v2.registry.extend(project_ownership_router.registry)

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -1,0 +1,17 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from hub.models import SitewideMessage
+from kpi.serializers.v2.tos import TermsOfServiceSerializer
+
+
+class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    """
+
+    queryset = SitewideMessage.objects.filter(slug__startswith='terms_of_service')
+    model = SitewideMessage
+    lookup_field = 'slug'
+    serializer_class = TermsOfServiceSerializer
+    pagination_class = None
+    permission_classes = (IsAuthenticated,)

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -7,6 +7,7 @@ from kpi.serializers.v2.tos import TermsOfServiceSerializer
 
 class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):
     """
+    TBC, Terms of service readonly endpoint
     """
 
     queryset = SitewideMessage.objects.filter(slug__startswith='terms_of_service')


### PR DESCRIPTION
### 📣 Summary
Fix blank page and generic error message when logging into KPI due to missing terms of service data



### 📖 Description
This PR introduces a new fallback endpoint to provide Terms of Service and Privacy Policy data, replacing the now-decommissioned `/sitewidemessage` endpoint.
The new endpoint ensures backward compatibility and allows the front-end to display the expected legal content without relying on the old API.

### 👀 Preview steps

1. From the shell, create a new user
   ```python 
   u = User.objects.create_user(username='username', password='password', email='myemail@domain.tld')
   EmailAddress(user=u, email=u.email, verified=True, primary=True)
   ```
2. Log into KPI with this user
3. 🔴 [on release branch] :
   - Receive the error "An error occurred" and get a blank page. 
   - Front end tries to call `/sitewide_messages/` which has been removed
4. Ensure to update your front-end assets (e.g.:  start `npm run watch`) 
5. 🟢 [on PR]:
   - See the terms of service are displayed
   - Front end calls `/api/v2/terms-of-service/` instead