### PR TITLE
feat(subsequences): do not allow users to un-accept automatic NLP responses DEV-1582

### DIFF
--- a/kobo/apps/subsequences/actions/base.py
+++ b/kobo/apps/subsequences/actions/base.py
@@ -820,7 +820,7 @@ class BaseAutomaticNLPAction(BaseManualNLPAction):
             '$defs': {
                 'lang': {'type': 'string', 'enum': self.languages},
                 'locale': {'type': ['string', 'null']},
-                'accepted': {'type': 'boolean'},
+                'accepted': {'const': True},
                 # Only null is permitted for `value`
                 'value_null_only': {'type': 'null'},
             },

--- a/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
@@ -35,7 +35,7 @@ def test_valid_user_data_passes_validation():
         {'language': 'fr', 'locale': 'fr-CA', 'value': None},
         # Accept transcript
         {'language': 'fr', 'accepted': True},
-        # Accept translat with locale
+        # Accept transcript with locale
         {'language': 'fr', 'locale': 'fr-CA', 'accepted': True},
     ]
 
@@ -99,7 +99,9 @@ def test_invalid_user_data_fails_validation():
         # Cannot push a status
         {'language': 'fr', 'status': 'in_progress'},
         # Cannot pass value and accepted at the same time
-        {'language': 'fr', 'value': None, 'accepted': False},
+        {'language': 'fr', 'value': None, 'accepted': True},
+        # Cannot un-accept
+        {'language': 'fr', 'accepted': False},
     ]
 
     for data in invalid_data:
@@ -121,8 +123,6 @@ def test_invalid_external_data_fails_validation():
         {},
         # Cannot accept an empty transcription
         {'language': 'es', 'accepted': True},
-        # Cannot deny an empty transcription
-        {'language': 'es', 'accepted': False},
         # Cannot pass value and accepted at the same time
         {'language': 'es', 'value': None, 'accepted': False},
         # Cannot have a value while in progress
@@ -188,7 +188,6 @@ def test_acceptance_does_not_produce_versions():
 
     first = {'language': 'fr', 'value': 'un'}
     second = {'language': 'fr', 'accepted': True}
-    third = {'language': 'fr', 'accepted': False}
     mock_sup_det = EMPTY_SUPPLEMENT
 
     mock_service = MagicMock()
@@ -196,7 +195,7 @@ def test_acceptance_does_not_produce_versions():
         'kobo.apps.subsequences.actions.automatic_google_transcription.GoogleTranscriptionService',  # noqa
         return_value=mock_service,
     ):
-        for data in first, second, third:
+        for data in first, second:
             value = data.get('value', '')
             # The 'value' field is not allowed in the payload, except when its
             # value is None.

--- a/kobo/apps/subsequences/tests/test_automatic_google_translation.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_translation.py
@@ -94,7 +94,9 @@ def test_invalid_user_data_fails_validation():
         # Cannot push a status
         {'language': 'fr', 'status': 'in_progress'},
         # Cannot pass value and accepted at the same time
-        {'language': 'fr', 'value': None, 'accepted': False},
+        {'language': 'fr', 'value': None, 'accepted': True},
+        # Cannot un-accept a translation
+        {'language': 'fr', 'accepted': False}
     ]
 
     for data in invalid_data:
@@ -114,10 +116,8 @@ def test_invalid_automatic_data_fails_validation():
         {},
         # Cannot accept an empty translation
         {'language': 'es', 'accepted': True},
-        # Cannot deny an empty translation
-        {'language': 'es', 'accepted': False},
         # Cannot pass value and accepted at the same time
-        {'language': 'es', 'value': None, 'accepted': False},
+        {'language': 'es', 'value': None, 'accepted': True},
         # Cannot have a value while in progress
         {'language': 'es', 'value': 'Ni idea', 'status': 'in_progress'},
         # Missing error property
@@ -179,7 +179,6 @@ def test_acceptance_does_not_produce_versions():
 
     first = {'language': 'fr', 'value': 'un'}
     second = {'language': 'fr', 'accepted': True}
-    third = {'language': 'fr', 'accepted': False}
     mock_sup_det = EMPTY_SUPPLEMENT
 
     mock_service = MagicMock()
@@ -187,7 +186,7 @@ def test_acceptance_does_not_produce_versions():
         'kobo.apps.subsequences.actions.automatic_google_translation.GoogleTranslationService',  # noqa
         return_value=mock_service,
     ):
-        for data in first, second, third:
+        for data in first, second:
             value = data.get('value', '')
             # The 'value' field is not allowed in the payload, except when its
             # value is None.


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Do not allow users to un-accept an automatic NLP response.


### 👀 Preview steps

1. ℹ️ have an account and a project with an audio question and at least one submission
2. Enable automatic and manual transcription 
3. Add a manual transcription
4. Request an automatic transcription
5. Accept the transcription
6. Try to un-accept the transcription by PATCHing the supplement endpoint with
```
{
"_version": "20250820",
"<question_xpath>: {"automatic_google_transcription": {"language":"en", "accepted": false}}"
}
```
7. 🔴 [on main] request succeeds and the data table now shows the old manual transcription
8. 🟢 [on PR] the request fails

