### PR TITLE
feat(frontend): setup default invalidations DEV-2010

### DIFF
--- a/jsapp/js/api/mutation-defaults/common.ts
+++ b/jsapp/js/api/mutation-defaults/common.ts
@@ -22,8 +22,6 @@ const filterPaginatedListSnapshots = ([listSnapshotKey]: [readonly unknown[], un
  */
 export const invalidatePaginatedList = (queryKey: readonly unknown[]) => {
   const listSnapshots = queryClient.getQueriesData({ queryKey: queryKey }).filter(filterPaginatedListSnapshots)
-  console.log(queryClient.getQueriesData({ queryKey: queryKey }))
-  console.log(listSnapshots)
   for (const [snapshotKey] of listSnapshots) queryClient.invalidateQueries({ queryKey: snapshotKey })
 }
 

--- a/jsapp/js/api/mutation-defaults/common.ts
+++ b/jsapp/js/api/mutation-defaults/common.ts
@@ -2,6 +2,11 @@ import type { Updater } from '@tanstack/react-query'
 import { queryClient } from '../queryClient'
 
 /**
+ * Marker appended by infinite-query hooks to distinguish those snapshots from regular list snapshots.
+ */
+export const INFINITE_QUERY_KEY_MARKER = 'infinite'
+
+/**
  * Beware that `getUsersListQueryKey(undefined)` (and alike) doesn't select all pages for list endpoint as expected!
  * Unfortunately, it will invalidate all specific users as well.
  *
@@ -23,6 +28,20 @@ const filterPaginatedListSnapshots = ([listSnapshotKey]: [readonly unknown[], un
 export const invalidatePaginatedList = (queryKey: readonly unknown[]) => {
   const listSnapshots = queryClient.getQueriesData({ queryKey: queryKey }).filter(filterPaginatedListSnapshots)
   for (const [snapshotKey] of listSnapshots) queryClient.invalidateQueries({ queryKey: snapshotKey })
+}
+
+/**
+ * Invalidate all infinite-query snapshots that share the provided query-key prefix.
+ *
+ * By convention, infinite-query keys append {@link INFINITE_QUERY_KEY_MARKER} as the last segment.
+ */
+export const invalidateInfiniteList = (queryKey: readonly unknown[]) => {
+  queryClient.invalidateQueries({
+    predicate: ({ queryKey: candidateKey }) =>
+      candidateKey.length > queryKey.length &&
+      queryKey.every((keyPart, index) => candidateKey[index] === keyPart) &&
+      candidateKey.at(-1) === INFINITE_QUERY_KEY_MARKER,
+  })
 }
 
 /**

--- a/jsapp/js/api/mutation-defaults/index.ts
+++ b/jsapp/js/api/mutation-defaults/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/export */
 // ^^ eslint doesn't understand direct exports.
 
+export * from './manage-projects-and-library-content'
 export * from './user-team-organization-usage'
 export * from './survey-data'
 

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -14,7 +14,7 @@ queryClient.setMutationDefaults(
         const assetsListQueryKey = getAssetsListQueryKey()
 
         invalidatePaginatedList(assetsListQueryKey)
-        // Invaliate infinite queries
+        // Invalidate infinite queries
         queryClient.invalidateQueries({
           predicate: ({ queryKey }) =>
             queryKey.length > assetsListQueryKey.length &&

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -14,6 +14,7 @@ queryClient.setMutationDefaults(
         const assetsListQueryKey = getAssetsListQueryKey()
 
         invalidatePaginatedList(assetsListQueryKey)
+        // Invaliate infinite queries
         queryClient.invalidateQueries({
           predicate: ({ queryKey }) =>
             queryKey.length > assetsListQueryKey.length &&

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -11,7 +11,15 @@ queryClient.setMutationDefaults(
   getAssetsPartialUpdateMutationOptions({
     mutation: {
       onSettled: (_data, _error, { uidAsset }) => {
-        invalidatePaginatedList(getAssetsListQueryKey())
+        const assetsListQueryKey = getAssetsListQueryKey()
+
+        invalidatePaginatedList(assetsListQueryKey)
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) =>
+            queryKey.length > assetsListQueryKey.length &&
+            assetsListQueryKey.every((keyPart, index) => queryKey[index] === keyPart) &&
+            queryKey[queryKey.length - 1] === 'infinite',
+        })
         invalidateItem(getAssetsRetrieveQueryKey(uidAsset))
       },
     },

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -19,7 +19,7 @@ queryClient.setMutationDefaults(
           predicate: ({ queryKey }) =>
             queryKey.length > assetsListQueryKey.length &&
             assetsListQueryKey.every((keyPart, index) => queryKey[index] === keyPart) &&
-            queryKey[queryKey.length - 1] === 'infinite',
+            queryKey.at(-1) === 'infinite',
         })
         invalidateItem(getAssetsRetrieveQueryKey(uidAsset))
       },

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -1,0 +1,19 @@
+import {
+  getAssetsListQueryKey,
+  getAssetsPartialUpdateMutationOptions,
+  getAssetsRetrieveQueryKey,
+} from '#/api/react-query/manage-projects-and-library-content'
+import { queryClient } from '../queryClient'
+import { invalidateItem, invalidatePaginatedList } from './common'
+
+queryClient.setMutationDefaults(
+  getAssetsPartialUpdateMutationOptions().mutationKey!,
+  getAssetsPartialUpdateMutationOptions({
+    mutation: {
+      onSettled: (_data, _error, { uidAsset }) => {
+        invalidatePaginatedList(getAssetsListQueryKey())
+        invalidateItem(getAssetsRetrieveQueryKey(uidAsset))
+      },
+    },
+  }),
+)

--- a/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
+++ b/jsapp/js/api/mutation-defaults/manage-projects-and-library-content.ts
@@ -4,7 +4,7 @@ import {
   getAssetsRetrieveQueryKey,
 } from '#/api/react-query/manage-projects-and-library-content'
 import { queryClient } from '../queryClient'
-import { invalidateItem, invalidatePaginatedList } from './common'
+import { invalidateInfiniteList, invalidateItem, invalidatePaginatedList } from './common'
 
 queryClient.setMutationDefaults(
   getAssetsPartialUpdateMutationOptions().mutationKey!,
@@ -14,13 +14,7 @@ queryClient.setMutationDefaults(
         const assetsListQueryKey = getAssetsListQueryKey()
 
         invalidatePaginatedList(assetsListQueryKey)
-        // Invalidate infinite queries
-        queryClient.invalidateQueries({
-          predicate: ({ queryKey }) =>
-            queryKey.length > assetsListQueryKey.length &&
-            assetsListQueryKey.every((keyPart, index) => queryKey[index] === keyPart) &&
-            queryKey.at(-1) === 'infinite',
-        })
+        invalidateInfiniteList(assetsListQueryKey)
         invalidateItem(getAssetsRetrieveQueryKey(uidAsset))
       },
     },

--- a/jsapp/js/api/mutation-defaults/survey-data.ts
+++ b/jsapp/js/api/mutation-defaults/survey-data.ts
@@ -386,7 +386,9 @@ queryClient.setMutationDefaults(
   getAssetsPairedDataDestroyMutationOptions({
     mutation: {
       onSettled: (_data, _error, { uidAsset }) => {
-        invalidatePaginatedList(getAssetsPairedDataListQueryKey(uidAsset))
+        const queryKey = getAssetsPairedDataListQueryKey(uidAsset)
+        invalidateItem(queryKey)
+        invalidatePaginatedList(queryKey)
       },
     },
   }),

--- a/jsapp/js/api/mutation-defaults/survey-data.ts
+++ b/jsapp/js/api/mutation-defaults/survey-data.ts
@@ -388,7 +388,6 @@ queryClient.setMutationDefaults(
       onSettled: (_data, _error, { uidAsset }) => {
         const queryKey = getAssetsPairedDataListQueryKey(uidAsset)
         invalidateItem(queryKey)
-        invalidatePaginatedList(queryKey)
       },
     },
   }),

--- a/jsapp/js/api/mutation-defaults/survey-data.ts
+++ b/jsapp/js/api/mutation-defaults/survey-data.ts
@@ -9,6 +9,8 @@ import {
   getAssetsDataListQueryKey,
   getAssetsDataSupplementPartialUpdateMutationOptions,
   getAssetsDataSupplementRetrieveQueryKey,
+  getAssetsPairedDataDestroyMutationOptions,
+  getAssetsPairedDataListQueryKey,
 } from '#/api/react-query/survey-data'
 import type { ManualQualValue } from '#/components/processing/common/types'
 import { TransxVersionSortFunction } from '#/components/processing/common/utils'
@@ -374,6 +376,17 @@ queryClient.setMutationDefaults(
         if (queryClient.isMutating({ mutationKey }) > 1) return
 
         queryClient.setQueryData(queryKey, response)
+      },
+    },
+  }),
+)
+
+queryClient.setMutationDefaults(
+  getAssetsPairedDataDestroyMutationOptions().mutationKey!,
+  getAssetsPairedDataDestroyMutationOptions({
+    mutation: {
+      onSettled: (_data, _error, { uidAsset }) => {
+        invalidatePaginatedList(getAssetsPairedDataListQueryKey(uidAsset))
       },
     },
   }),

--- a/jsapp/js/components/formLanding/FormHistory.tsx
+++ b/jsapp/js/components/formLanding/FormHistory.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useEffect } from 'react'
 import UniversalTableCore, { type UniversalTableColumn } from '#/UniversalTable/UniversalTableCore'
 import { actions } from '#/actions'
 import type { VersionListResponse } from '#/api/models/versionListResponse'
+import { INFINITE_QUERY_KEY_MARKER } from '#/api/mutation-defaults/common'
 import { queryClient } from '#/api/queryClient'
 import {
   assetsVersionsList,
@@ -70,7 +71,9 @@ export default function FormHistory(props: FormHistoryProps) {
     const unlisteners = [
       // Whenever new version is deployed, we need to refresh
       actions.resources.deployAsset.completed.listen(() =>
-        queryClient.invalidateQueries({ queryKey: [...getAssetsVersionsListQueryKey(props.assetUid), 'infinite'] }),
+        queryClient.invalidateQueries({
+          queryKey: [...getAssetsVersionsListQueryKey(props.assetUid), INFINITE_QUERY_KEY_MARKER],
+        }),
       ),
     ]
     return () => {
@@ -80,8 +83,8 @@ export default function FormHistory(props: FormHistoryProps) {
 
   // Wrap Orval's raw fetching function in TanStack's useInfiniteQuery
   const historyInfiniteQuery = useInfiniteQuery({
-    // Attach 'infinite' to the generated key to prevent cache collisions with standard query calls
-    queryKey: [...getAssetsVersionsListQueryKey(props.assetUid), 'infinite'],
+    // Attach INFINITE_QUERY_KEY_MARKER to the generated key to prevent cache collisions with standard query calls
+    queryKey: [...getAssetsVersionsListQueryKey(props.assetUid), INFINITE_QUERY_KEY_MARKER],
     // `pageParam` is the result of `getNextPageParam`
     queryFn: ({ pageParam, signal }) =>
       // TODO: for now this returns all versions, and we need to display only the deployed ones

--- a/jsapp/js/components/permissions/copyTeamPermissions.component.tsx
+++ b/jsapp/js/components/permissions/copyTeamPermissions.component.tsx
@@ -3,6 +3,7 @@ import { useDebouncedValue, useDisclosure } from '@mantine/hooks'
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import alertify from 'alertifyjs'
 import React, { useState, useMemo, useEffect } from 'react'
+import { INFINITE_QUERY_KEY_MARKER } from '#/api/mutation-defaults/common'
 import { assetsList, getAssetsListQueryKey } from '#/api/react-query/manage-projects-and-library-content'
 import InfiniteScrollTrigger from '#/components/common/InfiniteScrollTrigger'
 import { COMMON_QUERIES } from '#/constants'
@@ -72,7 +73,7 @@ export default function CopyTeamPermissions({ asset }: CopyTeamPermissionsProps)
   }
 
   const assetsInfiniteQuery = useInfiniteQuery({
-    queryKey: [...getAssetsListQueryKey({ q: getAssetsListQuery() }), 'infinite'],
+    queryKey: [...getAssetsListQueryKey({ q: getAssetsListQuery() }), INFINITE_QUERY_KEY_MARKER],
     queryFn: ({ pageParam, signal }) =>
       assetsList({ limit: ITEMS_PER_PAGE, start: pageParam, q: getAssetsListQuery() }, { signal }),
     initialPageParam: 0,

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptPoll.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptPoll.tsx
@@ -33,8 +33,6 @@ export default function AutomaticTranscriptionInProgress({ asset, questionXpath,
     queryClient.isMutating({ mutationKey: getAssetsPairedDataPartialUpdateMutationOptions().mutationKey! }) > 0 ||
     queryClient.isMutating({ mutationKey: getAssetsDataSupplementPartialUpdateMutationOptions().mutationKey! }) > 0
 
-  console.log('mutationPending', mutationPending)
-
   // Don't race mutations, mutation response will Directly Update this.
   const querySupplement = useAssetsDataSupplementRetrieve(
     asset.uid,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 💭 Notes

A code change for future. An aftermath of #6936. Added default invalidations for few orval generated API hooks.

Changes here:
- `survey-data.ts` → `useAssetsPairedDataDestroy` invalidates the paired data list for the asset on settled
- `manage-projects-and-library-content.ts` → new file; `useAssetsPartialUpdate` invalidates both the paginated assets list and the specific asset item on settled

### 👀 Preview steps

Setup:

1. Use DevTools → **Network** tab
2. Open a project that has **Connect Projects** enabled

Test 1 → `useAssetsPairedDataDestroy` invalidates the paired-data list

1. Navigate to Project → Settings → Connect Projects
2. Make sure at least one source project is already attached
3. Clear the Network log
4. Click Remove on an attached source and confirm
5. 🟢 You should see a `DELETE /api/v2/assets/<uid>/paired-data/<paired-uid>/` request complete with `204`
6. 🟢 Immediately after, a `GET /api/v2/assets/<uid>/paired-data/` request fires automatically — this is the invalidation refetch
7. 🟢 Notice the removed source disappears from the list without a manual page reload

Test 2 → `useAssetsPartialUpdate` invalidates the asset list and item

1. Stay on the same Connect Projects panel
2. Clear the Network log
3. Toggle the Share data switch (on → off, or off → on).
4. 🟢 A `PATCH /api/v2/assets/<uid>/` request fires with `200`
5. 🟢 After it completes, two refetch requests fire:
   - `GET /api/v2/assets/` (the paginated list — `invalidatePaginatedList`)
   - `GET /api/v2/assets/<uid>/` (the specific asset — `invalidateItem`)
6. 🟢 Notice the sharing state reflects the server response. Other parts of the UI that depend on the asset would also pick up the refreshed data