### PR TITLE
fix(assets): handle anonymous user access on asset snapshot list DEV-1105

### DIFF
--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -423,7 +423,7 @@ class RelatedAssetPermissionsFilter(KpiObjectPermissionsFilter):
 
         user = get_database_user(request.user)
         organization = user.organization
-        if organization.is_admin_only(user):
+        if organization and organization.is_admin_only(user):
             # Admins do not receive explicit permission assignments,
             # but they have the same access to assets as the organization owner.
             org_assets = Asset.objects.filter(owner=organization.owner_user_object)

--- a/kpi/tests/api/v2/test_api_asset_snapshots.py
+++ b/kpi/tests/api/v2/test_api_asset_snapshots.py
@@ -260,6 +260,15 @@ class TestAssetSnapshotList(AssetSnapshotBase):
         response = self.client.post(snapshot_list_url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_asset_snapshot_list_handles_anonymous_user(self):
+        """
+        Test that list endpoint safely handles anonymous users
+        """
+        snapshot_list_url = reverse(self._get_endpoint('assetsnapshot-list'))
+        response = self.client.get(snapshot_list_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 0)
+
 
 class TestAssetSnapshotDetail(AssetSnapshotBase):
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes an issue where anonymous users received a 500 error when accessing the asset snapshots list endpoint. Anonymous requests now safely return an empty response instead of causing a server error.


### 📖 Description
Previously, the `/api/v2/asset_snapshots/` endpoint raised a server error when accessed anonymously, because the code attempted to access `organization.is_admin_only()` even when no organization was associated with the user.
This PR updates the filtering logic to handle anonymous users gracefully and adds a unit test to ensure no 500 error occurs in such cases.


### 👀 Preview steps
1. 🔴 [on release] Hit the `/api/v2/asset_snapshots/` endpoint anonymously. It returns a 500 error.
2. 🟢 [on PR] Hit the same endpoint again. It now returns a 200 response (with an empty list, as expected).
3. Test with an authenticated user, ensure their asset snapshots are still listed correctly.
