### PR TITLE
fix(permissions)!: fix mistake in long running job that deletes obsolete permissions

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0010_remove_from_kc_only_permission.py
+++ b/kobo/apps/long_running_migrations/jobs/0010_remove_from_kc_only_permission.py
@@ -12,4 +12,4 @@ def run():
         permission__codename=PERM_FROM_KC_ONLY
     )
     print(f'Deleting {objects.count()} ObjectPermission objects')
-    objects._raw_delete()
+    objects._raw_delete(using=objects.db)


### PR DESCRIPTION
### 💭 Notes
Fixes the _raw_delete call in the long running job 0010_remove_from_kc_only_permissions
Backport of #6308. 

### 👀 Preview steps
1. Use the django shell
2. Find the long running migration job and re-execute it, ensure it doesn't fail:
```
>>> lrm = LongRunningMigration.objects.filter(name__contains='0010_remove_from_kc_only').first()

>>> lrm.status = 'created'; lrm.save(); lrm.execute()

Deleting 0 ObjectPermission objects
```