### PR TITLE
ci(releases): changelog job should handle all cases DEV-1285

### DIFF
--- a/scripts/find_releases.sh
+++ b/scripts/find_releases.sh
@@ -71,7 +71,7 @@ do
 done
 
 echo "prev_minor=${prev_minor}" >> $GITHUB_OUTPUT
-if [[ $current_patch == "" ]]; then
+if [[ $current_patch == $current_minor ]]; then
     prev_patch="$(git tag -l "$prev_minor*" | grep -E "^$prev_minor.?$" | tail -1 || true)"
 else
     prev_patch="$(git tag -l "$current_minor*" | grep -E "^$current_minor.?$" | tail -1 || true)"


### PR DESCRIPTION
### 💭 Notes

Fix `prev_patch` to be the correct value for a new major release. Fixes #6543.

### 👀 Preview steps

1. `./scripts/find_releases.sh 2>&1 | grep 'prev_patch'`
2. 🟢 [on .43] it shows .43h
2. :red_circle: [on .47] it shows empty value
3. 🟢 [on PR] it shows nothing (because not on a release branch)
4. `git checkout release/2.025.47 && cherry-pick origin/kalvis/prev-patch`
3. 🟢 [on PR at .47] it shows .43h
6. `git reset HEAD^`