### PR TITLE
fix(subsequences): stamp empty supplements and unblock exports DEV-2036

### DIFF
--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -97,14 +97,19 @@ class Command(BaseCommand):
             content = ss.content.copy()
 
             if not content:
+                # Supplement was created by get_or_create but the process
+                # crashed before the final update(). No data to migrate;
+                # just stamp _version so the export guard stops blocking.
                 self.stdout.write(
                     self.style.WARNING(
-                        f'  Skipping supplement {ss.pk}'
-                        f' (asset={ss.asset.uid}, uuid={ss.submission_uuid}):'
-                        ' content is empty'
+                        f'  Supplement {ss.pk}'
+                        f' (asset={ss.asset.uid}, uuid={ss.submission_uuid})'
+                        ' has empty content — stamping _version'
                     )
                 )
-                skipped += 1
+                ss.content = {'_version': SCHEMA_VERSIONS[0]}
+                to_update.append(ss)
+                migrated += 1
                 continue
 
             try:

--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -102,7 +102,8 @@ class Command(BaseCommand):
                 # just stamp _version so the export guard stops blocking.
                 self.stdout.write(
                     self.style.WARNING(
-                        f'  Supplement {ss.pk}'
+                        f'  {"[dry-run] " if dry_run else ""}'
+                        f'Supplement {ss.pk}'
                         f' (asset={ss.asset.uid}, uuid={ss.submission_uuid})'
                         ' has empty content — stamping _version'
                     )

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -1073,6 +1073,7 @@ class SubmissionExportTaskBase(ImportExportTask):
             if source.advanced_features_set.exists() and (
                 SubmissionSupplement.objects.filter(asset=source)
                 .exclude(content__has_key='_version')
+                .exclude(content={})
                 .exists()
             ):
                 raise SupplementMigrationInProgress(


### PR DESCRIPTION
### 📣 Summary

Exports were permanently blocked for some projects due to incomplete NLP supplement records that the migration command could not fix.

### 👀 Preview steps

1. ℹ️ Have an asset with `QuestionAdvancedFeature` records and a `SubmissionSupplement` with `content={}` (simulates a crashed `revise_data`)
2. 🔴 [on main] Attempt an export — it blocks with `SupplementMigrationInProgress`; running the management command skips the supplement and does not fix it
3. 🟢 [on PR] Export proceeds normally; the management command stamps the empty supplement with `_version`