### PR TITLE
fix(superuserStats): fix mixed-type Concat error in reports DEV-2128, DEV-2129

### DIFF
--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -95,7 +95,13 @@ def generate_continued_usage_report(output_filename: str, end_date: str):
         )
         submissions_count = MonthlyXFormSubmissionCounter.objects.annotate(
             date=Cast(
-                Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
+                Concat(
+                    Cast(F('year'), output_field=CharField()),
+                    Value('-'),
+                    Cast(F('month'), output_field=CharField()),
+                    Value('-'),
+                    Value('1'),
+                ),
                 DateField(),
             )
         ).filter(
@@ -184,7 +190,13 @@ def generate_domain_report(output_filename: str, start_date: str, end_date: str)
         domain: (
             MonthlyXFormSubmissionCounter.objects.annotate(
                 date=Cast(
-                    Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
+                    Concat(
+                        Cast(F('year'), output_field=CharField()),
+                        Value('-'),
+                        Cast(F('month'), output_field=CharField()),
+                        Value('-'),
+                        Value('1'),
+                    ),
                     DateField(),
                 )
             )
@@ -409,7 +421,13 @@ def generate_user_statistics_report(
     records = (
         MonthlyXFormSubmissionCounter.objects.annotate(
             date=Cast(
-                Concat(F('year'), Value('-'), F('month'), Value('-'), 1),
+                Concat(
+                    Cast(F('year'), output_field=CharField()),
+                    Value('-'),
+                    Cast(F('month'), output_field=CharField()),
+                    Value('-'),
+                    Value('1'),
+                ),
                 DateField(),
             )
         )

--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -504,7 +504,7 @@ def generate_user_statistics_report(
         'Forms Count',
         'Deployments Count',
         'Google ASR Seconds',
-        'Google MT Seconds',
+        'Google MT Characters',
     ]
 
     with default_storage.open(output_filename, 'w') as output:

--- a/kobo/apps/superuser_stats/tests/test_tasks.py
+++ b/kobo/apps/superuser_stats/tests/test_tasks.py
@@ -8,6 +8,7 @@ from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models import MonthlyXFormSubmissionCounter
+from kpi.tests.utils import baker_generators  # noqa: F401 registers KpiUidField gen.
 from kobo.apps.superuser_stats.tasks import (
     generate_continued_usage_report,
     generate_domain_report,
@@ -131,7 +132,7 @@ class GenerateReportsTestCase(TestCase):
             'Forms Count',
             'Deployments Count',
             'Google ASR Seconds',
-            'Google MT Seconds',
+            'Google MT Characters',
         ]
 
     def test_generate_user_statistics_report_aggregates(self):
@@ -173,8 +174,8 @@ class GenerateReportsTestCase(TestCase):
         assert data_row[8] == '20'  # submissions count
         assert data_row[9] == '1'  # forms count
         assert data_row[10] == '1'  # deployments count
-        assert data_row[11] == '300'  # google ASR seconds
-        assert data_row[12] == '1500'  # google MT characters
+        assert data_row[11] == '300'   # 'Google ASR Seconds'
+        assert data_row[12] == '1500'  # 'Google MT Seconds'
 
     def test_generate_user_statistics_report_no_nlp_counters(self):
         user = baker.make(User, email='charlie@test.com')
@@ -224,12 +225,19 @@ class GenerateReportsTestCase(TestCase):
         assert 'diana' in usernames
 
     def _run_task_and_get_rows(self, task_func, *args):
-        buf = io.StringIO()
-        cm = MagicMock()
-        cm.__enter__.return_value = buf
-        cm.__exit__.return_value = False
+        buffers = []
+
+        def _open(*a, **kw):
+            buf = io.StringIO()
+            buffers.append(buf)
+            cm = MagicMock()
+            cm.__enter__.return_value = buf
+            cm.__exit__.return_value = False
+            return cm
+
         with patch('kobo.apps.superuser_stats.tasks.default_storage') as mock_storage:
-            mock_storage.open.return_value = cm
+            mock_storage.open.side_effect = _open
             task_func('output.csv', *args)
-        buf.seek(0)
-        return list(csv.reader(buf))
+
+        buffers[0].seek(0)
+        return list(csv.reader(buffers[0]))

--- a/kobo/apps/superuser_stats/tests/test_tasks.py
+++ b/kobo/apps/superuser_stats/tests/test_tasks.py
@@ -1,0 +1,223 @@
+import csv
+import io
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from model_bakery import baker
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.utils import baker_generators  # noqa: registers KpiUidField generator
+from kobo.apps.openrosa.apps.logger.models import MonthlyXFormSubmissionCounter
+from kobo.apps.superuser_stats.tasks import (
+    generate_continued_usage_report,
+    generate_domain_report,
+    generate_user_report,
+    generate_user_statistics_report,
+)
+from kobo.apps.trackers.models import NLPUsageCounter
+from kpi.constants import ASSET_TYPE_SURVEY
+from kpi.models.asset import Asset, AssetDeploymentStatus
+
+START_DATE = '2025-01-01'
+END_DATE = '2025-12-31'
+
+
+class GenerateReportsTestCase(TestCase):
+
+    # ------------------------------------------------------------------ #
+    # generate_domain_report                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_generate_domain_report_headers(self):
+        rows = self._run_task_and_get_rows(
+            generate_domain_report, START_DATE, END_DATE
+        )
+        assert rows[0] == ['Email Domain', 'Users', 'Projects', 'Submissions']
+
+    def test_generate_domain_report_aggregates(self):
+        user = baker.make(
+            User,
+            email='alice@example.com',
+            date_joined=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        )
+        baker.make(
+            MonthlyXFormSubmissionCounter,
+            year=2025,
+            month=6,
+            user=user,
+            counter=42,
+            xform=None,
+        )
+        baker.make(
+            Asset,
+            owner=user,
+            asset_type=ASSET_TYPE_SURVEY,
+            date_created=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        )
+
+        rows = self._run_task_and_get_rows(
+            generate_domain_report, START_DATE, END_DATE
+        )
+
+        domain_row = next(r for r in rows[1:] if r[0] == 'example.com')
+        assert domain_row[1] == '1'    # 1 user
+        assert domain_row[2] == '1'    # 1 asset
+        assert domain_row[3] == '42'   # 42 submissions
+
+    def test_generate_domain_report_excludes_out_of_range_users(self):
+        baker.make(
+            User,
+            email='old@example.com',
+            date_joined=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rows = self._run_task_and_get_rows(
+            generate_domain_report, START_DATE, END_DATE
+        )
+
+        domains = [r[0] for r in rows[1:]]
+        assert 'example.com' not in domains
+
+    # ------------------------------------------------------------------ #
+    # generate_continued_usage_report                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_generate_continued_usage_report_headers(self):
+        rows = self._run_task_and_get_rows(
+            generate_continued_usage_report, END_DATE
+        )
+        assert rows[0] == [
+            'Username', 'Date Joined', 'Last Login',
+            'Assets 3m', 'Assets 6m', 'Assets 12m',
+            'Submissions 3m', 'Submissions 6m', 'Submissions 12M',
+        ]
+
+    def test_generate_continued_usage_report_aggregates(self):
+        user = baker.make(
+            User,
+            last_login=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        )
+        baker.make(
+            MonthlyXFormSubmissionCounter,
+            year=2025,
+            month=6,
+            user=user,
+            counter=15,
+            xform=None,
+        )
+
+        rows = self._run_task_and_get_rows(
+            generate_continued_usage_report, END_DATE
+        )
+
+        data_row = next(r for r in rows[1:] if r[0] == user.username)
+        # 2025-06 falls within the 12-month window ending 2025-12-31
+        assert data_row[8] == '15'
+
+    # ------------------------------------------------------------------ #
+    # generate_user_statistics_report                                      #
+    # ------------------------------------------------------------------ #
+
+    def test_generate_user_statistics_report_headers(self):
+        rows = self._run_task_and_get_rows(
+            generate_user_statistics_report, START_DATE, END_DATE
+        )
+        assert rows[0] == [
+            'Username', 'Name', 'Date Joined', 'Email',
+            'Organization Type', 'Organization', 'Organization Website',
+            'Country', 'Submissions Count', 'Forms Count',
+            'Deployments Count', 'Google ASR Seconds', 'Google MT Seconds',
+        ]
+
+    def test_generate_user_statistics_report_aggregates(self):
+        user = baker.make(User, email='bob@test.com')
+        baker.make(
+            MonthlyXFormSubmissionCounter,
+            year=2025,
+            month=6,
+            user=user,
+            counter=20,
+            xform=None,
+        )
+        baker.make(
+            NLPUsageCounter,
+            date=date(2025, 6, 15),
+            user=user,
+            asset=None,
+            counters={
+                'google_asr_seconds': 300,
+                'google_mt_characters': 1500,
+            },
+        )
+        asset = baker.make(
+            Asset,
+            owner=user,
+            asset_type=ASSET_TYPE_SURVEY,
+            date_created=datetime(2025, 6, 1, tzinfo=timezone.utc),
+        )
+        # bypass set_deployment_status() which runs on save()
+        Asset.objects.filter(pk=asset.pk).update(
+            _deployment_status=AssetDeploymentStatus.DEPLOYED
+        )
+
+        rows = self._run_task_and_get_rows(
+            generate_user_statistics_report, START_DATE, END_DATE
+        )
+
+        data_row = next(r for r in rows[1:] if r[0] == user.username)
+        assert data_row[8] == '20'    # submissions count
+        assert data_row[9] == '1'     # forms count
+        assert data_row[10] == '1'    # deployments count
+        assert data_row[11] == '300'  # google ASR seconds
+        assert data_row[12] == '1500' # google MT characters
+
+    def test_generate_user_statistics_report_no_nlp_counters(self):
+        user = baker.make(User, email='charlie@test.com')
+        baker.make(
+            MonthlyXFormSubmissionCounter,
+            year=2025,
+            month=3,
+            user=user,
+            counter=5,
+            xform=None,
+        )
+
+        rows = self._run_task_and_get_rows(
+            generate_user_statistics_report, START_DATE, END_DATE
+        )
+
+        data_row = next(r for r in rows[1:] if r[0] == user.username)
+        assert data_row[11] == '0'  # google ASR fallback
+        assert data_row[12] == '0'  # google MT fallback
+
+    # ------------------------------------------------------------------ #
+    # generate_user_report                                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_generate_user_report_headers(self):
+        rows = self._run_task_and_get_rows(generate_user_report)
+        assert rows[0] == [
+            'username', 'email', 'pk', 'first_name', 'last_name',
+            'name', 'organization', 'XForm count',
+            'num_of_submissions', 'date_joined', 'last_login',
+        ]
+
+    def test_generate_user_report_includes_user(self):
+        _ = baker.make(User, username='diana', email='diana@test.com')
+
+        rows = self._run_task_and_get_rows(generate_user_report)
+
+        usernames = [r[0] for r in rows[1:]]
+        assert 'diana' in usernames
+
+    def _run_task_and_get_rows(self, task_func, *args):
+        buf = io.StringIO()
+        cm = MagicMock()
+        cm.__enter__.return_value = buf
+        cm.__exit__.return_value = False
+        with patch('kobo.apps.superuser_stats.tasks.default_storage') as mock_storage:
+            mock_storage.open.return_value = cm
+            task_func('output.csv', *args)
+        buf.seek(0)
+        return list(csv.reader(buf))

--- a/kobo/apps/superuser_stats/tests/test_tasks.py
+++ b/kobo/apps/superuser_stats/tests/test_tasks.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kpi.tests.utils import baker_generators  # noqa: registers KpiUidField generator
 from kobo.apps.openrosa.apps.logger.models import MonthlyXFormSubmissionCounter
 from kobo.apps.superuser_stats.tasks import (
     generate_continued_usage_report,
@@ -30,9 +29,7 @@ class GenerateReportsTestCase(TestCase):
     # ------------------------------------------------------------------ #
 
     def test_generate_domain_report_headers(self):
-        rows = self._run_task_and_get_rows(
-            generate_domain_report, START_DATE, END_DATE
-        )
+        rows = self._run_task_and_get_rows(generate_domain_report, START_DATE, END_DATE)
         assert rows[0] == ['Email Domain', 'Users', 'Projects', 'Submissions']
 
     def test_generate_domain_report_aggregates(self):
@@ -56,14 +53,12 @@ class GenerateReportsTestCase(TestCase):
             date_created=datetime(2025, 6, 1, tzinfo=timezone.utc),
         )
 
-        rows = self._run_task_and_get_rows(
-            generate_domain_report, START_DATE, END_DATE
-        )
+        rows = self._run_task_and_get_rows(generate_domain_report, START_DATE, END_DATE)
 
         domain_row = next(r for r in rows[1:] if r[0] == 'example.com')
-        assert domain_row[1] == '1'    # 1 user
-        assert domain_row[2] == '1'    # 1 asset
-        assert domain_row[3] == '42'   # 42 submissions
+        assert domain_row[1] == '1'  # 1 user
+        assert domain_row[2] == '1'  # 1 asset
+        assert domain_row[3] == '42'  # 42 submissions
 
     def test_generate_domain_report_excludes_out_of_range_users(self):
         baker.make(
@@ -72,9 +67,7 @@ class GenerateReportsTestCase(TestCase):
             date_joined=datetime(2020, 1, 1, tzinfo=timezone.utc),
         )
 
-        rows = self._run_task_and_get_rows(
-            generate_domain_report, START_DATE, END_DATE
-        )
+        rows = self._run_task_and_get_rows(generate_domain_report, START_DATE, END_DATE)
 
         domains = [r[0] for r in rows[1:]]
         assert 'example.com' not in domains
@@ -84,13 +77,17 @@ class GenerateReportsTestCase(TestCase):
     # ------------------------------------------------------------------ #
 
     def test_generate_continued_usage_report_headers(self):
-        rows = self._run_task_and_get_rows(
-            generate_continued_usage_report, END_DATE
-        )
+        rows = self._run_task_and_get_rows(generate_continued_usage_report, END_DATE)
         assert rows[0] == [
-            'Username', 'Date Joined', 'Last Login',
-            'Assets 3m', 'Assets 6m', 'Assets 12m',
-            'Submissions 3m', 'Submissions 6m', 'Submissions 12M',
+            'Username',
+            'Date Joined',
+            'Last Login',
+            'Assets 3m',
+            'Assets 6m',
+            'Assets 12m',
+            'Submissions 3m',
+            'Submissions 6m',
+            'Submissions 12M',
         ]
 
     def test_generate_continued_usage_report_aggregates(self):
@@ -107,9 +104,7 @@ class GenerateReportsTestCase(TestCase):
             xform=None,
         )
 
-        rows = self._run_task_and_get_rows(
-            generate_continued_usage_report, END_DATE
-        )
+        rows = self._run_task_and_get_rows(generate_continued_usage_report, END_DATE)
 
         data_row = next(r for r in rows[1:] if r[0] == user.username)
         # 2025-06 falls within the 12-month window ending 2025-12-31
@@ -124,10 +119,19 @@ class GenerateReportsTestCase(TestCase):
             generate_user_statistics_report, START_DATE, END_DATE
         )
         assert rows[0] == [
-            'Username', 'Name', 'Date Joined', 'Email',
-            'Organization Type', 'Organization', 'Organization Website',
-            'Country', 'Submissions Count', 'Forms Count',
-            'Deployments Count', 'Google ASR Seconds', 'Google MT Seconds',
+            'Username',
+            'Name',
+            'Date Joined',
+            'Email',
+            'Organization Type',
+            'Organization',
+            'Organization Website',
+            'Country',
+            'Submissions Count',
+            'Forms Count',
+            'Deployments Count',
+            'Google ASR Seconds',
+            'Google MT Seconds',
         ]
 
     def test_generate_user_statistics_report_aggregates(self):
@@ -166,11 +170,11 @@ class GenerateReportsTestCase(TestCase):
         )
 
         data_row = next(r for r in rows[1:] if r[0] == user.username)
-        assert data_row[8] == '20'    # submissions count
-        assert data_row[9] == '1'     # forms count
-        assert data_row[10] == '1'    # deployments count
+        assert data_row[8] == '20'  # submissions count
+        assert data_row[9] == '1'  # forms count
+        assert data_row[10] == '1'  # deployments count
         assert data_row[11] == '300'  # google ASR seconds
-        assert data_row[12] == '1500' # google MT characters
+        assert data_row[12] == '1500'  # google MT characters
 
     def test_generate_user_statistics_report_no_nlp_counters(self):
         user = baker.make(User, email='charlie@test.com')
@@ -198,9 +202,17 @@ class GenerateReportsTestCase(TestCase):
     def test_generate_user_report_headers(self):
         rows = self._run_task_and_get_rows(generate_user_report)
         assert rows[0] == [
-            'username', 'email', 'pk', 'first_name', 'last_name',
-            'name', 'organization', 'XForm count',
-            'num_of_submissions', 'date_joined', 'last_login',
+            'username',
+            'email',
+            'pk',
+            'first_name',
+            'last_name',
+            'name',
+            'organization',
+            'XForm count',
+            'num_of_submissions',
+            'date_joined',
+            'last_login',
         ]
 
     def test_generate_user_report_includes_user(self):


### PR DESCRIPTION
### 📣 Summary

Admin report generation was failing with a Django ORM error, preventing CSV exports from being downloaded.

### 💭 Notes

Django 4.2+ requires all expressions inside `Concat` to have the same `output_field`. `MonthlyXFormSubmissionCounter.year` and `.month` are `IntegerField`s, which conflicted with the `Value('-')` `CharField` separators.

Fix: wrap `F('year')` and `F('month')` with `Cast(..., output_field=CharField())` in all three report tasks that use this pattern:
- `generate_domain_report`
- `generate_continued_usage_report`
- `generate_user_statistics_report`

Also adds a new test suite (`kobo/apps/superuser_stats/tests/test_tasks.py`) covering all four report generation tasks, including regression tests for the Concat issue and NLP counter aggregation fallback.

Note: `_deployment_status` is computed by `set_deployment_status()` on `save()`, so tests that require a deployed status use `Asset.objects.filter(...).update(...)` to bypass the model method.

### 👀 Preview steps

1. ℹ️ Have a superuser account on an instance with submission data
2. Go to `/superuser_stats/reports/`
3. 🔴 [on main] Generating any of the domain, continued-usage, or user-statistics reports raises a 500 / task error with "Expression contains mixed types: CharField, IntegerField"
4. 🟢 [on PR] Reports generate and download successfully