### PR TITLE
feat(dataCollectors): display collection client URLs in Django Admin DEV-920

### DIFF
--- a/kobo/apps/data_collectors/admin.py
+++ b/kobo/apps/data_collectors/admin.py
@@ -6,8 +6,8 @@ from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.exceptions import ValidationError
 from django.db.models import Q
-from django_redis import get_redis_connection
 from django.utils.safestring import mark_safe
+from django_redis import get_redis_connection
 
 from kobo.apps.data_collectors.models import DataCollector, DataCollectorGroup
 from kpi.constants import ASSET_TYPE_SURVEY, PERM_MANAGE_ASSET
@@ -162,12 +162,10 @@ class DataCollectorAdmin(admin.ModelAdmin):
 
         items = ''
         for asset in obj.group.assets.all():
-            enketo_id = redis_client.get(f'or:{parsed_url.netloc}/key/{obj.token},{asset.uid}')
+            enketo_id = redis_client.get(
+                f'or:{parsed_url.netloc}/key/{obj.token},{asset.uid}'
+            )
             enketo_url = f'{settings.ENKETO_URL}/x/{enketo_id.decode()}'
-            items = items + f'<li><a href="{enketo_url}" target="_blank">{enketo_url}</a></li>'
+            items = items + f'• <a href="{enketo_url}" target="_blank">{asset.name} (#{asset.uid})</a><br>'  # noqa
 
-        return mark_safe(
-            '<div>'
-            f'  <ul>{items}</ul>'
-            '</div>'
-        )
+        return mark_safe(items)


### PR DESCRIPTION
### 📣 Summary
Show ready-to-use links for Enketo Express and KoboCollect on Data Collector pages in Django Admin

