### PR TITLE
fix(billing): enforce grace period using `datetime` on exceeded limit counters DEV-1021

### DIFF
--- a/kobo/apps/stripe/tasks.py
+++ b/kobo/apps/stripe/tasks.py
@@ -10,7 +10,7 @@ from kobo.celery import celery_app
 @celery_app.task
 def update_exceeded_limit_counters():
     qs = ExceededLimitCounter.objects.filter(
-        date_modified__date__lte=timezone.now().date() - timedelta(days=1)
+        date_modified__lte=timezone.now() - timedelta(hours=24)
     )
 
     for counter in qs:

--- a/kobo/apps/stripe/tests/test_celery_tasks.py
+++ b/kobo/apps/stripe/tests/test_celery_tasks.py
@@ -41,3 +41,77 @@ class StripeSignalsTestCase(BaseTestCase):
         ) as patched_update:
             update_exceeded_limit_counters()
             patched_update.assert_called_once_with(test_counter)
+
+
+class ExceededLimitCountersTestCase(BaseTestCase):
+    fixtures = ['test_data']
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.org = baker.make(Organization, id='123456abcdef')
+        cls.user = User.objects.get(username='someuser')
+        cls.org.add_user(cls.user, is_admin=True)
+
+    def test_counter_not_updated_before_24h(self):
+        """
+        A counter modified 23h ago should not be updated yet
+        """
+        recent = baker.make(
+            ExceededLimitCounter,
+            user=self.user,
+            date_modified=timezone.now() - timedelta(hours=23),
+        )
+        with patch(
+            'kobo.apps.stripe.tasks.update_or_remove_limit_counter'
+        ) as patched_update:
+            update_exceeded_limit_counters()
+            patched_update.assert_not_called()
+
+    def test_counter_updated_at_24h(self):
+        """
+        A counter modified 24h ago should be updated
+        """
+        old = baker.make(
+            ExceededLimitCounter,
+            user=self.user,
+            date_modified=timezone.now() - timedelta(hours=24),
+        )
+        with patch(
+            'kobo.apps.stripe.tasks.update_or_remove_limit_counter'
+        ) as patched_update:
+            update_exceeded_limit_counters()
+            patched_update.assert_called_once_with(old)
+
+    def test_counter_updated_after_28h(self):
+        """
+        A counter modified 28h ago should also be updated
+        """
+        old = baker.make(
+            ExceededLimitCounter,
+            user=self.user,
+            date_modified=timezone.now() - timedelta(hours=28),
+        )
+        with patch(
+            'kobo.apps.stripe.tasks.update_or_remove_limit_counter'
+        ) as patched_update:
+            update_exceeded_limit_counters()
+            patched_update.assert_called_once_with(old)
+
+    def test_counter_deleted_if_not_exceeded(self):
+        """
+        update_counter should delete if the user is no longer exceeding
+        """
+        counter = baker.make(
+            ExceededLimitCounter,
+            user=self.user,
+            date_modified=timezone.now() - timedelta(hours=28),
+        )
+        with patch(
+            'kobo.apps.stripe.utils.limit_enforcement.ServiceUsageCalculator.get_usage_balances',  # noqa
+            return_value={counter.limit_type: {'exceeded': False}},
+        ):
+            update_exceeded_limit_counters()
+            self.assertFalse(
+                ExceededLimitCounter.objects.filter(id=counter.id).exists()
+            )

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
@@ -54,8 +56,9 @@ def update_or_remove_limit_counter(counter, **kwargs):
     balance = balances[counter.limit_type]
     if not balance or not balance['exceeded']:
         counter.delete()
+        return
 
-    if counter.date_modified.date() < timezone.now().date():
-        delta = timezone.now().date() - counter.date_modified.date()
+    if counter.date_modified <= timezone.now() - timedelta(hours=24):
+        delta = timezone.now() - counter.date_modified
         counter.days += delta.days
         counter.save()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixed an issue where storage limit counters could update too early because only the calendar date was checked. Now the system respects a full 24-hour grace period before updating counters.


### 📖 Description
Previously, exceeded limit counters were filtered using only the date portion of `date_modified`. This meant that if a user exceeded their limit late in the day (e.g., 3 PM), the counter could be updated just after midnight instead of waiting the full 24 hours.  
We now compare the full `datetime` so counters are only updated once the full grace period has passed. This ensures fairer enforcement of storage limits and avoids premature counter increments or deletions.


### 👀 Preview steps

1. ℹ️ Have an account and a project that has exceeded the storage limits. 
2. Set the `days` field to `0` and backdate the `date_modified` field to 32–33 hours ago. For example:
```
   from django.utils import timezone
   from datetime import timedelta
   three_pm_two_days_ago = timezone.now().replace(
       hour=15, minute=0, second=0, microsecond=0
   ) - timedelta(days=2)
   ExceededLimitCounter.objects.filter(id=106).update(date_modified=three_pm_two_days_ago)
```
3. Configure the Celery beat schedule to a shorter interval so the update task runs more frequently.
4. 🔴 [on main] notice that the counter is updated to 2 days
5. 🟢 [on PR] notice that the counter is updated to 1 day
6. Repeat the same steps with different offsets (e.g., 24h, 28h, 48h, 52h, etc.).
7. 🟢 Verify that with this change, counters only update after a full 24 hours have elapsed and the increments are correct.
