### PR TITLE
fix(tooltip): replace deprecated button with new button in table cells

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -91,6 +91,7 @@ import pageState from '#/pageState.store'
 import type { PageStateStoreState } from '#/pageState.store'
 import { stores } from '#/stores'
 import { formatTimeDateShort } from '#/utils'
+import ActionIcon from '../common/ActionIcon'
 import LimitNotifications from '../usageLimits/limitNotifications.component'
 import RepeatGroupCell from './RepeatGroupCell'
 import AudioCell from './audioCell'
@@ -530,24 +531,22 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
             causing an unnecessary space under the last table row to happen.
             Let's try to fix this one day by introducing better tooltips.
             */}
-            <Button
-              type='text'
-              size='s'
-              startIcon='view'
-              tooltip={t('Open')}
-              tooltipPosition='left'
+            <ActionIcon
+              variant='transparent'
+              tooltip={t('Edit')}
+              iconName='view'
+              size='sm'
               onClick={() => {
                 this.launchSubmissionModal(row.original._id)
               }}
             />
 
             {userCanSeeEditIcon && userHasPermForSubmission('change_submissions', this.props.asset, row.original) && (
-              <Button
-                type='text'
-                size='s'
-                startIcon='edit'
+              <ActionIcon
+                variant='transparent'
                 tooltip={t('Edit')}
-                tooltipPosition='left'
+                iconName='edit'
+                size='sm'
                 onClick={() => {
                   this.launchEditSubmission(row.original._id)
                 }}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Replaces deprecated button with new button that fixes a tooltip issue in the data table

### 👀 Preview steps

1. ℹ️ have an account and a project with multiple submissions
2. select the 2nd submission in the data table
3. hover over the view or edit icons in the table row for the first submission
4. 🔴 [on main] notice that the tooltip is 'underneath' the next cell
5. 🟢 [on PR] notice that the tooltip is 'above' the next cell
