### PR TITLE
fix(languages): correct Orval-generated types for language services fields and LanguagesListParams DEV-2142 DEV-2143

### DIFF
--- a/jsapp/js/api/models/language.ts
+++ b/jsapp/js/api/models/language.ts
@@ -10,8 +10,8 @@ The endpoints are grouped by area of intended use. Each category contains relate
 **General note**: All projects (whether deployed or draft), as well as all library content (questions, blocks, templates, and collections) in the user-facing application are represented in the API as "assets".
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
-import type { LanguageTranscriptionServicesItem } from './languageTranscriptionServicesItem'
-import type { LanguageTranslationServicesItem } from './languageTranslationServicesItem'
+import type { LanguageTranscriptionServices } from './languageTranscriptionServices'
+import type { LanguageTranslationServices } from './languageTranslationServices'
 
 export interface Language {
   /** @maxLength 200 */
@@ -19,7 +19,7 @@ export interface Language {
   /** @maxLength 10 */
   code: string
   featured?: boolean
-  readonly transcription_services: readonly LanguageTranscriptionServicesItem[]
-  readonly translation_services: readonly LanguageTranslationServicesItem[]
+  readonly transcription_services: LanguageTranscriptionServices
+  readonly translation_services: LanguageTranslationServices
   regions: LanguageRegion[]
 }

--- a/jsapp/js/api/models/languageTranscriptionServices.ts
+++ b/jsapp/js/api/models/languageTranscriptionServices.ts
@@ -10,4 +10,4 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type LanguageTranscriptionServices = { [key: string]: unknown }
+export type LanguageTranscriptionServices = { [key: string]: { [key: string]: string } }

--- a/jsapp/js/api/models/languageTranscriptionServices.ts
+++ b/jsapp/js/api/models/languageTranscriptionServices.ts
@@ -10,7 +10,4 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type LanguageTranslationServicesItem = {
-  code?: string
-  name?: string
-}
+export type LanguageTranscriptionServices = { [key: string]: unknown }

--- a/jsapp/js/api/models/languageTranslationServices.ts
+++ b/jsapp/js/api/models/languageTranslationServices.ts
@@ -10,4 +10,4 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type LanguageTranslationServices = { [key: string]: unknown }
+export type LanguageTranslationServices = { [key: string]: { [key: string]: string } }

--- a/jsapp/js/api/models/languageTranslationServices.ts
+++ b/jsapp/js/api/models/languageTranslationServices.ts
@@ -10,7 +10,4 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export type LanguageTranscriptionServicesItem = {
-  code?: string
-  name?: string
-}
+export type LanguageTranslationServices = { [key: string]: unknown }

--- a/jsapp/js/api/models/languagesListParams.ts
+++ b/jsapp/js/api/models/languagesListParams.ts
@@ -20,6 +20,10 @@ export type LanguagesListParams = {
    */
   offset?: number
   /**
+   * Search languages by name or code
+   */
+  q?: string
+  /**
    * The initial index from which to return the results. Use with `limit`.
    */
   start?: number

--- a/kobo/apps/languages/schema_extensions/v2/languages/extensions.py
+++ b/kobo/apps/languages/schema_extensions/v2/languages/extensions.py
@@ -32,3 +32,16 @@ class ServicesFieldExtension(OpenApiSerializerFieldExtension):
                 }
             )
         )
+
+
+class ServicesDetailFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = (
+        'kobo.apps.languages.schema_extensions.v2.languages.fields.ServicesDetailField'
+    )
+
+    def map_serializer_field(self, auto_schema, direction):
+        return build_object_type(
+            additional_properties=build_object_type(
+                additional_properties=build_basic_type(OpenApiTypes.STR)
+            )
+        )

--- a/kobo/apps/languages/schema_extensions/v2/languages/extensions.py
+++ b/kobo/apps/languages/schema_extensions/v2/languages/extensions.py
@@ -41,7 +41,7 @@ class ServicesDetailFieldExtension(OpenApiSerializerFieldExtension):
 
     def map_serializer_field(self, auto_schema, direction):
         return build_object_type(
-            additional_properties=build_object_type(
-                additional_properties=build_basic_type(OpenApiTypes.STR)
+            additionalProperties=build_object_type(
+                additionalProperties=build_basic_type(OpenApiTypes.STR)
             )
         )

--- a/kobo/apps/languages/schema_extensions/v2/languages/fields.py
+++ b/kobo/apps/languages/schema_extensions/v2/languages/fields.py
@@ -5,5 +5,9 @@ class ServicesField(serializers.JSONField):
     pass
 
 
+class ServicesDetailField(serializers.JSONField):
+    pass
+
+
 class LanguageUrlField(serializers.URLField):
     pass

--- a/kobo/apps/languages/serializers/language.py
+++ b/kobo/apps/languages/serializers/language.py
@@ -3,7 +3,11 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from ..models.language import Language, LanguageRegion
-from ..schema_extensions.v2.languages.fields import LanguageUrlField, ServicesField
+from ..schema_extensions.v2.languages.fields import (
+    LanguageUrlField,
+    ServicesDetailField,
+    ServicesField
+)
 from .transcription import (
     TranscriptionServiceLanguageM2MSerializer,
     TranscriptionServiceSerializer,
@@ -46,7 +50,7 @@ class LanguageSerializer(serializers.ModelSerializer):
             'regions',
         )
 
-    @extend_schema_field(ServicesField)
+    @extend_schema_field(ServicesDetailField)
     def get_transcription_services(self, language):
         return TranscriptionServiceLanguageM2MSerializer(
             language.transcription_services.through.objects.select_related(
@@ -55,7 +59,7 @@ class LanguageSerializer(serializers.ModelSerializer):
             many=True,
         ).data
 
-    @extend_schema_field(ServicesField)
+    @extend_schema_field(ServicesDetailField)
     def get_translation_services(self, language):
         return TranslationServiceLanguageM2MSerializer(
             language.translation_services.through.objects.select_related(

--- a/kobo/apps/languages/views/language.py
+++ b/kobo/apps/languages/views/language.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 from collections import defaultdict
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 
 from kpi.utils.schema_extensions.markdown import read_md
 from kpi.utils.schema_extensions.response import open_api_200_ok_response
@@ -16,6 +17,15 @@ from .base import BaseViewSet
 @extend_schema_view(
     list=extend_schema(
         description=read_md('languages', 'languages/list.md'),
+        parameters=[
+            OpenApiParameter(
+                name='q',
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description='Search languages by name or code',
+            ),
+        ],
         responses=open_api_200_ok_response(
             LanguageListSerializer,
             raise_not_found=False,

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -11192,6 +11192,14 @@
                         }
                     },
                     {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Search languages by name or code"
+                    },
+                    {
                         "name": "start",
                         "required": false,
                         "in": "query",
@@ -25135,31 +25143,21 @@
                         "type": "boolean"
                     },
                     "transcription_services": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additional_properties": {
                             "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
+                            "additional_properties": {
+                                "type": "string"
                             }
                         },
                         "readOnly": true
                     },
                     "translation_services": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additional_properties": {
                             "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
+                            "additional_properties": {
+                                "type": "string"
                             }
                         },
                         "readOnly": true

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -25144,9 +25144,9 @@
                     },
                     "transcription_services": {
                         "type": "object",
-                        "additional_properties": {
+                        "additionalProperties": {
                             "type": "object",
-                            "additional_properties": {
+                            "additionalProperties": {
                                 "type": "string"
                             }
                         },
@@ -25154,9 +25154,9 @@
                     },
                     "translation_services": {
                         "type": "object",
-                        "additional_properties": {
+                        "additionalProperties": {
                             "type": "object",
-                            "additional_properties": {
+                            "additionalProperties": {
                                 "type": "string"
                             }
                         },

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -8113,6 +8113,11 @@ paths:
         description: Deprecated alias of `start`.
         schema:
           type: integer
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: Search languages by name or code
       - name: start
         required: false
         in: query
@@ -17851,24 +17856,18 @@ components:
         featured:
           type: boolean
         transcription_services:
-          type: array
-          items:
+          type: object
+          additional_properties:
             type: object
-            properties:
-              code:
-                type: string
-              name:
-                type: string
+            additional_properties:
+              type: string
           readOnly: true
         translation_services:
-          type: array
-          items:
+          type: object
+          additional_properties:
             type: object
-            properties:
-              code:
-                type: string
-              name:
-                type: string
+            additional_properties:
+              type: string
           readOnly: true
         regions:
           type: array

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -17857,16 +17857,16 @@ components:
           type: boolean
         transcription_services:
           type: object
-          additional_properties:
+          additionalProperties:
             type: object
-            additional_properties:
+            additionalProperties:
               type: string
           readOnly: true
         translation_services:
           type: object
-          additional_properties:
+          additionalProperties:
             type: object
-            additional_properties:
+            additionalProperties:
               type: string
           readOnly: true
         regions:


### PR DESCRIPTION
### 📣 Summary
This PR corrects two OpenAPI schema inaccuracies in the language endpoints that caused incorrect Orval-generated TypeScript types for the frontend.

### 📖 Description
This PR addresses two schema issues reported by the frontend against the language API endpoints.

**Issue 1: Incorrect schema for `transcription_services` / `translation_services` on the retrieve endpoint**

The list (`/api/v2/languages/`) and retrieve (`/api/v2/languages/{code}/`) endpoints return different shapes for the services fields, but both serializers were annotated with the same `@extend_schema_field(ServicesField)`, causing drf-spectacular to emit one schema for both, which matched only the list endpoint. This led Orval to generate an incorrect array type for the retrieve endpoint's response.

This is resolved by introducing a dedicated `ServicesDetailField` marker class and a corresponding `ServicesDetailFieldExtension` that emits the correct nested-object schema (`{ [serviceCode]: { [regionCode]: string } }`). 

`LanguageSerializer` (retrieve) is updated to use `ServicesDetailField`, while `LanguageListSerializer` (list) continues to use the existing `ServicesField`.

**Issue 2: Missing `q` query parameter in `LanguagesListParams`**

The `LanguageViewSet` relied on `BaseViewSet`'s `SearchFilter` backend to handle the `q` parameter at runtime, but drf-spectacular requires explicit `OpenApiParameter` declarations to include query params in the schema. As a result, `q` was absent from the generated `LanguagesListParams` type, forcing the frontend to cast hook calls with `as any`. This is resolved by adding an explicit `OpenApiParameter(name='q', ...)` declaration to the `list` action schema, consistent with the pattern already used in `TranscriptionServiceViewSet`.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

Check `/api/v2/docs` for the languages endpoints.
