### PR TITLE
feat(exports): Rename `ANONYMOUS_EXPORTS_GRACE_PERIOD` to `EXPORT_CLEANUP_GRACE_PERIOD` DEV-1371

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -475,9 +475,9 @@ CONSTANCE_CONFIG = {
         'Enable automatic deletion of attachments for users who have exceeded '
         'their storage limits.'
     ),
-    'ANONYMOUS_EXPORTS_GRACE_PERIOD': (
+    'EXPORT_CLEANUP_GRACE_PERIOD': (
         30,
-        'Number of minutes after which anonymous export tasks are cleaned up.',
+        'Number of minutes after which export tasks are cleaned up.',
     ),
     'LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD': (
         90,
@@ -733,7 +733,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'MASS_EMAIL_ENQUEUED_RECORD_EXPIRY',
         'MASS_EMAIL_TEST_EMAILS',
         'USAGE_LIMIT_ENFORCEMENT',
-        'ANONYMOUS_EXPORTS_GRACE_PERIOD',
+        'EXPORT_CLEANUP_GRACE_PERIOD',
     ),
     'Rest Services': (
         'ALLOW_UNSECURED_HOOK_ENDPOINTS',

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -82,11 +82,11 @@ def export_task_in_background(
 def cleanup_anonymous_exports(**kwargs):
     """
     Task to clean up export tasks created by the AnonymousUser that are older
-    than `ANONYMOUS_EXPORTS_GRACE_PERIOD`, excluding those that are still processing
+    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
     """
     BATCH_SIZE = 200
     cutoff_time = timezone.now() - timedelta(
-        minutes=config.ANONYMOUS_EXPORTS_GRACE_PERIOD
+        minutes=config.EXPORT_CLEANUP_GRACE_PERIOD
     )
 
     old_export_ids = (


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Renamed `ANONYMOUS_EXPORTS_GRACE_PERIOD` to `EXPORT_CLEANUP_GRACE_PERIOD` so it can be reused for other export deletion tasks, not just anonymous exports.