### PR TITLE
fix(admin): add admin action to bulk mark selected users as inactive DEV-1084

### DIFF
--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -121,10 +121,10 @@ class InactiveUsersAsOfFilter(SimpleListFilter):
 
     def lookups(self, request, model_admin):
         return (
-            ('90', 'Inactive ≥ 90 days'),
-            ('180', 'Inactive ≥ 180 days'),
-            ('365', 'Inactive ≥ 365 days'),
-            ('730', 'Inactive ≥ 730 days'),
+            ('90', 'Inactive > 90 days'),
+            ('180', 'Inactive > 180 days'),
+            ('365', 'Inactive > 365 days'),
+            ('730', 'Inactive > 730 days'),
         )
 
     def queryset(self, request, queryset):
@@ -197,7 +197,7 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
             {'fields': ('deployed_forms_count', 'monthly_submission_count')},
         ),
     )
-    actions = ['remove', 'delete']
+    actions = ['remove', 'delete', 'mark_inactive']
 
     class Media:
         css = {'all': ('admin/css/inline_as_fieldset.css',)}
@@ -229,6 +229,18 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
         users = list(queryset.values('pk', 'username'))
         self._remove_or_delete(
             request, users=users, grace_period=0, retain_placeholder=False
+        )
+
+    @admin.action(description='Mark selected users inactive')
+    def mark_inactive(self, request, queryset, **kwargs):
+        """
+        Mark selected users as inactive
+        """
+        updated_count = queryset.update(is_active=False)
+        self.message_user(
+            request,
+            f'{updated_count} user(s) marked inactive.',
+            level=messages.SUCCESS,
         )
 
     def deployed_forms_count(self, obj):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a new admin action in the Django user list allowing superusers to bulk mark selected users as inactive.

### 📖 Description
This update introduces a bulk action in the Django admin's `Users` page that lets superusers quickly mark multiple accounts as inactive.
The action is designed to complement the existing inactive users filter, after filtering inactive accounts (e.g., inactive for > 90 days), superusers can now select them and deactivate all in one step.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Log in as a superuser on your admin site.
2. Navigate to Admin -> Users (/admin/kobo_auth/user/).
3. Use the Inactive users filter (e.g., Inactive > 90 days) to list inactive accounts.
4. 🔴 [on release] There is no option to deactivate multiple users at once.
5. 🟢 [on PR] A new admin action appears in the dropdown labeled “Mark selected users inactive.”
6. Select one or more filtered users and choose “Mark selected users inactive” from the Action dropdown.
7. 🟢 The selected users are marked as inactive (`is_active=False`), and a confirmation message shows how many were updated.
