### PR TITLE
fix(subsequences): migrate qpath to xpath in SubmissionSupplements DEV-2094

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -59,7 +59,16 @@ def run(dry_run: bool = False):
                     continue
                 for action_id in actions_for_xpath.keys():
                     if (asset.uid, xpath, action_id) not in existing_qafs:
-                        params = build_params(asset, xpath, action_id)
+                        try:
+                            params = build_params(asset, xpath, action_id)
+                        except ValueError as ve:
+                            print(
+                                f'{logging_prefix} - failed to build params '
+                                f'for {xpath}, {action_id}: {ve}'
+                            )
+                            existing_qafs.add((asset.uid, xpath, action_id))
+                            continue
+
                         if not dry_run:
                             _, created = QuestionAdvancedFeature.objects.get_or_create(
                                 asset=asset,

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -57,7 +57,7 @@ def run(dry_run: bool = False):
         )
         with transaction.atomic():
             for xpath, actions_for_xpath in new_content.items():
-                if xpath == '_version':
+                if not isinstance(actions_for_xpath, dict):
                     continue
                 for action_id in actions_for_xpath.keys():
                     if (asset.uid, xpath, action_id) not in existing_qafs:

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -52,7 +52,7 @@ def run(dry_run: bool = False):
     for supplement in supplements_with_qpaths:
         print(f'{logging_prefix} - updating supplement {migrated+1}/{total}')
         asset = supplement.asset
-        new_content = get_sanitized_dict_keys(supplement.content, supplement.asset)
+        new_content = get_sanitized_dict_keys(logging_prefix, supplement.content, supplement.asset)
         with transaction.atomic():
             for xpath, actions_for_xpath in new_content.items():
                 if xpath == '_version':
@@ -85,7 +85,7 @@ def run(dry_run: bool = False):
     logging.info(f'{logging_prefix} - Done')
 
 
-def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
+def get_sanitized_dict_keys(logging_prefix: str, content_dict: dict, asset: 'Asset') -> dict | None:
     """
     Update `dict_to_update` keys created with `qpath`(if they are present) with
     their `xpath` counterpart.
@@ -95,7 +95,7 @@ def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
         if old_xpath == '_version':
             continue
         if '-' in old_xpath and '/' not in old_xpath:
-            xpath = qpath_to_xpath(old_xpath, asset)
+            xpath = qpath_to_xpath(logging_prefix, old_xpath, asset)
             if xpath == old_xpath:
                 continue
             del updated_dict[old_xpath]
@@ -103,7 +103,7 @@ def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
     return updated_dict
 
 
-def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
+def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'Asset') -> str:
     """
     We have abandoned `qpath` attribute in favor of `xpath`.
     Existing projects may still use it though.
@@ -120,5 +120,5 @@ def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
         if dashed_xpath == qpath:
             return xpath
 
-    logging.warning(f'[LRM 0024] - xpath for qpath {qpath} not found. Keeping as qpath.')
+    print(f'{logging_prefix} - xpath for qpath {qpath} not found. Keeping as qpath.')
     return qpath

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -1,0 +1,124 @@
+from copy import deepcopy
+
+from celery.exceptions import SoftTimeLimitExceeded
+from django.db import transaction
+
+from kobo.apps.long_running_migrations.models import (
+    LongRunningMigration,
+    LongRunningMigrationStatus,
+)
+from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
+from kobo.apps.subsequences.utils.versioning import build_params
+from kpi.utils.log import logging
+
+
+def run(dry_run: bool = False):
+    """
+    Migrate all SubmissionSupplement records that contain qpaths as keys
+    """
+    dry_run_prefix = ' (dry run)' if dry_run else ''
+    logging_prefix = f'[LRM 0024]{dry_run_prefix}'
+    # make sure migration 0023 is done
+    try:
+        previous_migration = LongRunningMigration.objects.get(
+            name='0023_migrate_submission_supplements'
+        )
+    except LongRunningMigration.DoesNotExist:
+        logging.info(f'{logging_prefix} - previous migration not present.')
+        # cheating: force a time limit exceeded error to make celery try again later
+        raise SoftTimeLimitExceeded
+    if previous_migration.status != LongRunningMigrationStatus.COMPLETED:
+        logging.info(f'{logging_prefix} - previous migration not completed.')
+        raise SoftTimeLimitExceeded
+
+    supplements_with_qpaths = SubmissionSupplement.objects.extra(
+        where=[
+            'EXISTS (SELECT 1 from '
+            'jsonb_each_text(subsequences_submissionsupplement.content)'
+            ' e where e.key ~ %s)'
+        ],
+        params=[r'.*-.*'],
+    ).select_related('asset')
+
+    if len(supplements_with_qpaths) == 0:
+        logging.info(f'{logging_prefix} - No more supplements to migrate.')
+        return
+
+    migrated = 0
+    total = supplements_with_qpaths.count()
+    # keep track of asset/xpath/action qafs we've already seen/created
+    existing_qafs: set[tuple[str, str, str]] = set()
+
+    for supplement in supplements_with_qpaths:
+        print(f'{logging_prefix} - updating supplement {migrated+1}/{total}')
+        asset = supplement.asset
+        new_content = get_sanitized_dict_keys(supplement.content, supplement.asset)
+        with transaction.atomic():
+            for xpath, actions_for_xpath in new_content.items():
+                if xpath == '_version':
+                    continue
+                for action_id in actions_for_xpath.keys():
+                    if (asset.uid, xpath, action_id) not in existing_qafs:
+                        params = build_params(asset, xpath, action_id)
+                        if not dry_run:
+                            _, created = QuestionAdvancedFeature.objects.get_or_create(
+                                asset=asset,
+                                question_xpath=xpath,
+                                action=action_id,
+                                defaults={'params': params},
+                            )
+                            if created:
+                                print(
+                                    f'{logging_prefix} - Created QAF asset={asset.uid}'
+                                    f' xpath={xpath} action={action_id}'
+                                )
+                        existing_qafs.add((asset.uid, xpath, action_id))
+            if not dry_run:
+                supplement.content = new_content
+                supplement.save(
+                    update_fields=[
+                        'content',
+                    ]
+                )
+            migrated += 1
+
+    logging.info(f'{logging_prefix} - Done')
+
+
+def get_sanitized_dict_keys(content_dict: dict, asset: 'Asset') -> dict | None:
+    """
+    Update `dict_to_update` keys created with `qpath`(if they are present) with
+    their `xpath` counterpart.
+    """
+    updated_dict = deepcopy(content_dict)
+    for old_xpath, values in content_dict.items():
+        if old_xpath == '_version':
+            continue
+        if '-' in old_xpath and '/' not in old_xpath:
+            xpath = qpath_to_xpath(old_xpath, asset)
+            if xpath == old_xpath:
+                continue
+            del updated_dict[old_xpath]
+            updated_dict[xpath] = values
+    return updated_dict
+
+
+def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
+    """
+    We have abandoned `qpath` attribute in favor of `xpath`.
+    Existing projects may still use it though.
+    We need to find the equivalent `xpath`.
+    """
+    for row in asset.content['survey']:
+        if '$qpath' in row and '$xpath' in row and row['$qpath'] == qpath:
+            return row['$xpath']
+
+    # Could not find it from the survey, let's try to detect it automatically
+    xpaths = asset.get_attachment_xpaths(deployed=True)
+    for xpath in xpaths:
+        dashed_xpath = xpath.replace('/', '-')
+        if dashed_xpath == qpath:
+            return xpath
+
+    logging.warn(f'[LRM 0024] - xpath for qpath {qpath} not found. Keeping as qpath.')
+    return qpath

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -120,5 +120,5 @@ def qpath_to_xpath(qpath: str, asset: 'Asset') -> str:
         if dashed_xpath == qpath:
             return xpath
 
-    logging.warn(f'[LRM 0024] - xpath for qpath {qpath} not found. Keeping as qpath.')
+    logging.warning(f'[LRM 0024] - xpath for qpath {qpath} not found. Keeping as qpath.')
     return qpath

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -40,7 +40,7 @@ def run(dry_run: bool = False):
         params=[r'.*-.*'],
     ).select_related('asset')
 
-    if len(supplements_with_qpaths) == 0:
+    if not supplements_with_qpaths.exists():
         logging.info(f'{logging_prefix} - No more supplements to migrate.')
         return
 
@@ -109,7 +109,7 @@ def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'Asset') -> str:
     Existing projects may still use it though.
     We need to find the equivalent `xpath`.
     """
-    for row in asset.content['survey']:
+    for row in asset.content.get('survey'):
         if '$qpath' in row and '$xpath' in row and row['$qpath'] == qpath:
             return row['$xpath']
 

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -52,7 +52,9 @@ def run(dry_run: bool = False):
     for supplement in supplements_with_qpaths:
         print(f'{logging_prefix} - updating supplement {migrated+1}/{total}')
         asset = supplement.asset
-        new_content = get_sanitized_dict_keys(logging_prefix, supplement.content, supplement.asset)
+        new_content = get_sanitized_dict_keys(
+            logging_prefix, supplement.content, supplement.asset
+        )
         with transaction.atomic():
             for xpath, actions_for_xpath in new_content.items():
                 if xpath == '_version':
@@ -94,7 +96,9 @@ def run(dry_run: bool = False):
     logging.info(f'{logging_prefix} - Done')
 
 
-def get_sanitized_dict_keys(logging_prefix: str, content_dict: dict, asset: 'Asset') -> dict | None:
+def get_sanitized_dict_keys(
+    logging_prefix: str, content_dict: dict, asset: 'kpi.models.Asset'
+) -> dict | None:
     """
     Update `dict_to_update` keys created with `qpath`(if they are present) with
     their `xpath` counterpart.

--- a/kobo/apps/long_running_migrations/migrations/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/migrations/0024_migrate_submission_supplement_qpaths.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.create(
+        name='0024_migrate_submission_supplement_qpaths'
+    )
+
+
+def delete_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.filter(
+        name='0024_migrate_submission_supplement_qpaths'
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0023_migrate_submission_supplements'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, delete_long_running_migration),
+    ]

--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -5,7 +5,10 @@ from django.db.models import Exists, OuterRef
 from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
 from kobo.apps.subsequences.constants import SCHEMA_VERSIONS
 from kobo.apps.subsequences.models import QuestionAdvancedFeature, SubmissionSupplement
-from kobo.apps.subsequences.utils.versioning import migrate_submission_supplementals
+from kobo.apps.subsequences.utils.versioning import (
+    build_params,
+    migrate_submission_supplementals,
+)
 from kpi.models import Asset
 
 CHUNK_SIZE = 500
@@ -197,63 +200,6 @@ class Command(BaseCommand):
             else:
                 self.stdout.write(self.style.WARNING(summary))
 
-    def _build_params(self, asset: Asset, xpath: str, action_id: str) -> list | dict:
-        """
-        Build params for a QuestionAdvancedFeature.
-
-        - manual_qual / automatic_bedrock_qual: extracts question definitions
-          from asset.advanced_features['qual']['qual_survey'].
-        - manual_transcription / automatic_google_transcription: language list
-          from asset.advanced_features['transcript']['languages'].
-        - manual_translation / automatic_google_translation: language list
-          from asset.advanced_features['translation']['languages'].
-        """
-        advanced_features = asset.advanced_features or {}
-
-        if action_id in ('manual_transcription', 'automatic_google_transcription'):
-            languages = advanced_features.get('transcript', {}).get('languages', [])
-            return [{'language': lang} for lang in languages]
-
-        if action_id in ('manual_translation', 'automatic_google_translation'):
-            languages = advanced_features.get('translation', {}).get('languages', [])
-            return [{'language': lang} for lang in languages]
-
-        if action_id in ('manual_qual', 'automatic_bedrock_qual'):
-            qual_survey = advanced_features.get('qual', {}).get('qual_survey', [])
-            # qual_survey items may use 'xpath' (slash) or 'qpath' (dash) as the key
-            questions = [
-                q
-                for q in qual_survey
-                if q.get('xpath') == xpath or q.get('qpath') == xpath
-            ]
-            params = []
-            for q in questions:
-                for required in ('uuid', 'type', 'labels'):
-                    if required not in q:
-                        raise ValueError(
-                            f"qual_survey item missing required field '{required}'"
-                        )
-                entry = {
-                    'uuid': q['uuid'],
-                    'type': QUAL_TYPE_MAP.get(q['type'], q['type']),
-                    'labels': q['labels'],
-                }
-                if 'choices' in q:
-                    entry['choices'] = [
-                        {
-                            k: v
-                            for k, v in c.items()
-                            if k in ('uuid', 'labels', 'options')
-                        }
-                        for c in q['choices']
-                    ]
-                if 'options' in q:
-                    entry['options'] = q['options']
-                params.append(entry)
-            return params
-
-        return {}
-
     def _create_missing_qafs(self, combos: set, dry_run: bool) -> None:
         """
         Create QuestionAdvancedFeature records for (asset_id, xpath, action_id)
@@ -307,7 +253,7 @@ class Command(BaseCommand):
             try:
                 with transaction.atomic():
                     for xpath, action_id in combos_for_asset:
-                        params = self._build_params(asset, xpath, action_id)
+                        params = build_params(asset, xpath, action_id)
                         self.stdout.write(
                             f'  {"[dry-run] " if dry_run else ""}'
                             f'Creating QAF asset={asset.uid}'

--- a/kobo/apps/subsequences/utils/versioning.py
+++ b/kobo/apps/subsequences/utils/versioning.py
@@ -103,6 +103,58 @@ def convert_nlp_params(
     return to_create
 
 
+def build_params(asset: 'kpi.models.Asset', xpath: str, action_id: str) -> list | dict:
+    """
+    Build params for a QuestionAdvancedFeature.
+
+    - manual_qual / automatic_bedrock_qual: extracts question definitions
+      from asset.advanced_features['qual']['qual_survey'].
+    - manual_transcription / automatic_google_transcription: language list
+      from asset.advanced_features['transcript']['languages'].
+    - manual_translation / automatic_google_translation: language list
+      from asset.advanced_features['translation']['languages'].
+    """
+    advanced_features = asset.advanced_features or {}
+
+    if action_id in ('manual_transcription', 'automatic_google_transcription'):
+        languages = advanced_features.get('transcript', {}).get('languages', [])
+        return [{'language': lang} for lang in languages]
+
+    if action_id in ('manual_translation', 'automatic_google_translation'):
+        languages = advanced_features.get('translation', {}).get('languages', [])
+        return [{'language': lang} for lang in languages]
+
+    if action_id in ('manual_qual', 'automatic_bedrock_qual'):
+        qual_survey = advanced_features.get('qual', {}).get('qual_survey', [])
+        # qual_survey items may use 'xpath' (slash) or 'qpath' (dash) as the key
+        questions = [
+            q for q in qual_survey if q.get('xpath') == xpath or q.get('qpath') == xpath
+        ]
+        params = []
+        for q in questions:
+            for required in ('uuid', 'type', 'labels'):
+                if required not in q:
+                    raise ValueError(
+                        f"qual_survey item missing required field '{required}'"
+                    )
+            entry = {
+                'uuid': q['uuid'],
+                'type': OLD_QUESTION_TYPE_TO_NEW.get(q['type'], q['type']),
+                'labels': q['labels'],
+            }
+            if 'choices' in q:
+                entry['choices'] = [
+                    {k: v for k, v in c.items() if k in ('uuid', 'labels', 'options')}
+                    for c in q['choices']
+                ]
+            if 'options' in q:
+                entry['options'] = q['options']
+            params.append(entry)
+        return params
+
+    return {}
+
+
 def migrate_advanced_features(
     asset: 'kpi.models.Asset', save_asset=True
 ) -> dict | None:


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Ensure old NLP data and QA question responses get exported.


### 📖 Description
Fixes a bug wherein older transcripts, translations, and qa question responses were not showing up in exports or the data table.


### 💭 Notes
A previous migration from `qpath`s to `xpath`s was done on the fly, so submission supplements that were not accessed were not updated. However, the `advanced_features` dict of the corresponding assets were updated to have xpaths, and no reference to the old qpaths.

The subsequent migration to the new subsequence version (`20240820`) looked at old submission supplements
to gather `(xpath, action)` pairs to determine what QAFs needed to be created, then used the `advanced_features` dict on the asset to populate the `params` of the new QAF. This led to the creation of QAFs that had a qpath instead of an xpath in `question_xpath` and an empty `params` list.

This PR queries all submission supplements for anything with a hyphen in the question name using `extra` and `rawSQL`. This is because there is no Django-native way of querying for keys in a JSONField that match a particular regex. While this does mean using postgres specific code, it prevents us from having to use a whole new schema version for what is essentially an edge case. 

The PR also creates any missing QAFs that may have not been created if every submission supplement for an asset used the old qpath. For safety, the QAFs are created in an `atomic` block while updating the submission supplement that necessitated them, so if something kills the update mid-process, we will still know they need to be created. We use a simple set to keep track of which QAFs were already created so we don't hit the DB more than necessary.

There is one small risk where we could end up with the migration infinitely in progress:
If there is a submission supplement with a qpath that has no xpath equivalent (ie the question was removed), we just keep the qpath as it is. This means it will be picked up every time we run the initial query to find the supplements that need migrating. If the job keeps getting interrupted and never actually returns, it will be infinitely marked "in progress". However this seems pretty unlikely unless there are lots and lots of submission supplements with deleted questions. Given that there are not that many submission supplements on prod to begin with, the risk seems acceptable. 

### 👀 Preview steps
It's a pill to actually get old data to test this, but you can make mock data that reasonably acts like old data. Make sure to start on the release branch so all supplements will have the old version.

1. ℹ️ have an account and a project with an audio question inside a group
2. ℹ️ have at least one submission with a transcript
3. Add a QA question and answer (manual)
4. Open a django shell
5. 
```
asset = Asset.objects.get(uid='<uid>')
for question in asset.content['survey']:
        if '$xpath' in question:
                question['$qpath'] = question['$xpath'].replace('/','-')  # imitate old qpaths
asset.save()

ss = SubmissionSupplement.objects.get(submission_uuid='<uuid>', asset=asset)
ss_content_copy = copy.deepcopy(ss.content)
for key in [ k for k in ss.content.keys() if '/' in k]:
        ss_content_copy[key.replace('/','-')] = copy.deepcopy(ss_content_copy[key])
        del ss_content_copy[k]
ss.content = ss_content_copy
ss.save()
```
6. Export data with all columns
7. 🔴 [on main] notice that the answer to the QA question is missing for your submission
8. Run LRM 24
9. 🟢 [on PR] Should report 1 supplement with old qpaths was updated
10. Export data with all columns
11. 🟢 notice QA answer is now present
