### PR TITLE
fix(table): ensure always use fresh enketo edit url DEV-1527

### DIFF
--- a/jsapp/js/enketoHandler.tsx
+++ b/jsapp/js/enketoHandler.tsx
@@ -62,7 +62,10 @@ class EnketoHandler {
     const urlId = this._getUrlId(assetUid, submissionUid, action)
 
     const enketoPromise = new Promise((resolve, reject) => {
-      if (this._hasEnketoUrl(urlId)) {
+      // Previously we were using cached enketo urls for both view and edit. For edit it turns out that it introduced
+      // a bug - after editing submission through enketo url and going back and tried editing again - old data was being
+      // shown in enketo url. The solution is to always get fresh url.
+      if (action === EnketoActions.view && this._hasEnketoUrl(urlId)) {
         this._openEnketoUrl(urlId)
         resolve(false)
       } else {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fix a bug when editing a submission for a consecutive time and withing 30 second window - was errorenously displaying old submission data.

### 💭 Notes

`enketoHandler` is a piece of code with functionality that allows opening a submission in enketo - either for viewing or for editing. It has a built in 30 second cache. Spent some time debugging this and ended up omitting the cache for enketo editing.

### 👀 Preview steps

Testig on `main` where bug 🔴 happens:

1. Have a project (one text question is enough) with a submission
2. Go to the Project → Data → Table
3. Click the pencil icon button to edit a submission
4. Change a response and submit the edited submission
5. Close the Enketo tab as directed
6. Immediately (within 30 seconds window) click the pencil icon button for the same submission again
7. Notice your edit from step (4) does not appear
8. If you were to submit this second edit, your work from (4) would be lost

On PR in step (7) 🟢 notice edit appears correctly