### PR TITLE
ci(openApi): enforce drf-spectacular warnings as errors DEV-1069

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -66,7 +66,13 @@ jobs:
         run: pip-sync dependencies/pip/dev_requirements.txt
 
       - name: Generate OpenAPI with drf-spectacular
-        run: ./scripts/generate_api.sh --skip-orval
+        run: |
+          if ./run.py -cf run --rm kpi ./scripts/generate_api.sh --skip-orval 2>&1 | tee /dev/tty | grep -q "Warning"; then
+            echo ""
+            echo "A warning found, aborted! Please treat drf-spectacular warnings as errors and resolve them."
+            echo "P.S. This is only the first warning. You may want to run the script locally to see all warnings at once."
+            exit 2
+          fi
 
       - name: Fail on uncommitted OpenAPI changes
         run: |


### PR DESCRIPTION
### 💭 Notes

It took a lot of work to clean up all the warnings, so let's not pile up warnings again.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

3. checkout a commit without drf-spectacular warnings, e.g. `git checkout 90ca1fd51`
1. [on `90ca1fd51`] run the equilavent one-liner locally
    ```
    if ./run.py -cf run --rm kpi ./scripts/generate_api.sh --skip-orval 2>&1 | tee /dev/tty | grep -q "Warning"; then echo 'Please resolve drf-spectacular warnings.'; sleep 2; fi
    ``` 
2. 🟢 [on `90ca1fd51`] notice that schema is generated normally
3. checkout a commit with drf-spectacular warnings, e.g. `git checkout 90ca1fd51^`
4. [on `90ca1fd51^`] run the oneliner again
5. 🟢 [on PR] notice that it detects a warning
