### PR TITLE
fix(connectProjects): deleted imported project issue DEV-2026

### DIFF
--- a/jsapp/js/actions/dataShareActions.js
+++ b/jsapp/js/actions/dataShareActions.js
@@ -70,15 +70,18 @@ dataShareActions.getAttachedSources.listen((assetUid) => {
       // backend response directly.
       // See: https://github.com/kobotoolbox/kpi/issues/3911
       response.results.forEach((source) => {
-        const sourceUid = getAssetUIDFromUrl(source.source)
+        const sourceUrl = source.source || ''
+        const sourceUid = getAssetUIDFromUrl(sourceUrl) || ''
+        const sourceName = source.source__name || t('Deleted project')
+        const filename = source.filename || t('Deleted project')
         allSources.push({
-          sourceName: truncateString(source.source__name, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
+          sourceName: truncateString(sourceName, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
           // Source's asset url
-          sourceUrl: source.source,
+          sourceUrl,
           sourceUid: sourceUid,
           // Fields that the connecting project has selected to import
-          linkedFields: source.fields,
-          filename: truncateFile(source.filename, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
+          linkedFields: source.fields || [],
+          filename: truncateFile(filename, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
           // Source project attachment endpoint
           attachmentUrl: source.url,
         })

--- a/jsapp/js/actions/dataShareActions.js
+++ b/jsapp/js/actions/dataShareActions.js
@@ -70,15 +70,17 @@ dataShareActions.getAttachedSources.listen((assetUid) => {
       // backend response directly.
       // See: https://github.com/kobotoolbox/kpi/issues/3911
       response.results.forEach((source) => {
-        const sourceUrl = source.source || ''
-        const sourceUid = getAssetUIDFromUrl(sourceUrl) || ''
+        const sourceUrl = source.source || null
+        const sourceUid = sourceUrl ? getAssetUIDFromUrl(sourceUrl) || null : null
+        const isSourceDeleted = !sourceUrl || !sourceUid
         const sourceName = source.source__name || t('Deleted project')
         const filename = source.filename || t('Deleted project')
         allSources.push({
           sourceName: truncateString(sourceName, MAX_DISPLAYED_STRING_LENGTH.connect_projects),
           // Source's asset url
           sourceUrl,
-          sourceUid: sourceUid,
+          sourceUid,
+          isSourceDeleted,
           // Fields that the connecting project has selected to import
           linkedFields: source.fields || [],
           filename: truncateFile(filename, MAX_DISPLAYED_STRING_LENGTH.connect_projects),

--- a/jsapp/js/components/dataAttachments/connectProjects.tsx
+++ b/jsapp/js/components/dataAttachments/connectProjects.tsx
@@ -40,8 +40,9 @@ interface ConnectProjectsState {
 
 interface AttachedSourceItem {
   sourceName: string
-  sourceUrl: string
-  sourceUid: string
+  sourceUrl: string | null
+  sourceUid: string | null
+  isSourceDeleted: boolean
   linkedFields: string[]
   filename: string
   attachmentUrl: string
@@ -319,7 +320,9 @@ class ConnectProjects extends React.Component<ConnectProjectsProps, ConnectProje
   generateFilteredAssetList() {
     const attachedSourceUids: string[] = []
     this.state.attachedSources.forEach((item) => {
-      attachedSourceUids.push(item.sourceUid)
+      if (item.sourceUid) {
+        attachedSourceUids.push(item.sourceUid)
+      }
     })
 
     // Filter out attached projects from displayed asset list
@@ -483,7 +486,12 @@ class ConnectProjects extends React.Component<ConnectProjectsProps, ConnectProje
                     type='secondary'
                     size='m'
                     startIcon='settings'
-                    onClick={() =>
+                    isDisabled={item.isSourceDeleted}
+                    onClick={() => {
+                      if (item.isSourceDeleted || !item.sourceUid || !item.sourceUrl) {
+                        return
+                      }
+
                       this.showColumnFilterModal(
                         this.props.asset,
                         {
@@ -495,7 +503,7 @@ class ConnectProjects extends React.Component<ConnectProjectsProps, ConnectProje
                         item.linkedFields,
                         item.attachmentUrl,
                       )
-                    }
+                    }}
                   />
 
                   <Button


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixes a problem with Connect Projects UI when an imported project was removed before the import-link was deleted. The problem was causing an infinite loading spinner (or crash). 

### 💭 Notes

Changes here:
- Fixed the issue → mainly problem was that after removing project `source.source__name` is `null`, and code tried calling `truncateString()` on it expecting a string

This PR is a "port" of #6971 - a fix made on newer refactored code. This was intended to be minimal, as we don't want to use the code in this PR, as #6971 already (in the "future") fixed it.

### 👀 Preview steps

See steps [described at Linear task](https://linear.app/kobotoolbox/issue/DEV-2026/deleting-a-connected-project-causes-infinite-load-when-trying-to#steps-to-reproduce-bd538fc9)