### PR TITLE
fix(data): dynamically add empty validation status dict DEV-1159

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/instance.py
+++ b/kobo/apps/openrosa/apps/logger/models/instance.py
@@ -368,7 +368,7 @@ class Instance(AbstractTimeStampedModel):
         # For example:
         # if not self.validation_status:
         #    self.validation_status = self.asset.settings.get("validation_statuses")[0]
-        return self.validation_status
+        return self.validation_status or {}
 
 
 if Instance.XML_HASH_LENGTH / 2 != sha256().digest_size:

--- a/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
+++ b/kobo/apps/openrosa/apps/viewer/models/parsed_instance.py
@@ -11,7 +11,7 @@ from pymongo import UpdateOne
 from pymongo.errors import PyMongoError
 
 from kobo.apps.hook.utils.services import call_services
-from kobo.apps.openrosa.apps.logger.models import Instance, Note, XForm, Attachment
+from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, Note, XForm
 from kobo.apps.openrosa.apps.logger.models.attachment import AttachmentDeleteStatus
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kobo.apps.openrosa.libs.utils.common_tags import (

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -823,6 +823,9 @@ class BaseDeploymentBackend(abc.ABC):
             submission, all_attachment_xpaths
         )
         submission = self._inject_root_uuid(submission)
+        submission['_validation_status'] = (
+            submission.get('_validation_status', None) or {}
+        )
         return submission
 
     def _inject_root_uuid(self, submission: dict) -> dict:

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1160,10 +1160,10 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
             assert attachment['download_url'] == expected_new_download_urls[idx]
             assert attachment['question_xpath'] == expected_question_xpaths[idx]
 
-    def test_inject_root_uuid_if_not_present(self):
+    def test_inject_requires_properties_if_not_present(self):
         """
-        Ensure `meta/rootUUid` is present in API response even if rootUuid was
-        not present (e.g. like old submissions)
+        Ensure `meta/rootUUid` and `_validation_status` are present in API response
+        even if not present (e.g. like old submissions)
         """
         # remove "meta/rootUuid" from MongoDB
         submission = self.submissions_submitted_by_someuser[0]
@@ -1172,7 +1172,8 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
         )
         root_uuid = mongo_document.pop(META_ROOT_UUID)
         settings.MONGO_DB.instances.update_one(
-            {'_id': submission['_id']}, {'$unset': {META_ROOT_UUID: root_uuid}}
+            {'_id': submission['_id']},
+            {'$unset': {META_ROOT_UUID: root_uuid, '_validation_status': None}},
         )
 
         url = reverse(
@@ -1185,7 +1186,9 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
         response = self.client.get(url, {'format': 'json'})
         assert response.data['_id'] == submission['_id']
         assert META_ROOT_UUID in response.data
+        assert '_validation_status' in response.data
         assert response.data[META_ROOT_UUID] == root_uuid
+        assert response.data['_validation_status'] == {}
 
     def test_submitted_by_persists_after_user_deletion(self):
         # Simulate old submissions that don't have `submitted_by`


### PR DESCRIPTION
### 📣 Summary
Fix error when loading data tables for submissions created before validation_statuses were added.

### 💭 Notes
Backport of https://github.com/kobotoolbox/kpi/pull/6388
Set `_validation_status` to `{}` if it's None on the Instance (which may happen if instances are bulk updated or created) when saving to mongo, and, on the other side, set `_validation_status` to `{}` when returning mongo results if it would otherwise be empty.

### 👀 Preview steps


1. ℹ️ have an account and a project
2. Add submissions to the project
3. In a mongo shell, run `db.instances.updateMany({"_userform_id": "<username>_<asset_uid>"}, {$unset: {"_validation_status":""}})` . This will mimic old instances where `_validation_status` isn't present
4. Go to the data table for the project
5. 🔴 [on main] Error
6. 🟢 [on PR] Data table loads successfully
