### PR TITLE
fix(userReports): show correct role for members of multiple orgs DEV-1492

### DIFF
--- a/kobo/apps/user_reports/migrations/0002_create_user_reports_mv.py
+++ b/kobo/apps/user_reports/migrations/0002_create_user_reports_mv.py
@@ -1,41 +1,6 @@
 # flake8: noqa: E501
 
-from django.conf import settings
 from django.db import migrations
-from kobo.apps.user_reports.utils.sql_utils import (
-    get_mv_sql, DROP_MV_SQL, CREATE_INDEXES_SQL, DROP_INDEXES_SQL
-)
-
-CREATE_MV_SQL = get_mv_sql(mode='global')
-
-def manually_create_mv_instructions(apps, schema_editor):
-    print(
-        f"""
-        ⚠️ ATTENTION ⚠️
-        Run the SQL query below in PostgreSQL directly to create the materialized view:
-
-        {CREATE_MV_SQL}
-
-        Then run the SQL query below to create the indexes:
-
-        {CREATE_INDEXES_SQL}
-
-        """.replace(
-            'CREATE UNIQUE INDEX', 'CREATE UNIQUE INDEX CONCURRENTLY'
-        )
-    )
-
-
-def manually_drop_mv_instructions(apps, schema_editor):
-    print(
-        f"""
-        ⚠️ ATTENTION ⚠️
-        Run the SQL query below in PostgreSQL directly:
-
-        {DROP_MV_SQL}
-
-        """
-    )
 
 
 class Migration(migrations.Migration):
@@ -47,21 +12,6 @@ class Migration(migrations.Migration):
         ('accounts_mfa', '0001_squashed_0004_alter_mfamethod_date_created_and_more'),
     ]
 
-    if settings.SKIP_HEAVY_MIGRATIONS:
-        operations = [
-            migrations.RunPython(
-                manually_create_mv_instructions,
-                manually_drop_mv_instructions,
-            )
-        ]
-    else:
-        operations = [
-            migrations.RunSQL(
-                sql=CREATE_MV_SQL,
-                reverse_sql=DROP_MV_SQL,
-            ),
-            migrations.RunSQL(
-                sql=CREATE_INDEXES_SQL,
-                reverse_sql=DROP_INDEXES_SQL,
-            ),
-        ]
+    operations = [
+        migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop),
+    ]

--- a/kobo/apps/user_reports/migrations/0003_fix_user_role_scopping.py
+++ b/kobo/apps/user_reports/migrations/0003_fix_user_role_scopping.py
@@ -2,10 +2,10 @@
 from django.conf import settings
 from django.db import migrations
 
-from kobo.apps.user_reports.utils.sql_utils import (
+from kobo.apps.user_reports.utils.migrations import (
     CREATE_INDEXES_SQL,
+    CREATE_MV_SQL,
     DROP_MV_SQL,
-    get_mv_sql,
 )
 
 
@@ -20,7 +20,7 @@ def apply_fix(apps, schema_editor):
             
             Run the SQL query below in PostgreSQL directly to create the materialized view:
 
-            {get_mv_sql(mode='scoped')}
+            {CREATE_MV_SQL}
 
             Then run the SQL query below to create the indexes:
 
@@ -33,7 +33,7 @@ def apply_fix(apps, schema_editor):
         return
 
     schema_editor.execute(DROP_MV_SQL)
-    schema_editor.execute(get_mv_sql(mode='scoped'))
+    schema_editor.execute(CREATE_MV_SQL)
     schema_editor.execute(CREATE_INDEXES_SQL)
 
 


### PR DESCRIPTION
### 📣 Summary
Correct the `/api/v2/user-reports` endpoint to accurately reflect the user’s role for each organization they are part of.

### 💭 Notes
-moved the materialized view logic from the migration 0002 into `migrations.py` which will allow us to easily change/fix the database schema without having to replicate it in each new migration 

### 👀 Preview steps

1. ℹ️ have at least 3 accounts (ex: user1, user2, and user3)
2. Make user2 and user3's organizations multi-member
3. Set the `refresh-user-report-snapshot` task to run every minute:
base.py, line 1596
```
    # Schedule every 15 minutes
    'refresh-user-report-snapshot': {
        'task': 'kobo.apps.user_reports.tasks.refresh_user_report_snapshots',
 -->    'schedule': crontab(minute='*/1'),
        'options': {'queue': 'kpi_long_running_tasks_queue'},
    },
```
4. Add user1 to user2's organization as an admin
5. Check `/api/v2/user-reports` and verify that user1 is listed in user2's organization as an admin
6. Remove the user reports migrations: `./manage.py migrate user_reports zero`
7. In kobo/apps/organizations/models.py comment out line 100:  `# user.organization.delete()` (this will allow us to add multiple organizations to one user)
8. In the shell, get user1 and user3's organization and add user1 to user3's organization as a member:
```
user1 = User.objects.get(username='user1')
org = Organization.objects.get(id='orgID')
org.add_user(user1)
```
9. Run the user reports migrations: `./manage.py migrate user_reports`
10. Check `/api/v2/user-reports` and verify that user1 is listed twice and listed as the admin for both user2 and user3's organizations
11. 🔴 [on main] we have replicated the bug 🎉
12. [on PR] apply the new migration: `./manage.py migrate user_reports 0003_fix_user_role_scopping`
13. 🟢 Check `/api/v2/user-reports` and notice that user1 is listed as an admin for user2's org and a member of user3's org
