### PR TITLE
fix(exports): use empty object instead of null for empty payload

### DIFF
--- a/jsapp/js/components/activity/activityLogs.query.ts
+++ b/jsapp/js/components/activity/activityLogs.query.ts
@@ -76,7 +76,7 @@ const getFilterOptions = async (assetUid: string): Promise<LabelValuePair[]> => 
  * @returns {Promise<void>} The promise that starts the export
  */
 export const startActivityLogsExport = (assetUid: string) =>
-  fetchPost(endpoints.ASSET_HISTORY_EXPORT.replace(':asset_uid', assetUid), null, { notifyAboutError: false }).catch(
+  fetchPost(endpoints.ASSET_HISTORY_EXPORT.replace(':asset_uid', assetUid), {}, { notifyAboutError: false }).catch(
     (error) => {
       const failResponse: FailResponse = {
         status: 500,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes an issue where exporting project history activity results in a `403`, citing a `CSRF token` error.

### 💭 Notes

This updates a fix to DEV-833 where we are using the wrong parameters for `fetchPost`. Since this call doesn't need a payload that fix used `null` which caused this bug

### 👀 Preview steps

1. ℹ️ have an account and a project
2. ℹ️  have some email service set up
3. navigate to a project's settings > activity
4. ensure there is something to export (edit the form and save it)
5. click "export all data"
6. 🔴 [on main] notice that there is a error toast message and no export is created
7. 🟢 [on PR] notice that the export is created as expected
