### PR TITLE
chore(reversion): turn off reversion vacuum

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1371,11 +1371,6 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute=0),
         'options': {'queue': 'kpi_queue'},
     },
-    'remove-reversion-versions': {
-        'task': 'kpi.tasks.remove_old_versions',
-        'schedule': crontab(minute=0),
-        'options': {'queue': 'kpi_low_priority_queue'},
-    },
 }
 
 if STRIPE_ENABLED:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
We need to keep Version objects around a while longer since they are our only records of deleted Instances, at least until https://github.com/kobotoolbox/kpi/commit/c64a98290f8c00fe4370af67b436246ceec93071 is released
