### PR TITLE
fix(openrosa): sync anonymous submission permission during deployment

### DIFF
--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -53,6 +53,7 @@ from kobo.apps.openrosa.libs.utils.viewer_tools import get_mongo_userform_id
 from kobo.apps.subsequences.utils import stream_with_extras
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.constants import (
+    PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_SUBMISSIONS,
     PERM_DELETE_SUBMISSIONS,
     PERM_PARTIAL_SUBMISSIONS,
@@ -77,7 +78,7 @@ from kpi.models.paired_data import PairedData
 from kpi.utils.files import ExtendedContentFile
 from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
-from kpi.utils.object_permission import get_database_user
+from kpi.utils.object_permission import get_anonymous_user, get_database_user
 from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
 from ..exceptions import AttachmentUidMismatchException, BadFormatException
 from .base_backend import BaseDeploymentBackend
@@ -134,8 +135,16 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         self._xform = publish_xls_form(xlsx_file, self.asset.owner)
         self._xform.downloadable = active
         self._xform.kpi_asset_uid = self.asset.uid
+        self._xform.require_auth = not self.asset.has_perm(
+            get_anonymous_user(), PERM_ADD_SUBMISSIONS
+        )
         self._xform.save(
-            update_fields=['downloadable', 'kpi_asset_uid', 'date_modified']
+            update_fields=[
+                'downloadable',
+                'kpi_asset_uid',
+                'date_modified',
+                'require_auth',
+            ]
         )
 
         self.store_data(

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -27,6 +27,7 @@ from kobo.apps.project_ownership.models.transfer import Transfer
 from kpi.constants import (
     ASSET_TYPE_COLLECTION,
     ASSET_TYPE_SURVEY,
+    PERM_ADD_SUBMISSIONS,
     PERM_CHANGE_ASSET,
     PERM_MANAGE_ASSET,
     PERM_VIEW_ASSET,
@@ -790,8 +791,13 @@ class ShareAssetsTest(AssetsTestCase):
         self.asset.assign_perm(AnonymousUser(), PERM_VIEW_ASSET)
         # Check that both anonymous and `anotheruser` can view
         for user_obj in AnonymousUser(), self.anotheruser:
-            self.assertTrue(user_obj.has_perm(
-                PERM_VIEW_ASSET, self.asset))
+            self.assertTrue(user_obj.has_perm(PERM_VIEW_ASSET, self.asset))
+
+    def test_first_deployment_allows_anonymous_access(self):
+        asset = Asset.objects.create(asset_type=ASSET_TYPE_SURVEY, owner=self.user)
+        asset.assign_perm(AnonymousUser(), PERM_ADD_SUBMISSIONS)
+        asset.deploy(backend='mock', active=True)
+        assert asset.deployment.xform.require_auth is False
 
 
 class TestAssetNameSettingHandling(AssetsTestCase):


### PR DESCRIPTION
### 📣 Summary
Ensure anonymous submission permission is correctly propagated to OpenRosa so Enketo doesn’t ask for login when anonymous collection is enabled.

### 📖 Description
The issue occurred because the anonymous submission permission was not being copied to OpenRosa during form deployment. As a result, even though the KPI interface showed that anonymous submissions were allowed, the corresponding permission was missing in OpenRosa, causing Enketo to prompt for authentication.


### 👀 Preview steps

1. ℹ️ Configure a project in KPI with anonymous submissions enabled.
2. Deploy the form.
3. 🔴 [on release branch] open the Enketo link and notice it still asks for authentication.
4. 🟢 [on PR] open the same Enketo link and notice it opens directly without login.
