### PR TITLE
fix(imports): revert `uid_import` property in import endpoint response DEV-1156

### DIFF
--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -1033,7 +1033,7 @@ class AssetImportTaskTest(BaseTestCase):
         }
         post_url = reverse(self._get_endpoint('importtask-list'))
         response = self.client.post(post_url, task_data)
-        task = ImportTask.objects.get(uid=response.data['uid_import'])
+        task = ImportTask.objects.get(uid=response.data['uid'])
         audit_logs = task.messages['audit_logs']
         self.assertEqual(len(audit_logs), 1)
         audit_log_info = audit_logs[0]
@@ -1064,7 +1064,7 @@ class AssetImportTaskTest(BaseTestCase):
         }
         post_url = reverse(self._get_endpoint('importtask-list'))
         response = self.client.post(post_url, task_data)
-        task = ImportTask.objects.get(uid=response.data['uid_import'])
+        task = ImportTask.objects.get(uid=response.data['uid'])
         audit_logs = task.messages['audit_logs']
         self.assertEqual(len(audit_logs), 1)
         audit_log_info = audit_logs[0]

--- a/kpi/views/v2/import_task.py
+++ b/kpi/views/v2/import_task.py
@@ -121,7 +121,7 @@ class ImportTaskViewSet(viewsets.ReadOnlyModelViewSet):
         import_in_background.delay(import_task_uid=import_task.uid)
         return Response(
             {
-                'uid_import': import_task.uid,
+                'uid': import_task.uid,
                 'url': reverse(
                     'api_v2:importtask-detail',
                     kwargs={'uid_import': import_task.uid},


### PR DESCRIPTION
### 💭 Notes
The bug was a result of #6323. Supersedes #6366

### 👀 Preview steps

1. ℹ️ have an account
2. upload XLSForm
3. click import button
4. 🔴 [on release] receive an error message: TypeError
undefined is not an object (evaluating 'response.messages.error')
5. Check network tab and notice that a request was made to `http://kf.kobo.local/api/v2/imports/undefined/` returning a 404 
5. 🟢 [on PR] form is imported successfully 
