### PR TITLE
fix(assets): fix an error when searching assets with numeric-only queries DEV-1487

### DIFF
--- a/kpi/utils/query_parser/query_parser.py
+++ b/kpi/utils/query_parser/query_parser.py
@@ -143,6 +143,7 @@ class QueryParseActions:
         if elements[0].text == '':
             value = _get_value('', elements)
 
+            value = str(value) if not isinstance(value, str) else value
             if len(value) >= self.min_search_characters:
                 # Note that at least one term meets the minimum length
                 # requirement


### PR DESCRIPTION
### 📣 Summary
Fix a server error that occurred when users searched for assets using numeric-only search terms (e.g. 111).

