### PR TITLE
 fix(docs): fix bad url building DEV-878 

### DIFF
--- a/kobo/apps/project_views/schema_extensions/v2/extensions.py
+++ b/kobo/apps/project_views/schema_extensions/v2/extensions.py
@@ -91,7 +91,7 @@ class ExportResponseResultExtension(OpenApiSerializerFieldExtension):
     def map_serializer_field(self, auto_schema, direction):
         return build_url_type(
             'serve_private_file',
-            path='bob/exports/assets-bob-view_pvyHWBnzRw3GCJpFs6cMdem-2025-07-18T124015Z.csv',  # noqa
+            username='bob',
         )
 
 

--- a/kpi/schema_extensions/v2/export_tasks/extensions.py
+++ b/kpi/schema_extensions/v2/export_tasks/extensions.py
@@ -76,7 +76,7 @@ class ResultFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return build_url_type(
-            'serve_private_file',
+            'serve_asset_private_file',
             path='user/export/NEW PROJECT - all versions - False - 2025-01-01-01-01.csv',  # noqa
         )
 

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -47,6 +47,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'asset-export-settings-detail-format': '/api/v2/assets/{parent_lookup_asset}/export-settings/{uid}/data.{format}',  # noqa
         'asset-export-detail': '/api/v2/assets/{parent_lookup_asset}/exports/{uid}/',
         'serve_private_file': '/private-media/{username}/exports/assets-{username}-view_pvNNUan8EBhzfkrv6sCNuzR-2025-08-11T143443Z.csv',  # noqa
+        'serve_asset_private_file': '{path}',
         'asset-file-detail': '/api/v2/assets/{parent_lookup_asset}/files/{uid}/',
         'asset-file-content': '/api/v2/assets/{parent_lookup_asset}/files/{uid}/content/',  # noqa
         'hook-log-list': '/api/v2/assets/{parent_lookup_asset}/hooks/{parent_lookup_hook}/logs/',  # noqa

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -67,6 +67,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'enketo_view_link': '{path}',
         'importtask-detail': '/api/v2/imports/{uid}/',
         'organization-members-detail': '/api/v2/organizations/{organization_id}/members/{user__username}/',  # noqa
+        'project-ownership-invite-detail': '/api/v2/project-ownership/invites/{uid}/',
     }
 
     try:

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -68,6 +68,10 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'importtask-detail': '/api/v2/imports/{uid}/',
         'organization-members-detail': '/api/v2/organizations/{organization_id}/members/{user__username}/',  # noqa
         'project-ownership-invite-detail': '/api/v2/project-ownership/invites/{uid}/',
+        'projectview-detail': '/api/v2/project-views/{uid}/',
+        'projectview-assets': '/api/v2/project-views/{uid}/assets/',
+        'projectview-export': '/api/v2/project-views/{uid}/{obj_type}/export/',
+        'projectview-users': '/api/v2/project-views/{uid}/users/',
     }
 
     try:

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -46,7 +46,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'asset-export-settings-detail': '/api/v2/assets/{parent_lookup_asset}/export-settings/{uid}/',  # noqa
         'asset-export-settings-detail-format': '/api/v2/assets/{parent_lookup_asset}/export-settings/{uid}/data.{format}',  # noqa
         'asset-export-detail': '/api/v2/assets/{parent_lookup_asset}/exports/{uid}/',
-        'serve_private_file': '{path}',
+        'serve_private_file': '/private-media/{username}/exports/assets-{username}-view_pvNNUan8EBhzfkrv6sCNuzR-2025-08-11T143443Z.csv',  # noqa
         'asset-file-detail': '/api/v2/assets/{parent_lookup_asset}/files/{uid}/',
         'asset-file-content': '/api/v2/assets/{parent_lookup_asset}/files/{uid}/content/',  # noqa
         'hook-log-list': '/api/v2/assets/{parent_lookup_asset}/hooks/{parent_lookup_hook}/logs/',  # noqa

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -66,6 +66,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'enketo_edit_link': '{path}',
         'enketo_view_link': '{path}',
         'importtask-detail': '/api/v2/imports/{uid}/',
+        'organization-members-detail': '/api/v2/organizations/{organization_id}/members/{user__username}/',  # noqa
     }
 
     try:

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -65,6 +65,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'terms-of-service-detail': '/api/v2/terms-of-service/{slug}/',
         'enketo_edit_link': '{path}',
         'enketo_view_link': '{path}',
+        'importtask-detail': '/api/v2/imports/{uid}/',
     }
 
     try:

--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -72,6 +72,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
         'projectview-assets': '/api/v2/project-views/{uid}/assets/',
         'projectview-export': '/api/v2/project-views/{uid}/{obj_type}/export/',
         'projectview-users': '/api/v2/project-views/{uid}/users/',
+        'user-kpi-migrate': '/api/v2/users/{username}/migrate/{task_id}/',
     }
 
     try:


### PR DESCRIPTION
### 📣 Summary
Correct the URLs that are not being constructed correctly with the url_builder util.


### 👀 Preview steps
Go to `http://kf.kobo.local/api/v2/docs/`, when an endpoint has an URL, make sure it is properly constructed.

Bad example:
`/api/v2/user-detailurl/{username: bob}/`
Good example:
`/api/v2/users/bob/`
