### PR TITLE
fix(billing): remove handling for grandfathered free tier DEV-1731 

### DIFF
--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -13,7 +13,6 @@ import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import Button from '#/components/common/ButtonNew'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import { ACTIVE_STRIPE_STATUSES } from '#/constants'
-import type { FreeTierThresholds } from '#/envStore'
 import envStore from '#/envStore'
 import { useRefreshApiFetcher } from '#/hooks/useRefreshApiFetcher.hook'
 import useWhen from '#/hooks/useWhen.hook'
@@ -42,11 +41,6 @@ type DataUpdates =
   | {
       type: 'month' | 'year'
     }
-
-export interface FreeTierOverride extends FreeTierThresholds {
-  name: string | null
-  [key: `feature_list_${number}`]: string | null
-}
 
 const initialState: PlanState = {
   subscribedProduct: null,
@@ -123,25 +117,6 @@ export default function Plan() {
     (subscription: SubscriptionInfo) => ACTIVE_STRIPE_STATUSES.includes(subscription.status),
     [],
   )
-
-  const freeTierOverride = useMemo((): FreeTierOverride | null => {
-    if (envStore.isReady) {
-      const thresholds = envStore.data.free_tier_thresholds
-      const display = envStore.data.free_tier_display
-      const featureList: { [key: string]: string | null } = {}
-
-      display.feature_list.forEach((feature, key) => {
-        featureList[`feature_list_${key + 1}`] = feature
-      })
-
-      return {
-        name: display.name,
-        ...thresholds,
-        ...featureList,
-      }
-    }
-    return null
-  }, [envStore.isReady])
 
   const hasActiveSubscription = useMemo(() => {
     if (state.subscribedProduct) {
@@ -408,7 +383,6 @@ export default function Plan() {
                 <div className={styles.stripePlans} key={product.id}>
                   <PlanContainer
                     key={product.price.id}
-                    freeTierOverride={freeTierOverride}
                     expandComparison={expandComparison}
                     isSubscribedProduct={isSubscribedProduct}
                     product={product}

--- a/jsapp/js/account/plans/planContainer.component.tsx
+++ b/jsapp/js/account/plans/planContainer.component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 
 import classnames from 'classnames'
-import type { FreeTierOverride, PlanState } from '#/account/plans/plan.component'
+import type { PlanState } from '#/account/plans/plan.component'
 import styles from '#/account/plans/plan.module.scss'
 import { PlanButton } from '#/account/plans/planButton.component'
 import { useDisplayPrice } from '#/account/plans/useDisplayPrice.hook'
@@ -14,7 +14,6 @@ interface PlanContainerProps {
   product: SinglePricedProduct
   isDisabled: boolean
   isSubscribedProduct: (product: SinglePricedProduct) => boolean
-  freeTierOverride: FreeTierOverride | null
   expandComparison: boolean
   state: PlanState
   filteredPriceProducts: SinglePricedProduct[]
@@ -27,7 +26,6 @@ interface PlanContainerProps {
 export const PlanContainer = ({
   product,
   state,
-  freeTierOverride,
   expandComparison,
   filteredPriceProducts,
   isDisabled,
@@ -60,12 +58,8 @@ export const PlanContainer = ({
 
   const isDowngrading = useMemo(() => isDowngrade(activeSubscriptions, product.price), [activeSubscriptions, product])
 
-  const getFeatureMetadata = (product: SinglePricedProduct, featureItem: string) => {
-    if (product.price.unit_amount === 0 && freeTierOverride && freeTierOverride.hasOwnProperty(featureItem)) {
-      return freeTierOverride[featureItem as keyof FreeTierOverride]
-    }
-    return product.price.metadata?.[featureItem] || product.metadata[featureItem]
-  }
+  const getFeatureMetadata = (product: SinglePricedProduct, featureItem: string) =>
+    product.price.metadata?.[featureItem] || product.metadata[featureItem]
 
   const renderFeaturesList = (
     items: Array<{
@@ -147,9 +141,7 @@ export const PlanContainer = ({
         })}
       >
         <div className={styles.planDetailsContainer}>
-          <h1 className={styles.priceName}>
-            {product.price?.unit_amount ? product.name : freeTierOverride?.name || product.name}
-          </h1>
+          <h1 className={styles.priceName}>{product.name}</h1>
           <div className={styles.priceTitle}>{displayPrice}</div>
           <ul className={styles.featureContainer}>
             {recordKeys(product.metadata).map(

--- a/jsapp/js/account/subscriptionStore.ts
+++ b/jsapp/js/account/subscriptionStore.ts
@@ -3,7 +3,6 @@ import { PlanNames, type Product, type SubscriptionInfo } from '#/account/stripe
 import { fetchGet, handleApiFail } from '#/api'
 import { ACTIVE_STRIPE_STATUSES, ROOT_URL } from '#/constants'
 import type { PaginatedResponse } from '#/dataInterface'
-import envStore from '#/envStore'
 
 const PRODUCTS_URL = '/api/v2/stripe/products/'
 
@@ -44,14 +43,13 @@ class SubscriptionStore {
   /*
    * The plan name displayed to the user. This will display, in order of precedence:
    * * The user's active plan subscription
-   * * The FREE_TIER_DISPLAY["name"] setting (if the user registered before FREE_TIER_CUTOFF_DATE
    * * The free plan
    */
   public get planName() {
     if (this.planResponse.length && this.planResponse[0].items.length) {
       return this.planResponse[0].items[0].price.product.name
     }
-    return envStore.data?.free_tier_display?.name || PlanNames.FREE
+    return PlanNames.FREE
   }
 
   private onFetchSubscriptionInfoDone(response: PaginatedResponse<SubscriptionInfo>) {

--- a/jsapp/js/endpoints/environment.mocks.ts
+++ b/jsapp/js/endpoints/environment.mocks.ts
@@ -22,16 +22,6 @@ const environmentResponse: EnvironmentResponse = {
   frontend_max_retry_time: 120,
   use_team_label: true,
   usage_limit_enforcement: false,
-  free_tier_display: {
-    name: null,
-    feature_list: [],
-  },
-  free_tier_thresholds: {
-    storage: null,
-    data: null,
-    transcription_minutes: null,
-    translation_chars: null,
-  },
   sector_choices: [
     ['Public Administration', 'Public Administration'],
     ['Arts, Entertainment, and Recreation', 'Arts, Entertainment, and Recreation'],

--- a/jsapp/js/envStore.ts
+++ b/jsapp/js/envStore.ts
@@ -31,8 +31,6 @@ export interface EnvironmentResponse {
   mfa_code_length: number
   stripe_public_key: string | null
   social_apps: SocialApp[]
-  free_tier_thresholds: FreeTierThresholds
-  free_tier_display: FreeTierDisplay
   enable_custom_password_guidance_text: boolean
   custom_password_localized_help_text: string
   enable_password_entropy_meter: boolean
@@ -75,18 +73,6 @@ export interface SocialApp {
   client_id: string
 }
 
-export interface FreeTierThresholds {
-  storage: number | null
-  data: number | null
-  transcription_minutes: number | null
-  translation_chars: number | null
-}
-
-export interface FreeTierDisplay {
-  name: string | null
-  feature_list: [string] | []
-}
-
 type ProjectMetadataFieldKey = 'description' | 'sector' | 'country' | 'operational_purpose' | 'collects_pii'
 
 export class EnvStoreData {
@@ -118,13 +104,6 @@ export class EnvStoreData {
   public mfa_code_length = 6
   public stripe_public_key: string | null = null
   public social_apps: SocialApp[] = []
-  public free_tier_thresholds: FreeTierThresholds = {
-    storage: null,
-    data: null,
-    transcription_minutes: null,
-    translation_chars: null,
-  }
-  public free_tier_display: FreeTierDisplay = { name: null, feature_list: [] }
   public enable_custom_password_guidance_text = false
   public custom_password_localized_help_text = ''
   public enable_password_entropy_meter = false
@@ -219,8 +198,6 @@ class EnvStore {
     this.data.mfa_code_length = response.mfa_code_length
     this.data.stripe_public_key = response.stripe_public_key
     this.data.social_apps = response.social_apps
-    this.data.free_tier_thresholds = response.free_tier_thresholds
-    this.data.free_tier_display = response.free_tier_display
     this.data.open_rosa_server = response.open_rosa_server
 
     this.data.allow_self_account_deletion = Boolean(response.allow_self_account_deletion)

--- a/kobo/apps/stripe/constants.py
+++ b/kobo/apps/stripe/constants.py
@@ -7,16 +7,4 @@ ACTIVE_STRIPE_STATUSES = [
     'trialing',
 ]
 
-FREE_TIER_NO_THRESHOLDS = {
-    'storage': None,
-    'data': None,
-    'transcription_minutes': None,
-    'translation_chars': None,
-}
-
-FREE_TIER_EMPTY_DISPLAY = {
-    'name': None,
-    'feature_list': [],
-}
-
 ORGANIZATION_USAGE_MAX_CACHE_AGE = timedelta(minutes=15)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -3,7 +3,7 @@ import os
 import string
 import subprocess
 import warnings
-from datetime import datetime, timedelta
+from datetime import timedelta
 from mimetypes import add_type
 from urllib.parse import quote_plus
 
@@ -16,7 +16,6 @@ from django.utils.translation import get_language_info
 from django.utils.translation import gettext_lazy as t
 from pymongo import MongoClient
 
-from kobo.apps.stripe.constants import FREE_TIER_EMPTY_DISPLAY, FREE_TIER_NO_THRESHOLDS
 from kpi.constants import PERM_DELETE_ASSET, PERM_MANAGE_ASSET
 from kpi.utils.json import LazyJSONSerializable
 
@@ -438,26 +437,6 @@ CONSTANCE_CONFIG = {
         'Number of days to keep submission history',
         'positive_int',
     ),
-    'FREE_TIER_THRESHOLDS': (
-        LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS),
-        'Free tier thresholds: storage in kilobytes, '
-        'data (number of submissions), '
-        'minutes of transcription, '
-        'number of translation characters',
-        # Use custom field for schema validation
-        'free_tier_threshold_jsonschema',
-    ),
-    'FREE_TIER_DISPLAY': (
-        LazyJSONSerializable(FREE_TIER_EMPTY_DISPLAY),
-        'Free tier frontend settings: name to use for the free tier, '
-        'array of text strings to display on the feature list of the Plans page',
-        'free_tier_display_jsonschema',
-    ),
-    'FREE_TIER_CUTOFF_DATE': (
-        datetime(2050, 1, 1).date(),
-        'Users on the free tier who registered before this date will\n'
-        'use the custom plan defined by FREE_TIER_DISPLAY and FREE_TIER_LIMITS.',
-    ),
     'PROJECT_TRASH_RETENTION': (
         7,
         'Number of days to keep projects in trash after users (soft-)deleted '
@@ -677,14 +656,6 @@ CONSTANCE_CONFIG = {
 }
 
 CONSTANCE_ADDITIONAL_FIELDS = {
-    'free_tier_threshold_jsonschema': [
-        'kpi.fields.jsonschema_form_field.FreeTierThresholdField',
-        {'widget': 'django.forms.Textarea'},
-    ],
-    'free_tier_display_jsonschema': [
-        'kpi.fields.jsonschema_form_field.FreeTierDisplayField',
-        {'widget': 'django.forms.Textarea'},
-    ],
     'i18n_text_jsonfield_schema': [
         'kpi.fields.jsonschema_form_field.I18nTextJSONField',
         {'widget': 'django.forms.Textarea'},
@@ -810,11 +781,6 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'ASSET_SNAPSHOT_DAYS_RETENTION',
         'IMPORT_TASK_DAYS_RETENTION',
         'SUBMISSION_HISTORY_RETENTION',
-    ),
-    'Tier settings': (
-        'FREE_TIER_THRESHOLDS',
-        'FREE_TIER_DISPLAY',
-        'FREE_TIER_CUTOFF_DATE',
     ),
 }
 

--- a/kpi/fields/jsonschema_form_field.py
+++ b/kpi/fields/jsonschema_form_field.py
@@ -27,54 +27,6 @@ class JsonSchemaFormField(CharField):
         return value
 
 
-class FreeTierThresholdField(JsonSchemaFormField):
-    """
-    Validates that the input has required properties with expected types
-    """
-
-    def __init__(self, *args, **kwargs):
-        schema = {
-            'type': 'object',
-            'uniqueItems': True,
-            'properties': {
-                'storage': {'type': ['integer', 'null']},
-                'data': {'type': ['integer', 'null']},
-                'transcription_minutes': {'type': ['integer', 'null']},
-                'translation_chars': {'type': ['integer', 'null']},
-            },
-            'required': [
-                'storage',
-                'data',
-                'transcription_minutes',
-                'translation_chars',
-            ],
-            'additionalProperties': False,
-        }
-        super().__init__(*args, schema=schema, **kwargs)
-
-
-class FreeTierDisplayField(JsonSchemaFormField):
-    """
-    Validates that the input has required properties with expected types
-    """
-
-    def __init__(self, *args, **kwargs):
-        schema = {
-            'type': 'object',
-            'uniqueItems': True,
-            'properties': {
-                'name': {'type': ['string', 'null']},
-                'feature_list': {
-                    'type': 'array',
-                    'items': {'type': 'string'},
-                },
-            },
-            'required': ['name', 'feature_list'],
-            'additionalProperties': False,
-        }
-        super().__init__(*args, schema=schema, **kwargs)
-
-
 class I18nTextJSONField(JsonSchemaFormField):
     """
     Validates that the input is an object which contains at least the 'default'

--- a/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
+++ b/kpi/migrations/0051_set_free_tier_thresholds_to_default.py
@@ -1,15 +1,8 @@
-from constance import config
 from django.db import migrations
 
-from kobo.apps.stripe.constants import FREE_TIER_NO_THRESHOLDS
-from kpi.utils.json import LazyJSONSerializable
 
-
-def reset_free_tier_thresholds(apps, schema_editor):
-    # The constance defaults for FREE_TIER_THRESHOLDS changed, so we set existing config to the new default value
-    setattr(config, 'FREE_TIER_THRESHOLDS', LazyJSONSerializable(FREE_TIER_NO_THRESHOLDS))
-
-
+# The free tier option for older users is no longer offered,
+# so the migration here has been removed
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -18,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            reset_free_tier_thresholds,
+            migrations.RunPython.noop,
             migrations.RunPython.noop,
         )
     ]


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Remove code for setting/handling "free tier" subscriptions.

### 📖 Description
When we initially introduced our current subscription system, we added a "free tier" plan as an interim option for users who registered before the new system went into effect. That time has passed and we no longer need the related code.

### 💭 Notes
Especially on the frontend, the name "free tier" is very confusing because we still have a free tier. When a user doesn't have a subscription, they are by default considered to be on our default "community" plan, which is free. You can see in some of the frontend code I deleted that even I was confused about this in the past.

### 👀 Preview steps
The goal here is for nothing to change. No one is eligible for the old "free tier" plan anymore, so we just want to make sure removing the code doesn't change anything for community plan users. 

1. On a stripe-enabled and synced and nlp-enabled instance, create an account
2. Make a project with an audio question, submit a short audio response, and make an automatic translation 
3. Observe that your usage page reflects standard community plan limits and usage relative to those limits
4. Purchase a file storage addon and a recurring NLP addon
5. Repeat step 3