### PR TITLE
fix(orgs): allow admin of organizations to use the bulk delete UI

### DIFF
--- a/jsapp/js/projects/projectsTable/projectBulkActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectBulkActions.tsx
@@ -5,6 +5,7 @@ import { userCan } from '#/components/permissions/utils'
 import type { AssetResponse, ProjectViewAsset } from '#/dataInterface'
 import BulkDeletePrompt from './bulkActions/bulkDeletePrompt'
 import actionsStyles from './projectActions.module.scss'
+import {OrganizationUserRole, useOrganizationQuery} from '#/account/organization/organizationQuery'
 
 interface ProjectBulkActionsProps {
   /** A list of selected assets for bulk operations. */
@@ -21,7 +22,8 @@ function userCanDeleteAssets(assets: Array<AssetResponse | ProjectViewAsset>) {
  */
 export default function ProjectBulkActions(props: ProjectBulkActionsProps) {
   const [isDeletePromptOpen, setIsDeletePromptOpen] = useState(false)
-  const canBulkDelete = userCanDeleteAssets(props.assets)
+  const orgQuery = useOrganizationQuery()
+  const canBulkDelete = userCanDeleteAssets(props.assets) || orgQuery.data?.request_user_role === OrganizationUserRole.admin
 
   let tooltipForDelete = t('Delete projects')
   if (canBulkDelete) {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Admins of multi member organizations can now use the bulk delete UI.

1. have 3 accounts
2. create an MMO with 1 account
3. make one account an admin
4. make the last account a non-admin of the MMO
5. ℹ️ on the non-admin account, make a few projects
6. on the admin account, multi-select the org projects
7. 🔴 [on main] notice that the delete button is greyed out
8. 🟢 [on PR] notice that the delete button is not greyed out
9. do that another thing
10. 🟢 notice that this changed like that
