### PR TITLE
fix(audioRecording): background audio file being soft deleted on creation DEV-976

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import logging
 import os
 import re
 import sys

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
-import logging
 import os
 import re
 import sys
@@ -901,6 +900,7 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
         Q(media_file_basename__endswith='.enc')
         | Q(media_file_basename='audit.csv')
         | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$')
+        | Q(media_file_basename__regex=r'^background-audio-\d{8}_\d{6}\.webm$')
     ).order_by('-id')
 
     latest_attachments, remaining_attachments_ids = [], []

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -900,8 +900,8 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     queryset = Attachment.objects.filter(instance=instance).exclude(
         Q(media_file_basename__endswith='.enc')
         | Q(media_file_basename='audit.csv')
-        | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$')
-        | Q(media_file_basename__regex=r'^background-audio-\d{8}_\d{6}\.webm$')
+        | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$') # background audio file by Collect
+        | Q(media_file_basename__regex=r'^background-audio-\d{8}_\d{6}\.webm$') # background audio file by Enketo
     ).order_by('-id')
 
     latest_attachments, remaining_attachments_ids = [], []


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR adds the pattern for the background audio file generated by Enketo to the fix to avoid it being soft-deleted on creation

### 👀 Preview steps
1. ℹ️ have an account
2. ℹ️ have a project with background audio and another media, like audio question
3. ⚠️ The current main of Enketo needs to be used to test this
4. Post a submission
5. 🔴 [on main] the generated background audio file gets deleted (only the name of the file appears in the data-table and it's marked as deleted on database)
6. 🟢 [on PR] background audio file appears normally
