### PR TITLE
fix(map): blank map for questions in group fix DEV-2093

### DIFF
--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -481,7 +481,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   updateWrapperQuery(selectedQuestion: string | null, nextViewBy: string, pageLimit: number) {
     const fq = ['_id']
     if (selectedQuestion) {
-      fq.push(selectedQuestion)
+      fq.push(this.nameOfFieldInGroup(selectedQuestion))
     }
     if (nextViewBy) {
       fq.push(this.nameOfFieldInGroup(nextViewBy))
@@ -526,12 +526,14 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
       selectedQuestion = null
     }
 
-    // We set the selected question in this state as well for the display in the MapSettings modal
-    this.setState({ foundSelectedQuestion: selectedQuestion })
+    const selectedQuestionPath = selectedQuestion ? this.nameOfFieldInGroup(selectedQuestion) : null
+
+    // Persist normalized selected geopoint key used by data API and submission payload.
+    this.setState({ foundSelectedQuestion: selectedQuestionPath })
 
     // If totalCount hasn't populated yet, set pageLimit to 1
     if (this.props.totalCount === undefined) {
-      this.updateWrapperQuery(selectedQuestion, nextViewBy, 1)
+      this.updateWrapperQuery(selectedQuestionPath, nextViewBy, 1)
       return
     }
 
@@ -550,7 +552,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
 
     const pageLimit = queryLimit / SUBMISSIONS_PER_PAGE
 
-    this.updateWrapperQuery(selectedQuestion, nextViewBy, pageLimit)
+    this.updateWrapperQuery(selectedQuestionPath, nextViewBy, pageLimit)
   }
 
   rebuildMapLayers(map: L.Map) {
@@ -1033,7 +1035,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   nameOfFieldInGroup(fieldName: string): string {
     if (this.props.asset.content?.survey) {
       const flatPaths = getSurveyFlatPaths(this.props.asset.content.survey)
-      return flatPaths[fieldName]
+      return flatPaths[fieldName] || fieldName
     }
     // Fallback - should never happen
     return fieldName

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -478,10 +478,11 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     this.overrideStyles(upcomingMapSettings)
   }
 
-  updateWrapperQuery(selectedQuestion: string | null, nextViewBy: string, pageLimit: number) {
+  // `selectedQuestionPath` is normalized in `createDataQuery()` before calling this helper.
+  updateWrapperQuery(selectedQuestionPath: string | null, nextViewBy: string, pageLimit: number) {
     const fq = ['_id']
-    if (selectedQuestion) {
-      fq.push(this.nameOfFieldInGroup(selectedQuestion))
+    if (selectedQuestionPath) {
+      fq.push(selectedQuestionPath)
     }
     if (nextViewBy) {
       fq.push(this.nameOfFieldInGroup(nextViewBy))


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Support Docs Updates, if any
4. [x] draft PR with a title <type>(<scope>)<!>: <title> DEV-1234
5. [x] assign yourself, tag PR: at least Front end and/or Back end or workflow
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixed the Project → Data → Map so geopoint answers inside groups are now shown correctly instead of incorrectly showing "No geopoint responses have been received".

### 💭 Notes

Changes here:
- Map component: index.tsx
  - Normalized selected geopoint question names to their flat-path field keys before building the submissions query.
  - Reused the same normalized key when parsing coordinates, so grouped geopoint values are read from the correct submission field.
  - Added a safe fallback in grouped-field path resolution so non-grouped names continue to work as expected.

#7041 fixes this bug on an older code

### 👀 Preview steps

1. ℹ️ Have an account with access to a deployed project.
2. Create or open a form that has one geopoint question inside a group.
3. Submit at least one response with a valid location for that grouped geopoint question.
4. Open the project and go to Data → Map.
5. 🔴 [on main] Notice the map may say "No geopoint responses have been received".
6. 🟢 [on PR] Notice the location point(s) are displayed on the map.
7. Optional sanity check: open a form with a top-level geopoint (not in a group) and confirm it still displays correctly.