### PR TITLE
fix(subsequences): better error from creation of features with incorrect params DEV-1441

### DIFF
--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -1,6 +1,7 @@
 import jsonschema.exceptions
 from rest_framework import serializers
 
+from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
 from kobo.apps.subsequences.models import QuestionAdvancedFeature
 
 
@@ -43,3 +44,12 @@ class QuestionAdvancedFeatureSerializer(serializers.ModelSerializer):
         ).exists():
             raise serializers.ValidationError('Action for this question already exists')
         return super().create(validated_data)
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        Action = ACTION_IDS_TO_CLASSES[attrs.get('action')]
+        try:
+            Action.validate_params(attrs.get('params'))
+        except jsonschema.exceptions.ValidationError as ve:
+            raise serializers.ValidationError(ve)
+        return data

--- a/kobo/apps/subsequences/tests/api/v2/test_views.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_views.py
@@ -144,3 +144,14 @@ class QuestionAdvancedFeatureViewSetTestCase(BaseTestCase):
         self.asset.refresh_from_db()
         assert self.asset.advanced_features.get('_version') == '20250820'
         assert res.status_code == status.HTTP_201_CREATED
+
+    def test_cannot_create_feature_with_invalid_params(self):
+        res = self.client.post(
+            self.list_actions_url,
+            data={
+                'action': 'manual_translation',
+                'params': json.dumps([{'bad': 'stuff'}]),
+                'question_xpath': 'q1',
+            },
+        )
+        assert res.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Validate `params` before creating new advanced features.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. `curl -X POST -H 'Authorization: Token <your token>' http://kf.kobo.local/api/v2/assets/<asset_uid>/advanced-features --json '{"question_xpath": <xpath>, "action": "manual_transcription", "params": [{"something":"bad"}]}'
3. 🔴 [on refactor-subsequences-2025] request 500s
4. 🟢 [on PR] request 400s

