### PR TITLE
chore(deps): bum react-cookie from 4.0.1 to 8.0.1

### DIFF
--- a/jsapp/js/stores.js
+++ b/jsapp/js/stores.js
@@ -15,14 +15,11 @@
  * See: https://github.com/kobotoolbox/kpi/issues/3908
  */
 
-import { Cookies } from 'react-cookie'
 import { toast } from 'react-hot-toast'
 import Reflux from 'reflux'
 import { notify } from '#/utils'
 import { actions } from './actions'
 import { parseTags } from './assetParserUtils'
-
-const cookies = new Cookies()
 
 function changes(orig_obj, new_obj) {
   var out = {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "qrcode.react": "^3.1.0",
         "react": "^18.3.1",
         "react-autobind": "^1.0.6",
-        "react-cookie": "^4.0.3",
+        "react-cookie": "^4.1.1",
         "react-copy-to-clipboard": "^5.0.2",
         "react-debounce-input": "^3.2.2",
         "react-dnd": "^16.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "qrcode.react": "^3.1.0",
         "react": "^18.3.1",
         "react-autobind": "^1.0.6",
-        "react-cookie": "^4.1.1",
+        "react-cookie": "^8.0.1",
         "react-copy-to-clipboard": "^5.0.2",
         "react-debounce-input": "^3.2.2",
         "react-dnd": "^16.0.1",
@@ -6115,11 +6115,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
-    },
     "node_modules/@types/create-react-class": {
       "version": "15.6.8",
       "resolved": "https://registry.npmjs.org/@types/create-react-class/-/create-react-class-15.6.8.tgz",
@@ -6237,12 +6232,15 @@
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
       "dependencies": {
-        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -21614,13 +21612,14 @@
       "integrity": "sha512-+BTreuQUUGv1Tv4GbcFNk+1L8U60ZSdxLUs3OVUPsShzxLFYcTYcNf2wzMt3GEU4iFA8Px7SpofpX+uiL03QyQ=="
     },
     "node_modules/react-cookie": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
-      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-8.0.1.tgz",
+      "integrity": "sha512-QNdAd0MLuAiDiLcDU/2s/eyKmmfMHtjPUKJ2dZ/5CcQ9QKUium4B3o61/haq6PQl/YWFqC5PO8GvxeHKhy3GFA==",
+      "license": "MIT",
       "dependencies": {
-        "@types/hoist-non-react-statics": "^3.0.1",
-        "hoist-non-react-statics": "^3.0.0",
-        "universal-cookie": "^4.0.0"
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^8.0.0"
       },
       "peerDependencies": {
         "react": ">= 16.3.0"
@@ -26550,20 +26549,21 @@
       "license": "MIT"
     },
     "node_modules/universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-8.0.1.tgz",
+      "integrity": "sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==",
+      "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
+        "cookie": "^1.0.2"
       }
     },
     "node_modules/universal-cookie/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/universalify": {
@@ -31704,11 +31704,6 @@
         "@types/node": "*"
       }
     },
-    "@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
-    },
     "@types/create-react-class": {
       "version": "15.6.8",
       "resolved": "https://registry.npmjs.org/@types/create-react-class/-/create-react-class-15.6.8.tgz",
@@ -31820,11 +31815,10 @@
       }
     },
     "@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
       "requires": {
-        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -42817,13 +42811,13 @@
       "integrity": "sha512-+BTreuQUUGv1Tv4GbcFNk+1L8U60ZSdxLUs3OVUPsShzxLFYcTYcNf2wzMt3GEU4iFA8Px7SpofpX+uiL03QyQ=="
     },
     "react-cookie": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
-      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-8.0.1.tgz",
+      "integrity": "sha512-QNdAd0MLuAiDiLcDU/2s/eyKmmfMHtjPUKJ2dZ/5CcQ9QKUium4B3o61/haq6PQl/YWFqC5PO8GvxeHKhy3GFA==",
       "requires": {
-        "@types/hoist-non-react-statics": "^3.0.1",
-        "hoist-non-react-statics": "^3.0.0",
-        "universal-cookie": "^4.0.0"
+        "@types/hoist-non-react-statics": "^3.3.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^8.0.0"
       }
     },
     "react-copy-to-clipboard": {
@@ -46384,18 +46378,17 @@
       }
     },
     "universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-8.0.1.tgz",
+      "integrity": "sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==",
       "requires": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
+        "cookie": "^1.0.2"
       },
       "dependencies": {
         "cookie": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+          "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "qrcode.react": "^3.1.0",
     "react": "^18.3.1",
     "react-autobind": "^1.0.6",
-    "react-cookie": "^4.1.1",
+    "react-cookie": "^8.0.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-debounce-input": "^3.2.2",
     "react-dnd": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "qrcode.react": "^3.1.0",
     "react": "^18.3.1",
     "react-autobind": "^1.0.6",
-    "react-cookie": "^4.0.3",
+    "react-cookie": "^4.1.1",
     "react-copy-to-clipboard": "^5.0.2",
     "react-debounce-input": "^3.2.2",
     "react-dnd": "^16.0.1",


### PR DESCRIPTION
### 💭 Notes

Our usage of `react-cookie` is very minimal. Bumping through 4 major versions didn't break anything :angel:

Resolves https://github.com/kobotoolbox/kpi/security/dependabot/147