### PR TITLE
fix(qual): default to false if verification missing DEV-1982

### DIFF
--- a/kobo/apps/subsequences/actions/qual.py
+++ b/kobo/apps/subsequences/actions/qual.py
@@ -434,7 +434,7 @@ class BaseQualAction(BaseAction):
                 'xpath': self.source_question_xpath,
                 'labels': qual_question.get('labels', {}),
                 SORT_BY_DATE_FIELD: selected_version[self.DATE_CREATED_FIELD],
-                'verified': selected_version['verified'],
+                'verified': selected_version.get('verified', False),
                 'source': self.source,
             }
         return results_dict

--- a/kobo/apps/subsequences/tests/api/v2/test_api.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_api.py
@@ -587,8 +587,8 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
                                     'value': 'Answer',
                                 },
                                 '_dateCreated': '2025-12-15T22:22:00+00:00',
-                                '_dateAccepted': '2025-12-15T22:22:00+00:00',
                                 '_uuid': '15ccc864-0e83-48f2-be1d-dc2adb9297f4',
+                                'verified': False,
                             }
                         ],
                     },
@@ -602,8 +602,8 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
                                     'value': '83212060-fd18-445a-b121-ad82c2e5811d',
                                 },
                                 '_dateCreated': '2025-12-15T22:22:00+00:00',
-                                '_dateAccepted': '2025-12-15T22:22:00+00:00',
                                 '_uuid': 'f2b4c6b1-3c6a-4a7f-9e55-1a8c2a0a7c91',
+                                'verified': False,
                             }
                         ],
                     },
@@ -620,8 +620,8 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
                                     ],
                                 },
                                 '_dateCreated': '2025-12-15T22:22:00+00:00',
-                                '_dateAccepted': '2025-12-15T22:22:00+00:00',
                                 '_uuid': '8c9a8e44-7a3d-4c58-b7bb-5f2a1c6e5c3a',
+                                'verified': False,
                             }
                         ],
                     },

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -363,8 +363,8 @@ class TestVersioning(TestCase):
                                     'value': 'music123',
                                 },
                                 '_dateCreated': now.isoformat(),
-                                '_dateAccepted': now.isoformat(),
                                 '_uuid': 'uuid5',
+                                'verified': False,
                             }
                         ],
                     },
@@ -378,8 +378,8 @@ class TestVersioning(TestCase):
                                     'value': 2,
                                 },
                                 '_dateCreated': now.isoformat(),
-                                '_dateAccepted': now.isoformat(),
                                 '_uuid': 'uuid6',
+                                'verified': False,
                             }
                         ],
                     },

--- a/kobo/apps/subsequences/utils/versioning.py
+++ b/kobo/apps/subsequences/utils/versioning.py
@@ -189,8 +189,8 @@ def migrate_qual_data(supplemental_data: dict) -> dict | None:
         new_version = {
             '_data': {'uuid': question_uuid, 'value': value},
             '_dateCreated': now,
-            '_dateAccepted': now,
             '_uuid': str(uuid.uuid4()),
+            'verified': False,
         }
 
         new_qual_dict[question_uuid] = {


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fix an error loading the data table with older submissions


### 📖 Description
Loading a data table for a survey with older submissions that had QA data from before verification was released caused a 500 and displayed a long error message.


### 💭 Notes
Defaults the verification column to 'False' if not present. Also fixes a related issue in the migration code that was setting `_dateAccepted,` which is not a field used for qual questions. This PR does not address the issue of qual questions that have already been migrated. There is other work in progress to do a large-scale migration and that work should probably be combined with fixing this issue for pre-existing data.


### 👀 Preview steps
Start out on the 2.026.07 branch to create data using the old code

1. Create a project with an audio question and add a submission
2. Add a QA question and answer to the submission
3. Switch to main
4. Navigate to the data table
5. 🔴 [on main] Error
6. 🟢 [on PR] the table loads with the verified column set to False

