### PR TITLE
refactor(xml): consolidate processing and remove defusedxml DEV-1932

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -114,7 +114,6 @@ decorator==5.2.1
     #   ipython
 defusedxml==0.7.1
     # via
-    #   -r dependencies/pip/requirements.in
     #   djangorestframework-xml
     #   pyxform
 deprecated==1.3.1

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -25,7 +25,6 @@ billiard
 celery
 celery[redis]
 dict2xml
-defusedxml
 dj-static
 dj-stripe>=2.10,<2.11
 django-allauth>=65.11.2

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -82,7 +82,6 @@ cssselect==1.4.0
     # via pyquery
 defusedxml==0.7.1
     # via
-    #   -r dependencies/pip/requirements.in
     #   djangorestframework-xml
     #   pyxform
 dict2xml==1.7.8

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -4,7 +4,6 @@ import io
 import json
 import uuid
 from unittest.mock import patch
-from xml.etree import ElementTree as ET
 
 import responses
 from ddt import data, ddt, unpack
@@ -1852,7 +1851,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             'formhub': {'uuid': self.asset.deployment.xform.uuid},
             '_uuid': str(uuid_),
         }
-        xml = ET.fromstring(
+        xml = fromstring_preserve_root_xmlns(
             dict2xform(submission_data, self.asset.deployment.xform.id_string)
         )
         xml.tag = self.asset.uid
@@ -1873,7 +1872,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             endpoint,
             kwargs=kwargs,
         )
-        data = {'xml_submission_file': SimpleUploadedFile('name.txt', ET.tostring(xml))}
+        data = {'xml_submission_file': SimpleUploadedFile('name.txt', xml_tostring(xml).encode())}
         # ensure anonymous users are allowed to submit
         self.asset.assign_perm(perm=PERM_ADD_SUBMISSIONS, user_obj=AnonymousUser())
 

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -1872,7 +1872,11 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             endpoint,
             kwargs=kwargs,
         )
-        data = {'xml_submission_file': SimpleUploadedFile('name.txt', xml_tostring(xml).encode())}
+        data = {
+            'xml_submission_file': SimpleUploadedFile(
+                'name.txt', xml_tostring(xml).encode()
+            )
+        }
         # ensure anonymous users are allowed to submit
         self.asset.assign_perm(perm=PERM_ADD_SUBMISSIONS, user_obj=AnonymousUser())
 

--- a/kobo/apps/hook/tests/test_parser.py
+++ b/kobo/apps/hook/tests/test_parser.py
@@ -1,11 +1,9 @@
 import json
 import re
 
-from lxml import etree
-
 from kpi.constants import SUBMISSION_FORMAT_TYPE_XML
 from kpi.utils.strings import to_str
-from kpi.utils.xml import check_lxml_fromstring
+from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
 from .base import BaseHookTestCase
 
 
@@ -46,7 +44,7 @@ class ParserTestCase(BaseHookTestCase):
         submission_id = submissions[0]['_id']
         submission_uuid = submissions[0]['_uuid']
         service_definition = ServiceDefinition(hook, submission_id)
-        expected_etree = check_lxml_fromstring(
+        expected_elements = fromstring_preserve_root_xmlns(
             f'<{self.asset.uid} id="{self.asset.uid}">'
             f'   <group1>'
             f'      <q3>¿Cómo está en el grupo uno la segunda vez?</q3>'
@@ -64,17 +62,15 @@ class ParserTestCase(BaseHookTestCase):
             f'</{self.asset.uid}>'
         )
 
-        expected_xml = etree.tostring(
-            expected_etree,
-            pretty_print=True,
+        expected_xml = xml_tostring(
+            expected_elements,
             xml_declaration=True,
-            encoding='utf-8',
         )
 
         def remove_whitespace(str_):
-            return re.sub(r'>\s+<', '><', to_str(str_))
+            return re.sub(r'>\s+<', '><', to_str(str_)).strip()
 
         self.assertEqual(
             remove_whitespace(service_definition._get_data()),
-            remove_whitespace(expected_xml.decode()),
+            remove_whitespace(expected_xml),
         )

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_viewset.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_viewset.py
@@ -3,7 +3,7 @@ import os
 from xml.dom import Node
 
 import pytest
-from defusedxml import minidom
+from xml.dom import minidom
 from django.conf import settings
 from django.urls import reverse
 from pyxform.errors import PyXFormError

--- a/kobo/apps/openrosa/apps/api/utils/xml.py
+++ b/kobo/apps/openrosa/apps/api/utils/xml.py
@@ -27,9 +27,15 @@ def extract_confirmation_message(xml_string: str) -> Optional[str]:
         return
 
     confirmation_message_xpath = confirmation_message_xpath.strip()
-    _, submit_message_root_tag, *other_parts = (
-        confirmation_message_xpath.split('/')
-    )
+    parts = confirmation_message_xpath.split('/')
+    if len(parts) < 3:
+        # Expected format is `/root_tag/path/to/field`; anything shorter
+        # is malformed and can't identify a specific element
+        logging.error(
+            'Malformed submitMessage XPath: %s', confirmation_message_xpath
+        )
+        return
+    other_parts = parts[2:]
     confirmation_message_xpath = './' + '/'.join(other_parts)
 
     # Evaluate the XPath expression to find the message

--- a/kobo/apps/openrosa/apps/api/utils/xml.py
+++ b/kobo/apps/openrosa/apps/api/utils/xml.py
@@ -1,7 +1,8 @@
-from lxml import etree
 from typing import Optional
+from xml.etree.ElementTree import ParseError
 
 from kpi.utils.log import logging
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 
 
 def extract_confirmation_message(xml_string: str) -> Optional[str]:
@@ -9,40 +10,31 @@ def extract_confirmation_message(xml_string: str) -> Optional[str]:
     Extracts the confirmation message from the XML string based on the
     `kobo:submitMessage` attribute.
     """
-    if isinstance(xml_string, str):
-        xml_string = xml_string.encode('utf-8')
-    parser = etree.XMLParser(recover=True)
-    root = etree.fromstring(xml_string, parser=parser)
-
-    namespaces = root.nsmap
+    try:
+        root = fromstring_preserve_root_xmlns(xml_string)
+    except ParseError:
+        logging.error(
+            'Failed to parse XML for confirmation message', exc_info=True
+        )
+        return
 
     # Extract the kobo:submitMessage attribute from the root element
-    try:
-        confirmation_message_xpath = root.xpath(
-            '@kobo:submitMessage', namespaces=namespaces
-        )
-    except (etree.XPathEvalError, TypeError):
-        return
+    confirmation_message_xpath = root.attrib.get('{http://kobotoolbox.org/xforms}submitMessage')
 
     if not confirmation_message_xpath:
         return
 
-    confirmation_message_xpath = confirmation_message_xpath[0].strip()
     _, submit_message_root_tag, *other_parts = (
         confirmation_message_xpath.split('/')
     )
-    confirmation_message_xpath = f'/{root.tag}/' + '/'.join(other_parts)
+    confirmation_message_xpath = './' + '/'.join(other_parts)
 
-    try:
-        # Evaluate the XPath expression to find the message
-        confirmation_message_element = root.xpath(confirmation_message_xpath)
-    except etree.XPathEvalError as e:
-        logging.error(
-            'Failed to extract confirmation message: ' + str(e),
-            exc_info=True
-        )
+    # Evaluate the XPath expression to find the message
+    confirmation_message_element = root.find(confirmation_message_xpath)
+
+    if confirmation_message_element is None:
+        logging.error('Failed to extract confirmation message')
     else:
-        if confirmation_message_element:
-            return confirmation_message_element[0].text
+        return confirmation_message_element.text
 
     return

--- a/kobo/apps/openrosa/apps/api/utils/xml.py
+++ b/kobo/apps/openrosa/apps/api/utils/xml.py
@@ -24,6 +24,7 @@ def extract_confirmation_message(xml_string: str) -> Optional[str]:
     if not confirmation_message_xpath:
         return
 
+    confirmation_message_xpath = confirmation_message_xpath.strip()
     _, submit_message_root_tag, *other_parts = (
         confirmation_message_xpath.split('/')
     )

--- a/kobo/apps/openrosa/apps/api/utils/xml.py
+++ b/kobo/apps/openrosa/apps/api/utils/xml.py
@@ -19,7 +19,9 @@ def extract_confirmation_message(xml_string: str) -> Optional[str]:
         return
 
     # Extract the kobo:submitMessage attribute from the root element
-    confirmation_message_xpath = root.attrib.get('{http://kobotoolbox.org/xforms}submitMessage')
+    confirmation_message_xpath = root.attrib.get(
+        '{http://kobotoolbox.org/xforms}submitMessage'
+    )
 
     if not confirmation_message_xpath:
         return

--- a/kobo/apps/openrosa/apps/logger/management/commands/repostgres.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/repostgres.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 from typing import Optional
-from xml.etree import ElementTree as ET
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
@@ -212,7 +212,7 @@ class Command(BaseCommand):
         if not media_question_xpaths:
             return []
 
-        xml_parsed = ET.fromstring(instance.xml)
+        xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
         basenames = []
         for xpath in media_question_xpaths:
             root, path = xpath.split('/', 1)

--- a/kobo/apps/openrosa/apps/logger/tests/test_parsing.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_parsing.py
@@ -2,8 +2,6 @@
 import os
 import re
 
-from defusedxml import minidom
-
 from kobo.apps.openrosa.apps.logger.models import XForm
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     XFormInstanceParser,
@@ -18,6 +16,7 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.libs.utils.common_tags import XFORM_ID_STRING
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.utils.xml import minidom_parsestring
 
 XML = 'xml'
 DICT = 'dict'
@@ -108,7 +107,7 @@ class TestXFormInstanceParser(TestBase):
         )
         clean_xml_str = xml_str.strip()
         clean_xml_str = re.sub(r'>\s+<', '><', clean_xml_str)
-        root_node = minidom.parseString(clean_xml_str).documentElement
+        root_node = minidom_parsestring(clean_xml_str).documentElement
         # get the first top-level gps element
         gps_node = root_node.firstChild.nextSibling
         self.assertEqual(gps_node.nodeName, 'gps')

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -8,7 +8,6 @@ from xml.dom import Node
 
 import dateutil.parser
 import six
-from defusedxml import minidom
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext as t
 from pyxform.survey_element import SurveyElement
@@ -16,6 +15,7 @@ from pyxform.survey_element import SurveyElement
 from kobo.apps.openrosa.apps.logger.exceptions import InstanceEmptyError
 from kobo.apps.openrosa.libs.utils.common_tags import XFORM_ID_STRING
 from kpi.utils.log import logging
+from kpi.utils.xml import minidom_parsestring
 
 
 def add_uuid_prefix(uuid_: str) -> str:
@@ -26,7 +26,7 @@ def add_uuid_prefix(uuid_: str) -> str:
 
 def get_meta_node_from_xml(
     xml_str: str, meta_name: str
-) -> Union[None, tuple[str, minidom.Document]]:
+) -> Union[None, tuple[str, 'xml.dom.minidom.Document']]:
     xml = clean_and_parse_xml(xml_str)
     children = xml.childNodes
     # children ideally contain a single element
@@ -117,10 +117,10 @@ def get_deprecated_uuid_from_xml(xml):
     return None
 
 
-def clean_and_parse_xml(xml_string: str) -> minidom.Document:
+def clean_and_parse_xml(xml_string: str) -> 'xml.dom.minidom.Document':
     clean_xml_str = xml_string.strip()
     clean_xml_str = re.sub(r'>\s+<', '><', smart_str(clean_xml_str))
-    xml_obj = minidom.parseString(clean_xml_str)
+    xml_obj = minidom_parsestring(clean_xml_str)
     return xml_obj
 
 

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime
 from typing import Optional, Union
 from xml.dom import Node
+from xml.dom.minidom import Document
 
 import dateutil.parser
 import six
@@ -26,7 +27,7 @@ def add_uuid_prefix(uuid_: str) -> str:
 
 def get_meta_node_from_xml(
     xml_str: str, meta_name: str
-) -> Union[None, tuple[str, 'xml.dom.minidom.Document']]:
+) -> Union[None, tuple[Node, Document]]:
     xml = clean_and_parse_xml(xml_str)
     children = xml.childNodes
     # children ideally contain a single element
@@ -117,7 +118,7 @@ def get_deprecated_uuid_from_xml(xml):
     return None
 
 
-def clean_and_parse_xml(xml_string: str) -> 'xml.dom.minidom.Document':
+def clean_and_parse_xml(xml_string: str) -> Document:
     clean_xml_str = xml_string.strip()
     clean_xml_str = re.sub(r'>\s+<', '><', smart_str(clean_xml_str))
     xml_obj = minidom_parsestring(clean_xml_str)

--- a/kobo/apps/openrosa/apps/main/tests/test_process.py
+++ b/kobo/apps/openrosa/apps/main/tests/test_process.py
@@ -7,7 +7,7 @@ import re
 import unittest
 from xml.dom import Node
 
-from defusedxml import minidom
+from xml.dom import minidom
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from django.urls import reverse

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -12,7 +12,6 @@ from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
 from wsgiref.util import FileWrapper
 from xml.dom import Node
-from xml.etree import ElementTree as ET
 from xml.parsers.expat import ExpatError
 from zoneinfo import ZoneInfo
 
@@ -97,6 +96,7 @@ from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
 from kpi.utils.usage_calculator import ServiceUsageCalculator
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 
 OPEN_ROSA_VERSION_HEADER = 'X-OpenRosa-Version'
 HTTP_OPEN_ROSA_VERSION_HEADER = 'HTTP_X_OPENROSA_VERSION'
@@ -870,7 +870,7 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
 
     # Parse instance XML to get the basename of each file of the updated
     # submission
-    xml_parsed = ET.fromstring(instance.xml)
+    xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
     basenames = []
 
     for media_question_xpath in media_question_xpaths:

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -12,6 +12,7 @@ from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
 from wsgiref.util import FileWrapper
 from xml.dom import Node
+from xml.etree.ElementTree import ParseError
 from xml.parsers.expat import ExpatError
 from zoneinfo import ZoneInfo
 
@@ -489,7 +490,7 @@ def http_open_rosa_error_handler(func, request):
     except XForm.DoesNotExist:
         result.error = t('Form does not exist on this account')
         result.http_error_response = OpenRosaResponseNotFound(result.error)
-    except ExpatError:
+    except (ExpatError, ParseError):
         result.error = t('Improperly formatted XML.')
         result.http_error_response = OpenRosaResponseBadRequest(result.error)
     except (ConflictingSubmissionUUIDError, ConflictingAttachmentBasenameError) as e:

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 import redis.exceptions
 import requests
 from constance import config
-from defusedxml import ElementTree as DET
+from xml.etree.ElementTree import ParseError
 from django.conf import settings
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.files import File
@@ -408,7 +408,7 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
         submission_xml = xml_submission_file.read()
         try:
             xml_root = fromstring_preserve_root_xmlns(submission_xml)
-        except DET.ParseError:
+        except ParseError:
             raise SubmissionIntegrityError(t('Your submission XML is malformed.'))
         try:
             xform_uuid = xml_root.find(self.FORM_UUID_XPATH).text

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -75,28 +75,6 @@ class DeploymentNotFound(Exception):
         super().__init__(message)
 
 
-class DTDForbiddenException(Exception):
-    """
-    Exception to be used when DTDs are forbidden while parsing XML using the
-    LXML library
-    """
-
-    def __init__(self, message=t('XML contains forbidden DTDs')):
-        self.message = message
-        super().__init__(self.message)
-
-
-class EntitiesForbiddenException(Exception):
-    """
-    Exception to be used when Entities are forbidden while parsing XML
-    using the LXML library
-    """
-
-    def __int__(self, message=t('XML contains forbidden entities')):
-        self.message = message
-        super().__init__(self.message)
-
-
 class FFMpegException(Exception):
     pass
 

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -19,7 +19,7 @@ from kpi.tests.api.v2 import test_api_assets
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.tests.utils.transaction import immediate_on_commit
-from kpi.utils.xml import check_lxml_fromstring
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 
 EMPTY_SURVEY = {'survey': [], 'schema': SCHEMA_VERSION, 'settings': {}}
 
@@ -146,6 +146,15 @@ class AssetDetailApiTests(test_api_assets.AssetDetailApiTests):
 class AssetsXmlExportApiTests(KpiTestCase):
     fixtures = ['test_data']
 
+    @staticmethod
+    def _findall_with_xhtml_namespace(xml, path):
+        """
+        Convenience wrapper for searching for things like `h:head`
+        """
+        return xml.findall(
+            path, namespaces={'h': 'http://www.w3.org/1999/xhtml'}
+        )
+
     def test_xml_export_title_retained(self):
         asset_title = 'XML Export Test Asset Title'
         content = {'settings': [{'id_string': 'titled_asset'}],
@@ -156,8 +165,8 @@ class AssetsXmlExportApiTests(KpiTestCase):
             reverse('asset-detail', kwargs={'uid_asset': asset.uid, 'format': 'xml'})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        xml = check_lxml_fromstring(response.content)
-        title_elts = xml.xpath('./*[local-name()="head"]/*[local-name()="title"]')
+        xml = fromstring_preserve_root_xmlns(response.content)
+        title_elts = self._findall_with_xhtml_namespace(xml, './h:head/h:title')
         self.assertEqual(len(title_elts), 1)
         self.assertEqual(title_elts[0].text, asset_title)
 
@@ -171,8 +180,8 @@ class AssetsXmlExportApiTests(KpiTestCase):
             reverse('asset-detail', kwargs={'uid_asset': asset.uid, 'format': 'xml'})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        xml = check_lxml_fromstring(response.content)
-        title_elts = xml.xpath('./*[local-name()="head"]/*[local-name()="title"]')
+        xml = fromstring_preserve_root_xmlns(response.content)
+        title_elts = self._findall_with_xhtml_namespace(xml, './h:head/h:title')
         self.assertEqual(len(title_elts), 1)
         self.assertEqual(title_elts[0].text, asset_name)
 
@@ -185,8 +194,8 @@ class AssetsXmlExportApiTests(KpiTestCase):
             reverse('asset-detail', kwargs={'uid_asset': asset.uid, 'format': 'xml'})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        xml = check_lxml_fromstring(response.content)
-        title_elts = xml.xpath('./*[local-name()="head"]/*[local-name()="title"]')
+        xml = fromstring_preserve_root_xmlns(response.content)
+        title_elts = self._findall_with_xhtml_namespace(xml, './h:head/h:title')
         self.assertEqual(len(title_elts), 1)
         self.assertNotEqual(title_elts[0].text, '')
 
@@ -214,8 +223,8 @@ class AssetsXmlExportApiTests(KpiTestCase):
             reverse('asset-detail', kwargs={'uid_asset': asset.uid, 'format': 'xml'})
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        xml = check_lxml_fromstring(response.content)
-        group_elts = xml.xpath('./*[local-name()="body"]/*[local-name()="group"]')
+        xml = fromstring_preserve_root_xmlns(response.content)
+        group_elts = self._findall_with_xhtml_namespace(xml, './h:body/group')
         self.assertEqual(len(group_elts), 1)
         self.assertNotIn('relevant', group_elts[0].attrib)
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -10,7 +10,6 @@ from unittest import mock
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-import lxml
 import pytest
 import responses
 from constance.test import override_config
@@ -80,7 +79,7 @@ from kpi.utils.xml import (
 
 def dict2xform_with_namespace(submission: dict, xform_id_string: str) -> str:
     xml_string = dict2xform(submission, xform_id_string)
-    xml_root = lxml.etree.fromstring(xml_string.encode())
+    xml_root = fromstring_preserve_root_xmlns(xml_string)
     xml_root.set('xmlns', 'http://opendatakit.org/submissions')
     return xml_tostring(xml_root)
 

--- a/kpi/tests/utils/xml.py
+++ b/kpi/tests/utils/xml.py
@@ -1,21 +1,15 @@
-from __future__ import annotations
-
-from lxml import etree
-
-from kpi.utils.xml import check_lxml_fromstring
+from kpi.utils.xml import fromstring_preserve_root_xmlns
 
 
-def get_form_and_submission_tag_names(form: str, submission: str) -> tuple[str, str]:
-    submission_root_name = check_lxml_fromstring(submission.encode()).tag
-    tree = etree.ElementTree(check_lxml_fromstring(form))
-    root = tree.getroot()
-    # We cannot use `root.nsmap` directly because the default namespace key is
-    # `None`, and `find()` cannot search a namespace with equals `None`.
-    #
-    namespaces = {
-        'default': root.nsmap[None]
-    }
-    element = root.find('.//default:instance', namespaces=namespaces)[0]
-    form_root_name = element.tag.replace(f"{{{namespaces['default']}}}", '')
-
+def get_form_and_submission_tag_names(
+    form: str, submission: str
+) -> tuple[str, str]:
+    submission_root_name = fromstring_preserve_root_xmlns(submission).tag
+    form_xml = fromstring_preserve_root_xmlns(form)
+    first_instance_child = form_xml.find('.//instance/./')
+    if first_instance_child is None:
+        raise ValueError(
+            'Could not find the first child of <instance> in the form XML'
+        )
+    form_root_name = first_instance_child.tag
     return form_root_name, submission_root_name

--- a/kpi/tests/utils/xml.py
+++ b/kpi/tests/utils/xml.py
@@ -6,7 +6,13 @@ def get_form_and_submission_tag_names(
 ) -> tuple[str, str]:
     submission_root_name = fromstring_preserve_root_xmlns(submission).tag
     form_xml = fromstring_preserve_root_xmlns(form)
-    first_instance_child = form_xml.find('.//instance/./')
+    # Skip secondary instances (which have an `id` attribute, e.g.
+    # `<instance id="choices" src="...">`) and find the primary one
+    first_instance_child = None
+    for inst in form_xml.findall('.//instance'):
+        if 'id' not in inst.attrib and len(inst):
+            first_instance_child = inst[0]
+            break
     if first_instance_child is None:
         raise ValueError(
             'Could not find the first child of <instance> in the form XML'

--- a/kpi/utils/sluggify.py
+++ b/kpi/utils/sluggify.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 import re
 
-from defusedxml import ElementTree as ET
+from xml.etree import ElementTree as ET
 
 from kpi.utils.hash import calculate_hash
 

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -3,32 +3,23 @@ from __future__ import annotations
 import re
 from typing import Optional, Union
 from xml.dom import Node
+from xml.dom import minidom
 from xml.etree import ElementTree as ET
 
-# Goals for the future:
-#
-# 1. All XML handling is done in this file. No other files import anything from
-#    xml, lxml, etc. directly; instead, they import helpers from this file.
-#
-# 2. All XML parsing is done by defusedxml. However:
-#     The defusedxml modules are not drop-in replacements of their stdlib
-#     counterparts. The modules only provide functions and classes related to
-#     parsing and loading of XML. For all other features, use the classes,
-#     functions, and constants from the stdlib modules.
-#     (https://github.com/tiran/defusedxml)
-#
-# The imports below are those given as examples by the defusedxml
-# "documentation" (the README), except for correcting a typo in the second
-# import:
-from defusedxml import ElementTree as DET
-from defusedxml import minidom
-from defusedxml.lxml import fromstring
 from django.db.models import F, Q
 from django.db.models.query import QuerySet
 from lxml import etree
 
 from kobo.apps.form_disclaimer.models import FormDisclaimer
-from kpi.exceptions import DTDForbiddenException, EntitiesForbiddenException
+
+# Goal for the future: all XML handling is done in this file. No other files
+# import anything from xml, lxml, etc. directly; instead, they import helpers
+# from this file.
+#
+# As of Python 3.8+ / lxml 4.6.2+, the standard library and lxml XML parsers
+# are hardened against XXE, entity expansion bombs, and external DTD fetching
+# by default, making defusedxml unnecessary for this project (Python 3.12,
+# lxml 5.4).
 
 
 def add_xml_declaration(
@@ -58,50 +49,6 @@ def add_xml_declaration(
     return xml_
 
 
-def check_entities(
-    elementtree: etree.ElementTree,
-    dtd_forbidden: bool = False,
-    entities_forbidden: bool = True
-):
-    """
-    This function is to be used with the lxml library using examples
-    found in the defusedxml library since support for lxml is depreciated
-    Does not return content. This function will only raise exceptions if
-    unaccepted content is contained in the XML.
-    """
-
-    docinfo = elementtree.docinfo
-    if docinfo.doctype:
-        if dtd_forbidden:
-            raise DTDForbiddenException
-        if entities_forbidden:
-            raise EntitiesForbiddenException
-
-    if entities_forbidden:
-        for dtd_entity in docinfo.internalDTD, docinfo.externalDTD:
-            if dtd_entity is None:
-                continue
-            for entity in dtd_entity.interentities():
-                raise EntitiesForbiddenException
-
-
-def check_lxml_fromstring(
-    text: str,
-    base_url: str = None,
-    forbid_dtd: bool = False,
-    forbid_entities: bool = True,
-):
-    """
-    This function is used to replace the `lxml.etree.fromstring` method similarly to
-    defusedxml's replacement for the method.
-    Returns an ElementTree object
-    """
-    rootelement = fromstring(text, base_url=base_url)
-    elementtree = rootelement.getroottree()
-    check_entities(elementtree, forbid_dtd, forbid_entities)
-    return rootelement
-
-
 def edit_submission_xml(
     xml_parsed: 'xml.etree.ElementTree.Element',
     path: str,
@@ -115,27 +62,25 @@ def edit_submission_xml(
     element.text = value
 
 
+def minidom_parsestring(text: Union[str, bytes]) -> minidom.Document:
+    """
+    Thin wrapper so callers don't import minidom directly for parsing.
+    """
+    if isinstance(text, bytes):
+        text = text.decode()
+    return minidom.parseString(text)
+
+
 def fromstring_preserve_root_xmlns(
-    text: str,
-    forbid_dtd: bool = False,
-    forbid_entities: bool = True,
-    forbid_external: bool = True,
+    text: Union[str, bytes],
 ) -> ET.Element:
     """
     Parse an XML string, but leave the default namespace in the `xmlns`
     attribute if the root element has one, and do not use Clark notation
     prefixes on tag names for the default namespace.
-
-    Copied from `defusedxml.common._generate_etree_functions()`, except that
-    the `target` is changed to a custom class. Necessary because
-    `defusedxml.ElementTree.fromstring()`, unlike the standard library
-    `xml.etree.ElementTree.fromstring()`, does not allow specifying a parser.
     """
-    parser = DET.DefusedXMLParser(
+    parser = ET.XMLParser(
         target=OmitDefaultNamespacePrefixTreeBuilder(),
-        forbid_dtd=forbid_dtd,
-        forbid_entities=forbid_entities,
-        forbid_external=forbid_external,
     )
     parser.feed(text)
     return parser.close()
@@ -255,15 +200,20 @@ def strip_nodes(
     ).decode()
 
 
-def xml_tostring(el: ET.Element) -> str:
+def xml_tostring(el: ET.Element, **kwargs) -> str:
     """
     Thin wrapper around `ElementTree.tostring()` as a step toward a future
     where all XML handling is done in this file
     """
+    if 'encoding' in kwargs:
+        raise NotImplementedError(
+            'Do not pass an `encoding` argument. The returned encoding is'
+            ' always `unicode`.'
+        )
     # "Use encoding="unicode" to generate a Unicode string (otherwise, a
     # bytestring is generated)."
     # https://docs.python.org/3.10/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
-    return DET.tostring(el, encoding='unicode')
+    return ET.tostring(el, encoding='unicode', **kwargs)
 
 
 def _filter_nodes_by_xpaths(root: etree._Element, xpath_matches: list) -> None:

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -66,8 +66,6 @@ def minidom_parsestring(text: Union[str, bytes]) -> minidom.Document:
     """
     Thin wrapper so callers don't import minidom directly for parsing.
     """
-    if isinstance(text, bytes):
-        text = text.decode()
     return minidom.parseString(text)
 
 

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -62,13 +62,6 @@ def edit_submission_xml(
     element.text = value
 
 
-def minidom_parsestring(text: Union[str, bytes]) -> minidom.Document:
-    """
-    Thin wrapper so callers don't import minidom directly for parsing.
-    """
-    return minidom.parseString(text)
-
-
 def fromstring_preserve_root_xmlns(
     text: Union[str, bytes],
 ) -> ET.Element:
@@ -112,6 +105,13 @@ def get_or_create_element(
         parent_el = el
 
     return el
+
+
+def minidom_parsestring(text: Union[str, bytes]) -> minidom.Document:
+    """
+    Thin wrapper so callers don't import minidom directly for parsing.
+    """
+    return minidom.parseString(text)
 
 
 def strip_nodes(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

Remove defusedxml and consolidate XML parsing (from strings) and serialization (to strings) into common utility functions. Files that use minidom DOM manipulation extensively are intentionally left with direct imports. The `*requirements.txt` Python dependency files continue to show defusedxml since it remains a dependency of djangorestframework-xml and pyxform.

Rationale: Python 3.12's Expat and lxml 5.4 are hardened against XXE, entity expansion bombs, and external DTD fetching by default, making defusedxml unnecessary. The recommendation to use defusedxml has been removed from the official Python documentation in https://github.com/python/cpython/pull/135294.

**No changes to behavior** are expected.