### PR TITLE
fix(api): correct `uid` value for asset snapshot manifest endpoint DEV-1144

### DIFF
--- a/kpi/models/asset_snapshot.py
+++ b/kpi/models/asset_snapshot.py
@@ -106,7 +106,7 @@ class AssetSnapshot(
         return reverse(
             viewname='assetsnapshot-manifest',
             format='xml',
-            kwargs={'uid': self.uid},
+            kwargs={'uid_asset_snapshot': self.uid},
             request=request
         )
 

--- a/kpi/views/v2/asset_snapshot.py
+++ b/kpi/views/v2/asset_snapshot.py
@@ -61,17 +61,6 @@ from kpi.versioning import OpenRosaAPIVersioning
 from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
 
 
-@extend_schema(
-    parameters=[
-        OpenApiParameter(
-            name='uid_asset_snapshot',
-            type=str,
-            location=OpenApiParameter.PATH,
-            required=True,
-            description='UID of the asset snapshot',
-        ),
-    ],
-)
 @extend_schema_view(
     # description for list
     list=extend_schema(
@@ -94,6 +83,15 @@ from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
             raise_access_forbidden=False,
         ),
         tags=['Form content'],
+        parameters=[
+            OpenApiParameter(
+                name='uid_asset_snapshot',
+                type=str,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description='UID of the asset snapshot',
+            ),
+        ],
     ),
     # description for post
     create=extend_schema(
@@ -138,6 +136,15 @@ from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
             raise_access_forbidden=False,
         ),
         tags=['Form content'],
+        parameters=[
+            OpenApiParameter(
+                name='uid_asset_snapshot',
+                type=str,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description='UID of the asset snapshot',
+            ),
+        ],
     ),
     update=extend_schema(
         exclude=True,
@@ -190,6 +197,15 @@ from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
             raise_access_forbidden=False,
         ),
         tags=['Form content'],
+        parameters=[
+            OpenApiParameter(
+                name='uid_asset_snapshot',
+                type=str,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description='UID of the asset snapshot',
+            ),
+        ],
     ),
     xform=extend_schema(
         description=read_md('kpi', 'asset_snapshots/xform.md'),
@@ -202,6 +218,15 @@ from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
             error_media_type='text/html',
         ),
         tags=['Form content'],
+        parameters=[
+            OpenApiParameter(
+                name='uid_asset_snapshot',
+                type=str,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description='UID of the asset snapshot',
+            ),
+        ],
     ),
     xml_with_disclaimer=extend_schema(
         description=read_md('kpi', 'asset_snapshots/xml_with_disclaimer.md'),
@@ -212,6 +237,15 @@ from kpi.views.v2.open_rosa import OpenRosaViewSetMixin
             raise_access_forbidden=False,
         ),
         tags=['Form content'],
+        parameters=[
+            OpenApiParameter(
+                name='uid_asset_snapshot',
+                type=str,
+                location=OpenApiParameter.PATH,
+                required=True,
+                description='UID of the asset snapshot',
+            ),
+        ],
     ),
 )
 class AssetSnapshotViewSet(OpenRosaViewSetMixin, AuditLoggedNoUpdateModelViewSet):

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -384,15 +384,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "in": "path",
-                        "name": "uid_asset_snapshot",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "UID of the asset snapshot",
-                        "required": true
                     }
                 ],
                 "tags": [
@@ -440,17 +431,6 @@
             "post": {
                 "operationId": "api_v2_asset_snapshots_create",
                 "description": "## Create an asset snapshot\n\nWhen creating an asset snapshot, you must provide either:\n\n- the asset (as a URI), or\n- the source (as a JSON object representing the asset)\n\n…but not both.\n",
-                "parameters": [
-                    {
-                        "in": "path",
-                        "name": "uid_asset_snapshot",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "UID of the asset snapshot",
-                        "required": true
-                    }
-                ],
                 "tags": [
                     "Form content"
                 ],

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -291,12 +291,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - in: path
-        name: uid_asset_snapshot
-        schema:
-          type: string
-        description: UID of the asset snapshot
-        required: true
       tags:
       - Form content
       security:
@@ -331,13 +325,6 @@ paths:
         - the source (as a JSON object representing the asset)
 
         …but not both.
-      parameters:
-      - in: path
-        name: uid_asset_snapshot
-        schema:
-          type: string
-        description: UID of the asset snapshot
-        required: true
       tags:
       - Form content
       requestBody:


### PR DESCRIPTION
### 📣 Summary
Fix `uid` value that was missed in #6323 resulting in form previews and submission edits failures. 

### 💭 Notes
Also fixed the asset snapshot documentation where GET and POST to `/api/v2/asset_snapshots/` were requiring an `uid_asset_snapshot` parameter. 

### 👀 Preview steps
1. ℹ️ have an account and a project
2. Click the preview button 
3. 🔴 [on main] Server responds with 500 and shows error modal
4. 🟢 [on PR] Form preview works 
5. 🟢 [on PR] verify that submission edits succeed
6. Checkout the documentation: `api/v2/docs`
7. 🟢 verify that GET and POST to `/api/v2/asset_snapshots/` doesn't require an `uid_asset_snapshot` parameter
