### PR TITLE
fix(processing): optimistically update automated transx DEV-1675

### DIFF
--- a/jsapp/js/api/mutation-defaults/survey-data.ts
+++ b/jsapp/js/api/mutation-defaults/survey-data.ts
@@ -291,6 +291,20 @@ queryClient.setMutationDefaults(
           }
         }
       },
+      /**
+       * Good example of a Direct Update, for cases when mutation returns the whole response.
+       *
+       * Note: use `onSettled` instead of `onSuccess` to be executed AFTER global invalidation logic
+       * in order to cancel it. See more `onSettledInvalidateSnapshots`.
+       *
+       * See more at https://tkdodo.eu/blog/mastering-mutations-in-react-query#direct-updates
+       */
+      onSettled: async (response, error, { rootUuid, uidAsset }, _context) => {
+        if (error) return
+        const queryKey = getAssetsDataSupplementRetrieveQueryKey(uidAsset, rootUuid)
+        queryClient.cancelQueries({ queryKey, exact: true })
+        queryClient.setQueryData(queryKey, response)
+      },
     },
   }),
 )

--- a/jsapp/js/api/queryClient.ts
+++ b/jsapp/js/api/queryClient.ts
@@ -28,6 +28,9 @@ const onErrorRestoreSnapshots = (
  * - If server response will match current cache, then not even a re-render will happen. Better be safe and confirm.
  * - If server response will NOT match current cache, then it will update cache and re-render accordingly.
  *
+ * Note: global and query's `onSuccess` is called BEFORE global and query's `onSettled`.
+ * In order to cancel invalidation's query, it must be within `onSettled`.
+ *
  * To be used together with {@link optimisticallyUpdateList} and {@link optimisticallyUpdateItem}.
  */
 const onSettledInvalidateSnapshots = (
@@ -41,7 +44,6 @@ const onSettledInvalidateSnapshots = (
   // re-fetch of current invalidation may overwrite next mutation's optimistic update with outdated value.
   // See more at https://tkdodo.eu/blog/concurrent-optimistic-updates-in-react-query.
   if (queryClient.isMutating({ mutationKey: mutation.options.mutationKey }) !== 1) return
-
   for (const [snapshotKey] of (context as CommonContext)?.snapshots ?? [])
     queryClient.invalidateQueries({ queryKey: snapshotKey })
 }


### PR DESCRIPTION
### 💭 Notes

Frontend can't guess what backend would return on success, so always pretend that the initial response is "in_progress".

It's ok in both scenarios where backend instantly returns and "overwrites" the latest version, or actually goes into "in_progress" and pushes a new latest version, because frontend cares only about the latest version.

It fixes nothing on it's own, but enables unblocks other issues that will depend on this.

### 👀 Preview steps

1. ℹ️ have an account and a project and a submission with an audio
2. add this console.log to `processing/index.tsx`:
    ```
      console.log(supplement['Use_the_camera_s_mic_ne_to_record_a_sound']['automatic_google_transcription'])
    ```
2. create automatic transcription
4. 🔴 [on main] notice that nothing logs while it loads.
5. 🟢 [on PR] notice that it instantly logs another version with "in_progress" status.
