### PR TITLE
ci(backend): run biome for static files too DEV-862

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -12,6 +12,12 @@ darker:
   - 'pyproject.toml'               # rules
   - '.github/workflows/darker.yml' # ci
 
+biome:
+  - '*.(js|jsx|ts|tsx)'                # js or ts files.
+  - 'biome.jsonc'                      # configuration.
+  - '{package*.json,patches/*.patch}'  # npm + postinstall
+  - '.github/workflows/biome.yml'      # ci
+
 pytest:
   - '{kpi,kobo,hub}/**/*.!(md)'    # backend
   - 'dependencies/**/*.!(md)'      # pip
@@ -22,7 +28,7 @@ npm-test:
   - '{jsapp,test,webpack,static,scripts}/**/*.!(md|py|sh|bash)'               # frontend
   - '{package*.json,patches/*.patch,scripts/copy_fonts.py}'                   # npm + postinstall
   - '{tsconfig.json,.swcrc,.babelrc*,.browserslistrc}'                        # compilers
-  - '{.editorconfig,.stylelint*,.eslint*,coffeelint*,biome.jsonc}'            # linters
+  - '{.editorconfig,.stylelint*,.eslint*,coffeelint*}'                        # linters
   - '.gitignore'                                                              # (can affect tools)
   - '.github/workflows/{npm-test,chromatic}.yml'                              # ci
 

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,0 +1,49 @@
+# Biome is a seperate workflow because it should be run both on frontend source files and backend static files.
+
+name: biome
+
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.18.1' # version that's pinned in Dockerfile for kpi release
+          check-latest: true # download newer semver match if available
+          cache: 'npm'
+
+      - name: Identify resolved node version
+        id: resolved-node-version
+        run: echo "NODE_VERSION=$(node --version)" >> "$GITHUB_OUTPUT"
+
+      # Cache: Use cache for node_modules
+      #        Keyed on os, node version, package-lock, and patches
+      - uses: actions/cache@v4
+        name: Check for cached node_modules
+        id: cache-nodemodules
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-node-v${{ steps.resolved-node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/package-lock.json', 'patches/**/*.patch') }}
+
+      # Cache hit:  If the cache key matches,
+      #             /node_modules/ will have been copied from a previous run.
+      #   (Run the post-install step, `npm run copy-fonts`)
+      - name: Run copy-fonts (if using cached node_modules)
+        if: steps.cache-nodemodules.outputs.cache-hit == 'true'
+        run: npm run copy-fonts
+
+      # Cache miss: If node_modules has not been cached,
+      #             `npm install`
+      #   (This includes `npm run copy-fonts` as post-install step)
+      - name: Install JavaScript dependencies (npm install)
+        if: steps.cache-nodemodules.outputs.cache-hit != 'true'
+        run: npm install
+
+      # Check for Biome formatting errors
+      - name: Check Biome formatting, import order and linter
+        run: npm run lint:biome

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -8,6 +8,9 @@ jobs:
   darker:
     uses: ./.github/workflows/darker.yml
 
+  biome:
+    uses: ./.github/workflows/biome.yml
+
   pytest:
     uses: ./.github/workflows/pytest.yml
 
@@ -19,10 +22,12 @@ jobs:
       failure() &&
       (needs.darker.result == 'failure' || needs.darker.result == 'timed_out' ||
       needs.pytest.result == 'failure' || needs.pytest.result == 'timed_out' ||
+      needs.biome.result == 'failure' || needs.biome.result == 'timed_out' ||
       needs.npm-test.result == 'failure' || needs.npm-test.result == 'timed_out')
     needs:
       - darker
       - pytest
+      - biome
       - npm-test
     uses: './.github/workflows/zulip.yml'
     secrets: inherit

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       all:      ${{ steps.filter.outputs.all      }}
       darker:   ${{ steps.filter.outputs.darker   }}
+      biome:    ${{ steps.filter.outputs.biome    }}
       pytest:   ${{ steps.filter.outputs.pytest   }}
       npm-test: ${{ steps.filter.outputs.npm-test }}
 
@@ -23,6 +24,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.all == 'true' || needs.changes.outputs.darker == 'true'
     uses: ./.github/workflows/darker.yml
+
+  biome:
+    needs: changes
+    if: needs.changes.outputs.all == 'true' || needs.changes.outputs.biome == 'true'
+    uses: ./.github/workflows/biome.yml
 
   pytest:
     needs: changes

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -65,10 +65,6 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
-      # Check for Biome formatting errors
-      - name: Check Biome formatting, import order and linter
-        run: npm run lint:biome
-
       # Check for TypeScript errors
       - name: Check TypeScript
         run: npm run lint:types

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       all:      ${{ steps.filter.outputs.all      }}
       darker:   ${{ steps.filter.outputs.darker   }}
+      biome:    ${{ steps.filter.outputs.biome    }}
       pytest:   ${{ steps.filter.outputs.pytest   }}
       npm-test: ${{ steps.filter.outputs.npm-test }}
 
@@ -25,6 +26,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.all == 'true' || needs.changes.outputs.darker == 'true'
     uses: ./.github/workflows/darker.yml
+
+  biome:
+    needs: changes
+    if: needs.changes.outputs.all == 'true' || needs.changes.outputs.biome == 'true'
+    uses: ./.github/workflows/biome.yml
 
   pytest:
     needs: changes

--- a/.github/workflows/release-3-tag.yml
+++ b/.github/workflows/release-3-tag.yml
@@ -12,6 +12,9 @@ jobs:
   darker:
     uses: ./.github/workflows/darker.yml
 
+  biome:
+    uses: ./.github/workflows/biome.yml
+
   pytest:
     uses: ./.github/workflows/pytest.yml
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,6 +5,7 @@
       "node_modules/**",
       "jsapp/compiled/**",
       "*.css",
+      // Ignore minified committed JS files.
       "*.min.js",
       "*-min.js",
       "bootstrap*.js",


### PR DESCRIPTION
### 💭 Notes

So far biome was run only on frontend file changes although it checked also backend javascript static files.
That led to situations where a green PR can be merged but it would fail `main` where all workflows are run.
No more :)

### 👀 Preview steps
1. add a change to a `.js` file outside `jsapp/` folder
4. 🔴 [on main] notice that biome isn't run on CI
5. 🟢 [on PR] notice that biome is run on CI
