### PR TITLE
fix(constance): repair migration 0020 for constance 4 envelope format DEV-2027

### DIFF
--- a/hub/migrations/0020_fix_constance_json_field_corruption.py
+++ b/hub/migrations/0020_fix_constance_json_field_corruption.py
@@ -25,13 +25,13 @@ def fix_constance_json_field_corruption(apps, schema_editor):
     of a JSON object/array.
 
     Root cause: JsonSchemaFormField.clean() returned the raw input string
-    instead of the parsed Python object. Constance encoded that string as JSON,
-    so the DB ended up with e.g. '"{\\"default\\": ...}"' for a field that
-    should contain '{"default": ...}'.
+    instead of the parsed Python object.
 
-    After this migration, each affected key is stored as a proper JSON
-    object/array, and the constance cache is invalidated so the corrected
-    values are picked up immediately.
+    Constance 4 wraps every stored value in {"__type__": ..., "__value__": ...}.
+    The corruption manifests as __value__ being a JSON-encoded string instead of
+    the actual dict/list. The previous version of this migration incorrectly
+    assumed a plain double-encoded string at the root level (constance 3 format)
+    and skipped all records because it saw a dict (the envelope), not a string.
     """
     Constance = apps.get_model('constance', 'Constance')
 
@@ -51,31 +51,50 @@ def fix_constance_json_field_corruption(apps, schema_editor):
             )
             continue
 
-        if not isinstance(outer, str):
-            # Already a dict, list, or lazy_json_serializable envelope — no fix needed.
-            continue
+        # Constance 4 format: {"__type__": "...", "__value__": <actual value>}
+        if isinstance(outer, dict) and '__type__' in outer and '__value__' in outer:
+            inner_raw = outer['__value__']
+            if not isinstance(inner_raw, str):
+                # __value__ is already a dict/list — no fix needed.
+                continue
+            try:
+                inner = json.loads(inner_raw)
+            except json.JSONDecodeError:
+                logging.warning(
+                    'constance key %s: __value__ is not valid JSON, skipping', key
+                )
+                continue
+            if not isinstance(inner, (dict, list)):
+                logging.warning(
+                    'constance key %s: __value__ is not a dict/list (%s), skipping',
+                    key,
+                    type(inner).__name__,
+                )
+                continue
+            outer['__value__'] = inner
+            record.value = json.dumps(outer)
+            record.save(update_fields=['value'])
+            logging.info('constance key %s: repaired corrupted __value__ string', key)
 
-        # The outer value is a string: it was double-encoded. The real data is
-        # the result of parsing that string.
-        try:
-            inner = json.loads(outer)
-        except json.JSONDecodeError:
-            logging.warning(
-                'constance key %s: inner value is not valid JSON, skipping', key
-            )
-            continue
-
-        if not isinstance(inner, (dict, list)):
-            logging.warning(
-                'constance key %s: inner value is not a dict/list (%s), skipping',
-                key,
-                type(inner).__name__,
-            )
-            continue
-
-        record.value = json.dumps(inner)
-        record.save(update_fields=['value'])
-        logging.info('constance key %s: repaired corrupted string value', key)
+        elif isinstance(outer, str):
+            # Legacy constance 3 format: plain double-encoded string at root.
+            try:
+                inner = json.loads(outer)
+            except json.JSONDecodeError:
+                logging.warning(
+                    'constance key %s: inner value is not valid JSON, skipping', key
+                )
+                continue
+            if not isinstance(inner, (dict, list)):
+                logging.warning(
+                    'constance key %s: inner value is not a dict/list (%s), skipping',
+                    key,
+                    type(inner).__name__,
+                )
+                continue
+            record.value = json.dumps(inner)
+            record.save(update_fields=['value'])
+            logging.info('constance key %s: repaired corrupted string value', key)
 
     # Invalidate the constance cache so the corrected DB values are served
     # immediately without waiting for cache expiry.

--- a/kobo/apps/organizations/migrations/0003_copy_organization_uid_to_id.py
+++ b/kobo/apps/organizations/migrations/0003_copy_organization_uid_to_id.py
@@ -2,13 +2,13 @@ from django.db import migrations
 from django.db.models import F
 
 
-'''
+r"""
 `\d organizations_organization` says:
 
     TABLE "organizations_organizationinvitation" CONSTRAINT "…" FOREIGN KEY (organization_id) REFERENCES organizations_organization(id) DEFERRABLE INITIALLY DEFERRED
     TABLE "organizations_organizationowner" CONSTRAINT "…" FOREIGN KEY (organization_id) REFERENCES organizations_organization(id) DEFERRABLE INITIALLY DEFERRED
     TABLE "organizations_organizationuser" CONSTRAINT "…" FOREIGN KEY (organization_id) REFERENCES organizations_organization(id) DEFERRABLE INITIALLY DEFERRED
-'''
+"""
 
 def copy_uid_to_id(apps, schema_editor):
     Organization = apps.get_model("organizations", "Organization")


### PR DESCRIPTION
### 📣 Summary

Follow-up to #6968. Migration `0020_fix_constance_json_field_corruption` was silently skipping all records modified by Constance own migration and not repairing corrupted constance values, causing a 500 error on `/environment/`.

### 💭 Notes

Constance 4 wraps every stored value in `{"__type__": "...", "__value__": ...}` (introduced by `constance.0003_drop_pickle`). The previous migration logic checked `if not isinstance(outer, str)` at the root level — since constance 4 always stores a dict envelope at the root, all records were skipped.

The corruption lives one level deeper, in `__value__`, which holds a JSON-encoded string instead of the actual dict/list.

This PR fixes the migration to:
- Detect the constance 4 envelope and inspect `__value__`
- Parse and repair `__value__` when it is a string (double-encoded)
- Keep the legacy constance 3 path (plain double-encoded string at root) as fallback

Also fixes a `SyntaxWarning: invalid escape sequence '\d'` in `0003_copy_organization_uid_to_id.py` (Python 3.12).

### 👀 Preview steps
1. Checkout `release/2.016.12`
2. Modify `MFA_LOCALIZED_HELP_TEXT` (for example)
3. Checkout `release/2.016.13` (wait for the migrations to be applied)
4. Try to login as a regular user and receive a 500 from `/environment/`
5. Checkout this branch
6. Rollback migration hub 0020, then reapplyt it.
3. Verify all 4 keys return `dict`/`list`:
   ```python
   from constance import config
   for key in ['MFA_LOCALIZED_HELP_TEXT', 'CUSTOM_PASSWORD_GUIDANCE_TEXT', 'USER_METADATA_FIELDS', 'PROJECT_METADATA_FIELDS']:
       val = getattr(config, key)
       print('OK' if isinstance(val, (dict, list)) else 'BROKEN', key, type(val).__name__)
   ```
4. 🟢 All 4 lines print `OK`
5. 🟢 `/environment/` returns 200