### PR TITLE
docs(deprecation): fix correct version for `v1` deprecation

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,4 +1,4 @@
-# Endpoint deprecation as of release 2.025.14h
+# Endpoint deprecation as of release 2.025.29
 
 ⚠️ The deprecated endpoints listed below will be permanently removed with the first release of 2026, scheduled for the week of **January 19, 2026**.
 


### PR DESCRIPTION
### 📣 Summary
Update [DEPRECATION.md](./DEPRECATION.md) to reflect the correct deprecation version for `v1`, i.e. 2.025.29.
