### PR TITLE
refactor(notification): adjust story and add wrapper file

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -214,6 +214,11 @@ const tsConfig = {
           },
           {
             name: '@mantine/core',
+            importNames: ['Notification'],
+            message: "Use Notification from 'jsapp/js/components/common' instead.",
+          },
+          {
+            name: '@mantine/core',
             importNames: ['Select'],
             message: "Use Select from 'jsapp/js/components/common' instead.",
           },

--- a/jsapp/js/components/common/Notification.stories.tsx
+++ b/jsapp/js/components/common/Notification.stories.tsx
@@ -1,12 +1,20 @@
-import { Notification, type NotificationProps } from '@mantine/core'
+import type { MantineSize } from '@mantine/core'
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
-import { IconNames } from '#/k-icons'
-import { recordKeys } from '#/utils'
-import Icon, { type IconSize } from './icon'
+import * as TablerIcons from '@tabler/icons-react'
+import type { TablerIcon } from '@tabler/icons-react'
+import KoboIcon from './KoboIcon'
+import Notification, { type NotificationProps } from './Notification'
+
+const tablerIconEntries = Object.entries(TablerIcons).filter(
+  (entry): entry is [string, TablerIcon] =>
+    entry[0].startsWith('Icon') &&
+    (typeof entry[1] === 'function' || (typeof entry[1] === 'object' && entry[1] !== null)),
+)
+const tablerIconOptions = tablerIconEntries.map(([tablerIconName]) => tablerIconName).sort((a, b) => a.localeCompare(b))
+const tablerIconMapping = Object.fromEntries(tablerIconEntries)
 
 interface NotificationStory extends NotificationProps {
-  iconName: keyof typeof IconNames
-  iconSize: IconSize
+  iconSize: MantineSize
   message: string
 }
 
@@ -18,14 +26,14 @@ const meta: Meta<NotificationStory> = {
       description: 'Text in the notification',
       control: { type: 'text' },
     },
-    iconName: {
-      description: 'Icon to display',
-      options: [undefined, ...recordKeys(IconNames)],
+    icon: {
+      description: 'Tabler icon component rendered via KoboIcon',
+      options: tablerIconOptions,
       control: { type: 'select' },
     },
     iconSize: {
       description: 'Icon size',
-      options: ['xxs', 'xs', 's', 'm', 'l', 'xl'],
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
       control: { type: 'select' },
     },
   },
@@ -39,12 +47,18 @@ type Story = StoryObj<NotificationStory>
 export const Default: Story = {
   args: {
     title: 'Your transcripts are on their way!',
-    iconName: 'check',
-    iconSize: 's',
+    icon: 'IconCheckFilled',
+    iconSize: 'xs',
   },
-  render: (args) => (
-    <Notification {...args} icon={args.iconName ? <Icon name={args.iconName} size={args.iconSize} /> : undefined}>
-      <a href='#'>Click here</a> to monitor your progress or to cancel this job
-    </Notification>
-  ),
+  render: (args) => {
+    const selectedTablerIcon = typeof args.icon === 'string' ? tablerIconMapping[args.icon] : undefined
+    return (
+      <Notification
+        {...args}
+        icon={selectedTablerIcon ? <KoboIcon icon={selectedTablerIcon} size={args.iconSize} /> : undefined}
+      >
+        <a href='#'>Click here</a> to monitor your progress or to cancel this job
+      </Notification>
+    )
+  },
 }

--- a/jsapp/js/components/common/Notification.tsx
+++ b/jsapp/js/components/common/Notification.tsx
@@ -1,0 +1,6 @@
+import { Notification as NotificationMantine } from '@mantine/core'
+import type { NotificationProps as NotificationPropsMantine } from '@mantine/core'
+
+export type NotificationProps = NotificationPropsMantine
+
+export default NotificationMantine

--- a/jsapp/js/theme/kobo/Notification.ts
+++ b/jsapp/js/theme/kobo/Notification.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- This file is the Kobo wrapper around Mantine Notification.
 import { Notification } from '@mantine/core'
 import classes from './Notification.module.css'
 


### PR DESCRIPTION
### 💭 Notes

Changes the story to use new KoboIcon rather than legacy one. Added a common wrapper for Notifiaction and some other tiny cleanups.

### 👀 Preview steps

Open Notifiaction in Storybook.