### PR TITLE
ci(releases): push to beta cascades deploy DEV-1165

### DIFF
--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -132,6 +132,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+    - uses: ./.github/actions/checkout-with-github-app-token
+      with:
+        app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+        private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
 
     - name: deploy to beta
       run: |


### PR DESCRIPTION
### 💭 Notes

GITHUB_TOKEN push doesn't cascade workflows, manual or Github App token push does.