### PR TITLE
feat(dataCollectors): update enketo links when assigning assets to groups DEV-798

### DIFF
--- a/kobo/apps/data_collectors/admin.py
+++ b/kobo/apps/data_collectors/admin.py
@@ -59,7 +59,21 @@ class DataCollectorGroupAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         assets = form.cleaned_data['assets']
         super().save_model(request, obj, form, change)
-        obj.assets.set(assets)
+        new_asset_uids = list(obj.assets.values('uid'))
+        # we have to do this manually instead of using obj.assets.set()
+        # so we can call save() with adjust_content=False
+        for old_asset in obj.assets.all():
+            if old_asset.uid not in new_asset_uids:
+                old_asset.data_collector_group = None
+                old_asset.save(
+                    update_fields=['data_collector_group'], adjust_content=False
+                )
+        for new_asset in assets:
+            if new_asset.data_collector_group_id != obj.pk:
+                new_asset.data_collector_group = obj
+                new_asset.save(
+                    update_fields=['data_collector_group'], adjust_content=False
+                )
 
     def get_form(self, request, obj=..., change=..., **kwargs):
         form = super().get_form(request, obj, change, **kwargs)

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -233,6 +233,15 @@ class BaseDeploymentBackend(abc.ABC):
             duplicated_extras['submission'] = dest_uuid
             self.asset.update_submission_extra(duplicated_extras)
 
+    def create_enketo_survey_links_for_data_collectors(self):
+        data_collector_tokens = list(
+            self.asset.data_collector_group.data_collectors.values_list(
+                'token', flat=True
+            )
+        )
+        for token in data_collector_tokens:
+            self.set_data_collector_enketo_links(token)
+
     def delete(self):
         self.asset._deployment_data.clear()  # noqa
 
@@ -436,6 +445,10 @@ class BaseDeploymentBackend(abc.ABC):
     def redeploy(self, active: bool = None):
         pass
 
+    def remove_enketo_survey_links_for_data_collectors(self, tokens):
+        for token in tokens:
+            self.remove_data_collector_enketo_links(token)
+
     def remove_from_kc_only_flag(self, *args, **kwargs):
         # TODO: This exists only to support KoBoCAT (see #1161) and should be
         # removed, along with all places where it is called, once we remove
@@ -443,6 +456,10 @@ class BaseDeploymentBackend(abc.ABC):
 
         # Do nothing, without complaint, so that callers don't have to worry
         # about whether the back end is KoBoCAT or something else
+        pass
+
+    @abc.abstractmethod
+    def remove_data_collector_enketo_links(self, token):
         pass
 
     @abc.abstractmethod
@@ -483,6 +500,10 @@ class BaseDeploymentBackend(abc.ABC):
 
     @abc.abstractmethod
     def set_asset_uid(self, **kwargs) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def set_data_collector_enketo_links(self, token):
         pass
 
     @abc.abstractmethod

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -215,9 +215,9 @@ class BaseDeploymentBackend(abc.ABC):
     def calculated_submission_count(self, user: settings.AUTH_USER_MODEL, **kwargs):
         pass
 
-    @abc.abstractmethod
     def connect(self, active=False):
-        pass
+        if self.asset.data_collector_group_id is not None:
+            self.create_enketo_survey_links_for_data_collectors()
 
     def copy_submission_extras(self, origin_uuid: str, dest_uuid: str):
         """

--- a/kpi/deployment_backends/mock_backend.py
+++ b/kpi/deployment_backends/mock_backend.py
@@ -145,6 +145,12 @@ class MockDeploymentBackend(OpenRosaDeploymentBackend):
             if assign_perm:
                 self.asset.remove_perm(request.user, PERM_ADD_SUBMISSIONS)
 
+    def remove_data_collector_enketo_links(self, token):
+        pass
+
+    def set_data_collector_enketo_links(self, token):
+        pass
+
     def set_namespace(self, namespace):
         self.store_data(
             {

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -175,6 +175,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 'version': self.asset.version_id,
             }
         )
+        super().connect(active)
 
     @property
     def form_uuid(self):

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -21,9 +21,12 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from django_redis import get_redis_connection
-from pyxform.builder import create_survey_from_xls
 from rest_framework import exceptions, status
 
+from kobo.apps.data_collectors.utils import (
+    remove_data_collector_enketo_links,
+    set_data_collector_enketo_links,
+)
 from kobo.apps.openrosa.apps.logger.models import (
     Attachment,
     DailyXFormSubmissionCounter,
@@ -77,10 +80,11 @@ from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
-from .openrosa_utils import create_enketo_links
+from pyxform.builder import create_survey_from_xls
 from ..exceptions import AttachmentUidMismatchException, BadFormatException
 from .base_backend import BaseDeploymentBackend
 from .kc_access.utils import assign_applicable_kc_permissions, kc_transaction_atomic
+from .openrosa_utils import create_enketo_links
 
 
 class OpenRosaDeploymentBackend(BaseDeploymentBackend):
@@ -700,6 +704,12 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             'csv': '/'.join((reports_base_url, 'export.csv')),
         }
         return links
+
+    def set_data_collector_enketo_links(self, token):
+        set_data_collector_enketo_links(token, [self.xform.id_string])
+
+    def remove_data_collector_enketo_links(self, token):
+        remove_data_collector_enketo_links(token, [self.xform.id_string])
 
     def get_enketo_survey_links(self):
         if not self.get_data('backend_response'):

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -11,12 +11,12 @@ from django.contrib.postgres.indexes import BTreeIndex, GinIndex
 from django.db import models, transaction
 from django.db.models import F, Prefetch, Q
 from django.utils.translation import gettext_lazy as t
-from formpack.utils.flatten_content import flatten_content
-from formpack.utils.json_hash import json_hash
-from formpack.utils.kobo_locking import strip_kobo_locking_profile
 from taggit.managers import TaggableManager, _TaggableManager
 from taggit.utils import require_instance_manager
 
+from formpack.utils.flatten_content import flatten_content
+from formpack.utils.json_hash import json_hash
+from formpack.utils.kobo_locking import strip_kobo_locking_profile
 from kobo.apps.data_collectors.models import DataCollectorGroup
 from kobo.apps.reports.constants import DEFAULT_REPORTS_KEY, SPECIFIC_REPORTS_KEY
 from kobo.apps.subsequences.advanced_features_params_schema import (
@@ -500,12 +500,13 @@ class Asset(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # The two fields below are needed to keep a trace of the object state
+        # The fields below are needed to keep a trace of the object state
         # before any alteration. See `__self.__copy_hidden_fields()` for details
         # They must be set with an invalid value for their counterparts to
         # be the comparison is accurate.
         self.__parent_id_copy = -1
         self.__deployment_data_copy = None
+        self._initial_data_collector_group_id = -1
         self.__copy_hidden_fields()
 
     def __str__(self):
@@ -1563,6 +1564,13 @@ class Asset(
         ):
             self.__deployment_data_copy = copy.deepcopy(
                 self._deployment_data)
+        if (
+            fields is None
+            and 'data_collector_group_id' not in self.get_deferred_fields()
+            or fields
+            and 'data_collector_group_id' in fields
+        ):
+            self._initial_data_collector_group_id = self.data_collector_group_id
 
 
 class UserAssetSubscription(models.Model):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Create/update enketo links for data collectors when assigning assets to data collector groups.

### 📖 Description
Create the necessary enketo links for data collectors so they can view/submit to the assets to which their group has access.


### 💭 Notes
This PR handles the following situations: 

A deployed asset is added to a data collector group -> we generate links for every data collector in that group to that asset's endpoints
A deployed asset is removed from a data collector group -> we remove every link for every data collector in that group to that asset
An asset with a data collector group is deployed for the first time -> we generate links for every data collector in that group


### 👀 Preview steps
1. ℹ️ have a superuser account and at least one another account with a project my_project. Also have at least one undeployed project
2. In Django admin, create 2 new data collector groups (DCG_0 and DCG_1) with at least 2 data collectors each (DC_00, DC_01 for DCG_0 and DC_10, DC_11 for DCG_1)
3. In Django admin, assign my_project to DCG_0
4. In redis-cli, run hget "or:http://<kobo_url>/key/<DC_00's token>" "my_project_uid" and make note of the enketo_id you get back
5. In the browser, navigate to <enketo_url>/x/<enketo_id>. Take note of this url
6. 🟢 You should get an error message Request to http://kf.kobo.local:8080/key/<DC_00 token>/formList?formID=<my_project_uid> failed. This means it generated the correct request, but we haven't set up authentication yet so we expect it to fail
7. 🟢 Repeat steps 4-6 for DC_01
8. In Django admin, remove my_project from DCG_0 and assign it to DCG_1
9. Navigate to the enketo urls you used for DC_01 and DC_11
10. 🟢 Both old URLs should respond with Survey with this ID not found
11. Repeat steps 4-6 for DC_11 and DC_01
12. Add the undeployed project to DCG_0
13. Deploy the project
14. Repeat steps 4-6 for DC_00 using the new project uid
