### PR TITLE
fix(languageSelector): remove native cancel button on chrome DEV-360

### DIFF
--- a/jsapp/js/components/languages/languageSelector.scss
+++ b/jsapp/js/components/languages/languageSelector.scss
@@ -119,6 +119,11 @@
   &:focus {
     outline: none;
   }
+
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    display: none;
+  }
 }
 
 .language-selector__clear-selected-language,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Chrome no longer displays two clear search buttons ("x") in Language Selector component.

