### PR TITLE
ci(releases): run version even if a test fails DEV-1109

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -59,7 +59,7 @@ jobs:
       - biome
       - pytest
       - npm-test
-    if: ${{ !cancelled() && !failure() && needs.changes.result == 'success' }}
+    if: ${{ !cancelled() }}
     secrets: inherit
     uses: './.github/workflows/find-releases.yml'
 


### PR DESCRIPTION
### 💭 Notes

Always run version, so that failure notification has access to variables.

### 👀 Preview steps

See https://github.com/kobotoolbox/kpi/actions/runs/18171862423