### PR TITLE
fix(submissions): fix bulk update raises 500 instead of 400 DEV-1131

### DIFF
--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -996,7 +996,9 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             results.append(
                 {
                     'uuid': uuid,
-                    'root_uuid': backend_result['result'].root_uuid,
+                    'root_uuid': getattr(
+                        backend_result.get('result'), 'root_uuid', None
+                    ),
                     'status_code': status_code,
                     'message': message,
                 }


### PR DESCRIPTION
### 📣 Summary
Fixes a server error in bulk update by handling `None` results gracefully.

### 📖 Description
If a `backend_result` result is `None`, the response now returns a proper 400 instead of causing a 500.

See: https://github.com/kobotoolbox/kpi/pull/6281#issuecomment-3371644513

### 👀 Preview steps

1. ℹ️ Trigger a bulk update where the `backend_result` returns an error (e.g., user exceeds storage limit).
2. 🔴 [on release] Returns HTTP 500 with AttributeError.
3. 🟢 [on PR] Returns HTTP 400 with a proper error message.
