### PR TITLE
fix(CI): switch all automatic uses npm install to npm ci DEV-2118

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -38,11 +38,11 @@ jobs:
         run: npm run copy-fonts
 
       # Cache miss: If node_modules has not been cached,
-      #             `npm install`
+      #             `npm ci`
       #   (This includes `npm run copy-fonts` as post-install step)
-      - name: Install JavaScript dependencies (npm install)
+      - name: Install JavaScript dependencies (npm ci)
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       # Check for Biome formatting errors
       - name: Check Biome formatting, import order and linter

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -59,11 +59,11 @@ jobs:
         run: npm run copy-fonts
 
       # Cache miss: If node_modules has not been cached,
-      #             `npm install`
+      #             `npm ci`
       #   (This includes `npm run copy-fonts` as post-install step)
-      - name: Install JavaScript dependencies (npm install)
+      - name: Install JavaScript dependencies (npm ci)
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       # Ensure node_modules/.cache (used by Storybook) is empty
       - name: >

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -123,11 +123,11 @@ jobs:
         run: npm run copy-fonts
 
       # Cache miss: If node_modules has not been cached,
-      #             `npm install`
+      #             `npm ci`
       #   (This includes `npm run copy-fonts` as post-install step)
-      - name: Install JavaScript dependencies (npm install)
+      - name: Install JavaScript dependencies (npm ci)
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
       # Check for TypeScript errors
       - name: Generate react-query helpers with Orval

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -72,7 +72,7 @@ if [[ ! -d "${KPI_SRC_DIR}/staticfiles" ]] || ! python "${KPI_SRC_DIR}/docker/ch
 
         echo "Syncing \`npm\` packages…"
         if ( ! check-dependencies ); then
-            npm install --quiet > /dev/null 2>&1
+            npm ci --quiet > /dev/null 2>&1
         else
             npm run postinstall > /dev/null 2>&1
         fi

--- a/docker/webpack-dev-server.sh
+++ b/docker/webpack-dev-server.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# 
+#
 #   Convenience script. Start the webpack dev server
 #   in a temporary container from the host:
-# 
+#
 #     ./kobo-install/run.py -cf run --rm --publish 3000:3000 \
 #         kpi bash ./docker/webpack-dev-server.sh
 #
-#   This should launch successfully even if `node_modules` 
+#   This should launch successfully even if `node_modules`
 #   is removed from the built image.
 #
 set -e
-(check-dependencies || npm install) && npm run watch
+(check-dependencies || npm ci) && npm run watch

--- a/scripts/ci_locally.sh
+++ b/scripts/ci_locally.sh
@@ -62,7 +62,7 @@ echo -e '\n\n### Step: Install system dependencies for playwright'
 npx playwright install-deps
 
 echo -e '\n\n### Step: Install JavaScript dependencies'
-npm install
+npm ci
 git diff
 git diff-index --exit-code HEAD # Fail on uncommitted package-lock.json changes
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] delete this section before merging

### 📣 Summary
Switch all automated uses of `npm install` to `npm ci` to ensure version consistency and security.

### 💭 Notes
npm ci installs strictly from package-lock.json without resolving ranges or modifying the lockfile, whereas npm install can silently pull in newer patch/minor versions that weren't tested. This closes the gap between what developers test locally and what CI/Docker builds install.

Note: the global npm install for check-dependencies in Dockerfile is intentionally left as-is — npm ci cannot install a single package by git URL. Hopefully we will remove that old dependency at some point.
