### PR TITLE
fix(docs): fix `member` response and payload fields DEV-894

### DIFF
--- a/kpi/schema_extensions/v2/members/extensions.py
+++ b/kpi/schema_extensions/v2/members/extensions.py
@@ -1,12 +1,15 @@
 from drf_spectacular.extensions import OpenApiSerializerFieldExtension
-from drf_spectacular.plumbing import build_basic_type, build_object_type
+from drf_spectacular.plumbing import build_basic_type, build_object_type, \
+    build_choice_field
 from drf_spectacular.types import OpenApiTypes
 
 from kpi.schema_extensions.v2.generic.schema import (
     GENERIC_STRING_SCHEMA,
     USER_URL_SCHEMA,
 )
+from rest_framework import serializers
 from kpi.utils.schema_extensions.url_builder import build_url_type
+from .schema import CHOICES
 
 
 class InviteFieldExtension(OpenApiSerializerFieldExtension):
@@ -22,11 +25,16 @@ class InviteFieldExtension(OpenApiSerializerFieldExtension):
                 ),
                 'invited_by': USER_URL_SCHEMA,
                 'status': GENERIC_STRING_SCHEMA,
-                'invitee_role': GENERIC_STRING_SCHEMA,
-                'created': build_basic_type(OpenApiTypes.DATETIME),
+                'invitee_role': build_choice_field(
+                    field=serializers.ChoiceField(
+                        choices=CHOICES
+                    )
+                ),
+                'date_created': build_basic_type(OpenApiTypes.DATETIME),
                 'modified': build_basic_type(OpenApiTypes.DATETIME),
                 'invitee': GENERIC_STRING_SCHEMA,
-            }
+            },
+            required=['date_created', 'invitee'],
         )
 
 
@@ -38,6 +46,17 @@ class MemberUrlFieldExtension(OpenApiSerializerFieldExtension):
             'api_v2:organization-members-detail',
             organization_id='orgR6zUBwMHop2mgGygtFd6c',
             user__username='bob',
+        )
+
+
+class RoleChoiceFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.members.fields.RoleChoiceField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_choice_field(
+            field=serializers.ChoiceField(
+                choices=CHOICES
+            )
         )
 
 

--- a/kpi/schema_extensions/v2/members/extensions.py
+++ b/kpi/schema_extensions/v2/members/extensions.py
@@ -3,6 +3,7 @@ from drf_spectacular.plumbing import build_basic_type, build_object_type, \
     build_choice_field
 from drf_spectacular.types import OpenApiTypes
 
+from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.schema_extensions.v2.generic.schema import (
     GENERIC_STRING_SCHEMA,
     USER_URL_SCHEMA,
@@ -24,7 +25,11 @@ class InviteFieldExtension(OpenApiSerializerFieldExtension):
                     guid='f3ba00b2-372b-4283-9d57-adbe7d5b1bf1',
                 ),
                 'invited_by': USER_URL_SCHEMA,
-                'status': GENERIC_STRING_SCHEMA,
+                'status': build_choice_field(
+                    field=serializers.ChoiceField(
+                        choices=ImportExportStatusChoices
+                    )
+                ),
                 'invitee_role': build_choice_field(
                     field=serializers.ChoiceField(
                         choices=CHOICES

--- a/kpi/schema_extensions/v2/members/extensions.py
+++ b/kpi/schema_extensions/v2/members/extensions.py
@@ -9,7 +9,7 @@ from kpi.schema_extensions.v2.generic.schema import (
 )
 from rest_framework import serializers
 from kpi.utils.schema_extensions.url_builder import build_url_type
-from .schema import CHOICES
+from .schema import CHOICES, PAYLOAD_CHOICES
 
 
 class InviteFieldExtension(OpenApiSerializerFieldExtension):
@@ -30,11 +30,21 @@ class InviteFieldExtension(OpenApiSerializerFieldExtension):
                         choices=CHOICES
                     )
                 ),
-                'date_created': build_basic_type(OpenApiTypes.DATETIME),
+                'organization_name': GENERIC_STRING_SCHEMA,
+                'created': build_basic_type(OpenApiTypes.DATETIME),
                 'modified': build_basic_type(OpenApiTypes.DATETIME),
                 'invitee': GENERIC_STRING_SCHEMA,
             },
-            required=['date_created', 'invitee'],
+            required=[
+                'url',
+                'invited_by',
+                'status',
+                'invitee_role',
+                'invitee',
+                'organization_name',
+                'created',
+                'modified',
+            ],
         )
 
 
@@ -56,6 +66,17 @@ class RoleChoiceFieldExtension(OpenApiSerializerFieldExtension):
         return build_choice_field(
             field=serializers.ChoiceField(
                 choices=CHOICES
+            )
+        )
+
+
+class RoleChoicePayloadFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.members.fields.RoleChoicePayloadField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_choice_field(
+            field=serializers.ChoiceField(
+                choices=PAYLOAD_CHOICES
             )
         )
 

--- a/kpi/schema_extensions/v2/members/fields.py
+++ b/kpi/schema_extensions/v2/members/fields.py
@@ -9,5 +9,9 @@ class MemberUrlField(serializers.JSONField):
     pass
 
 
+class RoleChoiceField(serializers.CharField):
+    pass
+
+
 class UserUrlField(serializers.JSONField):
     pass

--- a/kpi/schema_extensions/v2/members/fields.py
+++ b/kpi/schema_extensions/v2/members/fields.py
@@ -13,5 +13,9 @@ class RoleChoiceField(serializers.CharField):
     pass
 
 
+class RoleChoicePayloadField(serializers.CharField):
+    pass
+
+
 class UserUrlField(serializers.JSONField):
     pass

--- a/kpi/schema_extensions/v2/members/schema.py
+++ b/kpi/schema_extensions/v2/members/schema.py
@@ -2,3 +2,9 @@ CHOICES = [
     ('admin', 'Admin'),
     ('member', 'Member'),
 ]
+
+PAYLOAD_CHOICES = [
+    ('admin', 'Admin'),
+    ('member', 'Member'),
+    ('owner', 'Owner'),
+]

--- a/kpi/schema_extensions/v2/members/schema.py
+++ b/kpi/schema_extensions/v2/members/schema.py
@@ -1,0 +1,4 @@
+CHOICES = [
+    ('admin', 'Admin'),
+    ('member', 'Member'),
+]

--- a/kpi/schema_extensions/v2/members/serializers.py
+++ b/kpi/schema_extensions/v2/members/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from kpi.utils.schema_extensions.serializers import inline_serializer_class
-from .fields import InviteField, MemberUrlField, UserUrlField
+from .fields import InviteField, MemberUrlField, UserUrlField, RoleChoiceField
 
 MemberListResponse = inline_serializer_class(
     name='MemberListResponse',
@@ -10,12 +10,13 @@ MemberListResponse = inline_serializer_class(
         'user': UserUrlField(),
         'user__username': serializers.CharField(),
         'user__email': serializers.EmailField(),
-        'user__name': serializers.CharField(),
+        'user__name': RoleChoiceField(),
         'role': serializers.CharField(),
         'user__has_mfa_enabled': serializers.BooleanField(),
+        'user__extra_details__name': serializers.CharField(),
         'date_joined': serializers.DateTimeField(),
         'user__is_active': serializers.BooleanField(),
-        'invite': InviteField(),
+        'invite': InviteField(required=True),
     },
 )
 
@@ -23,6 +24,6 @@ MemberListResponse = inline_serializer_class(
 MemberPatchRequest = inline_serializer_class(
     name='MemberPatchRequest',
     fields={
-        'role': serializers.CharField(),
+        'role': RoleChoiceField(),
     },
 )

--- a/kpi/schema_extensions/v2/members/serializers.py
+++ b/kpi/schema_extensions/v2/members/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from kpi.utils.schema_extensions.serializers import inline_serializer_class
-from .fields import InviteField, MemberUrlField, UserUrlField, RoleChoiceField
+from .fields import InviteField, MemberUrlField, UserUrlField, RoleChoiceField, RoleChoicePayloadField
 
 MemberListResponse = inline_serializer_class(
     name='MemberListResponse',
@@ -10,10 +10,9 @@ MemberListResponse = inline_serializer_class(
         'user': UserUrlField(),
         'user__username': serializers.CharField(),
         'user__email': serializers.EmailField(),
-        'user__name': RoleChoiceField(),
-        'role': serializers.CharField(),
-        'user__has_mfa_enabled': serializers.BooleanField(),
         'user__extra_details__name': serializers.CharField(),
+        'role': RoleChoiceField(),
+        'user__has_mfa_enabled': serializers.BooleanField(),
         'date_joined': serializers.DateTimeField(),
         'user__is_active': serializers.BooleanField(),
         'invite': InviteField(required=True),
@@ -24,6 +23,6 @@ MemberListResponse = inline_serializer_class(
 MemberPatchRequest = inline_serializer_class(
     name='MemberPatchRequest',
     fields={
-        'role': RoleChoiceField(),
+        'role': RoleChoicePayloadField(),
     },
 )


### PR DESCRIPTION
### 📣 Summary
Fixed members response and payload fields in `/api/v2/organizations/{organization_id}/members/`