### PR TITLE
docs(deprecation): update API v1 removal date

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,6 +1,6 @@
 # Endpoint deprecation as of release 2.025.29
 
-⚠️ The deprecated endpoints listed below will be permanently removed with the first release of 2026, scheduled for the week of **January 19, 2026**.
+⚠️ The deprecated endpoints listed below will be permanently removed with the first release of June 2026, scheduled for **June 2, 2026**.
 
 We strongly encourage all developers and users with integrations to update their systems as soon as possible to avoid disruption.
 A new support article will be available soon to guide users through the migration from KoboCAT `v1` to KPI `v2`.


### PR DESCRIPTION
### 📣 Summary
Reflect the new API v1 deprecation timeline by updating the removal date to June 2.

### 📖 Description
This documentation update revises the planned removal date for API v1, which has been officially postponed to June 2. All references to the prior deadline have been updated to ensure users, integrators, and administrators have accurate information about the deprecation schedule.
