### PR TITLE
fix(constance): isolate cache backend to avoid rolling deploy collisions DEV-2148

### DIFF
--- a/hub/migrations/0019_clear_constance_cache.py
+++ b/hub/migrations/0019_clear_constance_cache.py
@@ -5,13 +5,17 @@ from django.core.cache import caches
 
 def clear_constance_cache(apps, schema_editor):
     """
-    Clears all constance-related keys from the Django cache.
+    Clears all constance-related keys from the isolated constance cache backend.
 
-    When upgrading from a version that used a custom constance backend with a
-    broken get() method, the cache (Redis) may contain raw JSON strings instead
-    of decoded Python objects. This migration forces a full cache invalidation
-    so that constance repopulates from the database with correctly decoded
-    values on the next access.
+    Starting with this release, constance uses a dedicated cache backend
+    ('constance') with KEY_PREFIX='constance_4x' instead of the shared
+    'default' backend. This isolates constance cache keys from old workers
+    during rolling deploys, preventing cross-format deserialization errors
+    between constance 3.x and 4.x serialization formats.
+
+    This migration wipes the new namespace so that constance repopulates from
+    the database on first access, guaranteeing no stale data from a previous
+    deployment is served.
     """
     try:
         cache_backend_name = constance_settings.DATABASE_CACHE_BACKEND
@@ -21,6 +25,9 @@ def clear_constance_cache(apps, schema_editor):
         cache = caches[cache_backend_name]
         prefix = constance_settings.DATABASE_PREFIX
         keys = [f'{prefix}{key}' for key in constance_settings.CONFIG]
+        # 'autofilled' is a sentinel Constance sets after bulk-loading all keys
+        # from the DB into cache. Without clearing it, Constance would skip the
+        # autofill and never repopulate the individual keys we just deleted.
         keys.append(f'{prefix}autofilled')
         cache.delete_many(keys)
     except Exception:

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -806,7 +806,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
 
 # Tell django-constance to use a database model instead of Redis
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
-CONSTANCE_DATABASE_CACHE_BACKEND = 'default'
+CONSTANCE_DATABASE_CACHE_BACKEND = 'constance'
 
 
 # Warn developers to use `pytest` instead of `./manage.py test`
@@ -2007,6 +2007,12 @@ CACHES = {
     'enketo_redis_main': env.cache_url(
         'ENKETO_REDIS_MAIN_URL', default='redis://change-me.invalid/0'
     ),
+    # Isolated backend for Constance with a versioned key prefix to prevent
+    # cache format collisions between old and new workers during rolling deploys.
+    'constance': {
+        **env.cache_url(default='redis://change-me.invalid:6380/3'),
+        'KEY_PREFIX': 'constance_4x',
+    },
 }
 
 # How long to retain cached responses for kpi endpoints


### PR DESCRIPTION
### 📣 Summary

Fixes Constance 4.x upgrade cache key conflicts.

### 📖 Description

During a rolling deploy, old uWSGI workers (constance 3.x) and new workers (constance 4.x) coexist briefly and share the same Redis cache. Their serialization formats are incompatible, causing deserialization errors.

Fixes this by adding a dedicated constance cache backend with `KEY_PREFIX='constance_4x'`, isolating each worker generation into its own Redis namespace. 

### 💭 Notes

- Adds a dedicated `constance` cache backend with `KEY_PREFIX='constance_4x'` so each worker generation writes to its own Redis namespace.
- Migration `hub/0019` flushes the new namespace on deploy so constance repopulates from the database on first access.

### 👀 Preview steps

#### Prerequisites

- Apply the kobo-docker diff below to your local docker-compose.frontend.yml and docker-compose.frontend.override.yml.
- Build and start the app with this branch at least once so kobo-docker is running with a 2.026.13 image and the kpi service is available.
- Then bring the database to a ≤ 2.026.12 state before running the test, using one of two approaches:

- Option A — Restore a DB backup from ≤ 2.026.12
Restore a snapshot taken before migrations hub/0019 and hub/0020 were applied. Existing users and constance config are preserved.

- Option B — Full reset (start fresh)
Wipe the database and let the kpi_202612 container (2.026.12 image) apply all migrations from scratch. You will need to recreate users manually afterward (e.g. via createsuperuser).

<details>
<summary>kobo-docker diff</summary>

```diff
diff --git a/docker-compose.frontend.yml b/docker-compose.frontend.yml
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -36,6 +36,14 @@ x-anchors:
       kobo-fe-network:
 
 services:
+
+  kpi_202612:
+    <<: *django
+    networks:
+      kobo-fe-network:
+        aliases:
+          - kpi-202612.docker.container
+          - kpi-202612.internal
   kpi:
     <<: *django

diff --git a/docker-compose.frontend.override.yml b/docker-compose.frontend.override.yml
--- a/docker-compose.frontend.override.yml
+++ b/docker-compose.frontend.override.yml
@@ -1,6 +1,36 @@
 # For public, HTTPS servers.
 
 services:
+  kpi_202612:
+    image: kobotoolbox/kpi:2.026.12i
+    environment:
+      - UWSGI_WORKERS_COUNT=4
+      - UWSGI_CHEAPER_WORKERS_COUNT=2
+      - UWSGI_MAX_REQUESTS=1024
+      - UWSGI_CHEAPER_RSS_LIMIT_SOFT=1073741824
+      - UWSGI_HARAKIRI=120
+      - UWSGI_WORKER_RELOAD_MERCY=120
+      - WSGI=runserver_plus
+      - DJANGO_SETTINGS_MODULE=kobo.settings.dev
+    extra_hosts:
+      - kf.kobo.localhost:<ip.of.your.host>
+      - kc.kobo.localhost:<ip.of.your.host>
+      - ee.kobo.localhost:<ip.of.your.host>
+    ports:
+      - 8000:8000
+    networks:
+      kobo-be-network:
+        aliases:
+          - kpi.2.026.12
+          - kpi.2.026.12.docker.container
+
   kpi:
     build: ../kpi
```

</details>

#### Steps

**1. Start the old worker only** (constance 3.x — foreground, watch for errors):

```sh
./run.py -cf up kpi_202612
```

**2. Populate the constance 3.x cache** — in a separate terminal, poll `/me/` to warm the Redis cache with constance 3.x keys. All responses must be `200`:

```sh
while true; do
  echo -n "$(date +%H:%M:%S) → "
  curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Token <your-dev-token>" \
    "http://kf.kobo.localhost:8000/me/"
  sleep 0.5
done
```

**3. Start the new worker** (constance 4.x, this branch) while the polling script keeps running. Do **not** use `--force-recreate`:
```sh
./run.py -cf up -d
```
The polling script must keep returning `200` throughout the transition — no
`500` errors during the rolling restart.

**4. Validate in Redis** — connect to the cache DB and confirm the two namespaces coexist without overlap:
```sh
redis-cli -a $REDIS_PASSWORD -p 6380 -n 5
```

```
KEYS :1:USER_METADATA_FIELDS          # constance 3.x — old worker
KEYS constance_4x:1:USER_METADATA_FIELDS  # constance 4.x — new worker
```

Both keys must be present. The serialized values will be visually different
(different pickle structures), confirming each worker writes to its own
namespace without corrupting the other.