### PR TITLE
feat(constanceSettings): make self account deletion feature disabled by default DEV-1157

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -654,7 +654,7 @@ CONSTANCE_CONFIG = {
         '"test_users" query for MassEmailConfigs',
     ),
     'ALLOW_SELF_ACCOUNT_DELETION': (
-        True,
+        False,
         'Allow users to delete their own account.',
     ),
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Makes feature disabled by default.