### PR TITLE
feat(reversion): task to remove version objects DEV-946

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1365,7 +1365,12 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'kobo.apps.mass_emails.tasks.generate_mass_email_user_lists',
         'schedule': crontab(minute=0),
         'options': {'queue': 'kpi_queue'},
-    }
+    },
+    'remove-reversion-versions': {
+        'task': 'kpi.tasks.remove_old_versions',
+        'schedule': crontab(minute=0),
+        'options': {'queue': 'kpi_low_priority_queue'},
+    },
 }
 
 if STRIPE_ENABLED:
@@ -1985,6 +1990,7 @@ LOG_DELETION_BATCH_SIZE = 1000
 USER_ASSET_ORG_TRANSFER_BATCH_SIZE = 1000
 SUBMISSION_DELETION_BATCH_SIZE = 1000
 LONG_RUNNING_MIGRATION_BATCH_SIZE = 2000
+VERSION_DELETION_BATCH_SIZE = 1000
 
 # Number of stuck tasks should be restarted at a time
 MAX_RESTARTED_TASKS = 100

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
+from django.db.models import Min
+from reversion.models import Version
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.markdownx_uploader.tasks import remove_unused_markdown_files
@@ -14,6 +16,7 @@ from kpi.constants import LIMIT_HOURS_23
 from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_tasks
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import ImportTask, SubmissionExportTask
+from kpi.utils.log import logging
 
 
 @celery_app.task(
@@ -125,3 +128,15 @@ def perform_maintenance():
     remove_unused_markdown_files()
     remove_old_import_tasks()
     remove_old_asset_snapshots()
+
+
+@celery_app.task(time_limit=30, soft_time_limit=30)
+def remove_old_versions():
+    while min_id := Version.objects.aggregate(Min('pk'))['pk__min']:
+        queryset = Version.objects.filter(
+            pk__lt=min_id + settings.VERSION_DELETION_BATCH_SIZE
+        )
+        deleted = queryset.delete()
+        # leave at debug level so we don't flood the logs
+        logging.debug(f'Deleted {deleted[0]} version objects with pk < {min_id}')
+        time.sleep(10)

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -137,6 +137,6 @@ def remove_old_versions():
             pk__lt=min_id + settings.VERSION_DELETION_BATCH_SIZE
         )
         deleted = queryset.delete()
-        # leave at debug level so we don't flood the logs
+        # log at debug level so we don't flood the logs
         logging.debug(f'Deleted {deleted[0]} version objects with pk < {min_id}')
         time.sleep(10)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Background celery job to remove Version objects as we deprecate use of the library. The version table is likely to be one of the largest in the database so removing it all in one drop table command could be prohibitively expensive. There are `sleep`s built in to avoid overwhelming the table and the job will time out after 30m to avoid eating the queue.


### 👀 Preview steps

1. ℹ️ Ensure you have > 3 Version objects (you can do so by editing instances)
2. Set VERSION_DELETION_BATCH_SIZE to 2
3. Set the log level to debug
4. 🟢 [on PR] as the job runs, notice that versions are deleted 2 at a time

