### PR TITLE
perf(submissions): use `cache_for_request` to compute user usage balances DEV-1140

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.test.client import Client
 from django.test.testcases import LiveServerTestCase
 from django.test.utils import override_settings
 from django_digest.test import DigestAuth
@@ -244,6 +245,56 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
                 request.META.update(auth(request.META, response))
                 response = self.view(request, username=self.user.username)
                 self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
+    @override_config(USAGE_LIMIT_ENFORCEMENT=False)
+    def test_service_calculator_call_once_per_submission(self):
+        """
+        Ensure we don't call the ServiceUsageCalculator more than once per request
+        """
+
+        self.xform.require_auth = False
+        self.xform.save(update_fields=['require_auth'])
+        client = Client()
+        client.login(username='bob', password='bobbob')
+
+        s = self.surveys[0]
+        media_file = '1335783522563.jpg'
+        path = os.path.join(
+            self.main_directory,
+            'fixtures',
+            'transportation',
+            'instances',
+            s,
+            media_file,
+        )
+        with open(path, 'rb') as f:
+            f = InMemoryUploadedFile(
+                f,
+                'media_file',
+                media_file,
+                'image/jpg',
+                os.path.getsize(path),
+                None,
+            )
+            submission_path = os.path.join(
+                self.main_directory,
+                'fixtures',
+                'transportation',
+                'instances',
+                s,
+                s + '.xml',
+            )
+            with patch(
+                'kobo.apps.openrosa.libs.utils.logger_tools.ServiceUsageCalculator.get_usage_balances'  # noqa
+            ) as patched_balances:
+                with open(submission_path) as sf:
+                    data = {'xml_submission_file': sf, 'media_file': f}
+                    response = client.post('/bob/submission', data)
+                    assert response.status_code == status.HTTP_201_CREATED
+                    patched_balances.assert_called_once()
 
     def test_post_submission_anonymous(self):
 

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -65,7 +65,6 @@ from kobo.apps.openrosa.apps.logger.signals import (
     update_xform_daily_counter,
     update_xform_monthly_counter,
 )
-from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kobo.apps.openrosa.apps.logger.utils.counters import update_user_counters
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     XFormInstanceParser,
@@ -83,6 +82,7 @@ from kobo.apps.openrosa.libs.utils import common_tags
 from kobo.apps.openrosa.libs.utils.model_tools import queryset_iterator, set_uuid
 from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kobo.apps.organizations.constants import UsageType
+from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )

--- a/kobo/apps/stripe/utils/limit_enforcement.py
+++ b/kobo/apps/stripe/utils/limit_enforcement.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
+from django_request_cache import cache_for_request
 
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.stripe.utils.import_management import requires_stripe
@@ -25,14 +26,9 @@ def check_exceeded_limit(user, usage_type: UsageType, **kwargs):
         return
 
     ExceededLimitCounter = kwargs['exceeded_limit_counter_model']
-
-    # We disable usage calculator cache so we can get the most recent
-    # usage when this function is called after submissions or NLP
-    # actions
-    calculator = ServiceUsageCalculator(user, disable_cache=True)
-    balances = calculator.get_usage_balances()
-
+    balances = _get_usage_balances(user)
     balance = balances[usage_type]
+
     if balance and balance['exceeded']:
         counter, created = ExceededLimitCounter.objects.get_or_create(
             user=user,
@@ -59,3 +55,20 @@ def update_or_remove_limit_counter(counter, **kwargs):
         delta = timezone.now().date() - counter.date_modified.date()
         counter.days += delta.days
         counter.save()
+
+
+@cache_for_request
+def _get_usage_balances(user: 'kobo_auth.User') -> dict:
+    """
+    Cache the result of `get_usage_balances` for the duration of the request.
+
+    This avoids redundant recalculations when `check_exceeded_limit` is called
+    multiple times within the same request for different usage types.
+
+    Since ServiceUsageCalculator caching is disabled to ensure the most up-to-date
+    values after submissions or NLP actions, the first call already computes all usage
+    types, so subsequent calls can safely reuse the cached result.
+    """
+
+    calculator = ServiceUsageCalculator(user, disable_cache=True)
+    return calculator.get_usage_balances()


### PR DESCRIPTION
### 📣 Summary
Cache user usage balances for the duration of a request to avoid redundant recalculations.


### 📖 Description
This change introduces per-request caching for user usage balances using `cache_for_request`. The result of `get_usage_balances` is now cached for the lifetime of the current request, preventing multiple redundant recalculations when it’s called several times for different usage types.

Since balance caching is globally disabled to always reflect the latest values after submissions or NLP actions, this approach remains safe: the first call already computes all usage types, and subsequent calls within the same request reuse the cached result. 
