### PR TITLE
fix(exports): use empty object for empty payload DEV-959

### DIFF
--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -39,7 +39,7 @@ export async function getAccessLogs(limit: number, offset: number) {
  * @returns {Promise<void>} A promise that starts the export.
  */
 export const startAccessLogsExport = () =>
-  fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, null, { notifyAboutError: false }).catch((error) => {
+  fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, {}, { notifyAboutError: false }).catch((error) => {
     const failResponse: FailResponse = {
       status: 500,
       statusText: error.message || t('An error occurred while exporting the logs'),

--- a/jsapp/js/account/security/accessLogs/accessLogs.query.ts
+++ b/jsapp/js/account/security/accessLogs/accessLogs.query.ts
@@ -39,7 +39,7 @@ export async function getAccessLogs(limit: number, offset: number) {
  * @returns {Promise<void>} A promise that starts the export.
  */
 export const startAccessLogsExport = () =>
-  fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, { notifyAboutError: false }).catch((error) => {
+  fetchPost(endpoints.ACCESS_LOGS_EXPORT_URL, null, { notifyAboutError: false }).catch((error) => {
     const failResponse: FailResponse = {
       status: 500,
       statusText: error.message || t('An error occurred while exporting the logs'),


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Similar change to #6188. When using `fetchPost` with empty payload, we need to pass empty object. Here we were omitting the parameter, and thus `FetchDataOptions` were being passed (wrongly) to BE.