### PR TITLE
fix(permissions): drop guardian constraints DEV-1134

### DIFF
--- a/kobo/apps/openrosa/apps/main/migrations/0019_drop_guardian_constraints.py
+++ b/kobo/apps/openrosa/apps/main/migrations/0019_drop_guardian_constraints.py
@@ -16,7 +16,7 @@ def drop_fk(apps, schema_editor):
         for constraints in cur.fetchall():
             schema, table, constraint_name = constraints
             sql = (
-                f"ALTER TABLE '{schema}'.'{table}' DROP CONSTRAINT '{constraint_name}'"
+                f'ALTER TABLE {schema}.{table} DROP CONSTRAINT {constraint_name}'
             )
             cur.execute(sql)
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
After removing django guardian dependency, its tables and constraints are still present in the database. This PR includes a migration script that drops the remaining guardian constraints. The tables should be removed in a future migration, after we deem that they are no longer needed. 

### 👀 Preview steps
1. Restart your KPI instance 
2. Monitor in the logs that KoboCat migrations run without issues