### PR TITLE
fix(reactQuery): use of RequireOrg out of ReactQuery context DEV-1145

### DIFF
--- a/jsapp/js/app.jsx
+++ b/jsapp/js/app.jsx
@@ -22,7 +22,6 @@ import mixins from '#/mixins'
 import pageState from '#/pageState.store'
 import ProjectTopTabs from '#/project/projectTopTabs.component'
 import { RootContextProvider } from '#/rootContextProvider.component'
-import { RequireOrg } from '#/router/RequireOrg'
 import InvalidatedPassword from '#/router/invalidatedPassword.component'
 import { isInvalidatedPasswordRouteBlockerActive, isTOSAgreementRouteBlockerActive } from '#/router/routerUtils'
 import TOSAgreement from '#/router/tosAgreement.component'
@@ -68,19 +67,11 @@ class App extends React.Component {
 
   render() {
     if (isInvalidatedPasswordRouteBlockerActive()) {
-      return (
-        <RequireOrg>
-          <InvalidatedPassword />
-        </RequireOrg>
-      )
+      return <InvalidatedPassword />
     }
 
     if (isTOSAgreementRouteBlockerActive()) {
-      return (
-        <RequireOrg>
-          <TOSAgreement />
-        </RequireOrg>
-      )
+      return <TOSAgreement />
     }
 
     const assetid = routerGetAssetId()


### PR DESCRIPTION
### 📣 Summary
This PR fix the loading of TOS and Invalidated Password views

### 💭 Notes
- The loading of the views was failing due to `RequireOrg` being called out of `Reactquery` context.
- `RequireOrg` was removed since it's already part of the `BasicLayout` used in both views.

### 👀 Preview steps
1. ℹ️ have an account
2. Have a TOS defined
3. Have a user that needs to accept TOS (last_tos_accept_time can be removed from user extra details) 
4. Login with the user
5. 🔴 [on main] an error view is displayed when trying to load TOS view
6. 🟢 [on PR] TOS view loads normally
7. Alternativelly, the conditions on `render` function of `app.js` can be forced to `true` to load the views.
5. 🔴 [on main] an error view is displayed
8. 🟢 [on PR] views load normally
