### PR TITLE
docs(api): adding API endpoints for terms-of-service in KPI documentation DEV-844

### DIFF
--- a/kpi/docs/api/v2/tos/list.md
+++ b/kpi/docs/api/v2/tos/list.md
@@ -1,0 +1,1 @@
+## List the different terms of service

--- a/kpi/docs/api/v2/tos/retrieve.md
+++ b/kpi/docs/api/v2/tos/retrieve.md
@@ -1,0 +1,1 @@
+## Retrieve a specific terms of service

--- a/kpi/schema_extensions/imports.py
+++ b/kpi/schema_extensions/imports.py
@@ -21,3 +21,4 @@ import kpi.schema_extensions.v2.service_usage.extensions
 import kpi.schema_extensions.v2.tags.extensions
 import kpi.schema_extensions.v2.users.extensions
 import kpi.schema_extensions.v2.versions.extensions
+import kpi.schema_extensions.v2.tos.extensions

--- a/kpi/schema_extensions/v2/tos/extensions.py
+++ b/kpi/schema_extensions/v2/tos/extensions.py
@@ -1,0 +1,13 @@
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension
+
+from kpi.utils.schema_extensions.url_builder import build_url_type
+
+
+class TOSDetailURLFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.tos.fields.TOSDetailURLField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_url_type(
+            'api_v2:terms-of-service-detail',
+            slug='terms_of_service_fr'
+        )

--- a/kpi/schema_extensions/v2/tos/fields.py
+++ b/kpi/schema_extensions/v2/tos/fields.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class TOSDetailURLField(serializers.URLField):
+    pass

--- a/kpi/schema_extensions/v2/tos/serializers.py
+++ b/kpi/schema_extensions/v2/tos/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from kpi.utils.schema_extensions.serializers import inline_serializer_class
+from .fields import TOSDetailURLField
+
+TermsOfServiceResponse = inline_serializer_class(
+    name='TermsOfServiceResponse',
+    fields={
+        'url': TOSDetailURLField(),
+        'slug': serializers.CharField(),
+        'body': serializers.CharField(),
+    },
+)

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -36,6 +36,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'project-ownership-transfer-detail': '/api/v2/project-ownership/invites/{parent_lookup_invite_uid}/transfers/{uid}/',  # noqa
         'tags-detail': '/api/v2/tags/{taguid__uid}/',
         'tags-list': '/api/v2/tags/',
+        'terms-of-service-detail': '/api/v2/terms-of-service/{slug}/',
     }
 
     try:

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -4,8 +4,10 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 
 from hub.models import SitewideMessage
+from kpi.schema_extensions.v2.tos.serializers import TermsOfServiceResponse
 from kpi.serializers.v2.tos import TermsOfServiceSerializer
 from kpi.utils.schema_extensions.markdown import read_md
+from kpi.utils.schema_extensions.response import open_api_200_ok_response
 
 
 @extend_schema(
@@ -14,9 +16,15 @@ from kpi.utils.schema_extensions.markdown import read_md
 @extend_schema_view(
     list=extend_schema(
         description=read_md('kpi', 'tos/list.md'),
+        responses=open_api_200_ok_response(
+            TermsOfServiceResponse,
+        )
     ),
     retrieve=extend_schema(
         description=read_md('kpi', 'tos/retrieve.md'),
+        responses=open_api_200_ok_response(
+            TermsOfServiceResponse(many=False),
+        )
     )
 )
 class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -18,12 +18,17 @@ from kpi.utils.schema_extensions.response import open_api_200_ok_response
         description=read_md('kpi', 'tos/list.md'),
         responses=open_api_200_ok_response(
             TermsOfServiceResponse,
+            raise_access_forbidden=False,
+            raise_not_found=False,
+            validate_payload=False,
         )
     ),
     retrieve=extend_schema(
         description=read_md('kpi', 'tos/retrieve.md'),
         responses=open_api_200_ok_response(
             TermsOfServiceResponse(many=False),
+            raise_access_forbidden=False,
+            validate_payload=False,
         )
     )
 )

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -1,10 +1,23 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
 
 from hub.models import SitewideMessage
 from kpi.serializers.v2.tos import TermsOfServiceSerializer
 
 
+@extend_schema(
+    tags=['Terms of Services']
+)
+@extend_schema_view(
+    list=extend_schema(
+        description='list',
+    ),
+    retrieve=extend_schema(
+        description='retrieve',
+    )
+)
 class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     TBC, Terms of service readonly endpoint
@@ -16,3 +29,6 @@ class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = TermsOfServiceSerializer
     pagination_class = None
     permission_classes = (IsAuthenticated,)
+    renderer_classes = [
+        JSONRenderer,
+    ]

--- a/kpi/views/v2/tos.py
+++ b/kpi/views/v2/tos.py
@@ -5,6 +5,7 @@ from rest_framework.renderers import JSONRenderer
 
 from hub.models import SitewideMessage
 from kpi.serializers.v2.tos import TermsOfServiceSerializer
+from kpi.utils.schema_extensions.markdown import read_md
 
 
 @extend_schema(
@@ -12,15 +13,27 @@ from kpi.serializers.v2.tos import TermsOfServiceSerializer
 )
 @extend_schema_view(
     list=extend_schema(
-        description='list',
+        description=read_md('kpi', 'tos/list.md'),
     ),
     retrieve=extend_schema(
-        description='retrieve',
+        description=read_md('kpi', 'tos/retrieve.md'),
     )
 )
 class TermsOfServiceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     TBC, Terms of service readonly endpoint
+    """
+
+    """
+    ViewSet for managing the terms of service
+
+    Available actions:
+    - list           → GET /api/v2/terms-of-service/
+    - retrieve       → GET /api/v2/terms-of-service/{slug}/
+
+    Documentation:
+    - docs/api/v2/tos/list.md
+    - docs/api/v2/tos/retrieve.md
     """
 
     queryset = SitewideMessage.objects.filter(slug__startswith='terms_of_service')


### PR DESCRIPTION
### 📣 Summary
Added API documentation for `/api/v2/docs/terms-of-service` endpoint.

### 📖 Description
This PR introduces the endpoint documentation that will be used for the auto-generating API documentation of the `terms-of-service` endpoint. With these changes, users will be able to understand, test and use the `terms-of-service` endpoint more easily.

### 👀 Preview steps
To see the changes, visit `http://kf.kobo.local/api/v2/docs/`. The page of the Kobo API will now be visible and generated by swagger. To see the changes added to `terms-of-service` endpoint, scroll down to the category of the same name or make a research in the search bar. Documentation for the endpoint will be provided with a HTTP code, a body and/or a response when necessary.