### PR TITLE
fix(drawer): icon size DEV-1321

### DIFF
--- a/jsapp/js/components/Drawer.tsx
+++ b/jsapp/js/components/Drawer.tsx
@@ -51,11 +51,11 @@ export default function Drawer() {
     <bem.KDrawer>
       <bem.KDrawer__primaryIcons>
         <NavLink to={PROJECTS_ROUTES.MY_PROJECTS} className='k-drawer__link' data-tip={t('Projects')}>
-          <Icon name='projects' />
+          <Icon name='projects' size='inherit' />
         </NavLink>
 
         <NavLink to={ROUTES.LIBRARY} className='k-drawer__link' data-tip={t('Library')}>
-          <Icon name='library' />
+          <Icon name='library' size='inherit' />
         </NavLink>
       </bem.KDrawer__primaryIcons>
 

--- a/jsapp/js/components/common/icon.scss
+++ b/jsapp/js/components/common/icon.scss
@@ -7,6 +7,10 @@ $s-icon-m: 20px;
 $s-icon-l: 22px;
 $s-icon-xl: 28px;
 
+.k-icon--size-inherit {
+  font-size: inherit;
+}
+
 .k-icon--size-xxs {
   font-size: $s-icon-xxs;
 }

--- a/jsapp/js/components/common/icon.tsx
+++ b/jsapp/js/components/common/icon.tsx
@@ -6,8 +6,12 @@ import type { IconName } from '#/k-icons'
 
 /**
  * Check out `icon.scss` file for exact pixel values.
+ *
+ * Note: we have `inherit` option for backwards compatibility. It will cause the icon to be sized based on `font-size`
+ * of the parent. Context: sometimes we rendered icon by just having `k-icon` class name (i.e. without size), current
+ * implementation defaults to `s` size (behaviour difference).
  */
-export type IconSize = 'l' | 'm' | 's' | 'xl' | 'xs' | 'xxs'
+export type IconSize = 'l' | 'm' | 's' | 'xl' | 'xs' | 'xxs' | 'inherit'
 export type IconColor = 'mid-red' | 'storm' | 'teal' | 'amber' | 'blue'
 
 const DefaultSize = 's'


### PR DESCRIPTION
### 💭 Notes

Previous PR #6601 introduced small difference due to `<Icon>` now having default size. Now `<Icon>` has an option to inherit the size, bringing back the original looks of the Projects/Library icons.