### PR TITLE
fix(mfa): prevent MFA re-enrollment lockouts by centralizing deactivation cleanup DEV-2023

### DIFF
--- a/kobo/apps/accounts/mfa/admin.py
+++ b/kobo/apps/accounts/mfa/admin.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from django.contrib import admin
+from django.contrib import admin, messages
 
 from .models import (
     MfaMethodsWrapper,
@@ -17,6 +17,18 @@ class MfaMethodsWrapperAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request, obj=None):
         return False
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(super().get_readonly_fields(request, obj))
+        if obj and not obj.is_active:
+            readonly_fields.append('is_active')
+        return readonly_fields
+
+    def save_model(self, request, obj, form, change):
+        changed_data = getattr(form, 'changed_data', [])
+        if change and 'is_active' in changed_data and not obj.is_active:
+            obj.deactivate()
+        super().save_model(request, obj, form, change)
 
     def delete_queryset(self, request, queryset):
         # Trigger custom delete logic during bulk deletion

--- a/kobo/apps/accounts/mfa/admin.py
+++ b/kobo/apps/accounts/mfa/admin.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from django.contrib import admin, messages
+from django.contrib import admin
 
 from .models import (
     MfaMethodsWrapper,
@@ -28,6 +28,7 @@ class MfaMethodsWrapperAdmin(admin.ModelAdmin):
         changed_data = getattr(form, 'changed_data', [])
         if change and 'is_active' in changed_data and not obj.is_active:
             obj.deactivate()
+            return
         super().save_model(request, obj, form, change)
 
     def delete_queryset(self, request, queryset):

--- a/kobo/apps/accounts/mfa/flows.py
+++ b/kobo/apps/accounts/mfa/flows.py
@@ -1,6 +1,5 @@
 from allauth.headless.mfa.inputs import ActivateTOTPInput
 from allauth.mfa import signals
-from allauth.mfa.base.internal.flows import delete_and_cleanup
 from allauth.mfa.models import Authenticator
 from allauth.mfa.recovery_codes.internal.auth import RecoveryCodes
 from allauth.mfa.recovery_codes.internal.flows import auto_generate_recovery_codes
@@ -65,6 +64,4 @@ def deactivate_totp(request, name):
         )
     except MfaMethodsWrapper.DoesNotExist:
         raise NotFound
-    mfa.is_active = False
-    mfa.save()
-    delete_and_cleanup(request, mfa.totp)
+    mfa.deactivate(request=request)

--- a/kobo/apps/accounts/mfa/models.py
+++ b/kobo/apps/accounts/mfa/models.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 from allauth.mfa.models import Authenticator
+from allauth.mfa.base.internal.flows import delete_and_cleanup
 from django.conf import settings
 from django.db import models, transaction
+from django.http import HttpRequest
 from django.utils.timezone import now
 from trench.admin import MFAMethod as TrenchMFAMethod
 from trench.admin import MFAMethodAdmin as TrenchMFAMethodAdmin
@@ -95,6 +97,33 @@ class MfaMethodsWrapper(AbstractTimeStampedModel):
             # ToDo: Remove this Trench cleanup once the long-running MFA migration
             #  is complete and Trench is fully removed from the codebase
             MfaMethod.objects.filter(user_id=user_id, name=self.name).delete()
+
+    def deactivate(self, request: HttpRequest | None = None):
+        totp = self.totp
+        recovery_codes_id = self.recovery_codes_id
+
+        with kc_transaction_atomic(), transaction.atomic():
+            self.is_active = False
+            self.save(update_fields=['is_active'])
+
+            if totp:
+                if request is not None and getattr(request, 'user', None) == self.user:
+                    delete_and_cleanup(request, totp)
+                else:
+                    Authenticator.objects.filter(
+                        id=totp.pk, user_id=self.user_id
+                    ).delete()
+
+            if recovery_codes_id:
+                Authenticator.objects.filter(
+                    id=recovery_codes_id, user_id=self.user_id
+                ).delete()
+
+        # Keep the in-memory instance consistent
+        self.totp = None
+        self.totp_id = None
+        self.recovery_codes = None
+        self.recovery_codes_id = None
 
 
 class MfaMethod(TrenchMFAMethod, AbstractTimeStampedModel):

--- a/kobo/apps/accounts/mfa/tests/test_admin.py
+++ b/kobo/apps/accounts/mfa/tests/test_admin.py
@@ -1,0 +1,80 @@
+from allauth.mfa.models import Authenticator
+from django.contrib.admin.sites import site
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test.client import RequestFactory
+from django.urls import reverse
+from rest_framework import status
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.main.models import UserProfile
+from kpi.tests.kpi_test_case import BaseTestCase
+
+from ..admin import MfaMethodsWrapperAdmin
+from ..models import MfaMethodsWrapper
+from .utils import activate_mfa_for_user, get_mfa_code_for_user
+
+
+class MfaAdminTestCase(BaseTestCase):
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.someuser = User.objects.get(username='someuser')
+        self.admin_user = User.objects.create_superuser(
+            username='admin', password='admin'
+        )
+        activate_mfa_for_user(self.client, self.someuser)
+        self.model_admin = MfaMethodsWrapperAdmin(MfaMethodsWrapper, site)
+        self.request = self._build_request()
+
+    def _build_request(self):
+        request = RequestFactory().post('/')
+        request.user = self.admin_user
+
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        setattr(request, '_messages', FallbackStorage(request))
+        return request
+
+    @staticmethod
+    def _build_form(changed_data):
+        class DummyForm:
+            def __init__(self, changed_data):
+                self.changed_data = changed_data
+
+        return DummyForm(changed_data)
+
+    def test_admin_deactivation_cleans_up_authenticators(self):
+        mfa = MfaMethodsWrapper.objects.get(user=self.someuser, name='app')
+        self.assertNotIn(
+            'is_active', self.model_admin.get_readonly_fields(self.request, mfa)
+        )
+
+        mfa.is_active = False
+        form = self._build_form(['is_active'])
+        self.model_admin.save_model(self.request, mfa, form=form, change=True)
+
+        mfa.refresh_from_db()
+        profile = UserProfile.objects.get(user=self.someuser)
+        self.assertFalse(mfa.is_active)
+        self.assertIsNone(mfa.totp)
+        self.assertIsNone(mfa.recovery_codes)
+        self.assertEqual(Authenticator.objects.filter(user=self.someuser).count(), 0)
+        self.assertFalse(profile.is_mfa_active)
+        self.assertIn(
+            'is_active', self.model_admin.get_readonly_fields(self.request, mfa)
+        )
+
+        self.client.force_login(self.someuser)
+        self.client.post(reverse('mfa-activate', kwargs={'method': 'app'}))
+        code = get_mfa_code_for_user(self.someuser)
+        confirm_response = self.client.post(
+            reverse('mfa-confirm', kwargs={'method': 'app'}),
+            data={'code': str(code)},
+        )
+
+        self.assertEqual(confirm_response.status_code, status.HTTP_200_OK)
+        mfa.refresh_from_db()
+        self.assertTrue(mfa.is_active)

--- a/kobo/apps/accounts/mfa/tests/test_admin.py
+++ b/kobo/apps/accounts/mfa/tests/test_admin.py
@@ -1,6 +1,5 @@
 from allauth.mfa.models import Authenticator
 from django.contrib.admin.sites import site
-from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test.client import RequestFactory

--- a/kobo/apps/accounts/mfa/tests/test_api.py
+++ b/kobo/apps/accounts/mfa/tests/test_api.py
@@ -1,4 +1,5 @@
 from constance.test import override_config
+from allauth.mfa.models import Authenticator
 from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
@@ -88,6 +89,9 @@ class MfaApiTestCase(BaseTestCase):
         assert response.status_code == status.HTTP_200_OK
         mfamethods = MfaMethodsWrapper.objects.get(user=self.someuser)
         assert mfamethods.is_active is False
+        assert mfamethods.totp is None
+        assert mfamethods.recovery_codes is None
+        assert Authenticator.objects.filter(user=self.someuser).count() == 0
 
     def test_reactivate_generates_different_secret(self):
         """


### PR DESCRIPTION
### 📣 Summary
This PR fixes a desynchronization bug where deactivating an MFA wrapper via the Django Admin UI left orphaned Authenticator records in the database, breaking future re-enrollment. Cleanup logic has now been centralized in the model to ensure safe, consistent deletion across both API and Admin flows.

### 📖 Description
Previously, when a superuser disabled MFA through the Django Admin, the associated django-allauth Authenticator records were not removed. This left orphaned records in the database, causing a "Token Invalid" error when the user attempted to re-enroll.

This PR introduces a robust, centralized deactivate() method on the MfaMethodsWrapper model, ensuring that all related Authenticator records are properly cleaned up whenever MFA is disabled, regardless of the entry point (Admin or API).


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. Log in as a standard user and activate MFA.
2. Log out, log in as a superuser, and navigate to the "MFA Registrations" admin panel.
3. Uncheck the `is_active` box for the standard user and click Save.
4. Log back in as the standard user, navigate to security settings, and attempt to re-enable MFA.
5. 🔴 [On release branch] You will receive a "Token Invalid" error when submitting the code.
6. 🟢 [On PR] You will successfully re-enroll in MFA with a fresh secret.
