### PR TITLE
ci(enketo):update non-prod deploy pipeline with required enketo versi…

### DIFF
--- a/.github/workflows/nonprod-releases.yml
+++ b/.github/workflows/nonprod-releases.yml
@@ -67,13 +67,13 @@ jobs:
       - name: Deploy to beta
         if: github.ref_name == 'public-beta'
         run: |
-          helm -n kobo-dev upgrade beta oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${GITHUB_SHA} --set kpi.image.repository=$CI_REGISTRY_IMAGE --reuse-values
+          helm -n kobo-dev upgrade beta oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${GITHUB_SHA} --set kpi.image.repository=$CI_REGISTRY_IMAGE --set-string enketo.version=${{ vars.ENKETO_VERSION }} --reuse-values
 
       - name: Deploy to feature branch
         if: startsWith(github.ref_name, 'feature/')
         run: |
           BRANCH_TITLE=${GITHUB_REF_NAME#feature/}
-          helm -n kobo-dev upgrade --install $BRANCH_TITLE oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${GITHUB_SHA} --set kpi.image.repository=$CI_REGISTRY_IMAGE --reuse-values
+          helm -n kobo-dev upgrade --install $BRANCH_TITLE oci://ghcr.io/kobotoolbox/kobo --atomic --set-string kpi.version=${GITHUB_SHA} --set kpi.image.repository=$CI_REGISTRY_IMAGE --set-string enketo.version=${{ vars.ENKETO_VERSION }} --reuse-values
 
   trigger-main-deploy:
     needs: deploy


### PR DESCRIPTION
📣 Summary
Backport enketo ci version changes (https://github.com/kobotoolbox/kpi/commit/cf01957071f8bd734128e1d4d534105b476a50e2) to release/2.026.07