### PR TITLE
fix(SingleProcessingHeader): remove uuid prefix for currentSubmissionUid DEV-2104

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import type { AssetResponse } from '#/dataInterface'
-import { removeDefaultUuidPrefix } from '#/utils'
 import ButtonReturn from './ButtonReturn'
 import SelectQuestion from './SelectQuestion'
 import SelectSubmission from './SelectSubmission'
@@ -26,6 +25,7 @@ interface SingleProcessingHeaderProps {
 export default function SingleProcessingHeader({
   asset,
   submission,
+  currentSubmissionUid,
   questionLabelLanguage,
   xpath,
   hasUnsavedWork,
@@ -35,7 +35,7 @@ export default function SingleProcessingHeader({
       <SelectQuestion
         asset={asset}
         xpath={xpath}
-        currentSubmissionUid={removeDefaultUuidPrefix(submission['meta/rootUuid'])}
+        currentSubmissionUid={currentSubmissionUid}
         questionLabelLanguage={questionLabelLanguage}
         hasUnsavedWork={hasUnsavedWork}
       />

--- a/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import type { AssetResponse } from '#/dataInterface'
+import { removeDefaultUuidPrefix } from '#/utils'
 import ButtonReturn from './ButtonReturn'
 import SelectQuestion from './SelectQuestion'
 import SelectSubmission from './SelectSubmission'
@@ -34,7 +35,7 @@ export default function SingleProcessingHeader({
       <SelectQuestion
         asset={asset}
         xpath={xpath}
-        currentSubmissionUid={submission?.['meta/rootUuid']}
+        currentSubmissionUid={removeDefaultUuidPrefix(submission['meta/rootUuid'])}
         questionLabelLanguage={questionLabelLanguage}
         hasUnsavedWork={hasUnsavedWork}
       />


### PR DESCRIPTION
### 📣 Summary
Fixes an issue with incorrectly formatted uids that broke functionality in the audio processing view.

### 💭 Notes
The issue was that the `currentSubmissionUId` passed down to `SelectQuestion` component was not in the correct format. By just getting the meta/rootUuid property the uuid comes with a prefix, which is not used through the components. That caused the react query cache key to be out of sync with the uuid being used in the process, causing mutation fails.
The fix was to simple use the already existing currentUuid prop that is already passed down by the `SingleProcessingRoute` but was not being used in the header. That uuid is already used in the other components and ins in the correct format.

### 👀 Preview steps
1. ℹ️ have an account and a project with multiple audio question and data collected
2. open audio processing view
3. select a question other than the one opened by using the top-left question selector
3. start a transcription or try to delete an existing one
4. 🔴 [on main] notice that a blank view, or an error appears
5. 🟢 [on PR] notice that all operations work as expected