### PR TITLE
fix(formBuilder): remove broken button in select one validation UI DEV-1283

### DIFF
--- a/jsapp/xlform/src/mv.skipLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.skipLogicHelpers.coffee
@@ -260,27 +260,33 @@ module.exports = do ->
     use_criterion_builder_helper: () ->
       @builder ?= @helper_factory.create_builder()
       presenters = @builder.build_criterion_builder(@state.serialize())
+
       if presenters == false
-        # Note: pre-decaffination logic returned false, now it renders use_hand_code_helper instead. Seems to have no effect.
-        @use_hand_code_helper()
+        @state = null
       else
         @state = new skipLogicHelpers.SkipLogicCriterionBuilderHelper(presenters[0], presenters[1], @builder, @view_factory, @)
         @render @destination
+      return
     use_hand_code_helper: () ->
       @state = new skipLogicHelpers.SkipLogicHandCodeHelper(@state.serialize(), @builder, @view_factory, @)
       @render @destination
       return
-    use_mode_selector_helper: () ->
+    use_mode_selector_helper : () ->
       @helper_factory.survey.off null, null, @state
       @state = new skipLogicHelpers.SkipLogicModeSelectorHelper(@view_factory, @)
       @render @destination
       return
     constructor: (@model_factory, @view_factory, @helper_factory, serialized_criteria) ->
-      @state = serialize: () -> return serialized_criteria # Initial seeding, will be re-assigned a proper helper in next lines.
+      @state = serialize: () -> return serialized_criteria
       if !serialized_criteria? || serialized_criteria == ''
+        serialized_criteria = ''
         @use_mode_selector_helper()
       else
         @use_criterion_builder_helper()
+
+      if !@state?
+        @state = serialize: () -> return serialized_criteria
+        @use_hand_code_helper()
 
   class skipLogicHelpers.SkipLogicCriterionBuilderHelper
     determine_criterion_delimiter_visibility: () ->

--- a/jsapp/xlform/src/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.validationLogicHelpers.coffee
@@ -54,10 +54,19 @@ module.exports = do ->
         @state.button = @view_factory.create_empty()
       @render @destination
       return
+    constructor: (model_factory, view_factory, helper_factory, serialized_criteria) ->
+      @model_factory = model_factory
+      @view_factory = view_factory
+      @helper_factory = helper_factory
+
+      @state = serialize: () -> return serialized_criteria
+      if @questionTypeHasNoValidationOperators()
+        @use_hand_code_helper()
+      else
+        super(model_factory, view_factory, helper_factory, serialized_criteria)
 
     questionTypeHasNoValidationOperators: () ->
       typeId = @helper_factory.current_question.get('type').get('typeId')
-      # Note: Leszek: seems like a dead code, can't figure out how to setup a test to trigger it.
       if !typeId
         return console.error('no type id found for question', @helper_factory.current_question)
       operators = $skipLogicHelpers.question_types[typeId]?.operators


### PR DESCRIPTION
### 🗒️ Checklist
1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Temporary fix to disable the "Add a condition" button on the select one question validation criteria until a better solution can be found. For the time being clicking on validation will send the user to the manual option only

### 💭 Notes
This reverts commit a0e9ce1c055992fe21754a5b570e03b8d9b99e76.

### 👀 Preview steps
1. ℹ️ have an account and a project
2. add a select question to the form
3. go to Settings > validation criteria > Add a condition
4. 🔴 [on main] notice that the "add a condition" button doens't work as expected
5. 🟢 [on PR] notice that it is possible to still add manual validation, and there is no more broken button
