### PR TITLE
fix(icons): missing legacy icon mapping

### DIFF
--- a/jsapp/js/components/common/KoboIconMappings.ts
+++ b/jsapp/js/components/common/KoboIconMappings.ts
@@ -199,6 +199,7 @@ export const LegacyIconToTablerIconMap: Record<IconName, TablerIcon | undefined>
   tag: TablerIcons.IconTagFilled,
   'template-locked': undefined,
   template: TablerIcons.IconTemplate,
+  transcripts: undefined,
   trash: TablerIcons.IconTrashFilled,
   unfreeze: TablerIcons.IconTableOff,
   unsubscribe: undefined,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Resolve linting error on LegacyIcon mapping.

