### PR TITLE
fix(projectViews): searchbox missing in Org View DEV-1344

### DIFF
--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -102,6 +102,7 @@ export function isLibraryItemXformRoute(uid: string): boolean {
 export function isAnyProjectsViewRoute() {
   return (
     getCurrentPath() === PROJECTS_ROUTES.MY_PROJECTS ||
+    getCurrentPath() === PROJECTS_ROUTES.MY_ORG_PROJECTS ||
     getCurrentPath().startsWith(PROJECTS_ROUTES.CUSTOM_VIEW.replace(':viewUid', ''))
   )
 }


### PR DESCRIPTION
### 📣 Summary

Display search in top navigation for organization projects.

### 👀 Preview steps

1. Be an organization owner in org with multiple projects
2. Visit /#/projects/home
3. Notice search box in top navigation
4. Use dropdown in top section ("My Projects") and select organization name option
5. Notice no search box in top navigation