### PR TITLE
fix(submissions): consolidate version inference

### DIFF
--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -74,13 +74,16 @@ def build_formpack(asset, submission_stream=None, use_all_form_versions=True):
             return submission
 
         inferred = find_matching_version_uid(
-            submission, version_ids_newest_first, _reversion_ids,
+            submission,
+            version_ids_newest_first,
+            _reversion_ids,
             _alias_to_primary,
         )
         submission[INFERRED_VERSION_ID_KEY] = (
             # Fall back on the latest version
             # TODO: log a warning?
-            inferred or version_ids_newest_first[0]
+            inferred
+            or version_ids_newest_first[0]
         )
         return submission
 

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -78,8 +78,8 @@ from kpi.models.paired_data import PairedData
 from kpi.utils.files import ExtendedContentFile
 from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
-from kpi.utils.versions import find_matching_version_uid
 from kpi.utils.object_permission import get_anonymous_user, get_database_user
+from kpi.utils.versions import find_matching_version_uid
 from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
 from ..exceptions import AttachmentUidMismatchException, BadFormatException
 from .base_backend import BaseDeploymentBackend
@@ -1538,7 +1538,10 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 reversion_map[str(v._reversion_version)] = v.uid
 
         matched_uid = find_matching_version_uid(
-            submission, uids_newest_first, reversion_map, alias_to_primary,
+            submission,
+            uids_newest_first,
+            reversion_map,
+            alias_to_primary,
         )
 
         if matched_uid:
@@ -1597,9 +1600,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                     mongo_cursor = [submission]
 
                 # Retrieve the deployed version corresponding to the submission.
-                submission_version = self._infer_submission_version(
-                    submission
-                )
+                submission_version = self._infer_submission_version(submission)
 
                 # Compute attachment xpaths from that specific form version.
                 attachment_xpaths = (

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -23,6 +23,7 @@ from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
 from kpi.utils.strings import split_lines_to_list
 from kpi.utils.urls import versioned_reverse
+from kpi.utils.versions import find_matching_version_uid
 from kpi.utils.xml import (
     edit_submission_xml,
     fromstring_preserve_root_xmlns,
@@ -30,7 +31,6 @@ from kpi.utils.xml import (
     strip_nodes,
     xml_tostring,
 )
-from kpi.utils.versions import find_matching_version_uid
 from kpi.versioning import APIV2Versioning
 
 
@@ -844,7 +844,9 @@ class FindMatchingVersionUidTestCase(TestCase):
         ordered_ids = ['v123', 'v456']
         alias_to_primary = {'v456': 'v123'}
         result = find_matching_version_uid(
-            submission, ordered_ids, alias_to_primary=alias_to_primary,
+            submission,
+            ordered_ids,
+            alias_to_primary=alias_to_primary,
         )
         assert result == 'v123'
 
@@ -853,7 +855,9 @@ class FindMatchingVersionUidTestCase(TestCase):
         ordered_ids = ['v123']
         reversion_map = {'12345': 'v123'}
         result = find_matching_version_uid(
-            submission, ordered_ids, reversion_map=reversion_map,
+            submission,
+            ordered_ids,
+            reversion_map=reversion_map,
         )
         assert result == 'v123'
 

--- a/kpi/utils/versions.py
+++ b/kpi/utils/versions.py
@@ -2,7 +2,9 @@ from kobo.apps.reports.constants import FUZZY_VERSION_ID_KEY
 
 
 def find_matching_version_uid(
-    submission, version_uids_newest_first, reversion_map=None,
+    submission,
+    version_uids_newest_first,
+    reversion_map=None,
     alias_to_primary=None,
 ):
     """
@@ -21,8 +23,7 @@ def find_matching_version_uid(
     """
 
     submission_version_ids = [
-        val for key, val in submission.items()
-        if FUZZY_VERSION_ID_KEY in key and val
+        val for key, val in submission.items() if FUZZY_VERSION_ID_KEY in key and val
     ]
 
     if reversion_map:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Makes old export-generation code that matches fuzzy `__version__`s reusable, and starts using it in `OpenRosaDeploymentBackend` as well.

Also fixes a latent bug where matching on an `AssetVersion.uid_alias` would silently drop submissions from formpack exports.

Claude Opus 4.6 contributed to these changes, but @jnm takes full responsibility for them.