### PR TITLE
perfs(submissions): use same connection for the transaction and advisory lock DEV-1140

### DIFF
--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.files.base import File
 from django.core.mail import mail_admins
-from django.db import IntegrityError, connection, transaction
+from django.db import IntegrityError, connections, transaction
 from django.db.models import Q
 from django.http import (
     Http404,
@@ -372,7 +372,7 @@ def get_instance_lock(submission_uuid: str, xform_id: int) -> bool:
 
     try:
         with kc_transaction_atomic():
-            cur = connection.cursor()
+            cur = connections[settings.OPENROSA_DB_ALIAS].cursor()
             cur.execute('SELECT pg_try_advisory_lock(%s::bigint);', (int_lock,))
             acquired = cur.fetchone()[0]
             yield acquired


### PR DESCRIPTION
### 📣 Summary
<!-- Delete this section if changes are internal only. -->
<!-- One sentence summary for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 📖 Description
<!-- Delete this section if summary already said everything. -->
<!-- Full description for the public changelog, worded for non-technical seasoned Kobo users. -->

TODO

### 👷 Description for instance maintainers
<!-- Delete this section if everything is already said above. -->
<!-- Full description for the public changelog, worded for technical Kobo instance maintainers. -->

TODO

### 💭 Notes
<!-- Delete this section if empty. -->
<!-- Anything else useful that's not said above,worded for
reviewers, testers, and future git archaeologist collegues. Examples:
- screenshots, copy-pasted logs, etc.
- what was tried but didn't work,
- conscious short-term vs long-term tradeoffs,
- proactively answer likely questions,
-->

TODO

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. do this
3. do that
4. 🔴 [on main] notice that this isn't anywhere
5. 🟢 [on PR] notice that this is here
6. do that another thing
7. 🟢 notice that this changed like that
