### PR TITLE
fix(openAPI): improve schema for assets list response DEV-1580

### DIFF
--- a/jsapp/js/api/models/assetsListParams.ts
+++ b/jsapp/js/api/models/assetsListParams.ts
@@ -12,15 +12,19 @@ The endpoints are grouped by area of intended use. Each category contains relate
 
 export type AssetsListParams = {
   /**
-   * Number of results to return per page.
+   * Paginate results with limit parameter
    */
   limit?: number
   /**
-   * The initial index from which to return the results.
+   * Paginate results with offset parameter
    */
   offset?: number
   /**
    * Which field to use when ordering the results.
    */
   ordering?: string
+  /**
+   * Filter the results with search query
+   */
+  q?: string
 }

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -6,7 +6,12 @@ from operator import itemgetter
 from django.db.models import Count
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import OpenApiExample, extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import exceptions, renderers, status
 from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
@@ -191,6 +196,36 @@ from kpi.utils.ss_structure_to_mdtable import ss_structure_to_mdtable
             raise_access_forbidden=False,
             validate_payload=False,
         ),
+        parameters=[
+            OpenApiParameter(
+                name='q',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Filter the results with search query',
+            ),
+            OpenApiParameter(
+                name='offset',
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Paginate results with offset parameter',
+            ),
+            OpenApiParameter(
+                name='limit',
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Paginate results with limit parameter',
+            ),
+            OpenApiParameter(
+                name='ordering',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Which field to use when ordering the results.',
+            ),
+        ],
     ),
     metadata=extend_schema(
         description=read_md('kpi', 'assets/metadata.md'),

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -1155,31 +1155,36 @@
                 "description": "## Get user's assets\n\n\nSearch can be made with `q` parameter.\nSearch filters can be returned with results by passing `metadata=on` to querystring.\n\n\nResults can be sorted with `ordering` parameter, e.g.:\n\n```shell\ncurl -X GET https://kf.kobotoolbox.org/api/v2/assets/?ordering=-name\n```\n\n\nAllowed fields are:\n\n- `asset_type`\n- `date_modified`\n- `date_deployed`\n- `date_modified__date`\n- `date_deployed__date`\n- `name`\n- `settings__sector`\n- `settings__sector__value`\n- `settings__description`\n- `owner__username`\n- `owner__extra_details__data__name`\n- `owner__extra_details__data__organization`\n- `owner__email`\n- `_deployment_status`\n- `subscribers_count`\n\n\nNote: Collections can be displayed first with parameter `collections_first`, e.g.:\n\n```shell\ncurl -X GET https://kf.kobotoolbox.org/api/v2/assets/?collections_first=true&ordering=-name\n```\n",
                 "parameters": [
                     {
+                        "in": "query",
                         "name": "limit",
-                        "required": false,
-                        "in": "query",
-                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
-                        }
+                        },
+                        "description": "Paginate results with limit parameter"
                     },
                     {
+                        "in": "query",
                         "name": "offset",
-                        "required": false,
-                        "in": "query",
-                        "description": "The initial index from which to return the results.",
                         "schema": {
                             "type": "integer"
-                        }
+                        },
+                        "description": "Paginate results with offset parameter"
                     },
                     {
-                        "name": "ordering",
-                        "required": false,
                         "in": "query",
-                        "description": "Which field to use when ordering the results.",
+                        "name": "ordering",
                         "schema": {
                             "type": "string"
-                        }
+                        },
+                        "description": "Which field to use when ordering the results."
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter the results with search query"
                     }
                 ],
                 "tags": [

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -816,24 +816,26 @@ paths:
         curl -X GET https://kf.kobotoolbox.org/api/v2/assets/?collections_first=true&ordering=-name
         ```
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
+      - in: query
+        name: limit
         schema:
           type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
+        description: Paginate results with limit parameter
+      - in: query
+        name: offset
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
+        description: Paginate results with offset parameter
+      - in: query
+        name: ordering
         schema:
           type: string
+        description: Which field to use when ordering the results.
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: Filter the results with search query
       tags:
       - Manage projects and library content
       security:


### PR DESCRIPTION
### 💭 Notes

I've mimicked some other PRs and did some reverse search to find the place to fix this. Not 100% sure it's the proper way. I did add the `parameters=` for asset list API in `kpi/views/v2/asset.py` and then ran `./scripts/generate_api.sh` from withing container, picked out the changes to commit, and then ran `npm run build:orval`.

I need this for DEV-1323, so I did this in the meantime.

### 👀 Preview steps

Testing:
1. Know how defining OpenAPI on Backend should be done
2. Verify I didn't do something weird