### PR TITLE
fix(projectOwnership): only restart transfers that have been accepted DEV-1643

### DIFF
--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -170,7 +170,12 @@ class Invite(AbstractTimeStampedModel):
 class OrgMembershipAutoInviteManager(models.Manager):
 
     def create(self, **kwargs):
-        return super().create(invite_type=InviteType.ORG_MEMBERSHIP, **kwargs)
+        _ = kwargs.pop('status', InviteStatusChoices.ACCEPTED)
+        return super().create(
+            invite_type=InviteType.ORG_MEMBERSHIP,
+            status=InviteStatusChoices.ACCEPTED,
+            **kwargs,
+        )
 
     def get_queryset(self):
         return super().get_queryset().filter(invite_type=InviteType.ORG_MEMBERSHIP)

--- a/kobo/apps/project_ownership/tasks.py
+++ b/kobo/apps/project_ownership/tasks.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as t
 
+from kobo.apps.project_ownership.models.invite import InviteType
 from kobo.celery import celery_app
 from kpi.utils.mailer import EmailMessage, Mailer
 from .exceptions import AsyncTaskException, TransferStillPendingException
@@ -275,23 +276,30 @@ def task_restarter():
     # PENDING tasks were never started so don't consider them "stuck" even if they are
     # very old
 
-    is_accepted = Q(transfer__invite__status=InviteStatusChoices.ACCEPTED)
-
     stopped_in_progress_tasks = Q(
         date_modified__lte=resume_threshold,
         date_created__gt=stuck_threshold,
         status=TransferStatusChoices.IN_PROGRESS,
     ) & ~Q(status_type=TransferStatusTypeChoices.GLOBAL)
 
+    excluded_pending_user_ownership_invites = Q(
+        transfer__invite__invite_type=InviteType.USER_OWNERSHIP_TRANSFER,
+        transfer__invite__status=InviteStatusChoices.PENDING,
+    )
+
     # Don't start pending attachment tasks independently.
     # The submission task should take care of it
-    still_pending_tasks = Q(
-        status=TransferStatusChoices.PENDING,
-        date_modified__lte=resume_threshold,
-    ) & ~Q(status_type=TransferStatusTypeChoices.ATTACHMENTS)
+    still_pending_tasks = (
+        Q(
+            status=TransferStatusChoices.PENDING,
+            date_modified__lte=resume_threshold,
+        )
+        & ~Q(status_type=TransferStatusTypeChoices.ATTACHMENTS) # noqa
+        & ~excluded_pending_user_ownership_invites # noqa
+    )
 
     queryset = TransferStatus.objects.filter(
-        (stopped_in_progress_tasks | still_pending_tasks), is_accepted
+        stopped_in_progress_tasks | still_pending_tasks
     ).order_by('date_modified')
 
     for transfer_status in queryset:


### PR DESCRIPTION
### 📣 Summary
Ensure that project transfers only begin after the recipient has accepted the invitation, preventing projects from being moved before the transfer is authorized.

### Notes
This PR also contains an adjustment to ensure that invitations that are auto-accepted are marked as accepted as soon as they are created to avoid getting stuck in "pending" if the task fails.

### 👀 Preview steps

1. ℹ️ have an account (userA) and a project
2. Transfer the project to userB
3. Do NOT click on the link in the email userB received for the transfer 
4. Wait for several minutes 
5. 🔴 [on release] Refresh userB's project list and see the project has been transferred 
6. 🔴 [on release] Try to click on the link (logged in as userB) and receive an error that the invite has expired 
7. 🟢 [on pr] Refresh userB's project list and see the project has NOT been transferred 
8. 🟢 [on pr] Try to click on the link (logged in as userB) and successfully transfer the project 

To test org invitations:
1. Have an account with an mmo
2. Have another account with a project
3. Invite userB to the mmo
4. Update `project_ownership.utils.create_invite` to error just outside of the transaction block (eg by adding `x = 1/0`)
5. Restart the kpi_worker
6. As userB, accept the invite
7. Remove the error line
8. Restart the kpi_worker
9. Notice the transfer is restarted and successfully completes
