### PR TITLE
ci(ephemeral_envs): add ability to deploy an ephemeral environment off of a branch INFRA-461

### DIFF
--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -74,26 +74,22 @@ jobs:
 
       - name: set variables
         id: set_variables
+        env:
+          INPUT_TYPE: ${{ github.event.inputs.input_type }}
+          INPUT_VALUE: ${{ github.event.inputs.input_value }}
+          PR_TITLE: ${{ steps.get_pr_info.outputs.title }}
         run: |
-          ZULIP_TOPIC="${{ github.event.inputs.input_type }} ${{ github.event.inputs.input_value }}${{ github.event.inputs.input_type == 'PR' && format(' - {0}', steps.get_pr_info.outputs.title) || '' }}"
-          echo "zulip_topic=$ZULIP_TOPIC" >> $GITHUB_OUTPUT
-
-          if [ "${{ github.event.inputs.input_type }}" = "PR" ]; then
-            echo "ENV_NAME=pr-${{ github.event.inputs.input_value }}" >> $GITHUB_OUTPUT
+          if [ "$INPUT_TYPE" = "PR" ]; then
+            ZULIP_TOPIC="$INPUT_TYPE $INPUT_VALUE - $PR_TITLE"
+            echo "ENV_NAME=pr-$INPUT_VALUE" >> $GITHUB_OUTPUT
           else
-            # Sanitize: Lowercase, replace non-alphanumeric with hyphens
-            CLEAN_NAME=$(echo "${{ github.event.inputs.input_value }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^-//;s/-$//')
-
-            # Create a hash of the FULL branch name Using sha256 and taking 6 characters
-            HASH=$(echo -n "${{ github.event.inputs.input_value }}" | sha256sum | cut -c 1-6)
-
-            # Truncate name to 20 chars
+            ZULIP_TOPIC="$INPUT_TYPE $INPUT_VALUE"
+            CLEAN_NAME=$(echo "$INPUT_VALUE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^-//;s/-$//')
+            HASH=$(echo -n "$INPUT_VALUE" | sha256sum | cut -c 1-6)
             TRUNC_NAME=$(echo "$CLEAN_NAME" | cut -c 1-20)
-
-            ENV_NAME="br-$TRUNC_NAME-$HASH"
-
-            echo "ENV_NAME=$ENV_NAME" >> $GITHUB_OUTPUT
+            echo "ENV_NAME=br-$TRUNC_NAME-$HASH" >> $GITHUB_OUTPUT
           fi
+          echo "zulip_topic=$ZULIP_TOPIC" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -137,4 +133,4 @@ jobs:
     with:
       stream: "PR Preview Environments"
       topic: "${{ needs.build.outputs.zulip_topic }}"
-      content: "❌ Failed to deploy ephemeral environment for ${{ github.event.inputs.input_type }} #${{ github.event.inputs.input_value }} [run #${{github.run_number}}](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})"
+      content: "❌ Failed to deploy ephemeral environment for ${{ github.event.inputs.input_type }} ${{ github.event.inputs.input_value }} [run #${{github.run_number}}](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})"

--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -51,7 +51,7 @@ jobs:
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
           echo "Found commit hash: $COMMIT_HASH"
-          COMMIT_MESSAGE=$(git log -1 --pretty=%B | sed 's/"//g') # Remove double quotes to avoid issues
+          COMMIT_MESSAGE=$(git log -1 --format=%s | sed 's/"//g') # Remove double quotes to avoid issues
           echo "commit_message=$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -80,7 +80,8 @@ jobs:
           PR_TITLE: ${{ steps.get_pr_info.outputs.title }}
         run: |
           if [ "$INPUT_TYPE" = "PR" ]; then
-            ZULIP_TOPIC="$INPUT_TYPE $INPUT_VALUE - $PR_TITLE"
+            CLEAN_TITLE=$(echo "$PR_TITLE" | tr -d '"')
+            ZULIP_TOPIC="$INPUT_TYPE $INPUT_VALUE - $CLEAN_TITLE"
             echo "ENV_NAME=pr-$INPUT_VALUE" >> $GITHUB_OUTPUT
           else
             ZULIP_TOPIC="$INPUT_TYPE $INPUT_VALUE"

--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -32,13 +32,14 @@ jobs:
         id: get_pr_info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VALUE: ${{ github.event.inputs.input_value }}
         run: |
           # Use the GitHub CLI to find the branch name for the PR
-          BRANCH=$(gh pr view ${{ github.event.inputs.input_value }} \
+          BRANCH=$(gh pr view "$INPUT_VALUE" \
             --repo kobotoolbox/kpi \
             --json headRefName --template '{{.headRefName}}')
 
-          TITLE=$(gh pr view ${{ github.event.inputs.input_value }} \
+          TITLE=$(gh pr view "$INPUT_VALUE" \
             --repo kobotoolbox/kpi \
             --json title --template '{{.title}}')
 

--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -4,8 +4,16 @@ name: Deploy PR preview environment
 on:
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: 'The PR number from "kpi" to build'
+      input_type:
+        description: 'Deploy a PR or branch?'
+        required: true
+        type: choice
+        default: PR
+        options:
+          - PR
+          - Branch
+      input_value:
+        description: 'The PR number or branch name from "kpi" to deploy'
         required: true
         type: string
 
@@ -16,20 +24,21 @@ jobs:
       contents: read
       packages: write
     outputs:
-      title: ${{ steps.get_pr_info.outputs.title }}
+      zulip_topic: ${{ steps.set_variables.outputs.zulip_topic }}
 
     steps:
       - name: Get PR info
+        if: ${{ github.event.inputs.input_type == 'PR' }}
         id: get_pr_info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Use the GitHub CLI to find the branch name for the PR
-          BRANCH=$(gh pr view ${{ github.event.inputs.pr_number }} \
+          BRANCH=$(gh pr view ${{ github.event.inputs.input_value }} \
             --repo kobotoolbox/kpi \
             --json headRefName --template '{{.headRefName}}')
 
-          TITLE=$(gh pr view ${{ github.event.inputs.pr_number }} \
+          TITLE=$(gh pr view ${{ github.event.inputs.input_value }} \
             --repo kobotoolbox/kpi \
             --json title --template '{{.title}}')
 
@@ -37,11 +46,13 @@ jobs:
           echo "title=$TITLE" >> $GITHUB_OUTPUT
           echo "Found branch: $BRANCH"
 
+
       - name: Clone kpi repo at PR branch
         uses: actions/checkout@v6
         with:
           repository: kobotoolbox/kpi
-          ref: ${{ steps.get_pr_info.outputs.branch_name }}
+          #if the input type is PR, use the branch name from the previous step; otherwise, use the input value directly as the branch name
+          ref: ${{ github.event.inputs.input_type == 'PR' && steps.get_pr_info.outputs.branch_name || github.event.inputs.input_value }}
           path: kpi
 
       - name: Get commit info
@@ -61,35 +72,60 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: set variables
+        id: set_variables
+        run: |
+          ZULIP_TOPIC="${{ github.event.inputs.input_type }} ${{ github.event.inputs.input_value }}${{ github.event.inputs.input_type == 'PR' && format(' - {0}', steps.get_pr_info.outputs.title) || '' }}"
+          echo "zulip_topic=$ZULIP_TOPIC" >> $GITHUB_OUTPUT
+
+          if [ "${{ github.event.inputs.input_type }}" = "PR" ]; then
+            echo "ENV_NAME=pr-${{ github.event.inputs.input_value }}" >> $GITHUB_OUTPUT
+          else
+            # Sanitize: Lowercase, replace non-alphanumeric with hyphens
+            CLEAN_NAME=$(echo "${{ github.event.inputs.input_value }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^-//;s/-$//')
+
+            # Create a hash of the FULL branch name Using sha256 and taking 6 characters
+            HASH=$(echo -n "${{ github.event.inputs.input_value }}" | sha256sum | cut -c 1-6)
+
+            # Truncate name to 20 chars
+            TRUNC_NAME=$(echo "$CLEAN_NAME" | cut -c 1-20)
+
+            ENV_NAME="br-$TRUNC_NAME-$HASH"
+
+            echo "ENV_NAME=$ENV_NAME" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: ./kpi
           push: true
-          tags: ghcr.io/kobotoolbox/kpi:pr-${{ github.event.inputs.pr_number }}
+          tags: ghcr.io/kobotoolbox/kpi:${{ steps.set_variables.outputs.ENV_NAME }}
 
       - name: Generate GitHub App Token
-        id: app-token
+        id: app_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+          client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
           private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
           owner: kobotoolbox
           repositories: "devops"
 
-      - name: Trigger pr deploy build
+      - name: Trigger deployment workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: kpi_pr_deploy.yml
+          workflow: kpi_ephemeral_deploy.yml
           repo: kobotoolbox/devops
           ref: main
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app_token.outputs.token }}
           inputs: |
             {
-              "pr_number": "${{ github.event.inputs.pr_number }}",
-              "title": "${{ steps.get_pr_info.outputs.title }}",
+              "input_type": "${{ github.event.inputs.input_type }}",
+              "input_value": "${{ github.event.inputs.input_value }}",
+              "env_name": "${{ steps.set_variables.outputs.ENV_NAME }}",
               "commit_hash": "${{ steps.get_commit_info.outputs.commit_hash }}",
-              "commit_message": "${{ steps.get_commit_info.outputs.commit_message }}"
+              "commit_message": "${{ steps.get_commit_info.outputs.commit_message }}",
+              "zulip_topic": "${{ steps.set_variables.outputs.zulip_topic }}"
             }
 
   notify-failure:
@@ -100,5 +136,5 @@ jobs:
     secrets: inherit
     with:
       stream: "PR Preview Environments"
-      topic: PR ${{ github.event.inputs.pr_number }} - ${{ needs.build.outputs.title }}
-      content: "❌ Failed to deploy ephemeral environment for PR #${{ github.event.inputs.pr_number }} [run #${{github.run_number}}](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})"
+      topic: "${{ needs.build.outputs.zulip_topic }}"
+      content: "❌ Failed to deploy ephemeral environment for ${{ github.event.inputs.input_type }} #${{ github.event.inputs.input_value }} [run #${{github.run_number}}](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})"


### PR DESCRIPTION
### 💭 Notes

This updates the pr environment workflow to add the ability to deploy from either a PR or a branch.

I've also updated the app token generation to use client id instead of app ID as app ID is being deprecated.  I've manually stored the value in a org secret `KOBO_BOT_CLIENT_ID`

[Here](https://github.com/kobotoolbox/kpi/actions/runs/24586526965) is an example of it running with a pr input
[Here](https://github.com/kobotoolbox/kpi/actions/runs/24586540328) is an example of it running with a branch input