### PR TITLE
fix(tests): restore `_get_endpoint` helper usage for API endpoint resolution DEV-1952

### DIFF
--- a/kobo/apps/accounts/tests/test_api_tos.py
+++ b/kobo/apps/accounts/tests/test_api_tos.py
@@ -9,7 +9,7 @@ from kpi.tests.base_test_case import BaseTestCase
 
 class TOSTestCase(BaseTestCase):
     def setUp(self) -> None:
-        self.url = reverse('tos')
+        self.url = reverse(self._get_endpoint('tos'))
         self.user = baker.make(
             settings.AUTH_USER_MODEL, username='spongebob', email='me@sponge.bob'
         )

--- a/kobo/apps/audit_log/tests/test_one_time_auth.py
+++ b/kobo/apps/audit_log/tests/test_one_time_auth.py
@@ -13,6 +13,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.main.models import UserProfile
 from kpi.models import AuthorizedApplication
 from kpi.tests.base_test_case import BaseTestCase
+from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
 
 @ddt
@@ -20,6 +21,7 @@ class TestOneTimeAuthentication(BaseTestCase):
     """
     Tests for creating AuditLogs for one-time authentication methods
     """
+    URL_NAMESPACE = ROUTER_URL_NAMESPACE
 
     @classmethod
     def setUpClass(cls):

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -193,7 +193,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 'action': action,
             }
         }
-        url = reverse('api_v2:asset-bulk')
+        url = reverse(self._get_endpoint('asset-bulk'))
         response = self.client.post(url, data=payload, format='json')
         return response
 

--- a/kobo/apps/trash_bin/tests/test_attachment_trash_storage.py
+++ b/kobo/apps/trash_bin/tests/test_attachment_trash_storage.py
@@ -12,6 +12,7 @@ from kobo.apps.trash_bin.utils import move_to_trash, put_back
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.tests.mixins.create_asset_and_submission_mixin import AssetSubmissionTestMixin
 from kpi.tests.utils.transaction import immediate_on_commit
+from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
 
 class AttachmentTrashStorageCountersTestCase(BaseTestCase, AssetSubmissionTestMixin):
@@ -19,6 +20,8 @@ class AttachmentTrashStorageCountersTestCase(BaseTestCase, AssetSubmissionTestMi
     Test that moving an attachment to trash and restoring it updates the
     storage counters
     """
+    URL_NAMESPACE = ROUTER_URL_NAMESPACE
+
     def setUp(self):
         self.factory = APIRequestFactory()
         self.user = User.objects.create(username='owner')

--- a/kpi/tests/api/test_api_current_user.py
+++ b/kpi/tests/api/test_api_current_user.py
@@ -17,7 +17,7 @@ from kpi.utils.gravatar_url import gravatar_url
 
 class CurrentUserTestCase(BaseTestCase):
     def setUp(self) -> None:
-        self.url = reverse('currentuser-detail')
+        self.url = reverse(self._get_endpoint('currentuser-detail'))
         self.user = User.objects.create_user(
             username='delete_me',
             password='delete_me',

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -2688,6 +2688,8 @@ class TestCreatedByAndLastModifiedByAsset(BaseAssetTestCase):
 
 
 class TestAssetMetadataViewSet(BaseAssetTestCase):
+    URL_NAMESPACE = ROUTER_URL_NAMESPACE
+
     # don't use test_data fixture here because we need control over how many assets
     # each user has and what they contain
     @classmethod

--- a/kpi/tests/api/v2/test_api_logout_all.py
+++ b/kpi/tests/api/v2/test_api_logout_all.py
@@ -21,7 +21,8 @@ class TestLogoutAll(BaseTestCase):
         count = UserSession.objects.filter(user=user).count()
         self.assertEqual(count, 2)
         self.client.force_login(user)
-        self.client.post(reverse('logout_all'))
+        url = self._get_endpoint('logout_all')
+        self.client.post(reverse(url))
 
         # ensure both sessions have been deleted
         count = UserSession.objects.filter(user=user).count()
@@ -38,7 +39,8 @@ class TestLogoutAll(BaseTestCase):
 
         # login user2
         self.client.force_login(user2)
-        self.client.post(reverse('logout_all'))
+        url = self._get_endpoint('logout_all')
+        self.client.post(reverse(url))
 
         # ensure no sessions have been deleted
         count = UserSession.objects.filter().count()

--- a/kpi/tests/base_test_case.py
+++ b/kpi/tests/base_test_case.py
@@ -18,7 +18,7 @@ from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 
 class BaseTestCase(APITestCase):
 
-    URL_NAMESPACE = ROUTER_URL_NAMESPACE
+    URL_NAMESPACE = None
 
     @staticmethod
     def absolute_reverse(*args, **kwargs):


### PR DESCRIPTION
### 📣 Summary
Restore usage of _get_endpoint in unit tests to ensure URLs are generated using the API namespace helper.

### 📖 Description
This PR restores the use of the `_get_endpoint` helper method in multiple unit tests.

The helper constructs endpoint names using the configured API namespace defined in `BaseTestCase`, ensuring URLs are generated correctly via `reverse()`. Removing it caused tests to bypass the namespace logic and made them less flexible.

Keeping `_get_endpoint` allows the same tests to continue working if new API versions are introduced (e.g., v3) while maintaining consistent endpoint resolution across test cases.

The original PR [kpi#6585](https://github.com/kobotoolbox/kpi/pull/6585) was merged before this feedback was received, so this PR reintroduces the helper usage accordingly.