### PR TITLE
fix(attachment): preserve existing `media_file_name` during save DEV-1176

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/attachment.py
+++ b/kobo/apps/openrosa/apps/logger/models/attachment.py
@@ -187,8 +187,11 @@ class Attachment(AbstractTimeStampedModel, AudioTranscodingMixin):
             # if we're just updating the userid don't do all the size calculations
             super().save(*args, **kwargs)
             return
+
         if self.media_file:
-            self.media_file_basename = self.filename
+            if not self.media_file_basename:
+                self.media_file_basename = self.filename
+
             if self.mimetype == '':
                 # guess mimetype
                 mimetype, encoding = mimetypes.guess_type(self.media_file.name)

--- a/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
+++ b/kobo/apps/openrosa/apps/logger/tests/models/test_attachment.py
@@ -110,3 +110,43 @@ class TestAttachment(TestBase):
         attachment.refresh_from_db()
         self.assertEqual(attachment.user_id, user.id)
         self.assertEqual(attachment.xform_id, xform.id)
+
+    def test_set_media_base_name(self):
+        user = User.objects.create_user(username='testuser', password='testpassword')
+        f = open(
+            os.path.join(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                'Water_Translated_2011_03_10.xml',
+            )
+        )
+        xml = f.read()
+        f.close()
+        xform = XForm.objects.create(xml=xml, user=user)
+        instance = Instance.objects.all()[0]
+        instance.xform = xform
+        instance.save()
+
+        media_file = os.path.join(
+            self.this_directory,
+            'fixtures',
+            'transportation',
+            'instances',
+            self.surveys[0],
+            self.media_file,
+        )
+        with open(media_file, 'rb') as f:
+            attachment = Attachment.objects.create(
+                instance=instance,
+                media_file=ContentFile(f.read(), name=self.media_file),
+                media_file_basename='foo.jpg',
+            )
+
+        assert attachment.media_file_basename == 'foo.jpg'
+
+        attachment.delete()
+        with open(media_file, 'rb') as f:
+            attachment = Attachment.objects.create(
+                instance=instance,
+                media_file=ContentFile(f.read(), name=self.media_file),
+            )
+        assert attachment.media_file_basename == '1335783522563.jpg'


### PR DESCRIPTION
### 📣 Summary
Prevent the `media_file_name` field from being overwritten when it already has a value.


### 📖 Description
This change updates the save logic to skip reassigning media_file_name if it’s already set. Previously, saving an object could overwrite the original filename even when no new file was uploaded, leading to loss of the stored name. The fix ensures the existing filename is preserved unless explicitly updated.
