### PR TITLE
fix(nlp): reset polling status after auto translation finishes DEV-915

### DIFF
--- a/jsapp/js/components/processing/singleProcessingStore.ts
+++ b/jsapp/js/components/processing/singleProcessingStore.ts
@@ -666,6 +666,7 @@ class SingleProcessingStore extends Reflux.Store {
     }
 
     this.setNotPristine()
+    this.data.isPollingForTranslation = false
     this.trigger(this.data)
   }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug in NLP where attempting a second automatic translation resulted in a infinite loading screen

### 👀 Preview steps
1. ℹ️ have an account and a project
2. set up nlp automatic translations with these steps https://www.notion.so/kobotoolbox/Setting-up-NLP-and-Languages-bb607e3fed114993bb14338fe56c6ed4
3. create a project with text and audio questions
4. add submissions with both text and audio
5. open single processing view and add a transcription
6. follow the steps for automatic translation
7. after the first auto translation finishes attempt to do another auto translation
    - this can be done either by saving the first language, and selecting another or discarding the auto translation and attempting on the same language again
9. 🔴 [on main] notice that the confirm step is gone and you are now stuck in an infinite loading screen
10. 🟢 [on PR] notice that you are not stuck on an infinite loading screen, and the confirmation step is back
