### PR TITLE
fix(subsequences): return consistent _supplementData for list and detail endpoints

### DIFF
--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -455,6 +455,7 @@ class DataViewSet(
             'user': request.user,
             'format_type': format_type,
             'request': request,
+            'for_output': True,
         }
         filters = self._filter_mongo_query(request)
 


### PR DESCRIPTION
### 💭 Notes
This fix restores consistency between the list and detail subsequences endpoints by returning the same `_supplementData` structure in both cases. After the refactor, the detail endpoint was exposing a more detailed version of `_supplementData` instead of the simplified format used in the list view.
