### PR TITLE
feat(instanceHistory): Celery task to clean instance history records DEV-753

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tasks.py
@@ -217,11 +217,13 @@ def delete_expired_instance_history_records(chunk_size=10000, max_records=100000
         xform_instance=None,
     ).values_list('id', flat=True)[:max_records]
     n_objs = len(history_ids)
-    logging.warning(f'Found {n_objs} expired InstanceHistory objects. Cleaning up ...')
+    logging.info(f'Found {n_objs} expired InstanceHistory objects. Cleaning up ...')
     for page_start in range(0, n_objs, chunk_size):
         batch_ids = history_ids[page_start:page_start + chunk_size]
         logging.warning(
             f'Deleting batch of {len(batch_ids)} InstanceHistory objects...'
         )
         queryset = InstanceHistory.objects.filter(pk__in=batch_ids)
+        # We use _raw_delete to avoid going through the ORM delete process.
+        # This model is very simple and can be deleted directly without issues
         queryset._raw_delete(queryset.db)

--- a/kobo/apps/openrosa/apps/logger/tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tasks.py
@@ -219,7 +219,7 @@ def delete_expired_instance_history_records(chunk_size=1e4, max_records=1e6):
     n_objs = len(history_ids)
     logging.warning(f'Found {n_objs} expired InstanceHistory objects. Cleaning up ...')
     for page_start in range(0, n_objs, chunk_size):
-        batch_ids = history_ids[page_start : page_start + chunk_size]
+        batch_ids = history_ids[page_start:page_start + chunk_size]
         logging.warning(
             f'Deleting batch of {len(batch_ids)} InstanceHistory objects...'
         )

--- a/kobo/apps/openrosa/apps/logger/tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tasks.py
@@ -208,7 +208,7 @@ def sync_storage_counters(**kwargs):
 
 
 @celery_app.task
-def delete_expired_instance_history_records(chunk_size=1e4, max_records=1e6):
+def delete_expired_instance_history_records(chunk_size=10000, max_records=1000000):
     threshold_time = timezone.now() - timedelta(
         days=config.SUBMISSION_HISTORY_GRACE_PERIOD
     )

--- a/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
@@ -19,7 +19,7 @@ class TestLoggerTasks(TestBase):
     def test_delete_expired_instance_history_records(self):
         d0 = datetime(2024, 1, 1, 0, 0, 0, 0, pytz.UTC)
         for i in range(0, 60):
-            # TODO: set creation time to values separated by 5 days, since 300 days ago
+            # set creation time to values separated by 5 days, since 300 days ago
             record_date = d0 + timedelta(days=i * 5)
             InstanceHistory.objects.create(
                 xform_instance=None,

--- a/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
@@ -36,31 +36,25 @@ class TestLoggerTasks(TestBase):
         chunk_size = 5
         max_records = 20
         days_threshold = config.SUBMISSION_HISTORY_GRACE_PERIOD
-        now_mock = patch(
+        with patch(
             'django.utils.timezone.now',
             return_value=d0 + timedelta(days=days_threshold - 1),
-        )
-        now_mock.start()
-        delete_expired_instance_history_records(chunk_size, max_records)
-        now_mock.stop()
+        ):
+            delete_expired_instance_history_records(chunk_size, max_records)
         assert InstanceHistory.objects.all().count() == 64
 
-        now_mock = patch(
+        with patch(
             'django.utils.timezone.now',
             return_value=d0 + timedelta(days=days_threshold + 5 * 40),
-        )
-        now_mock.start()
-        delete_expired_instance_history_records(chunk_size, max_records)
-        now_mock.stop()
+        ):
+            delete_expired_instance_history_records(chunk_size, max_records)
         assert InstanceHistory.objects.all().count() == 44
 
         max_records = 60
-        now_mock = patch(
+        with patch(
             'django.utils.timezone.now',
             return_value=d0 + timedelta(days=days_threshold + 5 * 61),
-        )
-        now_mock.start()
-        delete_expired_instance_history_records(chunk_size, max_records)
-        now_mock.stop()
+        ):
+            delete_expired_instance_history_records(chunk_size, max_records)
         assert InstanceHistory.objects.all().count() == 4
         assert InstanceHistory.objects.filter(xform_instance__isnull=False).count() == 4

--- a/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytz
+from constance import config
+
+from kobo.apps.openrosa.apps.logger.models.instance import Instance, InstanceHistory
+from kobo.apps.openrosa.apps.logger.tasks import delete_expired_instance_history_records
+from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
+
+
+class TestLoggerTasks(TestBase):
+    def setUp(self):
+        TestBase.setUp(self)
+        self._publish_transportation_form()
+        for i in range(0, 4):
+            self._submit_transport_instance(i)
+
+    def test_delete_expired_instance_history_records(self):
+        d0 = datetime(2024, 1, 1, 0, 0, 0, 0, pytz.UTC)
+        for i in range(0, 60):
+            # TODO: set creation time to values separated by 5 days, since 300 days ago
+            record_date = d0 + timedelta(days=i * 5)
+            InstanceHistory.objects.create(
+                xform_instance=None,
+                date_created=record_date,
+                date_modified=record_date,
+            )
+        for instance in Instance.objects.filter(xform=self.xform):
+            InstanceHistory.objects.create(
+                xform_instance=instance,
+                date_created=d0,
+                date_modified=d0,
+            )
+
+        chunk_size = 5
+        max_records = 20
+        days_threshold = config.SUBMISSION_HISTORY_GRACE_PERIOD
+        now_mock = patch(
+            'django.utils.timezone.now',
+            return_value=d0 + timedelta(days=days_threshold - 1),
+        )
+        now_mock.start()
+        delete_expired_instance_history_records(chunk_size, max_records)
+        now_mock.stop()
+        assert InstanceHistory.objects.all().count() == 64
+
+        now_mock = patch(
+            'django.utils.timezone.now',
+            return_value=d0 + timedelta(days=days_threshold + 5 * 40),
+        )
+        now_mock.start()
+        delete_expired_instance_history_records(chunk_size, max_records)
+        now_mock.stop()
+        assert InstanceHistory.objects.all().count() == 44
+
+        max_records = 60
+        now_mock = patch(
+            'django.utils.timezone.now',
+            return_value=d0 + timedelta(days=days_threshold + 5 * 61),
+        )
+        now_mock.start()
+        delete_expired_instance_history_records(chunk_size, max_records)
+        now_mock.stop()
+        assert InstanceHistory.objects.all().count() == 4
+        assert InstanceHistory.objects.filter(xform_instance__isnull=False).count() == 4

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -426,6 +426,11 @@ CONSTANCE_CONFIG = {
         'Number of days to keep import tasks',
         'positive_int',
     ),
+    'SUBMISSION_HISTORY_GRACE_PERIOD': (
+        180,
+        'Number of days to keep submission history',
+        'positive_int',
+    ),
     'FREE_TIER_THRESHOLDS': (
         LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS),
         'Free tier thresholds: storage in kilobytes, '
@@ -783,6 +788,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     'Regular maintenance settings': (
         'ASSET_SNAPSHOT_DAYS_RETENTION',
         'IMPORT_TASK_DAYS_RETENTION',
+        'SUBMISSION_HISTORY_GRACE_PERIOD',
     ),
     'Tier settings': (
         'FREE_TIER_THRESHOLDS',
@@ -1294,6 +1300,11 @@ CELERY_BEAT_SCHEDULE = {
     'delete-daily-xform-submissions-counter': {
         'task': 'kobo.apps.openrosa.apps.logger.tasks.delete_daily_counters',
         'schedule': crontab(hour=0, minute=0),
+        'options': {'queue': 'kobocat_queue'},
+    },
+    'delete-expired-instance-history-records': {
+        'task': 'kobo.apps.openrosa.apps.logger.tasks.delete_expired_instance_history_records',
+        'schedule': crontab(day_of_week=1, hour=10, minute=0),
         'options': {'queue': 'kobocat_queue'}
     },
     # Schedule every 30 minutes

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1304,7 +1304,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     'delete-expired-instance-history-records': {
         'task': 'kobo.apps.openrosa.apps.logger.tasks.delete_expired_instance_history_records',  # noqa
-        'schedule': crontab(day_of_week=1, hour=10, minute=0),
+        'schedule': crontab(hour=1, minute=0),
         'options': {'queue': 'kobocat_queue'}
     },
     # Schedule every 30 minutes

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1303,7 +1303,7 @@ CELERY_BEAT_SCHEDULE = {
         'options': {'queue': 'kobocat_queue'},
     },
     'delete-expired-instance-history-records': {
-        'task': 'kobo.apps.openrosa.apps.logger.tasks.delete_expired_instance_history_records',
+        'task': 'kobo.apps.openrosa.apps.logger.tasks.delete_expired_instance_history_records',  # noqa
         'schedule': crontab(day_of_week=1, hour=10, minute=0),
         'options': {'queue': 'kobocat_queue'}
     },


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
InstanceHistory objects are kept for an amount of days given by the constance parameter SUBMISSION_HISTORY_GRACE_PERIOD. After this period has passed, the records that have no associated instance (xform_instance = NULL) are deleted by a celery task that runs weekly.

### 👀 Preview steps
This is covered with unit tests. However, to test you could:

1. Have a project with submissions
2. Delete some submissions 
3. Configure the constance parameter SUBMISSION_HISTORY_GRACE_PERIOD to 0 days. 
4. Get a shell (`./manage.py shell_plus`, via docker exec bash)  and inspect the InstanceHistory objects
```
InstanceHistory.objects.filter(xform_instance__isnull=True).count()
```
5. Manually call the task, from the shell:
```
from kobo.apps.openrosa.apps.logger.tasks import delete_expired_instance_history_records

delete_expired_instance_history_records()
```
6. Inspect again the count `InstanceHistory.objects.filter(xform_instance__isnull=True).count()`