### PR TITLE
feat(removeAttachments): add remove attachment activity constants DEV-962

### DIFF
--- a/jsapp/js/components/activity/activity.constants.ts
+++ b/jsapp/js/components/activity/activity.constants.ts
@@ -21,6 +21,7 @@ export enum AuditActions {
   'disconnect-project' = 'disconnect-project',
   'enable-sharing' = 'enable-sharing',
   export = 'export',
+  'in-trash' = 'in-trash',
   'modify-imported-fields' = 'modify-imported-fields',
   'modify-service' = 'modify-service',
   'modify-sharing' = 'modify-sharing',
@@ -119,6 +120,11 @@ const _AUDIT_ACTION_TYPES: Array<Omit<AuditActionDefinition, 'order'>> = [
     name: AuditActions['delete-media'],
     label: t('remove media attachment'),
     message: t('##username## removed a media attachment'),
+  },
+  {
+    name: AuditActions['in-trash'],
+    label: t('remove attachment'),
+    message: t('##username## removed an attachment'),
   },
   {
     name: AuditActions['modify-user-permissions'],


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR adds the nice name of "remove attachment" for the "in-trash" activity.

From (release branch):
<img width="1013" height="207" alt="image" src="https://github.com/user-attachments/assets/33e53131-a4d7-437d-9ea7-91493b0bb862" />

To (This PR):
<img width="1013" height="207" alt="image" src="https://github.com/user-attachments/assets/a7531fd2-9f6e-4b6c-bdba-f476d07f08ed" />


### 👀 Preview steps
1. ℹ️ have an account
2. ℹ️ have a project with media
3. Remove the attachments
4. Check the activity logs
5. 🔴 [on release] it says "user did in-trash action" for the action
6. 🟢 [on PR] it says "user removed an attachment" for the action
