### PR TITLE
fix(exports): display export language labels instead of code DEV-377

### DIFF
--- a/jsapp/js/components/projectDownloads/ProjectExportsList.tsx
+++ b/jsapp/js/components/projectDownloads/ProjectExportsList.tsx
@@ -191,10 +191,11 @@ export default class ProjectExportsList extends React.Component<ProjectExportsLi
     // doesn't exist in current form version
     let languageDisplay: React.ReactNode = <em>{t('Unknown')}</em>
     const langIndex = getLanguageIndex(this.props.asset, exportLangCast)
-    if (langIndex !== -1) {
-      languageDisplay = exportLangCast
-    } else if (EXPORT_FORMATS[exportLangCast]) {
+    if (EXPORT_FORMATS[exportLangCast]) {
+      // Regardless is there is a translation or not, the export has a label that we can display to the user
       languageDisplay = EXPORT_FORMATS[exportLangCast].label
+    } else {
+      languageDisplay = exportLangCast
     }
     return languageDisplay
   }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes issue where the default "language" is being shown as `_default` rather than the dropdown label "Labels". Now we always display the label and fall back to the language code if this somehow fails.

### 👀 Preview steps
1. ℹ️ have 2 projects with submissions
  1. one project with translations
  2. other one without translations 
3. Go to data exports
4. Set the "Value and header format" to "Labels" and export
5. 🔴 [on main] notice that the language in the "Exports" table shows `_default`
6. 🟢 [on PR] notice that the language in the "Exports" table shows "Labels"
7. Set the "Value and header format" to "XML values and headers" and export
8. 🟢 notice that the language in the "Exports" table shows "XML values and headers"
9. On the project with translations, navigate to data exports
10. 🟢 notice that the "Value and header format" dropdown does not have "Labels" and it's replaced with the project's languages
11. 🟢 notice that the exported files are identical between this branch and main
