### PR TITLE
fix(exports): prevent simultaneous identical exports DEV-2021

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -4,6 +4,7 @@ import os
 import posixpath
 import re
 import tempfile
+import time
 from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
@@ -1176,6 +1177,7 @@ class SubmissionExportTask(SubmissionExportTaskBase):
 
         # Take this opportunity to do some housekeeping
         self.log_and_mark_stuck_as_errored(self.user, source_url)
+        time.sleep(30)
 
         super()._run_task(messages)
 

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -4,7 +4,6 @@ import os
 import posixpath
 import re
 import tempfile
-import time
 from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
@@ -13,6 +12,7 @@ from zoneinfo import ZoneInfo
 
 import constance
 import dateutil.parser
+import formpack
 import requests
 from django.conf import settings
 from django.contrib.postgres.indexes import BTreeIndex, HashIndex
@@ -22,14 +22,6 @@ from django.db.models.functions import Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from openpyxl.utils.exceptions import InvalidFileException
-from private_storage.fields import PrivateFileField
-from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
-from rest_framework import exceptions
-from rest_framework.reverse import reverse
-from werkzeug.http import parse_options_header
-
-import formpack
 from formpack.constants import KOBO_LOCK_SHEET
 from formpack.schema.fields import (
     IdCopyField,
@@ -40,6 +32,13 @@ from formpack.schema.fields import (
 )
 from formpack.utils.kobo_locking import get_kobo_locking_profiles
 from formpack.utils.string import ellipsize
+from openpyxl.utils.exceptions import InvalidFileException
+from private_storage.fields import PrivateFileField
+from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
+from rest_framework import exceptions
+from rest_framework.reverse import reverse
+from werkzeug.http import parse_options_header
+
 from kobo.apps.openrosa.libs.utils.common_tags import META_ROOT_UUID
 from kobo.apps.reports.report_data import build_formpack
 from kobo.apps.storage_backends.base import default_kpi_private_storage
@@ -1106,29 +1105,29 @@ class SubmissionExportTaskBase(ImportExportTask):
         Returns the oldest timestamp allowed for an export task to be considered
         active (not stuck). Uses a generous grace period of 4x the celery time limit.
         """
-        max_export_run_time = getattr(
-            settings, 'CELERY_TASK_TIME_LIMIT', 2100)
-        max_allowed_export_age = datetime.timedelta(
-            seconds=max_export_run_time * 4)
+        max_export_run_time = getattr(settings, 'CELERY_TASK_TIME_LIMIT', 2100)
+        max_allowed_export_age = datetime.timedelta(seconds=max_export_run_time * 4)
         return datetime.datetime.now(tz=ZoneInfo('UTC')) - max_allowed_export_age
 
     @classmethod
     def get_active_exports(cls, user, **kwargs):
         """
-        Returns a queryset of exports for the given user that are 
-        currently in a non-terminal (CREATED or PROCESSING) state 
+        Returns a queryset of exports for the given user that are
+        currently in a non-terminal (CREATED or PROCESSING) state
         and haven't exceeded the maximum allowed run time.
         """
-        return cls.objects.filter(
-            user=user,
-            date_created__gt=cls.get_oldest_allowed_timestamp(),
-            **kwargs
-        ).exclude(
-            status__in=(
-                ImportExportStatusChoices.COMPLETE,
-                ImportExportStatusChoices.ERROR,
+        return (
+            cls.objects.filter(
+                user=user, date_created__gt=cls.get_oldest_allowed_timestamp(), **kwargs
             )
-        ).order_by('-date_created')
+            .exclude(
+                status__in=(
+                    ImportExportStatusChoices.COMPLETE,
+                    ImportExportStatusChoices.ERROR,
+                )
+            )
+            .order_by('-date_created')
+        )
 
     @classmethod
     @transaction.atomic

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -1101,6 +1101,36 @@ class SubmissionExportTaskBase(ImportExportTask):
         return pack.export(**options), submission_stream
 
     @classmethod
+    def get_oldest_allowed_timestamp(cls):
+        """
+        Returns the oldest timestamp allowed for an export task to be considered
+        active (not stuck). Uses a generous grace period of 4x the celery time limit.
+        """
+        max_export_run_time = getattr(
+            settings, 'CELERY_TASK_TIME_LIMIT', 2100)
+        max_allowed_export_age = datetime.timedelta(
+            seconds=max_export_run_time * 4)
+        return datetime.datetime.now(tz=ZoneInfo('UTC')) - max_allowed_export_age
+
+    @classmethod
+    def get_active_exports(cls, user, **kwargs):
+        """
+        Returns a queryset of exports for the given user that are 
+        currently in a non-terminal (CREATED or PROCESSING) state 
+        and haven't exceeded the maximum allowed run time.
+        """
+        return cls.objects.filter(
+            user=user,
+            date_created__gt=cls.get_oldest_allowed_timestamp(),
+            **kwargs
+        ).exclude(
+            status__in=(
+                ImportExportStatusChoices.COMPLETE,
+                ImportExportStatusChoices.ERROR,
+            )
+        ).order_by('-date_created')
+
+    @classmethod
     @transaction.atomic
     def log_and_mark_stuck_as_errored(cls, user, source):
         """
@@ -1109,15 +1139,8 @@ class SubmissionExportTaskBase(ImportExportTask):
 
         `source` is the source URL as included in the `data` attribute.
         """
-        # How long can an export possibly run, not including time spent waiting
-        # in the Celery queue?
-        max_export_run_time = getattr(
-            settings, 'CELERY_TASK_TIME_LIMIT', 2100)
-        # Allow a generous grace period
-        max_allowed_export_age = datetime.timedelta(
-            seconds=max_export_run_time * 4)
         this_moment = datetime.datetime.now(tz=ZoneInfo('UTC'))
-        oldest_allowed_timestamp = this_moment - max_allowed_export_age
+        oldest_allowed_timestamp = cls.get_oldest_allowed_timestamp()
         stuck_exports = cls.objects.filter(
             user=user,
             date_created__lt=oldest_allowed_timestamp,
@@ -1177,7 +1200,6 @@ class SubmissionExportTask(SubmissionExportTaskBase):
 
         # Take this opportunity to do some housekeeping
         self.log_and_mark_stuck_as_errored(self.user, source_url)
-        time.sleep(30)
 
         super()._run_task(messages)
 

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -1,7 +1,10 @@
 # coding: utf-8
+import datetime
 from typing import Optional
 
+from django.conf import settings
 from django.db import transaction
+from django.utils import timezone
 from django.utils.translation import gettext as t
 from formpack.constants import (
     EXPORT_SETTING_FIELDS,
@@ -30,6 +33,7 @@ from rest_framework.reverse import reverse
 
 from kpi.fields import ReadOnlyJSONField
 from kpi.models import Asset, SubmissionExportTask
+from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.tasks import export_in_background
 from kpi.utils.export_task import format_exception_values
 from kpi.utils.object_permission import get_database_user
@@ -60,8 +64,32 @@ class ExportTaskSerializer(serializers.ModelSerializer):
         )
 
     def create(self, validated_data: dict) -> SubmissionExportTask:
-        # Create a new export task
         user = get_database_user(self._get_request.user)
+
+        # Check for an existing processing task with the exact same parameters
+        max_export_run_time = getattr(settings, 'CELERY_TASK_TIME_LIMIT', 2100)
+        max_allowed_export_age = datetime.timedelta(seconds=max_export_run_time * 4)
+        this_moment = timezone.now()
+        oldest_allowed_timestamp = this_moment - max_allowed_export_age
+
+        existing_tasks = (
+            SubmissionExportTask.objects.filter(
+                user=user,
+                data=validated_data,
+                date_created__gt=oldest_allowed_timestamp,
+            )
+            .exclude(
+                status__in=(
+                    ImportExportStatusChoices.COMPLETE,
+                    ImportExportStatusChoices.ERROR,
+                )
+            )
+            .order_by('-date_created')
+        )
+        if existing_tasks.exists():
+            return existing_tasks.first()
+
+        # Create a new export task
         export_task = SubmissionExportTask.objects.create(
             user=user, data=validated_data
         )

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -1,10 +1,7 @@
 # coding: utf-8
-import datetime
 from typing import Optional
 
-from django.conf import settings
 from django.db import transaction
-from django.utils import timezone
 from django.utils.translation import gettext as t
 from formpack.constants import (
     EXPORT_SETTING_FIELDS,
@@ -33,7 +30,6 @@ from rest_framework.reverse import reverse
 
 from kpi.fields import ReadOnlyJSONField
 from kpi.models import Asset, SubmissionExportTask
-from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.tasks import export_in_background
 from kpi.utils.export_task import format_exception_values
 from kpi.utils.object_permission import get_database_user
@@ -68,8 +64,7 @@ class ExportTaskSerializer(serializers.ModelSerializer):
 
         # Check for an existing processing task with the exact same parameters
         existing_tasks = SubmissionExportTask.get_active_exports(
-            user=user,
-            data=validated_data
+            user=user, data=validated_data
         )
         if existing_tasks.exists():
             return existing_tasks.first()

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -67,24 +67,9 @@ class ExportTaskSerializer(serializers.ModelSerializer):
         user = get_database_user(self._get_request.user)
 
         # Check for an existing processing task with the exact same parameters
-        max_export_run_time = getattr(settings, 'CELERY_TASK_TIME_LIMIT', 2100)
-        max_allowed_export_age = datetime.timedelta(seconds=max_export_run_time * 4)
-        this_moment = timezone.now()
-        oldest_allowed_timestamp = this_moment - max_allowed_export_age
-
-        existing_tasks = (
-            SubmissionExportTask.objects.filter(
-                user=user,
-                data=validated_data,
-                date_created__gt=oldest_allowed_timestamp,
-            )
-            .exclude(
-                status__in=(
-                    ImportExportStatusChoices.COMPLETE,
-                    ImportExportStatusChoices.ERROR,
-                )
-            )
-            .order_by('-date_created')
+        existing_tasks = SubmissionExportTask.get_active_exports(
+            user=user,
+            data=validated_data
         )
         if existing_tasks.exists():
             return existing_tasks.first()

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -62,13 +62,6 @@ class ExportTaskSerializer(serializers.ModelSerializer):
     def create(self, validated_data: dict) -> SubmissionExportTask:
         user = get_database_user(self._get_request.user)
 
-        # Check for an existing processing task with the exact same parameters
-        existing_tasks = SubmissionExportTask.get_active_exports(
-            user=user, data=validated_data
-        )
-        if existing_tasks.exists():
-            return existing_tasks.first()
-
         # Create a new export task
         export_task = SubmissionExportTask.objects.create(
             user=user, data=validated_data

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -334,12 +334,19 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         assert response.status_code == status.HTTP_201_CREATED
         first_uid = response.json()['uid']
 
+        # Send an identical POST request while the first task is still in CREATED state
+        response1b = self.client.post(list_url, data=data)
+        assert response1b.status_code == status.HTTP_200_OK
+        created_state_uid = response1b.json()['uid']
+        assert first_uid == created_state_uid
+        assert SubmissionExportTask.objects.count() == 1
+
         # Update the task status to processing to simulate it being worked on
         task = SubmissionExportTask.objects.get(uid=first_uid)
         task.status = ImportExportStatusChoices.PROCESSING
         task.save()
 
-        # Send an identical POST request
+        # Send an identical POST request while the task is in PROCESSING state
         response2 = self.client.post(list_url, data=data)
         assert response2.status_code == status.HTTP_200_OK
         second_uid = response2.json()['uid']

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -316,6 +316,48 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         response = self.client.post(list_url, data=data)
         assert response.status_code == status.HTTP_201_CREATED
 
+    def test_create_export_task_already_running(self):
+        self.client.login(username='someuser', password='someuser')
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': self.asset.uid},
+        )
+        data = {
+            'type': 'csv',
+            'lang': '_default',
+            'group_sep': '/',
+            'hierarchy_in_labels': 'false',
+            'fields_from_all_versions': 'false',
+            'multiple_select': 'both',
+        }
+        response = self.client.post(list_url, data=data)
+        assert response.status_code == status.HTTP_201_CREATED
+        first_uid = response.json()['uid']
+
+        # Update the task status to processing to simulate it being worked on
+        task = SubmissionExportTask.objects.get(uid=first_uid)
+        task.status = ImportExportStatusChoices.PROCESSING
+        task.save()
+
+        # Send an identical POST request
+        response2 = self.client.post(list_url, data=data)
+        assert response2.status_code == status.HTTP_201_CREATED
+        second_uid = response2.json()['uid']
+
+        # Should return the exact same task
+        assert first_uid == second_uid
+        assert SubmissionExportTask.objects.count() == 1
+
+        # Send a different POST request (different type)
+        data['type'] = 'xls'
+        response3 = self.client.post(list_url, data=data)
+        assert response3.status_code == status.HTTP_201_CREATED
+        third_uid = response3.json()['uid']
+
+        # Should create a new task
+        assert first_uid != third_uid
+        assert SubmissionExportTask.objects.count() == 2
+
     def test_create_export_task_extended(self):
         self.client.login(username='someuser', password='someuser')
         list_url = reverse(

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -341,7 +341,7 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
 
         # Send an identical POST request
         response2 = self.client.post(list_url, data=data)
-        assert response2.status_code == status.HTTP_201_CREATED
+        assert response2.status_code == status.HTTP_200_OK
         second_uid = response2.json()['uid']
 
         # Should return the exact same task

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -13,7 +13,6 @@ from kobo.apps.audit_log.base_views import AuditLoggedNoUpdateModelViewSet
 from kobo.apps.audit_log.models import AuditType
 from kpi.filters import SearchFilter
 from kpi.models import SubmissionExportTask
-from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.permissions import ExportTaskPermission
 from kpi.schema_extensions.v2.export_tasks.serializers import (
     ExportCreatePayload,
@@ -155,8 +154,7 @@ class ExportTaskViewSet(
         )
         SubmissionExportTask.log_and_mark_stuck_as_errored(user, source)
         existing_tasks = SubmissionExportTask.get_active_exports(
-            user=user,
-            data__source=source
+            user=user, data__source=source
         )
         if existing_tasks.exists():
             # take the most recent if there are multiples

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -2,6 +2,7 @@
 import datetime
 
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import filters, status

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -204,7 +204,8 @@ class ExportTaskViewSet(
                         status=status.HTTP_200_OK,
                     )
 
-            # If no existing task blocked or deduplicated this request, proceed with creation
+            # If no existing task blocked or deduplicated this request,
+            # proceed with creation
             self.perform_create(serializer)
             headers = self.get_success_headers(serializer.data)
             return Response(

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -146,33 +146,64 @@ class ExportTaskViewSet(
 
     def create(self, request, *args, **kwargs):
         user = get_database_user(request.user)
-        if not is_user_anonymous(user):
-            return super().create(request, *args, **kwargs)
-        # only allow one anonymous export task to run at a time
-        source = reverse(
-            'asset-detail', kwargs={'uid_asset': self.asset.uid}, request=request
-        )
-        SubmissionExportTask.log_and_mark_stuck_as_errored(user, source)
-        existing_tasks = SubmissionExportTask.get_active_exports(
-            user=user, data__source=source
-        )
-        if existing_tasks.exists():
-            # take the most recent if there are multiples
-            existing_task = existing_tasks.first()
-            expected_latest_finish = existing_task.date_created + datetime.timedelta(
-                seconds=settings.CELERY_TASK_TIME_LIMIT
-            )
 
-            retry_after = max(
-                5,
-                int((expected_latest_finish - timezone.now()).total_seconds()),
-            )
+        # We must serialize the request data to get the validated_data for 
+        # the deduplication check
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+        
+        with transaction.atomic():
+            # Lock the user row to prevent concurrent bypasses of the 
+            # limit/deduplication checks
+            user.__class__.objects.select_for_update().get(pk=user.pk)
+            
+            if is_user_anonymous(user):
+                # only allow one anonymous export task to run at a time
+                source = reverse(
+                    'asset-detail', 
+                    kwargs={'uid_asset': self.asset.uid},
+                    request=request
+                )
+                SubmissionExportTask.log_and_mark_stuck_as_errored(user, source)
+                existing_tasks = SubmissionExportTask.get_active_exports(
+                    user=user, data__source=source
+                )
+                if existing_tasks.exists():
+                    # take the most recent if there are multiples
+                    existing_task = existing_tasks.first()
+                    expected_latest_finish = existing_task.date_created + datetime.timedelta(  # noqa E501
+                        seconds=settings.CELERY_TASK_TIME_LIMIT
+                    )
+
+                    retry_after = max(
+                        5,
+                        int((expected_latest_finish - timezone.now()).total_seconds()),
+                    )
+                    return Response(
+                        data={
+                            'error': f'Another export is already in progress. Please retry in'  # noqa E501
+                            f' {retry_after} seconds'
+                        },
+                        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        headers={'Retry-After': retry_after}
+                    )
+            else:
+                # Deduplicate identical processing exports for authenticated users
+                existing_tasks = SubmissionExportTask.get_active_exports(
+                    user=user, data=validated_data
+                )
+                if existing_tasks.exists():
+                    existing_task = existing_tasks.first()
+                    # Return 200 OK instead of 201 Created to signal reuse
+                    return Response(
+                        self.get_serializer(existing_task).data, 
+                        status=status.HTTP_200_OK
+                    )
+            
+            # If no existing task blocked or deduplicated this request, proceed with creation
+            self.perform_create(serializer)
+            headers = self.get_success_headers(serializer.data)
             return Response(
-                data={
-                    'error': f'Another export is already in progress. Please retry in'
-                    f' {retry_after} seconds'
-                },
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                headers={'Retry-After': retry_after}
+                serializer.data, status=status.HTTP_201_CREATED, headers=headers
             )
-        return super().create(request, *args, **kwargs)

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -147,23 +147,23 @@ class ExportTaskViewSet(
     def create(self, request, *args, **kwargs):
         user = get_database_user(request.user)
 
-        # We must serialize the request data to get the validated_data for 
+        # We must serialize the request data to get the validated_data for
         # the deduplication check
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         validated_data = serializer.validated_data
-        
+
         with transaction.atomic():
-            # Lock the user row to prevent concurrent bypasses of the 
+            # Lock the user row to prevent concurrent bypasses of the
             # limit/deduplication checks
             user.__class__.objects.select_for_update().get(pk=user.pk)
-            
+
             if is_user_anonymous(user):
                 # only allow one anonymous export task to run at a time
                 source = reverse(
-                    'asset-detail', 
+                    'asset-detail',
                     kwargs={'uid_asset': self.asset.uid},
-                    request=request
+                    request=request,
                 )
                 SubmissionExportTask.log_and_mark_stuck_as_errored(user, source)
                 existing_tasks = SubmissionExportTask.get_active_exports(
@@ -172,8 +172,11 @@ class ExportTaskViewSet(
                 if existing_tasks.exists():
                     # take the most recent if there are multiples
                     existing_task = existing_tasks.first()
-                    expected_latest_finish = existing_task.date_created + datetime.timedelta(  # noqa E501
-                        seconds=settings.CELERY_TASK_TIME_LIMIT
+                    expected_latest_finish = (
+                        existing_task.date_created
+                        + datetime.timedelta(
+                            seconds=settings.CELERY_TASK_TIME_LIMIT
+                        )
                     )
 
                     retry_after = max(
@@ -186,7 +189,7 @@ class ExportTaskViewSet(
                             f' {retry_after} seconds'
                         },
                         status=status.HTTP_503_SERVICE_UNAVAILABLE,
-                        headers={'Retry-After': retry_after}
+                        headers={'Retry-After': retry_after},
                     )
             else:
                 # Deduplicate identical processing exports for authenticated users
@@ -197,10 +200,10 @@ class ExportTaskViewSet(
                     existing_task = existing_tasks.first()
                     # Return 200 OK instead of 201 Created to signal reuse
                     return Response(
-                        self.get_serializer(existing_task).data, 
-                        status=status.HTTP_200_OK
+                        self.get_serializer(existing_task).data,
+                        status=status.HTTP_200_OK,
                     )
-            
+
             # If no existing task blocked or deduplicated this request, proceed with creation
             self.perform_create(serializer)
             headers = self.get_success_headers(serializer.data)

--- a/kpi/views/v2/export_task.py
+++ b/kpi/views/v2/export_task.py
@@ -154,26 +154,9 @@ class ExportTaskViewSet(
             'asset-detail', kwargs={'uid_asset': self.asset.uid}, request=request
         )
         SubmissionExportTask.log_and_mark_stuck_as_errored(user, source)
-        # to be super sure we don't get stuck on a hanging task, use the same logic as
-        # log_and_mark_stuck_as_errored to determine a cutoff date for the oldest
-        # running export
-        max_export_run_time = getattr(settings, 'CELERY_TASK_TIME_LIMIT', 2100)
-        max_allowed_export_age = datetime.timedelta(seconds=max_export_run_time * 4)
-        this_moment = timezone.now()
-        oldest_allowed_timestamp = this_moment - max_allowed_export_age
-        existing_tasks = (
-            SubmissionExportTask.objects.filter(
-                data__source=source,
-                user=user,
-                date_created__gt=oldest_allowed_timestamp
-            )
-            .exclude(
-                status__in=(
-                    ImportExportStatusChoices.COMPLETE,
-                    ImportExportStatusChoices.ERROR,
-                )
-            )
-            .order_by('-date_created')
+        existing_tasks = SubmissionExportTask.get_active_exports(
+            user=user,
+            data__source=source
         )
         if existing_tasks.exists():
             # take the most recent if there are multiples


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Identical duplicate API export requests are now intercepted and deduplicated. Instead of creating a new background Celery task, the API queries for an identical running export task belonging to the same user and returns it seamlessly to the frontend.

### 📖 Description
Previously, if the frontend (or a script) blindly retried this POST request with the exact same JSON payload before the first export finished, the system would make another background Celery task with the same parameters. The new implementation within `ExportTaskSerializer.create()` fixes this by first checking the database for any active SubmissionExportTask belonging to the current user that has an identical data payload (ensuring the configurations like fields, group_sep, type, etc., match exactly). If a matching task is found that is still in a CREATED or PROCESSING state, the serializer bypasses database creation and returns the existing task. This allows the frontend to continue polling the original task gracefully without duplicating the task and wasting resources.


### 👀 Preview steps

1. ℹ️ have an account and a project
2. Simulate a long export by adding  `time.sleep(30)` to the method `SubmissionExportTask,_run_task` at `/kpi/kpi/models/import_export_task.py`
3. Export the project data
4. within 30 seconds, duplicate your browser tab and export the data again with the same export configuration
5. 🔴 [on main] notice that this creates a duplicated export task
6. 🟢 [on PR] notice that this doesn't create a duplicated export task