### PR TITLE
ci(releases): run stabilize on release branching DEV-908

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -2,6 +2,7 @@ name: 'CD: stabilize'
 
 
 on:
+  create:
   push:
     branches: [ 'release/**' ]
 
@@ -10,6 +11,7 @@ jobs:
 
 
   changes:
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-24.04
     permissions: { pull-requests: read }
     steps:
@@ -52,11 +54,12 @@ jobs:
 
   version:
     needs:
+      - changes
       - darker
       - biome
       - pytest
       - npm-test
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && needs.changes.result == 'success' }}
     secrets: inherit
     uses: './.github/workflows/find-releases.yml'
 
@@ -64,7 +67,7 @@ jobs:
   changelog:
     needs:
       - version
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
     - name: post to Zulip Linear updated draft of changelog
@@ -76,7 +79,7 @@ jobs:
   deploy-to-beta:
     needs:
       - version
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
@@ -91,7 +94,7 @@ jobs:
     name: Merge forward
     needs:
       - version
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Generate a token to trigger a workflow from a workflow
@@ -135,7 +138,7 @@ jobs:
       - changelog
       - deploy-to-beta
       - merge-forward
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
     uses: './.github/workflows/zulip.yml'
     secrets: inherit
     with:


### PR DESCRIPTION
### 💭 Notes

Run all stabilize jobs (e.g. deploy to beta) also when a new release is branched.

Sadly a side-effect of this is a spam of skipped workflow runs (e.g. this one) for all newly created non-release branches.