### PR TITLE
ci(toolVersions): set kubectl and helm version from github environment variable 

### DIFF
--- a/.github/workflows/nonprod-releases.yml
+++ b/.github/workflows/nonprod-releases.yml
@@ -38,8 +38,8 @@ jobs:
 
       - uses: alexellis/arkade-get@master # https://github.com/alexellis/arkade-get?tab=readme-ov-file#why-do-we-use-use-master
         with:
-          kubectl: v1.33.3
-          helm: latest
+          kubectl: ${{ vars.KUBECTL_VERSION }}
+          helm: ${{ vars.HELM_VERSION }}
 
       - name: Update kubeconfig
         run: |


### PR DESCRIPTION
### 💭 Notes
Helm 4 was released yesterday, which breaks `latest` for helm.  This updates the nonprod deployment pipelines to utilize a github actions environment variable so that all pipelines use the correct version.
