### PR TITLE
feat(dataCollectors): improve Django Admin UX for data collector groups DEV-920

### DIFF
--- a/kobo/apps/data_collectors/admin.py
+++ b/kobo/apps/data_collectors/admin.py
@@ -21,8 +21,6 @@ class DataCollectorGroupAddForm(forms.ModelForm):
             'Only assets that are not already linked to another group are available.'
         ),
     )
-    # name = forms.CharField()
-    # owner = forms.ModelChoiceField(queryset=User.objects.all())
 
     class Meta:
         model = DataCollectorGroup


### PR DESCRIPTION
### 📣 Summary
Make data collector group management easier by adding autocomplete fields and a two-column selector for choosing projects.

### 📖 Description
This update focuses on usability in the Django Admin for data collector groups. It enables `autocomplete_fields` on large relations so admins can quickly search and select users or projects, and replaces the multi-choice with Django’s dual-list (filter) widget to pick projects in a clear left/right layout. 

### 👀 Preview steps

1. Follow 1-3 steps from #6258
2. 🔴 [on main] notice that owner list is dropdown and project list is a checkbox list
5. 🟢 [on PR] notice that owner list is a autocomplete dropdown and the project list is the dual-list widget
