### PR TITLE
fix(submissions): revert changes from #6428 that broke anonymous data collection

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -921,40 +921,6 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
                     f'http://testserver/collector/{dc.token}/submission',
                 )
 
-    def test_digest_auth_allows_submission_on_username_endpoint(self):
-        """
-        Test that Digest authentication works correctly on the
-        `/<username>/submission` endpoint when the xform requires auth
-        """
-        username = self.user.username
-
-        # Ensure that POST to `/<username>/submission` fails without auth
-        request = self.factory.post(f'/{username}/submission')
-        response = self.view(request, username=username)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-        # Ensure that POST to `/<username>/submission` with Digest auth
-        s = self.surveys[0]
-        submission_path = os.path.join(
-            self.main_directory, 'fixtures',
-            'transportation', 'instances', s, s + '.xml'
-        )
-        with open(submission_path) as sf:
-            request = self.factory.post(f'/{username}/submission', data={})
-            response = self.view(request, username=username)
-            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-            data = {'xml_submission_file': sf}
-
-            request = self.factory.post(f'/{username}/submission', data)
-            auth = DigestAuth('bob', 'bobbob')
-            request.META.update(auth(request.META, response))
-
-            response = self.view(request, username=username)
-            self.assertContains(
-                response, 'Successful submission', status_code=status.HTTP_201_CREATED
-            )
-
 
 class ConcurrentSubmissionTestCase(RequestMixin, LiveServerTestCase):
     """

--- a/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/viewsets/xform_submission_api.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as t
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, permissions, status
-from rest_framework.authentication import get_authorization_header
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.parsers import FormParser, JSONParser
@@ -249,12 +248,6 @@ class XFormSubmissionApi(
             # get the username from the user if not set
             user = get_database_user(request.user)
             username = user.username
-
-        # Return 401 if no authentication provided and there are no files,
-        # for digest authentication to work properly
-        has_auth = bool(get_authorization_header(request))
-        if not has_auth and not (bool(request.FILES) or bool(request.data)):
-            raise NotAuthenticated
 
         if request.method.upper() == 'HEAD':
             return Response(


### PR DESCRIPTION
### 📣 Summary
Reverts the changes introduced in [kpi#6428](https://github.com/kobotoolbox/kpi/pull/6428), included in release `2.025.43d`, which caused a regression preventing anonymous data collection.

### Notes 
Related to [DEV-1038](https://linear.app/kobotoolbox/issue/DEV-1038/500-error-with-authenticated-submissions-to-openrosa-endpoint-with) 
