### PR TITLE
fix(api): align detail action parameters with URL patterns DEV-1170

### DIFF
--- a/kobo/apps/hook/views/v2/hook.py
+++ b/kobo/apps/hook/views/v2/hook.py
@@ -181,7 +181,7 @@ class HookViewSet(
         serializer.save(asset=self.asset)
 
     @action(detail=True, methods=['PATCH'])
-    def retry(self, request, uid=None, *args, **kwargs):
+    def retry(self, request, uid_hook, *args, **kwargs):
         hook = self.get_object()
         response = {'detail': t('Task successfully scheduled')}
         status_code = status.HTTP_200_OK

--- a/kobo/apps/hook/views/v2/hook_log.py
+++ b/kobo/apps/hook/views/v2/hook_log.py
@@ -106,7 +106,7 @@ class HookLogViewSet(AssetNestedObjectViewsetMixin,
         return queryset
 
     @action(detail=True, methods=['PATCH'])
-    def retry(self, request, uid=None, *args, **kwargs):
+    def retry(self, request, uid_log, *args, **kwargs):
         """
         Retries to send data to external service.
         :param request: rest_framework.request.Request

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -381,7 +381,7 @@ class AssetViewSet(
 
     @extend_schema(tags=['Form content'])
     @action(detail=True)
-    def content(self, request, uid):
+    def content(self, request, uid_asset):
         asset = self.get_object()
         return Response(
             {
@@ -867,7 +867,7 @@ class AssetViewSet(
 
     @extend_schema(tags=['Form content'])
     @action(detail=True)
-    def valid_content(self, request, uid):
+    def valid_content(self, request, uid_asset):
         asset = self.get_object()
         return Response(
             {


### PR DESCRIPTION
### 📣 Summary
Ensure detail action method signatures use the correct parameter names defined in their URL patterns.

### 📖 Description
This fix updates several detail actions so their method parameters match the lookup fields defined in their corresponding URL patterns. Some actions were still using outdated parameter names, which caused runtime errors when resolving nested routes.


### 💭 Notes
Problematic endpoints: 
- `/api/v2/assets/<uid_asset>/valide_content/`
- `/api/v2/assets/<uid_asset>/content/`
- `/api/v2/project-views/<uid_project_view>/<obj_type>/export/`
- `/api/v2/project-views/<uid_project_view>/users/`

**Method signature was wrong but no 500 errors were raised**
- `/api/v2/assets/<uid_asset>/hooks/<uid_hook>/retry/`
- `/api/v2/assets/<uid_asset>/hooks/<uid_hook>/logs/<uid_log>/retry/`


### 👀 Preview steps

Go to each endpoint listed in Notes section
4. 🔴 [on release branch] notice that a 500 error is raised
5. 🟢 [on PR] notice that the endpoint returns the response as expected
