### PR TITLE
fix(formBuilder): use fresh asset data after creating template DEV-1758

### DIFF
--- a/jsapp/js/components/library/assetRoute.tsx
+++ b/jsapp/js/components/library/assetRoute.tsx
@@ -67,7 +67,9 @@ export default class AssetRoute extends React.Component<AssetRouteProps, AssetRo
   loadCurrentAsset() {
     const uid = getRouteAssetUid()
     if (uid) {
-      actions.resources.loadAsset({ id: uid })
+      // We need to force get the asset when visiting the route to ensure we get fresh one. Without this, navigating
+      // away from Form Buiilder here will result in cached data being displayed.
+      actions.resources.loadAsset({ id: uid }, true)
     }
   }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Due to asset caching we were displaying old data after navigating out of Form Builder and navigating back again. 

The data was not lost, i.e. saving template in Form Builder did save it on BE. The issue had potential of data loss though - when visiting Form Builder again (with cached data) it was possible to overwrite previously saved changes with older ones.

### 👀 Preview steps

1. Go to Library
2. Click "NEW" button and select "Template"
3. Add title and click "Create"
4. While in Form Builder add a question
5. Click "SAVE" and "x"
6. You end up on template page
7. 🔴 [on main] notice that in "Quick look" section it says "This template is empty."
8. 🟢 [on PR] notice that in "Quick look" section it correctly displays added question
9. Click on "Edit in Form builder" action button (top right, pencil icon)
10. You end up in Form Builder again
11. 🔴 [on main] notice that the question previously added is not there
12. 🟢 [on PR] notice that the question is there