### PR TITLE
fix(icon): change way of identifying legacy icons DEV-2069

### DIFF
--- a/jsapp/js/components/common/IconLegacySvgMappings.tsx
+++ b/jsapp/js/components/common/IconLegacySvgMappings.tsx
@@ -197,8 +197,17 @@ import ViewAllSvg from '../../../svg-icons/view-all.svg?react'
 import ViewSvg from '../../../svg-icons/view.svg?react'
 import WarningSvg from '../../../svg-icons/warning.svg?react'
 
-function wrapLegacySvgIcon(SvgComponent: ComponentType<SVGProps<SVGSVGElement>>): ComponentType<SvgIconProps> {
-  return function LegacySvgIcon({ size, color, style, ...svgProps }: SvgIconProps) {
+export type LegacySvgIconComponent = ComponentType<SvgIconProps> & {
+  isKoboLegacySvgIcon?: true
+}
+
+function wrapLegacySvgIcon(SvgComponent: ComponentType<SVGProps<SVGSVGElement>>): LegacySvgIconComponent {
+  const LegacySvgIcon: LegacySvgIconComponent = function LegacySvgIcon({
+    size,
+    color,
+    style,
+    ...svgProps
+  }: SvgIconProps) {
     const resolvedSize = typeof size === 'number' ? size : undefined
     const normalizedSvgProps = svgProps as unknown as SVGProps<SVGSVGElement>
 
@@ -217,6 +226,10 @@ function wrapLegacySvgIcon(SvgComponent: ComponentType<SVGProps<SVGSVGElement>>)
       />
     )
   }
+
+  LegacySvgIcon.isKoboLegacySvgIcon = true
+
+  return LegacySvgIcon
 }
 
 export const LegacyIconToSvgComponentMap: Record<IconName, ComponentType<SvgIconProps>> = {

--- a/jsapp/js/components/common/KoboIcon.tsx
+++ b/jsapp/js/components/common/KoboIcon.tsx
@@ -1,6 +1,7 @@
 import type { MantineSize } from '@mantine/core'
 import type { IconProps as SvgIconProps } from '@tabler/icons-react'
 import type { ComponentType } from 'react'
+import type { LegacySvgIconComponent } from './IconLegacySvgMappings'
 import type { IconColor } from './icon'
 
 const MantineSizeToPixelsMap: Record<MantineSize, number> = {
@@ -59,9 +60,8 @@ export default function KoboIcon({ icon, size, color, ...svgProps }: KoboIconPro
     return null
   }
   const IconComponent = icon
-  // Legacy SVG components wrapped by wrapLegacySvgIcon are named "LegacySvgIcon".
-  // Tabler icons use stroke width; legacy fill-based (or varied stroke width) SVGs should not have it applied.
-  const isLegacySvg = IconComponent.displayName === 'LegacySvgIcon' || IconComponent.name === 'LegacySvgIcon'
+  // Tabler icons use stroke width; wrapped legacy SVGs keep their own stroke/fill attributes.
+  const isLegacySvg = (IconComponent as LegacySvgIconComponent).isKoboLegacySvgIcon === true
   return (
     <IconComponent
       {...svgProps}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixes a problem with some icon rendering.

### 💭 Notes

Some icons were rendering as empty/transparent because the code that identifies legacy svg icons was wrong - it was setting `stroke` attribute for all icons rather than just tabler ones.

### 👀 Preview steps

Unfortunately the issue happens only on deployed storybook (see https://storybook.kbtdev.org/?path=%2Fstory%2Fdesign-system-koboicon--mantine-integration-examples) and I haven't found a way to reproduce it locally. I suspect the problem happens with production build, and previous way of identifying the legacy svgs stopped working because of code minification (that renamed some things we we're relying on).