### PR TITLE
fix(permissions)!: fix mistake in long running job that deletes obsolete permissions

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0010_remove_from_kc_only_permission.py
+++ b/kobo/apps/long_running_migrations/jobs/0010_remove_from_kc_only_permission.py
@@ -12,4 +12,4 @@ def run():
         permission__codename=PERM_FROM_KC_ONLY
     )
     print(f'Deleting {objects.count()} ObjectPermission objects')
-    objects._raw_delete()
+    objects._raw_delete(using=objects.db)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
Fixes the _raw_delete call in the long running job `0010_remove_from_kc_only_permissions` 

### 👀 Preview steps
1. Use the django shell
2. Find the long running migration job and re-execute it, ensure it doesn't fail:
```
>>> lrm = LongRunningMigration.objects.filter(name__contains='0010_remove_from_kc_only').first()

>>> lrm.status = 'created'; lrm.save(); lrm.execute()

Deleting 0 ObjectPermission objects
```