### PR TITLE
perf(attachments): access XForm directly from Attachment to avoid heavy joins on Instance table

### DIFF
--- a/kobo/apps/openrosa/apps/logger/signals.py
+++ b/kobo/apps/openrosa/apps/logger/signals.py
@@ -44,8 +44,7 @@ def pre_delete_attachment(instance, **kwargs):
     attachment = instance
     file_size = attachment.media_file_size
     only_update_counters = kwargs.pop('only_update_counters', False)
-    # TODO use deserialized XForm from Attachment model
-    xform = attachment.instance.xform
+    xform = attachment.xform
     user_id = xform.user_id
 
     if file_size and attachment.delete_status is None:
@@ -100,8 +99,7 @@ def post_save_attachment(instance, created, **kwargs):
     if not file_size:
         return
 
-    # TODO use deserialized XForm from Attachment model
-    xform = attachment.instance.xform
+    xform = attachment.xform
     user_id = xform.user_id
 
     update_storage_counters(xform.pk, user_id, file_size)

--- a/kobo/apps/openrosa/apps/viewer/views.py
+++ b/kobo/apps/openrosa/apps/viewer/views.py
@@ -247,7 +247,7 @@ def attachment_url(request, size='medium'):
 
         # Checks whether users are allowed to see the media file before giving them
         # the url
-        xform = attachment.instance.xform
+        xform = attachment.xform
 
         helper_auth_helper(request)
 

--- a/kobo/apps/openrosa/libs/serializers/attachment_serializer.py
+++ b/kobo/apps/openrosa/libs/serializers/attachment_serializer.py
@@ -40,7 +40,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
     small_download_url = serializers.SerializerMethodField()
     medium_download_url = serializers.SerializerMethodField()
     large_download_url = serializers.SerializerMethodField()
-    xform = serializers.ReadOnlyField(source='instance.xform.pk')
+    xform = serializers.ReadOnlyField(source='xform_id')
     instance = serializers.ReadOnlyField(source='instance.pk')
     filename = serializers.ReadOnlyField(source='media_file.name')
 


### PR DESCRIPTION
### 📣 Summary
Improve performance by linking attachments directly to their project.

### 📖 Description
This optimization allows retrieving the related `XForm` directly from the `Attachment` model, bypassing the need to join through the `Instance` table, which can be extremely large. By establishing a more direct relationship, the system reduces query complexity and execution time, significantly improving performance when loading or filtering attachments. 

