### PR TITLE
feat(exports): add celery task to delete old anonymous exports DEV-1358

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -477,7 +477,7 @@ CONSTANCE_CONFIG = {
     ),
     'ANONYMOUS_EXPORTS_GRACE_PERIOD': (
         30,
-        'Number of minutes after which anonymous export tasks are cleaned up.'
+        'Number of minutes after which anonymous export tasks are cleaned up.',
     ),
     'LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD': (
         90,
@@ -1453,7 +1453,7 @@ CELERY_BEAT_SCHEDULE = {
     'cleanup-anonymous-exports': {
         'task': 'kpi.tasks.cleanup_anonymous_exports',
         'schedule': crontab(minute='*/5'),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_low_priority_queue'},
     },
     # Schedule every 15 minutes
     'refresh-user-report-snapshot': {

--- a/kpi/tests/test_cleanup_anonymous_exports.py
+++ b/kpi/tests/test_cleanup_anonymous_exports.py
@@ -1,14 +1,13 @@
 import threading
-import time
 from datetime import timedelta
 
 from django.db import transaction
-from django.utils import timezone
 from django.test import TransactionTestCase
+from django.utils import timezone
 
 from kpi.models.import_export_task import (
     ImportExportStatusChoices,
-    SubmissionExportTask
+    SubmissionExportTask,
 )
 from kpi.tasks import cleanup_anonymous_exports
 from kpi.utils.object_permission import get_anonymous_user
@@ -52,62 +51,52 @@ class AnonymousExportCleanupTestCase(TransactionTestCase):
         Test that exports with PROCESSING status are never deleted
         """
         processing_export = self._create_export_task(
-            status=ImportExportStatusChoices.PROCESSING,
-            minutes_old=100
+            status=ImportExportStatusChoices.PROCESSING, minutes_old=100
         )
 
         cleanup_anonymous_exports()
         self.assertTrue(
-            SubmissionExportTask.objects.filter(
-                uid=processing_export.uid
-            ).exists()
+            SubmissionExportTask.objects.filter(uid=processing_export.uid).exists()
         )
 
     def test_concurrency_locked_rows_are_skipped(self):
         exports = [self._create_export_task(minutes_old=120) for _ in range(5)]
-        export_pks = [e.pk for e in exports]
-        locked_pks = export_pks[:3]
-        unlocked_pks = export_pks[3:]
+        locked_export = exports[0]
+        not_locked_exports = exports[1:]
 
-        def lock_and_hold():
-            """
-            Acquire lock on first 3 exports and hold for 5 seconds,
-            this will block cleanup from acquiring the lock on these rows and
-            in the meantime other rows should be cleaned up
-            """
+        lock_acquired = threading.Event()
+        release_lock = threading.Event()
+
+        def lock_row():
             with transaction.atomic():
-                # Acquire lock on first 3 exports
-                list(
-                    SubmissionExportTask.objects
-                    .select_for_update()
-                    .filter(pk__in=locked_pks)
+                # Lock the row
+                SubmissionExportTask.objects.select_for_update().get(
+                    pk=locked_export.pk
                 )
 
-                # Hold lock for 5 seconds,
-                # during this time cleanup should run
-                time.sleep(5)
+                # Signal that the lock is active
+                lock_acquired.set()
 
-        # Start thread that will hold the lock
-        lock_thread = threading.Thread(target=lock_and_hold, daemon=True)
-        lock_thread.start()
+                # Wait until the main thread signals we can release the lock
+                release_lock.wait()
 
-        # Give thread time to acquire lock
-        time.sleep(1)
+        t = threading.Thread(target=lock_row)
+        t.start()
 
-        # Run cleanup while lock is held
+        # Wait for the row-level lock to actually be acquired
+        lock_acquired.wait()
+
+        # Now cleanup should try select_for_update(nowait=True), causing DatabaseError
         cleanup_anonymous_exports()
 
-        # Wait for thread to finish
-        lock_thread.join(timeout=10)
+        # Let the locking thread finish its transaction
+        release_lock.set()
+        t.join()
 
-        # Verify locked rows were not deleted
-        remaining_locked = SubmissionExportTask.objects.filter(
-            pk__in=locked_pks
-        ).count()
-        self.assertEqual(remaining_locked, 3)
+        # Verify the locked row was not deleted
+        assert SubmissionExportTask.objects.filter(pk=locked_export.pk).exists()
 
         # Verify unlocked rows were deleted
-        remaining_unlocked = SubmissionExportTask.objects.filter(
-            pk__in=unlocked_pks
-        ).count()
-        self.assertEqual(remaining_unlocked, 0)
+        assert not SubmissionExportTask.objects.filter(
+            pk__in=[e.pk for e in not_locked_exports]
+        ).exists()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Automatically removes old anonymous exports to prevent outdated files from being accessible and to keep storage usage under control.


### 📖 Description
Anonymous exports are now cleaned up automatically after they expire. A new recurring background task deletes export files and their corresponding records once they are older than the value defined in `ANON_EXPORTS_CLEANUP_AGE` (configured in Constance, default: 30 minutes).

To ensure system stability, the cleanup runs in small batches of 50 exports per execution and uses a distributed lock to prevent multiple workers from deleting the same exports simultaneously. This keeps storage usage under control and prevents outdated anonymous export files from remaining accessible.

Authenticated exports and other project data are not affected.
