### PR TITLE
perf(storageCounters): use user profile counters instead of aggregated project counters DEV-1140

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -68,7 +68,7 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
             request = self.factory.post('/submission', data, format='json')
             auth = DigestAuth('bob', 'bobbob')
             request.META.update(auth(request.META, response))
-            expected_queries = FuzzyInt(43, 47)
+            expected_queries = FuzzyInt(42, 47)
             # In stripe-enabled environments usage limit enforcement
             # requires additional queries
             # TODO: Constance adds three extra queries when checking

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -47,6 +47,7 @@ class BaseServiceUsageTestCase(BaseAssetTestCase):
         super().setUpTestData()
         cls.anotheruser = User.objects.get(username='anotheruser')
         cls.someuser = User.objects.get(username='someuser')
+        cls.adminuser = User.objects.get(username='adminuser')
 
     def _create_asset(self, user=None):
         owner = user or self.anotheruser
@@ -263,6 +264,7 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
         self.add_submissions(count=2, asset=asset_3, username='someuser')
         results = get_storage_usage_by_user_id()
         assert results == {
+            self.adminuser.id: 0,
             self.someuser.id: 4 * self.expected_file_size(),
             self.anotheruser.id: 5 * self.expected_file_size(),
         }


### PR DESCRIPTION
### 📣 Summary
Improve performance by reading storage usage directly from user profile counters instead of aggregating data across projects.

### 📖 Description
This change replaces the previous approach of calculating storage usage by aggregating all related project counters with a faster, direct lookup from user profile counters. Since the profile already maintains accurate, up-to-date storage metrics, this avoids redundant aggregation queries and reduces database load. 

### 💭 Notes
`get_storage_usage_by_user_id()` now returns more results than before, since some user profiles may not be linked to any projects.
Based on tests on a large dataset, the new implementation is approximately 7-9 times faster than the previous version.
