### PR TITLE
feat(auditLogs): optimize search filter for audit log endpoints

### DIFF
--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -165,7 +165,7 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     filter_backends = (SearchFilter,)
     # audit logs have no n-to-many fields, so don't bother running "distinct" on
     # search results
-    requires_distinct = False
+    skip_distinct = True
 
     search_default_field_lookups = [
         'app_label__icontains',

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -163,6 +163,9 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         AuditLog.objects.select_related('user').all().order_by('-date_created')
     )
     filter_backends = (SearchFilter,)
+    # audit logs have no n-to-many fields, so don't bother running "distinct" on
+    # search results
+    requires_distinct = False
 
     search_default_field_lookups = [
         'app_label__icontains',

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -478,12 +478,14 @@ class SearchFilter(filters.BaseFilterBackend):
             # specified field is less than a set length of characters -
             # currently 3 (see `settings.MINIMUM_DEFAULT_SEARCH_CHARACTERS`)
             raise e
-
         try:
-            # If no search field is specified, the search term is compared
-            # to several default fields and therefore may return a copies
-            # of the same match, therefore the `distinct()` method is required
-            return queryset.filter(q_obj).distinct()
+            # If we are searching on an n-to-many field, we may get multiple results
+            # from the same model, so we need to de-duplicate with distinct(). Rely
+            # on the view to tell us if this is not necessary
+            if getattr(view, 'requires_distinct', True):
+                return queryset.filter(q_obj).distinct()
+            else:
+                return queryset.filter(q_obj)
         except (FieldError, ValueError):
             return queryset.model.objects.none()
 

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -482,10 +482,10 @@ class SearchFilter(filters.BaseFilterBackend):
             # If we are searching on an n-to-many field, we may get multiple results
             # from the same model, so we need to de-duplicate with distinct(). Rely
             # on the view to tell us if this is not necessary
-            if getattr(view, 'requires_distinct', True):
-                return queryset.filter(q_obj).distinct()
-            else:
+            if getattr(view, 'skip_distinct', False):
                 return queryset.filter(q_obj)
+            else:
+                return queryset.filter(q_obj).distinct()
         except (FieldError, ValueError):
             return queryset.model.objects.none()
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Performance enhancement for audit log, access log, and project history log endpoints.


### 💭 Notes
The SearchFilter automatically runs `distinct` on all queries in order to handle the possibility that searching on an n-to-many field has returned multiple results for the same object. This distinct is very slow, so add a property to the view that tells the SearchFilter to skip it. This property should only be set on models that do not have any kind of n-to-many fields.

### 👀 Preview steps
This is best previewed by running the server with `--print-sql` or turning on the debug toolbar 

1. ℹ️ have an account
2. Navigate to `api/v2/audit-logs/?q=user__username:<username>
3. 🟢 [on PR] Notice the audit log query does not use `distinct` for the search or for the count

