### PR TITLE
fix(dev): fix formpack version in dependencies files

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -277,7 +277,7 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@f6d4792760291f8d376de7100ce2ffe39edd4366#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@6f0c7601625f6bf962008b518eab934ca0fdbd57#egg=formpack
     # via -r dependencies/pip/requirements.in
 freezegun==1.5.1
     # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -225,7 +225,7 @@ fido2==2.0.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@f6d4792760291f8d376de7100ce2ffe39edd4366#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@6f0c7601625f6bf962008b518eab934ca0fdbd57#egg=formpack
     # via -r dependencies/pip/requirements.in
 frozenlist==1.4.1
     # via


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ran pip-compile script to update the formpack version to the latest commit 