### PR TITLE
fix(versions): convert version removal celery task to migration DEV-1227

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0012_remove_old_versions.py
+++ b/kobo/apps/long_running_migrations/jobs/0012_remove_old_versions.py
@@ -1,0 +1,18 @@
+import time
+
+from django.conf import settings
+from django.db.models import Min
+from reversion.models import Version
+
+from kpi.utils.log import logging
+
+
+def run():
+    while min_id := Version.objects.aggregate(Min('pk'))['pk__min']:
+        queryset = Version.objects.filter(
+            pk__lt=min_id + settings.VERSION_DELETION_BATCH_SIZE
+        ).only('pk')
+        deleted = queryset.delete()
+        # log at debug level so we don't flood the logs
+        logging.debug(f'Deleted {deleted[0]} version objects with pk < {min_id}')
+        time.sleep(10)

--- a/kobo/apps/long_running_migrations/migrations/0012_remove_old_versions.py
+++ b/kobo/apps/long_running_migrations/migrations/0012_remove_old_versions.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model('long_running_migrations', 'LongRunningMigration')  # noqa
+    LongRunningMigration.objects.create(
+        name='0012_remove_old_versions'
+    )
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0011_backfill_exceeded_limit_counters'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, noop),
+    ]

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -6,8 +6,6 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
-from django.db.models import Min
-from reversion.models import Version
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.markdownx_uploader.tasks import remove_unused_markdown_files
@@ -16,7 +14,6 @@ from kpi.constants import LIMIT_HOURS_23
 from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_tasks
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import ImportTask, SubmissionExportTask
-from kpi.utils.log import logging
 
 
 @celery_app.task(
@@ -128,15 +125,3 @@ def perform_maintenance():
     remove_unused_markdown_files()
     remove_old_import_tasks()
     remove_old_asset_snapshots()
-
-
-@celery_app.task(time_limit=30, soft_time_limit=30)
-def remove_old_versions():
-    while min_id := Version.objects.aggregate(Min('pk'))['pk__min']:
-        queryset = Version.objects.filter(
-            pk__lt=min_id + settings.VERSION_DELETION_BATCH_SIZE
-        ).only('pk')
-        deleted = queryset.delete()
-        # log at debug level so we don't flood the logs
-        logging.debug(f'Deleted {deleted[0]} version objects with pk < {min_id}')
-        time.sleep(10)


### PR DESCRIPTION

### 💭 Notes
Backport of https://github.com/kobotoolbox/kpi/pull/6434
Converts the remove_all_versions celery task (which accidentally had a time limit of 30 seconds) to a long-running migration to be in keeping with the rest of the long-running works.


### 👀 Preview steps

1. Run migrations
2. If empty, populate the Version table with
```
for i in range(100): 
     Revision.objects.create(date_created=timezone.now())
     Version.objects.create(revision_id=i, content_type_id=21)
```
3. Update `VERSION_DELETION_BATCH_SIZE` to 5
4. Restart the kpi_worker
5. Wait for the long-running migrations job to run
6. 🟢 The number of objects in the version table is decreased
7. 🟢 There are logs in the kpi_worker showing how many versions are deleted with each run
