### PR TITLE
feat(exports): remove project view exports older than `EXPORT_CLEANUP_GRACE_PERIOD` DEV-1370

### DIFF
--- a/kobo/apps/project_views/tasks.py
+++ b/kobo/apps/project_views/tasks.py
@@ -1,0 +1,12 @@
+from kobo.celery import celery_app
+from kpi.models import ProjectViewExportTask
+from kpi.utils.export_cleanup import delete_expired_exports
+
+
+@celery_app.task
+def cleanup_project_view_exports(**kwargs):
+    """
+    Task to clean up export tasks created by Project Views that are older
+    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    """
+    delete_expired_exports(ProjectViewExportTask)

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -16,7 +16,6 @@ from kpi.maintenance_tasks import remove_old_asset_snapshots, remove_old_import_
 from kpi.models.asset import Asset
 from kpi.models.import_export_task import (
     ImportTask,
-    ProjectViewExportTask,
     SubmissionExportTask,
     SubmissionSynchronousExport,
 )
@@ -105,15 +104,6 @@ def cleanup_synchronous_exports(**kwargs):
         )
         return
     delete_expired_exports(SubmissionSynchronousExport)
-
-
-@celery_app.task
-def cleanup_project_view_exports(**kwargs):
-    """
-    Task to clean up export tasks created by Project Views that are older
-    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
-    """
-    cleanup_exports_helper(ProjectViewExportTask)
 
 
 @celery_app.task

--- a/kpi/tests/test_cleanup_project_view_exports.py
+++ b/kpi/tests/test_cleanup_project_view_exports.py
@@ -7,11 +7,11 @@ from django.test import TransactionTestCase
 from django.utils import timezone
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.project_views.tasks import cleanup_project_view_exports
 from kpi.models.import_export_task import (
     ImportExportStatusChoices,
     ProjectViewExportTask,
 )
-from kpi.tasks import cleanup_project_view_exports
 
 
 class ProjectViewExportCleanupTestCase(TransactionTestCase):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Automatically removes old project-view exports to prevent outdated files from being accessible and to keep storage usage under control.

### 📖 Description
Project view exports are now cleaned up automatically after they expire. A new recurring background task `cleanup_project_view_exports` deletes export files and their corresponding records once they are older than the value defined in `EXPORT_CLEANUP_GRACE_PERIOD` (configured in Constance, default: 30 minutes).

To ensure system stability, the cleanup runs in small batches of 200 exports per execution and uses a distributed lock to prevent multiple workers from deleting the same exports simultaneously. This keeps storage usage under control and prevents outdated export files from remaining accessible.