### PR TITLE
fix(attachments): force `Content-Disposition` to `attachment` DEV-1200

### DIFF
--- a/kobo/apps/openrosa/apps/api/viewsets/attachment_viewset.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/attachment_viewset.py
@@ -160,8 +160,10 @@ class AttachmentViewSet(OpenRosaReadOnlyModelViewSet):
             and self.object.media_file is not None
         ):
             data = self.object.media_file.read()
-
-            return Response(data, content_type=self.object.mimetype)
+            headers = {
+                'Content-Disposition': f'attachment; filename={self.object.media_file_basename}',  # noqa
+            }
+            return Response(data, content_type=self.object.mimetype, headers=headers)
 
         filename = request.query_params.get('filename')
         serializer = self.get_serializer(self.object)

--- a/kobo/apps/openrosa/apps/viewer/views.py
+++ b/kobo/apps/openrosa/apps/viewer/views.py
@@ -297,6 +297,7 @@ def attachment_url(request, size='medium'):
 
             # Let nginx determine the correct content type
             response['Content-Type'] = ''
+            response['Content-Disposition'] = f'attachment; filename={attachment.media_file_basename}'  # noqa
             response['X-Accel-Redirect'] = protected_url
             return response
 

--- a/kpi/views/v2/attachment.py
+++ b/kpi/views/v2/attachment.py
@@ -248,7 +248,7 @@ class AttachmentViewSet(
         # Otherwise, let NGINX determine the correct content type and serve
         # the file
         headers = {
-            'Content-Disposition': f'inline; filename={attachment.media_file_basename}',
+            'Content-Disposition': f'attachment; filename={attachment.media_file_basename}',
             'X-Accel-Redirect': protected_path
         }
         response = Response(content_type='', headers=headers)


### PR DESCRIPTION
### 📣 Summary
Always send files with a `Content-Disposition: attachment` header to ensure proper download behavior.


### 📖 Description
This change enforces the `Content-Disposition` header to be set to attachment for all downloadable responses. Some files were previously displayed inline by browsers instead of being downloaded. By forcing this header, all files are now consistently offered as downloads.

### 👀 Preview steps

1. ℹ️ have an account and a project with attachments
2. Collect data
3. Go to the table view
4. Retrieve the link from the download CTA in the media preview modal
5. Paste the link in another browser window
4. 🔴 [on release branch] notice the `Content-Disposition` header for that file is `inline` and image can be viewed directly in the browser
5. 🟢 [on PR] notice the `Content-Disposition` header for that file is `attachment` and image is directly downloaded 