### PR TITLE
fix(formBuilder): accessing non existent attribute for group type DEV-1206

### DIFF
--- a/jsapp/xlform/src/view.row.coffee
+++ b/jsapp/xlform/src/view.row.coffee
@@ -60,7 +60,7 @@ module.exports = do ->
     # All row types are supported by UI by default. If some type has `supportedByUI` override in `model.configs.coffee`
     # we respect that.
     isSupportedByUI: ->
-      if @model.get('type').get('rowType').supportedByUI is false
+      if @model.get('type').get('rowType')?.supportedByUI is false
         return false
       return true
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR fixes an error when loading form builder containing a group.

### 💭 Notes
The type `group` doesn't contain the attribute `rowType`, which is being accessed when calculating the `isSupportedByUI`.
The fix just adds an optional chaining, which lets the attribute resolve to `undefined` and fall into the default clause of being true.

### 👀 Preview steps
1. ℹ️ have an account
2. Create a project with a group. e.g: [audio_demo.xlsx](https://github.com/user-attachments/files/23193243/audio_demo.xlsx)
3. open the form builder to edit the project
4. 🔴 [on main] notice an error on console and infinite loading
5. 🟢 [on PR] editor opens as expected with no errors