### PR TITLE
perf(migrations): instructions for faster migration of logger 0049

### DIFF
--- a/kobo/apps/openrosa/apps/logger/migrations/0049_alter_instance_history_allow_null_instance.py
+++ b/kobo/apps/openrosa/apps/logger/migrations/0049_alter_instance_history_allow_null_instance.py
@@ -17,18 +17,6 @@ def manually_set_nullable(apps, schema_editor):
     )
 
 
-def manually_set_non_nullable(apps, schema_editor):
-    print(
-        """
-        !!! ATTENTION !!!
-        If you have existing projects should run the SQL query below
-        in PostgreSQL directly:
-
-           > ALTER TABLE "logger_instancehistory" ALTER COLUMN "xform_instance_id" SET NOT NULL;
-        """
-    )
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -40,7 +28,7 @@ class Migration(migrations.Migration):
         operations = [
             migrations.RunPython(
                 manually_set_nullable,
-                manually_set_non_nullable,
+                migrations.RunPython.noop,
             )
         ]
     else:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Use SKIP_HEAVY_MIGRATIONS when updating the instance history table to allow null values. We don't need to do anything else because the work for on_delete is done in Python, not SQL, so there's no trigger or anything that needs to be modified.


### 👀 Preview steps

1. ℹ️ have an account and a project with some submissions
2. Edit a submission to make sure there is stuff in InstanceHistory
3.  In a kpi shell, run `./manage migrate 0048 --database kobocat` to go back a migration
4.  In a kpi shell, run `SKIP_HEAVY_MIGRATIONS=True ./manage migrate 0049 --database kobocat` 
5. In a postgres shell, run the sql command that is printed
6. Delete the edited submission
7. 🟢 notice that the InstanceHistory objects have instance_id=None
8. In a kpi shell, run `SKIP_HEAVY_MIGRATIONS=True ./manage migrate 0048 --database kobocat`  (should be a noop)
9. Locally update the code for InstanceHistory.instance to `on_delete=models.CASCADE` and remove `null=True` to simulate reverting the code
10. Edit and delete another submission
11. 🟢 (regression test) notice the related InstanceHistory object(s) are deleted


