### PR TITLE
fix(regionSelector): require region selection for transcriptions DEV-2102

### DIFF
--- a/jsapp/js/components/languages/regionSelector.tsx
+++ b/jsapp/js/components/languages/regionSelector.tsx
@@ -2,17 +2,15 @@ import './regionSelector.scss'
 
 import React from 'react'
 
+import { ActionIcon, Group, TextInput } from '@mantine/core'
 import bem, { makeBem } from '#/bem'
-import Button from '#/components/common/button'
+import Select from '#/components/common/Select'
 import Icon from '#/components/common/icon'
-import KoboSelect from '#/components/common/koboSelect'
-import type { KoboSelectOption } from '#/components/common/koboSelect'
 import languagesStore from './languagesStore'
 import type { DetailedLanguage, LanguageCode, TransxServiceCode } from './languagesStore'
 
 bem.RegionSelector = makeBem(null, 'region-selector', 'section')
 bem.RegionSelector__loading = makeBem(bem.RegionSelector, 'loading')
-bem.RegionSelector__rootLanguage = makeBem(bem.RegionSelector, 'root-language')
 
 interface RegionSelectorProps {
   isDisabled?: boolean
@@ -28,7 +26,7 @@ interface RegionSelectorProps {
 }
 
 interface RegionSelectorState {
-  options: KoboSelectOption[]
+  options: { label: string; value: string }[]
   selectedOption: LanguageCode | null
   language?: DetailedLanguage
 }
@@ -67,10 +65,15 @@ export default class RegionSelector extends React.Component<RegionSelectorProps,
         // Just a safe check if source didn't change as we waited for the response.
         if (this.props.rootLanguage === language.code) {
           const options = this.buildOptions(language)
+          const initialOption = options.length > 0 ? options[0].value : null
           this.setState({
             language: language,
             options: options,
+            selectedOption: initialOption,
           })
+          if (initialOption) {
+            this.props.onRegionChange(initialOption)
+          }
         }
       } catch (error) {
         // Here we use memoized value, as at this point the props might've changed.
@@ -79,7 +82,7 @@ export default class RegionSelector extends React.Component<RegionSelectorProps,
     }
   }
 
-  buildOptions(language: DetailedLanguage): KoboSelectOption[] {
+  buildOptions(language: DetailedLanguage): { label: string; value: string }[] {
     const outcome = []
 
     let serviceRegions
@@ -129,31 +132,37 @@ export default class RegionSelector extends React.Component<RegionSelectorProps,
 
     return (
       <bem.RegionSelector>
-        <bem.RegionSelector__rootLanguage>
-          <Icon name='language-alt' />
-
-          <label title={this.state.language.name}>{this.state.language.name}</label>
-
-          <Button
-            type='text'
-            size='s'
-            startIcon='close'
-            onClick={this.props.onCancel}
-            isDisabled={this.props.isDisabled}
+        <Group gap='xs'>
+          <TextInput
+            readOnly
+            size='sm'
+            value={this.state.language.name}
+            leftSection={<Icon name='language-alt' size='s' />}
+            w={220}
+            rightSection={
+              <ActionIcon
+                variant='transparent'
+                size='sm'
+                onClick={this.props.onCancel}
+                disabled={this.props.isDisabled}
+              >
+                <Icon name='close' size='xs' />
+              </ActionIcon>
+            }
           />
-        </bem.RegionSelector__rootLanguage>
 
-        {this.state.options.length !== 0 && (
-          <KoboSelect
-            name='regionselector'
-            type='gray'
-            size='m'
-            options={this.state.options}
-            selectedOption={this.state.selectedOption}
-            onChange={this.onOptionChange.bind(this)}
-            isDisabled={this.props.isDisabled}
-          />
-        )}
+          {this.state.options.length !== 0 && (
+            <Select
+              w={220}
+              data={this.state.options}
+              value={this.state.selectedOption}
+              size='sm'
+              onChange={(newValue) => this.onOptionChange(newValue)}
+              disabled={this.props.isDisabled}
+              placeholder={t('Select a region...')}
+            />
+          )}
+        </Group>
       </bem.RegionSelector>
     )
   }

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/StepCreateAutomated.tsx
@@ -153,7 +153,7 @@ export default function StepCreateAutomated({
             size='m'
             label={t('create transcript')}
             onClick={handleCreateTranscript}
-            isDisabled={anyPending}
+            isDisabled={anyPending || locale === null}
           />
         </div>
       </footer>


### PR DESCRIPTION
### 📣 Summary

Region selection is now required when creating an automatic transcript, so the first available region is now selected automatically. Fields were restyled for better experience.

### 💭 Notes

Previously, users could attempt to create an automatic transcript without selecting a region. Since for the new transcription model a region is now required,  the first available region is now automatically selected.
The `create transcription` button is now disabled when no region is selected. This is more of a safeguard against unexpected situations.

The region selector UI was also updated to use Mantine components (`TextInput` + `Select`) consistent with the rest of the design system, replacing the legacy `KoboSelect` component.


### 👀 Preview steps

1. ℹ️ Have an account with a project that has audio questions and automatic transcription enabled
2. Open a submission and navigate to the **Transcript** tab
3. Click **Begin**, then select a language that has multiple regions (e.g. English)
4. Click **Automatic**
5. 🔴 [on main] The region selector is gray, no region is pre-selected
6. 🟢 [on PR] A region is already pre-selected and the visuals are consistent with the rest of the app.