### PR TITLE
refactor(reactQuery): standard error flow for Orval DEV-948

### DIFF
--- a/jsapp/js/account/organization/MemberRemoveModal.tsx
+++ b/jsapp/js/account/organization/MemberRemoveModal.tsx
@@ -8,6 +8,7 @@ import KoboModalContent from '#/components/modals/koboModalContent'
 import KoboModalFooter from '#/components/modals/koboModalFooter'
 import KoboModalHeader from '#/components/modals/koboModalHeader'
 import envStore from '#/envStore'
+import { notify } from '#/utils'
 import { getSimpleMMOLabel } from './organization.utils'
 
 interface MemberRemoveModalProps {
@@ -35,9 +36,7 @@ export default function MemberRemoveModal({
   const orgMemberDestroy = useOrganizationsMembersDestroy({
     mutation: {
       onSettled: () => onConfirmDone(),
-    },
-    request: {
-      errorMessageDisplay: 'Failed to remove member',
+      onError: () => notify(t('Failed to remove member'), 'error'), // TODO: update message in backend (DEV-1218).
     },
   })
   const mmoLabel = getSimpleMMOLabel(envStore.data, subscriptionStore.activeSubscriptions[0], false, false)

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -21,7 +21,7 @@ import ButtonNew from '#/components/common/ButtonNew'
 import Avatar from '#/components/common/avatar'
 import Badge from '#/components/common/badge'
 import envStore from '#/envStore'
-import { formatDate } from '#/utils'
+import { formatDate, notify } from '#/utils'
 import InviteeActionsDropdown from './InviteeActionsDropdown'
 import MemberActionsDropdown from './MemberActionsDropdown'
 import MemberRoleSelector from './MemberRoleSelector'
@@ -49,9 +49,10 @@ export default function MembersRoute() {
       // The `refetchOnWindowFocus` option is `true` by default, I'm setting it
       // here so we don't forget about it.
       refetchOnWindowFocus: true,
-    },
-    request: {
-      errorMessageDisplay: t('There was an error getting the list.'),
+      throwOnError: () => {
+        notify(t('There was an error getting the list.'), 'error') // TODO: update message in backend (DEV-1218).
+        return false
+      },
     },
   })
 

--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -28,8 +28,8 @@ export default function AccessLogsSection() {
     },
   })
   const accessLogsMeExport = useAccessLogsMeExportCreate({
-    request: {
-      notifyAboutError: false,
+    mutation: {
+      onError: () => null, // supress default toast on error because <ExportToEmailButton/> handles error inline.
     },
   })
 
@@ -42,7 +42,7 @@ export default function AccessLogsSection() {
     } catch (error) {
       const failResponse: FailResponse = {
         status: 500,
-        statusText: (error as Error).message || t('An error occurred while exporting the logs'),
+        statusText: (error as Error).message || t('An error occurred while exporting the logs'), // TODO: update message in backend (DEV-1218).
       }
       throw failResponse
     }

--- a/jsapp/js/account/usage/useOrganizationsServiceUsageSummary.ts
+++ b/jsapp/js/account/usage/useOrganizationsServiceUsageSummary.ts
@@ -8,7 +8,7 @@ import {
 } from '#/api/react-query/user-team-organization-usage'
 import { USAGE_WARNING_RATIO } from '#/constants'
 import { useSession } from '#/stores/useSession'
-import { convertSecondsToMinutes, formatRelativeTime, recordEntries } from '#/utils'
+import { convertSecondsToMinutes, formatRelativeTime, notify, recordEntries } from '#/utils'
 import { UsageLimitTypes } from '../stripe.types'
 
 export interface OrganizationsServiceUsageSummary {
@@ -105,10 +105,10 @@ export const useOrganizationsServiceUsageSummary = (
       ...options,
       queryKey: getOrganizationsServiceUsageRetrieveQueryKey(organizationId!), // Note: for `any` see https://github.com/orval-labs/orval/issues/2396
       select: transformOrganizationsService,
-    },
-    request: {
-      includeHeaders: true,
-      errorMessageDisplay: t('There was an error fetching usage data.'),
+      throwOnError(_error, _query) {
+        notify(t('There was an error fetching usage data.'), 'error') // TODO: update message in backend (DEV-1218).
+        return false
+      },
     },
   })
 

--- a/jsapp/js/api.ts
+++ b/jsapp/js/api.ts
@@ -15,6 +15,8 @@ import { ROOT_URL } from './constants'
  * It can detect if we got HTML string as response and uses a generic message
  * instead of spitting it out. The error message displayed to the user can be
  * customized using the optional `toastMessage` argument.
+ *
+ * @deprecated - instead, use react-query + Orval.
  */
 export function handleApiFail(response: FailResponse, toastMessage?: string) {
   // Don't do anything if we purposefully aborted the request
@@ -118,6 +120,9 @@ export interface FetchDataOptions {
   includeHeaders?: boolean
 }
 
+/**
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchDataRaw = async <T>(
   /**
    * If you have full url to be called, remember to use `prependRootUrl` option.
@@ -213,6 +218,9 @@ export const fetchDataRaw = async <T>(
   return { data: responseJson, status: response.status, headers: response.headers } as T
 }
 
+/**
+ * @deprecated - instead, use react-query + Orval.
+ */
 const fetchData = async <T>(
   /**
    * If you have full url to be called, remember to use `prependRootUrl` option.
@@ -226,51 +234,81 @@ const fetchData = async <T>(
   const response = await fetchDataRaw<{ data: T; status: number; headers: unknown }>(path, method, body, options)
   return response.data
 }
-/** GET Kobo API at path */
+/**
+ * GET Kobo API at path
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchGet = async <T>(path: string, options?: FetchDataOptions) =>
   fetchData<T>(path, 'GET', undefined, options)
 
-/** GET data from Kobo API at url */
+/**
+ * GET data from Kobo API at url
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchGetUrl = async <T>(url: string, options?: FetchDataOptions) => {
   options = Object.assign({}, options, { prependRootUrl: false })
   return fetchData<T>(url, 'GET', undefined, options)
 }
 
-/** POST data to Kobo API at path */
+/**
+ * POST data to Kobo API at path
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPost = async <T>(path: string, data: Json, options?: FetchDataOptions) =>
   fetchData<T>(path, 'POST', data, options)
 
-/** POST data to Kobo API at url */
+/**
+ * POST data to Kobo API at url
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPostUrl = async <T>(url: string, data: Json, options?: FetchDataOptions) => {
   options = Object.assign({}, options, { prependRootUrl: false })
   return fetchData<T>(url, 'POST', data, options)
 }
 
-/** PATCH (update) data to Kobo API at path */
+/**
+ * PATCH (update) data to Kobo API at path
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPatch = async <T>(path: string, data: Json, options?: FetchDataOptions) =>
   fetchData<T>(path, 'PATCH', data, options)
 
-/** PATCH (update) data to Kobo API at url */
+/**
+ * PATCH (update) data to Kobo API at url
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPatchUrl = async <T>(path: string, data: Json, options?: FetchDataOptions) => {
   options = Object.assign({}, options, { prependRootUrl: false })
   return fetchData<T>(path, 'PATCH', data, options)
 }
 
-/** PUT (replace) data to Kobo API at path */
+/**
+ * PUT (replace) data to Kobo API at path
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPut = async <T>(path: string, data: Json, options?: FetchDataOptions) =>
   fetchData<T>(path, 'PUT', data, options)
 
-/** PUT (replace) data to Kobo API at url */
+/**
+ * PUT (replace) data to Kobo API at url
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchPutUrl = async <T>(path: string, data: Json, options?: FetchDataOptions) => {
   options = Object.assign({}, options, { prependRootUrl: false })
   return fetchData<T>(path, 'PUT', data, options)
 }
 
-/** DELETE something from Kobo API at path, data is optional */
+/**
+ * DELETE something from Kobo API at path, data is optional
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchDelete = async <T>(path: string, data?: Json, options?: FetchDataOptions) =>
   fetchData<T>(path, 'DELETE', data, options)
 
-/** DELETE something from Kobo API at url, data is optional */
+/**
+ * DELETE something from Kobo API at url, data is optional
+ * @deprecated - instead, use react-query + Orval.
+ */
 export const fetchDeleteUrl = async <T>(path: string, data?: Json, options?: FetchDataOptions) => {
   options = Object.assign({}, options, { prependRootUrl: false })
   return fetchData<T>(path, 'DELETE', data, options)

--- a/jsapp/js/api/ServerError.ts
+++ b/jsapp/js/api/ServerError.ts
@@ -1,0 +1,35 @@
+import type { ErrorDetail } from './models/errorDetail'
+import type { ErrorObject } from './models/errorObject'
+
+export class ServerError extends Error implements ErrorObject, ErrorDetail {
+  static async new(response: Response) {
+    let detail: any
+    const text = await response.text()
+    try {
+      detail = JSON.parse(text) as (ErrorObject | ErrorDetail)['detail']
+    } catch {
+      detail = text
+    }
+    return new ServerError(response, detail)
+  }
+
+  constructor(
+    public response: Response,
+    public detail: any,
+  ) {
+    super(`${response.status} ${response.statusText}`)
+    Error.captureStackTrace(this, this.constructor) // Hide custom error implementation details from end-users
+  }
+
+  get name() {
+    return `${this.constructor.name}`
+  }
+
+  toString() {
+    return typeof this.detail === 'string' ? this.detail : `${this.response.status} ${this.response.statusText}`
+  }
+
+  get [Symbol.toStringTag]() {
+    return this.toString()
+  }
+}

--- a/jsapp/js/api/onErrorDefaultHandler.ts
+++ b/jsapp/js/api/onErrorDefaultHandler.ts
@@ -1,0 +1,79 @@
+import { type Query, QueryClient } from '@tanstack/react-query'
+import { notify } from '#/utils'
+import { ServerError } from './ServerError'
+
+/**
+ * On error Orval's fetch mutator throws either:
+ * - TypeError
+ * - NotAllowedError (DOMException)
+ * - AbortError (DOMException)
+ * - {@link ServerError}
+ */
+export type OrvalFetchError = TypeError | DOMException | ServerError
+
+/**
+ * By default, every Orval request handles error with this routine, and the default can be overriden on per-hook basis.
+ *
+ * Error handling policy:
+ * - backend owns error content: keep error messages updated in backend, don't ignore/override them on frontend.
+ * - frontend owns error display: ideally nicely inline, by default with a toast using this default handler.
+ *
+ * Note that overriding default handler doesn't override snapshot restoration,
+ * because that's part of the global handler instead.
+ *
+ * Example usages:
+ * ```tsx
+ *   query: {
+ *     throwOnError: () => {                                      // BAD, don't override.
+ *       notify(t('some custom message'), 'error')
+ *       return false
+ *     },
+ *     throwOnError: () => null,                                  // BEST, but handle the error nicely inline instead!
+ *     // no override                                             // GOOD, leave it to the default handler.
+ *     throwOnError: (error: OrvalFetchError, query) => {         // GOOD, use callback for more than default handler.
+ *       // Do more stuff.
+ *       return onErrorDefaultHandler(error, query)
+ *     },
+ *   },
+ *   mutation: {
+ *     onError: () => notify(t('some custom message'), 'error'),  // BAD, don't override.
+ *     onError: () => null,                                       // BEST, but handle the error nicely inline instead!
+ *     // no override                                             // GOOD, leave it to the default handler.
+ *     onError: (error: OrvalFetchError, variables, context) => { // GOOD, use callback for more than default handler.
+ *       // Do more stuff.
+ *       onErrorDefaultHandler(error, variables, context)
+ *     },
+ *   },
+ * ```
+ */
+export function onErrorDefaultHandler(
+  error: OrvalFetchError,
+  _query: Query<unknown, OrvalFetchError, unknown, readonly unknown[]>,
+): boolean
+export function onErrorDefaultHandler(error: OrvalFetchError, _variables: unknown, _context: unknown): void
+export function onErrorDefaultHandler(
+  error: OrvalFetchError,
+  _variablesOrQuery: unknown | Query<unknown, OrvalFetchError, unknown, readonly unknown[]>,
+  _context?: unknown,
+): boolean | void {
+  if (error instanceof ServerError) {
+    let detail: string | null = null
+    try {
+      detail = typeof error.detail === 'string' ? error.detail : JSON.stringify(error.detail)
+    } catch {
+      detail = String(error.detail)
+    }
+    notify(String(error), 'error', {}, `${error.name}: ${error.message} | ${detail}`)
+  } else if (error instanceof TypeError) {
+    notify(String(error), 'error', {}, `${error.name}: ${error.message}`)
+  } else if (error instanceof DOMException && error.name === 'AbortError') {
+    // Don't display error if user aborted the request.
+  } else if (error instanceof DOMException && error.name === 'NotAllowedError') {
+    notify(String(error), 'error', {}, `${error.name}: ${error.message}`)
+  } else {
+    notify(String(error), 'error', {}, `${error.name}: ${error.message}`)
+  }
+
+  // Query's `throwOnError` by default returns a false, whereas Mutation's `onError` return nothing.
+  return _variablesOrQuery instanceof QueryClient ? false : undefined
+}

--- a/jsapp/js/api/orval.types.d.ts
+++ b/jsapp/js/api/orval.types.d.ts
@@ -1,0 +1,10 @@
+import './models/errorDetail'
+import './models/errorObject'
+
+// Extend error types with Error object like the custom fetch will return.
+declare module './models/errorDetail' {
+  interface ErrorDetail extends Error {}
+}
+declare module './models/errorObject' {
+  interface ErrorObject extends Error {}
+}

--- a/jsapp/js/api/queryClient.ts
+++ b/jsapp/js/api/queryClient.ts
@@ -1,4 +1,5 @@
 import { type Mutation, MutationCache, QueryClient } from '@tanstack/react-query'
+import { onErrorDefaultHandler } from './onErrorDefaultHandler'
 
 interface CommonContext {
   snapshots?: ReadonlyArray<readonly [ReadonlyArray<unknown>, unknown]>
@@ -49,13 +50,18 @@ const onSettledInvalidateSnapshots = (
 // Docs: https://tanstack.com/query/v5/docs/reference/QueryClient#queryclient
 // See: https://tanstack.com/query/v5/docs/framework/react/guides/important-defaults
 export const queryClient = new QueryClient({
-  // Global callbacks will run in addition to default callbacks before them.
+  // FYI: Global callbacks will run in addition to default callbacks before them.
   mutationCache: new MutationCache({
     onError: onErrorRestoreSnapshots,
     onSettled: onSettledInvalidateSnapshots,
   }),
-  // Default callbacks will run in addition to global callbacks after them, and may be overriden inline.
+  // FYI: Default callbacks will run in addition to global callbacks after them, and may be overriden inline.
   defaultOptions: {
-    mutations: {},
+    queries: {
+      throwOnError: onErrorDefaultHandler,
+    },
+    mutations: {
+      onError: onErrorDefaultHandler,
+    },
   },
 })

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -622,3 +622,5 @@ export function createDateQuery(startDate: string, endDate: string): MongoQuery 
 
   return andQuery
 }
+
+export const sleep = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(() => resolve(), ms))


### PR DESCRIPTION
### 💭 Notes

Let's define expected behavior for API error handling on frontend as follows (see `onErrorDefaultHandler`):
 * backend owns error content: keep error messages updated in backend, don't ignore/override them on frontend.
 * frontend owns error display: ideally nicely inline, by default with a toast using this default handler.
 
With that in mind, this PR introduces a default error handler `onErrorDefaultHandler` for the react query and refactors all react-query instances to use it properly. Dealing with frontend error message overrides will be done seperately as part of DEV-1218.

Out of scope of this PR are non-react-query API calls and the backend side for them, as both will be a long way to go.

This PR likely displays a few error toasts more than before, but I call it `refactor` instead of `fix` because AFAIK the error handling so far was undefined behavior and thus no expected behavior was changed. Let me know if you disagree.

### 👀 Preview steps

1. ℹ️ have two pending invites to your org
2. open member list in two windows side by side (switching tabs will make react-query to refetch)
3. remove the invite in one tab
4. change the invite's role in the other tab
6. 🟢 [on PR] notice a nice error toast (for ServerError)
7. invite the user again
8. in devtools set network to offline
4. change the invite's role again
6. 🟢 [on PR] notice a nice error toast (for TypeError), actually two for both mutation and invalidation
