### PR TITLE
fix(middleware): track v1 endpoint usage for Token-authenticated requests DEV-2025

### DIFF
--- a/hub/middleware.py
+++ b/hub/middleware.py
@@ -46,27 +46,31 @@ class V1AccessLoggingMiddleware(MiddlewareMixin):
     """
     Middleware to log access to deprecated v1 endpoints by authenticated users
     """
-    def process_request(self, request):
+    legacy_patterns = [
+        '/api/v1/',
+        '/assets/',
+        '/asset_snapshots/',
+        '/asset_subscriptions/',
+        '/exports/',
+        '/imports/',
+        '/permissions/',
+        '/reports/',
+        '/tags/',
+        '/authorized_application/',
+        '/users/',
+    ]
+
+    def process_response(self, request, response):
+        # DRF token/basic/oauth authentication runs during view processing,
+        # not in Django's request middleware phase. Tracking on the response
+        # path lets us see both session-authenticated browser requests and
+        # header-authenticated API requests
         if not request.user.is_authenticated:
-            return None
+            return response
 
-        legacy_patterns = [
-            '/api/v1/',
-            '/assets/',
-            '/asset_snapshots/',
-            '/asset_subscriptions/',
-            '/exports/',
-            '/imports/',
-            '/permissions/',
-            '/reports/',
-            '/tags/',
-            '/authorized_application/',
-            '/users/',
-        ]
-
-        if any(request.path.startswith(pattern) for pattern in legacy_patterns):
+        if any(request.path.startswith(pattern) for pattern in self.legacy_patterns):
             V1UserTracker.objects.update_or_create(
                 user=request.user,
                 defaults={'last_accessed_path': request.path},
             )
-        return None
+        return response

--- a/hub/tests/test_v1_tracking.py
+++ b/hub/tests/test_v1_tracking.py
@@ -1,4 +1,5 @@
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 
 from ddt import data, ddt, unpack
 from kobo.apps.kobo_auth.shortcuts import User
@@ -43,3 +44,16 @@ class V1TrackingTests(KpiTestCase):
 
         self.client.get(v1_url)
         self.assertEqual(V1UserTracker.objects.count(), 0)
+
+    def test_token_authenticated_v1_access_creates_tracker_entry(self):
+        self.client.logout()
+        token, _ = Token.objects.get_or_create(user=self.user)
+
+        response = self.client.get(
+            '/api/v1/user',
+            HTTP_AUTHORIZATION=f'Token {token.key}',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tracker_entry = V1UserTracker.objects.get(user=self.user)
+        self.assertEqual(tracker_entry.last_accessed_path, '/api/v1/user')


### PR DESCRIPTION
### 📣 Summary
Move `V1AccessLoggingMiddleware` logic to the response phase to correctly capture Token-authenticated API usage.

### 📖 Description
The `V1UserTracker` was failing to record activity from programmatic scripts using Token Authentication. This occurred because Django's `process_request` runs before the DRF view layer, leaving `request.user` as `AnonymousUser` during the initial check.

Fix:
- Relocated the tracking logic from `process_request` to `process_response` within `V1AccessLoggingMiddleware`.
- This ensures that `request.user` is fully populated by DRF's authentication classes before the logging logic executes.
- Updated the logic to only track successful, authenticated requests to the defined legacy patterns.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project with submissions
2. 🔴 [on main] Run the following script from the shell:
```
   import requests
   token = <your_token>
   form_id = <form_pk>
   url = f'http://kc.kobo.local/api/v1/data/{form_id}'
   headers = {'Authorization': f'Token {token}'}

   response = requests.get(url, headers=headers)
   if response.status_code == 200:
       data = response.json()
       print(data)
   else:
       print(f"Error: {response.status_code}, {response.text}")
```
3. Check the `V1UserTracker` table, there will be no entry for `/api/v1/data/<form_id>`.
4. 🟢 [on PR] Repeat the same request and check `V1UserTracker`, an entry for `/api/v1/data/<form_id>` should now be present.
5. Verify the table by calling the API from a browser or Postman.
