### PR TITLE
fix(sso): do not allow sso users to change email from account settings DEV-1005

### DIFF
--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -30,7 +30,7 @@ class EmailAddressSerializer(serializers.ModelSerializer):
         """
         user = self.context['request'].user
         organization = user.organization
-        if user.socialaccount_set.first():
+        if user.socialaccount_set.exists():
             raise serializers.ValidationError(
                 {'email': t('This action is not allowed.')}
             )

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -26,10 +26,14 @@ class EmailAddressSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         """
         Validates that only owners or admins of the organization can update
-        their email
+        their email and only if they don't have SSO
         """
         user = self.context['request'].user
         organization = user.organization
+        if user.socialaccount_set.first():
+            raise serializers.ValidationError(
+                {'email': t('This action is not allowed.')}
+            )
         if organization.is_owner(user) or organization.is_admin(user):
             return attrs
         raise serializers.ValidationError(
@@ -60,10 +64,10 @@ class SocialAccountSerializer(serializers.ModelSerializer):
 
     def get_email(self, obj):
         if obj.extra_data:
-            if "email" in obj.extra_data:
-                return obj.extra_data.get("email")
-            return obj.extra_data.get("userPrincipalName")  # MS oauth uses this
+            if 'email' in obj.extra_data:
+                return obj.extra_data.get('email')
+            return obj.extra_data.get('userPrincipalName')  # MS oauth uses this
 
     def get_username(self, obj):
         if obj.extra_data:
-            return obj.extra_data.get("username")
+            return obj.extra_data.get('username')

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -190,5 +190,5 @@ class EmailUpdateRestrictionTestCase(APITestCase):
         res = self.client.post(self.url_list, data, format='json')
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            self.member.emailaddress_set.filter(email=data['email']).count(), 0
+            user.emailaddress_set.filter(email=data['email']).count(), 0
         )

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -1,3 +1,4 @@
+from ddt import data, ddt
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
@@ -84,7 +85,7 @@ class AccountsEmailTestCase(APITestCase):
                 confirm_url = line.split('testserver')[1].rsplit('/', 1)[0]
         queries = FuzzyInt(15, 20)
         with self.assertNumQueries(queries):
-            res = self.client.post(confirm_url + "/")
+            res = self.client.post(confirm_url + '/')
         self.assertEqual(res.status_code, 302)
         self.assertTrue(
             self.user.emailaddress_set.filter(
@@ -101,6 +102,7 @@ class AccountsEmailTestCase(APITestCase):
         )
 
 
+@ddt
 class EmailUpdateRestrictionTestCase(APITestCase):
     """
     Test that only organization owners and admins can update their email.
@@ -170,4 +172,23 @@ class EmailUpdateRestrictionTestCase(APITestCase):
                 email=data['email']
             ).count(),
             1
+        )
+
+    @data('mmo_admin', 'mmo_owner', 'mmo_member', 'non_mmo_user')
+    def test_that_user_cannot_update_email_if_sso(self, user_type):
+        if user_type == 'mmo_admin':
+            user = self.admin
+        elif user_type == 'mmo_owner':
+            user = self.owner
+        elif user_type == 'mmo_member':
+            user = self.member
+        else:
+            user = self.non_mmo_user
+        baker.make('socialaccount.SocialAccount', user=user)
+        self.client.force_login(user)
+        data = {'email': 'nonmmo@example.com'}
+        res = self.client.post(self.url_list, data, format='json')
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            self.member.emailaddress_set.filter(email=data['email']).count(), 0
         )


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Do not allow users who use SSO login to change their emails via the Account Settings.


### 💭 Notes
Update the EmailAddress serializer to not create new EmailAddresses if the request user has SSO enabled. We can check this by seeing if the user has any linked SocialAccounts.

### 👀 Preview steps
Enable SSO locally 

1. ℹ️ have an account and a project
2. Enable SSO on the account
3. Go to Account Settings > Security
4. Open the network tab
5. Try to update your email
6. 🔴 [on release branch] The request will succeed. You will get a message "Check your email <new_email>..."
7. 🟢 [on PR] The request will return 400. There will be no error in the UI but that is something frontend is working on
