### PR TITLE
fix(frontend): type error in useServiceUsageQuery.ts

### DIFF
--- a/jsapp/js/account/usage/useServiceUsageQuery.ts
+++ b/jsapp/js/account/usage/useServiceUsageQuery.ts
@@ -120,7 +120,7 @@ interface ServiceUsageQueryParams {
   shouldForceInvalidation?: boolean
 }
 
-export const useServiceUsageQuery = (params?: ServiceUsageQueryParams): UseQueryResult<UsageState> => {
+export const useServiceUsageQuery = (params?: ServiceUsageQueryParams): UseQueryResult<UsageState | undefined> => {
   const { data: organizationData } = useOrganizationQuery()
 
   useEffect(() => {


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->

TODO

### 💭 Notes

Without the change I was getting this error:

```ERROR in ./jsapp/js/account/usage/useServiceUsageQuery.ts:135:3
TS2322: Type 'UseQueryResult<UsageState | undefined, Error>' is not assignable to type 'UseQueryResult<UsageState>'.
  Type 'QueryObserverRefetchErrorResult<UsageState | undefined, Error>' is not assignable to type 'UseQueryResult<UsageState>'.
    Type 'QueryObserverRefetchErrorResult<UsageState | undefined, Error>' is not assignable to type 'QueryObserverRefetchErrorResult<UsageState, Error>'.
      Type 'UsageState | undefined' is not assignable to type 'UsageState'.
        Type 'undefined' is not assignable to type 'UsageState'.
    133 |   }, [params?.shouldForceInvalidation])
    134 |
  > 135 |   return useQuery({
        |   ^^^^^^
    136 |     queryKey: [QueryKeys.serviceUsage, organizationData?.id],
    137 |     queryFn: () => loadUsage(organizationData?.id || null),
    138 |     // A low stale time is needed to avoid calling the API twice on some situations
```

TODO

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
