### PR TITLE
ci(storybook): Prevent Storybook cache from interfering with CI runs DEV-892

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -31,13 +31,14 @@ pytest:
   - '.github/workflows/pytest.yml' # ci
 
 npm-test:
-  - '{jsapp,test,webpack,static,scripts}/**/*.!(md|py|sh|bash)'               # frontend
-  - 'static/openapi/*'                                                        # API
-  - '{package*.json,patches/*.patch,scripts/copy_fonts.py}'                   # npm + postinstall
-  - '{tsconfig.json,.swcrc,.babelrc*,.browserslistrc}'                        # compilers
-  - '{.editorconfig,.stylelint*,.eslint*,coffeelint*}'                        # linters
-  - '.gitignore'                                                              # (can affect tools)
-  - '.github/workflows/{npm-test,chromatic}.yml'                              # ci
+  - '{jsapp,test,webpack,static,scripts}/**/*.!(md|py|sh|bash)' # frontend
+  - '.storybook/**/*.!(md)'                                     # storybook
+  - 'static/openapi/*'                                          # API
+  - '{package*.json,patches/*.patch,scripts/copy_fonts.py}'     # npm + postinstall
+  - '{tsconfig.json,.swcrc,.babelrc*,.browserslistrc}'          # compilers
+  - '{.editorconfig,.stylelint*,.eslint*,coffeelint*}'          # linters
+  - '.gitignore'                                                # (can affect tools)
+  - '.github/workflows/{npm-test,chromatic}.yml'                # ci
 
 # Notably, not included:
 # - '.github/workflows/release-*.yml'               # not running on a PR anyways.

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -65,6 +65,12 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm install
 
+      # Ensure node_modules/.cache (used by Storybook) is empty
+      - name: >
+          Erase and log ./node_modules/.cache
+          (before CI tests)
+        run: rm -rf --verbose ./node_modules/.cache
+
       # Check for TypeScript errors
       - name: Check TypeScript
         run: npm run lint:types
@@ -101,23 +107,12 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps webkit
 
-      # Eliminate Storybook's cache, if present.
-      - name: >
-          Delete Storybook cache (before Storybook run)
-        run: rm -rf --verbose ./node_modules/.cache/storybook
-
       # Storybook
       - name: Build and serve Storybook, test stories.
         run: npm run test:storybook
 
-      # Prevent Storybook from adding .cache/storybook to our node_modules cache.
-      # Keep me.
-      #  - Ideally, we're always instructing Storybook not to use a cache in CI,
-      #    but that can be challenging to maintain as it may change across
-      #    updates.
-      #  - If you're working on a Storybook PR, you may want to check if this
-      #    step is logging anything currently.
+      # Erase ./node_modules/.cache (used by Storybook)
       - name: >
-          Delete Storybook cache (after Storybook run)
-          Delete (and log) any contents of node_modules/.cache/storybook
-        run: rm -rf --verbose ./node_modules/.cache/storybook
+          Erase and log ./node_modules/.cache
+          (after CI tests, before caching node_modules)
+        run: rm -rf --verbose ./node_modules/.cache

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -101,6 +101,23 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps webkit
 
-      # Skipped until flaky storybook tests are fixed not to fail main with false-positive failures.
-      # - name: Build and serve Storybook, test stories.
-      #   run: npm run test:storybook
+      # Eliminate Storybook's cache, if present.
+      - name: >
+          Delete Storybook cache (before Storybook run)
+        run: rm -rf --verbose ./node_modules/.cache/storybook
+
+      # Storybook
+      - name: Build and serve Storybook, test stories.
+        run: npm run test:storybook
+
+      # Prevent Storybook from adding .cache/storybook to our node_modules cache.
+      # Keep me.
+      #  - Ideally, we're always instructing Storybook not to use a cache in CI,
+      #    but that can be challenging to maintain as it may change across
+      #    updates.
+      #  - If you're working on a Storybook PR, you may want to check if this
+      #    step is logging anything currently.
+      - name: >
+          Delete Storybook cache (after Storybook run)
+          Delete (and log) any contents of node_modules/.cache/storybook
+        run: rm -rf --verbose ./node_modules/.cache/storybook


### PR DESCRIPTION
### 💭 Notes

In CI, we're caching `node_modules`.

Some npm packages, including nyc, AVA, and storybook, use [`node_modules/.cache`](https://www.npmjs.com/package/find-cache-directory) to store info between runs. 

Storybook sometimes fails when trying to reuse its cache. (https://github.com/storybookjs/storybook/issues/13795)

Options to fix:

1. **(What this PR does)** - Erase the contents of the `node_modules/.cache/`, [as mentioned in the `find-cache-directory` library docs](https://www.npmjs.com/package/find-cache-directory#:~:text=If%20this%20pattern,rf%20./node_modules/.cache). 
2. (Alternative) - Use the `CACHE_DIR` environment variable to tell Storybook use an alternative directory, [as seen on this thread](https://github.com/storybookjs/storybook/discussions/25956) with mixed success.

Emptying the .cache folder seems reasonable to me right now, along with logging the contents of .cache in CI for transparency.

- References
  - https://github.com/storybookjs/storybook/issues/13795
  - https://github.com/storybookjs/storybook/discussions/25956

### 👀 Preview steps

- :green_circle: See the GitHub actions logs for this PR.

<img width="1575" height="1592" alt="image" src="https://github.com/user-attachments/assets/4a790e9e-2a3f-44e4-979f-b4278c223702" />
