### PR TITLE
fix(migrations): revert _reversion_version change in historical kpi 0015 migration DEV-838

### DIFF
--- a/kpi/migrations/0015_assetversion.py
+++ b/kpi/migrations/0015_assetversion.py
@@ -9,6 +9,7 @@ import kpi.fields
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('reversion', '0001_squashed_0004_auto_20160611_1202'),
         ('kpi', '0014_discoverable_subscribable_collections'),
     ]
 
@@ -24,7 +25,8 @@ class Migration(migrations.Migration):
                 ('deployed_content', models.JSONField(null=True)),
                 ('_deployment_data', models.JSONField(default=False)),
                 ('deployed', models.BooleanField(default=False)),
-                ('_reversion_version', models.IntegerField(null=True)),
+                ('_reversion_version', models.OneToOneField(null=True, on_delete=models.SET_NULL,
+                                                            to='reversion.Version')),
                 ('asset', models.ForeignKey(related_name='asset_versions',
                                             to='kpi.Asset', on_delete=models.CASCADE)),
             ],


### PR DESCRIPTION
### 👷 Description for instance maintainers

We are phasing out django-reversion, and #6200 removed references to it in `kpi/migrations/0015_assetversion.py`. However, by changing `_reversion_version` to an `IntegerField` in that historical migration, the newer `kpi/migrations/0069_alter_assetversion_reversion_version.py` no longer generated the correct SQL to properly drop `OneToOneField` key constraints and avoid renaming the database column. This reverts the change to `0015` ; the django-reversion dependency will have to stay until we can squash migrations.

### 👀 Preview steps

1. Have a local development environment with an empty database
1. Check out the `release/2.025.34` (previous release) branch
1. Run `scripts/migrate.sh`
1. Observe success
1. Check out `release/2.025.37` (the base branch for this PR)
1. Run `scripts/migrate.sh` again
1. Observe failure (`django.db.utils.ProgrammingError: column "_reversion_version" does not exist`)
1. Check out the branch for this PR, `revert-change-to-historical-assetversion-migration`
1. Run `scripts/migrate.sh` yet again
1. Observe success ✔️

Unit tests in CI handle migrating in one fell swoop from an empty database to the latest database state (as opposed to pausing at the previous release in the manual steps above).