### PR TITLE
fix(userReports): fix duplicated `social_accounts` in `/api/v2/user-reports/` DEV-1490

### DIFF
--- a/kobo/apps/user_reports/migrations/0004_fix_social_accounts_aggregation.py
+++ b/kobo/apps/user_reports/migrations/0004_fix_social_accounts_aggregation.py
@@ -1,0 +1,46 @@
+# flake8: noqa: E501
+from django.conf import settings
+from django.db import migrations
+
+from kobo.apps.user_reports.utils.migrations import (
+    CREATE_INDEXES_SQL,
+    CREATE_MV_SQL,
+    DROP_MV_SQL,
+)
+
+
+def apply_fix(apps, schema_editor):
+    if getattr(settings, 'SKIP_HEAVY_MIGRATIONS', False):
+        print(
+            f"""
+            ⚠️ ATTENTION ⚠️
+            Drop the existing materialized view
+
+            {DROP_MV_SQL}
+
+            Run the SQL query below in PostgreSQL directly to create the materialized view:
+
+            {CREATE_MV_SQL}
+
+            Then run the SQL query below to create the indexes:
+
+            {CREATE_INDEXES_SQL}
+
+            """.replace(
+                'CREATE UNIQUE INDEX', 'CREATE UNIQUE INDEX CONCURRENTLY'
+            )
+        )
+        return
+
+    schema_editor.execute(DROP_MV_SQL)
+    schema_editor.execute(CREATE_MV_SQL)
+    schema_editor.execute(CREATE_INDEXES_SQL)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [('user_reports', '0003_fix_user_role_scopping')]
+
+    operations = [
+        migrations.RunPython(apply_fix, reverse_code=migrations.RunPython.noop),
+    ]

--- a/kobo/apps/user_reports/tests/test_user_reports.py
+++ b/kobo/apps/user_reports/tests/test_user_reports.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
+from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
@@ -116,6 +117,54 @@ class UserReportsViewSetAPITestCase(BaseTestCase):
             user_with_sub['subscriptions'][0]['metadata']['organization_id'],
             self.subscription.metadata['organization_id'],
         )
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
+    def test_social_accounts_are_not_duplicated_with_multiple_subscriptions(self):
+        """
+        Ensure that social accounts are not duplicated when a user is attached to
+        multiple subscriptions
+        """
+        from djstripe.enums import BillingScheme
+        from djstripe.models import Customer
+
+        SocialAccount.objects.create(
+            user=self.someuser,
+            provider='acted',
+            uid='test-social-uid',
+        )
+
+        customer = baker.make(Customer, subscriber=self.organization)
+
+        # Create two subscriptions for same organization
+        baker.make(
+            'djstripe.Subscription',
+            customer=customer,
+            items__price__livemode=False,
+            items__price__billing_scheme=BillingScheme.per_unit,
+            livemode=False,
+            metadata={'organization_id': str(self.organization.id)},
+        )
+        baker.make(
+            'djstripe.Subscription',
+            customer=customer,
+            items__price__livemode=False,
+            items__price__billing_scheme=BillingScheme.per_unit,
+            livemode=False,
+            metadata={'organization_id': str(self.organization.id)},
+        )
+
+        refresh_user_reports_materialized_view(concurrently=False)
+
+        data = self._get_someuser_data()
+
+        social = data['social_accounts']
+        subs = data['subscriptions']
+
+        self.assertEqual(len(subs), 2)
+        self.assertEqual(len(social), 1)
+        self.assertEqual(social[0]['uid'], 'test-social-uid')
 
     def test_service_usage_data_is_correctly_returned(self):
         """

--- a/kobo/apps/user_reports/utils/migrations.py
+++ b/kobo/apps/user_reports/utils/migrations.py
@@ -108,15 +108,19 @@ CREATE_MV_BASE_SQL = f"""
             WHERE ued_tos.user_id = au.id
             AND ued_tos.private_data ? 'last_tos_accept_time'
         ) AS accepted_tos,
-        COALESCE(
-            jsonb_agg(
-                jsonb_build_object(
-                    'id', sa.id,
-                    'provider', sa.provider,
-                    'uid', sa.uid
-                )
-            ) FILTER (WHERE sa.id IS NOT NULL),
-            '[]'::jsonb
+        (
+            SELECT COALESCE(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id', s.id,
+                        'provider', s.provider,
+                        'uid', s.uid
+                    )
+                ),
+                '[]'::jsonb
+            )
+            FROM socialaccount_socialaccount s
+            WHERE s.user_id = au.id
         ) AS social_accounts,
         CASE
             WHEN org.id IS NOT NULL THEN jsonb_build_object(


### PR DESCRIPTION
### 📣 Summary
This PR fixes an issue where `social_accounts` in the `/api/v2/user-reports` API response could contain duplicate entries when a user had multiple subscriptions. The duplication was caused by JOIN fan-out in the materialized view and the use of jsonb_agg over the joined rowset.


### 📖 Description
Previously, the user reports could produce duplicates for connected social accounts under certain subscription scenarios. The underlying data was correct, but the way it was aggregated internally caused the duplication. The aggregation has now been corrected so that each linked social account appears only once, regardless of subscription count.

See [Linear](https://linear.app/kobotoolbox/issue/DEV-1490/duplicate-social-accounts-id-in-apiv2user-reports) for more context on this.

### 👀 Preview steps

1. Apply the latest migration
2. 🔴  [On main] Note that the API returns duplicated social accounts when a user has multiple subscriptions
3. 🟢  [On PR] The API returns only the correct single record
