### PR TITLE
fix(debug-toolbar): handle import error for debug toolbar in development settings DEV-2032

### DIFF
--- a/kobo/settings/dev.py
+++ b/kobo/settings/dev.py
@@ -7,8 +7,12 @@ LOGGING['handlers']['console'] = {
     'formatter': 'verbose'
 }
 
-INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
-MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+try:
+    import debug_toolbar  # noqa: F401
+    INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+except ModuleNotFoundError:
+    pass
 
 
 def show_toolbar(request):

--- a/kobo/settings/dev.py
+++ b/kobo/settings/dev.py
@@ -9,8 +9,8 @@ LOGGING['handlers']['console'] = {
 
 try:
     import debug_toolbar  # noqa: F401
-    INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
-    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+    INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)  # noqa: F405
+    MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')  # noqa: F405
 except ModuleNotFoundError:
     pass
 


### PR DESCRIPTION
### 💭 Notes

This PR fixes an issue shile loading the development wnvironment with `kobo-install` where the `debgu_toolbar` module was not being found, crashing at the environment starting up.
