### PR TITLE
fix(transcription): submission data not updating on navigation DEV-2097

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/index.tsx
@@ -34,7 +34,7 @@ export default function TranscriptTab({
 }: Props) {
   const transcriptVersion = getLatestTranscriptVersionItem(supplement, questionXpath)
 
-  // We need a key to force remounting the component when switching between submissions,
+  // We need a key to force remounting the component when switching between submissions.
   const submissionKey = submission._uuid
 
   if (

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/index.tsx
@@ -34,16 +34,20 @@ export default function TranscriptTab({
 }: Props) {
   const transcriptVersion = getLatestTranscriptVersionItem(supplement, questionXpath)
 
+  // We need a key to force remounting the component when switching between submissions,
+  const submissionKey = submission._uuid
+
   if (
     transcriptVersion &&
     isSupplementVersionAutomatic(transcriptVersion) &&
     (transcriptVersion as VersionOfAutomaticTranscript)?._data?.status === 'in_progress'
   ) {
-    return <TranscriptPoll asset={asset} questionXpath={questionXpath} submission={submission} />
+    return <TranscriptPoll key={submissionKey} asset={asset} questionXpath={questionXpath} submission={submission} />
   }
   if (transcriptVersion && isSupplementVersionWithValue(transcriptVersion)) {
     return (
       <TranscriptEdit
+        key={submissionKey}
         asset={asset}
         questionXpath={questionXpath}
         submission={submission}
@@ -57,6 +61,7 @@ export default function TranscriptTab({
 
   return (
     <TranscriptCreate
+      key={submissionKey}
       asset={asset}
       questionXpath={questionXpath}
       submission={submission}

--- a/jsapp/js/components/processing/SingleProcessingHeader/SelectQuestion.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/SelectQuestion.tsx
@@ -7,6 +7,7 @@ import type { LanguageCode } from '#/components/languages/languagesStore'
 import { goToProcessing } from '#/components/processing/routes.utils'
 import { QUESTION_TYPES } from '#/constants'
 import type { AssetResponse, SurveyRow } from '#/dataInterface'
+import protectorHelpers from '#/protector/protectorHelpers'
 import styles from './index.module.scss'
 
 interface Props {
@@ -14,6 +15,7 @@ interface Props {
   asset: AssetResponse
   questionLabelLanguage: LanguageCode | string
   xpath: string
+  hasUnsavedWork: boolean
 }
 
 /**
@@ -21,10 +23,18 @@ interface Props {
  * submissions and questions. It also has means of leaving Single Processing
  * via "DONE" button.
  */
-export default function SelectQuestion({ asset, currentSubmissionUid, questionLabelLanguage, xpath }: Props) {
+export default function SelectQuestion({
+  asset,
+  currentSubmissionUid,
+  questionLabelLanguage,
+  xpath,
+  hasUnsavedWork,
+}: Props) {
   const onQuestionSelectChange = (newXpath: string | null) => {
     if (newXpath !== null) {
-      goToProcessing(asset.uid, newXpath, currentSubmissionUid, true)
+      protectorHelpers.safeExecute(hasUnsavedWork, () =>
+        goToProcessing(asset.uid, newXpath, currentSubmissionUid, true),
+      )
     }
   }
 

--- a/jsapp/js/components/processing/SingleProcessingHeader/SelectSubmission.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/SelectSubmission.tsx
@@ -8,6 +8,7 @@ import {
 } from '#/api/react-query/survey-data'
 import Button from '#/components/common/button'
 import { goToProcessing } from '#/components/processing/routes.utils'
+import protectorHelpers from '#/protector/protectorHelpers'
 import { removeDefaultUuidPrefix } from '#/utils'
 import styles from './index.module.scss'
 
@@ -24,6 +25,7 @@ interface Props {
   submission?: DataResponse
   assetUid: string
   xpath: string
+  hasUnsavedWork: boolean
 }
 
 /**
@@ -31,7 +33,7 @@ interface Props {
  * submissions and questions. It also has means of leaving Single Processing
  * via "DONE" button.
  */
-export default function SelectSubmission({ assetUid, submission, xpath }: Props) {
+export default function SelectSubmission({ assetUid, submission, xpath, hasUnsavedWork }: Props) {
   if (!submission) return
 
   // Because submission times are only accurate to the second,_id
@@ -77,12 +79,16 @@ export default function SelectSubmission({ assetUid, submission, xpath }: Props)
 
   const goPrev = () => {
     if (!queryPrev.data) return
-    goToProcessing(assetUid, xpath, removeDefaultUuidPrefix(queryPrev.data.submission['meta/rootUuid']), true)
+    protectorHelpers.safeExecute(hasUnsavedWork, () =>
+      goToProcessing(assetUid, xpath, removeDefaultUuidPrefix(queryPrev.data!.submission['meta/rootUuid']), true),
+    )
   }
 
   const goNext = () => {
     if (!queryNext.data) return
-    goToProcessing(assetUid, xpath, removeDefaultUuidPrefix(queryNext.data.submission['meta/rootUuid']), true)
+    protectorHelpers.safeExecute(hasUnsavedWork, () =>
+      goToProcessing(assetUid, xpath, removeDefaultUuidPrefix(queryNext.data!.submission['meta/rootUuid']), true),
+    )
   }
 
   const isLoading = queryPrev.isPending || queryNext.isPending

--- a/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
@@ -37,7 +37,7 @@ export default function SingleProcessingHeader({
         currentSubmissionUid={submission?.['meta/rootUuid']}
         questionLabelLanguage={questionLabelLanguage}
       />
-      <SelectSubmission assetUid={asset.uid} xpath={xpath} submission={submission} />
+      <SelectSubmission assetUid={asset.uid} xpath={xpath} submission={submission} hasUnsavedWork={hasUnsavedWork} />
       <ButtonReturn assetUid={asset.uid} hasUnsavedWork={hasUnsavedWork} />
     </header>
   )

--- a/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
@@ -36,6 +36,7 @@ export default function SingleProcessingHeader({
         xpath={xpath}
         currentSubmissionUid={submission?.['meta/rootUuid']}
         questionLabelLanguage={questionLabelLanguage}
+        hasUnsavedWork={hasUnsavedWork}
       />
       <SelectSubmission assetUid={asset.uid} xpath={xpath} submission={submission} hasUnsavedWork={hasUnsavedWork} />
       <ButtonReturn assetUid={asset.uid} hasUnsavedWork={hasUnsavedWork} />


### PR DESCRIPTION
### 📣 Summary
Fixes an issue with using arrow navigation to switch to other submissions in audio processing view would not fully update submission data, causing possible data loss. Also, adds confirmation message when there is unsaved data in the view and a user tries to navigate to another question or submission.


### 💭 Notes
- A key (used submission._uuid) is needed to be given to components so they know when to update, or else react will likely retain the current state.
- `hasUnsavedData` was integrated into `SelectQuestion` and `SelectSubmission` to protect against navigation and data loss when unsaved data is present.

### 👀 Preview steps
1. ℹ️ have an account and a project with audio question data
2. enter the audio processing view
3. create an AUTOMATIC transcription
4. dont save nor discard, leaving the transcription in the validation state
5. use the top-right arrows to navigate to another submission
4. 🔴 [on main] notice that the submission data is not updated and, if the save button is pressed, data is saved in the current submission
5. 🟢 [on PR] notice that the submission data updates, displaying the correct state and data for the current submission
6. start a MANUAL transcription and fill in some text. Do not save nor discard
6. select another question from the top-left question selection
4. 🔴 [on main] notice that navigation occurs and unsaved data is lost
5. 🟢 [on PR] notice that a confirmation message appears to avoid data loss
6. start a MANUAL transcription and fill in some text. Do not save nor discard
6. press the arrow buttons on top right to navigate to another submission
4. 🔴 [on main] notice that navigation occurs and unsaved data is lost
5. 🟢 [on PR] notice that a confirmation message appears to avoid data loss