### PR TITLE
ci(releases): changelog job should handle all cases DEV-1285

### DIFF
--- a/.github/workflows/find-releases.yml
+++ b/.github/workflows/find-releases.yml
@@ -42,7 +42,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        fetch-depth: "0"
+        fetch-depth: 0
+        fetch-tags: true
     - name: Find next release tag and branch
       id: version
       run: |

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -104,14 +104,10 @@ jobs:
 
     - name: draft a changelog
       run: |
-        set -xe
-        npx git-cliff -u $(git log --format=format:%H origin/$PREV_BRANCH..origin/$CURRENT_BRANCH | tail -1)..origin/$CURRENT_BRANCH --tag $CURRENT_PATCH
+        npx git-cliff -u --tag $CURRENT_PATCH
 
     - name: commit the changelog to a dedicated branch
       run: |
-        set -xe
-        git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-        git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
         git checkout -B changelog/$CURRENT_PATCH
         git add -f CHANGELOG.md
         git commit -m "chore(releases): generate CHANGELOG.md for $CURRENT_PATCH"
@@ -140,7 +136,6 @@ jobs:
 
     - name: deploy to beta
       run: |
-        set -xe
         git checkout -B public-beta
         git push -f --set-upstream origin public-beta
 
@@ -221,7 +216,7 @@ jobs:
             && format(':warning: failed to update changelog: @*devs* please investigate [run #{0}]({1}/{2}/actions/runs/{3})!', github.run_number, github.server_url, github.repository, github.run_id)
             || needs.changelog.result == 'skipped'
               && ':skip_forward: changelog update skipped due failed automated tests.'
-              || format(':check: updated [changelog](https://github.com/kobotoolbox/kpi/blob/changelog/{0}/CHANGELOG.md)', needs.version.outputs.current_patch)
+              || format(':check: updated [changelog](https://github.com/kobotoolbox/kpi/blob/changelog/{0}/CHANGELOG.md) for `{1}..{0}`', needs.version.outputs.current_patch, needs.version.outputs.prev_patch)
           }}
         - ${{ (needs.deploy-to-beta.result == 'failure' || needs.deploy-to-beta.result == 'timed_out')
             && format(':warning: failed to queue to deploy to beta: @*devs* please investigate [run #{0}]({1}/{2}/actions/runs/{3})!', github.run_number, github.server_url, github.repository, github.run_id)

--- a/cliff.toml
+++ b/cliff.toml
@@ -139,7 +139,7 @@ filter_commits = false
 ## An array of link parsers for extracting external references, and turning them into URLs, using regex.
 link_parsers = []
 ## Include only the tags that belong to the current branch.
-use_branch_tags = false
+use_branch_tags = true
 ## Order releases topologically instead of chronologically.
 topo_order = false
 ## Order releases topologically instead of chronologically.

--- a/scripts/find_releases.sh
+++ b/scripts/find_releases.sh
@@ -21,7 +21,7 @@ echo "current_branch=${current_branch}" >> $GITHUB_OUTPUT
 current_minor=`echo "${current_branch}" | cut -d '/' -f 2`
 echo "current_minor=${current_minor}" >> $GITHUB_OUTPUT
 
-current_patch="$(git tag -l $current_minor* | tail -1)"
+current_patch="$(git tag -l "$current_minor*" | grep -E "^$current_minor.?$" | tail -1 || true)"
 if [[ $current_patch == "" ]]; then
     current_patch=$current_minor
 elif [[ $current_patch == $current_minor ]]; then
@@ -71,13 +71,17 @@ do
 done
 
 echo "prev_minor=${prev_minor}" >> $GITHUB_OUTPUT
-prev_patch="$(git tag -l $prev_minor* | tail -1)"
+if [[ $current_patch == "" ]]; then
+    prev_patch="$(git tag -l "$prev_minor*" | grep -E "^$prev_minor.?$" | tail -1 || true)"
+else
+    prev_patch="$(git tag -l "$current_minor*" | grep -E "^$current_minor.?$" | tail -1 || true)"
+fi
 echo "prev_patch=${prev_patch}" >> $GITHUB_OUTPUT
 echo "prev_branch=${prev_branch}" >> $GITHUB_OUTPUT
 echo "Previous release branch: '${prev_branch}'"
 echo "Previous patch version: '${prev_patch}'"
 
-if [[ $prev_patch == "" ]]; then
+if [[ "$(git tag -l $prev_minor* | grep -E "^$prev_minor.?$" | tail -1 || true)" == "" ]]; then
     echo "prev_released=false" >> $GITHUB_OUTPUT
 else
     echo "prev_released=true" >> $GITHUB_OUTPUT
@@ -116,7 +120,7 @@ do
 done
 
 echo "next_minor=${next_minor}" >> $GITHUB_OUTPUT
-next_patch="$(git tag -l $next_minor* | tail -1)"
+next_patch="$(git tag -l $next_minor* | grep -E "^$next_minor.?$" | tail -1 || true)"
 echo "next_patch=${next_patch}" >> $GITHUB_OUTPUT
 echo "next_branch=${next_branch}" >> $GITHUB_OUTPUT
 echo "Next release branch: '${next_branch}'"


### PR DESCRIPTION
### 💭 Notes

handle error when tailing 0 lines, add diff-range to the notification, and simplify code.

### 👀 Preview steps

To preview the change in the script file:

1. `./scripts/find_releases.sh 2>&1 | grep 'prev_patch'`
2. 🟢 [on .43] it shows .37g
3. 🟢 [on PR] it shows nothing (because not on a release branch)
4. `git checkout -B release/2.025.43`
5. 🟢 [on PR] it shows .43g
6. `git branch -f release/2.025.43 origin/release/2.025.43`