### PR TITLE
fix(formbuilder): groups don't move after creation DEV-1030

### DIFF
--- a/jsapp/xlform/src/model.base.coffee
+++ b/jsapp/xlform/src/model.base.coffee
@@ -68,12 +68,10 @@ module.exports = do ->
     precedingRow: ->
       ii = @_parent.models.indexOf(@)
       if ii isnt 0
-        @_parent.at(ii-1)
-      return
+        return @_parent.at(ii-1)
     nextRow: ->
       ii = @_parent.models.indexOf(@)
-      @_parent.at(ii+1)
-      return
+      return @_parent.at(ii+1)
     getSurvey: ->
       parent = @_parent
       if parent is null or parent is undefined


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Kobo support docs, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a regression where if a group is created in the formbuilder then it will be displayed at the top of the form. Groups are now created in the location of the top-most selected question.

### 👀 Preview steps
1. ℹ️ have an account and a project
2. add 3 questions
3. group the last 2 quetions
4. 🔴 [on main] notice that the new created group appears at the top of the form
5. 🟢 [on PR] notice that the new created group appears in the place of the top-most selected question (previous behaviour)
