### PR TITLE
fix(ci): pin pip<25.3 to restore compatibility with pip-tools 7.x

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pip-tools
-        run: python -m pip install pip-tools==7.\*
+        run: python -m pip install --no-cache-dir --upgrade "pip<25.3" "pip-tools==7.*"
 
       - name: Update Debian package lists
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get -y update

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pip-tools
-      run: python -m pip install pip-tools==7.\*
+      run: python -m pip install --no-cache-dir --upgrade "pip<25.3" "pip-tools==7.*"
     - name: Update Debian package lists
       run: sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
     - name: Install Debian dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV VIRTUAL_ENV=/opt/venv \
 
 RUN python -m venv "$VIRTUAL_ENV"
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install --quiet pip-tools==7.\*
+RUN python -m pip install --upgrade "pip<25.3" \
+    && python -m pip install "pip-tools==7.*"
 COPY ./dependencies/pip/requirements.txt "${TMP_DIR}/pip_dependencies.txt"
 RUN pip-sync "${TMP_DIR}/pip_dependencies.txt" 1>/dev/null
 


### PR DESCRIPTION
### 📣 Summary
Fixes a CI installation issue caused by an incompatibility between pip 25.3 and pip-tools 7.x.


### Notes

pip-tools 7.x relies on internal pip attributes (use_pep517) that were removed in pip 25.3, causing builds to fail with:

```
AttributeError: 'InstallRequirement' object has no attribute 'use_pep517'
```

This PR pins pip to <25.3 in CI and Docker builds to maintain compatibility until a new version of pip-tools officially supports pip 25.3+.