### PR TITLE
ci(releases): deploy to beta only newest release DEV-1060

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -114,10 +114,11 @@ jobs:
           git push -f --set-upstream origin changelog/$CURRENT_PATCH
 
 
+  # Note: deploy only the latest release branch instead of all cascading release branches.
   deploy-to-beta:
     needs:
       - version
-    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
+    if: ${{ !cancelled() && !failure() && needs.version.result == 'success' && needs.version.outputs.next_branch == 'main' }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### 💭 Notes

If a commit was pushed to the previous release branch that merges forward into the newest release, that would trigger two deploys to beta. Deploying previous release is unnecessary, as the newest release will deploy over it shortly after. Furthermore with unlucky timing it introduces risks for QA team to be confused what they are actually testing when.