### PR TITLE
fix(api): restore default renderers for API `v1` DEV-1006 

### DIFF
--- a/kobo/apps/openrosa/apps/api/viewsets/data_viewset.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/data_viewset.py
@@ -8,10 +8,10 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
-from rest_framework.settings import api_settings
 
 from kobo.apps.openrosa.apps.api.permissions import XFormDataPermissions
 from kobo.apps.openrosa.apps.api.tools import add_tags_to_instance
+from kobo.apps.openrosa.apps.api.utils.rest_framework import openrosa_drf_settings
 from kobo.apps.openrosa.apps.api.viewsets.xform_viewset import custom_response_handler
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
@@ -277,7 +277,7 @@ class DataViewSet(AnonymousUserPublicFormsMixin, OpenRosaModelViewSet):
     >
     >        HTTP 200 OK
     """
-    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [
+    renderer_classes = openrosa_drf_settings.DEFAULT_RENDERER_CLASSES + [
         renderers.XLSRenderer,
         renderers.XLSXRenderer,
         renderers.CSVRenderer,

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_viewset.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_viewset.py
@@ -9,11 +9,11 @@ from django.utils.translation import gettext as t
 from rest_framework import exceptions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.settings import api_settings
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.api import tools as utils
 from kobo.apps.openrosa.apps.api.permissions import XFormPermissions
+from kobo.apps.openrosa.apps.api.utils.rest_framework import openrosa_drf_settings
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
 from kobo.apps.openrosa.apps.viewer.models.export import Export
 from kobo.apps.openrosa.libs import filters
@@ -528,7 +528,7 @@ class XFormViewSet(
     >
     >        HTTP 200 OK
     """
-    renderer_classes = api_settings.DEFAULT_RENDERER_CLASSES + [
+    renderer_classes = openrosa_drf_settings.DEFAULT_RENDERER_CLASSES + [
         renderers.XLSRenderer,
         renderers.XLSXRenderer,
         renderers.CSVRenderer,


### PR DESCRIPTION
### 📣 Summary
Reinstate API v1’s renderer settings so browsers receive HTML by default instead of XML.

### 📖 Description
This change restores the default renderer configuration for API v1 after the v2 removal of BrowsableAPIRenderer inadvertently affected global content negotiation. Because many browsers send broad Accept headers that include XML, API v1 endpoints were returning XML even when the response payload was JSON. The fix scopes renderer settings per API version: v1 once again includes its original renderer set (with JSON prioritized and Browsable API where intended), while v2 keeps the leaner renderer list. 

### 👀 Preview steps

1. Go to https://kc.domain.tld/api/v1/
2. Navigate to endpoints (users, data, forms etc...)
3. 🔴 [on main] receive the error "error on line 1 at column 1:"
4. 🟢 [on PR] you can see the HTML documentation properly
