### PR TITLE
fix(openapi): add query parameter to AssetsDataListParams DEV-1626

### DIFF
--- a/jsapp/js/api/models/assetsDataListParams.ts
+++ b/jsapp/js/api/models/assetsDataListParams.ts
@@ -18,6 +18,10 @@ export type AssetsDataListParams = {
    */
   limit?: number
   /**
+   * Filter the results with search query
+   */
+  q?: string
+  /**
    * The initial index from which to return the results.
    */
   start?: number

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -154,6 +154,15 @@ from kpi.utils.xml import (
             require_auth=False,
             raise_access_forbidden=False,
         ),
+        parameters=[
+            OpenApiParameter(
+                name='q',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description='Filter the results with search query',
+            ),
+        ],
     ),
     retrieve=extend_schema(
         description=read_md('kpi', 'data/retrieve.md'),

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -2788,6 +2788,14 @@
                         }
                     },
                     {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter the results with search query"
+                    },
+                    {
                         "name": "start",
                         "required": false,
                         "in": "query",

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -1971,6 +1971,11 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: Filter the results with search query
       - name: start
         required: false
         in: query


### PR DESCRIPTION
### 👀 Preview steps
Verify that the AssetsDataList endpoint has a query string parameter:
<img width="645" height="545" alt="Screenshot 2026-01-22 at 3 56 21 PM" src="https://github.com/user-attachments/assets/f037b070-a938-433a-9212-486935bd8fbe" />

