### PR TITLE
feat(projectOwnership): add management command for retrying attachment transfers

### DIFF
--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -11,6 +11,7 @@ from kpi.models.import_export_task import (
     ImportExportTask,
     ProjectHistoryLogExportTask,
 )
+from kpi.paginators import FastPagination, Paginated
 from kpi.permissions import IsAuthenticated
 from kpi.tasks import export_task_in_background
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
@@ -168,6 +169,7 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         'model_name__icontains',
         'metadata__icontains',
     ]
+    pagination_class = FastPagination
 
 
 class AllAccessLogViewSet(AuditLogViewSet):
@@ -274,6 +276,7 @@ class AllAccessLogViewSet(AuditLogViewSet):
 
     queryset = AccessLog.objects.with_submissions_grouped().order_by('-date_created')
     serializer_class = AccessLogSerializer
+    pagination_class = Paginated
 
 
 class AccessLogViewSet(AuditLogViewSet):
@@ -334,6 +337,7 @@ class AccessLogViewSet(AuditLogViewSet):
     permission_classes = (IsAuthenticated,)
     filter_backends = (AccessLogPermissionsFilter,)
     serializer_class = AccessLogSerializer
+    pagination_class = Paginated
 
 
 def generate_ph_view_set_logstring(description, path, example_path, all):

--- a/kobo/apps/project_ownership/management/commands/retry_attachment_transfers.py
+++ b/kobo/apps/project_ownership/management/commands/retry_attachment_transfers.py
@@ -1,0 +1,35 @@
+from django.core.management.base import BaseCommand
+
+from kpi.utils.log import logging
+from ...models import (
+    Transfer,
+    TransferStatus,
+    TransferStatusChoices,
+    TransferStatusTypeChoices,
+)
+from ...utils import move_attachments
+
+
+class Command(BaseCommand):
+    help = (
+        'Resume project ownership transfers done under `2.024.33f` (and later) '
+        'which failed with error: "Model.save() got an unexpected keyword argument'
+        ' \'updated_fields\'"'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('transfer_uids', nargs='+', type=str)
+
+    def handle(self, *args, **options):
+        for transfer_uid in options.get('transfer_uids', []):
+            if not TransferStatus.objects.filter(
+                transfer__uid=transfer_uid,
+                status_type=TransferStatusTypeChoices.ATTACHMENTS,
+                status=TransferStatusChoices.FAILED,
+            ).exists():
+                logging.warn(
+                    f'No failed attachment transfers for {transfer_uid}. Will not continue.'
+                )
+                continue
+            transfer = Transfer.objects.get(uid=transfer_uid)
+            move_attachments(transfer)

--- a/kobo/apps/project_ownership/utils.py
+++ b/kobo/apps/project_ownership/utils.py
@@ -103,29 +103,42 @@ def move_attachments(transfer: 'project_ownership.Transfer'):
     # Moving files is pretty slow, thus it should run in a celery task.
     errors = False
     for attachment in attachments.iterator():
-        media_file_path = attachment.media_file.name
-        if not (
-            target_folder := get_target_folder(
-                transfer.invite.sender.username,
-                transfer.invite.recipient.username,
-                attachment.media_file.name,
-            )
-        ):
-            continue
-        else:
-            # There is no way to ensure atomicity when moving the file and saving the
-            # object to the database. Fingers crossed that the process doesn't get
-            # interrupted between these two operations.
-            if attachment.media_file.move(target_folder):
-                _delete_thumbnails(media_file_path)
-                attachment.save(update_fields=['media_file'])
-            else:
-                errors = True
-                logging.error(
-                    f'File {attachment.media_file_basename} (#{attachment.pk}) '
-                    f'could not be moved to {target_folder}'
+        try:
+            media_file_path = attachment.media_file.name
+            logging.info(f'Attempting to migrate {media_file_path}')
+            if not (
+                target_folder := get_target_folder(
+                    transfer.invite.sender.username,
+                    transfer.invite.recipient.username,
+                    attachment.media_file.name,
                 )
+            ):
+                continue
+            else:
+                # There is no way to ensure atomicity when moving the file and saving the
+                # object to the database. Fingers crossed that the process doesn't get
+                # interrupted between these two operations.
+                if attachment.media_file.move(target_folder):
+                    _delete_thumbnails(media_file_path)
+                    attachment.save(update_fields=['media_file'])
+                    logging.info(
+                        f'Successfully migrated {media_file_path} to {target_folder}'
+                    )
 
+                else:
+                    errors = True
+                    logging.error(
+                        f'File {attachment.media_file_basename} (#{attachment.pk}) '
+                        f'could not be moved to {target_folder}'
+                    )
+        except Exception as e:
+            # TODO: remove this general exception when we have a better idea of
+            # the errors
+            errors = True
+            logging.error(
+                f'Error moving {attachment.media_file_basename}', e, exc_info=True
+            )
+        finally:
             heartbeat = _update_heartbeat(heartbeat, transfer, async_task_type)
 
     if errors:

--- a/kobo/apps/project_views/views.py
+++ b/kobo/apps/project_views/views.py
@@ -14,7 +14,7 @@ from kpi.filters import AssetOrderingFilter, SearchFilter
 from kpi.mixins.asset import AssetViewSetListMixin
 from kpi.mixins.object_permission import ObjectPermissionViewSetMixin
 from kpi.models import Asset, ProjectViewExportTask
-from kpi.paginators import FastAssetPagination
+from kpi.paginators import FastPagination
 from kpi.permissions import IsAuthenticated
 from kpi.serializers.v2.asset import AssetMetadataListSerializer
 from kpi.serializers.v2.user import UserListSerializer
@@ -48,7 +48,7 @@ class ProjectViewViewSet(
         detail=True,
         methods=['GET'],
         filter_backends=[SearchFilter, AssetOrderingFilter],
-        pagination_class=FastAssetPagination,
+        pagination_class=FastPagination,
     )
     def assets(self, request, uid):
         if not user_has_view_perms(request.user, uid):

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -122,7 +122,7 @@ class DataPagination(LimitOffsetPagination):
     max_limit = settings.SUBMISSION_LIST_LIMIT
 
 
-class FastAssetPagination(Paginated):
+class FastPagination(Paginated):
     """
     Pagination class optimized for faster counting for DISTINCT queries on large tables.
 

--- a/kpi/tests/test_extended_file_field.py
+++ b/kpi/tests/test_extended_file_field.py
@@ -11,7 +11,7 @@ class ExtendedFileFieldTestCase(TestCase):
     fixtures = ['test_data']
 
     def test_move_file(self):
-        # Use AssetFile but could not any model which uses `ExtendedFileField`
+        # Use AssetFile but could be any model which uses `ExtendedFileField`
         asset = Asset.objects.get(pk=1)
         asset_file = AssetFile(
             asset=asset, user=asset.owner, file_type=AssetFile.FORM_MEDIA

--- a/kpi/urls/__init__.py
+++ b/kpi/urls/__init__.py
@@ -38,7 +38,7 @@ urlpatterns = [
         name='authenticate_user',
     ),
     path(
-        'api/v2/authorized-application/authenticate_user/',
+        'api/v2/authorized_application/authenticate_user/',
         AuthorizedApplicationUserViewSet.as_view({'post': 'authenticate_user'}),
         name='authorized-application-authenticate-user',
     ),


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add a process for retrying the transfer of attachments after a previous failure.


### 📖 Description
Add a management command that can be run to retry the transfer of attachments between old and new owners of a project after an initial failure.


### 💭 Notes
The management command takes a Transfer uid since `move_attachments` is called on a 

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
