### PR TITLE
Beccagraber/dev 2094 migrate q to xpath

### DIFF
--- a/jsapp/js/components/processing/common/constants.ts
+++ b/jsapp/js/components/processing/common/constants.ts
@@ -1,7 +1,7 @@
 /**
  * See also `SCHEMA_VERSIONS` at `kobo/apps/subsequences/constants.py`.
  */
-export const SUBSEQUENCES_SCHEMA_VERSION = '20250820'
+export const SUBSEQUENCES_SCHEMA_VERSION = '20260506'
 
 /**
  * For simplicity, when creating an object, let's use the server's interface for it to re-use hanndling. But:

--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -31,7 +31,7 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
 )
 from kobo.apps.openrosa.libs.utils.logger_tools import dict2xform
 from kobo.apps.subsequences.actions.automatic_bedrock_qual import OSS120, ClaudeSonnet
-from kobo.apps.subsequences.constants import Action
+from kobo.apps.subsequences.constants import Action, SCHEMA_VERSIONS
 from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
 from kobo.apps.subsequences.tests.constants import (
     FIXTURE_AUTOMATIC_QUAL_Q1_INTEGER_UUID,
@@ -592,7 +592,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
     def test_update_qa_creates_log(self):
         request_data = {
             'advanced_features': {
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 '_actionConfigs': {
                     'q1': {
                         'qual': [
@@ -2004,7 +2004,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 args=[self.asset.uid, submission['_uuid']],
             ),
             request_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     Action.MANUAL_QUAL: {
                         'uuid': question_uuid,
@@ -2052,7 +2052,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 args=[self.asset.uid, submission['_uuid']],
             ),
             request_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     Action.MANUAL_QUAL: {
                         'uuid': question_uuid,
@@ -2075,7 +2075,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 args=[self.asset.uid, submission['_uuid']],
             ),
             data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     Action.MANUAL_TRANSCRIPTION: {
                         'language': 'en',
@@ -2116,7 +2116,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             self.asset,
             submission,
             incoming_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     'manual_transcription': {'language': 'en', 'value': 'transcript'}
                 },
@@ -2134,7 +2134,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 ),
                 method=self.client.patch,
                 request_data={
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     'q1': {
                         Action.AUTOMATIC_BEDROCK_QUAL: {
                             'uuid': FIXTURE_AUTOMATIC_QUAL_Q1_INTEGER_UUID,
@@ -2170,7 +2170,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             self.asset,
             submission,
             incoming_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     'manual_transcription': {'language': 'en', 'value': 'transcript'}
                 },
@@ -2188,7 +2188,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 ),
                 method=self.client.patch,
                 request_data={
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     'q1': {
                         Action.AUTOMATIC_BEDROCK_QUAL: {
                             'uuid': FIXTURE_AUTOMATIC_QUAL_Q1_INTEGER_UUID,
@@ -2235,7 +2235,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             self.asset,
             submission,
             incoming_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     'manual_transcription': {'language': 'en', 'value': 'transcript'}
                 },
@@ -2253,7 +2253,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 ),
                 method=self.client.patch,
                 request_data={
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     'q1': {
                         Action.AUTOMATIC_BEDROCK_QUAL: {
                             'uuid': FIXTURE_AUTOMATIC_QUAL_Q1_INTEGER_UUID,
@@ -2293,7 +2293,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             self.asset,
             submission,
             incoming_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     'manual_transcription': {'language': 'en', 'value': 'transcript'}
                 },
@@ -2318,7 +2318,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
                 self.asset,
                 submission,
                 incoming_data={
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     'q1': {
                         action: action_data,
                     },
@@ -2332,7 +2332,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
             ),
             method=self.client.patch,
             request_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     action: {
                         'uuid': question_uuid,

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -60,7 +60,7 @@ def run():
         for supplement in SubmissionSupplement.objects.filter(asset__uid=uid):
             new_content = get_sanitized_dict_keys(supplement.content, asset)
             if new_content:
-                supplement.content = get_sanitized_dict_keys(supplement.content, asset)
+                supplement.content = new_content
                 migrated_supplements_with_qpaths += 1
             supplement.content['_version'] = '20260506'
             supplement.save(
@@ -110,14 +110,6 @@ def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
         if '$qpath' in row and '$xpath' in row and row['$qpath'] == qpath:
             return row['$xpath']
 
-    # If the `qpath` refers to a question that was renamed or deleted, it may
-    # no longer match any XPath in the form. In such cases, where it's still
-    # present in known_cols, skip this field by returning an empty string
-    dashed_qpath = qpath.replace('/', '-')
-    for known_col in asset.known_cols:
-        if known_col.startswith(dashed_qpath):
-            return ''
-
     # Could not find it from the survey, let's try to detect it automatically
     xpaths = asset.get_attachment_xpaths(deployed=True)
     for xpath in xpaths:
@@ -125,4 +117,5 @@ def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
         if dashed_xpath == qpath:
             return xpath
 
-    raise KeyError(f'xpath for {qpath} not found')
+    logging.warn(f'[LRM 0024] - xpath for qpath {qpath} not found. Keeping as qpath.')
+    return qpath

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -1,12 +1,11 @@
 import time
 from copy import deepcopy
 
-from django.core.management import call_command
-from django.core.management.base import CommandError
-from django.db.models import Exists, OuterRef
-
-from apps.long_running_migrations.models import LongRunningMigration, LongRunningMigrationStatus
-from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
+from kobo.apps.long_running_migrations.models import (
+    LongRunningMigration,
+    LongRunningMigrationStatus,
+)
+from kobo.apps.subsequences.models import SubmissionSupplement
 from kpi.models import Asset
 from kpi.utils.log import logging
 
@@ -30,7 +29,9 @@ def run():
 
     # make sure migration 0023 is done
     try:
-        previous_migration = LongRunningMigration.objects.get(name='0023_migrate_submission_supplements')
+        previous_migration = LongRunningMigration.objects.get(
+            name='0023_migrate_submission_supplements'
+        )
     except LongRunningMigration.DoesNotExist:
         logging.info('[LRM 0024] - previous migration not present.')
         return
@@ -43,7 +44,8 @@ def run():
         .values_list('asset__uid', flat=True)
         .distinct()
     )
-    migration_count = 0
+    migrated_supplements_with_qpaths = 0
+    migrated_supplements = 0
 
     total = len(old_uids)
     if total == 0:
@@ -59,11 +61,21 @@ def run():
             new_content = get_sanitized_dict_keys(supplement.content, asset)
             if new_content:
                 supplement.content = get_sanitized_dict_keys(supplement.content, asset)
-                supplement.save(update_fields=['content',])
-                migration_count+=1
+                supplement.save(
+                    update_fields=[
+                        'content',
+                    ]
+                )
+                migrated_supplements_with_qpaths += 1
+            supplement.content['_version'] = '20260506'
+            migrated_supplements += 1
         time.sleep(SLEEP_BETWEEN_ASSETS)
 
-    logging.info(f'[LRM 0024] - Done. Migrated {migration_count} submission supplements.')
+    logging.info(
+        f'[LRM 0024] - Done. Migrated {migrated_supplements} submission supplements.'
+        f' {migrated_supplements_with_qpaths} supplements with qpaths updated.'
+    )
+
 
 def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
     """

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -1,0 +1,116 @@
+import time
+from copy import deepcopy
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db.models import Exists, OuterRef
+
+from apps.long_running_migrations.models import LongRunningMigration, LongRunningMigrationStatus
+from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
+from kpi.models import Asset
+from kpi.utils.log import logging
+
+SLEEP_BETWEEN_ASSETS = 0.5
+
+
+def run():
+    """
+    Migrate all SubmissionSupplement records that are still in an old schema
+    format (_version is not the latest)
+
+    Iterates over all assets that have at least one un-migrated supplement and
+    delegates to the `migrate_submission_supplements` management command for
+    each asset. The management command handles renaming qpaths to xpaths within
+    SubmissionSupplements.
+
+    This job is resumable: if it is interrupted (e.g. SoftTimeLimitExceeded),
+    the next Beat cycle will pick up the remaining assets with any supplements
+    still in the old format
+    """
+
+    # make sure migration 0023 is done
+    try:
+        previous_migration = LongRunningMigration.objects.get(name='0023_migrate_submission_supplements')
+    except LongRunningMigration.DoesNotExist:
+        logging.info('[LRM 0024] - previous migration not present.')
+        return
+    if previous_migration.status != LongRunningMigrationStatus.COMPLETED:
+        logging.info('[LRM 0024] - previous migration not completed.')
+        return
+
+    old_uids = set(
+        SubmissionSupplement.objects.exclude(content___version='20260506')
+        .values_list('asset__uid', flat=True)
+        .distinct()
+    )
+    migration_count = 0
+
+    total = len(old_uids)
+    if total == 0:
+        logging.info('[LRM 0024] - Nothing to migrate.')
+        return
+
+    logging.info(f'[LRM 0024] - {total} asset(s) with old supplements to migrate')
+
+    for i, uid in enumerate(old_uids, start=1):
+        logging.info(f'[LRM 0024] - [{i}/{total}] Migrating asset {uid}')
+        asset = Asset.objects.get(uid=uid)
+        for supplement in SubmissionSupplement.objects.filter(asset__uid=uid):
+            new_content = get_sanitized_dict_keys(supplement.content, asset)
+            if new_content:
+                supplement.content = get_sanitized_dict_keys(supplement.content, asset)
+                supplement.save(update_fields=['content',])
+                migration_count+=1
+        time.sleep(SLEEP_BETWEEN_ASSETS)
+
+    logging.info(f'[LRM 0024] - Done. Migrated {migration_count} submission supplements.')
+
+def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
+    """
+    Update `dict_to_update` keys created with `qpath`(if they are present) with
+    their `xpath` counterpart.
+    """
+    updated_dict = deepcopy(content_dict)
+    changed = False
+    for old_xpath, values in content_dict.items():
+        if old_xpath == '_version':
+            continue
+        if '-' in old_xpath and '/' not in old_xpath:
+            xpath = qpath_to_xpath(old_xpath, asset)
+            if xpath == old_xpath:
+                continue
+            del updated_dict[old_xpath]
+            updated_dict[xpath] = values
+            changed = True
+    if not changed:
+        return None
+
+    return updated_dict
+
+
+def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
+    """
+    We have abandoned `qpath` attribute in favor of `xpath`.
+    Existing projects may still use it though.
+    We need to find the equivalent `xpath`.
+    """
+    for row in asset.content['survey']:
+        if '$qpath' in row and '$xpath' in row and row['$qpath'] == qpath:
+            return row['$xpath']
+
+    # If the `qpath` refers to a question that was renamed or deleted, it may
+    # no longer match any XPath in the form. In such cases, where it's still
+    # present in known_cols, skip this field by returning an empty string
+    dashed_qpath = qpath.replace('/', '-')
+    for known_col in asset.known_cols:
+        if known_col.startswith(dashed_qpath):
+            return ''
+
+    # Could not find it from the survey, let's try to detect it automatically
+    xpaths = asset.get_attachment_xpaths(deployed=True)
+    for xpath in xpaths:
+        dashed_xpath = xpath.replace('/', '-')
+        if dashed_xpath == qpath:
+            return xpath
+
+    raise KeyError(f'xpath for {qpath} not found')

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -61,13 +61,13 @@ def run():
             new_content = get_sanitized_dict_keys(supplement.content, asset)
             if new_content:
                 supplement.content = get_sanitized_dict_keys(supplement.content, asset)
-                supplement.save(
-                    update_fields=[
-                        'content',
-                    ]
-                )
                 migrated_supplements_with_qpaths += 1
             supplement.content['_version'] = '20260506'
+            supplement.save(
+                update_fields=[
+                    'content',
+                ]
+            )
             migrated_supplements += 1
         time.sleep(SLEEP_BETWEEN_ASSETS)
 

--- a/kobo/apps/long_running_migrations/migrations/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/migrations/0024_migrate_submission_supplement_qpaths.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.create(
+        name='0024_migrate_submission_supplement_qpaths'
+    )
+
+
+def delete_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.filter(
+        name='0024_migrate_submission_supplement_qpaths'
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0023_migrate_submission_supplements'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, delete_long_running_migration),
+    ]

--- a/kobo/apps/subsequences/README.md
+++ b/kobo/apps/subsequences/README.md
@@ -83,7 +83,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "automatic_google_transcription": {
             "language": "es"
@@ -129,7 +129,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "automatic_google_transcription": {
             "language": "es"
@@ -158,7 +158,7 @@ How these selections are determined varies by feature.
             ]
           }
         },
-        "_version":"20250820"
+        "_version":"20260506"
       }
       ```
       </details>
@@ -191,7 +191,7 @@ How these selections are determined varies by feature.
                    "_dateCreated": "2026-01-28T15:21:06.416445Z"
                  }
                ],
-              "_version":"20250820"
+              "_version":"20260506"
             }
          }
       }
@@ -205,7 +205,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "automatic_google_transcription": {
             "language": "es",
@@ -242,7 +242,7 @@ How these selections are determined varies by feature.
                    "_dateCreated": "2026-01-28T15:21:06.416445Z"
                  }
                ],
-              "_version":"20250820"
+              "_version":"20260506"
             }
          }
       }
@@ -256,7 +256,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "automatic_google_transcription": {
             "language": "es",
@@ -302,7 +302,7 @@ How these selections are determined varies by feature.
                    "_dateCreated": "2026-01-28T15:21:06.416445Z"
                  }
                ],
-              "_version":"20250820"
+              "_version":"20260506"
             }
          }
       }
@@ -371,7 +371,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "manual_translation": {
             "language": "es",
@@ -393,7 +393,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "manual_transcription": {
             "language": "en",
@@ -425,7 +425,7 @@ How these selections are determined varies by feature.
              "_dateModified":"2026-01-28T16:08:16.297609Z"
           }
         },
-        "_version":"20250820"
+        "_version":"20260506"
       }
       ```
       </details>
@@ -437,7 +437,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "manual_translation": {
             "language": "es",
@@ -490,7 +490,7 @@ How these selections are determined varies by feature.
                }
             }
          },
-         "_version":"20250820"
+         "_version":"20260506"
       }
       ```
       </details>
@@ -590,7 +590,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "manual_qual": {
             "uuid": "7d51e4d4-5ff5-4db7-b70f-a1861a149593",
@@ -634,7 +634,7 @@ How these selections are determined varies by feature.
 
       ```json
       {
-        "_version": "20250820",
+        "_version": "20260506",
         "audio_question": {
           "manual_qual": {
             "uuid": "7d51e4d4-5ff5-4db7-b70f-a1861a149593",

--- a/kobo/apps/subsequences/actions/base.py
+++ b/kobo/apps/subsequences/actions/base.py
@@ -45,7 +45,7 @@ from ..type_aliases import (
 idea of example content in asset.advanced_features (what kind of actions are activated
 per question)
 {
-    '_version': '20250820',
+    '_version': '20260506',
     '_schema': {
         'my_audio_question': {
             'manual_transcription': [
@@ -66,7 +66,7 @@ per question)
 
 idea of example data in SubmissionSupplement based on the above
 {
-    '_version': '20250820',
+    '_version': '20260506',
     'my_audio_question': {
         'manual_transcription': {
             # TODO: think about wrapping in language dictionary like translations

--- a/kobo/apps/subsequences/actions/qual.py
+++ b/kobo/apps/subsequences/actions/qual.py
@@ -156,7 +156,7 @@ class BaseQualAction(BaseAction):
         """
         POST to "/api/v2/assets/<asset uid>/data/<submission uuid>/supplemental/"
         {
-            '_version': '20250820',
+            '_version': '20260506',
             'question_name_xpath': {
                 'manual_qual': {
                     'uuid': '24a68b0a-62fb-4122-8377-412810b2f45d',

--- a/kobo/apps/subsequences/constants.py
+++ b/kobo/apps/subsequences/constants.py
@@ -20,6 +20,7 @@ GOOGLE_CACHE_TIMEOUT = 28800  # 8 hours
 GOOGLE_CODE = 'goog'
 
 SCHEMA_VERSIONS = [
+    '20260506',
     '20250820',
     None,
 ]

--- a/kobo/apps/subsequences/schemas.py
+++ b/kobo/apps/subsequences/schemas.py
@@ -30,7 +30,7 @@ ACTION_PARAMS_SCHEMA = {
             },
             'type': 'object',
         },
-        '_version': {'const': '20250820'},
+        '_version': {'const': SCHEMA_VERSIONS[0]},
     },
     'type': 'object',
 }

--- a/kobo/apps/subsequences/tests/api/v2/test_api.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_api.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kobo.apps.organizations.constants import UsageType
@@ -51,7 +52,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         )
 
         # Simulate a completed transcription, first.
-        mock_submission_supplement = {'_version': '20250820', 'q1': QUESTION_SUPPLEMENT}
+        mock_submission_supplement = {'_version': SCHEMA_VERSIONS[0], 'q1': QUESTION_SUPPLEMENT}
         SubmissionSupplement.objects.create(
             submission_uuid=self.submission_uuid,
             content=mock_submission_supplement,
@@ -68,7 +69,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
 
     def test_patch_submission_with_nonexistent_instance_404s(self):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -123,7 +124,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
 
     def test_asset_post_submission_extra_with_transcript(self):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -151,7 +152,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
                 )
         assert response.status_code == status.HTTP_200_OK
         expected_data = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     '_dateCreated': now_iso,
@@ -174,7 +175,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
 
     def test_valid_manual_transcription(self):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -206,7 +207,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_translation': {
                     'language': 'es',
@@ -230,7 +231,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_transcription': {
                     'language': 'en',
@@ -266,7 +267,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_translation': {
                     'language': 'es',
@@ -306,7 +307,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         ).values_list('action', flat=True)
         for automatic_action in automatic_actions:
             payload = {
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     automatic_action: {
                         'language': 'es',
@@ -331,7 +332,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
 
         # Try to set 'accepted' status when translation is not complete
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_translation': {
                     'language': 'fr',
@@ -621,7 +622,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
                     },
                 },
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
         assert response.data == expected_response
 
@@ -630,7 +631,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
     def test_cannot_patch_if_question_does_not_have_action_configured(self):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_translation': {
                     'language': 'es',
@@ -657,7 +658,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
             params=[{'language': 'es'}],
         )
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'bananas': {
                     'language': 'es',
@@ -685,7 +686,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'languageCode': 'es',  # wrong attribute
@@ -712,7 +713,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Try to set 'accepted' status when translation is not complete
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_transcription': {
                     'language': 'es',
@@ -751,7 +752,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
         )
         # Try to ask for translation
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_translation': {
                     'language': 'fr',
@@ -788,7 +789,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Attempt to "delete" a non-existent transcription
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -851,7 +852,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
                     ],
                 }
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -862,7 +863,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Attempt to "delete" a non-existent transcription
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_transcription': {
                     'language': 'en',
@@ -897,7 +898,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Add a valid transcript
         transcript_payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -911,7 +912,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Delete the transcript
         delete_payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'en',
@@ -925,7 +926,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Attempt to translate
         translation_payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_translation': {
                     'language': 'es',
@@ -987,7 +988,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
                     ],
                 }
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -998,7 +999,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Attempt to translate
         translation_payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {'automatic_google_translation': {'language': 'es'}},
         }
 
@@ -1072,7 +1073,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
                     ],
                 },
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -1083,7 +1084,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
 
         # Attempt to translate
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_translation': {
                     'language': 'es',
@@ -1123,7 +1124,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
             params=[{'language': 'es'}],
         )
 
-        mock_submission_supplement = {'_version': '20250820', 'q1': QUESTION_SUPPLEMENT}
+        mock_submission_supplement = {'_version': SCHEMA_VERSIONS[0], 'q1': QUESTION_SUPPLEMENT}
         SubmissionSupplement.objects.create(
             submission_uuid=self.submission_uuid,
             content=mock_submission_supplement,
@@ -1169,7 +1170,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
                     ],
                 },
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
         SubmissionSupplement.objects.update_or_create(
             asset=self.asset,
@@ -1178,7 +1179,7 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {'manual_translation': {'language': 'es', 'value': 'Spanish'}},
         }
         response = self.client.patch(
@@ -1222,7 +1223,7 @@ class SubmissionSupplementAPIUsageLimitsTestCase(SubsequenceBaseTestCase):
         self, usage_limit_enforcement, expected_result_code
     ):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'automatic_google_transcription': {
                     'language': 'en',

--- a/kobo/apps/subsequences/tests/api/v2/test_api.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_api.py
@@ -52,7 +52,10 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
         )
 
         # Simulate a completed transcription, first.
-        mock_submission_supplement = {'_version': SCHEMA_VERSIONS[0], 'q1': QUESTION_SUPPLEMENT}
+        mock_submission_supplement = {
+            '_version': SCHEMA_VERSIONS[0],
+            'q1': QUESTION_SUPPLEMENT
+        }
         SubmissionSupplement.objects.create(
             submission_uuid=self.submission_uuid,
             content=mock_submission_supplement,
@@ -1124,7 +1127,10 @@ class SubmissionSupplementAPIValidationTestCase(SubsequenceBaseTestCase):
             params=[{'language': 'es'}],
         )
 
-        mock_submission_supplement = {'_version': SCHEMA_VERSIONS[0], 'q1': QUESTION_SUPPLEMENT}
+        mock_submission_supplement = {
+            '_version': SCHEMA_VERSIONS[0],
+            'q1': QUESTION_SUPPLEMENT
+        }
         SubmissionSupplement.objects.create(
             submission_uuid=self.submission_uuid,
             content=mock_submission_supplement,

--- a/kobo/apps/subsequences/tests/api/v2/test_permissions.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_permissions.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.subsequences.models import QuestionAdvancedFeature
 from kobo.apps.subsequences.tests.api.v2.base import SubsequenceBaseTestCase
@@ -124,7 +125,7 @@ class SubsequencePermissionTestCase(SubsequenceBaseTestCase):
     @unpack
     def test_can_write(self, username, shared, status_code):
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'es',
@@ -162,7 +163,7 @@ class SubsequencePermissionTestCase(SubsequenceBaseTestCase):
 
         if status_code == status.HTTP_200_OK:
             expected = {
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'q1': {
                     'manual_transcription': {
                         '_dateCreated': '2024-04-08T15:27:00Z',
@@ -201,7 +202,7 @@ class SubsequencePartialPermissionTestCase(SubsequenceBaseTestCase):
         )
         self.client.force_login(anotheruser)
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     'language': 'es',

--- a/kobo/apps/subsequences/tests/api/v2/test_views.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_views.py
@@ -4,6 +4,7 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.subsequences.models import QuestionAdvancedFeature
 from kobo.apps.subsequences.tests.constants import OLD_STYLE_ADVANCED_FEATURES
@@ -102,7 +103,7 @@ class QuestionAdvancedFeatureViewSetTestCase(BaseTestCase):
         self.client.get(self.list_actions_url)
         self.asset.refresh_from_db()
         # what's actually created is tested elsewhere, just check that we migrated
-        assert self.asset.advanced_features.get('_version') == '20250820'
+        assert self.asset.advanced_features.get('_version') == SCHEMA_VERSIONS[0]
 
     def test_create_advanced_features_fails_if_feature_exists_in_old_field(self):
         QuestionAdvancedFeature.objects.all().delete()
@@ -142,7 +143,7 @@ class QuestionAdvancedFeatureViewSetTestCase(BaseTestCase):
             },
         )
         self.asset.refresh_from_db()
-        assert self.asset.advanced_features.get('_version') == '20250820'
+        assert self.asset.advanced_features.get('_version') == SCHEMA_VERSIONS[0]
         assert res.status_code == status.HTTP_201_CREATED
 
     def test_cannot_create_feature_with_invalid_params(self):

--- a/kobo/apps/subsequences/tests/test_automatic_bedrock_qual.py
+++ b/kobo/apps/subsequences/tests/test_automatic_bedrock_qual.py
@@ -30,6 +30,7 @@ from kobo.apps.subsequences.constants import (
     QUESTION_TYPE_SELECT_ONE,
     QUESTION_TYPE_TEXT,
     Action,
+    SCHEMA_VERSIONS,
 )
 from kobo.apps.subsequences.exceptions import (
     AnalysisQuestionNotFound,
@@ -109,7 +110,7 @@ class BaseAutomaticBedrockQualTestCase(BaseTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 Action.MANUAL_TRANSCRIPTION: {
                     'language': 'en',
@@ -257,7 +258,7 @@ class TestBedrockAutomaticBedrockQual(BaseAutomaticBedrockQualTestCase):
         )
 
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 Action.AUTOMATIC_BEDROCK_QUAL: {
                     'uuid': BEDROCK_QUAL_TEXT_UUID,
@@ -644,7 +645,7 @@ class TestAutomaticQAThrottling(BaseAutomaticBedrockQualTestCase):
             args=[self.asset.uid, self.submission_uuid],
         )
         self.qa_payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 Action.AUTOMATIC_BEDROCK_QUAL: {
                     'uuid': BEDROCK_QUAL_TEXT_UUID
@@ -685,7 +686,7 @@ class TestAutomaticQAThrottling(BaseAutomaticBedrockQualTestCase):
         they are not throttled
         """
         payload = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 Action.MANUAL_QUAL: {
                     'uuid': 'a94c2b17-5f6e-4d88-8b31-2e9a7c6f54d0',

--- a/kobo/apps/subsequences/tests/test_models.py
+++ b/kobo/apps/subsequences/tests/test_models.py
@@ -14,7 +14,7 @@ from ..actions import (
     AutomaticGoogleTranscriptionAction,
     AutomaticGoogleTranslationAction,
 )
-from ..constants import SUBMISSION_UUID_FIELD
+from ..constants import SUBMISSION_UUID_FIELD, SCHEMA_VERSIONS
 from ..exceptions import InvalidAction, InvalidXPath
 from ..models import QuestionAdvancedFeature, SubmissionSupplement
 from .constants import EMPTY_SUPPLEMENT
@@ -32,7 +32,7 @@ class MockNLPService:
 class SubmissionSupplementTestCase(TestCase):
 
     EXPECTED_SUBMISSION_SUPPLEMENT = {
-        '_version': '20250820',
+        '_version': SCHEMA_VERSIONS[0],
         'group_name/question_name': {
             'manual_transcription': {
                 '_dateCreated': '2024-04-08T15:27:00Z',
@@ -158,7 +158,7 @@ class SubmissionSupplementTestCase(TestCase):
             self.asset,
             self.submission,
             incoming_data={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 self.xpath: {
                     f'manual_{nlp_action}': {'language': language, 'value': value}
                 },
@@ -185,7 +185,7 @@ class SubmissionSupplementTestCase(TestCase):
                     self.asset,
                     self.submission,
                     incoming_data={
-                        '_version': '20250820',
+                        '_version': SCHEMA_VERSIONS[0],
                         self.xpath: {
                             f'automatic_google_{nlp_action}': {'language': language}
                         },
@@ -196,7 +196,7 @@ class SubmissionSupplementTestCase(TestCase):
                         self.asset,
                         self.submission,
                         incoming_data={
-                            '_version': '20250820',
+                            '_version': SCHEMA_VERSIONS[0],
                             self.xpath: {
                                 f'automatic_google_{nlp_action}': {
                                     'language': language,
@@ -396,7 +396,7 @@ class SubmissionSupplementTestCase(TestCase):
                     self.asset,
                     self.submission,
                     {
-                        '_version': '20250820',
+                        '_version': SCHEMA_VERSIONS[0],
                         self.xpath: {
                             'manual_transcription': {
                                 'language': 'ar',
@@ -424,7 +424,7 @@ class SubmissionSupplementTestCase(TestCase):
                     self.asset,
                     self.submission,
                     {
-                        '_version': '20250820',
+                        '_version': SCHEMA_VERSIONS[0],
                         self.xpath: {
                             'manual_translation': {
                                 'language': 'es',
@@ -450,7 +450,7 @@ class SubmissionSupplementTestCase(TestCase):
                     self.asset,
                     self.submission,
                     {
-                        '_version': '20250820',
+                        '_version': SCHEMA_VERSIONS[0],
                         self.xpath: {
                             'manual_transcription': {
                                 'language': 'ar',
@@ -469,7 +469,7 @@ class SubmissionSupplementTestCase(TestCase):
                     self.asset,
                     self.submission,
                     {
-                        '_version': '20250820',
+                        '_version': SCHEMA_VERSIONS[0],
                         self.xpath: {
                             'manual_translation': {
                                 'language': 'es',
@@ -488,7 +488,7 @@ class SubmissionSupplementTestCase(TestCase):
                 self.asset,
                 self.submission,
                 {
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     self.xpath: {'my_other_action': {'param': 'foo'}},
                 },
             )
@@ -500,7 +500,7 @@ class SubmissionSupplementTestCase(TestCase):
                 self.asset,
                 self.submission,
                 {
-                    '_version': '20250820',
+                    '_version': SCHEMA_VERSIONS[0],
                     'group_name/other_question_name': {
                         'manual_translation': {
                             'language': 'en',

--- a/kobo/apps/subsequences/tests/test_submission_stream.py
+++ b/kobo/apps/subsequences/tests/test_submission_stream.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from kobo.apps.openrosa.apps.logger.exceptions import ConflictingSubmissionUUIDError
-from kobo.apps.subsequences.constants import SUPPLEMENT_KEY, Action
+from kobo.apps.subsequences.constants import SUPPLEMENT_KEY, Action, SCHEMA_VERSIONS
 from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
 from kobo.apps.subsequences.utils.supplement_data import stream_with_supplements
 from kpi.models import Asset
@@ -151,7 +151,7 @@ class TestSubmissionStream(TestCase):
             submission_uuid='1c05898e-b43c-491d-814c-79595eb84e81',
             asset=self.asset,
             content={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'Tell_me_a_story': {
                     Action.MANUAL_QUAL: qual_action_data,
                 },
@@ -161,7 +161,7 @@ class TestSubmissionStream(TestCase):
             submission_uuid='1c05898e-b43c-491d-814c-79595eb84e82',
             asset=self.asset,
             content={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'Tell_me_a_story': {
                     Action.MANUAL_QUAL: qual_action_data,
                 },

--- a/kobo/apps/subsequences/tests/test_tasks.py
+++ b/kobo/apps/subsequences/tests/test_tasks.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseTestCase
 from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
-from kobo.apps.subsequences.constants import Action
+from kobo.apps.subsequences.constants import Action, SCHEMA_VERSIONS
 from kobo.apps.subsequences.tasks import poll_run_external_process_failure
 
 
@@ -156,7 +156,7 @@ class TestPollRunExternalProcessFailure(BaseTestCase):
 
         # Setup initial 'in_progress' state in the SubmissionSupplement
         incoming_data = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             self.question_xpath: {
                 self.action_id: {'language': 'en'}
             }

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -273,7 +273,7 @@ class TestVersioning(TestCase):
                 migrated = migrate_submission_supplementals(old_version)
 
         new_version = {
-            '_version': '20250820',
+            '_version': '20250506',
             'Audio_question': {
                 'automatic_google_transcription': {
                     '_dateCreated': a_year_and_a_day_ago,

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -273,7 +273,7 @@ class TestVersioning(TestCase):
                 migrated = migrate_submission_supplementals(old_version)
 
         new_version = {
-            '_version': '20250506',
+            '_version': '20260506',
             'Audio_question': {
                 'automatic_google_transcription': {
                     '_dateCreated': a_year_and_a_day_ago,

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -392,11 +392,11 @@ class TestVersioning(TestCase):
         copied = copy.deepcopy(self.asset.advanced_features)
         migrate_advanced_features(self.asset)
         self.asset.refresh_from_db()
-        assert self.asset.advanced_features == {'_version': '20250820', **copied}
+        assert self.asset.advanced_features == {'_version': '20260506', **copied}
 
     def test_migrate_without_save(self):
         migrate_advanced_features(self.asset, save_asset=False)
-        assert self.asset.advanced_features.get('_version') == '20250820'
+        assert self.asset.advanced_features.get('_version') == '20260506'
         self.asset.refresh_from_db()
         assert self.asset.advanced_features.get('_version') is None
 

--- a/kobo/apps/subsequences/utils/versioning.py
+++ b/kobo/apps/subsequences/utils/versioning.py
@@ -205,7 +205,9 @@ def migrate_qual_data(supplemental_data: dict) -> dict | None:
 
 
 def migrate_submission_supplementals(supplemental_data: dict) -> dict | None:
-    if supplemental_data.get('_version') == SCHEMA_VERSIONS[0]:
+    if supplemental_data.get('_version') in SCHEMA_VERSIONS[0:2]:
+        # no real migration necessary between 20250820 and 20260506
+        supplemental_data['_version'] = SCHEMA_VERSIONS[0]
         return supplemental_data
     supplemental = {
         '_version': SCHEMA_VERSIONS[0],

--- a/kpi/schema_extensions/v2/data/examples.py
+++ b/kpi/schema_extensions/v2/data/examples.py
@@ -1,5 +1,7 @@
 from drf_spectacular.utils import OpenApiExample
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
+
 
 def get_data_supplement_examples() -> list[OpenApiExample]:
     """
@@ -35,7 +37,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Transcription',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_transcription': {'language': 'fr', 'value': 'Bonjour'}
                 },
@@ -46,7 +48,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
             'Manual Transcription (with "locale")',
             description='The `locale` field is optional.',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_transcription': {
                         'language': 'fr',
@@ -60,7 +62,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Translation',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_translation': {'language': 'en', 'value': 'Hello'},
                 },
@@ -70,7 +72,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Automic Google Transcription',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automatic_google_transcription': {'language': 'fr'}
                 },
@@ -80,7 +82,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Automic Google Translation',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automatic_google_translation': {'language': 'en'},
                 },
@@ -100,7 +102,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
                 '`<language>` is the language code, e.g. `en`.'
             ),
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {'language': '<language>', 'value': None},
                 },
@@ -116,7 +118,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
                 '`accepted` is a boolean. It can `true` or `false`.'
             ),
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {'language': '<language>', 'accepted': True},
                 },
@@ -126,7 +128,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Qualitative Analysis – Integer Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'uuid': '11111111-1111-1111-1111-111111111111',
@@ -140,7 +142,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Qualitative Analysis – Text Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'uuid': '22222222-2222-2222-2222-222222222222',
@@ -153,7 +155,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Qualitative Analysis – Single Choice Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'uuid': '33333333-3333-3333-3333-333333333333',
@@ -167,7 +169,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Qualitative Analysis – Multiple Choice Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'uuid': '44444444-4444-4444-4444-444444444444',
@@ -184,7 +186,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Manual Qualitative Analysis – Tags Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'uuid': '44444444-4444-4444-4444-444444444444',
@@ -198,7 +200,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Automatic Bedrock Qualitative Analysis – Any Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automatic_bedrock_qual': {
                         'uuid': '44444444-4444-4444-4444-444444444444',
@@ -210,7 +212,7 @@ def _get_data_supplement_patch_payload_request_examples() -> list[OpenApiExample
         OpenApiExample(
             'Verify Qualitative Analysis Response – Any Question',
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         'uuid': '44444444-4444-4444-4444-4444444444444',
@@ -237,7 +239,7 @@ def _get_data_supplement_response_examples():
             name='Manual Transcription',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_transcription': {
                         '_dateCreated': iso0,
@@ -261,7 +263,7 @@ def _get_data_supplement_response_examples():
             name='Manual Transcription (with "locale")',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_transcription': {
                         '_dateCreated': iso0,
@@ -286,7 +288,7 @@ def _get_data_supplement_response_examples():
             name='Manual Translation',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_translation': {
                         'en': {
@@ -335,7 +337,7 @@ def _get_data_supplement_response_examples():
             name='Automated Google Transcription',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automated_google_transcription': {
                         '_dateCreated': iso0,
@@ -368,7 +370,7 @@ def _get_data_supplement_response_examples():
             name='Automated Google Translation',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automated_google_translation': {
                         'fr': {
@@ -437,7 +439,7 @@ def _get_data_supplement_response_examples():
             name='Qualitative Analysis – Integer Question',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         '66666666-6666-6666-6666-666666666666': {
@@ -470,7 +472,7 @@ def _get_data_supplement_response_examples():
             name='Qualitative Analysis – Text Question',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         'aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff': {
@@ -503,7 +505,7 @@ def _get_data_supplement_response_examples():
             name='Qualitative Analysis – Single Choice Question',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         '77777777-7777-7777-7777-777777777777': {
@@ -536,7 +538,7 @@ def _get_data_supplement_response_examples():
             name='Qualitative Analysis – Multiple Choice Question',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         '88888888-8888-8888-8888-888888888888': {
@@ -572,7 +574,7 @@ def _get_data_supplement_response_examples():
             name='Manual Qualitative Analysis – Tags Question',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'manual_qual': {
                         'bbbbbbbb-cccc-dddd-eeee-ffffffffffff': {
@@ -598,7 +600,7 @@ def _get_data_supplement_response_examples():
             name='Qualitative Analysis – Verified Response',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     '<action_id>': {
                         'bbbbbbbb-cccc-dddd-eeee-ffffffffffff': {
@@ -630,7 +632,7 @@ def _get_data_supplement_response_examples():
             name='Automatic Qualitative Analysis – Failed response',
             response_only=True,
             value={
-                '_version': '20250820',
+                '_version': SCHEMA_VERSIONS[0],
                 'question_name_xpath': {
                     'automatic_bedrock_qual': {
                         'bbbbbbbb-cccc-dddd-eeee-ffffffffffff': {

--- a/kpi/schema_extensions/v2/data/extensions.py
+++ b/kpi/schema_extensions/v2/data/extensions.py
@@ -10,6 +10,7 @@ from drf_spectacular.plumbing import (
 )
 from drf_spectacular.types import OpenApiTypes
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kpi.schema_extensions.v2.data.mixins import (
     SupplementalDataComponentsRegistrationMixin,
 )
@@ -150,7 +151,7 @@ class DataSupplementPayloadExtension(
             properties={
                 '_version': {
                     'type': 'string',
-                    'example': '20250820',
+                    'example': SCHEMA_VERSIONS[0],
                 }
             },
             # Use a named schema component for `additionalProperties` because the
@@ -270,7 +271,7 @@ class DataSupplementResponseExtension(
             properties={
                 '_version': {
                     'type': 'string',
-                    'example': '20250820',
+                    'example': SCHEMA_VERSIONS[0],
                 }
             },
             # Use a named schema component for `additionalProperties` because the

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from django_digest.test import Client as DigestClient
 from rest_framework import status
 
+from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.audit_log.models import ProjectHistoryLog
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import InstanceIdMissingError
@@ -1280,7 +1281,7 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
                     ],
                 }
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -1350,7 +1351,7 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
                     ],
                 },
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -1417,7 +1418,7 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
                     ],
                 },
             },
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
         }
 
         SubmissionSupplement.objects.create(
@@ -2809,7 +2810,7 @@ class SubmissionDuplicateApiTests(
 
     def test_duplicate_submission_with_extras(self):
         dummy_extra = {
-            '_version': '20250820',
+            '_version': SCHEMA_VERSIONS[0],
             'q1': {
                 'manual_transcription': {
                     '_dateCreated': '2025-01-01T00:00:00Z',

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -4160,7 +4160,7 @@
                                 "examples": {
                                     "ManualTranscription": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4183,7 +4183,7 @@
                                     },
                                     "ManualTranscription(with\"locale\")": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4207,7 +4207,7 @@
                                     },
                                     "ManualTranslation": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_translation": {
                                                     "en": {
@@ -4255,7 +4255,7 @@
                                     },
                                     "AutomatedGoogleTranscription": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automated_google_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4287,7 +4287,7 @@
                                     },
                                     "AutomatedGoogleTranslation": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automated_google_translation": {
                                                     "fr": {
@@ -4355,7 +4355,7 @@
                                     },
                                     "QualitativeAnalysis–IntegerQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "66666666-6666-6666-6666-666666666666": {
@@ -4382,7 +4382,7 @@
                                     },
                                     "QualitativeAnalysis–TextQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff": {
@@ -4409,7 +4409,7 @@
                                     },
                                     "QualitativeAnalysis–SingleChoiceQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "77777777-7777-7777-7777-777777777777": {
@@ -4436,7 +4436,7 @@
                                     },
                                     "QualitativeAnalysis–MultipleChoiceQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "88888888-8888-8888-8888-888888888888": {
@@ -4466,7 +4466,7 @@
                                     },
                                     "ManualQualitativeAnalysis–TagsQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_qual": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -4495,7 +4495,7 @@
                                     },
                                     "QualitativeAnalysis–VerifiedResponse": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -4523,7 +4523,7 @@
                                     },
                                     "AutomaticQualitativeAnalysis–FailedResponse": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automatic_bedrock_qual": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -4665,7 +4665,7 @@
                             "examples": {
                                 "ManualTranscription": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_transcription": {
                                                 "language": "fr",
@@ -4677,7 +4677,7 @@
                                 },
                                 "ManualTranscription(with\"locale\")": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_transcription": {
                                                 "language": "fr",
@@ -4691,7 +4691,7 @@
                                 },
                                 "ManualTranslation": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_translation": {
                                                 "language": "en",
@@ -4703,7 +4703,7 @@
                                 },
                                 "AutomicGoogleTranscription": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "automatic_google_transcription": {
                                                 "language": "fr"
@@ -4714,7 +4714,7 @@
                                 },
                                 "AutomicGoogleTranslation": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "automatic_google_translation": {
                                                 "language": "en"
@@ -4725,7 +4725,7 @@
                                 },
                                 "DeleteNLPAction": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "<action_id>": {
                                                 "language": "<language>",
@@ -4738,7 +4738,7 @@
                                 },
                                 "AcceptAutomaticNLPAction": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "<action_id>": {
                                                 "language": "<language>",
@@ -4751,7 +4751,7 @@
                                 },
                                 "ManualQualitativeAnalysis–IntegerQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_qual": {
                                                 "uuid": "11111111-1111-1111-1111-111111111111",
@@ -4764,7 +4764,7 @@
                                 },
                                 "ManualQualitativeAnalysis–TextQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_qual": {
                                                 "uuid": "22222222-2222-2222-2222-222222222222",
@@ -4776,7 +4776,7 @@
                                 },
                                 "ManualQualitativeAnalysis–SingleChoiceQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_qual": {
                                                 "uuid": "33333333-3333-3333-3333-333333333333",
@@ -4789,7 +4789,7 @@
                                 },
                                 "ManualQualitativeAnalysis–MultipleChoiceQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_qual": {
                                                 "uuid": "44444444-4444-4444-4444-444444444444",
@@ -4805,7 +4805,7 @@
                                 },
                                 "ManualQualitativeAnalysis–TagsQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "manual_qual": {
                                                 "uuid": "44444444-4444-4444-4444-444444444444",
@@ -4821,7 +4821,7 @@
                                 },
                                 "AutomaticBedrockQualitativeAnalysis–AnyQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "automatic_bedrock_qual": {
                                                 "uuid": "44444444-4444-4444-4444-444444444444"
@@ -4832,7 +4832,7 @@
                                 },
                                 "VerifyQualitativeAnalysisResponse–AnyQuestion": {
                                     "value": {
-                                        "_version": "20250820",
+                                        "_version": "20260506",
                                         "question_name_xpath": {
                                             "<action_id>": {
                                                 "uuid": "44444444-4444-4444-4444-4444444444444",
@@ -4866,7 +4866,7 @@
                                 "examples": {
                                     "ManualTranscription": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4889,7 +4889,7 @@
                                     },
                                     "ManualTranscription(with\"locale\")": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4913,7 +4913,7 @@
                                     },
                                     "ManualTranslation": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_translation": {
                                                     "en": {
@@ -4961,7 +4961,7 @@
                                     },
                                     "AutomatedGoogleTranscription": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automated_google_transcription": {
                                                     "_dateCreated": "2025-01-01T12:00:00Z",
@@ -4993,7 +4993,7 @@
                                     },
                                     "AutomatedGoogleTranslation": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automated_google_translation": {
                                                     "fr": {
@@ -5061,7 +5061,7 @@
                                     },
                                     "QualitativeAnalysis–IntegerQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "66666666-6666-6666-6666-666666666666": {
@@ -5088,7 +5088,7 @@
                                     },
                                     "QualitativeAnalysis–TextQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff": {
@@ -5115,7 +5115,7 @@
                                     },
                                     "QualitativeAnalysis–SingleChoiceQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "77777777-7777-7777-7777-777777777777": {
@@ -5142,7 +5142,7 @@
                                     },
                                     "QualitativeAnalysis–MultipleChoiceQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "88888888-8888-8888-8888-888888888888": {
@@ -5172,7 +5172,7 @@
                                     },
                                     "ManualQualitativeAnalysis–TagsQuestion": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "manual_qual": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -5201,7 +5201,7 @@
                                     },
                                     "QualitativeAnalysis–VerifiedResponse": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "<action_id>": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -5229,7 +5229,7 @@
                                     },
                                     "AutomaticQualitativeAnalysis–FailedResponse": {
                                         "value": {
-                                            "_version": "20250820",
+                                            "_version": "20260506",
                                             "question_name_xpath": {
                                                 "automatic_bedrock_qual": {
                                                     "bbbbbbbb-cccc-dddd-eeee-ffffffffffff": {
@@ -19139,7 +19139,7 @@
                 "properties": {
                     "_version": {
                         "type": "string",
-                        "example": "20250820"
+                        "example": "20260506"
                     }
                 },
                 "additionalProperties": {
@@ -23223,7 +23223,7 @@
                 "properties": {
                     "_version": {
                         "type": "string",
-                        "example": "20250820"
+                        "example": "20260506"
                     }
                 },
                 "additionalProperties": {

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -3010,7 +3010,7 @@ paths:
               examples:
                 ManualTranscription:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3025,7 +3025,7 @@ paths:
                   summary: Manual Transcription
                 ManualTranscription(with"locale"):
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3041,7 +3041,7 @@ paths:
                   summary: Manual Transcription (with "locale")
                 ManualTranslation:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_translation:
                         en:
@@ -3073,7 +3073,7 @@ paths:
                   summary: Manual Translation
                 AutomatedGoogleTranscription:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automated_google_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3094,7 +3094,7 @@ paths:
                   summary: Automated Google Transcription
                 AutomatedGoogleTranslation:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automated_google_translation:
                         fr:
@@ -3140,7 +3140,7 @@ paths:
                   summary: Automated Google Translation
                 QualitativeAnalysis–IntegerQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         66666666-6666-6666-6666-666666666666:
@@ -3159,7 +3159,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–TextQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff:
@@ -3178,7 +3178,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–SingleChoiceQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         77777777-7777-7777-7777-777777777777:
@@ -3197,7 +3197,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–MultipleChoiceQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         88888888-8888-8888-8888-888888888888:
@@ -3218,7 +3218,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 ManualQualitativeAnalysis–TagsQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_qual:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -3237,7 +3237,7 @@ paths:
                   summary: Manual Qualitative Analysis – Tags Question
                 QualitativeAnalysis–VerifiedResponse:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -3256,7 +3256,7 @@ paths:
                   description: '`<action_id>` can  be either `manual_qual` or `automatic_bedrock_qual`. '
                 AutomaticQualitativeAnalysis–FailedResponse:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automatic_bedrock_qual:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -3362,7 +3362,7 @@ paths:
             examples:
               ManualTranscription:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_transcription:
                       language: fr
@@ -3370,7 +3370,7 @@ paths:
                 summary: Manual Transcription
               ManualTranscription(with"locale"):
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_transcription:
                       language: fr
@@ -3380,7 +3380,7 @@ paths:
                 description: The `locale` field is optional.
               ManualTranslation:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_translation:
                       language: en
@@ -3388,21 +3388,21 @@ paths:
                 summary: Manual Translation
               AutomicGoogleTranscription:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     automatic_google_transcription:
                       language: fr
                 summary: Automic Google Transcription
               AutomicGoogleTranslation:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     automatic_google_translation:
                       language: en
                 summary: Automic Google Translation
               DeleteNLPAction:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     <action_id>:
                       language: <language>
@@ -3414,7 +3414,7 @@ paths:
                   e.g. `en`.'
               AcceptAutomaticNLPAction:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     <action_id>:
                       language: <language>
@@ -3425,7 +3425,7 @@ paths:
                   code, e.g. `en`.<br>`accepted` is a boolean. It can `true` or `false`.'
               ManualQualitativeAnalysis–IntegerQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_qual:
                       uuid: 11111111-1111-1111-1111-111111111111
@@ -3434,7 +3434,7 @@ paths:
                 description: Set `value` to `null` to delete.
               ManualQualitativeAnalysis–TextQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_qual:
                       uuid: 22222222-2222-2222-2222-222222222222
@@ -3442,7 +3442,7 @@ paths:
                 summary: Manual Qualitative Analysis – Text Question
               ManualQualitativeAnalysis–SingleChoiceQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_qual:
                       uuid: 33333333-3333-3333-3333-333333333333
@@ -3451,7 +3451,7 @@ paths:
                 description: Set `value` to the empty string `""` to delete.
               ManualQualitativeAnalysis–MultipleChoiceQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_qual:
                       uuid: 44444444-4444-4444-4444-444444444444
@@ -3462,7 +3462,7 @@ paths:
                 description: Set `value` to the empty string `""` to delete.
               ManualQualitativeAnalysis–TagsQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     manual_qual:
                       uuid: 44444444-4444-4444-4444-444444444444
@@ -3473,14 +3473,14 @@ paths:
                 description: Set `value` an empty array `[]` to delete.
               AutomaticBedrockQualitativeAnalysis–AnyQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     automatic_bedrock_qual:
                       uuid: 44444444-4444-4444-4444-444444444444
                 summary: Automatic Bedrock Qualitative Analysis – Any Question
               VerifyQualitativeAnalysisResponse–AnyQuestion:
                 value:
-                  _version: '20250820'
+                  _version: '20260506'
                   question_name_xpath:
                     <action_id>:
                       uuid: 44444444-4444-4444-4444-4444444444444
@@ -3503,7 +3503,7 @@ paths:
               examples:
                 ManualTranscription:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3518,7 +3518,7 @@ paths:
                   summary: Manual Transcription
                 ManualTranscription(with"locale"):
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3534,7 +3534,7 @@ paths:
                   summary: Manual Transcription (with "locale")
                 ManualTranslation:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_translation:
                         en:
@@ -3566,7 +3566,7 @@ paths:
                   summary: Manual Translation
                 AutomatedGoogleTranscription:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automated_google_transcription:
                         _dateCreated: '2025-01-01T12:00:00Z'
@@ -3587,7 +3587,7 @@ paths:
                   summary: Automated Google Transcription
                 AutomatedGoogleTranslation:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automated_google_translation:
                         fr:
@@ -3633,7 +3633,7 @@ paths:
                   summary: Automated Google Translation
                 QualitativeAnalysis–IntegerQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         66666666-6666-6666-6666-666666666666:
@@ -3652,7 +3652,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–TextQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff:
@@ -3671,7 +3671,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–SingleChoiceQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         77777777-7777-7777-7777-777777777777:
@@ -3690,7 +3690,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 QualitativeAnalysis–MultipleChoiceQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         88888888-8888-8888-8888-888888888888:
@@ -3711,7 +3711,7 @@ paths:
                     \n\n`status` will only be present for automatic_actions."
                 ManualQualitativeAnalysis–TagsQuestion:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       manual_qual:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -3730,7 +3730,7 @@ paths:
                   summary: Manual Qualitative Analysis – Tags Question
                 QualitativeAnalysis–VerifiedResponse:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       <action_id>:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -3749,7 +3749,7 @@ paths:
                   description: '`<action_id>` can  be either `manual_qual` or `automatic_bedrock_qual`. '
                 AutomaticQualitativeAnalysis–FailedResponse:
                   value:
-                    _version: '20250820'
+                    _version: '20260506'
                     question_name_xpath:
                       automatic_bedrock_qual:
                         bbbbbbbb-cccc-dddd-eeee-ffffffffffff:
@@ -13645,7 +13645,7 @@ components:
       properties:
         _version:
           type: string
-          example: '20250820'
+          example: '20260506'
       additionalProperties:
         $ref: '#/components/schemas/SupplementalDataResponseAction'
       required:
@@ -16579,7 +16579,7 @@ components:
       properties:
         _version:
           type: string
-          example: '20250820'
+          example: '20260506'
       additionalProperties:
         $ref: '#/components/schemas/PatchedDataSupplementPayloadOneOf'
       required:


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure old NLP data and QA question responses get exported.


### 📖 Description
Fixes a bug wherein older transcripts, translations, and qa question responses were not showing up in exports or the data table.


### 💭 Notes
A previous migration from `qpath`s to `xpath`s was done on the fly, so submission supplements that were not accessed were not updated. However, the `advanced_features` dict of the corresponding assets were updated to have xpaths, and no reference to the old qpaths.

The subsequent migration to the new subsequence version (`20240820`) looked at old submission supplements
to gather `(xpath, action)` pairs to determine what QAFs needed to be created, then used the `advanced_features` dict on the asset to populate the `params` of the new QAF. This led to the creation of QAFs that had a qpath instead of an xpath in `question_xpath` and an empty `params` list.

This PR creates a new schema version for SubmissionSupplements where all qpaths are migrated to xpaths using mappings from the asset. The migration is done as a long-running migration that will update every SubmissionSupplement in the db. Even those that don't have qpaths will be marked with the new schema version just to mark that they have been looked at.

This might be a bit overkill for what is essentially an edge case but we have no good way of querying for how many SubmissionSupplements still have lingering qpaths since it involves looking at a regex on a nested key in a JSON field.  This way we can simply query for any SubmissionSupplements that have the old `_version`.

### 👀 Preview steps
It's a pill to actually get old data to test this, but you can make mock data that reasonably acts like old data. Make sure to start on the release branch so all supplements will have the old version.

1. ℹ️ have an account and a project with an audio question inside a group
2. ℹ️ have at least one submission with a transcript
3. Add a QA question and answer (manual)
4. Open a django shell
5. 
```
asset = Asset.objects.get(uid='<uid>')
for question in asset.content['survey']:
        if '$xpath' in question:
                question['$qpath'] = question['$xpath'].replace('/','-')  # imitate old qpaths
asset.save()

ss = SubmissionSupplement.objects.get(submission_uuid='<uuid>', asset=asset)
ss_content_copy = copy.deepcopy(ss.content)
for key in [ k for k in ss.content.keys() if '/' in k]:
        ss_content_copy[k.replace('/','-')] = copy.deepcopy(ss_content_copy[k])
        del ss_content_copy[k]
ss.content = ss_content_copy
ss.save()
```
6. Export data with all columns
7. 🔴 [on main] notice that the answer to the QA question is missing for your submission
8. Run LRM 24
9. 🟢 [on PR] Should report 1 supplement with old qpaths was updated
10. Export data with all columns
11. 🟢 notice QA answer is now present
