### PR TITLE
fix(exports): only try to clean up deployed versions DEV-1053

### DIFF
--- a/kpi/utils/bugfix.py
+++ b/kpi/utils/bugfix.py
@@ -54,7 +54,7 @@ def repair_file_column_content_and_save(asset, include_versions=True) -> bool:
         # Previous versions of the content may need repair, regardless of
         # whether or not the current content did
         for pk, version_content in (
-            asset.asset_versions.filter(date_modified__gte=BAD_TIME)
+            asset.asset_versions.filter(date_modified__gte=BAD_TIME, deployed=True)
             .select_for_update()
             .values_list('pk', 'version_content')
         ):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
Developer-only change to only run `repair_file_column_content_in_place` on deployed versions of an asset. Hopefully this will stop the OOM errors affecting some exports.
Tested in a python shell on global. There isn't an easy way to recreate/test the problem locally and this is meant to be a quick patch so preview steps are left out.
