### PR TITLE
docs(hsts): note that production overrides Django config INFRA-297

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -45,8 +45,9 @@ if public_request_scheme == 'https' or SECURE_PROXY_SSL_HEADER:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
 
-# These HSTS settings are sometimes overriden via nginx like in the `kobo-helm-chart` repository or by the AWS ALB/Azure app gateway
-# If you see the header returned with other values, check these places first
+# These HSTS settings are sometimes overriden via nginx like in the `kobo-helm-chart`
+# repository or by the AWS ALB/Azure app gateway. If you see the header returned
+# with other values, check these places first
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool('SECURE_HSTS_INCLUDE_SUBDOMAINS', False)
 SECURE_HSTS_PRELOAD = env.bool('SECURE_HSTS_PRELOAD', False)
 SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', 0)


### PR DESCRIPTION
### 💭 Notes
The HSTS headers that django can return are sometimes removed/overridden by other infrastructure.  This adds a comment around that fact to help anyone in the future that may be troubleshooting why the headers don't match what is expected. 