### PR TITLE
fix(formbuilder): force select2 compatibility with jquery DEV-2134

### DIFF
--- a/jsapp/js/main.js
+++ b/jsapp/js/main.js
@@ -30,7 +30,7 @@ window.$ = window.jQuery = $
 // TODO: remove when select2 is replaced.
 $.isArray = Array.isArray
 $.isFunction = (value) => typeof value === 'function'
-$.trim = (value) => (value == null ? '' : String.prototype.trim.call(value))
+$.trim = (value) => (value == null ? '' : (value + '').trim())
 import React from 'react'
 
 import * as Sentry from '@sentry/react'

--- a/jsapp/js/main.js
+++ b/jsapp/js/main.js
@@ -26,6 +26,11 @@ import $ from 'jquery'
 // jQuery v4 ESM no longer auto-populates window.$/window.jQuery
 // The xlform/Backbone layer reads these globals directly, so we must assign them.
 window.$ = window.jQuery = $
+// jQuery 4 removed $.isArray, $.isFunction, and $.trim. Polyfill for select2 3.x compatibility.
+// TODO: remove when select2 is replaced.
+$.isArray = Array.isArray
+$.isFunction = (value) => typeof value === 'function'
+$.trim = (value) => (value == null ? '' : String.prototype.trim.call(value))
 import React from 'react'
 
 import * as Sentry from '@sentry/react'


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes incompatibility between outdated select2 dependency and jquery v4 via polyfills

### 💭 Notes
Bumping jquery to v4 (#7015) broke the select2 component we use in formbuilder. Select2 is an abandoned dependency we will most likely be stuck with until we rewrite the formbuilder. As such, our choices seem to be: Don't upgrade jquery or add a hack to keep select2 working. I went with the latter, but I'm open to other approaches.

### 👀 Preview steps
1. In formbuilder, try to open "settings" for an individual question 
2. 🔴 [on main] It errors and does nothing
3. 🟢 [on PR] Settings view opens and the tags and appearance selects in "question options" and dropdowns under "skip logic" work correctly.  