### PR TITLE
fix(account): disallow editing email if linked to social account DEV-1011

### DIFF
--- a/jsapp/js/account/security/email/emailSection.component.tsx
+++ b/jsapp/js/account/security/email/emailSection.component.tsx
@@ -112,6 +112,8 @@ export default function EmailSection() {
   const unverifiedEmail = email.emails.find((userEmail) => !userEmail.verified && !userEmail.primary)
   const isReady = session.isInitialLoadComplete && 'email' in currentAccount
   const userCanChangeEmail = orgQuery.data?.is_mmo ? orgQuery.data.request_user_role !== 'member' : true
+  const isSSO =
+    session.isInitialLoadComplete && 'social_accounts' in currentAccount && currentAccount.social_accounts.length >= 1
 
   return (
     <section className={securityStyles.securitySection}>
@@ -131,6 +133,7 @@ export default function EmailSection() {
             placeholder={t('Type new email address')}
             onChange={onTextFieldChange.bind(onTextFieldChange)}
             type='email'
+            disabled={isSSO}
           />
         ) : (
           <div className={styles.emailText}>{email.newEmail}</div>
@@ -177,7 +180,7 @@ export default function EmailSection() {
               handleSubmit()
             }}
           >
-            <Button label='Change' size='m' type='primary' onClick={handleSubmit} />
+            <Button label='Change' size='m' type='primary' onClick={handleSubmit} isDisabled={isSSO} />
           </form>
         </div>
       )}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 👀 Preview steps

1. ℹ️ Register an account
2. Go to Account Settings → Security
3. 🟢 Notice that you are able to change email

1. ℹ️ Set up SSO (there is a guide on Notion)
2. ℹ️ Register an account through SSO
3. Go to Account Settings → Security
4. 🔴 [on main] Notice that you are able to change email and it doesn't seem to work correctly
5. 🟢 [on PR] notice that email changing is disabled
