### PR TITLE
fix(asset): prevent translation errors after adding hints to a form DEV-1363 DEV-1385

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -503,6 +503,7 @@ class Asset(
         Can be disabled / skipped by calling with parameter:
         asset.save(adjust_content=False)
         """
+        self.__normalize_settings_and_translations(self.content)
         self._standardize(self.content)
 
         self._make_default_translation_first(self.content)
@@ -1561,6 +1562,39 @@ class Asset(
             and 'data_collector_group_id' in fields
         ):
             self._initial_data_collector_group_id = self.data_collector_group_id
+
+    def __normalize_settings_and_translations(self, content):
+        """
+        Ensures settings are a dictionary, preserves existing translations from the DB,
+        and prevents the 'null' language leak by suffixing plain strings with the
+        default language.
+        """
+        settings_data = content.get('settings', {})
+        if isinstance(settings_data, list):
+            flattened_settings = {}
+            for item in settings_data:
+                if isinstance(item, dict):
+                    flattened_settings.update(item)
+            content['settings'] = flattened_settings
+            settings_data = flattened_settings
+
+        # Get existing translations from DB so they don't disappear
+        existing_translations = []
+        if self.pk:
+            db_instance = Asset.objects.filter(pk=self.pk).only('content').first()
+            if db_instance and 'translations' in db_instance.content:
+                existing_translations = db_instance.content['translations']
+
+        # If payload is empty of translations but DB has them, restore them
+        if not content.get('translations') and existing_translations:
+            content['translations'] = existing_translations
+
+        # Suffix plain hint strings to the default language
+        default_lang = settings_data.get('default_language')
+        if default_lang:
+            for row in content.get('survey', []):
+                if 'hint' in row and isinstance(row['hint'], str):
+                    row[f'hint::{default_lang}'] = row.pop('hint')
 
 
 class UserAssetSubscription(models.Model):


### PR DESCRIPTION
### 📣 Summary
Allow users to add hints to forms which have translations before deploying the form. 

### 💭 Notes
Also fixes [DEV-1385](https://linear.app/kobotoolbox/issue/DEV-1385/translation-gets-removed-when-saving-a-form-with-text-question) (Translation gets removed when saving a form with text question)

### 👀 Preview steps
1. ℹ️ Create a form (undeployed).
2. Add a default language and a new language. (ex: [English (en), French (fr)] )
3. Return to the Formbuilder, add a hint or guidance hint.
4. Exit Formbuilder.
5. 🔴 [on main] Notice there is a new unnamed language and that the second language has been removed.
6. 🟢 [on PR] Notice that both original languages are present. 
7.  Return to Formbuilder.
8. 🔴 [on main] Notice the Formbuilder is has an error and is inaccessible due to the unnamed language
9. 🟢 [on PR] Notice that the Formbuilder has no errors and you can edit the survey normally