### PR TITLE
fix(exports): simplify account log export prompt DEV-471

### DIFF
--- a/jsapp/js/components/exportToEmailButton/exportToEmailButton.component.tsx
+++ b/jsapp/js/components/exportToEmailButton/exportToEmailButton.component.tsx
@@ -2,26 +2,8 @@ import { useState } from 'react'
 
 import { handleApiFail } from '#/api'
 import type { FailResponse } from '#/dataInterface'
+import { notify } from '#/utils'
 import Button from '../common/button'
-import KoboPrompt from '../modals/koboPrompt'
-
-const MessageModal = ({ onClose }: { onClose: () => void }) => (
-  <KoboPrompt
-    isOpen
-    onRequestClose={onClose}
-    title={t('Exporting data')}
-    buttons={[
-      {
-        label: 'Ok',
-        onClick: onClose,
-      },
-    ]}
-  >
-    {t(
-      "Your export request is currently being processed. Once the export is complete, you'll receive an email with all the details.",
-    )}
-  </KoboPrompt>
-)
 
 /**
  * Button to be used in views that export data to email.
@@ -35,14 +17,13 @@ export default function ExportToEmailButton({
   exportFunction: () => Promise<unknown>
   label: string
 }) {
-  const [isMessageOpen, setIsMessageOpen] = useState(false)
   const [isPending, setIsPending] = useState(false)
 
   const handleClick = () => {
     setIsPending(true)
     exportFunction()
       .then(() => {
-        setIsMessageOpen(true)
+        notify(t("Export is being generated, you will recieve an email once it's done"))
       })
       .catch((error) => handleApiFail(error as FailResponse))
       .finally(() => {
@@ -53,7 +34,6 @@ export default function ExportToEmailButton({
   return (
     <>
       <Button size='m' type='primary' label={label} startIcon='download' onClick={handleClick} isPending={isPending} />
-      {isMessageOpen && <MessageModal onClose={() => setIsMessageOpen(false)} />}
     </>
   )
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Notifications for exporting access logs now match notifications for project activity logs

### 👀 Preview steps
1. ℹ️ have an account
2. do stuff that would be logged on the access logs, like sign in with a different browser
3. go to access logs in account settings
4. click "Export log data"
5. 🔴 [on main] notice that there is a modal popup
6. 🟢 [on PR] notice that the modal popup is replaced with a notify toast
7. open dev tools and turn off network
8. click "Export log data"
9. 🟢 notice that the error message toast is not interfered with
