### PR TITLE
fix(map): blank map for questions in group fix DEV-2093

### DIFF
--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -447,7 +447,9 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
       selectedQuestion = null
     }
 
-    this.setState({ foundSelectedQuestion: selectedQuestion })
+    const selectedQuestionPath = selectedQuestion ? this.nameOfFieldInGroup(selectedQuestion) : null
+
+    this.setState({ foundSelectedQuestion: selectedQuestionPath })
 
     let queryLimit = QUERY_LIMIT_DEFAULT
     if (this.state.overridenStyles?.querylimit) {
@@ -457,8 +459,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     }
 
     const fq = ['_id']
-    if (selectedQuestion) {
-      fq.push(selectedQuestion)
+    if (selectedQuestionPath) {
+      fq.push(selectedQuestionPath)
     }
     if (nextViewBy) {
       fq.push(this.nameOfFieldInGroup(nextViewBy))
@@ -902,7 +904,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   nameOfFieldInGroup(fieldName: string): string {
     if (this.props.asset.content?.survey) {
       const flatPaths = getSurveyFlatPaths(this.props.asset.content.survey)
-      return flatPaths[fieldName]
+      return flatPaths[fieldName] || fieldName
     }
     // Fallback - should never happen
     return fieldName


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at #Support Docs Updates, if any
4. [x] draft PR with a title <type>(<scope>)<!>: <title> DEV-1234
5. [x] assign yourself, tag PR: at least Front end and/or Back end or workflow
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary

Fixed the Project → Data → Map so geopoint answers inside groups are now shown correctly instead of incorrectly showing "No geopoint responses have been received".

### 💭 Notes

Changes here:
- Map component: index.tsx
  - Normalized selected geopoint question names to their flat-path field keys before building the submissions query.
  - Reused the same normalized key when parsing coordinates, so grouped geopoint values are read from the correct submission field.
  - Added a safe fallback in grouped-field path resolution so non-grouped names continue to work as expected.

#7034 fixes that bug on a newer code

### 👀 Preview steps

1. ℹ️ Have an account with access to a deployed project.
2. Create or open a form that has one geopoint question inside a group.
3. Submit at least one response with a valid location for that grouped geopoint question.
4. Open the project and go to Data → Map.
5. 🔴 [on main] Notice the map may say "No geopoint responses have been received".
6. 🟢 [on PR] Notice the location point(s) are displayed on the map.
7. Optional sanity check: open a form with a top-level geopoint (not in a group) and confirm it still displays correctly.