### PR TITLE
fix(trashBin): fail immediately for missing XForms

### DIFF
--- a/kobo/apps/trash_bin/utils/project.py
+++ b/kobo/apps/trash_bin/utils/project.py
@@ -64,6 +64,18 @@ def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: 'kpi.As
     try:
         asset.deployment.xform
     except (MissingXFormException, InvalidXFormException):
+        # FIXME: Yes, we want to remove these stranded submissions, but:
+        # 1. `XForm.id_string` is not unique (it's unique only with `XForm.user`)
+        # 2. We haven't ensured that indexes exist for this query, and so huge
+        #     sequential scans that are allowed for 35+ minutes are stressing
+        #     the database servers
+        # Just fail for now as a hotfix until we figure out what to do.
+        # Discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/Project.20deletion.20hammering.20MongoDB/near/688972
+        logging.error(f'TrashBin: not attempting to delete MongoDB orphans')
+        raise
+
+        # Below code is dead for now!
+
         # Submissions are lingering in MongoDB but XForm has been
         # already deleted
         xform_id_string = asset.deployment.backend_response['id_string']
@@ -78,6 +90,8 @@ def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: 'kpi.As
         logging.warning(f'TrashBin: {deleted_orphans} deleted MongoDB orphans')
 
         return
+
+        # ^^^ End of dead code ^^^
 
     while True:
         audit_logs = []


### PR DESCRIPTION
This is a hotfix until a proper solution for removing stranded MongoDB submissions can be developed

### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->

TODO

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

TODO

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
