### PR TITLE
build: use latest version of `Formpack` to add `big-image` support DEV-1172

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@376224bedf54ed668f90f7950597e0572ae7bcae#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@f6d4792760291f8d376de7100ce2ffe39edd4366#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
--e git+https://github.com/kobotoolbox/formpack.git@376224bedf54ed668f90f7950597e0572ae7bcae#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@f6d4792760291f8d376de7100ce2ffe39edd4366#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -8,7 +8,7 @@
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/trevoriancox/django-dont-vary-on.git@01a804122b7ddcdc22f50b40993f91c27b03bef6#egg=django-dont-vary-on
     # via -r dependencies/pip/requirements.in
--e git+https://github.com/kobotoolbox/formpack.git@376224bedf54ed668f90f7950597e0572ae7bcae#egg=formpack
+-e git+https://github.com/kobotoolbox/formpack.git@f6d4792760291f8d376de7100ce2ffe39edd4366#egg=formpack
     # via -r dependencies/pip/requirements.in
 -e git+https://github.com/dimagi/python-digest@5c94bb74516b977b60180ee832765c0695ff2b56#egg=python_digest
     # via -r dependencies/pip/requirements.in


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Update KPI to use the latest Formpack release, which adds support for `big-image` as a valid media type in export workflow.


### 📖 Description
This PR updates the formpack dependency hash in `requirements.in`, `requirements.txt`, and `dev_requirements.txt` to use the commit from [formpack#336](https://github.com/kobotoolbox/formpack/pull/336). That PR introduces support for `big-image` as a valid media type to prevent translation mismatches in exports.

Please see the [linear comment](https://linear.app/kobotoolbox/issue/DEV-1172/mismatched-labels-and-translations-export-failure#comment-19b12f71) for more details.


### 👀 Preview steps

1. ℹ️ Download the form: [test_form.xlsx](https://github.com/user-attachments/files/23559753/test_form.xlsx)
2. Deploy the form and submit at least one response.
3. 🔴 [on release] try exporting the data, it fails with ` TranslationError: Mismatched labels and translations: [label] [None, big-image] 1!=2.`
4. 🟢 [on PR] try exporting the data, the export should complete successfully.
