### PR TITLE
docs(api): adding API endpoints for tags in KPI documentation DEV-828

### DIFF
--- a/kpi/docs/api/v2/tags/list.md
+++ b/kpi/docs/api/v2/tags/list.md
@@ -1,0 +1,1 @@
+## List current user's assets' tags

--- a/kpi/docs/api/v2/tags/retrieve.md
+++ b/kpi/docs/api/v2/tags/retrieve.md
@@ -1,1 +1,1 @@
-## Retrieve a tag
+## Retrieve a tag's data

--- a/kpi/docs/api/v2/tags/retrieve.md
+++ b/kpi/docs/api/v2/tags/retrieve.md
@@ -1,0 +1,1 @@
+## Retrieve a tag

--- a/kpi/schema_extensions/imports.py
+++ b/kpi/schema_extensions/imports.py
@@ -21,3 +21,4 @@ import kpi.schema_extensions.v2.users.extensions
 import kpi.schema_extensions.v2.service_usage.extensions
 import kpi.schema_extensions.v2.permissions.extensions
 import kpi.schema_extensions.v2.versions.extensions
+import kpi.schema_extensions.v2.tags.extensions

--- a/kpi/schema_extensions/v2/tags/extensions.py
+++ b/kpi/schema_extensions/v2/tags/extensions.py
@@ -1,0 +1,35 @@
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension
+from drf_spectacular.plumbing import build_array_type
+
+from kpi.utils.schema_extensions.url_builder import build_url_type
+
+
+class AssetListFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.tags.fields.AssetListField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_array_type(
+            schema=build_url_type(
+                'api_v2:asset-detail',
+                uid='a5owyo85mHyFazzgsZK45c'
+            )
+        )
+
+
+class TagUrlFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.tags.fields.TagUrlField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_url_type(
+            'tags-detail',
+            taguid__uid='tg3c5giitsQUMCJNNoDEpQ'
+        )
+
+
+class ParentUrlFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.tags.fields.ParentUrlField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_url_type(
+            'tags-list'
+        )

--- a/kpi/schema_extensions/v2/tags/fields.py
+++ b/kpi/schema_extensions/v2/tags/fields.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+
+class AssetListField(serializers.ListField):
+    pass
+
+
+class TagUrlField(serializers.URLField):
+    pass
+
+
+class ParentUrlField(serializers.URLField):
+    pass

--- a/kpi/schema_extensions/v2/tags/serializers.py
+++ b/kpi/schema_extensions/v2/tags/serializers.py
@@ -1,0 +1,29 @@
+from kpi.utils.schema_extensions.serializers import inline_serializer_class
+from rest_framework import serializers
+
+from .fields import (
+    AssetListField,
+    TagUrlField,
+    ParentUrlField,
+)
+
+
+TagListResponse = inline_serializer_class(
+    name='TagListResponse',
+    fields={
+        'name': serializers.CharField(),
+        'url': TagUrlField(),
+    },
+)
+
+
+TagRetrieveResponse = inline_serializer_class(
+    name='TagRetrieveResponse',
+    fields={
+        'name': serializers.CharField(),
+        'url': TagUrlField(),
+        'assets': AssetListField(),
+        'parent': ParentUrlField(),
+        'uid': serializers.CharField(),
+    },
+)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -1,9 +1,12 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from taggit.models import Tag
 
 from kpi.models import Asset, TagUid
 
+from kpi.schema_extensions.v2.tags.fields import TagUrlField, ParentUrlField
 
 class TagSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
@@ -15,9 +18,11 @@ class TagSerializer(serializers.ModelSerializer):
         model = Tag
         fields = ('name', 'url', 'assets', 'parent', 'uid')
 
+    @extend_schema_field(ParentUrlField)
     def get_parent(self, obj):
         return reverse('tags-list', request=self.context.get('request', None))
 
+    @extend_schema_field(OpenApiTypes.OBJECT)
     def get_assets(self, obj):
         request = self.context.get('request', None)
         return [
@@ -25,6 +30,7 @@ class TagSerializer(serializers.ModelSerializer):
             for asset_uid in Asset.objects.values_list('uid', flat=True)
         ]
 
+    @extend_schema_field(TagUrlField)
     def get_url(self, obj):
         request = self.context.get('request', None)
         tag_uid, _ = TagUid.objects.get_or_create(tag=obj)

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -34,6 +34,8 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'attachment-thumb': '/api/v2/assets/{parent_lookup_asset}/data/{parent_lookup_data}/attachments/{pk}/{suffix}/',  # noqa
         'paired-data-detail': '/api/v2/assets/{parent_lookup_asset}/paired-data/{paired_data_uid}',  # noqa
         'project-ownership-transfer-detail': '/api/v2/project-ownership/invites/{parent_lookup_invite_uid}/transfers/{uid}/',  # noqa
+        'tags-detail': '/api/v2/tags/{taguid__uid}/',
+        'tags-list': '/api/v2/tags/',
     }
 
     try:

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -7,9 +7,11 @@ from taggit.models import Tag
 from kpi.constants import PERM_VIEW_ASSET
 from kpi.filters import SearchFilter
 from kpi.models import Asset
+from kpi.schema_extensions.v2.tags.serializers import TagListResponse, TagRetrieveResponse
 from kpi.serializers.v2.tag import TagListSerializer, TagSerializer
 from kpi.utils.object_permission import get_database_user, get_objects_for_user
 from kpi.utils.schema_extensions.markdown import read_md
+from kpi.utils.schema_extensions.response import open_api_200_ok_response
 
 
 @extend_schema(
@@ -18,9 +20,15 @@ from kpi.utils.schema_extensions.markdown import read_md
 @extend_schema_view(
     list=extend_schema(
         description=read_md('kpi', 'tags/list.md'),
+        responses=open_api_200_ok_response(
+            TagListResponse,
+        )
     ),
     retrieve=extend_schema(
         description=read_md('kpi', 'tags/retrieve.md'),
+        responses=open_api_200_ok_response(
+            TagRetrieveResponse,
+        )
     ),
 )
 class TagViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -9,6 +9,7 @@ from kpi.filters import SearchFilter
 from kpi.models import Asset
 from kpi.serializers.v2.tag import TagListSerializer, TagSerializer
 from kpi.utils.object_permission import get_database_user, get_objects_for_user
+from kpi.utils.schema_extensions.markdown import read_md
 
 
 @extend_schema(
@@ -16,10 +17,10 @@ from kpi.utils.object_permission import get_database_user, get_objects_for_user
 )
 @extend_schema_view(
     list=extend_schema(
-        description='list',
+        description=read_md('kpi', 'tags/list.md'),
     ),
     retrieve=extend_schema(
-        description='retrieve',
+        description=read_md('kpi', 'tags/retrieve.md'),
     ),
 )
 class TagViewSet(viewsets.ReadOnlyModelViewSet):
@@ -30,6 +31,19 @@ class TagViewSet(viewsets.ReadOnlyModelViewSet):
     renderer_classes = [
         JSONRenderer,
     ]
+
+    """
+    Viewset for managing the current user's tags
+
+    Available actions:
+    - list                  → GET /api/v2/tags/
+    - retrieve              → GET /api/v2/tags/{taguid__uid}/
+
+    Documentation:
+    - docs/api/v2/tags/list.md
+    - docs/api/v2/tags/retrieve.md
+    """
+
 
     def get_queryset(self, *args, **kwargs):
         user = get_database_user(self.request.user)

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -1,5 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import viewsets
+from rest_framework.renderers import JSONRenderer
 from taggit.models import Tag
 
 from kpi.constants import PERM_VIEW_ASSET
@@ -9,11 +11,25 @@ from kpi.serializers.v2.tag import TagListSerializer, TagSerializer
 from kpi.utils.object_permission import get_database_user, get_objects_for_user
 
 
+@extend_schema(
+    tags=['Tags']
+)
+@extend_schema_view(
+    list=extend_schema(
+        description='list',
+    ),
+    retrieve=extend_schema(
+        description='retrieve',
+    ),
+)
 class TagViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
     lookup_field = 'taguid__uid'
     filter_backends = (SearchFilter,)
+    renderer_classes = [
+        JSONRenderer,
+    ]
 
     def get_queryset(self, *args, **kwargs):
         user = get_database_user(self.request.user)

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -22,12 +22,17 @@ from kpi.utils.schema_extensions.response import open_api_200_ok_response
         description=read_md('kpi', 'tags/list.md'),
         responses=open_api_200_ok_response(
             TagListResponse,
+            raise_not_found=False,
+            raise_access_forbidden=False,
+            validate_payload=False,
         )
     ),
     retrieve=extend_schema(
         description=read_md('kpi', 'tags/retrieve.md'),
         responses=open_api_200_ok_response(
             TagRetrieveResponse,
+            raise_access_forbidden=False,
+            validate_payload=False,
         )
     ),
 )


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/tags` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `tags` endpoint. With these changes, users will be able to understand, test and use the `tags` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `tags` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.