### PR TITLE
fix(billing): remove days filter on usage counter updates DEV-1001

### DIFF
--- a/kobo/apps/stripe/tasks.py
+++ b/kobo/apps/stripe/tasks.py
@@ -10,7 +10,6 @@ from kobo.celery import celery_app
 @celery_app.task
 def update_exceeded_limit_counters():
     qs = ExceededLimitCounter.objects.filter(
-        days__gt=0,
         date_modified__date__lte=timezone.now().date() - timedelta(days=1)
     )
 

--- a/kobo/apps/stripe/tests/test_celery_tasks.py
+++ b/kobo/apps/stripe/tests/test_celery_tasks.py
@@ -23,25 +23,16 @@ class StripeSignalsTestCase(BaseTestCase):
 
     def test_clear_usage_cache_and_counters_on_save(self):
         """
-        Ensure that task runs updates for counters more than one day old
-        and not modified in past day
+        Ensure that task runs updates for counters not modified in past day
         """
         test_counter = baker.make(
             ExceededLimitCounter,
             user=self.someuser,
-            days=1,
             date_modified=timezone.now().date() - timedelta(days=2),
         )
         baker.make(
             ExceededLimitCounter,
             user=self.someuser,
-            days=0,
-            date_modified=timezone.now().date() - timedelta(days=2),
-        )
-        baker.make(
-            ExceededLimitCounter,
-            user=self.someuser,
-            days=1,
             date_modified=timezone.now().date() - timedelta(hours=4),
         )
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensures counters are updated even if their `days` field is set to 0.

### 💭 Notes
Now that we set this field to zero on counter creation, there is no point in filtering on this field anymore. Filtering the date modified should be sufficient.

### 👀 Preview steps
Probably not practical to test locally. Unit tests included.
1. On a stripe-enabled instance, create a user on community plan. Set ENDPOINT_CACHE_DURATION to 1 for ease of testing.
2. Make a submission with an audio file
3. Set community plan limit to below size of submitted file.
4. Make another submission (will be rejected). A counter will be created with days field set to 0.
5. Wait until celery task runs the next day, check to see that counter `days` field is set to 1.
