### PR TITLE
fix(accounts): block self-deletion when the account still owns data DEV-1124

### DIFF
--- a/kpi/tests/api/test_api_current_user.py
+++ b/kpi/tests/api/test_api_current_user.py
@@ -136,7 +136,7 @@ class CurrentUserTestCase(BaseTestCase):
 
     @override_config(ALLOW_SELF_ACCOUNT_DELETION=True)
     def test_cannot_delete_if_account_is_not_empty(self):
-        asset = Asset.objects.create(
+        Asset.objects.create(
             owner=self.user,
             content={},
             name='Empty project',

--- a/kpi/tests/api/test_api_current_user.py
+++ b/kpi/tests/api/test_api_current_user.py
@@ -9,6 +9,8 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.constants import ASSET_TYPE_SURVEY
+from kpi.models import Asset
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.utils.gravatar_url import gravatar_url
 
@@ -22,6 +24,7 @@ class CurrentUserTestCase(BaseTestCase):
             is_active=True,
         )
 
+    @override_config(ALLOW_SELF_ACCOUNT_DELETION=True)
     def test_user_deactivation(self):
         # Check user account is as expected
         assert self.user.is_active is True
@@ -127,6 +130,29 @@ class CurrentUserTestCase(BaseTestCase):
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
         # Check the db to make sure that no changes were made
+        self.user.refresh_from_db()
+        assert self.user.is_active is True
+        assert self.user.extra_details.date_removal_requested is None
+
+    @override_config(ALLOW_SELF_ACCOUNT_DELETION=True)
+    def test_cannot_delete_if_account_is_not_empty(self):
+        asset = Asset.objects.create(
+            owner=self.user,
+            content={},
+            name='Empty project',
+            asset_type=ASSET_TYPE_SURVEY,
+        )
+
+        # Prepare and send the request
+        self.client.login(username='delete_me', password='delete_me')
+        payload = {
+            'confirm': self.user.extra_details.uid,
+        }
+        response = self.client.delete(self.url, data=payload, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'You still own projects' in str(response.data['detail'])
+
+        # Check the db to make sure the expected changes were made
         self.user.refresh_from_db()
         assert self.user.is_active is True
         assert self.user.extra_details.date_removal_requested is None

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.trash_bin.utils import move_to_trash
+from kpi.constants import ASSET_TYPE_EMPTY
 from kpi.schema_extensions.v2.me.serializers import (
     CurrentUserDeleteRequest,
     MeListResponse,
@@ -83,6 +84,15 @@ class CurrentUserViewSet(viewsets.ModelViewSet):
         confirm = request.data.get('confirm')
         if confirm != user.extra_details.uid:
             raise serializers.ValidationError({'detail': t('Invalid confirmation')})
+
+        if user.assets.exclude(asset_type=ASSET_TYPE_EMPTY).count():
+            raise serializers.ValidationError(
+                {
+                    'detail': t(
+                        'You still own projects. Delete or transfer them first.'
+                    )
+                }
+            )
 
         user = {'pk': user.pk, 'username': user.username}
 

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -87,11 +87,7 @@ class CurrentUserViewSet(viewsets.ModelViewSet):
 
         if user.assets.exclude(asset_type=ASSET_TYPE_EMPTY).count():
             raise serializers.ValidationError(
-                {
-                    'detail': t(
-                        'You still own projects. Delete or transfer them first.'
-                    )
-                }
+                {'detail': t('You still own projects. Delete or transfer them first.')}
             )
 
         user = {'pk': user.pk, 'username': user.username}

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -85,7 +85,7 @@ class CurrentUserViewSet(viewsets.ModelViewSet):
         if confirm != user.extra_details.uid:
             raise serializers.ValidationError({'detail': t('Invalid confirmation')})
 
-        if user.assets.exclude(asset_type=ASSET_TYPE_EMPTY).count():
+        if user.assets.exclude(asset_type=ASSET_TYPE_EMPTY).exists():
             raise serializers.ValidationError(
                 {'detail': t('You still own projects. Delete or transfer them first.')}
             )

--- a/static/openapi/schema_openrosa.json
+++ b/static/openapi/schema_openrosa.json
@@ -256,6 +256,229 @@
                 }
             }
         },
+        "/key/{token}/formList": {
+            "get": {
+                "operationId": "form_list_data_collector",
+                "description": "## Implement part of the OpenRosa Form List API\n\n⚠️This endpoint is **only available** from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️\n\nThis endpoint is used for adding submissions as a data collector.\n",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "token",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^\\w+$"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "OpenRosa Form List"
+                ],
+                "security": [
+                    {
+                        "TokenAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/XFormList"
+                                }
+                            }
+                        },
+                        "description": null
+                    }
+                }
+            }
+        },
+        "/key/{token}/submission": {
+            "post": {
+                "operationId": "submission_data_collector",
+                "description": "## Implement the OpenRosa Form Submission API\n\n⚠️This endpoint is only available from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️\n\nThis endpoint is used for adding submissions as a data collector.\n\n",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "format",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json",
+                                "xml"
+                            ]
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "token",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^\\w+$"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "OpenRosa Form Submission"
+                ],
+                "requestBody": {
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OpenRosaPayload"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "BasicAuth": []
+                    },
+                    {
+                        "TokenAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OpenRosaResponse"
+                                }
+                            }
+                        },
+                        "description": null
+                    },
+                    "401": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorDetail"
+                                },
+                                "examples": {
+                                    "NotAuthenticated": {
+                                        "value": {
+                                            "detail": "Authentication credentials were not provided."
+                                        },
+                                        "summary": "Not authenticated"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorDetail"
+                                },
+                                "examples": {
+                                    "NotFound": {
+                                        "value": {
+                                            "detail": "Not found."
+                                        },
+                                        "summary": "Not Found"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorObject"
+                                },
+                                "examples": {
+                                    "BadRequest": {
+                                        "value": {
+                                            "detail": {
+                                                "field_name": [
+                                                    "Error message"
+                                                ]
+                                            }
+                                        },
+                                        "summary": "Bad request"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/key/{token}/xformsManifest/{id}": {
+            "get": {
+                "operationId": "manifest_data_collector",
+                "description": "## Implement part of the OpenRosa Manifest API\n\n⚠️This endpoint is **only available** from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️\n\nThis endpoint return the URLs of form media files so they can be fetched and displayed as needed during form rendering.\nThis endpoints will also open the form in **creation** mode and is used as an anonymous user.\n",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[\\d+^/]+$"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "token",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^\\w+$"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "OpenRosa Form Manifest"
+                ],
+                "security": [
+                    {
+                        "TokenAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OpenRosaFormManifestResponse"
+                                }
+                            }
+                        },
+                        "description": null
+                    },
+                    "404": {
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorDetail"
+                                },
+                                "examples": {
+                                    "NotFound": {
+                                        "value": {
+                                            "detail": "Not found."
+                                        },
+                                        "summary": "Not Found"
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/submission": {
             "post": {
                 "operationId": "submission_authenticated",

--- a/static/openapi/schema_openrosa.yaml
+++ b/static/openapi/schema_openrosa.yaml
@@ -182,6 +182,158 @@ paths:
               schema:
                 $ref: '#/components/schemas/XFormList'
           description: null
+  /key/{token}/formList:
+    get:
+      operationId: form_list_data_collector
+      description: |
+        ## Implement part of the OpenRosa Form List API
+
+        ⚠️This endpoint is **only available** from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️
+
+        This endpoint is used for adding submissions as a data collector.
+      parameters:
+      - in: path
+        name: token
+        schema:
+          type: string
+          pattern: ^\w+$
+        required: true
+      tags:
+      - OpenRosa Form List
+      security:
+      - TokenAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XFormList'
+          description: null
+  /key/{token}/submission:
+    post:
+      operationId: submission_data_collector
+      description: |+
+        ## Implement the OpenRosa Form Submission API
+
+        ⚠️This endpoint is only available from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️
+
+        This endpoint is used for adding submissions as a data collector.
+
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - json
+          - xml
+      - in: path
+        name: token
+        schema:
+          type: string
+          pattern: ^\w+$
+        required: true
+      tags:
+      - OpenRosa Form Submission
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/OpenRosaPayload'
+        required: true
+      security:
+      - BasicAuth: []
+      - TokenAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/OpenRosaResponse'
+          description: null
+        '401':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+              examples:
+                NotAuthenticated:
+                  value:
+                    detail: Authentication credentials were not provided.
+                  summary: Not authenticated
+          description: ''
+        '404':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+              examples:
+                NotFound:
+                  value:
+                    detail: Not found.
+                  summary: Not Found
+          description: ''
+        '400':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorObject'
+              examples:
+                BadRequest:
+                  value:
+                    detail:
+                      field_name:
+                      - Error message
+                  summary: Bad request
+          description: ''
+  /key/{token}/xformsManifest/{id}:
+    get:
+      operationId: manifest_data_collector
+      description: |
+        ## Implement part of the OpenRosa Manifest API
+
+        ⚠️This endpoint is **only available** from the Kobocat domains (ex: kc.kobotoolbox.org or kc-eu.kobotoolbox.org)⚠️
+
+        This endpoint return the URLs of form media files so they can be fetched and displayed as needed during form rendering.
+        This endpoints will also open the form in **creation** mode and is used as an anonymous user.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: ^[\d+^/]+$
+        required: true
+      - in: path
+        name: token
+        schema:
+          type: string
+          pattern: ^\w+$
+        required: true
+      tags:
+      - OpenRosa Form Manifest
+      security:
+      - TokenAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/OpenRosaFormManifestResponse'
+          description: null
+        '404':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+              examples:
+                NotFound:
+                  value:
+                    detail: Not found.
+                  summary: Not Found
+          description: ''
   /submission:
     post:
       operationId: submission_authenticated


### PR DESCRIPTION
### 📣 Summary
Prevent users from deleting their own account if it still contains projects, collections, blocks, questions, templates, or other owned resources.

### 📖 Description
This change adds an “emptiness” check to the self-deletion flow. A user can only delete their account if it no longer owns any resources (e.g., projects, collections, blocks, questions, templates) and has no remaining ownership ties. If the account is not empty, the delete request is rejected.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. Make sure the Admin > Constance > Config > `ALLOW_SELF_ACCOUNT_DELETION` is checked
3. Try to delete your account
4. 🔴 [on main] the request is successful
5. 🟢 [on PR] the request is rejected with a 400
