### PR TITLE
feat(autoqa): remove feature flag DEV-1980

### DIFF
--- a/jsapp/js/account/addOns/addOns.component.tsx
+++ b/jsapp/js/account/addOns/addOns.component.tsx
@@ -10,7 +10,6 @@ import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import type { BadgeColor } from '#/components/common/badge'
 import Badge from '#/components/common/badge'
 import LimitNotifications from '#/components/usageLimits/limitNotifications.component'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import useWhen from '#/hooks/useWhen.hook'
 import { formatDate } from '#/utils'
 import { ProductsContext } from '../useProducts.hook'
@@ -23,7 +22,6 @@ export default function addOns() {
   const [organization] = useOrganizationAssumed()
   const [products] = useContext(ProductsContext)
   const [isBusy, setIsBusy] = useState(true)
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
   const oneTimeAddOnsContext = useContext(OneTimeAddOnsContext)
   const oneTimeAddOnSubscriptions = oneTimeAddOnsContext.oneTimeAddOns
 
@@ -179,7 +177,7 @@ export default function addOns() {
                   description={t('Increase your transcription minutes and translations characters.')}
                 />
               )}
-              {autoQAEnabled && !!llmProducts.length && (
+              {!!llmProducts.length && (
                 <AddOnProductRow
                   products={llmProducts}
                   isBusy={isBusy}

--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -11,7 +11,6 @@ import UsageContainer from '#/account/usage/usageContainer'
 import { YourPlan } from '#/account/usage/yourPlan.component'
 import LimitNotifications from '#/components/usageLimits/limitNotifications.component'
 import envStore from '#/envStore'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import useWhenStripeIsEnabled from '#/hooks/useWhenStripeIsEnabled.hook'
 import { convertSecondsToMinutes, formatDate } from '#/utils'
 import { OneTimeAddOnsContext } from '../useOneTimeAddonList.hook'
@@ -207,18 +206,16 @@ export default function Usage() {
           title={t('Translation characters')}
           dateRange={dateRange}
         />
-        {useFeatureFlag(FeatureFlag.autoQAEnabled) && (
-          <UsageContainer
-            usage={usageQuery.data.data.llm_requests.llm_requests_current_period}
-            remainingLimit={limits.llmRequestsRemainingLimit}
-            recurringLimit={limits.llmRequestsRecurringLimit}
-            oneTimeAddOns={filterAddOns(USAGE_TYPE.LLM)}
-            period={billingPeriod}
-            type={USAGE_TYPE.LLM}
-            title={t('Automatic analysis requests')}
-            dateRange={dateRange}
-          />
-        )}
+        <UsageContainer
+          usage={usageQuery.data.data.llm_requests.llm_requests_current_period}
+          remainingLimit={limits.llmRequestsRemainingLimit}
+          recurringLimit={limits.llmRequestsRecurringLimit}
+          oneTimeAddOns={filterAddOns(USAGE_TYPE.LLM)}
+          period={billingPeriod}
+          type={USAGE_TYPE.LLM}
+          title={t('Automatic analysis requests')}
+          dateRange={dateRange}
+        />
       </Group>
     </div>
   )

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -15,7 +15,6 @@ import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import AssetStatusBadge from '#/components/common/assetStatusBadge'
 import Button from '#/components/common/button'
 import Icon from '#/components/common/icon'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import type { ProjectFieldDefinition } from '#/projects/projectViews/constants'
 import type { ProjectsTableOrder } from '#/projects/projectsTable/projectsTable'
 import SortableProjectColumnHeader from '#/projects/projectsTable/sortableProjectColumnHeader'
@@ -132,17 +131,12 @@ const ProjectBreakdown = () => {
       size: 100,
       cellFormatter: (data: CustomAssetUsage) => data.nlp_usage_current_period.total_nlp_mt_characters.toLocaleString(),
     },
-    ...(useFeatureFlag(FeatureFlag.autoQAEnabled)
-      ? [
-          {
-            key: 'llm_requests',
-            label: t('Automatic analysis requests'),
-            size: 100,
-            cellFormatter: (data: CustomAssetUsage) =>
-              data.nlp_usage_current_period.total_nlp_llm_requests.toLocaleString(),
-          },
-        ]
-      : []),
+    {
+      key: 'llm_requests',
+      label: t('Automatic analysis requests'),
+      size: 100,
+      cellFormatter: (data: CustomAssetUsage) => data.nlp_usage_current_period.total_nlp_llm_requests.toLocaleString(),
+    },
     {
       key: 'staus',
       label: (

--- a/jsapp/js/components/common/multiCheckbox.tsx
+++ b/jsapp/js/components/common/multiCheckbox.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { Stack, Text } from '@mantine/core'
 import bem, { makeBem } from '#/bem'
 import Checkbox from '#/components/common/checkbox'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 
 bem.MultiCheckbox = makeBem(null, 'multi-checkbox', 'ul')
 bem.MultiCheckbox__item = makeBem(bem.MultiCheckbox, 'item', 'li')
@@ -38,8 +37,6 @@ interface MultiCheckboxProps {
  * Use optional `bem.MultiCheckbox__wrapper` to display a frame around it.
  */
 export default function MultiCheckbox(props: MultiCheckboxProps) {
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
-
   function onChange(itemIndex: number, isChecked: boolean) {
     const updatedList = props.items
     updatedList[itemIndex].checked = isChecked
@@ -59,10 +56,10 @@ export default function MultiCheckbox(props: MultiCheckboxProps) {
                   onChange(itemIndex, isChecked)
                 }}
                 // When there's a hint displayed, the label needs to be more prominent
-                label={autoQAEnabled && item.hint ? <strong>{item.label}</strong> : item.label}
+                label={item.hint ? <strong>{item.label}</strong> : item.label}
               />
 
-              {autoQAEnabled && item.hint && (
+              {item.hint && (
                 <Text pl='26px' fz='xs' m='0' ta='left' c='var(--mantine-color-gray-2)'>
                   {item.hint}
                 </Text>

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/AnalysisQuestionEditor/SelectXFieldsEditor.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/AnalysisQuestionEditor/SelectXFieldsEditor.tsx
@@ -5,7 +5,6 @@ import type { ResponseQualSelectQuestionParams } from '#/api/models/responseQual
 import type { ResponseQualSelectQuestionParamsChoicesItem } from '#/api/models/responseQualSelectQuestionParamsChoicesItem'
 import Button from '#/components/common/button'
 import TextBox from '#/components/common/textBox'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { generateUuid } from '#/utils'
 import styles from './SelectXFieldsEditor.module.scss'
 
@@ -20,8 +19,6 @@ interface Props {
  * expose editing the choice label to users - the choice uuid is pregenerated.
  */
 export default function SelectXFieldsEditor({ qaQuestion, onChange, disabled }: Props) {
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
-
   function handleChangeLabel(uuid: string, newLabel: string) {
     onChange(
       qaQuestion.choices.map((choice) => ({
@@ -91,20 +88,18 @@ export default function SelectXFieldsEditor({ qaQuestion, onChange, disabled }: 
                 />
               </Group>
 
-              {autoQAEnabled && (
-                <Box>
-                  <Input
-                    value={hintValue}
-                    onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-                      handleChangeHint(choice.uuid, evt.target.value)
-                    }}
-                    placeholder={t('Add a hint (optional)')}
-                    variant='transparent'
-                    size='s'
-                    disabled={disabled}
-                  />
-                </Box>
-              )}
+              <Box>
+                <Input
+                  value={hintValue}
+                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                    handleChangeHint(choice.uuid, evt.target.value)
+                  }}
+                  placeholder={t('Add a hint (optional)')}
+                  variant='transparent'
+                  size='s'
+                  disabled={disabled}
+                />
+              </Box>
             </Stack>
           )
         })}

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/AnalysisQuestionEditor/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/AnalysisQuestionEditor/index.tsx
@@ -8,7 +8,6 @@ import Button from '#/components/common/button'
 import Icon from '#/components/common/icon'
 import TextBox from '#/components/common/textBox'
 import { LOCALLY_EDITED_PLACEHOLDER_UUID } from '#/components/processing/common/constants'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { generateUuid } from '#/utils'
 import { type AdvancedFeatureResponseManualQual, getQuestionTypeDefinition } from '../../../../common/utils'
 import KeywordSearchFieldsEditor from './KeywordSearchFieldsEditor'
@@ -42,7 +41,6 @@ export default function AnalysisQuestionEditor({
   }
 
   const [newQaQuestion, setNewQaQuestion] = useState<ResponseManualQualActionParams>(() => clonedeep(qaQuestion))
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
   const [errorMessageLabel, setErrorMessageLabel] = useState<string | undefined>()
   const [errorMessageChoices, setErrorMessageChoices] = useState<string | undefined>()
 
@@ -162,19 +160,17 @@ export default function AnalysisQuestionEditor({
         </form>
       </header>
 
-      {autoQAEnabled && (
-        <Box pl='40px' mb='12px'>
-          <Input
-            value={hintValue}
-            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-              handleChangeHint(evt.target.value)
-            }}
-            placeholder={t('Add a hint (optional)')}
-            variant='transparent'
-            size='s'
-          />
-        </Box>
-      )}
+      <Box pl='40px' mb='12px'>
+        <Input
+          value={hintValue}
+          onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+            handleChangeHint(evt.target.value)
+          }}
+          placeholder={t('Add a hint (optional)')}
+          variant='transparent'
+          size='s'
+        />
+      </Box>
 
       {newQaQuestion.type === 'qualAutoKeywordCount' && (
         <KeywordSearchFieldsEditor

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
@@ -1,7 +1,6 @@
 import { NumberInput } from '@mantine/core'
 import React, { useEffect, useState } from 'react'
 import type { QualVersionItem } from '#/components/processing/common/types'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 import styles from '../../../common/styles.module.scss'
 
@@ -16,7 +15,6 @@ export default function IntegerResponseForm({ qaAnswer, onSave, disabled, isAnsw
   // `value` can be a (empty) string when you remove it
   const [value, setValue] = useState<number | string | undefined>(((qaAnswer?._data as any)?.value as number) ?? '')
   const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
 
   // Sync local state when a new version is set (e.g. after AI generation)
   useEffect(() => {
@@ -45,7 +43,7 @@ export default function IntegerResponseForm({ qaAnswer, onSave, disabled, isAnsw
       }}
       value={value}
       onChange={handleChange}
-      placeholder={autoQAEnabled ? t('Type your response or use AI') : t('Type your response')}
+      placeholder={t('Type your response or use AI')}
       onBlur={handleSave}
       disabled={disabled}
     />

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/MultipleResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/MultipleResponseForm.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import type { ResponseQualSelectQuestionParams } from '#/api/models/responseQualSelectQuestionParams'
 import MultiCheckbox, { type MultiCheckboxItem } from '#/components/common/multiCheckbox'
 import type { QualVersionItem } from '#/components/processing/common/types'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import styles from '../../../common/styles.module.scss'
 import { useShowHints } from '../../../common/utils'
 
@@ -24,7 +23,6 @@ export default function SelectMultipleResponseForm({
   isAnswerAIGenerated,
 }: Props) {
   const [showHints] = useShowHints()
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
 
   const handleChange = (items: MultiCheckboxItem[]) => {
     // Use new variable/reference to ensure state is updated before saving
@@ -48,10 +46,7 @@ export default function SelectMultipleResponseForm({
           .map((choice) => ({
             name: choice.uuid,
             label: choice.labels._default,
-            hint:
-              showHints && autoQAEnabled
-                ? (choice.hint?.labels as { [key: string]: string | undefined })?._default
-                : undefined,
+            hint: showHints ? (choice.hint?.labels as { [key: string]: string | undefined })?._default : undefined,
             checked: (((qaAnswer?._data as any)?.value as string[]) ?? []).includes(choice.uuid),
           }))}
         onChange={handleChange}

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/RadioGroup.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/RadioGroup.tsx
@@ -1,6 +1,5 @@
 import { Radio, Stack, Text } from '@mantine/core'
 import React, { type ChangeEvent } from 'react'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { useShowHints } from '../../../common/utils'
 
 export interface RadioGroupOption {
@@ -18,7 +17,6 @@ interface RadioGroupProps {
 }
 
 export default function RadioGroup({ options, value, onChange, disabled }: RadioGroupProps) {
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
   const [showHints] = useShowHints()
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -34,12 +32,12 @@ export default function RadioGroup({ options, value, onChange, disabled }: Radio
               <Radio
                 value={option.uuid}
                 // When there's a hint displayed, the label needs to be more prominent
-                label={showHints && autoQAEnabled && option.hint ? <strong>{option.label}</strong> : option.label}
+                label={showHints && option.hint ? <strong>{option.label}</strong> : option.label}
                 onChange={handleChange}
                 checked={value === option.uuid}
                 disabled={disabled || option.disabled}
               />
-              {showHints && autoQAEnabled && option.hint && (
+              {showHints && option.hint && (
                 <Text pl='26px' fz='xs' m='0' ta='left' c='var(--mantine-color-gray-2)'>
                   {option.hint}
                 </Text>

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/ResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/ResponseForm.tsx
@@ -8,7 +8,6 @@ import Icon from '#/components/common/icon'
 
 import type { ResponseManualQualActionParams } from '#/api/models/responseManualQualActionParams'
 import type { QualVersionItem } from '#/components/processing/common/types'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { getQuestionTypeDefinition, hasEmptyValueAnswer, useShowHints } from '../../../common/utils'
 
 interface Props {
@@ -54,7 +53,6 @@ export default function ResponseForm({
   const [verificationStatus, setVerificationStatus] = useState<boolean | undefined>(undefined)
   const [isGenerating, setIsGenerating] = useState(false)
   const [showHints] = useShowHints()
-  const ffAutoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
 
   useEffect(() => {
     setVerificationStatus(undefined)
@@ -199,7 +197,7 @@ export default function ResponseForm({
         )}
       </Group>
 
-      {showHints && ffAutoQAEnabled && hintValue && (
+      {showHints && hintValue && (
         <Text pl='40px' m='0' ta='left' c='var(--mantine-color-gray-2)' mt='calc(-1 * var(--stack-gap))'>
           {hintValue}
         </Text>
@@ -208,7 +206,7 @@ export default function ResponseForm({
       {/* Hard coded left padding to account for the 32px icon size + 8px gap */}
       {children && <Box pl='40px'>{children}</Box>}
 
-      {shouldDisplayAnyButtonOrBadge && ffAutoQAEnabled && (
+      {shouldDisplayAnyButtonOrBadge && (
         <Group pl='40px' w='100%' align='center'>
           {shouldDisplayGenerateWithAIButton && (
             <ButtonNew

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
@@ -1,7 +1,6 @@
 import { Textarea } from '@mantine/core'
 import React, { useEffect, useState } from 'react'
 import type { QualVersionItem } from '#/components/processing/common/types'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 import styles from '../../../common/styles.module.scss'
 
@@ -15,7 +14,6 @@ interface Props {
 export default function TextResponseForm({ qaAnswer, onSave, disabled, isAnswerAIGenerated }: Props) {
   const [value, setValue] = useState<string>(((qaAnswer?._data as any)?.value as string) ?? '')
   const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
   // Sync local state when a new version is set (e.g. after AI generation)
   useEffect(() => {
     const newValue = ((qaAnswer?._data as any)?.value as string) ?? ''
@@ -43,7 +41,7 @@ export default function TextResponseForm({ qaAnswer, onSave, disabled, isAnswerA
       minRows={2}
       value={value}
       onChange={handleChange}
-      placeholder={autoQAEnabled ? t('Type your response or use AI') : t('Type your response')}
+      placeholder={t('Type your response or use AI')}
       onBlur={handleBlur}
       disabled={disabled}
     />

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisHeader.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisHeader.tsx
@@ -14,7 +14,6 @@ import KoboDropdown from '#/components/common/koboDropdown'
 import ToggleSwitch from '#/components/common/toggleSwitch'
 import { userCan } from '#/components/permissions/utils'
 import type { AssetResponse } from '#/dataInterface'
-import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { getAllTranslationsFromSupplementData, getLatestTranscriptVersionItem } from '../../common/utils'
 import styles from './AnalysisHeader.module.scss'
 import { ANALYSIS_QUESTION_TYPES } from './common/constants'
@@ -38,7 +37,6 @@ export default function AnalysisHeader({ asset, questionXpath, supplement, qaQue
   const transcriptVersion = getLatestTranscriptVersionItem(supplement, questionXpath)
   const translationVersions = getAllTranslationsFromSupplementData(supplement, questionXpath)
 
-  const autoQAEnabled = useFeatureFlag(FeatureFlag.autoQAEnabled)
   const [showHints, setShowHints] = useShowHints()
 
   // Note: Technically correct would be to filter for the 3 specific mutations we are interested in,
@@ -96,7 +94,7 @@ export default function AnalysisHeader({ asset, questionXpath, supplement, qaQue
           isDisabled={!userCan('manage_asset', asset) || !!qaQuestion}
         />
 
-        {autoQAEnabled && <ToggleSwitch label={t('Show hints')} checked={showHints} onChange={setShowHints} />}
+        <ToggleSwitch label={t('Show hints')} checked={showHints} onChange={setShowHints} />
       </Group>
 
       <span>

--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -5,8 +5,7 @@ import { recordValues } from './utils'
  * For our sanity, use camel case and match key with value.
  */
 export enum FeatureFlag {
-  //exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
-  autoQAEnabled = 'autoQAEnabled', //Comment out when we have active FFs
+  exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
 }
 
 /**


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Remove feature flag for automatic qualitative analysis in preparation for release.

### 👀 Preview steps
I won't leave detailed instructions here, because technically the changes cover the entire feature. None of the logic here was particularly complex, so there shouldn't be any changes. I'd just recommend taking a quick look at the feature with Stripe enabled if you want to confirm.