### PR TITLE
fix(mantine): add MantineProvider to BasicLayout DEV-998

### DIFF
--- a/jsapp/js/router/basicLayout.component.tsx
+++ b/jsapp/js/router/basicLayout.component.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
+import { MantineProvider } from '@mantine/core'
 import { QueryClientProvider } from '@tanstack/react-query'
 import DocumentTitle from 'react-document-title'
 import bem from '#/bem'
 import AccountMenu from '#/components/header/accountMenu'
 import MainHeaderBase from '#/components/header/mainHeaderBase.component'
 import MainHeaderLogo from '#/components/header/mainHeaderLogo.component'
+import { themeKobo } from '#/theme'
 import { queryClient } from '../query/queryClient'
 import ToasterConfig from '../toasterConfig'
 import { Tracking } from './useTracking'
@@ -22,18 +24,20 @@ export default function BasicLayout(props: BasicLayoutProps) {
   return (
     <DocumentTitle title='KoboToolbox'>
       <QueryClientProvider client={queryClient}>
-        <Tracking />
-        <ToasterConfig />
-        <div className='header-stretch-bg' />
+        <MantineProvider theme={themeKobo}>
+          <Tracking />
+          <ToasterConfig />
+          <div className='header-stretch-bg' />
 
-        <bem.PageWrapper className='mdl-layout mdl-layout--fixed-header'>
-          <MainHeaderBase>
-            <MainHeaderLogo />
-            <AccountMenu />
-          </MainHeaderBase>
+          <bem.PageWrapper className='mdl-layout mdl-layout--fixed-header'>
+            <MainHeaderBase>
+              <MainHeaderLogo />
+              <AccountMenu />
+            </MainHeaderBase>
 
-          <bem.PageWrapper__content className='mdl-layout__content'>{props.children}</bem.PageWrapper__content>
-        </bem.PageWrapper>
+            <bem.PageWrapper__content className='mdl-layout__content'>{props.children}</bem.PageWrapper__content>
+          </bem.PageWrapper>
+        </MantineProvider>
       </QueryClientProvider>
     </DocumentTitle>
   )


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR fixes a bug where the users that need to accept TOS and fill required fields that use Mantine get an error for MantineProvider not being available.

### 👀 Preview steps
1. ℹ️ have an account
2. ℹ️ create a TOS
3. ℹ️ Make `country` (or other select field) a required field
4. Log out and log in
5. 🔴 [on main] The app is gona crash due to lack of Mantine
6. 🟢 [on PR] The required fields should be displayed properly in the TOS view
