### PR TITLE
feat(api): Add filtering and ordering support for /`user-reports` endpoint DEV-287

### DIFF
--- a/kobo/apps/user_reports/migrations/0002_create_user_reports_mv.py
+++ b/kobo/apps/user_reports/migrations/0002_create_user_reports_mv.py
@@ -264,7 +264,7 @@ CREATE_MV_SQL = """
                 )
             ) FILTER (WHERE sub.id IS NOT NULL),
             '[]'::jsonb
-        )::text AS subscriptions
+        ) AS subscriptions
     FROM auth_user au
     LEFT JOIN organizations_organizationuser ou ON au.id = ou.user_id
     LEFT JOIN organizations_organization org ON ou.organization_id = org.id

--- a/kobo/apps/user_reports/migrations/0003_add_user_reports_mv_indexes.py
+++ b/kobo/apps/user_reports/migrations/0003_add_user_reports_mv_indexes.py
@@ -1,0 +1,118 @@
+from django.db import migrations
+
+CREATE_PG_TRGM = 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+DROP_PG_TRGM = 'DROP EXTENSION IF EXISTS pg_trgm;'
+
+# Btree functional indexes for fast case-insensitive prefix (istartswith) searches
+CREATE_IDX_EMAIL_LOWER = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_email_lower_textpat
+ON user_reports_mv (lower(email) text_pattern_ops);
+"""
+DROP_IDX_EMAIL_LOWER = """
+DROP INDEX IF EXISTS idx_user_reports_email_lower_textpat;
+"""
+
+CREATE_IDX_USERNAME_LOWER = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_username_lower_textpat
+ON user_reports_mv (lower(username) text_pattern_ops);
+"""
+DROP_IDX_USERNAME_LOWER = """
+DROP INDEX IF EXISTS idx_user_reports_username_lower_textpat;
+"""
+
+# GIN index for JSONB subscriptions column
+CREATE_IDX_SUBSCRIPTIONS_GIN = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_subscriptions_gin
+ON user_reports_mv USING gin (subscriptions);
+"""
+DROP_IDX_SUBSCRIPTIONS_GIN = """
+DROP INDEX IF EXISTS idx_user_reports_subscriptions_gin;
+"""
+
+# Numeric / ordering indexes
+CREATE_IDX_SUBMISSIONS_ALL_TIME = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_submission_all_time
+ON user_reports_mv (submission_counts_all_time);
+"""
+DROP_IDX_SUBMISSIONS_ALL_TIME = """
+DROP INDEX IF EXISTS idx_user_reports_submission_all_time;
+"""
+
+CREATE_IDX_CURRENT_PERIOD_SUB = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_current_period_submissions
+ON user_reports_mv (current_period_submissions);
+"""
+DROP_IDX_CURRENT_PERIOD_SUB = """
+DROP INDEX IF EXISTS idx_user_reports_current_period_submissions;
+"""
+
+CREATE_IDX_STORAGE_BYTES = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_storage_bytes
+ON user_reports_mv (storage_bytes_total);
+"""
+DROP_IDX_STORAGE_BYTES = """
+DROP INDEX IF EXISTS idx_user_reports_storage_bytes;
+"""
+
+CREATE_IDX_DATE_JOINED = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_date_joined
+ON user_reports_mv (date_joined);
+"""
+DROP_IDX_DATE_JOINED = """
+DROP INDEX IF EXISTS idx_user_reports_date_joined;
+"""
+
+CREATE_IDX_LAST_LOGIN = """
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_reports_last_login
+ON user_reports_mv (last_login);
+"""
+DROP_IDX_LAST_LOGIN = """
+DROP INDEX IF EXISTS idx_user_reports_last_login;
+"""
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("user_reports", "0002_create_user_reports_mv"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=CREATE_PG_TRGM,
+            reverse_sql=DROP_PG_TRGM
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_EMAIL_LOWER,
+            reverse_sql=DROP_IDX_EMAIL_LOWER
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_USERNAME_LOWER,
+            reverse_sql=DROP_IDX_USERNAME_LOWER
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_SUBSCRIPTIONS_GIN,
+            reverse_sql=DROP_IDX_SUBSCRIPTIONS_GIN
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_SUBMISSIONS_ALL_TIME,
+            reverse_sql=DROP_IDX_SUBMISSIONS_ALL_TIME
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_CURRENT_PERIOD_SUB,
+            reverse_sql=DROP_IDX_CURRENT_PERIOD_SUB
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_STORAGE_BYTES,
+            reverse_sql=DROP_IDX_STORAGE_BYTES
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_DATE_JOINED,
+            reverse_sql=DROP_IDX_DATE_JOINED
+        ),
+        migrations.RunSQL(
+            sql=CREATE_IDX_LAST_LOGIN,
+            reverse_sql=DROP_IDX_LAST_LOGIN
+        ),
+    ]

--- a/kobo/apps/user_reports/utils/filters.py
+++ b/kobo/apps/user_reports/utils/filters.py
@@ -1,0 +1,118 @@
+from django_filters import rest_framework as filters
+
+from kobo.apps.user_reports.models import UserReports
+
+
+class UserReportsFilter(filters.FilterSet):
+    """
+    Filter for the `/user-reports` endpoint (materialized view `user_reports_mv`)
+
+    Examples of usage:
+    - Filter by username (case-insensitive, starts with):
+      `?username=john`
+    - Filter by email (case-insensitive, starts with):
+        `?email=example`
+
+    - Filter by date joined (greater than or equal to):
+        `?date_joined_gte=2023-01-01T00:00:00Z`
+    - Filter by date joined (less than or equal to):
+        `?date_joined_lte=2023-12-31T23:59:59Z`
+
+    - Filter by total storage bytes (greater than or equal to):
+        `?total_storage_bytes_gte=1000000`
+    - Filter by total storage bytes (less than or equal to):
+        `?total_storage_bytes_lte=5000000`
+
+    - Filter by has subscriptions (boolean):
+        `?has_subscriptions=true` or `?has_subscriptions=false`
+    - Filter by subscription status (exact match):
+        `?subscription_status=active`
+    """
+
+    username = filters.CharFilter(field_name='username', lookup_expr='istartswith')
+    email = filters.CharFilter(field_name='email', lookup_expr='istartswith')
+
+    date_joined_gte = filters.DateTimeFilter(
+        field_name='date_joined', lookup_expr='gte'
+    )
+    date_joined_lte = filters.DateTimeFilter(
+        field_name='date_joined', lookup_expr='lte'
+    )
+    last_login_gte = filters.DateTimeFilter(field_name='last_login', lookup_expr='gte')
+    last_login_lte = filters.DateTimeFilter(field_name='last_login', lookup_expr='lte')
+    total_storage_bytes_gte = filters.NumberFilter(
+        field_name='storage_bytes_total', lookup_expr='gte'
+    )
+    total_storage_bytes_lte = filters.NumberFilter(
+        field_name='storage_bytes_total', lookup_expr='lte'
+    )
+    total_submission_count_all_time_gte = filters.NumberFilter(
+        field_name='submission_counts_all_time', lookup_expr='gte'
+    )
+    total_submission_count_all_time_lte = filters.NumberFilter(
+        field_name='submission_counts_all_time', lookup_expr='lte'
+    )
+    total_submission_count_current_period_gte = filters.NumberFilter(
+        field_name='current_period_submissions', lookup_expr='gte'
+    )
+    total_submission_count_current_period_lte = filters.NumberFilter(
+        field_name='current_period_submissions', lookup_expr='lte'
+    )
+    total_nlp_usage_asr_seconds_all_time_gte = filters.NumberFilter(
+        field_name='nlp_usage_asr_seconds_total', lookup_expr='gte'
+    )
+    total_nlp_usage_asr_seconds_all_time_lte = filters.NumberFilter(
+        field_name='nlp_usage_asr_seconds_total', lookup_expr='lte'
+    )
+    total_nlp_usage_mt_characters_all_time_gte = filters.NumberFilter(
+        field_name='nlp_usage_mt_characters_total', lookup_expr='gte'
+    )
+    total_nlp_usage_mt_characters_all_time_lte = filters.NumberFilter(
+        field_name='nlp_usage_mt_characters_total', lookup_expr='lte'
+    )
+    has_subscriptions = filters.BooleanFilter(method='filter_has_subscriptions')
+    subscription_status = filters.CharFilter(method='filter_subscription_status')
+    subscription_id = filters.CharFilter(method='filter_subscription_id')
+
+    class Meta:
+        model = UserReports
+        fields = [
+            'username',
+            'email',
+            'date_joined_gte',
+            'date_joined_lte',
+            'last_login_gte',
+            'last_login_lte',
+            'total_storage_bytes_gte',
+            'total_storage_bytes_lte',
+            'total_submission_count_all_time_gte',
+            'total_submission_count_all_time_lte',
+            'total_submission_count_current_period_gte',
+            'total_submission_count_current_period_lte',
+            'total_nlp_usage_asr_seconds_all_time_gte',
+            'total_nlp_usage_asr_seconds_all_time_lte',
+            'total_nlp_usage_mt_characters_all_time_gte',
+            'total_nlp_usage_mt_characters_all_time_lte',
+            'has_subscriptions',
+            'subscription_status',
+            'subscription_id',
+        ]
+
+    def filter_has_subscriptions(self, queryset, name, value):
+        if value is None:
+            return queryset
+
+        if value:
+            return queryset.exclude(subscriptions=[])
+        else:
+            return queryset.filter(subscriptions=[])
+
+    def filter_subscription_status(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(subscriptions__contains=[{'status': value}])
+
+    def filter_subscription_id(self, queryset, name, value):
+        if not value:
+            return queryset
+        return queryset.filter(subscriptions__contains=[{'id': value}])

--- a/kobo/apps/user_reports/views.py
+++ b/kobo/apps/user_reports/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from kobo.apps.audit_log.permissions import SuperUserPermission
 from kobo.apps.user_reports.models import UserReports
 from kobo.apps.user_reports.seralizers import UserReportsSerializer
+from kobo.apps.user_reports.utils.filters import UserReportsFilter
 from kpi.paginators import LimitOffsetPagination
 from kpi.permissions import IsAuthenticated
 from kpi.schema_extensions.v2.user_reports.serializers import UserReportsListResponse
@@ -43,6 +44,7 @@ class UserReportsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     pagination_class = LimitOffsetPagination
     permission_classes = (IsAuthenticated, SuperUserPermission)
     filter_backends = [DjangoFilterBackend, OrderingFilter, SearchFilter]
+    filterset_class = UserReportsFilter
 
     ordering_fields = [
         'username',
@@ -50,7 +52,7 @@ class UserReportsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         'date_joined',
         'last_login',
         'storage_bytes_total',
-        'submission_counts_current_month',
+        'current_period_submissions',
         'submission_counts_all_time',
         'nlp_usage_asr_seconds_total',
         'nlp_usage_mt_characters_total',
@@ -58,7 +60,6 @@ class UserReportsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         'deployed_asset_count',
     ]
     ordering = ['username']
-    search_fields = ['username', 'email', 'first_name', 'last_name']
 
     def list(self, request, *args, **kwargs):
         if not settings.STRIPE_ENABLED:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds robust filtering and ordering capabilities to the /user-reports API endpoint, enabling users and admins to query large user datasets efficiently by date, usage metrics, and subscription attributes, all backed by the optimized materialized view for scalable performance on millions of records.

### 📖 Description
This PR introduces the filtering and ordering layer for the `/user-reports` endpoint, built on top of the existing materialized view (`user_reports_mv`) that aggregates user-level billing and usage data.

Also, added targeted indexes on high-cardinality numeric and timestamp columns to support range queries without full table scans.