### PR TITLE
fix(processing): preselect latest translation (automatic or manual) DEV-1678 DEV-1656

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationEdit/HeaderLanguageAndDate.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationEdit/HeaderLanguageAndDate.tsx
@@ -3,7 +3,7 @@ import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import { AsyncLanguageDisplayLabel } from '#/components/languages/languagesUtils'
 import type { TranslationVersionItem } from '#/components/processing/common/types'
-import { isSupplementVersionWithValue } from '#/components/processing/common/utils'
+import { TransxVersionSortFunction, isSupplementVersionWithValue } from '#/components/processing/common/utils'
 import bodyStyles from '../../../common/processingBody.module.scss'
 import TransxSelector from '../../../components/transxSelector'
 import TransxDate from '../../components/transxDate'
@@ -23,7 +23,10 @@ export default function HeaderLanguageAndDate({
   translationVersions,
   onChangeLanguageCode,
 }: Props) {
-  const existingTranslations = translationVersions?.filter(isSupplementVersionWithValue)
+  const existingTranslations = translationVersions
+    ?.filter(isSupplementVersionWithValue)
+    .sort(TransxVersionSortFunction)
+    .reverse()
 
   return (
     <React.Fragment>

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -54,7 +54,7 @@ export const isSupplementVersionAutomatic = (
  * @param b - Second version item
  * @returns Comparison result for sorting
  */
-const TransxVersionSortFunction = (a: TransxVersionItem, b: TransxVersionItem): number => {
+export const TransxVersionSortFunction = (a: TransxVersionItem, b: TransxVersionItem): number => {
   return a._dateCreated < b._dateCreated ? 1 : -1
 }
 
@@ -236,10 +236,12 @@ export const getAutomaticTranslationsFromSupplementData = (
 export const getLatestAutomaticTranslationVersionItem = (
   supplementData: DataSupplementResponse,
   xpath: string,
-  languageCode: LanguageCode,
+  languageCode?: LanguageCode,
+  includeWithoutValue = true,
 ): TranslationVersionItem | undefined => {
-  const allTranslations = getAllTranslationsFromSupplementData(supplementData, xpath, true)
-  return allTranslations.find((translation) => translation._data.language === languageCode)
+  const allTranslations = getAllTranslationsFromSupplementData(supplementData, xpath, includeWithoutValue)
+  const filtered = allTranslations.filter((translation) => !languageCode || translation._data.language === languageCode)
+  return filtered.sort(TransxVersionSortFunction)[0] as TranslationVersionItem | undefined
 }
 
 /**
@@ -253,7 +255,7 @@ export const getLatestAutomaticTranslationVersionItem = (
 export const getAllTranslationsFromSupplementData = (
   supplementData: DataSupplementResponse,
   xpath: string,
-  includeWithoutValue?: true,
+  includeWithoutValue = true,
 ): TranslationVersionItem[] => {
   const translations = [
     getManualTranslationsFromSupplementData(supplementData, xpath),


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
- Fixed loading of the latest valid (non deleted/with value) translation when none other is selected. 
- That also affects the preselected translation, displaying the "pending" automatic translation
- After a save, I'm now forcing an invalidation of the currently selected language to display the latest (the recently saved) translation
- I've added sorting to the translation list to display it in order. This makes it easier to visualize and check if existing translations and deleting are behaving as should

### 👀 Preview steps
1. ℹ️ have an account, project, audio data and transcription generated
2. Open translation Tab
5. 🟢 [on PR] Latest translation should appear if any exists
6. Add an automatic translation, wait for the generation and press Save
7. 🟢 [on PR] The recently saved translation should be selected and displayed
