### PR TITLE
feat(docs): change status field type to enum DEV-869

### DIFF
--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
@@ -3,8 +3,10 @@ from drf_spectacular.plumbing import (
     build_array_type,
     build_basic_type,
     build_object_type,
+    build_choice_field,
 )
 from drf_spectacular.types import OpenApiTypes
+from rest_framework import serializers
 
 from kpi.schema_extensions.v2.generic.schema import (
     ASSET_URL_SCHEMA,
@@ -13,6 +15,28 @@ from kpi.schema_extensions.v2.generic.schema import (
     USER_URL_SCHEMA,
 )
 from kpi.utils.schema_extensions.url_builder import build_url_type
+
+
+class MemberInviteStatus:
+    CHOICES = [
+      ('accepted', 'Accepted'),
+      ('cancelled', 'Cancelled'),
+      ('declined', 'Declined'),
+      ('expired', 'Expired'),
+      ('pending', 'Pending'),
+      ('Resent', 'Resent'),
+    ]
+
+
+class EnumTest(OpenApiSerializerFieldExtension):
+    target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.StatusEnumField'  # noqa
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_choice_field(
+            field=serializers.ChoiceField(
+                choices=MemberInviteStatus.CHOICES
+            )
+        )
 
 
 class InviteAssetFieldExtension(OpenApiSerializerFieldExtension):

--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
@@ -17,28 +17,6 @@ from kpi.schema_extensions.v2.generic.schema import (
 from kpi.utils.schema_extensions.url_builder import build_url_type
 
 
-class MemberInviteStatus:
-    CHOICES = [
-      ('accepted', 'Accepted'),
-      ('cancelled', 'Cancelled'),
-      ('declined', 'Declined'),
-      ('expired', 'Expired'),
-      ('pending', 'Pending'),
-      ('Resent', 'Resent'),
-    ]
-
-
-class EnumTest(OpenApiSerializerFieldExtension):
-    target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.StatusEnumField'  # noqa
-
-    def map_serializer_field(self, auto_schema, direction):
-        return build_choice_field(
-            field=serializers.ChoiceField(
-                choices=MemberInviteStatus.CHOICES
-            )
-        )
-
-
 class InviteAssetFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.InviteAssetField'  # noqa
 
@@ -60,6 +38,26 @@ class RecipientSenderUrlFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return USER_URL_SCHEMA
+
+
+class StatusEnumFieldExtension(OpenApiSerializerFieldExtension):
+    CHOICES = [
+      ('accepted', 'Accepted'),
+      ('cancelled', 'Cancelled'),
+      ('declined', 'Declined'),
+      ('expired', 'Expired'),
+      ('pending', 'Pending'),
+      ('Resent', 'Resent'),
+    ]
+
+    target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.StatusEnumField'  # noqa
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_choice_field(
+            field=serializers.ChoiceField(
+                choices=StatusEnumFieldExtension.CHOICES
+            )
+        )
 
 
 class TransferFieldExtension(OpenApiSerializerFieldExtension):

--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/fields.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/fields.py
@@ -13,5 +13,9 @@ class RecipientSenderUrlField(serializers.URLField):
     pass
 
 
+class StatusEnumField(serializers.CharField):
+    pass
+
+
 class TransferField(serializers.JSONField):
     pass

--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/serializers.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/serializers.py
@@ -5,8 +5,10 @@ from .fields import (
     InviteAssetField,
     InviteUrlField,
     RecipientSenderUrlField,
+    StatusEnumField,
     TransferField,
 )
+
 
 ProjectInviteCreatePayload = inline_serializer_class(
     name='ProjectInviteCreatePayload',
@@ -21,7 +23,7 @@ ProjectInviteResponse = inline_serializer_class(
     fields={
         'url': InviteUrlField(),
         'sender |  recipient': RecipientSenderUrlField(),
-        'status': serializers.CharField(),
+        'status': StatusEnumField(),
         'date_created': serializers.DateTimeField(),
         'date_modified': serializers.DateTimeField(),
         'transfers': TransferField(),
@@ -31,6 +33,6 @@ ProjectInviteResponse = inline_serializer_class(
 InviteUpdatePayload = inline_serializer_class(
     name='InviteUpdatePayload',
     fields={
-        'status': serializers.CharField(),
+        'status': StatusEnumField(),
     },
 )


### PR DESCRIPTION
### 📣 Summary
Changed status field type from string to enum to better represent the api.
