### PR TITLE
chore(drf-spectacular): add local url for kobo-compose for schema generation

### DIFF
--- a/kpi/utils/schema_extensions/url_builder.py
+++ b/kpi/utils/schema_extensions/url_builder.py
@@ -20,6 +20,7 @@ def build_url_type(viewname: str, **kwargs) -> dict:
     DEV_DOMAIN_NAMES = [
         'http://kpi',
         'http://kf.kobo.local',
+        'http://kf.kobo.local:8080',
         'http://kf.kobo.localhost',
     ]
 


### PR DESCRIPTION
### 💭 Notes
Allows devs who use kobo-compose to run `generate_api.sh` 
