### PR TITLE
fix(connectProjects): deleted imported project issue DEV-2026

### DIFF
--- a/jsapp/js/components/dataAttachments/common.ts
+++ b/jsapp/js/components/dataAttachments/common.ts
@@ -2,6 +2,7 @@ export interface AttachedSourceItem {
   sourceName: string
   sourceUrl: string
   sourceUid: string
+  isSourceDeleted: boolean
   linkedFields: string[]
   filename: string
   attachmentUrl: string

--- a/jsapp/js/components/dataAttachments/connect-projects.scss
+++ b/jsapp/js/components/dataAttachments/connect-projects.scss
@@ -111,12 +111,7 @@
 
   .connect-projects__import-list-item {
     padding-bottom: 10px;
-
-    i.k-icon-check {
-      font-size: 32px;
-      margin-right: 5px;
-      color: colors.$kobo-blue;
-    }
+    align-items: center;
 
     .connect-projects__import-labels {
       position: absolute;

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -56,7 +56,8 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
   const {
     data: attachedSourcesResponse,
     isFetched: isInitialised,
-    isPending: isLoadingAttachedSources,
+    isPending: isPendingAttachedSources,
+    isFetching: isFetchingAttachedSources,
     refetch: refetchAttachedSources,
   } = useAssetsPairedDataList(asset.uid)
   const { mutate: detachSourceMutate, isPending: isDetachingSource } = useAssetsPairedDataDestroy()
@@ -68,6 +69,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
     },
   })
 
+  const isLoadingAttachedSources = isPendingAttachedSources || isFetchingAttachedSources
   const isLoading = isLoadingAttachedSources || isDetachingSource || isPatchingDataSharing
 
   const sharingEnabledAssetsLoaded = Boolean(sharingEnabledAssetsResponse?.data)

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -93,6 +93,9 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
       const sourceUrl = typeof source.source === 'string' ? source.source : ''
       const sourceUid = sourceUrl ? (getAssetUIDFromUrl(sourceUrl) ?? '') : ''
       const sourceNameRaw = typeof source.source__name === 'string' ? source.source__name : ''
+      // `source__name` is `null` when the source asset no longer exists (it was deleted). The empty-string check is
+      // a defensive fallback: assets can technically have a blank name (e.g. legacy records or direct API writes)
+      // TODO: update this code after https://linear.app/kobotoolbox/issue/DEV-2034/ is done.
       const isSourceDeleted = source.source__name === null || sourceNameRaw.trim().length === 0
       const attachmentUrl = typeof source.url === 'string' ? source.url : ''
 

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -56,7 +56,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
   const {
     data: attachedSourcesResponse,
     isFetched: isInitialised,
-    isFetching: isFetchingAttachedSources,
+    isPending: isLoadingAttachedSources,
     refetch: refetchAttachedSources,
   } = useAssetsPairedDataList(asset.uid)
   const { mutate: detachSourceMutate, isPending: isDetachingSource } = useAssetsPairedDataDestroy()
@@ -68,7 +68,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
     },
   })
 
-  const isLoading = isFetchingAttachedSources || isDetachingSource || isPatchingDataSharing
+  const isLoading = isLoadingAttachedSources || isDetachingSource || isPatchingDataSharing
 
   const sharingEnabledAssetsLoaded = Boolean(sharingEnabledAssetsResponse?.data)
 
@@ -84,16 +84,38 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
 
   const attachedSources = useMemo<AttachedSourceItem[]>(() => {
     const payload = attachedSourcesResponse?.data
-    const sources = payload && 'results' in payload ? payload.results : []
+    const sources = payload && 'results' in payload && Array.isArray(payload.results) ? payload.results : []
 
-    return sources.map((source) => ({
-      sourceName: truncateString(source.source__name, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
-      sourceUrl: source.source,
-      sourceUid: getAssetUIDFromUrl(source.source) || '',
-      linkedFields: source.fields,
-      filename: truncateFile(source.filename, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
-      attachmentUrl: source.url,
-    }))
+    return sources.flatMap((source) => {
+      const sourceUrl = typeof source.source === 'string' ? source.source : ''
+      const sourceUid = sourceUrl ? (getAssetUIDFromUrl(sourceUrl) ?? '') : ''
+      const sourceNameRaw = typeof source.source__name === 'string' ? source.source__name : ''
+      const isSourceDeleted = sourceNameRaw.trim().length === 0
+      const attachmentUrl = typeof source.url === 'string' ? source.url : ''
+
+      // Skip malformed records that cannot be removed or displayed safely.
+      if (attachmentUrl === '') {
+        return []
+      }
+
+      return [
+        {
+          sourceName: truncateString(
+            isSourceDeleted ? t('Deleted project') : sourceNameRaw,
+            MAX_DISPLAYED_STRING_LENGTH.connect_projects,
+          ),
+          sourceUrl,
+          sourceUid,
+          isSourceDeleted,
+          linkedFields: Array.isArray(source.fields) ? source.fields : [],
+          filename: truncateFile(
+            typeof source.filename === 'string' ? source.filename : '',
+            MAX_DISPLAYED_STRING_LENGTH.connect_projects,
+          ),
+          attachmentUrl,
+        },
+      ]
+    })
   }, [attachedSourcesResponse])
 
   // Note: we wrap most of the functions in `useCallback`, because they are being referenced in

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -70,6 +70,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
   })
 
   const isLoadingAttachedSources = isPendingAttachedSources || isFetchingAttachedSources
+  const isImportsLoading = isLoadingAttachedSources || isDetachingSource
   const isLoading = isLoadingAttachedSources || isDetachingSource || isPatchingDataSharing
 
   const sharingEnabledAssetsLoaded = Boolean(sharingEnabledAssetsResponse?.data)
@@ -389,7 +390,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
                 sharingEnabledAssetsLoaded={sharingEnabledAssetsLoaded}
                 filteredAssets={filteredAssets}
                 value={newSource}
-                isLoading={isLoading}
+                isLoading={isImportsLoading}
                 isInitialised={isInitialised}
                 sourceError={fieldsErrors.source}
                 onSourceChange={onSourceChange}
@@ -400,7 +401,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
             onFilenameChange={onFilenameChange}
             onConfirmAttachment={onConfirmAttachment}
             isInitialised={isInitialised}
-            isLoading={isLoading}
+            isLoading={isImportsLoading}
             attachedSources={attachedSources}
             showColumnFilterModal={showColumnFilterModal}
             onRemoveAttachment={onRemoveAttachment}

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -92,7 +92,7 @@ function ConnectProjects({ asset }: { asset: AssetResponse }) {
       const sourceUrl = typeof source.source === 'string' ? source.source : ''
       const sourceUid = sourceUrl ? (getAssetUIDFromUrl(sourceUrl) ?? '') : ''
       const sourceNameRaw = typeof source.source__name === 'string' ? source.source__name : ''
-      const isSourceDeleted = sourceNameRaw.trim().length === 0
+      const isSourceDeleted = source.source__name === null || sourceNameRaw.trim().length === 0
       const attachmentUrl = typeof source.url === 'string' ? source.url : ''
 
       // Skip malformed records that cannot be removed or displayed safely.

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -82,7 +82,8 @@ export default function ConnectProjectsImports({
                   type='secondary'
                   size='m'
                   startIcon='settings'
-                  tooltip={t('Configure')}
+                  tooltip={item.isSourceDeleted ? t('Cannot configure deleted project') : t('Configure')}
+                  isDisabled={item.isSourceDeleted || !item.sourceUid || !item.sourceUrl}
                   onClick={() =>
                     showColumnFilterModal(
                       {

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -69,7 +69,7 @@ export default function ConnectProjectsImports({
   return (
     <>
       <Modal opened={isRemovalModalOpened} onClose={closeRemovalConfirmation} title={t('Remove project?')}>
-        <Text>{t('Are you sure you want to remove imported project?')}</Text>
+        <Text>{t('Are you sure you want to remove the imported project?')}</Text>
         <Group justify='flex-end' mt='md'>
           <ButtonNew size='md' onClick={closeRemovalConfirmation}>
             {t('Cancel')}

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -63,6 +63,7 @@ export default function ConnectProjectsImports({
   }
 
   const shouldShowInitialLoading = !isInitialised
+  const shouldShowLoadingWithEmptyRows = isInitialised && isLoading && attachedSources.length === 0
   const shouldShowEmptyState = isInitialised && !isLoading && attachedSources.length === 0
   const shouldShowAttachedSources = attachedSources.length > 0
 
@@ -101,7 +102,7 @@ export default function ConnectProjectsImports({
         <h3 className='connect-projects__list-header'>{t('Imported')}</h3>
 
         <ul className='connect-projects__import-list'>
-          {shouldShowInitialLoading && (
+          {(shouldShowInitialLoading || shouldShowLoadingWithEmptyRows) && (
             <li className='connect-projects__import-list-item'>
               <LoadingSpinner message={t('Loading imported projects')} />
             </li>

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -1,8 +1,11 @@
-import React from 'react'
-import Button from '#/components/common/button'
+import { Group, Modal, Text } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import React, { useState } from 'react'
+import ButtonNew from '#/components/common/ButtonNew'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import TextBox from '#/components/common/textBox'
 import type { AssetResponse } from '#/dataInterface'
+import ActionIcon from '../common/ActionIcon'
 import Icon from '../common/icon'
 import type { AttachedSourceItem } from './common'
 
@@ -36,84 +39,123 @@ export default function ConnectProjectsImports({
   showColumnFilterModal,
   onRemoveAttachment,
 }: ConnectProjectsImportsProps) {
+  const [attachmentToRemove, setAttachmentToRemove] = useState<string | null>(null)
+  const [isRemovalModalOpened, { open: openRemovalModal, close: closeRemovalModal }] = useDisclosure(false)
+
+  const openRemovalConfirmation = (attachmentUrl: string) => {
+    setAttachmentToRemove(attachmentUrl)
+    openRemovalModal()
+  }
+
+  const closeRemovalConfirmation = () => {
+    setAttachmentToRemove(null)
+    closeRemovalModal()
+  }
+
+  const confirmRemoval = () => {
+    if (!attachmentToRemove) {
+      closeRemovalConfirmation()
+      return
+    }
+
+    onRemoveAttachment(attachmentToRemove)
+    closeRemovalConfirmation()
+  }
+
   return (
-    <div className='connect-projects__import'>
-      <div className='connect-projects__import-form'>
-        {selectComponent}
+    <>
+      <Modal opened={isRemovalModalOpened} onClose={closeRemovalConfirmation} title={t('Remove project?')}>
+        <Text>{t('Are you sure you want to remove imported project?')}</Text>
+        <Group justify='flex-end' mt='md'>
+          <ButtonNew size='md' onClick={closeRemovalConfirmation}>
+            {t('Cancel')}
+          </ButtonNew>
+          <ButtonNew size='md' variant='danger' onClick={confirmRemoval} disabled={isLoading}>
+            {t('Remove project')}
+          </ButtonNew>
+        </Group>
+      </Modal>
 
-        <TextBox
-          className='connect-projects-textbox'
-          placeholder={t('Give a unique name to the import')}
-          value={newFilename}
-          size='m'
-          onChange={onFilenameChange}
-          errors={fieldsErrors.filename}
-        />
+      <div className='connect-projects__import'>
+        <div className='connect-projects__import-form'>
+          {selectComponent}
 
-        <Button type='primary' size='m' onClick={onConfirmAttachment} label={t('Import')} />
-      </div>
+          <TextBox
+            className='connect-projects-textbox'
+            placeholder={t('Give a unique name to the import')}
+            value={newFilename}
+            size='m'
+            onChange={onFilenameChange}
+            errors={fieldsErrors.filename}
+          />
 
-      <h3 className='connect-projects__list-header'>{t('Imported')}</h3>
+          <ButtonNew variant='filled' size='md' onClick={onConfirmAttachment}>
+            {t('Import')}
+          </ButtonNew>
+        </div>
 
-      <ul className='connect-projects__import-list'>
-        {(!isInitialised || isLoading) && (
-          <li className='connect-projects__import-list-item'>
-            <LoadingSpinner message={t('Loading imported projects')} />
-          </li>
-        )}
+        <h3 className='connect-projects__list-header'>{t('Imported')}</h3>
 
-        {isInitialised && !isLoading && attachedSources.length === 0 && (
-          <li className='connect-projects__import-list-item--no-imports'>{t('No data imported')}</li>
-        )}
-
-        {!isLoading &&
-          attachedSources.length > 0 &&
-          attachedSources.map((item) => (
-            <li key={item.attachmentUrl} className='connect-projects__import-list-item'>
-              <Icon
-                size='xl'
-                name={item.isSourceDeleted ? 'close' : 'check'}
-                color={item.isSourceDeleted ? 'mid-red' : 'blue'}
-              />
-
-              <div className='connect-projects__import-labels'>
-                <span className='connect-projects__import-labels-filename'>{item.filename}</span>
-
-                <span className='connect-projects__import-labels-source'>{item.sourceName}</span>
-              </div>
-
-              <div className='connect-projects__import-options'>
-                <Button
-                  type='secondary'
-                  size='m'
-                  startIcon='settings'
-                  tooltip={item.isSourceDeleted ? t('Cannot configure deleted project') : t('Configure')}
-                  isDisabled={item.isSourceDeleted || !item.sourceUid || !item.sourceUrl}
-                  onClick={() =>
-                    showColumnFilterModal(
-                      {
-                        uid: item.sourceUid,
-                        name: item.sourceName,
-                        url: item.sourceUrl,
-                      },
-                      item.filename,
-                      item.linkedFields,
-                      item.attachmentUrl,
-                    )
-                  }
-                />
-
-                <Button
-                  type='secondary-danger'
-                  size='m'
-                  startIcon='trash'
-                  tooltip={t('Remove')}
-                  onClick={() => onRemoveAttachment(item.attachmentUrl)}
-                />
-              </div>
+        <ul className='connect-projects__import-list'>
+          {(!isInitialised || isLoading) && (
+            <li className='connect-projects__import-list-item'>
+              <LoadingSpinner message={t('Loading imported projects')} />
             </li>
-          ))}
-      </ul>
-    </div>
+          )}
+
+          {isInitialised && !isLoading && attachedSources.length === 0 && (
+            <li className='connect-projects__import-list-item--no-imports'>{t('No data imported')}</li>
+          )}
+
+          {!isLoading &&
+            attachedSources.length > 0 &&
+            attachedSources.map((item) => (
+              <li key={item.attachmentUrl} className='connect-projects__import-list-item'>
+                <Icon
+                  size='xl'
+                  name={item.isSourceDeleted ? 'close' : 'check'}
+                  color={item.isSourceDeleted ? 'mid-red' : 'blue'}
+                />
+
+                <div className='connect-projects__import-labels'>
+                  <span className='connect-projects__import-labels-filename'>{item.filename}</span>
+
+                  <span className='connect-projects__import-labels-source'>{item.sourceName}</span>
+                </div>
+
+                <div className='connect-projects__import-options'>
+                  <ActionIcon
+                    variant='light'
+                    size='md'
+                    iconName='settings'
+                    tooltip={item.isSourceDeleted ? t('Cannot configure deleted project') : t('Configure')}
+                    disabled={item.isSourceDeleted || !item.sourceUid || !item.sourceUrl}
+                    onClick={() =>
+                      showColumnFilterModal(
+                        {
+                          uid: item.sourceUid,
+                          name: item.sourceName,
+                          url: item.sourceUrl,
+                        },
+                        item.filename,
+                        item.linkedFields,
+                        item.attachmentUrl,
+                      )
+                    }
+                  />
+
+                  <ActionIcon
+                    variant='danger-secondary'
+                    size='md'
+                    iconName='trash'
+                    tooltip={t('Remove')}
+                    onClick={() => openRemovalConfirmation(item.attachmentUrl)}
+                  />
+                </div>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </>
   )
 }

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -62,6 +62,10 @@ export default function ConnectProjectsImports({
     closeRemovalConfirmation()
   }
 
+  const shouldShowInitialLoading = !isInitialised
+  const shouldShowEmptyState = isInitialised && !isLoading && attachedSources.length === 0
+  const shouldShowAttachedSources = attachedSources.length > 0
+
   return (
     <>
       <Modal opened={isRemovalModalOpened} onClose={closeRemovalConfirmation} title={t('Remove project?')}>
@@ -97,18 +101,17 @@ export default function ConnectProjectsImports({
         <h3 className='connect-projects__list-header'>{t('Imported')}</h3>
 
         <ul className='connect-projects__import-list'>
-          {(!isInitialised || isLoading) && (
+          {shouldShowInitialLoading && (
             <li className='connect-projects__import-list-item'>
               <LoadingSpinner message={t('Loading imported projects')} />
             </li>
           )}
 
-          {isInitialised && !isLoading && attachedSources.length === 0 && (
+          {shouldShowEmptyState && (
             <li className='connect-projects__import-list-item--no-imports'>{t('No data imported')}</li>
           )}
 
-          {!isLoading &&
-            attachedSources.length > 0 &&
+          {shouldShowAttachedSources &&
             attachedSources.map((item) => (
               <li key={item.attachmentUrl} className='connect-projects__import-list-item'>
                 <Icon

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -132,7 +132,7 @@ export default function ConnectProjectsImports({
                     size='md'
                     iconName='settings'
                     tooltip={item.isSourceDeleted ? t('Cannot configure deleted project') : t('Configure')}
-                    disabled={item.isSourceDeleted || !item.sourceUid || !item.sourceUrl}
+                    disabled={isLoading || item.isSourceDeleted || !item.sourceUid || !item.sourceUrl}
                     onClick={() =>
                       showColumnFilterModal(
                         {
@@ -152,6 +152,7 @@ export default function ConnectProjectsImports({
                     size='md'
                     iconName='trash'
                     tooltip={t('Remove')}
+                    disabled={isLoading}
                     onClick={() => openRemovalConfirmation(item.attachmentUrl)}
                   />
                 </div>

--- a/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjectsImports.tsx
@@ -3,6 +3,7 @@ import Button from '#/components/common/button'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import TextBox from '#/components/common/textBox'
 import type { AssetResponse } from '#/dataInterface'
+import Icon from '../common/icon'
 import type { AttachedSourceItem } from './common'
 
 interface ConnectProjectsImportsProps {
@@ -69,7 +70,11 @@ export default function ConnectProjectsImports({
           attachedSources.length > 0 &&
           attachedSources.map((item) => (
             <li key={item.attachmentUrl} className='connect-projects__import-list-item'>
-              <i className='k-icon k-icon-check' />
+              <Icon
+                size='xl'
+                name={item.isSourceDeleted ? 'close' : 'check'}
+                color={item.isSourceDeleted ? 'mid-red' : 'blue'}
+              />
 
               <div className='connect-projects__import-labels'>
                 <span className='connect-projects__import-labels-filename'>{item.filename}</span>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixes a problem with Connect Projects UI when an imported project was removed before the import-link was deleted. The problem was causing an infinite loading spinner (or crash). 

Also migrated few old icons and buttons to latest components. Also introduced a confirmation for imported project removing.

### 💭 Notes

I think the issue reported on Linear was a bit different from issue on `main` branch given [the recent connectProjects PRs](https://github.com/kobotoolbox/kpi/pulls?q=is%3Aclosed%20is%3Apr%20author%3Amagicznyleszek%20connectProjects). When I tested it, I was getting a crash, and Linear issue describes infinite spinner (in the same area though).

I allowed myself to polish the UI a bit, as it was bugging me while debugging ;)

Changes here:
- Fixed the issue → mainly problem was that after removing project `source.source__name` is `null`, and code tried calling `truncateString()` on it expecting a string
- Migrated `<i>` to `<Icon>` component
- For deleted imported project, I show different icon to make it clearer
- Deleted imported project has now disabled "Configure" button and a description override
- Migrated `<Button>` to `<ActionIcon>` and `<ButtonNew>`
- When removing an imported project, we now display confirmation modal

I recommend "Hide whitespace" in "Files changed" tab settings

### 👀 Preview steps

See steps [described at Linear task](https://linear.app/kobotoolbox/issue/DEV-2026/deleting-a-connected-project-causes-infinite-load-when-trying-to#steps-to-reproduce-bd538fc9)