### PR TITLE
fix(billing): set days to 0 on ExceededLimitCounter creation DEV-978

### DIFF
--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -37,7 +37,6 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
         counter, created = ExceededLimitCounter.objects.get_or_create(
             user=user,
             limit_type=usage_type,
-            defaults={'days': 1},
         )
 
         if not created and counter.date_modified.date() < timezone.now().date():


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Use the model default 0 for `days` field when creating an `ExceededLimitCounter`.

### 📖 Description
This was already the default on the model and doesn't have much of an impact, but works more sensibly with the attachment deletion grace period, so if the grace period is 1, an attachment will not be subject to deletion on the day a exceeded limit counter was created.

### 👀 Preview steps
1. On a stripe-enabled instance, create a user on community plan. Set ENDPOINT_CACHE_DURATION to 1 for ease of testing.
2. Make a submission with an audio file
3. Set community plan limit to below size of submitted file.
4. Make another submission (will be rejected)
5. Check django shell to see a newly created counter with the `days` field set to 0.
