### PR TITLE
feat(qual): show most recently created qual answers instead of most recently accepted DEV-1497

### DIFF
--- a/kobo/apps/subsequences/actions/mixins.py
+++ b/kobo/apps/subsequences/actions/mixins.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from dateutil import parser
 
+from ..constants import SORT_BY_DATE_FIELD
 from ..exceptions import TranscriptionNotFound
 from ..type_aliases import SimplifiedOutputCandidatesByColumnKey
 
@@ -35,7 +36,7 @@ class TranscriptionActionMixin:
             self.col_type: {
                 'languageCode': version_data['_data']['language'],
                 'value': version_data['_data']['value'],
-                self.DATE_ACCEPTED_FIELD: version_data.get(self.DATE_ACCEPTED_FIELD),
+                SORT_BY_DATE_FIELD: version_data.get(self.DATE_ACCEPTED_FIELD),
             }
         }
 
@@ -318,6 +319,6 @@ class TranslationActionMixin:
             result[key] = {
                 'languageCode': version_data['_data']['language'],
                 'value': version_data['_data']['value'],
-                self.DATE_ACCEPTED_FIELD: version_data.get(self.DATE_ACCEPTED_FIELD),
+                SORT_BY_DATE_FIELD: version_data.get(self.DATE_ACCEPTED_FIELD),
             }
         return result

--- a/kobo/apps/subsequences/actions/qual.py
+++ b/kobo/apps/subsequences/actions/qual.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 from rest_framework.exceptions import ValidationError
 
-from ..type_aliases import SimplifiedOutputCandidatesByColumnKey
-from .base import ActionClassConfig, BaseAction
+from kobo.apps.subsequences.actions.base import BaseAction, ActionClassConfig
+from kobo.apps.subsequences.constants import SORT_BY_DATE_FIELD
+from kobo.apps.subsequences.type_aliases import SimplifiedOutputCandidatesByColumnKey
 
 
 class ManualQualAction(BaseAction):
@@ -325,12 +326,10 @@ class ManualQualAction(BaseAction):
 
             versions_sorted = sorted(
                 versions,
-                key=lambda x: x.get(self.DATE_ACCEPTED_FIELD, ''),
+                key=lambda x: x.get(self.DATE_CREATED_FIELD, ''),
                 reverse=True,
             )
             selected_version = versions_sorted[0]
-            if not selected_version.get(self.DATE_ACCEPTED_FIELD):
-                continue
 
             selected_response_data = selected_version.get(self.VERSION_DATA_FIELD, {})
             if not selected_response_data:
@@ -365,12 +364,12 @@ class ManualQualAction(BaseAction):
                 output_value = value
 
             results_dict[('qual', qual_uuid)] = {
-                    'value': output_value,
-                    'type': qual_question['type'],
-                    'xpath': self.source_question_xpath,
-                    'labels': qual_question.get('labels', {}),
-                    self.DATE_ACCEPTED_FIELD: selected_version[self.DATE_ACCEPTED_FIELD]
-                }
+                'value': output_value,
+                'type': qual_question['type'],
+                'xpath': self.source_question_xpath,
+                'labels': qual_question.get('labels', {}),
+                SORT_BY_DATE_FIELD: selected_version[self.DATE_CREATED_FIELD],
+            }
         return results_dict
 
     def update_params(self, incoming_params):

--- a/kobo/apps/subsequences/constants.py
+++ b/kobo/apps/subsequences/constants.py
@@ -2,6 +2,7 @@ from django.db import models
 
 SUBMISSION_UUID_FIELD = 'meta/rootUuid'  # FIXME: import from elsewhere
 SUPPLEMENT_KEY = '_supplementalDetails'  # leave unchanged for backwards compatibility
+SORT_BY_DATE_FIELD = '_sortByDate'
 
 # Could allow more types in the future? See
 # formpack.utils.replace_aliases.MEDIA_TYPES

--- a/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
@@ -366,6 +366,6 @@ def test_transform_data_for_output():
         'transcript': {
             'value': 'bonjour',
             'languageCode': 'fr',
-            '_dateAccepted': None,
+            '_sortByDate': None,
         },
     }

--- a/kobo/apps/subsequences/tests/test_automatic_google_translation.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_translation.py
@@ -439,12 +439,12 @@ def test_transform_data_for_output():
         ('translation', 'es'): {
             'value': 'Hola otra vez',
             'languageCode': 'es',
-            '_dateAccepted': None,
+            '_sortByDate': None,
         },
         ('translation', 'fr'): {
             'value': 'bonjour',
             'languageCode': 'fr',
-            '_dateAccepted': None,
+            '_sortByDate': None,
         },
     }
 

--- a/kobo/apps/subsequences/tests/test_manual_transcription.py
+++ b/kobo/apps/subsequences/tests/test_manual_transcription.py
@@ -193,6 +193,6 @@ def test_transform_data_for_output():
         'transcript': {
             'value': 'bonjour',
             'languageCode': 'fr',
-            '_dateAccepted': retrieved_data['_versions'][0]['_dateAccepted'],
+            '_sortByDate': retrieved_data['_versions'][0]['_dateAccepted'],
         },
     }

--- a/kobo/apps/subsequences/tests/test_manual_translation.py
+++ b/kobo/apps/subsequences/tests/test_manual_translation.py
@@ -192,12 +192,12 @@ def test_transform_data_for_output():
         ('translation', 'en'): {
             'value': 'hello again',
             'languageCode': 'en',
-            '_dateAccepted': retrieved_data['en']['_versions'][0]['_dateAccepted'],
+            '_sortByDate': retrieved_data['en']['_versions'][0]['_dateAccepted'],
         },
         ('translation', 'fr'): {
             'value': 'bonjour',
             'languageCode': 'fr',
-            '_dateAccepted': retrieved_data['fr']['_versions'][0]['_dateAccepted'],
+            '_sortByDate': retrieved_data['fr']['_versions'][0]['_dateAccepted'],
         },
     }
 

--- a/kobo/apps/subsequences/tests/test_qual.py
+++ b/kobo/apps/subsequences/tests/test_qual.py
@@ -887,11 +887,10 @@ class TestQualActionMethods(TestCase):
         )
         assert medical_item['labels'] == {'_default': 'Medical', 'ar': 'طبي'}
 
-    def test_transform_data_prefers_newest_date_accepted_version(self):
+    def test_transform_data_prefers_newest_date_created_version(self):
         """
         Test that when multiple versions exist for a qual question, the version
-        with the newest `_dateAccepted` is used for output, even if it is not
-        the most recently created version
+        with the newest `_dateCreated` is used for output
         """
         action = ManualQualAction(self.source_xpath, self.action_params)
 
@@ -926,7 +925,7 @@ class TestQualActionMethods(TestCase):
         assert len(output.keys()) == 1
 
         text_item = output.get(('qual', 'qual-text-uuid'))
-        assert text_item['value'] == 'Revised note'
+        assert text_item['value'] == 'Final note'
 
     def test_update_params_sets_missing_questions_to_deleted_and_moved_to_the_end(self):
         params = [


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Display the most recent QA answers in the data table and exports rather than the most recently accepted.

### 💭 Notes
In preparation for Automatic QA. 
Internal link: https://linear.app/kobotoolbox/issue/DEV-1497/refactor-submissionsupplementretrieve-data-to-allow-unaccepted-data#comment-9521edef


### 👀 Preview steps
Regression test only, until we have automatic qual analysis this shouldn't actually change what shows up in the data table because manual answers are automatically accepted.

See https://github.com/kobotoolbox/kpi/pull/6559 for steps
