### PR TITLE
fix(constance): `JsonSchemaFormField.clean()` must return parsed object DEV-2027

### DIFF
--- a/hub/migrations/0020_fix_constance_json_field_corruption.py
+++ b/hub/migrations/0020_fix_constance_json_field_corruption.py
@@ -1,0 +1,108 @@
+import json
+
+from constance import settings as constance_settings
+from django.core.cache import caches
+from django.db import migrations
+
+from kpi.utils.log import logging
+
+# These four constance keys use JsonSchemaFormField subclasses and must be
+# stored as dict/list. A bug in clean() caused them to be stored as plain JSON
+# strings instead. The constance 0003_drop_pickle migration preserved the
+# corruption: a pickled str becomes a JSON-encoded string in the DB, so
+# constance still reads back a str instead of a dict/list.
+KEYS_TO_FIX = [
+    'MFA_LOCALIZED_HELP_TEXT',
+    'CUSTOM_PASSWORD_GUIDANCE_TEXT',
+    'USER_METADATA_FIELDS',
+    'PROJECT_METADATA_FIELDS',
+]
+
+
+def fix_constance_json_field_corruption(apps, schema_editor):
+    """
+    Repair constance keys whose stored value is a JSON-encoded string instead
+    of a JSON object/array.
+
+    Root cause: JsonSchemaFormField.clean() returned the raw input string
+    instead of the parsed Python object. Constance encoded that string as JSON,
+    so the DB ended up with e.g. '"{\\"default\\": ...}"' for a field that
+    should contain '{"default": ...}'.
+
+    After this migration, each affected key is stored as a proper JSON
+    object/array, and the constance cache is invalidated so the corrected
+    values are picked up immediately.
+    """
+    Constance = apps.get_model('constance', 'Constance')
+
+    for key in KEYS_TO_FIX:
+        try:
+            record = Constance.objects.get(key=key)
+        except Constance.DoesNotExist:
+            # Never saved via admin — the default from CONSTANCE_CONFIG
+            # (always a correct dict/list) will be used at runtime.
+            continue
+
+        try:
+            outer = json.loads(record.value)
+        except (json.JSONDecodeError, TypeError):
+            logging.warning(
+                'constance key %s: stored value is not valid JSON, skipping', key
+            )
+            continue
+
+        if not isinstance(outer, str):
+            # Already a dict, list, or lazy_json_serializable envelope — no fix needed.
+            continue
+
+        # The outer value is a string: it was double-encoded. The real data is
+        # the result of parsing that string.
+        try:
+            inner = json.loads(outer)
+        except json.JSONDecodeError:
+            logging.warning(
+                'constance key %s: inner value is not valid JSON, skipping', key
+            )
+            continue
+
+        if not isinstance(inner, (dict, list)):
+            logging.warning(
+                'constance key %s: inner value is not a dict/list (%s), skipping',
+                key,
+                type(inner).__name__,
+            )
+            continue
+
+        record.value = json.dumps(inner)
+        record.save(update_fields=['value'])
+        logging.info('constance key %s: repaired corrupted string value', key)
+
+    # Invalidate the constance cache so the corrected DB values are served
+    # immediately without waiting for cache expiry.
+    try:
+        cache_backend_name = constance_settings.DATABASE_CACHE_BACKEND
+        if cache_backend_name:
+            cache = caches[cache_backend_name]
+            prefix = constance_settings.DATABASE_PREFIX
+            keys = [f'{prefix}{key}' for key in KEYS_TO_FIX]
+            cache.delete_many(keys)
+    except Exception:
+        # Never block a migration for a cache flush failure.
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hub', '0019_clear_constance_cache'),
+        # Must run after 0003_drop_pickle so that previously pickled values are
+        # already in JSON format before we inspect and repair them.
+        ('constance', '0003_drop_pickle'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fix_constance_json_field_corruption,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -78,8 +78,8 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
             # USAGE_LIMIT_ENFORCEMENT variable. But we use caching
             # so should find a way to keep that out of this count
             if settings.STRIPE_ENABLED:
-                # But because of cache, sometimes goes down to 62
-                expected_queries = FuzzyInt(62, 90)
+                # But because of cache, sometimes goes down to 60
+                expected_queries = FuzzyInt(60, 90)
             with self.assertNumQueries(expected_queries):
                 self.view(request)
 

--- a/kpi/fields/jsonschema_form_field.py
+++ b/kpi/fields/jsonschema_form_field.py
@@ -19,17 +19,26 @@ class JsonSchemaFormField(CharField):
         return super().prepare_value(value)
 
     def clean(self, value):
+        # Constance may pass an already-decoded Python object (dict/list) when
+        # the DB value was stored correctly (e.g. via the lazy_json_serializable
+        # codec). Accept it directly rather than round-tripping through JSON.
+        if isinstance(value, (dict, list)):
+            instance = value
+        else:
+            try:
+                instance = json.loads(value)
+            except json.JSONDecodeError as e:
+                raise ValidationError(t('Enter valid JSON.') + ' ' + str(e))
         try:
-            instance = json.loads(value)
             jsonschema.validate(instance, self.schema)
-        except json.JSONDecodeError as e:
-            # Message written to match `IntegerField`, which uses the
-            # imperative: "Enter a whole number."
-            raise ValidationError(t('Enter valid JSON.') + ' ' + str(e))
         except jsonschema.exceptions.ValidationError as e:
             # `str(e)` is too verbose (it includes the entire schema)
             raise ValidationError(t('Enter valid JSON.') + ' ' + e.message)
-        return value
+        # Must return the parsed object, not the raw string. Constance pickles
+        # (3.x) or JSON-encodes (4.x) the return value directly — returning a
+        # string here would store a string in the DB and cause TypeErrors when
+        # the setting is later accessed as a dict/list.
+        return instance
 
 
 class I18nTextJSONField(JsonSchemaFormField):
@@ -103,12 +112,14 @@ class MetadataFieldsListField(JsonSchemaFormField):
         super().__init__(*args, schema=schema, **kwargs)
 
     def clean(self, value):
+        # super().clean() returns a parsed list, never a raw string.
         value = super().clean(value)
 
         if not self.REQUIRED_FIELDS:
             return value
 
-        instance = json.loads(value)
+        # `value` is already a list here — do not call json.loads() on it.
+        instance = value
 
         if set(self.REQUIRED_FIELDS) - set(d['name'] for d in instance):
             raise ValidationError(
@@ -117,7 +128,7 @@ class MetadataFieldsListField(JsonSchemaFormField):
                     '`, `'.join(self.REQUIRED_FIELDS)
                 )
             )
-        return value
+        return instance
 
 
 class UserMetadataFieldsListField(MetadataFieldsListField):

--- a/kpi/tests/test_jsonschema_form_field.py
+++ b/kpi/tests/test_jsonschema_form_field.py
@@ -1,0 +1,89 @@
+import json
+
+import pytest
+from django.forms import ValidationError
+
+from kpi.fields.jsonschema_form_field import (
+    I18nTextJSONField,
+    MetadataFieldsListField,
+    UserMetadataFieldsListField,
+)
+
+VALID_I18N = {'default': 'Hello', 'fr': 'Bonjour'}
+
+VALID_METADATA_LIST = [
+    {'name': 'name', 'required': True},
+    {'name': 'email', 'required': False},
+]
+
+
+class TestI18nTextJSONFieldClean:
+
+    def setup_method(self):
+        self.field = I18nTextJSONField()
+
+    def test_clean_dict_input_returns_dict(self):
+        assert self.field.clean(VALID_I18N) == VALID_I18N
+
+    def test_clean_json_string_returns_dict(self):
+        assert self.field.clean(json.dumps(VALID_I18N)) == VALID_I18N
+
+    def test_clean_invalid_json_raises(self):
+        with pytest.raises(ValidationError):
+            self.field.clean('{not valid json}')
+
+    def test_clean_schema_violation_from_dict_raises(self):
+        # 'default' key is required by the schema
+        with pytest.raises(ValidationError):
+            self.field.clean({'fr': 'Bonjour'})
+
+    def test_clean_schema_violation_from_string_raises(self):
+        with pytest.raises(ValidationError):
+            self.field.clean(json.dumps({'fr': 'Bonjour'}))
+
+
+class TestMetadataFieldsListFieldClean:
+
+    def setup_method(self):
+        self.field = MetadataFieldsListField()
+
+    def test_clean_list_input_returns_list(self):
+        assert self.field.clean(VALID_METADATA_LIST) == VALID_METADATA_LIST
+
+    def test_clean_json_string_returns_list(self):
+        assert self.field.clean(json.dumps(VALID_METADATA_LIST)) == VALID_METADATA_LIST
+
+    def test_clean_invalid_json_raises(self):
+        with pytest.raises(ValidationError):
+            self.field.clean('[not valid json]')
+
+    def test_clean_schema_violation_raises(self):
+        # 'required' key is mandatory per the schema
+        with pytest.raises(ValidationError):
+            self.field.clean([{'name': 'username'}])
+
+
+class TestUserMetadataFieldsListFieldClean:
+    """
+    UserMetadataFieldsListField.REQUIRED_FIELDS = ['name'], meaning an entry
+    with name='name' must always be present in the list.
+    """
+
+    def setup_method(self):
+        self.field = UserMetadataFieldsListField()
+
+    def test_clean_list_with_required_field_passes(self):
+        assert self.field.clean(VALID_METADATA_LIST) == VALID_METADATA_LIST
+
+    def test_clean_json_string_with_required_field_passes(self):
+        assert self.field.clean(json.dumps(VALID_METADATA_LIST)) == VALID_METADATA_LIST
+
+    def test_clean_list_missing_required_field_raises(self):
+        data = [{'name': 'email', 'required': False}]
+        with pytest.raises(ValidationError):
+            self.field.clean(data)
+
+    def test_clean_json_string_missing_required_field_raises(self):
+        data = [{'name': 'email', 'required': False}]
+        with pytest.raises(ValidationError):
+            self.field.clean(json.dumps(data))


### PR DESCRIPTION
### 📣 Summary

Saving certain admin settings (MFA help text, password guidance, user/project metadata fields) via the Django admin could cause crashes for end users, such as a broken MFA login flow or broken user profile pages.

### 💭 Notes

`JsonSchemaFormField.clean()` was returning `value` (raw JSON string) instead of `instance` (parsed Python object). Constance encodes the return value of `clean()` directly, so it stored a string in the DB. At runtime, code accessing these settings as dict/list received a string instead, causing `TypeError: string indices must be integers`.

Four constance keys are affected: 
- `MFA_LOCALIZED_HELP_TEXT`
- `CUSTOM_PASSWORD_GUIDANCE_TEXT` 
- `USER_METADATA_FIELDS`
- `PROJECT_METADATA_FIELDS`

A data migration (`hub/migrations/0020_fix_constance_json_field_corruption.py`) repairs existing corrupted values:
- Depends on `constance.0003_drop_pickle` so it runs after the pickle→JSON migration on prod
- Double-parses any value that is a JSON-encoded string to recover the actual dict/list
- Flushes the constance cache for the affected keys after repair
- Skips values that are already correct (dict, list, or `lazy_json_serializable` envelope)


### 👀 Preview steps

1. ℹ️ Have a superuser account
2. Go to Django admin → Constance → Config
3. Edit `MFA_LOCALIZED_HELP_TEXT` — save without changing anything
4. 🔴 [on release/2.026.13] Log out, try MFA login → crash (`string indices must be integers`)
5. 🟢 [on PR] Same flow → MFA login works normally