### PR TITLE
fix(subsequences): update background processing to support new `_data` structure DEV-1443

### DIFF
--- a/kobo/apps/subsequences/actions/base.py
+++ b/kobo/apps/subsequences/actions/base.py
@@ -855,20 +855,32 @@ class BaseAutomaticNLPAction(BaseManualNLPAction):
           returned and passed back to `revise_data()`.
         """
 
+        current_version = action_supplemental_data.get(self.VERSION_DATA_FIELD, {})
+
         # If the client sent "accepted" while the supplement is already complete,
         # return the completed translation/transcription right away. `revise_data()`
         # will handle the merge and final validation of this acceptance.
         accepted = action_data.get('accepted', None)
-        if action_supplemental_data.get('status') == 'complete' and accepted is not None:
-            return {
-                'value': action_supplemental_data['value'],
-                'status': 'complete',
-            }
+
+        if accepted is not None:
+            if current_version.get('status') == 'complete':
+                return {
+                    'value': current_version['value'],
+                    'status': 'complete',
+                }
+            else:
+                # Intentionally return `action_data` as-is to force JSON schema
+                # validation to fail.
+                # The `{'accepted': true|false}` structure is only valid once the
+                # action has completed.
+                return action_data
 
         # If the client explicitly removed a previously stored result,
-        # preserve the deletion by returning a `deleted` status instead
-        # of reprocessing with the external service.
-        # TODO add comment for delete here
+        # preserve that deletion by returning a `deleted` status instead
+        # of reprocessing the data with the external service.
+        #
+        # An empty string is not considered a deletion.
+        # JSON Schema validation will later enforce that `value` is None.
         if 'value' in action_data:
             return {
                 'value': action_data['value'],
@@ -886,7 +898,7 @@ class BaseAutomaticNLPAction(BaseManualNLPAction):
             accepted is None
             and service_data['status'] == 'in_progress'
         ):
-            if action_supplemental_data.get('status') == 'in_progress':
+            if current_version.get('status') == 'in_progress':
                 return None
             else:
                 # Make Celery update in the background.

--- a/kobo/apps/subsequences/tasks.py
+++ b/kobo/apps/subsequences/tasks.py
@@ -32,6 +32,8 @@ def poll_run_external_process(
     action_id: str,
     action_data: dict,
 ):
+    from .actions.base import BaseAction
+
     Asset = apps.get_model('kpi', 'Asset')  # noqa: N806
     SubmissionSupplement = apps.get_model('subsequences', 'SubmissionSupplement')  # noqa: N806
     incoming_data = {
@@ -43,7 +45,7 @@ def poll_run_external_process(
 
     last_action_version = supplement_data[question_xpath][action_id]['_versions'][0]
 
-    if last_action_version['status'] == 'in_progress':
+    if last_action_version[BaseAction.VERSION_DATA_FIELD]['status'] == 'in_progress':
         raise SubsequenceTimeoutError(
             f'{action_id} is still in progress for submission '
             f'{submission[SUBMISSION_UUID_FIELD]}'


### PR DESCRIPTION
### 📣 Summary
Restore background and NLP processing by reading values from the new `_data` field.

### 📖 Description
This fix updates the background processing logic to support the new data structure where value, language, and status (when present) are now nested under a `_data` dictionary. Some automated NLP actions were broken because they were still looking for these fields at the top level, where they can no longer exist. 

### 👀 Preview steps

1. ℹ️ have an account and a project with an audio question
2. submit an audio file (longer than 2 minutes)
3. use the shell to process an automatic action (look at Linear for snippet)
4. 🔴 [on main] notice that the background process never starts, and if user sends acceptance, external service is still called
5. 🟢 [on PR] notice that everything works as expected
