### PR TITLE
fix(swaggerUI): restore search bar functionality with collapsed tags

### DIFF
--- a/kpi/static/js/swagger/swagger-smart-search.js
+++ b/kpi/static/js/swagger/swagger-smart-search.js
@@ -13,6 +13,14 @@ window.onload = () => {
     newInput.addEventListener('input', () => {
       const query = newInput.value.toLowerCase()
 
+      // When tags are collapsed, their content is not in the DOM and we cannot search
+      // for keywords.
+      if (query !== '') {
+        expandAllTags()
+      } else {
+        collapseAllTags()
+      }
+
       tags.forEach((tag) => {
         let showTag = false
         const operations = tag.querySelectorAll('.opblock')
@@ -31,4 +39,18 @@ window.onload = () => {
       })
     })
   }, 200)
+}
+
+function expandAllTags() {
+  document.querySelectorAll('#swagger-ui .opblock-tag').forEach((btn) => {
+    const section = btn.closest('.opblock-tag-section')
+    if (section && !section.classList.contains('is-open')) btn.click()
+  })
+}
+
+function collapseAllTags() {
+  document.querySelectorAll('#swagger-ui .opblock-tag').forEach((btn) => {
+    const section = btn.closest('.opblock-tag-section')
+    if (section && section.classList.contains('is-open')) btn.click()
+  })
 }


### PR DESCRIPTION
### 📣 Summary
Fix Swagger UI search so results appear even when endpoint groups are collapsed by default.

### 📖 Description
With the recent change to load Swagger UI with all tags collapsed, the search bar stopped working because Swagger only rendered the DOM nodes for endpoints when their tag was expanded. This fix ensures the search feature indexes and filters all available endpoints regardless of their collapsed state, restoring the expected behavior for users browsing the API documentation.

### 👀 Preview steps

1. Go to `/api/v2/docs/`
2. Try to search for something (e.g. `logs`)
4. 🔴 [on release branch] every tag disappear and search is broken
5. 🟢 [on PR] search works as expected (and all tags expanded)
