### PR TITLE
feat(metadata): update project summary to include extra project metadata DEV-1530

### DIFF
--- a/jsapp/js/components/formSummary/formSummaryProjectInfo.tsx
+++ b/jsapp/js/components/formSummary/formSummaryProjectInfo.tsx
@@ -5,11 +5,12 @@ import { getCountryDisplayString, getSectorDisplayString } from '#/assetUtils'
 import bem from '#/bem'
 import AssetStatusBadge from '#/components/common/assetStatusBadge'
 import Avatar from '#/components/common/avatar'
+import { EXTRA_PROJECT_METADATA_FIELD_TYPES } from '#/constants'
 import type { AssetResponse, PaginatedResponse, SubmissionResponse } from '#/dataInterface'
 import { dataInterface } from '#/dataInterface'
 import envStore from '#/envStore'
 import sessionStore from '#/stores/session'
-import { formatTime } from '#/utils'
+import { currentLang, formatTime } from '#/utils'
 
 interface FormSummaryProjectInfoProps {
   asset: AssetResponse
@@ -41,6 +42,37 @@ export default function FormSummaryProjectInfo(props: FormSummaryProjectInfoProp
 
   // Support custom labels for project metadata, if defined
   const metadata = envStore.data.getProjectMetadataFieldsAsSimpleDict()
+
+  // Compute extra metadata fields that have a non-empty value
+  const extraMetadata = props.asset.settings.extra_metadata ?? {}
+  const lang = currentLang()
+  const extraFieldsWithValues = envStore.data.extra_project_metadata_fields
+    .filter((field) => {
+      const value = extraMetadata[field.name]
+      return value !== undefined && value !== null && value !== '' && !(Array.isArray(value) && value.length === 0)
+    })
+    .map((field) => {
+      const value = extraMetadata[field.name]
+      let displayValue: string
+
+      if (field.type === EXTRA_PROJECT_METADATA_FIELD_TYPES.SINGLE_SELECT) {
+        const opt = field.options?.find((o) => o.name === value)
+        displayValue = opt ? envStore.data.getExtraFieldLabel(opt, lang) : String(value ?? '')
+      } else if (field.type === EXTRA_PROJECT_METADATA_FIELD_TYPES.MULTI_SELECT) {
+        const values = Array.isArray(value) ? value : []
+        displayValue =
+          values
+            .map((v) => {
+              const opt = field.options?.find((o) => o.name === v)
+              return opt ? envStore.data.getExtraFieldLabel(opt, lang) : v
+            })
+            .join(', ') || '-'
+      } else {
+        displayValue = String(value ?? '') || '-'
+      }
+
+      return { field, displayValue }
+    })
 
   return (
     <bem.FormView__row>
@@ -167,6 +199,18 @@ export default function FormSummaryProjectInfo(props: FormSummaryProjectInfoProp
                 {props.asset.settings.collects_pii?.label ?? '-'}
               </bem.FormView__cell>
             )}
+          </bem.FormView__group>
+        )}
+
+        {/* extra metadata fields */}
+        {extraFieldsWithValues.length > 0 && (
+          <bem.FormView__group m='items'>
+            {extraFieldsWithValues.map(({ field, displayValue }) => (
+              <bem.FormView__cell key={field.name} m='padding'>
+                <bem.FormView__label>{envStore.data.getExtraFieldLabel(field, lang)}</bem.FormView__label>
+                {displayValue}
+              </bem.FormView__cell>
+            ))}
           </bem.FormView__group>
         )}
       </bem.FormView__cell>

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -614,6 +614,7 @@ export interface AssetSettings {
   collects_pii?: LabelValuePair | null
   operational_purpose?: LabelValuePair | null
   country_codes?: string[]
+  extra_metadata?: Record<string, string | string[] | null>
 }
 
 /** This is the asset object Frontend uses with the endpoints. */


### PR DESCRIPTION
### 🗒️ Checklist

1. [X] run linter locally
2. [X] update developer docs (API, README, inline, etc.), if any
3. [X] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [X] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [X] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [X] fill in the template below and delete template comments
7. [X] review thyself: read the diff and repro the preview as written
8. [X] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Update the Project Summary page to show the custom metadata fields configured during the project setup process.

### 👀 Preview steps

1. ℹ️ Have several different types (text, single, multi select) of "Extra Project Metadata Fields" in the Django admin
2. Log into a regular user account
3. Create a new project with some extra project metadata
5. 🟢 [on PR] navigate to the Project Summary after the survey has been created and notice that the extra project metadata are displayed
7. 🟢 Ensure that the data is displayed correctly and that multi-select options are displayed as a comma-separated list