### PR TITLE
build(frontend): delete unused webpack-dev-middleware (again) DEV-2083

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,7 +204,6 @@
         "webpack": "^5.105.0",
         "webpack-bundle-tracker": "^1.5.0",
         "webpack-cli": "^6.0.1",
-        "webpack-dev-middleware": "^6.1.3",
         "webpack-dev-server": "^5.2.2",
         "webpack-extract-translation-keys-plugin": "^6.1.0",
         "whatwg-fetch": "^3.6.20"

--- a/package.json
+++ b/package.json
@@ -200,7 +200,6 @@
     "webpack": "^5.105.0",
     "webpack-bundle-tracker": "^1.5.0",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-middleware": "^6.1.3",
     "webpack-dev-server": "^5.2.2",
     "webpack-extract-translation-keys-plugin": "^6.1.0",
     "whatwg-fetch": "^3.6.20"


### PR DESCRIPTION
### 💭 Notes

Delete unused `webpack-dev-middleware`. 

Timeline:
- Original add: pmusaraj, commit 5c8821c193, “WIP build app using webpack 4” on 2018-05-29
- Removed: Leszek Pietrzak, commit 5fc6769ff3, “remove unused webpack-dev-middleware dependency” on 2018-09-28
- Re-added: Phil Edwards, commit 5c7a8d1bb6, “Update react to v18, allowing semver updates” on 2024-06-27

Closes #6990 