### PR TITLE
[NA] Setting correct version on main deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,8 +42,8 @@ deploy-staging:
     - BRANCH_TITLE=${CI_COMMIT_BRANCH#feature/}
     - |
       if [ "$CI_COMMIT_BRANCH" = "main" ]; then
-        helm -n kobo-dev upgrade staging-main oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
-        helm -n kobo-dev upgrade staging-nobill oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.image.tag=${CI_COMMIT_SHORT_SHA} --reuse-values
+        helm -n kobo-dev upgrade staging-main oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${CI_COMMIT_SHORT_SHA} --reuse-values
+        helm -n kobo-dev upgrade staging-nobill oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${CI_COMMIT_SHORT_SHA} --reuse-values
       elif [ "$CI_COMMIT_BRANCH" = "feature/api-documentation" ]; then
         helm -n kobo-dev upgrade --install docs oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${CI_COMMIT_SHORT_SHA} --reuse-values
       else


### PR DESCRIPTION
There was a bad merge commit ~2 weeks ago that left the deploy command in a old configuration, which lead to main deployments not working correctly.  This updates the gitlab pipeline to use the proper version.