### PR TITLE
feat(autoqa): informative error for autoqa requests on unapproved transcripts DEV-1939

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/index.tsx
@@ -79,11 +79,23 @@ export default function AnalysisQuestionsList({
       // Override default error handler to show a user-friendly message
       // instead of the raw server response (which may contain HTML).
       onError: (err) => {
-        if (err instanceof ServerError && err.response.status === 402) {
-          setIsLimitBlockModalOpen(true)
-        } else {
-          notify.error(t('Failed to generate AI response. Please try again later.'))
+        const genericError = t('Failed to generate AI response. Please try again later.')
+        if (!(err instanceof ServerError)) {
+          notify.error(genericError)
+          return
         }
+        if (err.response.status === 402) {
+          setIsLimitBlockModalOpen(true)
+          return
+        }
+        // TODO: This is a brittle solution for isolating this particular err.
+        // We may be able to remove it if we make it impossible for users to request
+        // AI responses on unsaved errors
+        if (err.detail === 'No transcription found') {
+          notify.error(t('No transcription found. If there is an existing transcription it may need to be saved.'))
+          return
+        }
+        notify.error(genericError)
       },
     },
   })


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Returns a more informative error when users request an AI generated response for a transcript that has not been approved.

### 👀 Preview steps
1. Request an automatic transcription of an audio response, but do not "save" the response after it comes back
2. Go to Analysis tab
3. Click "Generate with AI" for a QA question
4. Verify that an informative error message is displayed.
5. Save the transcription
6. In browser devtools, block the endpoint for PATCHing request for AI generated response
7. Click "Generate with AI" for a QA question
8. Verify that a generic error message is displayed