### PR TITLE
refactor: rename retention environment variable to be clearer and more consistent DEV-1392

### DIFF
--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -205,7 +205,7 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
     def remove(self, request, queryset, **kwargs):
         """
         Put users in trash and schedule their data deletion according to
-        constance setting `ACCOUNT_TRASH_GRACE_PERIOD`. Keep only their
+        constance setting `ACCOUNT_TRASH_RETENTION`. Keep only their
         username.
         """
         if not request.user.is_superuser:
@@ -213,14 +213,14 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
 
         users = list(queryset.values('pk', 'username'))
         self._remove_or_delete(
-            request, users=users, grace_period=config.ACCOUNT_TRASH_GRACE_PERIOD
+            request, users=users, grace_period=config.ACCOUNT_TRASH_RETENTION
         )
 
     @admin.action(description='Delete selected users (keep nothing)')
     def delete(self, request, queryset, **kwargs):
         """
         Put users in trash and schedule their account deletion according to
-        constance setting `ACCOUNT_TRASH_GRACE_PERIOD`. Remove everything.
+        constance setting `ACCOUNT_TRASH_RETENTION`. Remove everything.
         """
         if not request.user.is_superuser:
             return

--- a/kobo/apps/audit_log/tasks.py
+++ b/kobo/apps/audit_log/tasks.py
@@ -61,7 +61,7 @@ def spawn_logs_cleaning_tasks():
 def cleanup_access_log_exports(**kwargs):
     """
     Task to clean up export tasks created by access logs that are older
-    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    than `EXPORT_RETENTION`, excluding those that are still processing
     """
     delete_expired_exports(AccessLogExportTask)
 
@@ -70,6 +70,6 @@ def cleanup_access_log_exports(**kwargs):
 def cleanup_project_history_log_exports(**kwargs):
     """
     Task to clean up export tasks created by project history logs that are older
-    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    than `EXPORT_RETENTION`, excluding those that are still processing
     """
     delete_expired_exports(ProjectHistoryLogExportTask)

--- a/kobo/apps/openrosa/apps/logger/tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tasks.py
@@ -210,7 +210,7 @@ def sync_storage_counters(**kwargs):
 @celery_app.task
 def delete_expired_instance_history_records(chunk_size=10000, max_records=1000000):
     threshold_time = timezone.now() - timedelta(
-        days=config.SUBMISSION_HISTORY_GRACE_PERIOD
+        days=config.SUBMISSION_HISTORY_RETENTION
     )
     history_ids = InstanceHistory.objects.filter(
         date_created__lte=threshold_time,

--- a/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_tasks.py
@@ -35,7 +35,7 @@ class TestLoggerTasks(TestBase):
 
         chunk_size = 5
         max_records = 20
-        days_threshold = config.SUBMISSION_HISTORY_GRACE_PERIOD
+        days_threshold = config.SUBMISSION_HISTORY_RETENTION
         with patch(
             'django.utils.timezone.now',
             return_value=d0 + timedelta(days=days_threshold - 1),

--- a/kobo/apps/project_views/tasks.py
+++ b/kobo/apps/project_views/tasks.py
@@ -7,6 +7,6 @@ from kpi.utils.export_cleanup import delete_expired_exports
 def cleanup_project_view_exports(**kwargs):
     """
     Task to clean up export tasks created by Project Views that are older
-    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    than `EXPORT_RETENTION`, excluding those that are still processing
     """
     delete_expired_exports(ProjectViewExportTask)

--- a/kobo/apps/trash_bin/models/__init__.py
+++ b/kobo/apps/trash_bin/models/__init__.py
@@ -32,7 +32,7 @@ class BaseTrash(AbstractTimeStampedModel):
     request_author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     metadata = models.JSONField(default=dict)
     # Celery will run a task at a specific moment - according to the Constance
-    # setting `ACCOUNT_TRASH_GRACE_PERIOD` - to delete (or remove) the object.
+    # setting `ACCOUNT_TRASH_RETENTION` - to delete (or remove) the object.
     # Because this setting can be changed at any time, its value can be
     # different when the celery task runs later than the object creation. Therefore,
     # this field helps to know whether a periodic task will run automatically or

--- a/kobo/apps/trash_bin/tasks/__init__.py
+++ b/kobo/apps/trash_bin/tasks/__init__.py
@@ -66,7 +66,7 @@ def task_restarter():
 
     # 1) Restart account deletion tasks
     pending_grace_period = timezone.now() - timedelta(
-        days=config.ACCOUNT_TRASH_GRACE_PERIOD
+        days=config.ACCOUNT_TRASH_RETENTION
     )
     stuck_threshold = timezone.now() - timedelta(
         seconds=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT + 60 * 5
@@ -86,7 +86,7 @@ def task_restarter():
 
     # 2) Restart project deletion tasks
     pending_grace_period = timezone.now() - timedelta(
-        days=config.PROJECT_TRASH_GRACE_PERIOD
+        days=config.PROJECT_TRASH_RETENTION
     )
     stuck_project_ids = (
         ProjectTrash.objects.values_list('pk', flat=True)
@@ -102,7 +102,7 @@ def task_restarter():
 
     # 3) Restart attachment deletion tasks
     pending_grace_period = timezone.now() - timedelta(
-        days=config.ATTACHMENT_TRASH_GRACE_PERIOD
+        days=config.ATTACHMENT_TRASH_RETENTION
     )
     stuck_attachment_ids = AttachmentTrash.objects.values_list(
         'pk', flat=True

--- a/kobo/apps/trash_bin/tasks/attachment.py
+++ b/kobo/apps/trash_bin/tasks/attachment.py
@@ -85,7 +85,7 @@ def schedule_auto_attachment_cleanup_for_users(**stripe_models):
 
     exceeded_counters = ExceededLimitCounter.objects.filter(
         limit_type=UsageType.STORAGE_BYTES,
-        days__gte=config.LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD
+        days__gte=config.OVER_LIMIT_ATTACHMENT_RETENTION
     )
 
     logging.info(f'Found {len(exceeded_counters)} users exceeding storage limits.')
@@ -147,7 +147,7 @@ def auto_delete_excess_attachments(user_id: int, **stripe_models):
         move_to_trash(
             user,
             attachments_to_trash,
-            config.ATTACHMENT_TRASH_GRACE_PERIOD,
+            config.ATTACHMENT_TRASH_RETENTION,
             'attachment',
         )
 

--- a/kobo/apps/trash_bin/tests/storage_cleanup/test_attachment_cleanup.py
+++ b/kobo/apps/trash_bin/tests/storage_cleanup/test_attachment_cleanup.py
@@ -43,7 +43,7 @@ class AttachmentCleanupTestCase(BaseTestCase, AssetSubmissionTestMixin):
         ExceededLimitCounter.objects.create(
             user=self.owner,
             limit_type=UsageType.STORAGE_BYTES,
-            days=config.LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD + 1,
+            days=config.OVER_LIMIT_ATTACHMENT_RETENTION + 1,
         )
 
         with patch(
@@ -190,14 +190,14 @@ class AttachmentCleanupTestCase(BaseTestCase, AssetSubmissionTestMixin):
         ExceededLimitCounter.objects.create(
             user=self.owner,
             limit_type=UsageType.STORAGE_BYTES,
-            days=config.LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD + 1
+            days=config.OVER_LIMIT_ATTACHMENT_RETENTION + 1
         )
 
         # Non-qualifying user (within grace period)
         ExceededLimitCounter.objects.create(
             user=anotheruser,
             limit_type=UsageType.STORAGE_BYTES,
-            days=config.LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD - 1
+            days=config.OVER_LIMIT_ATTACHMENT_RETENTION - 1
         )
 
         with patch(
@@ -278,7 +278,7 @@ class AttachmentCleanupTestCase(BaseTestCase, AssetSubmissionTestMixin):
         counter = ExceededLimitCounter.objects.create(
             user=self.owner,
             limit_type=UsageType.STORAGE_BYTES,
-            days=config.LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD + 1,
+            days=config.OVER_LIMIT_ATTACHMENT_RETENTION + 1,
         )
         self.assertTrue(Attachment.objects.filter(pk=self.attachment.pk).exists())
 

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -236,7 +236,7 @@ class AccountTrashTestCase(TestCase):
         A freshly created task should not be restarted if it is in grace period.
         """
         someuser = get_user_model().objects.get(username='someuser')
-        grace_period = config.ACCOUNT_TRASH_GRACE_PERIOD
+        grace_period = config.ACCOUNT_TRASH_RETENTION
         admin = get_user_model().objects.get(username='adminuser')
 
         if is_time_frozen:
@@ -465,7 +465,7 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
         """
         someuser = get_user_model().objects.get(username='someuser')
         asset = someuser.assets.first()
-        grace_period = config.PROJECT_TRASH_GRACE_PERIOD
+        grace_period = config.PROJECT_TRASH_RETENTION
 
         if is_time_frozen:
             frozen_time = '2024-12-10'
@@ -860,7 +860,7 @@ class AttachmentTrashTestCase(TestCase, AssetSubmissionTestMixin):
                 'attachment_uid': attachment.uid,
                 'attachment_basename': attachment.media_file_basename,
             }],
-            grace_period=config.ATTACHMENT_TRASH_GRACE_PERIOD,
+            grace_period=config.ATTACHMENT_TRASH_RETENTION,
             trash_type='attachment',
             retain_placeholder=False,
         )

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -432,7 +432,7 @@ CONSTANCE_CONFIG = {
         'Number of days to keep import tasks',
         'positive_int',
     ),
-    'SUBMISSION_HISTORY_GRACE_PERIOD': (
+    'SUBMISSION_HISTORY_RETENTION': (
         180,
         'Number of days to keep submission history',
         'positive_int',
@@ -457,13 +457,13 @@ CONSTANCE_CONFIG = {
         'Users on the free tier who registered before this date will\n'
         'use the custom plan defined by FREE_TIER_DISPLAY and FREE_TIER_LIMITS.',
     ),
-    'PROJECT_TRASH_GRACE_PERIOD': (
+    'PROJECT_TRASH_RETENTION': (
         7,
         'Number of days to keep projects in trash after users (soft-)deleted '
         'them and before automatically hard-deleting them by the system',
         'positive_int',
     ),
-    'ACCOUNT_TRASH_GRACE_PERIOD': (
+    'ACCOUNT_TRASH_RETENTION': (
         30 * 6,
         'Number of days to keep deactivated accounts in trash before '
         'automatically hard-deleting all their projects and data.\n'
@@ -471,7 +471,7 @@ CONSTANCE_CONFIG = {
         'having the system empty it automatically.',
         'positive_int_minus_one',
     ),
-    'ATTACHMENT_TRASH_GRACE_PERIOD': (
+    'ATTACHMENT_TRASH_RETENTION': (
         7,
         'Number of days to keep attachments in trash after users (soft-)deleted '
         'them and before automatically hard-deleting them by the system',
@@ -482,7 +482,7 @@ CONSTANCE_CONFIG = {
         'Enable automatic deletion of attachments for users who have exceeded '
         'their storage limits.'
     ),
-    'EXPORT_CLEANUP_GRACE_PERIOD': (
+    'EXPORT_RETENTION': (
         30,
         (
             'Number of minutes after which export tasks are cleaned up.\n'
@@ -490,7 +490,7 @@ CONSTANCE_CONFIG = {
         ),
         'positive_int',
     ),
-    'LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD': (
+    'OVER_LIMIT_ATTACHMENT_RETENTION': (
         90,
         'Number of days to keep attachments after the user has exceeded their '
         'storage limits.'
@@ -734,7 +734,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'ACADEMY_URL',
         'COMMUNITY_URL',
         'SYNCHRONOUS_EXPORT_CACHE_MAX_AGE',
-        'EXPORT_CLEANUP_GRACE_PERIOD',
+        'EXPORT_RETENTION',
         'EXPOSE_GIT_REV',
         'FRONTEND_MIN_RETRY_TIME',
         'FRONTEND_MAX_RETRY_TIME',
@@ -798,17 +798,17 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'PROJECT_OWNERSHIP_AUTO_ACCEPT_INVITES',
     ),
     'Trash bin': (
-        'ACCOUNT_TRASH_GRACE_PERIOD',
-        'ATTACHMENT_TRASH_GRACE_PERIOD',
-        'PROJECT_TRASH_GRACE_PERIOD',
-        'LIMIT_ATTACHMENT_REMOVAL_GRACE_PERIOD',
+        'ACCOUNT_TRASH_RETENTION',
+        'ATTACHMENT_TRASH_RETENTION',
+        'PROJECT_TRASH_RETENTION',
+        'OVER_LIMIT_ATTACHMENT_RETENTION',
         'AUTO_DELETE_ATTACHMENTS',
         'ALLOW_SELF_ACCOUNT_DELETION',
     ),
     'Regular maintenance settings': (
         'ASSET_SNAPSHOT_DAYS_RETENTION',
         'IMPORT_TASK_DAYS_RETENTION',
-        'SUBMISSION_HISTORY_GRACE_PERIOD',
+        'SUBMISSION_HISTORY_RETENTION',
     ),
     'Tier settings': (
         'FREE_TIER_THRESHOLDS',

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -251,7 +251,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         move_to_trash(
             request_author=user,
             objects_list=attachments,
-            grace_period=config.ATTACHMENT_TRASH_GRACE_PERIOD,
+            grace_period=config.ATTACHMENT_TRASH_RETENTION,
             trash_type='attachment',
         )
         ParsedInstance.bulk_update_attachments(list(submission_ids))

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -187,7 +187,7 @@ class AssetBulkActionsSerializer(serializers.Serializer):
     def _create_tasks(self, assets: list[dict]):
         try:
             return move_to_trash(
-                self.__user, assets, config.PROJECT_TRASH_GRACE_PERIOD, 'asset'
+                self.__user, assets, config.PROJECT_TRASH_RETENTION, 'asset'
             )
         except TrashIntegrityError:
             # We do not want to ignore conflicts. If so, something went wrong.

--- a/kpi/tasks.py
+++ b/kpi/tasks.py
@@ -79,7 +79,7 @@ def export_task_in_background(
 def cleanup_anonymous_exports(**kwargs):
     """
     Task to clean up export tasks created by the AnonymousUser that are older
-    than `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    than `EXPORT_RETENTION`, excluding those that are still processing
     """
     anon_user = get_anonymous_user()
     delete_expired_exports(SubmissionExportTask, extra_params={'user': anon_user})
@@ -89,11 +89,11 @@ def cleanup_anonymous_exports(**kwargs):
 def cleanup_synchronous_exports(**kwargs):
     """
     Task to clean up old synchronous exports that are older than
-    `EXPORT_CLEANUP_GRACE_PERIOD`, excluding those that are still processing
+    `EXPORT_RETENTION`, excluding those that are still processing
     """
 
     grace_period = max(
-        config.EXPORT_CLEANUP_GRACE_PERIOD,
+        config.EXPORT_RETENTION,
         config.SYNCHRONOUS_EXPORT_CACHE_MAX_AGE,
     )
     delete_expired_exports(SubmissionSynchronousExport, grace_period=grace_period)

--- a/kpi/tests/test_export_tasks.py
+++ b/kpi/tests/test_export_tasks.py
@@ -133,7 +133,7 @@ def to_snake(name: str) -> str:
 
 
 @ddt
-@override_config(EXPORT_CLEANUP_GRACE_PERIOD=30)
+@override_config(EXPORT_RETENTION=30)
 @override_config(SYNCHRONOUS_EXPORT_CACHE_MAX_AGE=30)
 class ExportCleanupTestCase(TransactionTestCase):
     """
@@ -167,7 +167,7 @@ class ExportCleanupTestCase(TransactionTestCase):
     @unpack
     def test_exports_older_than_grace_period_are_deleted(self, model, cleanup_task):
         """
-        Exports older than EXPORT_CLEANUP_GRACE_PERIOD should be deleted.
+        Exports older than EXPORT_RETENTION should be deleted.
         """
 
         old_export = self._create_export(model=model, minutes_old=31)
@@ -250,13 +250,13 @@ class ExportCleanupTestCase(TransactionTestCase):
             model.objects.filter(pk__in=[e.pk for e in unlocked_exports]).exists()
         )
 
-    @override_config(EXPORT_CLEANUP_GRACE_PERIOD=5)
+    @override_config(EXPORT_RETENTION=5)
     @override_config(SYNCHRONOUS_EXPORT_CACHE_MAX_AGE=600)
     def test_synchronous_export_cleanup_respects_cache_age(self):
         """
         Verify that synchronous exports are kept as long as they remain within
         SYNCHRONOUS_EXPORT_CACHE_MAX_AGE, even if they exceed
-        EXPORT_CLEANUP_GRACE_PERIOD.
+        EXPORT_RETENTION.
 
         Once older than the cache max age, they must be deleted.
         """

--- a/kpi/utils/export_cleanup.py
+++ b/kpi/utils/export_cleanup.py
@@ -25,7 +25,7 @@ def delete_expired_exports(
         extra_params = {}
 
     if not grace_period:
-        grace_period = config.EXPORT_CLEANUP_GRACE_PERIOD
+        grace_period = config.EXPORT_RETENTION
 
     cut_off = timezone.now() - timedelta(minutes=grace_period)
     old_export_ids = (

--- a/kpi/views/current_user.py
+++ b/kpi/views/current_user.py
@@ -97,7 +97,7 @@ class CurrentUserViewSet(viewsets.ModelViewSet):
             # but it should never happen since no non-active/trashed users should be
             # able to call this endpoint. A 403 should occur before.
             move_to_trash(
-                request.user, [user], config.ACCOUNT_TRASH_GRACE_PERIOD, 'user'
+                request.user, [user], config.ACCOUNT_TRASH_RETENTION, 'user'
             )
             request.user.is_active = False
             request.user.save(update_fields=['is_active'])


### PR DESCRIPTION
### 📣 Summary
Improve clarity and consistency of the retention setting name, making it easier for superusers in Constance and for future development.

### 📖 Description
This refactor updates the name of the retention-related environment variable to a more explicit and consistent form. The clearer naming helps superusers quickly understand its purpose in Constance and reduces ambiguity for developers working with retention logic. No behavioral changes are introduced—only improved readability and maintainability.
