### PR TITLE
fix(data table): correct order of NLP columns DEV-1291

### DIFF
--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -754,10 +754,11 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
 
           // Detect supplemental details column and put it after its source column.
           if (q === undefined && key.startsWith(SUPPLEMENTAL_DETAILS_PROP)) {
-            const supplementalColumnSource = key.split('/')[1]
-            // Add extra step for grouped items
-            const sourceCleaned = supplementalColumnSource.replace(/-/g, '/').split('/').at(-1) || ''
-            const sourceColumn = columnsToRender.find((column) => column.id === flatPaths[sourceCleaned])
+            const keyArray = key.split('/')
+            const relatedKey = keyArray.at(-2)
+            const sourceColumn = relatedKey
+              ? columnsToRender.find((column) => column.id === flatPaths[relatedKey])
+              : undefined
             if (sourceColumn) {
               // This way if we have a source column with index `2`, and
               // the supplemental column with index `5`, we will set


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Corrects sorting of data table columns to ensure NLP/QA supplemental data is placed after relevant questions.

### 👀 Preview steps
Relevant test survey data can be found in [DEV-1291](https://linear.app/kobotoolbox/issue/DEV-1291/order-of-transcript-translation-qual-analysis-columns-in-data-table-is).

1. Create survey from provided xls form
2. Submit audio response and create manual transcript/translation plus QA question (as suggested in Linear)
4. 🔴 [on main] See incorrect ordering of supplemental data columns
5. 🟢 [on PR] See correct ordering
6. Try it with non-grouped questions to ensure those are ordered correctly, as well.