### PR TITLE
fix(auth): stop sending password reset emails to unknown accounts DEV-1108

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1541,6 +1541,7 @@ CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT = int(
 ACCOUNT_ADAPTER = 'kobo.apps.accounts.adapter.AccountAdapter'
 ACCOUNT_USERNAME_VALIDATORS = 'kobo.apps.accounts.validators.username_validators'
 ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 ACCOUNT_EMAIL_VERIFICATION = env.str('ACCOUNT_EMAIL_VERIFICATION', 'mandatory')
 ACCOUNT_FORMS = {
     'login': 'kobo.apps.accounts.mfa.forms.MfaLoginForm',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Prevent password reset emails from being sent to unregistered email addresses while keeping the same non-revealing message on the reset page.


### 📖 Description
Previously, Kobo would send a password reset email even when the entered email address was not associated with any existing account.
This behavior, inherited from django-allauth defaults, could lead to unsolicited emails being sent to arbitrary addresses.

This PR updates the configuration to:
- Set `ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False`, ensuring no email is sent if the address doesn’t match any account.
- Preserve the existing UI message to avoid exposing valid accounts and maintain account-enumeration protection.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project
2. Request a password reset for your registered email address and confirm that a reset email is received.
3. Request a password reset for your unregistered email address.
4. 🔴 [on release] notice that a password reset email is sent.
5. 🟢 [on PR] notice that no email is sent.
6. Notice that throughout all tests, the UI message remains unchanged.
