### PR TITLE
feat(projectHistoryLogs): add data collector group info to submissions DEV-1149

### DIFF
--- a/kobo/apps/audit_log/models.py
+++ b/kobo/apps/audit_log/models.py
@@ -648,6 +648,12 @@ class ProjectHistoryLog(AuditLog):
             if is_data_collector:
                 metadata['submission']['data_collector_uid'] = request.user.uid
                 metadata['submission']['data_collector_name'] = request.user.name
+                metadata['submission'][
+                    'data_collector_group_uid'
+                ] = request.user.group_uid
+                metadata['submission'][
+                    'data_collector_group_name'
+                ] = request.user.group_name
 
             logs.append(
                 ProjectHistoryLog(

--- a/kobo/apps/data_collectors/authentication.py
+++ b/kobo/apps/data_collectors/authentication.py
@@ -53,6 +53,8 @@ class DataCollectorTokenAuthentication(BaseAuthentication):
                 server_user.assets = list(group.assets.values_list('uid', flat=True))
                 server_user.name = collector.name
                 server_user.uid = collector.uid
+                server_user.group_uid = group.uid
+                server_user.group_name = group.name
             return server_user, key
         except DataCollector.DoesNotExist:
             raise AuthenticationFailed('Invalid token.')


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add data collector group name and uid to project history logs when submissions are from data collectors.


### 👀 Preview steps

1. ℹ️ have an account and a project
2. In Django admin, create a data collector group and assign the project to it
3. In Django admin, create a data collector and add it to the group
4. Using the link provided in admin, submit a new submission to the project
5. Go to `/api/v2/assets/<uid>/history`
6. 🟢 [on PR] The new log will have the data collector group name and uid in the metadata

