### PR TITLE
test(xforms): improve xform list API tests DEV-1188

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_list_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_list_api.py
@@ -744,21 +744,10 @@ class TestXFormListAsOrgAdminApiBase(TestXFormListApiBase):
         self.assertEqual(response['Content-Type'], 'text/xml; charset=utf-8')
 
     def test_head_xform_manifest(self):
-<<<<<<< HEAD
-        base_url = reverse(
-            'manifest-url',
-            kwargs={'pk': self.xform.pk},
-        )
-        client = DigestClient()
-        client.set_authorization('alice', 'alicealice', 'Digest')
-
-        response = client.head(base_url)
-=======
         self._load_metadata(self.xform)
         response = self.client.head(self.manifest_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         response = self.digest_client.head(self.manifest_url)
->>>>>>> 6f143300a (test(xforms): more robust unit tests for xform list)
         self.validate_openrosa_head_response(response)
 
     def test_head_xform_media(self):


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging


### 💭 Notes
Update XForm list api tests to be more sensitive to changes in the request flow. Recently we had a few bugs make it into production that had to do with how the request is handled before it gets to the view. Since the existing tests were only at the view level, it did not catch the errors.
While including the whole request processing in test makes it less of a "unit" test, it makes the tests more likely to catch errors that occur as a result of the combination of view code and request processing code. Since the view code relies on information set by django's request processing, it makes sense to test them together.
There is more consolidation that could be done on these tests as many are probably redundant (especially testing anonymous access to various endpoints) but that is outside the scope of this work.


### 👀 Preview steps
Unit-test only, but a good verification is to locally revert the changes from https://github.com/kobotoolbox/kpi/pull/6412 and https://github.com/kobotoolbox/kpi/pull/6397, and run the test suite. Several tests should fail, then succeed when the changes are put back in.

