### PR TITLE
feat(metadata): ensure extra metadata fields are nested in asset settings DEV-2072 

### DIFF
--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -846,6 +846,25 @@ class Asset(
         except IndexError:
             return None
 
+    def validate_and_normalize_settings(self):
+        if not self.settings:
+            self.settings = {}
+            return
+
+        if not isinstance(self.settings, dict):
+            self.settings = {}
+            return
+
+        if 'extra_metadata' not in self.settings:
+            return
+
+        extra_metadata = self.settings.get('extra_metadata')
+
+        if extra_metadata is None:
+            self.settings['extra_metadata'] = {}
+        elif not isinstance(extra_metadata, dict):
+            self.settings['extra_metadata'] = {}
+
     @staticmethod
     def optimize_queryset_for_list(queryset):
         """Used by serializers to improve performance when listing assets"""
@@ -974,6 +993,8 @@ class Asset(
 
         if not update_fields or update_fields and 'advanced_features' in update_fields:
             migrate_advanced_features(self, save_asset=False)
+
+        self.validate_and_normalize_settings()
 
         # standardize settings (only when required)
         if (
@@ -1216,6 +1237,18 @@ class Asset(
             count = count + 1
 
         return f'{count} {self.date_modified:(%Y-%m-%d %H:%M:%S)}'
+
+    @staticmethod
+    def _get_core_settings_fields():
+        return {
+            'sector',
+            'country',
+            'description',
+            'collects_pii',
+            'organization',
+            'country_codes',
+            'operational_purpose',
+        }
 
     def _populate_report_styles(self):
         default = self.report_styles.get(DEFAULT_REPORTS_KEY, {})

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -855,6 +855,8 @@ class Asset(
             self.settings = {}
             return
 
+        # Run unconditionally for all asset types to ensure a consistent
+        # 'extra_metadata' namespace across surveys, templates, and library items.
         if 'extra_metadata' not in self.settings:
             return
 
@@ -994,7 +996,8 @@ class Asset(
         if not update_fields or update_fields and 'advanced_features' in update_fields:
             migrate_advanced_features(self, save_asset=False)
 
-        self.validate_and_normalize_settings()
+        if not update_fields or 'settings' in update_fields:
+            self.validate_and_normalize_settings()
 
         # standardize settings (only when required)
         if (

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -1238,18 +1238,6 @@ class Asset(
 
         return f'{count} {self.date_modified:(%Y-%m-%d %H:%M:%S)}'
 
-    @staticmethod
-    def _get_core_settings_fields():
-        return {
-            'sector',
-            'country',
-            'description',
-            'collects_pii',
-            'organization',
-            'country_codes',
-            'operational_purpose',
-        }
-
     def _populate_report_styles(self):
         default = self.report_styles.get(DEFAULT_REPORTS_KEY, {})
         specifieds = self.report_styles.get(SPECIFIC_REPORTS_KEY, {})

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -1196,3 +1196,133 @@ class TestAssetDataCollectors(TestCase):
         patched_set_links.assert_any_call(self.dc0.token)
         patched_set_links.assert_any_call(self.dc1.token)
         assert len(patched_set_links.call_args) == 2
+
+
+class TestExtraMetadataFields(TestCase):
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.user = User.objects.get(username='someuser')
+
+    def test_custom_fields_are_preserved_in_extra_metadata(self):
+        asset = Asset.objects.create(
+            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={
+                'country': [],
+                'description': 'Test description',
+                'extra_metadata': {
+                    'CustomField': 'custom_value',
+                },
+            },
+        )
+        asset.refresh_from_db()
+
+        self.assertEqual(asset.settings['description'], 'Test description')
+        self.assertEqual(asset.settings['country'], [])
+        self.assertIn('extra_metadata', asset.settings)
+        self.assertEqual(
+            asset.settings['extra_metadata']['CustomField'],
+            'custom_value',
+        )
+
+    def test_core_fields_are_preserved_in_settings(self):
+        core_fields = {
+            'country': [{'label': 'USA', 'value': 'us'}],
+            'sector': {},
+            'description': 'desc',
+            'collects_pii': True,
+            'organization': 'org',
+            'country_codes': ['us'],
+            'operational_purpose': 'purpose',
+        }
+
+        asset = Asset.objects.create(
+            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            asset_type=ASSET_TYPE_SURVEY,
+            settings=core_fields.copy(),
+        )
+        asset.refresh_from_db()
+
+        for field_name, expected_value in core_fields.items():
+            self.assertIn(field_name, asset.settings)
+            self.assertEqual(asset.settings[field_name], expected_value)
+
+    def test_mixed_core_and_extra_metadata_fields(self):
+        asset = Asset.objects.create(
+            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={
+                'country': [{'label': 'Canada', 'value': 'ca'}],
+                'description': 'Test form',
+                'collects_pii': False,
+                'extra_metadata': {
+                    'TestField': 'test_value',
+                    'Animal': {'label': 'Cat', 'value': 'cat'},
+                },
+            },
+        )
+        asset.refresh_from_db()
+
+        self.assertEqual(
+            asset.settings['country'],
+            [{'label': 'Canada', 'value': 'ca'}],
+        )
+        self.assertEqual(asset.settings['description'], 'Test form')
+        self.assertEqual(asset.settings['collects_pii'], False)
+        self.assertEqual(
+            asset.settings['extra_metadata']['TestField'],
+            'test_value',
+        )
+        self.assertEqual(
+            asset.settings['extra_metadata']['Animal'],
+            {'label': 'Cat', 'value': 'cat'},
+        )
+
+    def test_array_values_in_extra_metadata(self):
+        asset = Asset.objects.create(
+            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={
+                'extra_metadata': {
+                    'Test': [
+                        {'label': 'First question', 'value': 'q1'},
+                        {'label': 'Second question', 'value': 'q2'},
+                    ],
+                },
+            },
+        )
+        asset.refresh_from_db()
+
+        test_array = asset.settings['extra_metadata']['Test']
+        self.assertEqual(len(test_array), 2)
+        self.assertEqual(test_array[0]['label'], 'First question')
+        self.assertEqual(test_array[1]['value'], 'q2')
+
+    def test_collision_prevention_custom_vs_core(self):
+        asset = Asset.objects.create(
+            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={
+                'country': [{'label': 'Core', 'value': 'core'}],
+                'extra_metadata': {
+                    'country': 'Custom',
+                },
+            },
+        )
+        asset.refresh_from_db()
+
+        self.assertEqual(
+            asset.settings['country'],
+            [{'label': 'Core', 'value': 'core'}],
+        )
+        self.assertEqual(
+            asset.settings['extra_metadata']['country'],
+            'Custom',
+        )

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -1204,125 +1204,68 @@ class TestExtraMetadataFields(TestCase):
 
     def setUp(self):
         self.user = User.objects.get(username='someuser')
+        self.client.force_login(self.user)
 
-    def test_custom_fields_are_preserved_in_extra_metadata(self):
+    def test_save_normalizes_invalid_extra_metadata(self):
         asset = Asset.objects.create(
-            content={'survey': [{'type': 'text', 'name': 'q1'}]},
             owner=self.user,
             asset_type=ASSET_TYPE_SURVEY,
-            settings={
-                'country': [],
-                'description': 'Test description',
-                'extra_metadata': {
-                    'CustomField': 'custom_value',
-                },
-            },
+            settings={'extra_metadata': None},
         )
+
         asset.refresh_from_db()
 
-        self.assertEqual(asset.settings['description'], 'Test description')
-        self.assertEqual(asset.settings['country'], [])
-        self.assertIn('extra_metadata', asset.settings)
-        self.assertEqual(
-            asset.settings['extra_metadata']['CustomField'],
-            'custom_value',
-        )
+        self.assertIsInstance(asset.settings['extra_metadata'], dict)
+        self.assertEqual(asset.settings['extra_metadata'], {})
 
-    def test_core_fields_are_preserved_in_settings(self):
-        core_fields = {
-            'country': [{'label': 'USA', 'value': 'us'}],
-            'sector': {},
-            'description': 'desc',
-            'collects_pii': True,
-            'organization': 'org',
-            'country_codes': ['us'],
-            'operational_purpose': 'purpose',
-        }
-
+    def test_save_normalizes_non_dict_extra_metadata(self):
         asset = Asset.objects.create(
-            content={'survey': [{'type': 'text', 'name': 'q1'}]},
             owner=self.user,
             asset_type=ASSET_TYPE_SURVEY,
-            settings=core_fields.copy(),
+            settings={'extra_metadata': 'invalid'},
         )
+
         asset.refresh_from_db()
 
-        for field_name, expected_value in core_fields.items():
-            self.assertIn(field_name, asset.settings)
-            self.assertEqual(asset.settings[field_name], expected_value)
+        self.assertEqual(asset.settings['extra_metadata'], {})
 
-    def test_mixed_core_and_extra_metadata_fields(self):
+    def test_update_without_settings_skips_normalization(self):
         asset = Asset.objects.create(
-            content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            owner=self.user,
+            name='Old Name',
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={'extra_metadata': {'Manager': 'Alex'}},
+        )
+
+        asset.name = 'New Name'
+        asset.save(update_fields=['name', 'content'])
+
+        asset.refresh_from_db()
+        self.assertEqual(asset.name, 'New Name')
+        self.assertEqual(asset.settings['extra_metadata']['Manager'], 'Alex')
+
+    def test_extra_metadata_lookup_filters_assets(self):
+        matching_asset = Asset.objects.create(
+            name='Matching Asset',
             owner=self.user,
             asset_type=ASSET_TYPE_SURVEY,
-            settings={
-                'country': [{'label': 'Canada', 'value': 'ca'}],
-                'description': 'Test form',
-                'collects_pii': False,
-                'extra_metadata': {
-                    'TestField': 'test_value',
-                    'Animal': {'label': 'Cat', 'value': 'cat'},
-                },
-            },
-        )
-        asset.refresh_from_db()
-
-        self.assertEqual(
-            asset.settings['country'],
-            [{'label': 'Canada', 'value': 'ca'}],
-        )
-        self.assertEqual(asset.settings['description'], 'Test form')
-        self.assertEqual(asset.settings['collects_pii'], False)
-        self.assertEqual(
-            asset.settings['extra_metadata']['TestField'],
-            'test_value',
-        )
-        self.assertEqual(
-            asset.settings['extra_metadata']['Animal'],
-            {'label': 'Cat', 'value': 'cat'},
-        )
-
-    def test_array_values_in_extra_metadata(self):
-        asset = Asset.objects.create(
             content={'survey': [{'type': 'text', 'name': 'q1'}]},
+            settings={'extra_metadata': {'ProjectManager': 'Tom'}},
+        )
+
+        Asset.objects.create(
+            name='Non-Matching',
             owner=self.user,
             asset_type=ASSET_TYPE_SURVEY,
-            settings={
-                'extra_metadata': {
-                    'Test': [
-                        {'label': 'First question', 'value': 'q1'},
-                        {'label': 'Second question', 'value': 'q2'},
-                    ],
-                },
-            },
-        )
-        asset.refresh_from_db()
-
-        test_array = asset.settings['extra_metadata']['Test']
-        self.assertEqual(len(test_array), 2)
-        self.assertEqual(test_array[0]['label'], 'First question')
-        self.assertEqual(test_array[1]['value'], 'q2')
-
-    def test_collision_prevention_custom_vs_core(self):
-        asset = Asset.objects.create(
             content={'survey': [{'type': 'text', 'name': 'q1'}]},
-            owner=self.user,
-            asset_type=ASSET_TYPE_SURVEY,
-            settings={
-                'country': [{'label': 'Core', 'value': 'core'}],
-                'extra_metadata': {
-                    'country': 'Custom',
-                },
-            },
+            settings={'extra_metadata': {'ProjectManager': 'Bob'}},
         )
-        asset.refresh_from_db()
 
-        self.assertEqual(
-            asset.settings['country'],
-            [{'label': 'Core', 'value': 'core'}],
+        base_url = reverse('api_v2:asset-list')
+        response = self.client.get(
+            f'{base_url}?q=settings__extra_metadata__icontains:Tom'
         )
-        self.assertEqual(
-            asset.settings['extra_metadata']['country'],
-            'Custom',
-        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['results'][0]['uid'], matching_asset.uid)

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -445,6 +445,7 @@ class AssetViewSet(
         'name__icontains',
         'owner__username__icontains',
         'settings__description__icontains',
+        'settings__extra_metadata__icontains',
         'summary__icontains',
         'tags__name__icontains',
         'uid__icontains',


### PR DESCRIPTION
### 📣 Summary
Added extra project metadata fields to the asset settings under a dedicated section to ensure a more organized and reliable data structure

### 💭 Notes
This backend update expects custom metadata fields to be passed from the frontend under `settings.extra_metadata`. This avoids collisions when a custom field has the same name as a core setting, such as `country`.

### 👀 Preview steps
To see the changes, test asset creation via the Django shell, as the frontend isn't implemented yet.

1. ℹ️ have an account
2. Open the Django shell
3. Get your user and create new asset with extra metadata:
```
user = User.objects.get(username='your_username')
asset = Asset.objects.create(
    name='test survey',
    owner=user,
    asset_type='survey',
    settings={
        'description': 'test',
        'country': [{'label': 'Canada', 'value': 'ca'}],
        'extra_metadata': {
            'ProjectManager': 'Alex',
            'Department': 'Research',
            'country': 'USA'
        }
    }
)
```
4. Obtain the newly created asset's uid and check out the endpoint: `/api/v2/assets/{asset_uid}`
5. 🟢 [on PR] Notice that the extra metadata is nicely nested under settings. Should look something like:
```
"settings": {
    "sector": {},
    "country": [
      {
        "label": "Canada",
        "value": "ca"
      }
    ],
    "description": "test",
    "organization": "",
    "country_codes": [
      "ca"
    ],
    "extra_metadata": {
      "country": "USA",
      "Department": "Research",
      "ProjectManager": "Alex"
    }
  },
```
6. 🟢 notice that we have two of the same keys 'country' that are not colliding 
7. Test filtering: `api/v2/assets/?q=settings__extra_metadata__icontains:Alex` and ensure that the correct asset is returned
8. Also test that library items are created with the correct nested `extra_metadata`
