### PR TITLE
fix(dataCollectors): fix adding assets to groups in admin DEV-798

### DIFF
--- a/kobo/apps/data_collectors/admin.py
+++ b/kobo/apps/data_collectors/admin.py
@@ -63,14 +63,12 @@ class DataCollectorGroupAdmin(admin.ModelAdmin):
         # we have to do this manually instead of using obj.assets.set()
         # so we can call save() with adjust_content=False
         for old_asset in obj.assets.all():
-            print(f'{old_asset.uid} in {new_asset_uids}?')
             if old_asset.uid not in new_asset_uids:
                 old_asset.data_collector_group = None
                 old_asset.save(
                     update_fields=['data_collector_group'], adjust_content=False
                 )
         for new_asset in assets:
-            print(f'{new_asset.data_collector_group_id} = {obj.pk}?')
             if new_asset.data_collector_group_id != obj.pk:
                 new_asset.data_collector_group = obj
                 new_asset.save(

--- a/kobo/apps/data_collectors/tests/test_admin.py
+++ b/kobo/apps/data_collectors/tests/test_admin.py
@@ -1,0 +1,94 @@
+from django.contrib.admin.sites import site
+from django.test import RequestFactory, TestCase
+
+from kobo.apps.data_collectors.admin import DataCollectorGroupAdmin
+from kobo.apps.data_collectors.models import DataCollector, DataCollectorGroup
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.models import Asset
+
+
+class AdminTestCase(TestCase):
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.someuser = User.objects.get(username='someuser')
+        self.data_collector_group = DataCollectorGroup.objects.create(
+            name='DCG_0', owner=self.someuser
+        )
+        self.dc0 = DataCollector.objects.create(
+            group=self.data_collector_group, name='dc0'
+        )
+        self.dc1 = DataCollector.objects.create(
+            group=self.data_collector_group, name='dc1'
+        )
+        self.asset = Asset.objects.filter(owner=self.someuser).first()
+        self.asset.data_collector_group = self.data_collector_group
+        self.asset.save()
+
+    def test_form_only_shows_available_assets(self):
+        admin = DataCollectorGroupAdmin(DataCollectorGroup, site)
+        request = RequestFactory().get('/')
+        request.user = User.objects.get(username='adminuser')
+        asset_from_another_user = Asset.objects.create(
+            owner=User.objects.get(username='anotheruser')
+        )
+        asset_in_another_group = Asset.objects.create(
+            owner=self.someuser,
+            data_collector_group=DataCollectorGroup.objects.create(
+                name='DCG_1', owner=self.someuser
+            ),
+        )
+        available_asset = Asset.objects.filter(owner=self.someuser)[1]
+        FormClass = admin.get_form(request=request, obj=self.data_collector_group)
+        assets_in_queryset = FormClass.base_fields['assets'].queryset.all()
+        assert asset_from_another_user not in assets_in_queryset
+        assert asset_in_another_group not in assets_in_queryset
+        assert available_asset in assets_in_queryset
+        # make sure we include assets already belonging to the group
+        assert self.asset in assets_in_queryset
+
+
+    def test_add_assets_to_group(self):
+        admin = DataCollectorGroupAdmin(DataCollectorGroup, site)
+        add_asset = Asset.objects.filter(owner=self.someuser)[1]
+        add_asset.save()
+        request = RequestFactory().post(
+            '/',
+            data={
+                'owner': self.someuser.pk,
+                'name': 'dc0',
+                'assets': [self.asset.pk, add_asset.pk],
+            },
+        )
+        request.user = User.objects.get(username='adminuser')
+        DCForm = admin.get_form(request, self.data_collector_group, change=True)
+        form = DCForm(request.POST, request.FILES, instance=self.data_collector_group)
+        form.is_valid()
+        admin.save_model(
+            request=request, obj=self.data_collector_group, form=form, change=True
+        )
+        self.asset.refresh_from_db()
+        add_asset.refresh_from_db()
+        assert self.asset.data_collector_group_id == self.data_collector_group.pk
+        assert add_asset.data_collector_group_id == self.data_collector_group.pk
+
+    def test_remove_assets_from_group(self):
+        admin = DataCollectorGroupAdmin(DataCollectorGroup, site)
+        asset_to_remove = Asset.objects.filter(owner=self.someuser)[1]
+        asset_to_remove.data_collector_group = self.data_collector_group
+        asset_to_remove.save()
+        request = RequestFactory().post(
+            '/',
+            data={'owner': self.someuser.pk, 'name': 'dc0', 'assets': [self.asset.pk]},
+        )
+        request.user = User.objects.get(username='adminuser')
+        DCForm = admin.get_form(request, self.data_collector_group, change=True)
+        form = DCForm(request.POST, request.FILES, instance=self.data_collector_group)
+        form.is_valid()
+        admin.save_model(
+            request=request, obj=self.data_collector_group, form=form, change=True
+        )
+        self.asset.refresh_from_db()
+        asset_to_remove.refresh_from_db()
+        assert self.asset.data_collector_group_id == self.data_collector_group.pk
+        assert asset_to_remove.data_collector_group_id is None


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug that was removing old assets from data collector groups when new ones were added.

### 💭 Notes
We were using an incorrect list of old assets, which resulted in us removing the data collector group from the old assets (eg the ones that weren't being added). We did not call refresh_from_db after removing the data collector group, so the code did not realize it needed to add the data collector group back. This PR fixes the initial problem (accidentally removing the data collector group) so we don't need to refresh from db to make sure we didn't remove anything.
Adds some tests so the error doesn't happen again :).


### 👀 Preview steps

1. ℹ️ have an admin account, at least 2 projects, and a data collector group
2. Add one asset to the data collector group and hit `Save and continue editing`
3. Add another asset to the data collector group and hit `Save and continue editing`
4. 🔴 [on main] The initial asset has been removed from the group
5. 🟢 [on PR] The initial asset is still in the group along with the one that was added

