### PR TITLE
fix(nlp): don't crash when translating a transcript DEV-1397

### DIFF
--- a/jsapp/js/components/processing/transcript/stepConfig.component.tsx
+++ b/jsapp/js/components/processing/transcript/stepConfig.component.tsx
@@ -27,7 +27,7 @@ export default function StepConfig() {
       serviceUsageData?.data.limitExceedList.includes(UsageLimitTypes.TRANSCRIPTION) &&
       envStore.data.usage_limit_enforcement,
     [
-      (serviceUsageData?.data as OrganizationsServiceUsageSummary).limitExceedList,
+      (serviceUsageData?.data as OrganizationsServiceUsageSummary)?.limitExceedList,
       envStore.data.usage_limit_enforcement,
     ],
   )


### PR DESCRIPTION
### 📣 Summary

KPI won't crash anymore when clicking "begin" button to add a translation in the NLP view.

### 💭 Notes

Bug introduced at #6305.

### 👀 Preview steps

1. ℹ️ have an account and a project with audio question and a submission
2. open NLP view
3. add transcription
4. open translation tab
5. click "begin"
6. 🔴 [on main] crash with "Unexpected Application Error: can't access property "limitExceedList" of undefined"
7. 🟢 [on PR] works
