### PR TITLE
fix(massEmails): get name from user extra_details with no backup DEV-925

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -272,12 +272,9 @@ class MassEmailSender:
         logging.info(f'Processing MassEmailRecord({record})')
         org_user = record.user.organization.organization_users.get(user=record.user)
         plan_name = self.get_plan_name(org_user)
-        # prefer the user-entered name for full name, but use the one from admin
-        # as a backup
-        backup_full_name = record.user.first_name + ' ' + record.user.last_name
         data = {
             'username': record.user.username,
-            'full_name': record.user.extra_details.data.get('name', backup_full_name),
+            'full_name': record.user.extra_details.data.get('name', None),
             'plan_name': plan_name,
             'date_created': record.date_created.strftime('%Y-%m-%d %H:%M'),
         }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Use the full user name in the user extra_details object, for mass email templates. If the user has no name it defaults to None. 

👀 Preview steps

This is most easily tested with MASS_EMAILS_CONDENSE_SEND set to true.

1. Using a user account, add a full name in Account Settings
2. Add the user's email to Constance > MASS_EMAIL_TEST_EMAILS
3. Create a new mass email config using the test_users query that uses ##full_name## somewhere in the template and set it to live
4. 🟢 At the next email send, the name entered in the account settings should be rendered in the email
