### PR TITLE
chore(biome): constraint run to jsapp folder DEV-1746

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,21 +1,15 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
+    "include": ["jsapp/**"],
     "ignore": [
-      "node_modules/**",
       "jsapp/compiled/**",
       "*.css",
-      // Ignore generated OpenAPI schema.
-      "static/openapi/*",
       // Ignore minified committed JS files.
       "*.min.js",
       "*-min.js",
       "bootstrap*.js",
-      "jquery*.js",
-      "kobo/apps/openrosa/apps/logger/fixtures/*",
-      "kpi/static/js/swagger/swagger-ui-bundle.js",
-      "kpi/static/js/swagger/swagger-ui-standalone-preset.js",
-      "msw-mocks/*"
+      "jquery*.js"
     ]
   },
   "vcs": {


### PR DESCRIPTION
### 💭 Notes
- added jsapp as the included files folder
- removed the excluded filters that are not affected anymore

### 👀 Preview steps
1. ℹ️ make Biome linting mistakes out of jsapp folder
2. run Biome
4. 🔴 [on main] notice that Biome points out the error
5. 🟢 [on PR] notice that Biome won't check the file anymore
