### PR TITLE
fix(analysis): Fix UI wording and gap sizes DEV-1195

### DIFF
--- a/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
+++ b/jsapp/js/components/processing/analysis/editors/analysisQuestionEditor.component.tsx
@@ -201,7 +201,8 @@ export default function AnalysisQuestionEditor(props: AnalysisQuestionEditorProp
 
       {qaDefinition.additionalFieldNames && (
         // Hard coded left padding to account for the 32px icon size + 8px gap
-        <Stack pl={'40px'}>
+        // 0px gap because the children still did not get a mantine refactor so we must respect existing styles
+        <Stack pl={'40px'} gap={'0px'}>
           {question.type === 'qual_auto_keyword_count' && (
             <KeywordSearchFieldsEditor
               questionUuid={question.uuid}

--- a/jsapp/js/components/processing/analysis/responseForms/responseWrapper.component.tsx
+++ b/jsapp/js/components/processing/analysis/responseForms/responseWrapper.component.tsx
@@ -109,7 +109,7 @@ export default function ResponseWrapper(props: ResponseWrapperProps) {
               </ButtonNew>
 
               <ButtonNew size='md' onClick={deleteQuestion} variant='danger'>
-                {t('Delete account')}
+                {t('Delete')}
               </ButtonNew>
             </Group>
           </Stack>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Cleared up some confusing UI mistakes in the button wording and gap sizes.

### 👀 Preview steps

1. ℹ️ have an account and a project with NLP compatible submissions
2. Go to analysis tab in NLP
3. create a question
4. delete the question
5. 🔴 [on main] notice that the modal says "delete account"
6. 🟢 [on PR] notice that the modal just says "delete"
7. create a select question
8. add some options
5. 🔴 [on main] notice that there is a big gap between options
10. 🟢 notice that the gap is the same size as production (10px)
