### PR TITLE
fix(migration): prevent OOM crashes and race conditions in long running migrations DEV-1745

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0011_backfill_exceeded_limit_counters.py
+++ b/kobo/apps/long_running_migrations/jobs/0011_backfill_exceeded_limit_counters.py
@@ -8,26 +8,24 @@ from kobo.apps.stripe.utils.limit_enforcement import check_exceeded_limit
 if settings.STRIPE_ENABLED:
     from kobo.apps.stripe.models import ExceededLimitCounter
 
-CHUNK_SIZE = 1000
-
 
 def process_user(user_id, username):
-    try:
-        user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
-        print(f'Race condition catched: user_id={user_id} no longer exists')
+    if not User.objects.filter(pk=user_id).exists():
+        print(f'Race condition catched: User(pk={user_id}) no longer exists')
         return 0
-    
+
     print(f'Checking exceeded limits for {username}...')
     counter = ExceededLimitCounter.objects.filter(
         user_id=user_id,
         limit_type=UsageType.STORAGE_BYTES,
     ).first()
+
+    user = User.objects.get(pk=user_id)
     if counter is None:
         counter = check_exceeded_limit(user, UsageType.STORAGE_BYTES)
-
     user.extra_details.data['done_storage_limits_check'] = True
     user.extra_details.save()
+
     return 1 if counter is None else 0
 
 
@@ -41,7 +39,7 @@ def get_queryset(from_user_pk: int) -> QuerySet:
             # Filter out users that already went through the exceeded limits check
             extra_details__data__done_storage_limits_check__isnull=True,
         )
-        .values('id', 'username')[:CHUNK_SIZE]
+        .values('id', 'username')[:settings.LONG_RUNNING_MIGRATION_BATCH_SIZE]
     )
 
     return users
@@ -64,8 +62,8 @@ def run():
             break
         print(f'Processing {users_count} users from {last_pk}')
         last_pk = users[users_count - 1]['id']
-        
-        for user in users
+
+        for user in users:
             result = process_user(user['id'], user['username'])
             if type(result) is int:
                 created_counters += result


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes
Using threads in long running migrations can be a bad idea because the worker pods can crash due to high memory usage. Race conditions were also detected, described in the linear issue. This PR fixes both issues in two migration jobs: `kobo/apps/long_running_migrations/jobs/0011_backfill_exceeded_limit_counters.py` and `kobo/apps/long_running_migrations/jobs/0013_migrate_mfa_data.py`

### 👀 Preview steps
1. Ensure Stripe is enabled
 
### To test the migration  0013_migrate_mfa_data.

2. Execute this via `./manage.py shell_plus`:
``` 
In [1]: from kobo.apps.long_running_migrations.models import LongRunningMigrationStatus
In [2]: migration = LongRunningMigration.objects.get(name='0011_backfill_exceeded_limit_counters')
   ...: migration.status = LongRunningMigrationStatus.CREATED
   ...: migration.save()
In [3]: user = User.objects.filter(
   ...:     organizations_organizationuser__organizationowner__id__isnull=False,
   ...:     extra_details__data__done_storage_limits_check__isnull=True
   ...: ).first()
In [4]: user
Out[4]: <User: mfa_user_test>
```
3. If you have no users to test the migration then create one case for testing, for example you can do something like this:
```
user = User.objects.filter(
        organizations_organizationuser__organizationowner__id__isnull=False
    ).first()
if user:
    if 'done_storage_limits_check' in user.extra_details.data:
        del user.extra_details.data['done_storage_limits_check']
        user.extra_details.save()
        print(f"Cleared flag for user: {user.username}")
```
4. Execute the migration and check that the user was processed:
```
In [5]: migration.execute()
Executing migration for batch including mfa_user_test...
Processing 4 users from 0
Checking exceeded limits for mfa_user_test...
Checking exceeded limits for userplan_c...
Checking exceeded limits for userplan_e...
Checking exceeded limits for addonuser1b...
Done. Created 4 counters.

In [6]: user.refresh_from_db()
In [8]: user.extra_details.data.get('done_storage_limits_check')
Out[8]: True
```

### To test the migration  0013_migrate_mfa_data.
5. In my case, I had to run the long running migrations again because the migration 0013_migrate_mfa_data did not exist
```
migration = LongRunningMigration.objects.get(name='0013_migrate_mfa_data')
migration.status = LongRunningMigrationStatus.CREATED
migration.save()
```

6. Find users to test the migration: 
```
In [16]: user = User.objects.filter(
    ...:     mfa_methods__is_active=True,
    ...:     mfa_methods_wrapper__id__isnull=True
    ...: ).first()

In [17]: user
```

7. In my case there are no longer any users that can be migrated, so I created one:

```
username = 'test_mfa_migration'
user = User.objects.create(username=username)
user.set_password('kobo1234')
user.save()
print(f"Created user: {username}")

mfa_method = MfaMethod.objects.create(
    user=user,
    name='app',
    secret='47S5BTX6UCDYI63H', 
    is_active=True,
    is_primary=True,
)

```
9. Execute:

```

In [27]: migration.execute()
Processing 1 users from 0
Migrating MFA data for user test_mfa_migration...
Done. Migrated 1 users with Trench MFA data.

In [28]: wrapper = MfaMethodsWrapper.objects.filter(user__username='test_mfa_migration').first()

In [29]: if wrapper and wrapper.is_active:
    ...:     print("SUCCESS: User was migrated to Allauth MFA wrapper.")
SUCCESS: User was migrated to Allauth MFA wrapper.


```
