### PR TITLE
ci(releases): set origin for pushing DEV-301

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -111,7 +111,7 @@ jobs:
           git checkout -B changelog/$CURRENT_PATCH
           git add -f CHANGELOG.md
           git commit -m "chore(releases): generate CHANGELOG.md for $CURRENT_PATCH"
-          git push -f
+          git push -f --set-upstream origin changelog/$CURRENT_PATCH
 
 
   deploy-to-beta:


### PR DESCRIPTION
### 💭 Notes

Fixes CI failure introduced in 40b2905