### PR TITLE
fix(constance): read Google Constance vars from env DEV-2087

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -348,12 +348,16 @@ CONSTANCE_CONFIG = {
             ' the operations API. '
         )
     ),
+    # We are adopting the `CONSTANCE_` prefix as the new standard for all env
+    # variables that override Constance defaults. Legacy variables (e.g., KOBO_*)
+    # will be deprecated and migrated to this new pattern after the upcoming
+    # migration to Constance 4.x
     'ASR_MT_GOOGLE_PROJECT_ID': (
-        'kobo-asr-mt',
+        env.str('CONSTANCE_ASR_MT_GOOGLE_PROJECT_ID', 'kobo-asr-mt'),
         'ID of the Google Cloud project used to access ASR/MT APIs',
     ),
     'ASR_MT_GOOGLE_STORAGE_BUCKET_PREFIX': (
-        'kobo-asr-mt-tmp',
+        env.str('CONSTANCE_ASR_MT_GOOGLE_STORAGE_BUCKET_PREFIX', 'kobo-asr-mt-tmp'),
         (
             'Prefix for temporary ASR/MT files stored on Google Cloud. Useful'
             ' for lifecycle rules: files under this prefix can be deleted after'
@@ -362,7 +366,7 @@ CONSTANCE_CONFIG = {
         ),
     ),
     'ASR_MT_GOOGLE_TRANSLATION_LOCATION': (
-        'us-central1',
+        env.str('CONSTANCE_ASR_MT_GOOGLE_TRANSLATION_LOCATION', 'us-central1'),
         (
             'Google Cloud location to use for large translation tasks. It'
             ' cannot be `global`, and Google only allows certain locations.'


### PR DESCRIPTION
### 📣 Summary
This PR reads Google Constance variables from the env except `ASR_MT_GOOGLE_CREDENTIALS`.
