### PR TITLE
refactor(libraryAssetForm): remove mixins DEV-2126

### DIFF
--- a/jsapp/js/components/modalForms/libraryAssetForm.js
+++ b/jsapp/js/components/modalForms/libraryAssetForm.js
@@ -3,8 +3,6 @@ import React from 'react'
 import clonedeep from 'lodash.clonedeep'
 import { when } from 'mobx'
 import autoBind from 'react-autobind'
-import reactMixin from 'react-mixin'
-import Reflux from 'reflux'
 import { actions } from '#/actions'
 import assetUtils from '#/assetUtils'
 import bem from '#/bem'
@@ -17,9 +15,9 @@ import managedCollectionsStore from '#/components/library/managedCollectionsStor
 import ExtraProjectMetadataFields from '#/components/modalForms/extraProjectMetadataFields'
 import { ASSET_TYPES } from '#/constants'
 import envStore from '#/envStore'
-import mixins from '#/mixins'
 import pageState from '#/pageState.store'
 import { withRouter } from '#/router/legacy'
+import { getRouteAssetUid, isAnyLibraryRoute } from '#/router/routerUtils'
 import sessionStore from '#/stores/session'
 import { notify } from '#/utils'
 import ModalBackButton from './ModalBackButton'
@@ -143,8 +141,9 @@ export class LibraryAssetFormComponent extends React.Component {
         tag_string: this.state.fields.tags,
       }
 
-      if (this.isLibrarySingle() && params.asset_type !== ASSET_TYPES.collection.id) {
-        const found = managedCollectionsStore.find(this.currentAssetID())
+      const currentAssetUid = getRouteAssetUid()
+      if (currentAssetUid && isAnyLibraryRoute() && params.asset_type !== ASSET_TYPES.collection.id) {
+        const found = managedCollectionsStore.find(currentAssetUid)
         if (found && found.asset_type === ASSET_TYPES.collection.id) {
           // when creating from within a collection page, make the new asset
           // a child of this collection
@@ -288,8 +287,5 @@ export class LibraryAssetFormComponent extends React.Component {
     )
   }
 }
-
-reactMixin(LibraryAssetFormComponent.prototype, Reflux.ListenerMixin)
-reactMixin(LibraryAssetFormComponent.prototype, mixins.contextRouter)
 
 export const LibraryAssetForm = withRouter(LibraryAssetFormComponent)


### PR DESCRIPTION
### 💭 Notes

Tiny cleanup for `libraryAssetForm.js` - stop using the deprecated `contextRouter` mixin, and drop a Reflux listener mixin that wasn't doing anything.

Changes here:

- `jsapp/js/components/modalForms/libraryAssetForm.js`
  - Removed `reactMixin(..., mixins.contextRouter)`. The only two methods it provided to this component were `this.isLibrarySingle()` and `this.currentAssetID()`, both of which are thin wrappers around `routerUtils`. Replaced them at the one call site with `isAnyLibraryRoute()` + `getRouteAssetUid()` from `#/router/routerUtils`, reusing the uid for both the guard and the `managedCollectionsStore.find(...)` call so we don't read the route twice.
  - Removed `reactMixin(..., Reflux.ListenerMixin)`. The component already manages its own `this.unlisteners` array and never calls `this.listenTo` / `this.stopListeningToAll`, so the mixin was effectively dead weight.
  - Dropped the now-unused `reactMixin`, `Reflux`, and `mixins` imports.

No behavior changes — same code path, same guard, same store lookup, just without the inheritance gymnastics. Reviewer should find this boring in the best way.

This is 1st part of preparation for actual DEV-2126 fix.

### 👀 Preview steps

1. ℹ️ have an account
2. go to **Library**
3. open a collection (so you're on a "library single" page)
4. click **NEW** → **Template** to open the create-template modal
5. fill in a name and hit **Create**
6. 🟢 notice the new template lands inside the collection you were viewing (parent relationship still works)
7. go back to **Library** root (not inside any collection)
8. click **NEW** → **Template**, create one
9. 🟢 notice it lands at the library root, not parented to anything
10. for good measure: edit an existing template's details and save
11. 🟢 notice it saves and the modal closes as before