### PR TITLE
fix(submissions)!: handle duplicate UUIDs when editing submissions DEV-1751

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_instance_creation.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_instance_creation.py
@@ -296,7 +296,7 @@ class TestInstanceCreation(TestCase):
         # Simulate legacy data: remove root_uuid to create ambiguity
         Instance.objects.filter(pk=first_instance.pk).update(root_uuid=None)
 
-        # Create a duplicate instance with the same UUID (simulates old bug/race condition)
+        # Create a duplicate instance with the same UUID
         second_instance = Instance.objects.create(
             xml=xml_content,
             user=self.user,

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -1031,6 +1031,7 @@ def _get_instance_from_deprecated_id(
 
     return instance, old_uuid
 
+
 def _has_edit_xform_permission(
     request: 'rest_framework.request.Request', xform: XForm
 ) -> bool:


### PR DESCRIPTION
### 📣 Summary
⚠️ **BREAKING:** Submission edits now fail explicitly when duplicate UUIDs cannot be disambiguated, instead of silently editing the first match.

### 📖 Description
In rare cases, legacy data may contain multiple submissions with identical UUIDs. When attempting to edit such submissions, the system would fail to identify the correct submission to update, resulting in errors.

This fix introduces disambiguation logic using the `root_uuid` field to properly identify the target submission when multiple instances share the same UUID. The system now:
- Uses `root_uuid` to disambiguate when multiple submissions have the same deprecated UUID
- Properly rejects edit attempts when disambiguation is impossible (e.g., when all duplicates have null `root_uuid`)
- Raises clear error messages when conflicts cannot be resolved

### 💭 Notes
- This addresses a specific bug where editing submissions would fail with `MultipleObjectsReturned` errors
- The fix maintains backward compatibility with submissions that have null `root_uuid` values
- Added comprehensive test coverage for three scenarios:
  1. ✅ Edit succeeds when duplicate UUIDs can be disambiguated via root_uuid
  2. ❌ Edit fails when root_uuid doesn't match any duplicate
  3. ❌ Edit fails when all duplicates have null root_uuid
- The root cause was duplicate UUIDs in legacy data (pre-uniqueness enforcement)
