### PR TITLE
fix(formbuilder): skip "add a condition" for 9 unhandled question types DEV-1283 DEV-1284

### DIFF
--- a/jsapp/xlform/src/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.validationLogicHelpers.coffee
@@ -46,8 +46,12 @@ module.exports = do ->
 
   class validationLogicHelpers.ValidationLogicHelperContext extends $skipLogicHelpers.SkipLogicHelperContext
     use_mode_selector_helper: () ->
-      @state = new validationLogicHelpers.ValidationLogicModeSelectorHelper @view_factory, @
-      @render @destination
+      if @questionTypeHasNoValidationOperators()
+        @use_hand_code_helper()
+      else
+        @state = new validationLogicHelpers.ValidationLogicModeSelectorHelper @view_factory, @
+        @render @destination
+      return
     use_hand_code_helper: () ->
       @state = new validationLogicHelpers.ValidationLogicHandCodeHelper(@state.serialize(), @builder, @view_factory, @)
       if @questionTypeHasNoValidationOperators()


### PR DESCRIPTION
### 📣 Summary

In formbuilder, hide the not working "add a condition" button for 9 affect question types - Select One, Select Many, Point, Photo, Audio, Video, Line, Area, Acknowledge.

### 💭 Notes

Regression since #5982 - redefining that constructor was important. But because redefining constructors should be impossible in the first place, fixed the problem in another way.

The button should work and not be hidden for Select One and Select Many question types but fixing that is out of scope of this PR. 

### 👀 Preview steps

1. create a new form or edit existing one
2. go to "settings" for affect question type
   1. :arrow_forward: go to "validation criteria" tab
   2. 🔴 [on main] arrive in the choice step between "add a condition" and "Manually enter your validation logic in XLSForm code"
   3. :arrow_forward: [on main] click "Manually enter your validation logic in XLSForm code"
   4. 🔴 [on main] arrive in manual step, and see a red trash icon on right
   5. 🟢 [on PR] arrive directly in the manual step
   6. 🟢 [on PR] don't see the red trash icon on right there
3. go to "settings" for unaffected question type
    1. :arrow_forward: go to "validation criteria" tab
    2. 🟢 arrive in the choice step
    3. :arrow_forward: click "Manually enter your validation logic in XLSForm code"
    4. 🟢 see the trash icon