### PR TITLE
fix(formBuilder): null language on multilingual XLSForm save DEV-2095

### DIFF
--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -46,7 +46,12 @@ export function unnullifyTranslations(surveyDataJSON: string, assetContent: Asse
   // set default_language
   let defaultLang = assetContent.translations_0
   if (!defaultLang) {
-    defaultLang = null
+    // Fallback: after a background re-fetch, state.asset.content is replaced with a
+    // fresh API object that doesn't have translations_0 (a frontend-only mutation).
+    // launchAppForSurveyContent early-returns in that case (app already initialized),
+    // so the mutation never runs again. Derive the default language from
+    // settings.default_language to avoid sending plain `label` keys to the backend.
+    defaultLang = assetContent.settings?.default_language || null
   }
   if (!surveyData.settings[0].default_language && defaultLang !== null) {
     surveyData.settings[0].default_language = defaultLang

--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -32,27 +32,19 @@ export function surveyToValidJson(survey: Survey) {
 /**
  * This function reverses what `nullifyTranslations` did to the form data.
  */
-export function unnullifyTranslations(surveyDataJSON: string, assetContent: AssetContent) {
+export function unnullifyTranslations(surveyDataJSON: string, surveyInitialParams: AssetContent) {
   // Here we assume that parsed JSON will be `FlatSurvey`. If we ever pass some other string in here, the code would
   // crash. If this ever happens, let's add some checks.
   const surveyData: FlatSurvey = JSON.parse(surveyDataJSON)
 
   let translatedProps: string[] = []
-  if (assetContent.translated) {
-    translatedProps = assetContent.translated
+  if (surveyInitialParams.translated) {
+    translatedProps = surveyInitialParams.translated
   }
 
   // TRANSLATIONS HACK (Part 2/2):
   // set default_language
-  let defaultLang = assetContent.translations_0
-  if (!defaultLang) {
-    // Fallback: after a background re-fetch, state.asset.content is replaced with a
-    // fresh API object that doesn't have translations_0 (a frontend-only mutation).
-    // launchAppForSurveyContent early-returns in that case (app already initialized),
-    // so the mutation never runs again. Derive the default language from
-    // settings.default_language to avoid sending plain `label` keys to the backend.
-    defaultLang = assetContent.settings?.default_language || null
-  }
+  const defaultLang = surveyInitialParams.translations_0 || null
   if (!surveyData.settings[0].default_language && defaultLang !== null) {
     surveyData.settings[0].default_language = defaultLang
   }

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -427,11 +427,12 @@ export default function EditableForm(props: EditableFormProps) {
     }
 
     let surveyJSON = surveyToValidJson(app.survey)
+    const surveyJSONWithMatrix = koboMatrixParser({ source: surveyJSON }).source
+    if (surveyJSONWithMatrix) {
+      surveyJSON = surveyJSONWithMatrix
+    }
     if (app.survey._initialParams?.translations_0) {
-      const surveyJSONWithMatrix = koboMatrixParser({ source: surveyJSON }).source
-      if (surveyJSONWithMatrix) {
-        surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, app.survey._initialParams)
-      }
+      surveyJSON = unnullifyTranslations(surveyJSON, app.survey._initialParams)
     }
     // We normally have `content` as an actual object, not a stringified representation, but since
     // `actions.resources.updateAsset` already works with JSON string, let's extend the types

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -379,8 +379,8 @@ export default function EditableForm(props: EditableFormProps) {
     }
 
     let surveyJSON = surveyToValidJson(app?.survey)
-    if (state.asset?.content) {
-      surveyJSON = unnullifyTranslations(surveyJSON, state.asset.content)
+    if (app?.survey._initialParams?.translations_0) {
+      surveyJSON = unnullifyTranslations(surveyJSON, app.survey._initialParams)
     }
     let params: KoboMatrixParserParams & { asset?: string } = { source: surveyJSON }
 
@@ -427,10 +427,10 @@ export default function EditableForm(props: EditableFormProps) {
     }
 
     let surveyJSON = surveyToValidJson(app.survey)
-    if (state.asset?.content) {
+    if (app.survey._initialParams?.translations_0) {
       const surveyJSONWithMatrix = koboMatrixParser({ source: surveyJSON }).source
       if (surveyJSONWithMatrix) {
-        surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, state.asset.content)
+        surveyJSON = unnullifyTranslations(surveyJSONWithMatrix, app.survey._initialParams)
       }
     }
     // We normally have `content` as an actual object, not a stringified representation, but since
@@ -615,7 +615,7 @@ export default function EditableForm(props: EditableFormProps) {
 
     try {
       if (assetContent) {
-        survey = dkobo_xlform.model.Survey.loadDict(assetContent)
+        survey = dkobo_xlform.model.Survey.loadDict(clonedeep(assetContent))
         if (newState.files && newState.files.length > 0) {
           survey.availableFiles = newState.files
         }

--- a/jsapp/xlform/src/model.survey.d.ts
+++ b/jsapp/xlform/src/model.survey.d.ts
@@ -4,7 +4,7 @@
 // It was reviewed by a dev, but one who doesn't have full understanding of Backbone, plus Form Builder code written in
 // CoffeeScript is quite old and rarely maintained - increasing the risk of having errors in here.
 import type { AnyRowTypeName } from '#/constants'
-import type { AssetResponseFile } from '#/dataInterface'
+import type { AssetContent, AssetResponseFile } from '#/dataInterface'
 import { BaseModel } from './model.base'
 import type { ChoiceLists } from './model.choices'
 import type { SurveyDetails } from './model.surveyDetail'
@@ -76,6 +76,7 @@ export class Survey extends SurveyFragment {
     errors: any[]
   }
   availableFiles?: AssetResponseFile[]
+  _initialParams: AssetContent | Record<string, never>
 
   constructor(options?: any, addlOpts?: any)
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -1472,12 +1472,18 @@ class Asset(
         if not content.get('translations') and existing_translations:
             content['translations'] = existing_translations
 
-        # Suffix plain hint strings to the default language
+        # Suffix plain hint and label strings to the default language
         default_lang = settings_data.get('default_language')
         if default_lang:
             for row in content.get('survey', []):
                 if 'hint' in row and isinstance(row['hint'], str):
                     row[f'hint::{default_lang}'] = row.pop('hint')
+            # Only suffix plain labels for multilingual forms. On single-language
+            # forms, plain `label` is the expected format for an unnamed translation.
+            if len(existing_translations) > 1:
+                for row in content.get('survey', []) + content.get('choices', []):
+                    if 'label' in row and isinstance(row['label'], str):
+                        row[f'label::{default_lang}'] = row.pop('label')
 
 
 class UserAssetSubscription(models.Model):

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -319,6 +319,62 @@ class AssetContentTests(AssetsTestCase):
 
         self.assertIn('hint', asset.content['translated'])
 
+    def test_fix_unnamed_language_leak_on_label_save(self):
+        """
+        Verifies that saving a multilingual form with plain `label` keys (as sent
+        by the Formbuilder when translations_0 is missing from state.asset.content
+        after a background re-fetch) does not create an unnamed (None) language.
+        """
+        languages = ['English (en)', 'French (fr)']
+        initial_content = {
+            'schema': '1',
+            'survey': [
+                {'name': 'start', 'type': 'start'},
+                {'name': 'end', 'type': 'end'},
+                {
+                    'name': 'q1',
+                    'type': 'text',
+                    'label': ['My question', 'Ma question'],
+                },
+            ],
+            'settings': {'default_language': 'English (en)'},
+            'translations': languages,
+            'translated': ['label'],
+        }
+
+        asset = Asset.objects.create(
+            owner=self.user, asset_type='survey', content=initial_content
+        )
+
+        # Simulate a Formbuilder save where translations_0 was missing from
+        # state.asset.content (background re-fetch scenario). The frontend sends
+        # plain `label` keys instead of `label::English (en)`.
+        flat_payload = {
+            'survey': [
+                {'name': 'start', 'type': 'start'},
+                {'name': 'end', 'type': 'end'},
+                {
+                    'name': 'q1',
+                    'type': 'text',
+                    'label': 'Modified question',
+                    'label::French (fr)': 'Question modifiée',
+                },
+            ],
+            'choices': [],
+            'settings': [{'default_language': 'English (en)'}],
+        }
+
+        asset.content = flat_payload
+        asset.save()
+        asset.refresh_from_db()
+
+        assert asset.content['translations'] == ['English (en)', 'French (fr)']
+        assert None not in asset.content['translations']
+        q1 = next(
+            r for r in asset.content['survey'] if r.get('name') == 'q1'
+        )
+        assert q1['label'] == ['Modified question', 'Question modifiée']
+
     def test_flatten_empty_relevant(self):
         content = self._wrap_field('relevant', [])
         a1 = Asset.objects.create(content=content, asset_type='survey')


### PR DESCRIPTION
### 📣 Summary

Opening the Form Builder fails with a "language needs to be configured" error after saving a multilingual form (one with labels in multiple languages and a `default_language` setting).

### 📖 Description

When a multilingual XLSForm (with labels in two or more languages and a `default_language` set) is uploaded and then edited in the Form Builder, saving the form once corrupts the language configuration. On the next attempt to open the Form Builder, an error appears indicating a language needs to be configured. Visiting "Manage Languages" shows an unknown blank language has been created, and the form becomes uneditable.

### 💭 Notes

Root cause — frontend (unnullifyTranslations in formBuilderUtils.ts)

When the Form Builder loads, inputParser.parse() mutates its input object to add translations_0 (the default language name), nullify translations[0], and normalize settings from an array to an object. Survey.loadDict was passing state.asset.content directly, so those mutations landed on the live state.asset.content object. React Query's background re-fetch then replaced state.asset with a fresh API response, losing those mutations. launchAppForSurveyContent early-returns because app is already initialised, so the mutations never run again. At save time, unnullifyTranslations was reading state.asset.content, found translations_0 = undefined, set defaultLang = null, and skipped the rename — plain label keys reached the backend.

**Fix — frontend**

Pass clonedeep(assetContent) to Survey.loadDict so inputParser.parse() mutates only the copy. state.asset.content stays as the raw API object; any React Query re-fetch replaces it with identical data and no mutations are lost.

At both save paths (previewForm and saveForm), pass app.survey._initialParams to unnullifyTranslations instead of state.asset.content. _initialParams is assigned at Survey construction time directly from the already-mutated parse result and is stable for the lifetime of the Survey instance.

Guard both call sites on app.survey._initialParams?.translations_0 rather than state.asset?.content, so the rename only runs when a default language is known — correctly skipping new forms and monolingual forms.

**Fix — backend defensive (`__normalize_settings_and_translations` in `asset.py`)**

`expand_content_in_place` already flags a plain `label` column as `UNTRANSLATED` and appends `None` to the translations list, producing a spurious unnamed language. The method already converts plain `hint` strings to `hint::default_lang`; the same is now done for `label`, but only when `len(existing_translations) > 1` to leave single-language forms (where a plain `label` is intentional) unchanged. Choices rows are also covered.

### 👀 Preview steps

1. ℹ️ Create an XLSForm with two language columns (`label::English (en)`, `label::French (fr)`) and `default_language: English (en)` in the settings sheet.
2. Upload it as a new project (or replace an existing form).
3. Open the Form Builder — it loads without error.
4. Modify any question label, then save and close.
5. 🔴 [on main] Re-opening the Form Builder shows an error about an unnamed language; "Manage Languages" reveals a blank/unknown language entry.
6. 🟢 [on PR] Re-opening the Form Builder works correctly; both original languages are present.