### PR TITLE
fix(processing): update responses when switching submissions DEV-2008

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
@@ -1,25 +1,41 @@
 import { NumberInput } from '@mantine/core'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
 interface Props {
   qaAnswer?: _DataSupplementResponseOneOfManualQualVersionsItem
+  submissionUid: string
   disabled: boolean
   onSave: (value: number | null) => Promise<unknown>
 }
 
-export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Props) {
+export default function IntegerResponseForm({ qaAnswer, submissionUid, onSave, disabled }: Props) {
   const [value, setValue] = useState<number | undefined>((qaAnswer?._data.value as number) ?? undefined)
+  const [isDirty, setIsDirty] = useState(false)
   const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
+
+  // New submissions should always display their own saved value.
+  useEffect(() => {
+    clearTimeout(typingTimer)
+    setValue((qaAnswer?._data.value as number) ?? undefined)
+    setIsDirty(false)
+  }, [submissionUid])
+
+  // Within a single submission, avoid clobbering local typing with server updates.
+  useEffect(() => {
+    if (isDirty) return
+    setValue((qaAnswer?._data.value as number) ?? undefined)
+  }, [qaAnswer?._uuid, isDirty])
 
   const handleSave = async () => {
     clearTimeout(typingTimer)
     await onSave(value ?? null)
   }
 
-  const handleChange = (value: string | number) => {
-    setValue(value as number)
+  const handleChange = (inputValue: string | number) => {
+    setIsDirty(true)
+    setValue(inputValue === '' ? undefined : (inputValue as number))
     clearTimeout(typingTimer)
     setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save
   }

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
@@ -1,5 +1,5 @@
 import { NumberInput } from '@mantine/core'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
@@ -11,28 +11,17 @@ interface Props {
 
 export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Props) {
   const [value, setValue] = useState<number | undefined>((qaAnswer?._data.value as number) ?? undefined)
-  const typingTimerRef = useRef<NodeJS.Timeout | undefined>()
+  const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
 
-  const clearTypingTimer = () => {
-    if (!typingTimerRef.current) return
-    clearTimeout(typingTimerRef.current)
-    typingTimerRef.current = undefined
-  }
-
-  useEffect(() => () => clearTypingTimer(), [])
-
-  const handleSave = async (valueToSave: number | undefined) => {
-    clearTypingTimer()
-    await onSave(valueToSave ?? null)
+  const handleSave = async () => {
+    clearTimeout(typingTimer)
+    await onSave(value ?? null)
   }
 
   const handleChange = (inputValue: string | number) => {
-    const nextValue = inputValue === '' ? undefined : (inputValue as number)
-    setValue(nextValue)
-    clearTypingTimer()
-    typingTimerRef.current = setTimeout(() => {
-      handleSave(nextValue)
-    }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
+    setValue(inputValue as number)
+    clearTimeout(typingTimer)
+    setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save
   }
 
   return (
@@ -40,9 +29,7 @@ export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Prop
       value={value}
       onChange={handleChange}
       placeholder={t('Type your answer')}
-      onBlur={() => {
-        handleSave(value)
-      }}
+      onBlur={handleSave}
       disabled={disabled}
     />
   )

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
@@ -1,43 +1,38 @@
 import { NumberInput } from '@mantine/core'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
 interface Props {
   qaAnswer?: _DataSupplementResponseOneOfManualQualVersionsItem
-  submissionUid: string
   disabled: boolean
   onSave: (value: number | null) => Promise<unknown>
 }
 
-export default function IntegerResponseForm({ qaAnswer, submissionUid, onSave, disabled }: Props) {
+export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Props) {
   const [value, setValue] = useState<number | undefined>((qaAnswer?._data.value as number) ?? undefined)
-  const [isDirty, setIsDirty] = useState(false)
-  const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
+  const typingTimerRef = useRef<NodeJS.Timeout | undefined>()
 
-  // New submissions should always display their own saved value.
-  useEffect(() => {
-    clearTimeout(typingTimer)
-    setValue((qaAnswer?._data.value as number) ?? undefined)
-    setIsDirty(false)
-  }, [submissionUid])
+  const clearTypingTimer = () => {
+    if (!typingTimerRef.current) return
+    clearTimeout(typingTimerRef.current)
+    typingTimerRef.current = undefined
+  }
 
-  // Within a single submission, avoid clobbering local typing with server updates.
-  useEffect(() => {
-    if (isDirty) return
-    setValue((qaAnswer?._data.value as number) ?? undefined)
-  }, [qaAnswer?._uuid, isDirty])
+  useEffect(() => () => clearTypingTimer(), [])
 
-  const handleSave = async () => {
-    clearTimeout(typingTimer)
-    await onSave(value ?? null)
+  const handleSave = async (valueToSave: number | undefined) => {
+    clearTypingTimer()
+    await onSave(valueToSave ?? null)
   }
 
   const handleChange = (inputValue: string | number) => {
-    setIsDirty(true)
-    setValue(inputValue === '' ? undefined : (inputValue as number))
-    clearTimeout(typingTimer)
-    setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save
+    const nextValue = inputValue === '' ? undefined : (inputValue as number)
+    setValue(nextValue)
+    clearTypingTimer()
+    typingTimerRef.current = setTimeout(() => {
+      void handleSave(nextValue)
+    }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
   }
 
   return (
@@ -45,7 +40,9 @@ export default function IntegerResponseForm({ qaAnswer, submissionUid, onSave, d
       value={value}
       onChange={handleChange}
       placeholder={t('Type your answer')}
-      onBlur={handleSave}
+      onBlur={() => {
+        void handleSave(value)
+      }}
       disabled={disabled}
     />
   )

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/IntegerResponseForm.tsx
@@ -31,7 +31,7 @@ export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Prop
     setValue(nextValue)
     clearTypingTimer()
     typingTimerRef.current = setTimeout(() => {
-      void handleSave(nextValue)
+      handleSave(nextValue)
     }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
   }
 
@@ -41,7 +41,7 @@ export default function IntegerResponseForm({ qaAnswer, onSave, disabled }: Prop
       onChange={handleChange}
       placeholder={t('Type your answer')}
       onBlur={() => {
-        void handleSave(value)
+        handleSave(value)
       }}
       disabled={disabled}
     />

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
@@ -1,17 +1,32 @@
 import { Textarea } from '@mantine/core'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
 interface Props {
   qaAnswer?: _DataSupplementResponseOneOfManualQualVersionsItem
+  submissionUid: string
   disabled: boolean
   onSave: (value: string) => Promise<unknown>
 }
 
-export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) {
+export default function TextResponseForm({ qaAnswer, submissionUid, onSave, disabled }: Props) {
   const [value, setValue] = useState<string>((qaAnswer?._data.value as string) ?? '')
+  const [isDirty, setIsDirty] = useState(false)
   const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
+
+  // New submissions should always display their own saved value.
+  useEffect(() => {
+    clearTimeout(typingTimer)
+    setValue((qaAnswer?._data.value as string) ?? '')
+    setIsDirty(false)
+  }, [submissionUid])
+
+  // Within a single submission, avoid clobbering local typing with server updates.
+  useEffect(() => {
+    if (isDirty) return
+    setValue((qaAnswer?._data.value as string) ?? '')
+  }, [qaAnswer?._uuid, isDirty])
 
   const handleSave = async () => {
     clearTimeout(typingTimer)
@@ -19,6 +34,7 @@ export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) 
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setIsDirty(true)
     setValue(event.currentTarget.value)
     clearTimeout(typingTimer)
     setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
@@ -1,5 +1,5 @@
 import { Textarea } from '@mantine/core'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
@@ -11,28 +11,17 @@ interface Props {
 
 export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) {
   const [value, setValue] = useState<string>((qaAnswer?._data.value as string) ?? '')
-  const typingTimerRef = useRef<NodeJS.Timeout | undefined>()
+  const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
 
-  const clearTypingTimer = () => {
-    if (!typingTimerRef.current) return
-    clearTimeout(typingTimerRef.current)
-    typingTimerRef.current = undefined
-  }
-
-  useEffect(() => () => clearTypingTimer(), [])
-
-  const handleSave = async (valueToSave: string) => {
-    clearTypingTimer()
-    await onSave(valueToSave)
+  const handleSave = async () => {
+    clearTimeout(typingTimer)
+    await onSave(value)
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const nextValue = event.currentTarget.value
-    setValue(nextValue)
-    clearTypingTimer()
-    typingTimerRef.current = setTimeout(() => {
-      handleSave(nextValue)
-    }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
+    setValue(event.currentTarget.value)
+    clearTimeout(typingTimer)
+    setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save
   }
 
   return (
@@ -42,9 +31,7 @@ export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) 
       value={value}
       onChange={handleChange}
       placeholder={t('Type your answer')}
-      onBlur={() => {
-        handleSave(value)
-      }}
+      onBlur={handleSave}
       disabled={disabled}
     />
   )

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
@@ -31,7 +31,7 @@ export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) 
     setValue(nextValue)
     clearTypingTimer()
     typingTimerRef.current = setTimeout(() => {
-      void handleSave(nextValue)
+      handleSave(nextValue)
     }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
   }
 
@@ -43,7 +43,7 @@ export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) 
       onChange={handleChange}
       placeholder={t('Type your answer')}
       onBlur={() => {
-        void handleSave(value)
+        handleSave(value)
       }}
       disabled={disabled}
     />

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TextResponseForm.tsx
@@ -1,43 +1,38 @@
 import { Textarea } from '@mantine/core'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import type { _DataSupplementResponseOneOfManualQualVersionsItem } from '#/api/models/_dataSupplementResponseOneOfManualQualVersionsItem'
 import { AUTO_SAVE_TYPING_DELAY } from '../../../common/constants'
 
 interface Props {
   qaAnswer?: _DataSupplementResponseOneOfManualQualVersionsItem
-  submissionUid: string
   disabled: boolean
   onSave: (value: string) => Promise<unknown>
 }
 
-export default function TextResponseForm({ qaAnswer, submissionUid, onSave, disabled }: Props) {
+export default function TextResponseForm({ qaAnswer, onSave, disabled }: Props) {
   const [value, setValue] = useState<string>((qaAnswer?._data.value as string) ?? '')
-  const [isDirty, setIsDirty] = useState(false)
-  const [typingTimer, setTypingTimer] = useState<NodeJS.Timeout>()
+  const typingTimerRef = useRef<NodeJS.Timeout | undefined>()
 
-  // New submissions should always display their own saved value.
-  useEffect(() => {
-    clearTimeout(typingTimer)
-    setValue((qaAnswer?._data.value as string) ?? '')
-    setIsDirty(false)
-  }, [submissionUid])
+  const clearTypingTimer = () => {
+    if (!typingTimerRef.current) return
+    clearTimeout(typingTimerRef.current)
+    typingTimerRef.current = undefined
+  }
 
-  // Within a single submission, avoid clobbering local typing with server updates.
-  useEffect(() => {
-    if (isDirty) return
-    setValue((qaAnswer?._data.value as string) ?? '')
-  }, [qaAnswer?._uuid, isDirty])
+  useEffect(() => () => clearTypingTimer(), [])
 
-  const handleSave = async () => {
-    clearTimeout(typingTimer)
-    await onSave(value)
+  const handleSave = async (valueToSave: string) => {
+    clearTypingTimer()
+    await onSave(valueToSave)
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setIsDirty(true)
-    setValue(event.currentTarget.value)
-    clearTimeout(typingTimer)
-    setTypingTimer(setTimeout(handleSave, AUTO_SAVE_TYPING_DELAY)) // After some seconds we auto save
+    const nextValue = event.currentTarget.value
+    setValue(nextValue)
+    clearTypingTimer()
+    typingTimerRef.current = setTimeout(() => {
+      void handleSave(nextValue)
+    }, AUTO_SAVE_TYPING_DELAY) // After some seconds we auto save
   }
 
   return (
@@ -47,7 +42,9 @@ export default function TextResponseForm({ qaAnswer, submissionUid, onSave, disa
       value={value}
       onChange={handleChange}
       placeholder={t('Type your answer')}
-      onBlur={handleSave}
+      onBlur={() => {
+        void handleSave(value)
+      }}
       disabled={disabled}
     />
   )

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
@@ -134,7 +134,6 @@ export default function AnalysisQuestionListItem({
         },
       })
     }
-    console.log('adf')
     setQaQuestion(undefined)
   }
 

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import classnames from 'classnames'
 import type { Identifier, XYCoord } from 'dnd-core'
@@ -93,11 +93,6 @@ export default function AnalysisQuestionListItem({
   // this is needed so that the "clear" button works immediately without waiting for server response
   const [localRadioValue, setLocalRadioValue] = useState<string | undefined>()
 
-  // Ensure select-one reflects the current submission after arrow navigation.
-  useEffect(() => {
-    setLocalRadioValue(undefined)
-  }, [rootUuid])
-
   const mutationSaveAnswer = useAssetsDataSupplementPartialUpdate({ mutation: { scope: { id: 'qa-answer' } } })
   const mutationCreateQuestion = useAssetsAdvancedFeaturesCreate({ mutation: { scope: { id: 'qa-question' } } })
   const mutationPatchQuestion = useAssetsAdvancedFeaturesPartialUpdate({ mutation: { scope: { id: 'qa-question' } } })
@@ -162,15 +157,14 @@ export default function AnalysisQuestionListItem({
     setQaQuestion(undefined)
   }
 
-  const handleReorderQuestions = (reorderedParams: ResponseQualActionParams[]) => {
-    return mutationPatchQuestion.mutateAsync({
+  const handleReorderQuestions = (reorderedParams: ResponseQualActionParams[]) =>
+    mutationPatchQuestion.mutateAsync({
       uidAsset: asset.uid,
       uidAdvancedFeature: advancedFeature.uid,
       data: {
         params: reorderedParams,
       },
     })
-  }
 
   const disabledAnswer =
     !userCan('change_submissions', asset) || mutationCreateQuestion.isPending || mutationPatchQuestion.isPending
@@ -367,12 +361,7 @@ export default function AnalysisQuestionListItem({
             onEdit={setQaQuestion}
             onDelete={handleDeleteQuestion}
           >
-            <IntegerResponseForm
-              qaAnswer={queryAnswer.data}
-              submissionUid={rootUuid}
-              disabled={disabledAnswer}
-              onSave={handleSaveAnswer}
-            />
+            <IntegerResponseForm qaAnswer={queryAnswer.data} disabled={disabledAnswer} onSave={handleSaveAnswer} />
           </ResponseForm>
         )
       }
@@ -384,12 +373,7 @@ export default function AnalysisQuestionListItem({
             onEdit={setQaQuestion}
             onDelete={handleDeleteQuestion}
           >
-            <TextResponseForm
-              qaAnswer={queryAnswer.data}
-              submissionUid={rootUuid}
-              disabled={disabledAnswer}
-              onSave={handleSaveAnswer}
-            />
+            <TextResponseForm qaAnswer={queryAnswer.data} disabled={disabledAnswer} onSave={handleSaveAnswer} />
           </ResponseForm>
         )
       }

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
@@ -363,7 +363,12 @@ export default function AnalysisQuestionListItem({
             onEdit={setQaQuestion}
             onDelete={handleDeleteQuestion}
           >
-            <IntegerResponseForm qaAnswer={queryAnswer.data} disabled={disabledAnswer} onSave={handleSaveAnswer} />
+            <IntegerResponseForm
+              qaAnswer={queryAnswer.data}
+              submissionUid={rootUuid}
+              disabled={disabledAnswer}
+              onSave={handleSaveAnswer}
+            />
           </ResponseForm>
         )
       }
@@ -375,7 +380,12 @@ export default function AnalysisQuestionListItem({
             onEdit={setQaQuestion}
             onDelete={handleDeleteQuestion}
           >
-            <TextResponseForm qaAnswer={queryAnswer.data} disabled={disabledAnswer} onSave={handleSaveAnswer} />
+            <TextResponseForm
+              qaAnswer={queryAnswer.data}
+              submissionUid={rootUuid}
+              disabled={disabledAnswer}
+              onSave={handleSaveAnswer}
+            />
           </ResponseForm>
         )
       }

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import classnames from 'classnames'
 import type { Identifier, XYCoord } from 'dnd-core'
@@ -92,6 +92,11 @@ export default function AnalysisQuestionListItem({
   // Local state for optimistic UI of SelectOne radio button value
   // this is needed so that the "clear" button works immediately without waiting for server response
   const [localRadioValue, setLocalRadioValue] = useState<string | undefined>()
+
+  // Ensure select-one reflects the current submission after arrow navigation.
+  useEffect(() => {
+    setLocalRadioValue(undefined)
+  }, [rootUuid])
 
   const mutationSaveAnswer = useAssetsDataSupplementPartialUpdate({ mutation: { scope: { id: 'qa-answer' } } })
   const mutationCreateQuestion = useAssetsAdvancedFeaturesCreate({ mutation: { scope: { id: 'qa-question' } } })

--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/index.tsx
@@ -55,18 +55,20 @@ export default function AnalysisQuestionsList({
   }
 
   const qaQuestions = localParams
-    .filter((qaQuestion) => !qaQuestion.options?.deleted)
+    .filter((questionParam) => !questionParam.options?.deleted)
     // TODO: we temporarily hide Keyword Search from the UI until
     // https://github.com/kobotoolbox/kpi/issues/4594 is done
-    .filter((qaQuestion) => qaQuestion.type !== 'qualAutoKeywordCount')
+    .filter((questionParam) => questionParam.type !== 'qualAutoKeywordCount')
 
   const isAnyQuestionBeingEdited = !!qaQuestion
+  const submissionKey = submission['meta/rootUuid'] ?? submission._uuid
 
   return (
     <DndProvider backend={HTML5Backend}>
       <ul className={styles.root}>
         {qaQuestion && !qaQuestions.some(({ uuid }) => uuid === qaQuestion?.uuid) && (
           <AnalysisQuestionListItem
+            key={`${submissionKey}-${qaQuestion.uuid}`}
             asset={asset}
             advancedFeature={localAdvancedFeature}
             submission={submission}
@@ -79,23 +81,21 @@ export default function AnalysisQuestionsList({
             isAnyQuestionBeingEdited={isAnyQuestionBeingEdited}
           />
         )}
-        {qaQuestions.map((qaQuestionItem, index) => {
-          return (
-            <AnalysisQuestionListItem
-              key={qaQuestionItem.uuid}
-              asset={asset}
-              advancedFeature={localAdvancedFeature}
-              submission={submission}
-              qaQuestion={qaQuestionItem}
-              setQaQuestion={setQaQuestion}
-              questionXpath={questionXpath}
-              index={index}
-              moveRow={moveRow}
-              editMode={qaQuestion?.uuid === qaQuestionItem.uuid}
-              isAnyQuestionBeingEdited={isAnyQuestionBeingEdited}
-            />
-          )
-        })}
+        {qaQuestions.map((qaQuestionItem, index) => (
+          <AnalysisQuestionListItem
+            key={`${submissionKey}-${qaQuestionItem.uuid}`}
+            asset={asset}
+            advancedFeature={localAdvancedFeature}
+            submission={submission}
+            qaQuestion={qaQuestionItem}
+            setQaQuestion={setQaQuestion}
+            questionXpath={questionXpath}
+            index={index}
+            moveRow={moveRow}
+            editMode={qaQuestion?.uuid === qaQuestionItem.uuid}
+            isAnyQuestionBeingEdited={isAnyQuestionBeingEdited}
+          />
+        ))}
       </ul>
     </DndProvider>
   )


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

When navigating between submissions in the Processing view using the prev/next arrows, text and integer analysis question would continue displaying the previous submission's answer instead of the new one.

### 💭 Notes

The components held local controlled state initialised from props on mount. Because React reused the mounted component instances across submission changes, the local state was never reset.

Changes here:
- `AnalysisQuestionsList/index.tsx` — Added `submissionKey` and used it as part of each list item's key. This causes React to unmount and remount all question items when the submission changes, resetting their local state automatically
- Some small refactors

### 👀 Preview steps

Prerequisites
- Ensure you have a deployed project with audio question
- The project must contain at least two submissions

1. Navigate to the Processing View from Data Table
2. Create two new analysis questions: text and integer
3. For first submission enter values "Test" and "123"
4. Use prev/next arrow at the top to navigate to the second submission
5. 🔴 [on main] Notice text and integer questions retain answers from first submission
6. 🟢 [on PR] Notice text and integer questions are empty