### PR TITLE
feat(massEmails): get name from extra details DEV-903

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -274,7 +274,7 @@ class MassEmailSender:
         plan_name = self.get_plan_name(org_user)
         data = {
             'username': record.user.username,
-            'full_name': record.user.first_name + ' ' + record.user.last_name,
+            'full_name': record.user.extra_details.data['name'],
             'plan_name': plan_name,
             'date_created': record.date_created.strftime('%Y-%m-%d %H:%M'),
         }

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -272,9 +272,12 @@ class MassEmailSender:
         logging.info(f'Processing MassEmailRecord({record})')
         org_user = record.user.organization.organization_users.get(user=record.user)
         plan_name = self.get_plan_name(org_user)
+        # prefer the user-entered name for full name, but use the one from admin
+        # as a backup
+        backup_full_name = record.user.first_name + ' ' + record.user.last_name
         data = {
             'username': record.user.username,
-            'full_name': record.user.extra_details.data['name'],
+            'full_name': record.user.extra_details.data.get('name', backup_full_name),
             'plan_name': plan_name,
             'date_created': record.date_created.strftime('%Y-%m-%d %H:%M'),
         }


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Use the user-entered name in mass email templates.

### 💭 Notes
When a user enters their name, it actually ends up in user.extra_details.data['name'] rather than in user.first_name + user.last_name. The latter is only inputted in Django admin. Use the user-inputted name for the full name when sending emails. 'Name' is always set in extra details via standardize_json_field so we shouldn't get any key errors, even if the user hasn't entered a name.

### 👀 Preview steps
This is most easily tested with `MASS_EMAILS_CONDENSE_SEND` set to true.

1. ℹ️ have an account
2. Add a full name in Account Settings
3. Add the user's email to Constance > MASS_EMAIL_TEST_EMAILS
4. Create a new mass email config using the `test_users` query that uses `##full_name##` somewhere in the template and set it to live
6. 🟢 At the next email send, the name entered in the account settings should be rendered in the email

