### PR TITLE
fix(nlp): update v1 speech recognition model to 'latest_long' DEV-2086

### DIFF
--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -81,6 +81,7 @@ class GoogleTranscriptionService(GoogleService):
         speech_client = speech.SpeechClient(credentials=self.credentials)
         config = speech.RecognitionConfig(
             language_code=source_lang,
+            model='latest_long',
             enable_automatic_punctuation=True,
         )
 


### PR DESCRIPTION
### 📣 Summary

Improved automatic transcription quality by specifying the correct speech recognition model (v1 STT).

### 📖 Description

Audio transcriptions now use Google's `latest_long` model instead of the unspecified default, which produced lower quality results.

### 💭 Notes

The `RecognitionConfig` did not specify a `model`, causing Google to use a legacy default. 

### 👀 Preview steps

1. Have an account with a project containing an audio question
2. Submit an audio response (ideally conversational speech, 30-60s)
3. Trigger automatic transcription
4. 🔴 [on main] transcription is severely truncated/inaccurate
5. 🟢 [on PR] transcription captures full content of the audio
