### PR TITLE
fix(subsequences): require default in labels DEV-1619

### DIFF
--- a/jsapp/js/api/models/qualSelectQuestionParamsChoicesItemLabels.ts
+++ b/jsapp/js/api/models/qualSelectQuestionParamsChoicesItemLabels.ts
@@ -10,4 +10,7 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type QualSelectQuestionParamsChoicesItemLabels = { [key: string]: string }
+export type QualSelectQuestionParamsChoicesItemLabels = {
+  _default: string
+  [key: string]: string
+}

--- a/jsapp/js/api/models/qualSelectQuestionParamsLabels.ts
+++ b/jsapp/js/api/models/qualSelectQuestionParamsLabels.ts
@@ -10,4 +10,7 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type QualSelectQuestionParamsLabels = { [key: string]: string }
+export type QualSelectQuestionParamsLabels = {
+  _default: string
+  [key: string]: string
+}

--- a/jsapp/js/api/models/qualSimpleQuestionParamsLabels.ts
+++ b/jsapp/js/api/models/qualSimpleQuestionParamsLabels.ts
@@ -10,4 +10,7 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type QualSimpleQuestionParamsLabels = { [key: string]: string }
+export type QualSimpleQuestionParamsLabels = {
+  _default: string
+  [key: string]: string
+}

--- a/kpi/schema_extensions/v2/subsequences/extensions.py
+++ b/kpi/schema_extensions/v2/subsequences/extensions.py
@@ -64,7 +64,11 @@ class SubsequenceParamsFieldExtension(
         definitions = {
             'qualLabels': {
                 'type': 'object',
+                'properties': {
+                    '_default': {'type': 'string'},
+                },
                 'additionalProperties': {'type': 'string'},
+                'required': ['_default'],
             },
             'qualQuestionType': {
                 'type': 'string',

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -22717,9 +22717,17 @@
                     },
                     "labels": {
                         "type": "object",
+                        "properties": {
+                            "_default": {
+                                "type": "string"
+                            }
+                        },
                         "additionalProperties": {
                             "type": "string"
-                        }
+                        },
+                        "required": [
+                            "_default"
+                        ]
                     },
                     "choices": {
                         "type": "array",
@@ -22729,9 +22737,17 @@
                             "properties": {
                                 "labels": {
                                     "type": "object",
+                                    "properties": {
+                                        "_default": {
+                                            "type": "string"
+                                        }
+                                    },
                                     "additionalProperties": {
                                         "type": "string"
-                                    }
+                                    },
+                                    "required": [
+                                        "_default"
+                                    ]
                                 },
                                 "uuid": {
                                     "type": "string",
@@ -22778,9 +22794,17 @@
                     },
                     "labels": {
                         "type": "object",
+                        "properties": {
+                            "_default": {
+                                "type": "string"
+                            }
+                        },
                         "additionalProperties": {
                             "type": "string"
-                        }
+                        },
+                        "required": [
+                            "_default"
+                        ]
                     },
                     "options": {
                         "type": "object"

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -16186,8 +16186,13 @@ components:
           $ref: '#/components/schemas/QualSelectQuestionParamsTypeEnum'
         labels:
           type: object
+          properties:
+            _default:
+              type: string
           additionalProperties:
             type: string
+          required:
+          - _default
         choices:
           type: array
           items:
@@ -16196,8 +16201,13 @@ components:
             properties:
               labels:
                 type: object
+                properties:
+                  _default:
+                    type: string
                 additionalProperties:
                   type: string
+                required:
+                - _default
               uuid:
                 type: string
                 format: uuid
@@ -16229,8 +16239,13 @@ components:
           $ref: '#/components/schemas/QualSimpleQuestionParamsTypeEnum'
         labels:
           type: object
+          properties:
+            _default:
+              type: string
           additionalProperties:
             type: string
+          required:
+          - _default
         options:
           type: object
       required:


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
In API, specify that the `labels` object in any qual question must contain a `_default` label that is a string


### 👀 Preview steps
old: 
<img width="544" height="382" alt="Screenshot from 2026-01-21 12-42-56" src="https://github.com/user-attachments/assets/1e4df3fb-378c-40a7-b245-9201dc30f57b" />

new:
<img width="568" height="406" alt="Screenshot from 2026-01-21 12-43-32" src="https://github.com/user-attachments/assets/4d9ef13b-95a5-45fb-b762-5a635038c1b2" />

