### PR TITLE
fix(docs): fix `organization invite` enum fields DEV-907

### DIFF
--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
@@ -16,7 +16,7 @@ from kpi.schema_extensions.v2.generic.schema import (
 )
 from kpi.utils.schema_extensions.url_builder import build_url_type
 from kobo.apps.project_ownership.models.choices import InviteStatusChoices
-
+from kobo.apps.organizations.models import OrganizationInviteStatusChoices
 
 class InviteAssetFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.InviteAssetField'  # noqa
@@ -48,7 +48,7 @@ class StatusEnumFieldExtension(OpenApiSerializerFieldExtension):
     def map_serializer_field(self, auto_schema, direction):
         return build_choice_field(
             field=serializers.ChoiceField(
-                choices=InviteStatusChoices.choices
+                choices=OrganizationInviteStatusChoices.choices
             )
         )
 

--- a/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
+++ b/kobo/apps/project_ownership/schema_extensions/v2/project_ownership/invites/extensions.py
@@ -15,8 +15,8 @@ from kpi.schema_extensions.v2.generic.schema import (
     USER_URL_SCHEMA,
 )
 from kpi.utils.schema_extensions.url_builder import build_url_type
-from kobo.apps.project_ownership.models.choices import InviteStatusChoices
 from kobo.apps.organizations.models import OrganizationInviteStatusChoices
+
 
 class InviteAssetFieldExtension(OpenApiSerializerFieldExtension):
     target_class = 'kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.fields.InviteAssetField'  # noqa

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1017,7 +1017,7 @@ SPECTACULAR_SETTINGS = {
     ],
     'ENUM_NAME_OVERRIDES': {
         'InviteStatusChoicesEnum': 'kobo.apps.organizations.models.OrganizationInviteStatusChoices.choices',  # noqa
-        'InviteeRoleEnum': 'kpi.schema_extensions.v2.members.schema.ROLE_CHOICES_PAYLOAD_ENUM'
+        'InviteeRoleEnum': 'kpi.schema_extensions.v2.members.schema.ROLE_CHOICES_PAYLOAD_ENUM'  # noqa
     }
 }
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1016,7 +1016,7 @@ SPECTACULAR_SETTINGS = {
         'kpi.authentication.TokenAuthentication',
     ],
     'ENUM_NAME_OVERRIDES': {
-        'InviteStatusChoicesEnum': 'kobo.apps.project_ownership.models.choices.InviteStatusChoices.choices'  # noqa
+        'InviteStatusChoicesEnum': 'kobo.apps.organizations.models.OrganizationInviteStatusChoices.choices'  # noqa
     }
 }
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1016,7 +1016,8 @@ SPECTACULAR_SETTINGS = {
         'kpi.authentication.TokenAuthentication',
     ],
     'ENUM_NAME_OVERRIDES': {
-        'InviteStatusChoicesEnum': 'kobo.apps.organizations.models.OrganizationInviteStatusChoices.choices'  # noqa
+        'InviteStatusChoicesEnum': 'kobo.apps.organizations.models.OrganizationInviteStatusChoices.choices',  # noqa
+        'InviteeRoleEnum': 'kpi.schema_extensions.v2.members.schema.ROLE_CHOICES_PAYLOAD_ENUM'
     }
 }
 

--- a/kpi/schema_extensions/v2/invites/extensions.py
+++ b/kpi/schema_extensions/v2/invites/extensions.py
@@ -2,7 +2,10 @@ from drf_spectacular.extensions import (
     OpenApiSerializerExtension,
     OpenApiSerializerFieldExtension,
 )
-from drf_spectacular.plumbing import build_object_type
+from drf_spectacular.plumbing import build_object_type, build_choice_field
+from rest_framework import serializers
+
+from kobo.apps.organizations.models import OrganizationInviteStatusChoices
 
 from kpi.schema_extensions.v2.generic.schema import (
     GENERIC_ARRAY_SCHEMA,
@@ -10,6 +13,7 @@ from kpi.schema_extensions.v2.generic.schema import (
 )
 from kpi.utils.schema_extensions.url_builder import build_url_type
 from .schema import INVITE_ROLE_SCHEMA, INVITE_STATUS_SCHEMA
+from ..members.schema import ROLE_CHOICES_PAYLOAD_ENUM
 
 
 class InvitedByUrlFieldExtension(OpenApiSerializerFieldExtension):
@@ -62,4 +66,15 @@ class InviteUrlFieldExtension(OpenApiSerializerFieldExtension):
             'api_v2:organization-invites-detail',
             organization_id='orgR6zUBwMHop2mgGygtFd6c',
             guid='f3ba00b2-372b-4283-9d57-adbe7d5b1bf1',
+        )
+
+
+class InviteRoleFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.invites.fields.InviteRoleField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_choice_field(
+            field=serializers.ChoiceField(
+                choices=ROLE_CHOICES_PAYLOAD_ENUM
+            )
         )

--- a/kpi/schema_extensions/v2/invites/extensions.py
+++ b/kpi/schema_extensions/v2/invites/extensions.py
@@ -5,8 +5,6 @@ from drf_spectacular.extensions import (
 from drf_spectacular.plumbing import build_object_type, build_choice_field
 from rest_framework import serializers
 
-from kobo.apps.organizations.models import OrganizationInviteStatusChoices
-
 from kpi.schema_extensions.v2.generic.schema import (
     GENERIC_ARRAY_SCHEMA,
     USER_URL_SCHEMA,

--- a/kpi/schema_extensions/v2/invites/fields.py
+++ b/kpi/schema_extensions/v2/invites/fields.py
@@ -1,6 +1,10 @@
 from rest_framework import serializers
 
 
+class InviteesRoleEnumField(serializers.CharField):
+    pass
+
+
 class InviteesField(serializers.ListField):
     pass
 
@@ -10,4 +14,8 @@ class InviteUrlField(serializers.URLField):
 
 
 class InvitedByUrlField(serializers.URLField):
+    pass
+
+
+class InviteRoleField(serializers.CharField):
     pass

--- a/kpi/schema_extensions/v2/invites/serializers.py
+++ b/kpi/schema_extensions/v2/invites/serializers.py
@@ -4,13 +4,18 @@ from kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.
     StatusEnumField
 )
 from kpi.utils.schema_extensions.serializers import inline_serializer_class
-from .fields import InvitedByUrlField, InviteesField, InviteUrlField
+from .fields import (
+    InvitedByUrlField,
+    InviteesField,
+    InviteRoleField,
+    InviteUrlField,
+)
 
 InviteCreatePayload = inline_serializer_class(
     name='InviteCreatePayload',
     fields={
         'invitees': InviteesField(),
-        'role': serializers.CharField(),
+        'role': InviteRoleField(),
     },
 )
 
@@ -19,7 +24,7 @@ InvitePatchPayload = inline_serializer_class(
     name='InvitePatchPayload',
     fields={
         'status': serializers.CharField(),
-        'role': serializers.CharField(),
+        'role': InviteRoleField(),
     },
 )
 
@@ -30,7 +35,7 @@ InviteResponse = inline_serializer_class(
         'url': InviteUrlField(),
         'invited_by': InvitedByUrlField(),
         'status': StatusEnumField(),
-        'invitee_role': serializers.CharField(),
+        'invitee_role': InviteRoleField(),
         'created': serializers.DateTimeField(),
         'modified': serializers.DateTimeField(),
         'invitee': serializers.CharField(),

--- a/kpi/schema_extensions/v2/members/extensions.py
+++ b/kpi/schema_extensions/v2/members/extensions.py
@@ -7,7 +7,6 @@ from drf_spectacular.plumbing import (
 from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
 
-from kobo.apps.project_ownership.models.choices import InviteStatusChoices
 from kobo.apps.organizations.models import OrganizationInviteStatusChoices
 from kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.extensions import (  # noqa
     StatusEnumFieldExtension,

--- a/kpi/schema_extensions/v2/members/extensions.py
+++ b/kpi/schema_extensions/v2/members/extensions.py
@@ -8,6 +8,7 @@ from drf_spectacular.types import OpenApiTypes
 from rest_framework import serializers
 
 from kobo.apps.project_ownership.models.choices import InviteStatusChoices
+from kobo.apps.organizations.models import OrganizationInviteStatusChoices
 from kobo.apps.project_ownership.schema_extensions.v2.project_ownership.invites.extensions import (  # noqa
     StatusEnumFieldExtension,
 )
@@ -33,7 +34,7 @@ class InviteFieldExtension(OpenApiSerializerFieldExtension):
                 'invited_by': USER_URL_SCHEMA,
                 'status': build_choice_field(
                     field=serializers.ChoiceField(
-                        choices=InviteStatusChoices.choices
+                        choices=OrganizationInviteStatusChoices.choices
                     )
                 ),
                 'invitee_role': build_choice_field(


### PR DESCRIPTION
### 📣 Summary
Fixed `organization invite` enum fields in `/api/v2/organizations/{organization_id}/invites/` & `/api/v2/organizations/{organization_id}/members/`

### 📖 Description
This PR fixes the enums from the `/api/v2/organizations/{organization_id}/invites/` & `/api/v2/organizations/{organization_id}/members/` endpoints by verifying and changing the needed fields. 

### 👀 Preview steps
1.  Visit `http://kf.kobo.local/api/v2/docs/` and go to the `api/v2/docs/` endpoint.
2. Look at the endpoint's schema (organization member schema available with the `schema` option) and compare with the model. The fields must be the same.
3. Get a reference from the api (at `/api/v2/organizations/{organization_id}/invites/`) and compare with schema, enum fields must be the same- especially the status and invitee_role
4. Do the same for `/api/v2/organizations/{organization_id}/members/` 