### PR TITLE
fix(select): clear button styles DEV-2088

### DIFF
--- a/jsapp/js/components/common/Select.tsx
+++ b/jsapp/js/components/common/Select.tsx
@@ -1,5 +1,6 @@
 import type { SelectProps } from '@mantine/core'
-import { CloseButton, Group, Select as MantineSelect } from '@mantine/core'
+// eslint-disable-next-line no-restricted-imports -- This file is the Kobo wrapper around Mantine Select.
+import { Select as MantineSelect } from '@mantine/core'
 import { useEffect, useState } from 'react'
 
 import type { IconSize } from './icon'
@@ -43,21 +44,11 @@ const Select = <Datum extends string = string>(props: SelectPropsNarrow<Datum>) 
     props.onChange?.(newValue as Datum | null, option as ComboboxItem<Datum>)
   }
 
-  const clear = () => {
-    setValue(null)
-    props.onClear?.()
-  }
-
   useEffect(() => {
     setValue(props.value || null)
   }, [props.value])
 
   const iconSize = typeof props.size === 'string' ? iconSizeMap[props.size] : 's'
-
-  const clearButton =
-    props.clearable && value && !props.disabled && !props.readOnly ? (
-      <CloseButton onClick={clear} icon={<Icon name='close' size={iconSize} />} />
-    ) : null
 
   return (
     <MantineSelect
@@ -66,12 +57,7 @@ const Select = <Datum extends string = string>(props: SelectPropsNarrow<Datum>) 
       onChange={onChange}
       onDropdownOpen={() => setIsOpened(true)}
       onDropdownClose={() => setIsOpened(false)}
-      rightSection={
-        <Group gap={1} mr='sm'>
-          {clearButton}
-          <Icon name={isOpened ? 'angle-up' : 'angle-down'} size={iconSize} />
-        </Group>
-      }
+      rightSection={<Icon name={isOpened ? 'angle-up' : 'angle-down'} size={iconSize} />}
     />
   )
 }

--- a/jsapp/js/theme/kobo/Select.module.css
+++ b/jsapp/js/theme/kobo/Select.module.css
@@ -38,6 +38,12 @@
   width: auto;
 }
 
+/* Mantine sets this padding inline for combined clear+chevron section, so we must override it. */
+.section[data-position='right'] [data-combined-clear-section],
+.section[data-position='right']:not(:has([data-combined-clear-section])) {
+  padding-inline-end: var(--mantine-spacing-sm) !important;
+}
+
 .section i {
   display: flex;
   color: var(--mantine-color-gray-4);
@@ -45,8 +51,16 @@
 
 .section button {
   background-color: transparent;
+  color: var(--mantine-color-gray-4);
 }
 
 .section button:hover {
   background-color: transparent;
+  color: var(--mantine-color-gray-4);
+}
+
+/* Make the built in clear icon look the same as our icon */
+.section button svg {
+  stroke: currentcolor;
+  stroke-width: 0.5;
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixes Select UI when clearable option is enabled.

### 💭 Notes

Changes here:
- Removed custom clear button from `Select` and using the built in one
- Restyled the clear button SVG to look similar to our icon
- Fixed paddings of `Select` right section items

### 👀 Preview steps

1. Run Storybook
2. In `Select` stories, enable `clearable` option
3. Choose an option
4. 🔴 [on main] notice that you see two "x" buttons and padding changes
5. 🟢 [on PR] notice that there is one "x" button and padding doesn't change
