### PR TITLE
fix(modal): being displayed off center at 480px height viewport

### DIFF
--- a/jsapp/js/components/modals/koboModal.scss
+++ b/jsapp/js/components/modals/koboModal.scss
@@ -41,7 +41,7 @@ $kobo-modal-header-icon-margin: 10px;
     }
   }
 
-  @media all and (min-height: (breakpoints.$b480 + 1px)) {
+  @media all and (min-height: (breakpoints.$b480)) {
     transform: translate(-50%, -55%);
   }
 }


### PR DESCRIPTION
### 📣 Summary

When viewport had exactly 480px height, modals were being displayed off center, partially outside the screen.

### 💭 Notes

A mistake in media queries left 1px uncovered.