### PR TITLE
fix: prevent IntegrityError when running `create_kobo_superuser` management command DEV-1987

### DIFF
--- a/kpi/management/commands/create_kobo_superuser.py
+++ b/kpi/management/commands/create_kobo_superuser.py
@@ -35,13 +35,18 @@ class Command(BaseCommand):
             )
             sys.exit(1)
 
-        # Fix any superuser missing a user profile or email address
+        # Validate superuser email address
         EmailAddress.objects.get_or_create(
-            user=user, email=user.email, verified=True, primary=True
+            user=user,
+            email=user.email,
+            defaults={'verified': True, 'primary': True},
         )
+
         if kobocat_database_ready:
+            # Create superuser's profile
             UserProfile.objects.get_or_create(
-                user_id=user.pk, validated_password=True
+                user_id=user.pk,
+                defaults={'validated_password': True},
             )
             self.stdout.write(
                 f'Superuser `{super_username}` successfully created.'

--- a/kpi/management/commands/create_kobo_superuser.py
+++ b/kpi/management/commands/create_kobo_superuser.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 import sys
 import os
 
+from allauth.account.models import EmailAddress
 from django.core.management.base import BaseCommand
 from django.db.utils import ProgrammingError
 
@@ -15,23 +15,38 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         super_username = os.getenv('KOBO_SUPERUSER_USERNAME', 'kobo')
-        if User.objects.filter(username=super_username).count() > 0:
+        if User.objects.filter(username=super_username).exists():
             self.stdout.write('User already exists.')
             sys.exit()
 
+        kobocat_database_ready = True
         try:
             user = User.objects.create_superuser(
-                os.getenv('KOBO_SUPERUSER_USERNAME', 'kobo'),
+                super_username,
                 os.getenv('KOBO_SUPERUSER_EMAIL', 'kobo@example.com'),
                 os.getenv('KOBO_SUPERUSER_PASSWORD', 'kobo'))
-            user.emailaddress_set.create(email=user.email, verified=True, primary=True)
-        except ProgrammingError:  # Signals fail when `kc` database
-            pass                  # doesn't exist yet.
+        except ProgrammingError:
+            # Signals fail when `kc` database doesn't exist yet.
+            kobocat_database_ready = False
+            user = User.objects.get(username=super_username)
         except Exception as e:
-            self.stdout.write('Superuser could not be created.\n'
-                              'Error: {}'.format(str(e)))
-        else:
-            UserProfile.objects.create(user=user)
+            self.stderr.write(
+                'Superuser could not be created.\n' 'Error: {}'.format(str(e))
+            )
+            sys.exit(1)
 
-        if User.objects.filter(username=super_username).count() > 0:
-            self.stdout.write('Superuser successfully created.')
+        # Fix any superuser missing a user profile or email address
+        EmailAddress.objects.get_or_create(
+            user=user, email=user.email, verified=True, primary=True
+        )
+        if kobocat_database_ready:
+            UserProfile.objects.get_or_create(
+                user_id=user.pk, validated_password=True
+            )
+            self.stdout.write(
+                f'Superuser `{super_username}` successfully created.'
+            )
+        else:
+            self.stdout.write(
+                f'Superuser `{super_username}` created but not synced to KC database'
+            )

--- a/kpi/tests/test_create_kobo_superuser.py
+++ b/kpi/tests/test_create_kobo_superuser.py
@@ -45,7 +45,8 @@ class CreateKoboSuperuserCommandTest(TestCase):
             user=user, email=self.EMAIL, verified=True, primary=True
         ).exists()
         mock_userprofile.objects.get_or_create.assert_called_once_with(
-            user_id=user.pk, validated_password=True
+            user_id=user.pk,
+            defaults={'validated_password': True},
         )
         assert f'Superuser `{self.USERNAME}` successfully created.' in out.getvalue()
 
@@ -75,7 +76,9 @@ class CreateKoboSuperuserCommandTest(TestCase):
 
         mock_user_cls.objects.get.assert_called_once_with(username=self.USERNAME)
         mock_email_cls.objects.get_or_create.assert_called_once_with(
-            user=mock_user, email=mock_user.email, verified=True, primary=True
+            user=mock_user,
+            email=mock_user.email,
+            defaults={'verified': True, 'primary': True},
         )
         mock_userprofile_cls.objects.get_or_create.assert_not_called()
         assert 'not synced to KC database' in out.getvalue()

--- a/kpi/tests/test_create_kobo_superuser.py
+++ b/kpi/tests/test_create_kobo_superuser.py
@@ -1,0 +1,96 @@
+import os
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.db.utils import ProgrammingError
+from django.test import TestCase
+
+from allauth.account.models import EmailAddress
+from kobo.apps.kobo_auth.shortcuts import User
+
+
+MODULE = 'kpi.management.commands.create_kobo_superuser'
+
+
+class CreateKoboSuperuserCommandTest(TestCase):
+
+    USERNAME = 'kobo_superuser_test'
+    EMAIL = 'kobo_test@example.com'
+    PASSWORD = 'kobo_test_pass'
+
+    def _env(self):
+        return {
+            'KOBO_SUPERUSER_USERNAME': self.USERNAME,
+            'KOBO_SUPERUSER_EMAIL': self.EMAIL,
+            'KOBO_SUPERUSER_PASSWORD': self.PASSWORD,
+        }
+
+    @patch(f'{MODULE}.UserProfile')
+    def test_creates_superuser_successfully(self, mock_userprofile):
+        """
+        Superuser, EmailAddress, and UserProfile are all created when none
+        exist.
+        """
+        mock_userprofile.objects.get_or_create.return_value = (MagicMock(), True)
+        out = StringIO()
+
+        with patch.dict(os.environ, self._env()):
+            call_command('create_kobo_superuser', stdout=out)
+
+        user = User.objects.get(username=self.USERNAME)
+        assert user.is_superuser
+        assert EmailAddress.objects.filter(
+            user=user, email=self.EMAIL, verified=True, primary=True
+        ).exists()
+        mock_userprofile.objects.get_or_create.assert_called_once_with(
+            user_id=user.pk, validated_password=True
+        )
+        assert f'Superuser `{self.USERNAME}` successfully created.' in out.getvalue()
+
+    @patch(f'{MODULE}.UserProfile')
+    @patch(f'{MODULE}.EmailAddress')
+    @patch(f'{MODULE}.User')
+    def test_programming_error_recovers_and_skips_profile(
+        self, mock_user_cls, mock_email_cls, mock_userprofile_cls
+    ):
+        """
+        When the KC database raises ProgrammingError during superuser creation
+        (signal-level failure), the user is retrieved from the KPI DB,
+        EmailAddress is still created, and UserProfile is skipped.
+        """
+        mock_user = MagicMock()
+        mock_user.email = self.EMAIL
+        mock_user.pk = 999
+
+        mock_user_cls.objects.filter.return_value.exists.return_value = False
+        mock_user_cls.objects.create_superuser.side_effect = ProgrammingError
+        mock_user_cls.objects.get.return_value = mock_user
+        mock_email_cls.objects.get_or_create.return_value = (MagicMock(), True)
+
+        out = StringIO()
+        with patch.dict(os.environ, self._env()):
+            call_command('create_kobo_superuser', stdout=out)
+
+        mock_user_cls.objects.get.assert_called_once_with(username=self.USERNAME)
+        mock_email_cls.objects.get_or_create.assert_called_once_with(
+            user=mock_user, email=mock_user.email, verified=True, primary=True
+        )
+        mock_userprofile_cls.objects.get_or_create.assert_not_called()
+        assert 'not synced to KC database' in out.getvalue()
+
+    def test_exits_if_user_already_exists(self):
+        """
+        Command exits cleanly when the superuser already exists, without
+        creating a duplicate.
+        """
+        User.objects.create_superuser(self.USERNAME, self.EMAIL, self.PASSWORD)
+        out = StringIO()
+
+        with patch.dict(os.environ, self._env()):
+            with pytest.raises(SystemExit):
+                call_command('create_kobo_superuser', stdout=out)
+
+        assert User.objects.filter(username=self.USERNAME).count() == 1
+        assert 'User already exists.' in out.getvalue()


### PR DESCRIPTION
### 📣 Summary

Running `create_kobo_superuser` could crash with an `IntegrityError` when trying to create the user profile.

### 💭 Notes

- `UserProfile.objects.create` and `EmailAddress.create` replaced with `get_or_create` to avoid `IntegrityError` on duplicate records.
- Secondary fix: when `ProgrammingError` is raised inside `create_superuser` (KC DB not ready, signal-level failure), the `user` variable was never assigned, causing a `NameError` on the subsequent `EmailAddress.objects.get_or_create(user=user, ...)` call. Fix: retrieve the already-saved user via `User.objects.get(username=super_username)`.
- Three unit tests added: happy path, `ProgrammingError` recovery (mocked), and early-exit when user already exists.

### Preview steps:
1. from release branch, run `KOBO_SUPERUSER_USERNAME=foobar ./manage.py create_kobo_superuser` and receive an IntegrityError
2. from this branch, receive the message "Superuser xxx successfully created."  