### PR TITLE
fix(qual): return error for a bad single select DEV-1543

### DIFF
--- a/kobo/apps/subsequences/prompts.py
+++ b/kobo/apps/subsequences/prompts.py
@@ -146,10 +146,15 @@ def parse_choices_response(
     selected_answer_indexes = [
         i for i, value in enumerate(separated_answers) if value == 'TRUE'
     ]
-    if not allow_multiple and len(selected_answer_indexes) > 1:
-        raise InvalidResponseFromLLMException(
-            'LLM returned multiple answers for a single select'
-        )
+    if not allow_multiple:
+        if len(selected_answer_indexes) > 1:
+            raise InvalidResponseFromLLMException(
+                'LLM returned multiple answers for a single select'
+            )
+        if len(selected_answer_indexes) == 0:
+            raise InvalidResponseFromLLMException(
+                'LLM returned no answers for a single select'
+            )
     return selected_answer_indexes
 
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
When the LLM cannot answer a single-select question, store the answer as a failed response rather than returning a 500 for the whole request.


### 👀 Preview steps
1. ℹ️ have an account and a project with an audio question and a submission
2. Enable manual transcripts with
```
curl -H 'Authorization: Token <your_token>' http://kf.kobo.local/api/v2/assets/<asset_uid>/advanced-features/ 
--json '{"question_xpath":"<xpath>", "action":"manual_transcription", "params": [{"language":"en"}]}'
```
3. Enable automatic QA with 
```
curl -H 'Authorization: Token <your_token>' --json @- http://kf.kobo.local/api/v2/assets/<asset_uid>/advanced-features/ 
```
and the following pasted into std-in (labels are important, and make sure to replace <xpath> with your xpath)
```
{
  "question_xpath": "<xpath>",
  "action": "automatic_bedrock_qual",
  "params": [
    {
      "type": "qualSelectOne",
      "uuid": "1a8b748b-f470-4c40-bc09-ce2b1197f503",
      "labels": {
        "_default": "Are they happy?"
      },
      "choices": [
        {
          "uuid": "3c7aacdc-8971-482a-9528-68e64730fc99",
          "labels": {
            "_default": "Yes"
          }
        },
        {
          "uuid": "7e31c6a5-5eac-464c-970c-62c383546a94",
          "labels": {
            "_default": "No"
          }
        }
      ]
    },
  ]
}
```

5. Add a manual transcript with (value is important)
```
curl -X PATCH -H 'Authorization: Token <your_token>' http://kf.kobo.local/api/v2/assets/<asset_uid>/data/<submission_uuid>/supplement/ --json '{"_version": "20250820",  "<question_xpath>": {"manual_transcription": {"language":"en", "value":"This is a transcript"}} }'
```
6. Request automatic QA for the select one question with
```
curl -X PATCH -H 'Authorization: Token <your_token>' http://kf.kobo.local/api/v2/assets/<asset_uid>/data/<submission_uuid>/supplement/ --json '{"_version": "20250820",  "<question_xpath>": {"automatic_bedrock_qual": {"uuid":"1a8b748b-f470-4c40-bc09-ce2b1197f503"}}}'
```
7. In a django shell, get the submission supplement with `ss = SubmissionSupplement.objects.get(submission_uuid=<submission_uuid>)`
8. The most recent answer to the select question will be in `ss.content['<question_xpath>']['automatic_bedrock_qual']['1a8b748b-f470-4c40-bc09-ce2b1197f503']['_versions'][0]['_data']`
9. :green_circle: The data should containt `"status": "failed", "error": "LLM returned no answers for a single select"`


