### PR TITLE
fix(subsequences): fix 500 error from half-migrated assets DEV-2030

### DIFF
--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -130,8 +130,11 @@ class Command(BaseCommand):
                 if xpath == '_version' or not isinstance(action_data, dict):
                     continue
                 for action_id in action_data:
-                    if action_id in ACTION_IDS_TO_CLASSES:
-                        missing_qaf_combos.add((ss.asset_id, xpath, action_id))
+                    if not QuestionAdvancedFeature.objects.filter(
+                        asset=ss.asset, question_xpath=xpath, action=action_id
+                    ).exists():
+                        if action_id in ACTION_IDS_TO_CLASSES:
+                            missing_qaf_combos.add((ss.asset_id, xpath, action_id))
 
             ss.content = migrated_content
             to_update.append(ss)

--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -316,12 +316,13 @@ class Command(BaseCommand):
                             )
                             if created:
                                 asset_qaf_created += 1
-                    asset.advanced_features['_version'] = SCHEMA_VERSIONS[0]
-                    asset.save(
-                        update_fields=['advanced_features'],
-                        create_version=False,
-                        adjust_content=False,
-                    )
+                    if not dry_run:
+                        asset.advanced_features['_version'] = SCHEMA_VERSIONS[0]
+                        asset.save(
+                            update_fields=['advanced_features'],
+                            create_version=False,
+                            adjust_content=False,
+                        )
             except Exception as e:
                 self.stderr.write(f'  ERROR creating QAFs for asset={asset.uid}: {e}')
                 qaf_errors += len(combos_for_asset)

--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -3,6 +3,7 @@ from django.db import transaction
 from django.db.models import Exists, OuterRef
 
 from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
 from kobo.apps.subsequences.utils.versioning import migrate_submission_supplementals
 from kpi.models import Asset
@@ -130,11 +131,8 @@ class Command(BaseCommand):
                 if xpath == '_version' or not isinstance(action_data, dict):
                     continue
                 for action_id in action_data:
-                    if not QuestionAdvancedFeature.objects.filter(
-                        asset=ss.asset, question_xpath=xpath, action=action_id
-                    ).exists():
-                        if action_id in ACTION_IDS_TO_CLASSES:
-                            missing_qaf_combos.add((ss.asset_id, xpath, action_id))
+                    if action_id in ACTION_IDS_TO_CLASSES:
+                        missing_qaf_combos.add((ss.asset_id, xpath, action_id))
 
             ss.content = migrated_content
             to_update.append(ss)
@@ -318,6 +316,12 @@ class Command(BaseCommand):
                             )
                             if created:
                                 asset_qaf_created += 1
+                    asset.advanced_features['_version'] = SCHEMA_VERSIONS[0]
+                    asset.save(
+                        update_fields=['advanced_features'],
+                        create_version=False,
+                        adjust_content=False,
+                    )
             except Exception as e:
                 self.stderr.write(f'  ERROR creating QAFs for asset={asset.uid}: {e}')
                 qaf_errors += len(combos_for_asset)

--- a/kobo/apps/subsequences/utils/versioning.py
+++ b/kobo/apps/subsequences/utils/versioning.py
@@ -152,7 +152,9 @@ def migrate_advanced_features(
                 features_to_create.extend(convert_qual_params(asset, value))
 
         # DANGER: this does not go through validate_params
-        QuestionAdvancedFeature.objects.bulk_create(features_to_create)
+        QuestionAdvancedFeature.objects.bulk_create(
+            features_to_create, ignore_conflicts=True
+        )
 
         # restore the old dict, but mark that we've already migrated
         asset.advanced_features = copied


### PR DESCRIPTION
### 📣 Summary

Fixes a 500 error when opening the NLP panel on projects that went through an incomplete migration.

### 💭 Notes

Two fixes:
- `bulk_create(..., ignore_conflicts=True)` in `versioning.py` so re-running after a partial failure no longer raises on duplicate rows.
- `_create_missing_qafs` now stamps `advanced_features['_version']` after creating QAFs, and the `asset.save()` is correctly gated on `not dry_run` (it was writing to the DB even during `--dry-run`).

### 👀 Preview steps

1. Checkout an old version (prior to subsequences refactor, e.g. `2.025.47`) if you don't have old projects with NLP data.
2. Create a project with an audio question (skip if projects already exist)
3. Submit data
4. Open NLP modal and transcribe the audio file.
5. Checkout `2.026.12` (don't forget to rebuild the image and restart all your containers)
6. Repeat step 3 and 4
7. Stop the LRM 0023
7. Simulate half migrated project. From the shell run
```python
a = Asset.objects.get(uid='xx')
a.advanced_features.pop('_version')
af = a.advanced_features
Asset.objects.filter(pk=a.pk).update(advanced_features=af)
```
2. 🔴 [on release branch] Open the NLP panel on that project — 500 error.
3. 🟢 [on PR] Open the NLP panel on that project — panel opens without error.