### PR TITLE
fix(subsequences): use correct method for getting xpath DEV-2094

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -127,7 +127,7 @@ def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'kpi.models.Asset') -
             return row['$xpath']
 
     # Could not find it from the survey, let's try to detect it automatically
-    xpaths = asset.get_all_attachment_xpaths(deployed=True)
+    xpaths = asset.get_all_attachment_xpaths()
     for xpath in xpaths:
         dashed_xpath = xpath.replace('/', '-')
         if dashed_xpath == qpath:

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -50,7 +50,7 @@ def run(dry_run: bool = False):
     existing_qafs: set[tuple[str, str, str]] = set()
 
     for supplement in supplements_with_qpaths:
-        print(f'{logging_prefix} - updating supplement {migrated+1}/{total}')
+        logging.info(f'{logging_prefix} - updating supplement {migrated+1}/{total}')
         asset = supplement.asset
         new_content = get_sanitized_dict_keys(
             logging_prefix, supplement.content, supplement.asset
@@ -64,7 +64,7 @@ def run(dry_run: bool = False):
                         try:
                             params = build_params(asset, xpath, action_id)
                         except ValueError as ve:
-                            print(
+                            logging.warning(
                                 f'{logging_prefix} - failed to build params '
                                 f'for {xpath}, {action_id}: {ve}'
                             )
@@ -79,7 +79,7 @@ def run(dry_run: bool = False):
                                 defaults={'params': params},
                             )
                             if created:
-                                print(
+                                logging.info(
                                     f'{logging_prefix} - Created QAF asset={asset.uid}'
                                     f' xpath={xpath} action={action_id}'
                                 )
@@ -116,7 +116,7 @@ def get_sanitized_dict_keys(
     return updated_dict
 
 
-def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'Asset') -> str:
+def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'kpi.models.Asset') -> str:
     """
     We have abandoned `qpath` attribute in favor of `xpath`.
     Existing projects may still use it though.
@@ -127,11 +127,11 @@ def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'Asset') -> str:
             return row['$xpath']
 
     # Could not find it from the survey, let's try to detect it automatically
-    xpaths = asset.get_attachment_xpaths(deployed=True)
+    xpaths = asset.get_all_attachment_xpaths(deployed=True)
     for xpath in xpaths:
         dashed_xpath = xpath.replace('/', '-')
         if dashed_xpath == qpath:
             return xpath
 
-    print(f'{logging_prefix} - xpath for qpath {qpath} not found. Keeping as qpath.')
+    logging.warning(f'{logging_prefix} - xpath for qpath {qpath} not found. Keeping as qpath.')
     return qpath

--- a/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
+++ b/kobo/apps/long_running_migrations/jobs/0024_migrate_submission_supplement_qpaths.py
@@ -133,5 +133,7 @@ def qpath_to_xpath(logging_prefix: str, qpath: str, asset: 'kpi.models.Asset') -
         if dashed_xpath == qpath:
             return xpath
 
-    logging.warning(f'{logging_prefix} - xpath for qpath {qpath} not found. Keeping as qpath.')
+    logging.warning(
+        f'{logging_prefix} ' f'- xpath for qpath {qpath} not found. Keeping as qpath.'
+    )
     return qpath


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug in the previous migration that was causing it to exit with an error.

### 💭 Notes
Also replaces all print statements with log statements for better visibility.


### 👀 Preview steps
It's a pill to actually get old data to test this, but you can make mock data that reasonably acts like old data. Make sure to start on the release branch so all supplements will have the old version.

1. ℹ️ have an account and a project with an audio question inside a group
2. ℹ️ have at least one submission with a transcript
3. Add a QA question and answer (manual)
4. Open a django shell
5. 
```
asset = Asset.objects.get(uid='<uid>')
ss = SubmissionSupplement.objects.get(submission_uuid='<uuid>', asset=asset)
ss_content_copy = copy.deepcopy(ss.content)
for key in [ k for k in ss.content.keys() if '/' in k]:
        ss_content_copy[key.replace('/','-')] = copy.deepcopy(ss_content_copy[key])
        del ss_content_copy[key]
ss.content = ss_content_copy
ss.save()
```
8. Run LRM 24
9. 🟢 [on release] Fails with an AttributeError
11. 🟢 [on PR] migration succeeds

