### PR TITLE
fix(userReports): fix missing subscription for orgs when stripe metadata lacks `organization_id` DEV-1735

### DIFF
--- a/kobo/apps/user_reports/migrations/0005_fix_infinite_usage_and_last_updated.py
+++ b/kobo/apps/user_reports/migrations/0005_fix_infinite_usage_and_last_updated.py
@@ -1,41 +1,5 @@
 # flake8: noqa: E501
-from django.conf import settings
 from django.db import migrations
-
-from kobo.apps.user_reports.utils.migrations import (
-    CREATE_INDEXES_SQL,
-    CREATE_MV_SQL,
-    DROP_MV_SQL,
-)
-
-
-def apply_fix(apps, schema_editor):
-    if getattr(settings, 'SKIP_HEAVY_MIGRATIONS', False):
-        print(
-            f"""
-            ⚠️ ATTENTION ⚠️
-            Drop the existing materialized view
-
-            {DROP_MV_SQL}
-
-            Run the SQL query below in PostgreSQL directly to create the materialized view:
-
-            {CREATE_MV_SQL}
-
-            Then run the SQL query below to create the indexes:
-
-            {CREATE_INDEXES_SQL}
-
-            """.replace(
-                'CREATE UNIQUE INDEX', 'CREATE UNIQUE INDEX CONCURRENTLY'
-            )
-        )
-        return
-
-    # This pulls the *latest* SQL from your updated migrations.py
-    schema_editor.execute(DROP_MV_SQL)
-    schema_editor.execute(CREATE_MV_SQL)
-    schema_editor.execute(CREATE_INDEXES_SQL)
 
 
 class Migration(migrations.Migration):
@@ -43,5 +7,5 @@ class Migration(migrations.Migration):
     dependencies = [('user_reports', '0004_fix_social_accounts_aggregation')]
 
     operations = [
-        migrations.RunPython(apply_fix, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(migrations.RunPython.noop, migrations.RunPython.noop),
     ]

--- a/kobo/apps/user_reports/migrations/0006_fix_org_subscriptions_missing_metadata.py
+++ b/kobo/apps/user_reports/migrations/0006_fix_org_subscriptions_missing_metadata.py
@@ -1,0 +1,47 @@
+# flake8: noqa: E501
+from django.conf import settings
+from django.db import migrations
+
+from kobo.apps.user_reports.utils.migrations import (
+    CREATE_INDEXES_SQL,
+    CREATE_MV_SQL,
+    DROP_MV_SQL,
+)
+
+
+def apply_fix(apps, schema_editor):
+    if getattr(settings, 'SKIP_HEAVY_MIGRATIONS', False):
+        print(
+            f"""
+            ⚠️ ATTENTION ⚠️
+            Drop the existing materialized view
+
+            {DROP_MV_SQL}
+
+            Run the SQL query below in PostgreSQL directly to create the materialized view:
+
+            {CREATE_MV_SQL}
+
+            Then run the SQL query below to create the indexes:
+
+            {CREATE_INDEXES_SQL}
+
+            """.replace(
+                'CREATE UNIQUE INDEX', 'CREATE UNIQUE INDEX CONCURRENTLY'
+            )
+        )
+        return
+
+    # This pulls the *latest* SQL from your updated migrations.py
+    schema_editor.execute(DROP_MV_SQL)
+    schema_editor.execute(CREATE_MV_SQL)
+    schema_editor.execute(CREATE_INDEXES_SQL)
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [('user_reports', '0005_fix_infinite_usage_and_last_updated')]
+
+    operations = [
+        migrations.RunPython(apply_fix, reverse_code=migrations.RunPython.noop),
+    ]

--- a/kobo/apps/user_reports/utils/migrations.py
+++ b/kobo/apps/user_reports/utils/migrations.py
@@ -428,8 +428,8 @@ NO_STRIPE_SUBSCRIPTIONS = """
     """
 
 STRIPE_JOINS = """
-    LEFT JOIN djstripe_subscription sub ON sub.metadata->>'organization_id' = org.id::text
-    LEFT JOIN djstripe_customer cust ON sub.customer_id = cust.id
+    LEFT JOIN djstripe_customer cust ON cust.subscriber_id = org.id::text
+    LEFT JOIN djstripe_subscription sub ON sub.customer_id = cust.id
     """
 
 NO_STRIPE_JOINS = ''


### PR DESCRIPTION
### 📣 Summary
Fixed an issue where subscriptions were not displaying in user reports if the Stripe subscription metadata was missing or incomplete.

### 📖 Description
Previously, the user reports relied on a specific metadata field (`organization_id`) within the Stripe subscription object to link it to an organization. This caused valid subscriptions created without this metadata such as those created manually via the Stripe Dashboard to be hidden from reports.

This update changes the SQL join logic in the materialized view to use the native relationship between the Stripe Customer and the Organization (`subscriber_id`). This ensures all valid subscriptions are correctly identified and displayed, regardless of whether the `organization_id` metadata tag is present on the subscription object.