### PR TITLE
feat(userreports): allow configurable page size for userreport API DEV-2112

### DIFF
--- a/kobo/apps/user_reports/tests/test_user_reports.py
+++ b/kobo/apps/user_reports/tests/test_user_reports.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from allauth.socialaccount.models import SocialAccount
+from constance.test import override_config
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
@@ -454,6 +455,21 @@ class UserReportsViewSetAPITestCase(BaseTestCase):
         self.assertEqual(sub_data['id'], subscription.id)
         self.assertEqual(sub_data['customer'], customer.id)
         self.assertEqual(sub_data['metadata'], {})
+
+    def test_offset_limit_set_by_constance(self):
+        for i in range(20):
+            User.objects.create(username=f'user_{i}')
+        refresh_user_report_snapshots()
+        with override_config(USER_REPORTS_PAGE_SIZE_LIMIT=10):
+            response = self.client.get(f'{self.url}?limit=1')
+            results = response.data['results']
+            assert len(results) == 1
+            response = self.client.get(f'{self.url}')
+            results = response.data['results']
+            assert len(results) == 10
+            response = self.client.get(f'{self.url}?limit=100')
+            results = response.data['results']
+            assert len(results) == 10
 
     def _get_someuser_data(self):
 

--- a/kobo/apps/user_reports/views.py
+++ b/kobo/apps/user_reports/views.py
@@ -9,7 +9,7 @@ from kobo.apps.audit_log.permissions import SuperUserPermission
 from kobo.apps.user_reports.models import UserReports
 from kobo.apps.user_reports.seralizers import UserReportsSerializer
 from kpi.filters import SearchFilter
-from kpi.paginators import NoCountPagination, use_config_limit
+from kpi.paginators import NoCountPagination, use_constance_config_limit
 from kpi.permissions import IsAuthenticated
 from kpi.schema_extensions.v2.user_reports.serializers import UserReportsListResponse
 from kpi.utils.schema_extensions.markdown import read_md
@@ -40,7 +40,7 @@ class UserReportsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     queryset = UserReports.objects.all()
     serializer_class = UserReportsSerializer
-    pagination_class = use_config_limit(NoCountPagination)
+    pagination_class = use_constance_config_limit(NoCountPagination)
     permission_classes = (IsAuthenticated, SuperUserPermission)
     filter_backends = [DjangoFilterBackend, OrderingFilter, SearchFilter]
 

--- a/kobo/apps/user_reports/views.py
+++ b/kobo/apps/user_reports/views.py
@@ -9,7 +9,7 @@ from kobo.apps.audit_log.permissions import SuperUserPermission
 from kobo.apps.user_reports.models import UserReports
 from kobo.apps.user_reports.seralizers import UserReportsSerializer
 from kpi.filters import SearchFilter
-from kpi.paginators import NoCountPagination
+from kpi.paginators import NoCountPagination, use_config_limit
 from kpi.permissions import IsAuthenticated
 from kpi.schema_extensions.v2.user_reports.serializers import UserReportsListResponse
 from kpi.utils.schema_extensions.markdown import read_md
@@ -40,7 +40,7 @@ class UserReportsViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     queryset = UserReports.objects.all()
     serializer_class = UserReportsSerializer
-    pagination_class = NoCountPagination
+    pagination_class = use_config_limit(NoCountPagination)
     permission_classes = (IsAuthenticated, SuperUserPermission)
     filter_backends = [DjangoFilterBackend, OrderingFilter, SearchFilter]
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -673,6 +673,11 @@ CONSTANCE_CONFIG = {
         False,
         'Allow users to delete their own account.',
     ),
+    'USER_REPORTS_PAGE_SIZE_LIMIT': (
+        1000,
+        'Max page size for the user report endpoint',
+        'positive_int',
+    )
 }
 
 CONSTANCE_ADDITIONAL_FIELDS = {
@@ -739,6 +744,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'MASS_EMAIL_ENQUEUED_RECORD_EXPIRY',
         'MASS_EMAIL_TEST_EMAILS',
         'USAGE_LIMIT_ENFORCEMENT',
+        'USER_REPORTS_PAGE_SIZE_LIMIT',
     ),
     'Rest Services': (
         'ALLOW_UNSECURED_HOOK_ENDPOINTS',

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -676,7 +676,7 @@ CONSTANCE_CONFIG = {
     'USER_REPORTS_PAGE_SIZE_LIMIT': (
         1000,
         'Max page size for the user report endpoint',
-        'positive_int',
+        'natural_int',
     )
 }
 
@@ -707,15 +707,9 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'kpi.fields.jsonschema_form_field.MetadataFieldsListField',
         {'widget': 'django.forms.Textarea'},
     ],
-    'positive_int': ['django.forms.fields.IntegerField', {
-        'min_value': 0
-    }],
-    'positive_int_minus_one': ['django.forms.fields.IntegerField', {
-        'min_value': -1
-    }],
-    'positive_int': ['django.forms.fields.IntegerField', {
-        'min_value': 0
-    }],
+    'positive_int': ['django.forms.fields.IntegerField', {'min_value': 0}],
+    'positive_int_minus_one': ['django.forms.fields.IntegerField', {'min_value': -1}],
+    'natural_int': ['django.forms.fields.IntegerField', {'min_value': 1}],
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from typing import Union
 
+from constance import config
 from django.conf import settings
 from django.db.models.query import QuerySet
 from django_request_cache import cache_for_request
@@ -292,3 +293,22 @@ class NoCountPagination(DefaultPagination):
 
         offset = self.offset + self.limit
         return replace_query_param(url, self.offset_query_param, offset)
+
+def custom_max_limit(cls, max_limit):
+    cls.max_limit = max_limit
+    return cls
+
+def use_config_limit(cls):
+    class DynamicPaginator(cls):
+        def __init__(self):
+            max_limit = config.USER_REPORTS_PAGE_SIZE_LIMIT
+            PaginationClass = custom_max_limit(cls, max_limit)
+            self._paginator = PaginationClass()
+
+        def paginate_queryset(self, queryset, request, view=None):
+            return self._paginator.paginate_queryset(queryset, request, view)
+
+        def get_paginated_response(self, data):
+            return self._paginator.get_paginated_response(data)
+
+    return DynamicPaginator

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -294,11 +294,13 @@ class NoCountPagination(DefaultPagination):
         offset = self.offset + self.limit
         return replace_query_param(url, self.offset_query_param, offset)
 
+
 def custom_max_limit(cls, max_limit):
     class NewMaxLimit(cls):
         pass
     NewMaxLimit.max_limit = max_limit
     return NewMaxLimit
+
 
 def use_constance_config_limit(cls):
     class DynamicPaginator(cls):

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -295,8 +295,10 @@ class NoCountPagination(DefaultPagination):
         return replace_query_param(url, self.offset_query_param, offset)
 
 def custom_max_limit(cls, max_limit):
-    cls.max_limit = max_limit
-    return cls
+    class NewMaxLimit(cls):
+        pass
+    NewMaxLimit.max_limit = max_limit
+    return NewMaxLimit
 
 def use_constance_config_limit(cls):
     class DynamicPaginator(cls):

--- a/kpi/paginators.py
+++ b/kpi/paginators.py
@@ -298,7 +298,7 @@ def custom_max_limit(cls, max_limit):
     cls.max_limit = max_limit
     return cls
 
-def use_config_limit(cls):
+def use_constance_config_limit(cls):
     class DynamicPaginator(cls):
         def __init__(self):
             max_limit = config.USER_REPORTS_PAGE_SIZE_LIMIT


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Set the max page size for `/api/v2/user-reports` in Constance.

### Notes
We don't want to make a habit of overriding the max page size, so right now the class factory only looks at a new USER_REPORTS_PAGE_SIZE_LIMIT configuration. If eventually we want to do this on more pages we can genericize the method.


### 👀 Preview steps

1. ℹ️ have several accounts (at least 10)
2. In a Django shell, run `refresh_user_report_snapshots`
3. In Constance, set `USER_REPORTS_PAGE_SIZE_LIMIT` to 5
4. Navigate to `/api/v2/user-reports`
5. 🟢 [on PR] notice that only 5 results are returned
6. Navigate to `/api/v2/user-reports?limit=2`
7. 🟢 [on PR] notice that only 2 results are returned
8. Navigate to `/api/v2/user-reports?limit=10`
9. 🟢 notice only 5 results are returned
