### PR TITLE
fix(formBuilder): new choice button missing DEV-982

### DIFF
--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -31,7 +31,6 @@ module.exports = do ->
         @$el.removeClass("hidden")
       else
         @$el.addClass("hidden")
-      return
 
       # sortable is usually enabled, but sometimes (e.g. locking restriction
       # enabled) it is not


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

A `return` was added in the middle of `render` function causing the important code to be not called. PR #6103 is the culprit: https://github.com/kobotoolbox/kpi/pull/6103/files#diff-8c424b52e69e7cfc99655e25f2e0b2bf1e62109d4aa3bc07d6c46ea9f558fe69R34