### PR TITLE
fix(sso): update primary email when enabling SSO DEV-1005

### DIFF
--- a/kobo/apps/accounts/apps.py
+++ b/kobo/apps/accounts/apps.py
@@ -6,3 +6,9 @@ from django.apps import AppConfig
 class AccountExtrasConfig(AppConfig):
     name = "kobo.apps.accounts"
     verbose_name = "Account Extras"
+
+    def ready(self):
+        # Makes sure all signal handlers are connected
+        from kobo.apps.accounts import signals
+
+        super().ready()

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -13,6 +13,7 @@ class EmailAddressSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         # First delete any non-primary, unconfirmed emails
         request = self.context['request']
+        breakpoint()
         request.user.emailaddress_set.exclude(
             email=validated_data['email']
         ).filter(primary=False, verified=False).delete()

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -26,11 +26,15 @@ class EmailAddressSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         """
         Validates that only owners or admins of the organization can update
-        their email and only if they don't have SSO
+        their email and only if they don't have an SSO-provided email
         """
-        user = self.context['request'].user
+        request = self.context['request']
+        user = request.user
         organization = user.organization
-        if user.socialaccount_set.exists():
+        # check if we have an SSO-provided email
+        # assume if we have an email address and an SSO account then the email comes
+        # from the SSO
+        if user.socialaccount_set.exists() and user.emailaddress_set.exists():
             raise serializers.ValidationError(
                 {'email': t('This action is not allowed.')}
             )

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -13,7 +13,6 @@ class EmailAddressSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         # First delete any non-primary, unconfirmed emails
         request = self.context['request']
-        breakpoint()
         request.user.emailaddress_set.exclude(
             email=validated_data['email']
         ).filter(primary=False, verified=False).delete()

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -26,14 +26,10 @@ class EmailAddressSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         """
         Validates that only owners or admins of the organization can update
-        their email and only if they don't have SSO
+        their email
         """
         user = self.context['request'].user
         organization = user.organization
-        if user.socialaccount_set.exists():
-            raise serializers.ValidationError(
-                {'email': t('This action is not allowed.')}
-            )
         if organization.is_owner(user) or organization.is_admin(user):
             return attrs
         raise serializers.ValidationError(
@@ -64,10 +60,10 @@ class SocialAccountSerializer(serializers.ModelSerializer):
 
     def get_email(self, obj):
         if obj.extra_data:
-            if 'email' in obj.extra_data:
-                return obj.extra_data.get('email')
-            return obj.extra_data.get('userPrincipalName')  # MS oauth uses this
+            if "email" in obj.extra_data:
+                return obj.extra_data.get("email")
+            return obj.extra_data.get("userPrincipalName")  # MS oauth uses this
 
     def get_username(self, obj):
         if obj.extra_data:
-            return obj.extra_data.get('username')
+            return obj.extra_data.get("username")

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -1,0 +1,29 @@
+from allauth.account.models import EmailAddress
+from allauth.account.utils import cleanup_email_addresses
+from allauth.socialaccount.models import SocialLogin, SocialAccount
+from allauth.socialaccount.signals import social_account_added, social_account_updated, pre_social_login
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+
+@receiver(social_account_added)
+def update_email(*args, **kwargs):
+    sociallogin = kwargs.get('sociallogin')
+    request = kwargs.get('request')
+    social_email_addresses = sociallogin.email_addresses
+    social_user = sociallogin.user
+    for social_email in social_email_addresses:
+        # the auto-created EmailAddresses don't have the user already attached (?!)
+        social_email.user = social_user
+    existing_email_addresses = list(EmailAddress.objects.filter(user=social_user))
+    # put the social email addresses first so they get marked as primary
+    all_email_addresses = [*social_email_addresses, *existing_email_addresses]
+    emails, primary = cleanup_email_addresses(request, all_email_addresses)
+    primary.set_as_primary()
+    EmailAddress.objects.bulk_create(
+        emails,
+        update_conflicts=True,
+        unique_fields=['email','user_id'],
+        update_fields=['primary']
+    )
+

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -21,6 +21,11 @@ def update_email(*args, **kwargs):
     # put the social email addresses first so they get marked as primary
     all_email_addresses = [*social_email_addresses, *existing_email_addresses]
     emails, primary = cleanup_email_addresses(request, all_email_addresses)
+
+    # cleanup_email_addresses doesn't actually call set_as_primary on the primary
+    # email so do that now
+    primary.set_as_primary()
+
     # update existing emails to reflect that they are no longer primary
     # and add any new emails from the SocialLogin
     EmailAddress.objects.bulk_create(

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -1,8 +1,7 @@
 from allauth.account.models import EmailAddress
+from allauth.account.signals import email_confirmed
 from allauth.account.utils import cleanup_email_addresses
-from allauth.socialaccount.models import SocialLogin, SocialAccount
-from allauth.socialaccount.signals import social_account_added, social_account_updated, pre_social_login
-from django.db.models.signals import post_save
+from allauth.socialaccount.signals import social_account_added
 from django.dispatch import receiver
 
 
@@ -26,4 +25,10 @@ def update_email(*args, **kwargs):
         unique_fields=['email','user_id'],
         update_fields=['primary']
     )
-
+    # for some reason allauth doesn't emit the email confirmed signal even though
+    # SocialLogin emails come in already confirmed
+    email_confirmed.send(
+        sender=EmailAddress,
+        request=request,
+        email_address=primary,
+    )

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -10,6 +10,9 @@ def update_email(*args, **kwargs):
     sociallogin = kwargs.get('sociallogin')
     request = kwargs.get('request')
     social_email_addresses = sociallogin.email_addresses
+    # if the provider doesn't use email, don't bother updating addresses
+    if not social_email_addresses:
+        return
     social_user = sociallogin.user
     for social_email in social_email_addresses:
         # the auto-created EmailAddresses don't have the user already attached (?!)
@@ -26,8 +29,9 @@ def update_email(*args, **kwargs):
         unique_fields=['email','user_id'],
         update_fields=['primary']
     )
-    # for some reason allauth doesn't emit the email confirmed signal even though
-    # SocialLogin emails come in already confirmed
+    # for some reason allauth doesn't emit the email confirmed signal even
+    # though if we're calling the social_account_added signal, the email has been
+    # verified
     email_confirmed.send(
         sender=EmailAddress,
         request=request,

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -18,7 +18,8 @@ def update_email(*args, **kwargs):
     # put the social email addresses first so they get marked as primary
     all_email_addresses = [*social_email_addresses, *existing_email_addresses]
     emails, primary = cleanup_email_addresses(request, all_email_addresses)
-    primary.set_as_primary()
+    # update existing emails to reflect that they are no longer primary
+    # and add any new emails from the SocialLogin
     EmailAddress.objects.bulk_create(
         emails,
         update_conflicts=True,

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -1,3 +1,4 @@
+from allauth.account.models import EmailAddress
 from ddt import data, ddt
 from django.conf import settings
 from django.core import mail
@@ -185,10 +186,13 @@ class EmailUpdateRestrictionTestCase(APITestCase):
         else:
             user = self.non_mmo_user
         baker.make('socialaccount.SocialAccount', user=user)
+        # in real life connecting the social account would have made an EmailAddress
+        email_address = baker.make('account.emailaddress', user=user)
         self.client.force_login(user)
-        data = {'email': 'nonmmo@example.com'}
+        data = {'email': 'new@example.com'}
         res = self.client.post(self.url_list, data, format='json')
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            user.emailaddress_set.filter(email=data['email']).count(), 0
-        )
+        self.assertEqual(user.emailaddress_set.count(), 1)
+        user_email = EmailAddress.objects.get(user=user)
+        self.assertEqual(user_email.email, email_address.email)
+        self.assertEqual(user.emailaddress_set.count(), 1)

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -188,10 +188,13 @@ class EmailUpdateRestrictionTestCase(APITestCase):
         baker.make('socialaccount.SocialAccount', user=user)
         # in real life connecting the social account would have made an EmailAddress
         email_address = baker.make('account.emailaddress', user=user)
+        self.assertNotEqual(email_address.email, 'new@example.com')
         self.client.force_login(user)
         data = {'email': 'new@example.com'}
         res = self.client.post(self.url_list, data, format='json')
         self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        # just check that the EmailAddress objects haven't changed;
+        # user.email relies on signal handlers so is tested in test_signals
         self.assertEqual(user.emailaddress_set.count(), 1)
         user_email = EmailAddress.objects.get(user=user)
         self.assertEqual(user_email.email, email_address.email)

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -1,4 +1,3 @@
-from ddt import data, ddt
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
@@ -85,7 +84,7 @@ class AccountsEmailTestCase(APITestCase):
                 confirm_url = line.split('testserver')[1].rsplit('/', 1)[0]
         queries = FuzzyInt(15, 20)
         with self.assertNumQueries(queries):
-            res = self.client.post(confirm_url + '/')
+            res = self.client.post(confirm_url + "/")
         self.assertEqual(res.status_code, 302)
         self.assertTrue(
             self.user.emailaddress_set.filter(
@@ -102,7 +101,6 @@ class AccountsEmailTestCase(APITestCase):
         )
 
 
-@ddt
 class EmailUpdateRestrictionTestCase(APITestCase):
     """
     Test that only organization owners and admins can update their email.
@@ -172,23 +170,4 @@ class EmailUpdateRestrictionTestCase(APITestCase):
                 email=data['email']
             ).count(),
             1
-        )
-
-    @data('mmo_admin', 'mmo_owner', 'mmo_member', 'non_mmo_user')
-    def test_that_user_cannot_update_email_if_sso(self, user_type):
-        if user_type == 'mmo_admin':
-            user = self.admin
-        elif user_type == 'mmo_owner':
-            user = self.owner
-        elif user_type == 'mmo_member':
-            user = self.member
-        else:
-            user = self.non_mmo_user
-        baker.make('socialaccount.SocialAccount', user=user)
-        self.client.force_login(user)
-        data = {'email': 'nonmmo@example.com'}
-        res = self.client.post(self.url_list, data, format='json')
-        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            user.emailaddress_set.filter(email=data['email']).count(), 0
         )

--- a/kobo/apps/accounts/tests/test_email.py
+++ b/kobo/apps/accounts/tests/test_email.py
@@ -1,3 +1,4 @@
+from ddt import data, ddt
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
@@ -84,7 +85,7 @@ class AccountsEmailTestCase(APITestCase):
                 confirm_url = line.split('testserver')[1].rsplit('/', 1)[0]
         queries = FuzzyInt(15, 20)
         with self.assertNumQueries(queries):
-            res = self.client.post(confirm_url + "/")
+            res = self.client.post(confirm_url + '/')
         self.assertEqual(res.status_code, 302)
         self.assertTrue(
             self.user.emailaddress_set.filter(
@@ -101,6 +102,7 @@ class AccountsEmailTestCase(APITestCase):
         )
 
 
+@ddt
 class EmailUpdateRestrictionTestCase(APITestCase):
     """
     Test that only organization owners and admins can update their email.
@@ -170,4 +172,23 @@ class EmailUpdateRestrictionTestCase(APITestCase):
                 email=data['email']
             ).count(),
             1
+        )
+
+    @data('mmo_admin', 'mmo_owner', 'mmo_member', 'non_mmo_user')
+    def test_that_user_cannot_update_email_if_sso(self, user_type):
+        if user_type == 'mmo_admin':
+            user = self.admin
+        elif user_type == 'mmo_owner':
+            user = self.owner
+        elif user_type == 'mmo_member':
+            user = self.member
+        else:
+            user = self.non_mmo_user
+        baker.make('socialaccount.SocialAccount', user=user)
+        self.client.force_login(user)
+        data = {'email': 'nonmmo@example.com'}
+        res = self.client.post(self.url_list, data, format='json')
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            user.emailaddress_set.filter(email=data['email']).count(), 0
         )

--- a/kobo/apps/accounts/tests/test_signals.py
+++ b/kobo/apps/accounts/tests/test_signals.py
@@ -1,6 +1,6 @@
-from allauth.socialaccount.models import SocialLogin, SocialAccount
-from django.test import TestCase, RequestFactory
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialLogin
+from django.test import RequestFactory, TestCase
 
 from kobo.apps.accounts.signals import update_email
 from kobo.apps.kobo_auth.shortcuts import User
@@ -20,14 +20,11 @@ class TestAccountSignals(TestCase):
     def test_social_login_connect_updates_primary_email(self):
         request = RequestFactory().get('/')
         new_email = EmailAddress(
-            user=self.user,
             email='someuser_sso@example.com',
             verified=True,
             primary=True
         )
-        social_login = SocialLogin(
-            email_addresses=[new_email]
-        )
+        social_login = SocialLogin(email_addresses=[new_email], user=self.user)
         update_email(request=request, sociallogin=social_login)
         # we should have gotten rid of any old EmailAddresses
         assert EmailAddress.objects.count() == 1

--- a/kobo/apps/accounts/tests/test_signals.py
+++ b/kobo/apps/accounts/tests/test_signals.py
@@ -19,16 +19,17 @@ class TestAccountSignals(TestCase):
 
     def test_social_login_connect_updates_primary_email(self):
         request = RequestFactory().get('/')
-        new_email = EmailAddress(
+        new_address = EmailAddress(
             email='someuser_sso@example.com',
             verified=True,
             primary=True
         )
-        social_login = SocialLogin(email_addresses=[new_email], user=self.user)
+        social_login = SocialLogin(email_addresses=[new_address], user=self.user)
         update_email(request=request, sociallogin=social_login)
         # we should have gotten rid of any old EmailAddresses
         assert EmailAddress.objects.count() == 1
-        address = EmailAddress.objects.first()
-        assert address.email == 'someuser_sso@example.com'
-        assert address.verified
-        assert address.primary
+        found_address = EmailAddress.objects.first()
+        assert found_address.email == new_address.email
+        assert found_address.verified
+        assert found_address.primary
+        assert self.user.email == new_address.email

--- a/kobo/apps/accounts/tests/test_signals.py
+++ b/kobo/apps/accounts/tests/test_signals.py
@@ -1,0 +1,37 @@
+from allauth.socialaccount.models import SocialLogin, SocialAccount
+from django.test import TestCase, RequestFactory
+from allauth.account.models import EmailAddress
+
+from kobo.apps.accounts.signals import update_email
+from kobo.apps.kobo_auth.shortcuts import User
+
+
+class TestAccountSignals(TestCase):
+    fixtures = ['test_data']
+    def setUp(self):
+        self.user = User.objects.get(username='someuser')
+        self.email_address = EmailAddress.objects.create(
+            user=self.user,
+            email=self.user.email,
+            verified=True,
+            primary=True
+        )
+
+    def test_social_login_connect_updates_primary_email(self):
+        request = RequestFactory().get('/')
+        new_email = EmailAddress(
+            user=self.user,
+            email='someuser_sso@example.com',
+            verified=True,
+            primary=True
+        )
+        social_login = SocialLogin(
+            email_addresses=[new_email]
+        )
+        update_email(request=request, sociallogin=social_login)
+        # we should have gotten rid of any old EmailAddresses
+        assert EmailAddress.objects.count() == 1
+        address = EmailAddress.objects.first()
+        assert address.email == 'someuser_sso@example.com'
+        assert address.verified
+        assert address.primary

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -2,6 +2,7 @@ import datetime
 from zoneinfo import ZoneInfo
 
 import constance
+from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.password_validation import validate_password
@@ -38,6 +39,7 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     accepted_tos = serializers.SerializerMethodField()
     organization = serializers.SerializerMethodField()
     extra_details__uid = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -136,6 +138,12 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_extra_details__uid(self, obj):
         return obj.extra_details.uid
+
+    def get_email(self, obj):
+        try:
+            return EmailAddress.objects.get(user=obj, primary=True).email
+        except EmailAddress.DoesNotExist:
+            return self.email
 
     def to_representation(self, obj):
         if obj.is_anonymous:

--- a/kpi/serializers/current_user.py
+++ b/kpi/serializers/current_user.py
@@ -2,7 +2,6 @@ import datetime
 from zoneinfo import ZoneInfo
 
 import constance
-from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.password_validation import validate_password
@@ -39,7 +38,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
     accepted_tos = serializers.SerializerMethodField()
     organization = serializers.SerializerMethodField()
     extra_details__uid = serializers.SerializerMethodField()
-    email = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -138,12 +136,6 @@ class CurrentUserSerializer(serializers.ModelSerializer):
 
     def get_extra_details__uid(self, obj):
         return obj.extra_details.uid
-
-    def get_email(self, obj):
-        try:
-            return EmailAddress.objects.get(user=obj, primary=True).email
-        except EmailAddress.DoesNotExist:
-            return self.email
 
     def to_representation(self, obj):
         if obj.is_anonymous:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Update a user's email if they enable SSO and do not allow them to change it as long as SSO is enabled.

### 📖 Description
When a user connects their account to an SSO provider with an email address, we should update their email address to match the email used by the SSO. Once this is set, the user should not be allowed to change it.


### 💭 Notes
This PR makes the assumption that if a user has a SocialAccount and an EmailAddress, the email address probably came from the SSO and so should not be changed. There is an edge case where this wouldn't be true:
1. ACCOUNT_EMAIL_REQUIRED = False
2. The SSO provider does not use email
3. The user separately created and verified their email

However, this should be extremely rare, and it's very hard to determine if an EmailAddress came from an SSO, so we're choosing to keep the assumption in.

Besides preventing users from updating their emails if they have SSO enabled, this PR also takes care of setting the correct email address for a user if they enable SSO on a pre-existing account. It's somewhat surprising allauth doesn't do this automatically, though it seems like something they considered: https://github.com/pennersr/django-allauth/blob/52e90f442ee4f5c2f15f609d130f4b61397b6f3c/allauth/socialaccount/models.py#L313. In case we get multiple email addresses from the SSO provider, which is possible, we use allauth's `cleanup_email_addresses` to select the correct primary one and set all the other ones to not-primary. Then we manually send the email_confirmed signal to indicate that we have confirmed this new primary email, since by the time the `social_account_added` signal is called, we know the email has been confirmed. The existing handler for the signal takes care of cleaning up the rest of the non-primary emails.

We do this instead of removing all the non-primary addresses just in case we ever change the logic around what to do when we have a new verified email and decide we want to allow >1 email per user.


### 👀 Preview steps
Enable SSO locally.

1. ℹ️ have an account and a project. Use a different email for the account than you will use for SSO.
5. In Account Settings > Security, enable Single Sign-On
6. Connect your account with Kobo Google Apps
7. Return to Account Settings > Security
8. 🔴 [on release] The email address has not changed
9. 🟢 [on PR] The email address has changed to the SSO email
10. Try to change the email
11. 🔴 [on release] You are able to update the email
12. 🟢 [on PR] updating the email results in a 400 (this will not yet be reflected in the UI, but if you reload the page you should see that the email hasn't changed)
