### PR TITLE
fix(projectSettings): unnecessary modal padding DEV-910

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.module.scss
+++ b/jsapp/js/components/modalForms/projectSettings.module.scss
@@ -14,7 +14,8 @@
   margin-bottom: 30px;
 }
 
-.projectDetails {
+// `.modal` has it's own padding, we don't need it
+.projectDetails:not(.modal) {
   padding: 40px;
 }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

We use `ProjectSettings` component in the NEW project modal and in the Project → Settings → General. In modal the component doesn't need paddings, but in project settings it does. This PR removes paddings from modal.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. go to Project → Settings → General
3. 🟢 [on PR] notice that padding looks fine
4. 🟢 [on main] notice that padding looks fine
5. Click "NEW" button to create new project
6. Select "Build from scratch" option
7. 🔴 [on main] notice that the padding is huge
8. 🟢 [on PR] notice that padding looks fine
