### PR TITLE
fix(assets): exclude assets from inactive accounts from asset list DEV-1768

### DIFF
--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -365,7 +365,9 @@ class KpiObjectPermissionsFilter(filters.BaseFilterBackend):
             perms = ObjectPermission.objects.filter(
                 deny=False,
                 user=user,
-                permission_id=view_asset_perm_id)
+                permission_id=view_asset_perm_id,
+                asset__owner__is_active=True,
+            )
 
         return perms.values('asset')
 

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -475,6 +475,72 @@ class AssetListApiTests(BaseAssetTestCase):
         assert response.data['results'][0]['uid'] == asset.uid
         assert response.data['results'][0]['date_deployed'] is None
 
+    def test_shared_asset_appears_in_grantee_list(self):
+        """
+        An asset owned by someuser and shared with anotheruser must appear
+        in anotheruser's asset list, alongside anotheruser's own assets.
+        """
+        anotheruser = User.objects.get(username='anotheruser')
+
+        # Use the existing fixture asset owned by someuser (pk=1)
+        shared_asset = Asset.objects.get(pk=1)
+        shared_asset.assign_perm(anotheruser, PERM_VIEW_ASSET)
+
+        # Create an asset owned by anotheruser
+        own_asset = Asset.objects.create(
+            owner=anotheruser,
+            name='Anotheruser own asset',
+            asset_type=ASSET_TYPE_SURVEY,
+        )
+
+        # Fetch the asset list as anotheruser
+        self.client.force_login(anotheruser)
+        response = self.client.get(self.list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        result_uids = [r['uid'] for r in response.data['results']]
+
+        # The asset shared by someuser must appear in the list
+        assert shared_asset.uid in result_uids
+        # Anotheruser's own asset must also appear
+        assert own_asset.uid in result_uids
+
+    def test_shared_asset_hidden_when_owner_inactive(self):
+        """
+        When someuser becomes inactive (is_active=False), assets owned by
+        someuser and shared with anotheruser must no longer appear in
+        anotheruser's asset list. Anotheruser's own assets must still appear.
+        """
+        someuser = User.objects.get(username='someuser')
+        anotheruser = User.objects.get(username='anotheruser')
+
+        # Use the existing fixture asset owned by someuser (pk=1)
+        shared_asset = Asset.objects.get(pk=1)
+        shared_asset.assign_perm(anotheruser, PERM_VIEW_ASSET)
+
+        # Create an asset owned by anotheruser
+        own_asset = Asset.objects.create(
+            owner=anotheruser,
+            name='Anotheruser own asset',
+            asset_type=ASSET_TYPE_SURVEY,
+        )
+
+        # Deactivate someuser
+        someuser.is_active = False
+        someuser.save()
+
+        # Fetch the asset list as anotheruser
+        self.client.force_login(anotheruser)
+        response = self.client.get(self.list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        result_uids = [r['uid'] for r in response.data['results']]
+
+        # The asset from the inactive owner must NOT appear in the list
+        assert shared_asset.uid not in result_uids
+        # Anotheruser's own asset must still appear
+        assert own_asset.uid in result_uids
+
 
 class AssetProjectViewListApiTests(BaseAssetTestCase):
     fixtures = ['test_data']


### PR DESCRIPTION
### 📣 Summary

Assets shared by a deactivated user no longer appear in other users' project lists.

### 📖 Description

When a user account was deactivated (`is_active=False`), assets they owned and had shared with other users were still appearing in those users' asset lists, causing a 500 error when the list was fetched. The fix filters out assets whose owner is inactive when resolving explicitly shared permissions.

### 💭 Notes

- Only one line changed in `kpi/filters.py` (added `asset__owner__is_active=True` filter).
- Two regression tests added in `AssetListApiTests` to cover the shared-asset visibility and the inactive-owner exclusion scenarios.

### 👀 Preview steps

1. ℹ️ Have two accounts: **someuser** (owner) and **anotheruser** (grantee). someuser shares a project with anotheruser.
2. 🟢 [on PR] Fetch anotheruser's asset list — the shared project appears correctly.
3. Deactivate someuser's account (`is_active=False`).
4. 🔴 [on main] Fetch anotheruser's asset list — results in a 500 error or includes the shared project incorrectly.
5. 🟢 [on PR] Fetch anotheruser's asset list — the shared project is no longer listed; anotheruser's own projects are unaffected.