### PR TITLE
feat(enketo): allow user media for preview iframe DEV-847

### DIFF
--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -334,7 +334,7 @@ class BigModal extends React.Component {
           )}
           {this.props.params.type === MODAL_TYPES.ENKETO_PREVIEW && this.state.enketopreviewlink && (
             <div className='enketo-holder'>
-              <iframe src={this.state.enketopreviewlink} />
+              <iframe src={this.state.enketopreviewlink} allow='camera *; microphone *; geolocation *' />
             </div>
           )}
           {this.props.params.type === MODAL_TYPES.ENKETO_PREVIEW && !this.state.enketopreviewlink && <LoadingSpinner />}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR adds the `allow` attribute to the form preview iframe to allow the use of user media from thre preview.
Geolocation was also added, since there are geolocation widgets in Enketo.

1. ℹ️ have an account and a project with an audio question
2. Setup Enketo to work with KPI ([docs](https://www.notion.so/kobotoolbox/2025-08-11-Frontend-meetup-24c7e515f65480f8976cf77c61514d71)) 
3. Pull the `feat-audio-recording` branch from Enketo
4. Open the form in the Preview (eye icon from the form  view)
5. Try to record audio
6. 🟢 The microphone should be accessible by the form
