### PR TITLE
feat(qual): add new addon category for automatic qa DEV-1082

### DIFF
--- a/jsapp/js/account/addOns/addOnProductRow.component.tsx
+++ b/jsapp/js/account/addOns/addOnProductRow.component.tsx
@@ -27,7 +27,7 @@ export const AddOnProductRow = ({
   organization,
   isRecurring,
   displayName,
-  description
+  description,
 }: AddOnProductRowProps) => {
   const [selectedProduct, setSelectedProduct] = useState(products[0])
   const [selectedPrice, setSelectedPrice] = useState<Product['prices'][0]>(selectedProduct.prices[0])

--- a/jsapp/js/account/addOns/addOns.component.tsx
+++ b/jsapp/js/account/addOns/addOns.component.tsx
@@ -67,7 +67,7 @@ export default function addOns() {
   }
 
   function ActivePreviousAddons(
-    addOns: SubscriptionInfo[],
+    recurringAddOns: SubscriptionInfo[],
     oneTimeAddOns: OneTimeAddOn[],
     activeStatus: string,
     available: boolean,
@@ -81,7 +81,7 @@ export default function addOns() {
           <label className={styles.addOnsHeader}>{label}</label>
         </caption>
         <tbody>
-          {addOns.map((product) => {
+          {recurringAddOns.map((product) => {
             if (product.status === activeStatus) {
               return (
                 <tr className={styles.row} key={product.id}>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Adds a new row to the list of addons on the addon page to display addons for automatic QA.

### 💭 Notes
I did some refactoring to the AddonProductRow sub-component. We aren't iterating over an unknown list of addon products, so it makes more sense to set the description and label when instantiating the component rather than having the component figure out what to do itself. 

Also note that I am restricting the scope of work here to addons page. There will be some other work required to make sure we are calculating usage/limit display values correctly in other parts of the app, but I will do that separately.

### 👀 Preview steps

1. On a stripe-enabled and synced (just Price and Product are necessary) instance, navigate to the addons page.
2. See the new addon category for "Automatic analysis requests"
3. Purchase an addon
4. Sync with Stripe and navigate back to addons page. Note: To sync one-time addons (after purchase) you need to sync the stripe models for PaymentIntent and Charge. I highly recommend doing this [manually from the django shell](https://www.notion.so/kobotoolbox/Setting-Up-Stripe-9a958a84d6324ec8a4ca887b820eb8cf?source=copy_link#af89c0f8ab944c1bb8ea26a218e12000). Otherwise, if you use djstripe_sync_models, go get a cup of coffee or something because it will take ~10 minutes. 
5. See the purchased addon at the bottom of the page 
