### PR TITLE
fix(usageLimits): transfer button blocking when enforcing config is false

### DIFF
--- a/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
@@ -48,9 +48,10 @@ export default function TransferProjects(props: TransferProjectsProps) {
 
   const isTransferBlocked = useMemo(
     () =>
-      !serviceUsageData ||
-      serviceUsageData.limitExceedList.includes(UsageLimitTypes.STORAGE) ||
-      serviceUsageData.limitExceedList.includes(UsageLimitTypes.SUBMISSION),
+      envStore.data.usage_limit_enforcement &&
+      (!serviceUsageData ||
+        serviceUsageData.limitExceedList.includes(UsageLimitTypes.STORAGE) ||
+        serviceUsageData.limitExceedList.includes(UsageLimitTypes.SUBMISSION)),
     [serviceUsageData],
   )
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR fixes the blocking of project transfer button by not blocking when the env config for enforcing user limits is false.


### 👀 Preview steps
1. ℹ️ have an account and a project
2. Make the account/owner over usage limit
3. Navigate to project settings > sharing
4. With the enforcing usage limits config TRUE, check if Transfer button is disabled
5. With the enforcing usage limits config FALSE:
6. 🔴 [on main] notice that transfer button is disabled
7. 🟢 [on PR] notice that transfer button is no enabled
