### PR TITLE
fix(submissions): fix bulk update raises 500 instead of 400 DEV-1131 

### DIFF
--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -997,7 +997,9 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             results.append(
                 {
                     'uuid': uuid,
-                    'root_uuid': backend_result['result'].root_uuid,
+                    'root_uuid': getattr(
+                        backend_result.get('result'), 'root_uuid', None
+                    ),
                     'status_code': status_code,
                     'message': message,
                 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a server error in bulk update by handling `None` results gracefully.

### 📖 Description
If a `backend_result` result is `None`, the response now returns a proper 400 instead of causing a 500.

See: https://github.com/kobotoolbox/kpi/pull/6281#issuecomment-3371644513

### 👀 Preview steps

1. ℹ️ Trigger a bulk update where the `backend_result` returns an error (e.g., user exceeds storage limit).
2. 🔴 [on release] Returns HTTP 500 with AttributeError.
3. 🟢 [on PR] Returns HTTP 400 with a proper error message.
