### PR TITLE
feat(projectOwnership): log errors in transferring attachments DEV-842

### DIFF
--- a/kpi/tests/test_extended_file_field.py
+++ b/kpi/tests/test_extended_file_field.py
@@ -11,7 +11,7 @@ class ExtendedFileFieldTestCase(TestCase):
     fixtures = ['test_data']
 
     def test_move_file(self):
-        # Use AssetFile but could not any model which uses `ExtendedFileField`
+        # Use AssetFile but could be any model which uses `ExtendedFileField`
         asset = Asset.objects.get(pk=1)
         asset_file = AssetFile(
             asset=asset, user=asset.owner, file_type=AssetFile.FORM_MEDIA


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Right now we are swallowing errors when trying to move attachments. The jobs occasionally fail and the lack of logging makes it difficult to diagnose, so this logs the error before returning False.

### 👀 Preview steps
Make sure you are using s3 storage

1. ℹ️ have at least 2 accounts and a project with an image question
2. Add a few submissions with attachments to the project
3. Transfer the project to another user
4. Before accepting the transfer, update `kpi.fields.file.py:20-23` with
```
        from django.apps import apps
        Attachment = apps.get_model(model_name='Attachment', app_label='logger')
        if isinstance(self.instance, Attachment):
            name = 'bad name'
        else:
            name = self.name
        copy_source = {
            'Bucket': self.storage.bucket.name,
            'Key': name,
        }
```
Make sure to restart the worker to pick up the changes
5. As the other user, accept the transfer invitation
6. 🔴 [on main] Notice there is only an `AsyncTaskException` in the worker logs
7. 🟢 [on PR] Notice there is both an `AsyncTaskException` and a more detailed `ClientError` in the logs

