### PR TITLE
feat(dataCollectors): create authentication class for data collectors DEV-787

### DIFF
--- a/kobo/apps/data_collectors/authentication.py
+++ b/kobo/apps/data_collectors/authentication.py
@@ -1,0 +1,46 @@
+from django.contrib.auth.models import AnonymousUser
+from rest_framework.authentication import BaseAuthentication
+
+from kobo.apps.data_collectors.models import DataCollector
+from kobo.apps.openrosa.apps.logger.models import XForm
+from kpi.constants import PERM_ADD_SUBMISSIONS
+
+
+class DataCollectorUser(AnonymousUser):
+    @property
+    def is_authenticated(self):
+        # Always return True. This is a way to tell if
+        # the user has been authenticated in permissions
+        return True
+
+    assets = []
+    name = None
+
+    def has_perm(self, perm, obj=...):
+        if perm != PERM_ADD_SUBMISSIONS:
+            return False
+        if not isinstance(obj, XForm):
+            return False
+        return obj.kpi_asset_uid in self.assets
+
+
+class DataCollectorTokenAuthentication(BaseAuthentication):
+    def authenticate(self, request):
+        context = request.parser_context
+        kwargs = context.get('kwargs', {})
+        token = kwargs.get('token', None)
+        if not token:
+            return None
+        return self.authenticate_credentials(token)
+
+    def authenticate_credentials(self, key):
+        try:
+            collector = DataCollector.objects.get(token=key)
+            server_user = DataCollectorUser()
+            group = collector.group
+            if group:
+                server_user.assets = list(group.assets.values_list('uid', flat=True))
+                server_user.name = collector.name
+            return server_user, key
+        except DataCollector.DoesNotExist:
+            raise DataCollector.AuthenticationFailed('Invalid token.')

--- a/kobo/apps/data_collectors/tests/test_authentication.py
+++ b/kobo/apps/data_collectors/tests/test_authentication.py
@@ -1,0 +1,52 @@
+from django.test import RequestFactory, TestCase, override_settings
+
+from kobo.apps.data_collectors.authentication import (
+    DataCollectorTokenAuthentication,
+    DataCollectorUser,
+)
+from kobo.apps.data_collectors.models import DataCollector, DataCollectorGroup
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.constants import PERM_ADD_SUBMISSIONS, PERM_MANAGE_ASSET
+from kpi.models import Asset
+
+
+@override_settings(DEFAULT_DEPLOYMENT_BACKEND='mock')
+class TestDataCollectorAuthentication(TestCase):
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.authenticator = DataCollectorTokenAuthentication()
+        self.someuser = User.objects.get(username='someuser')
+        self.asset = Asset.objects.filter(owner=self.someuser).first()
+        self.asset.save()
+        self.asset.deploy(backend='mock')
+
+    def test_data_collector_token_authentication(self):
+        request = RequestFactory().get('/')
+        setattr(request, 'parser_context', {'kwargs': {'token': 'token_a'}})
+        data_collector_group = DataCollectorGroup.objects.create(
+            name='DCG', owner=self.someuser
+        )
+        data_collector_group.assets.add(self.asset)
+        DataCollector.objects.create(
+            name='DC_a', token='token_a', group=data_collector_group
+        )
+        authenticated_user, token = self.authenticator.authenticate(request)
+        assert isinstance(authenticated_user, DataCollectorUser)
+        assert authenticated_user.assets == [self.asset.uid]
+
+    def test_data_collector_user_permissions(self):
+        user = DataCollectorUser()
+        user.assets = [self.asset.uid]
+        xform = self.asset.deployment.xform
+
+        second_asset = Asset.objects.filter(owner=self.someuser)[1]
+        # deploy it so we get an xform
+        second_asset.save()
+        second_asset.deploy(backend='mock')
+
+        assert user.has_perm(PERM_ADD_SUBMISSIONS, xform)
+        # user should only have add submission permission
+        assert not user.has_perm(PERM_MANAGE_ASSET, xform)
+        # no permission for an asset not in the asset list
+        assert not user.has_perm(PERM_ADD_SUBMISSIONS, second_asset.deployment.xform)


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
Developer-only changes. Sets up the authentication class we will use to authenticate DataCollectors, who have authentication tokens but are not actual Django users. 
Since we need some kind of user to verify permissions, we create a new "fake" user class, DataCollectorUser, that inherits from AnonymousUser. This type of user has a list of assets it is allowed to view/submit to.
When we authenticate, we grab the token from the url and use it to look up a DataCollector object. If there is one, we create a new DataCollectorUser and give it a list of assets corresponding to the assets belonging to the DataCollector's group. This DataCollecotrUser's only permissions are PERM_ADD_SUBMISSION on any asset in its whitelist.

### 👀 Preview steps
None, dev-only.