### PR TITLE
feat(auth): handle SCIM reactivation logic DEV-1683

### DIFF
--- a/kobo/apps/kobo_scim/constants.py
+++ b/kobo/apps/kobo_scim/constants.py
@@ -1,0 +1,8 @@
+SCIM_SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User'
+SCIM_SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+SCIM_SCHEMA_ERROR = 'urn:ietf:params:scim:api:messages:2.0:Error'
+SCIM_SCHEMA_LIST_RESPONSE = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
+SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG = 'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'
+SCIM_SCHEMA_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema'
+SCIM_SCHEMA_RESOURCE_TYPE = 'urn:ietf:params:scim:schemas:core:2.0:ResourceType'
+SCIM_SCHEMA_PATCH_OP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'

--- a/kobo/apps/kobo_scim/constants.py
+++ b/kobo/apps/kobo_scim/constants.py
@@ -2,7 +2,9 @@ SCIM_SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User'
 SCIM_SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group'
 SCIM_SCHEMA_ERROR = 'urn:ietf:params:scim:api:messages:2.0:Error'
 SCIM_SCHEMA_LIST_RESPONSE = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
-SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG = 'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'
+SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG = (
+    'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'
+)
 SCIM_SCHEMA_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema'
 SCIM_SCHEMA_RESOURCE_TYPE = 'urn:ietf:params:scim:schemas:core:2.0:ResourceType'
 SCIM_SCHEMA_PATCH_OP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'

--- a/kobo/apps/kobo_scim/pagination.py
+++ b/kobo/apps/kobo_scim/pagination.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 
-from kpi.paginators import DefaultPagination
 from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_LIST_RESPONSE
+from kpi.paginators import DefaultPagination
 
 
 class ScimPagination(DefaultPagination):

--- a/kobo/apps/kobo_scim/pagination.py
+++ b/kobo/apps/kobo_scim/pagination.py
@@ -1,6 +1,7 @@
 from rest_framework.response import Response
 
 from kpi.paginators import DefaultPagination
+from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_LIST_RESPONSE
 
 
 class ScimPagination(DefaultPagination):
@@ -34,7 +35,7 @@ class ScimPagination(DefaultPagination):
 
         return Response(
             {
-                'schemas': ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+                'schemas': [SCIM_SCHEMA_LIST_RESPONSE],
                 'totalResults': self.count,
                 'itemsPerPage': len(data),
                 'startIndex': start_index,
@@ -56,7 +57,7 @@ class ScimPagination(DefaultPagination):
                 'schemas': {
                     'type': 'array',
                     'items': {'type': 'string'},
-                    'example': ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+                    'example': [SCIM_SCHEMA_LIST_RESPONSE],
                 },
                 'totalResults': {'type': 'integer', 'example': 100},
                 'itemsPerPage': {'type': 'integer', 'example': 10},

--- a/kobo/apps/kobo_scim/schema_extensions/v2/generic/serializers.py
+++ b/kobo/apps/kobo_scim/schema_extensions/v2/generic/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_ERROR
+
 
 class ScimErrorSerializer(serializers.Serializer):
     """
@@ -8,7 +10,7 @@ class ScimErrorSerializer(serializers.Serializer):
 
     schemas = serializers.ListField(
         child=serializers.CharField(),
-        default=['urn:ietf:params:scim:api:messages:2.0:Error'],
+        default=[SCIM_SCHEMA_ERROR],
     )
     detail = serializers.CharField(
         help_text='A detailed, human-readable message.'

--- a/kobo/apps/kobo_scim/serializers.py
+++ b/kobo/apps/kobo_scim/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_GROUP, SCIM_SCHEMA_USER
 from kobo.apps.kobo_scim.models import ScimGroup
 
 
@@ -26,7 +27,7 @@ class ScimUserSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.ANY)
     def get_schemas(self, obj):
-        return ['urn:ietf:params:scim:schemas:core:2.0:User']
+        return [SCIM_SCHEMA_USER]
 
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_name(self, obj):
@@ -88,7 +89,7 @@ class ScimGroupSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.ANY)
     def get_schemas(self, obj):
-        return ['urn:ietf:params:scim:schemas:core:2.0:Group']
+        return [SCIM_SCHEMA_GROUP]
 
     @extend_schema_field(OpenApiTypes.ANY)
     def get_members(self, obj):

--- a/kobo/apps/kobo_scim/tests/test_scim_groups_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_groups_api.py
@@ -4,6 +4,11 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.kobo_scim.constants import (
+    SCIM_SCHEMA_GROUP,
+    SCIM_SCHEMA_PATCH_OP,
+    SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG,
+)
 from kobo.apps.kobo_scim.models import IdentityProvider, ScimGroup
 
 
@@ -74,7 +79,7 @@ class ScimGroupsAPITests(APITestCase):
 
         data = response.json()
         self.assertIn(
-            'urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig',
+            SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG,
             data['schemas'],
         )
         self.assertTrue(data['patch']['supported'])
@@ -89,7 +94,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            'schemas': [SCIM_SCHEMA_GROUP],
             'displayName': 'Engineers',
             'externalId': 'sys-eng-group-id',
             'members': [
@@ -180,7 +185,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            'schemas': [SCIM_SCHEMA_GROUP],
             'displayName': 'New Name',
             'externalId': 'new-id',
             'members': [{'value': str(self.user2.id)}],  # Replacing user1 with user2
@@ -208,7 +213,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
                 {
                     'op': 'add',
@@ -242,7 +247,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
                 {
                     'op': 'add',
@@ -273,7 +278,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
                 {
                     'op': 'remove',
@@ -303,7 +308,7 @@ class ScimGroupsAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
                 {'op': 'remove', 'path': f'members[value eq "{self.user2.id}"]'}
             ],

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -6,6 +6,11 @@ from rest_framework.test import APITestCase
 from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import AuditLog
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.kobo_scim.constants import (
+    SCIM_SCHEMA_LIST_RESPONSE,
+    SCIM_SCHEMA_PATCH_OP,
+    SCIM_SCHEMA_USER,
+)
 from kobo.apps.kobo_scim.models import IdentityProvider
 
 
@@ -90,7 +95,7 @@ class ScimUsersAPITests(APITestCase):
         data = response.json()
 
         self.assertIn(
-            'urn:ietf:params:scim:api:messages:2.0:ListResponse', data['schemas']
+            SCIM_SCHEMA_LIST_RESPONSE, data['schemas']
         )
         self.assertEqual(data['totalResults'], 2)
         self.assertEqual(data['itemsPerPage'], 2)
@@ -111,7 +116,7 @@ class ScimUsersAPITests(APITestCase):
     def test_create_user_success(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'schemas': [SCIM_SCHEMA_USER],
             'userName': 'newscimuser',
             'name': {'givenName': 'New', 'familyName': 'Scim'},
             'emails': [
@@ -156,7 +161,7 @@ class ScimUsersAPITests(APITestCase):
         # Note: Not linked to SocialAccount yet!
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'schemas': [SCIM_SCHEMA_USER],
             'userName': 'idp_username',
             'emails': [{'primary': True, 'value': 'existing_match@example.com'}],
             'active': True,
@@ -189,7 +194,7 @@ class ScimUsersAPITests(APITestCase):
         )
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'schemas': [SCIM_SCHEMA_USER],
             'userName': 'rejoined_user',
             'emails': [{'primary': True, 'value': 'rejoined@example.com'}],
             'active': True,
@@ -227,7 +232,7 @@ class ScimUsersAPITests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertIn('urn:ietf:params:scim:schemas:core:2.0:User', data['schemas'])
+        self.assertIn(SCIM_SCHEMA_USER, data['schemas'])
         self.assertEqual(data['userName'], 'jdoe')
         self.assertEqual(data['active'], True)
 
@@ -387,7 +392,7 @@ class ScimUsersAPITests(APITestCase):
         )
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [{'op': 'replace', 'path': 'active', 'value': False}],
         }
 
@@ -412,7 +417,7 @@ class ScimUsersAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
                 {'op': 'replace', 'path': 'name.familyName', 'value': 'Smith'}
             ],
@@ -525,17 +530,17 @@ class ScimUsersAPITests(APITestCase):
 
         # Setup: james01 (SSO linked), james02 (password auth), james03 (password auth)
         james01 = User.objects.create_user(
-            username='james01', email='james@nrc.org', is_active=True
+            username='james01', email='james@test.org', is_active=True
         )
         SocialAccount.objects.create(
             user=james01, provider=self.social_app.provider_id, uid='james-sso-uid'
         )
 
         james02 = User.objects.create_user(
-            username='james02', email='james@nrc.org', is_active=True
+            username='james02', email='james@test.org', is_active=True
         )
         james03 = User.objects.create_user(
-            username='james03', email='james@nrc.org', is_active=True
+            username='james03', email='james@test.org', is_active=True
         )
 
         # Should deactivate all 3
@@ -553,7 +558,7 @@ class ScimUsersAPITests(APITestCase):
 
         # Reactivate via PATCH
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [{'op': 'replace', 'path': 'active', 'value': True}],
         }
         response = self.client.patch(
@@ -576,24 +581,24 @@ class ScimUsersAPITests(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         james01 = User.objects.create_user(
-            username='james01', email='james@nrc.org', is_active=False
+            username='james01', email='james@test.org', is_active=False
         )
         SocialAccount.objects.create(
             user=james01, provider=self.social_app.provider_id, uid='james-sso-uid-post'
         )
 
         james02 = User.objects.create_user(
-            username='james02', email='james@nrc.org', is_active=False
+            username='james02', email='james@test.org', is_active=False
         )
         james03 = User.objects.create_user(
-            username='james03', email='james@nrc.org', is_active=False
+            username='james03', email='james@test.org', is_active=False
         )
 
         # Reprovision via POST
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'schemas': [SCIM_SCHEMA_USER],
             'userName': 'james01',
-            'emails': [{'primary': True, 'value': 'james@nrc.org'}],
+            'emails': [{'primary': True, 'value': 'james@test.org'}],
             'active': True,
             'externalId': 'james-sso-uid-post',
         }

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -94,9 +94,7 @@ class ScimUsersAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        self.assertIn(
-            SCIM_SCHEMA_LIST_RESPONSE, data['schemas']
-        )
+        self.assertIn(SCIM_SCHEMA_LIST_RESPONSE, data['schemas'])
         self.assertEqual(data['totalResults'], 2)
         self.assertEqual(data['itemsPerPage'], 2)
         self.assertEqual(data['startIndex'], 1)
@@ -523,7 +521,7 @@ class ScimUsersAPITests(APITestCase):
     def test_reactivation_only_enables_sso_linked_accounts(self):
         """
         Verify that when a user is reactivated via SCIM, only the accounts linked to
-        an SSO provider are reactivated. Password-auth accounts with the same email 
+        an SSO provider are reactivated. Password-auth accounts with the same email
         remain disabled.
         """
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -514,3 +514,101 @@ class ScimUsersAPITests(APITestCase):
 
         self.user1.refresh_from_db()
         self.assertFalse(self.user1.is_active)
+
+    def test_reactivation_only_enables_sso_linked_accounts(self):
+        """
+        Verify that when a user is reactivated via SCIM, only the accounts linked to
+        an SSO provider are reactivated. Password-auth accounts with the same email 
+        remain disabled.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
+
+        # Setup: james01 (SSO linked), james02 (password auth), james03 (password auth)
+        james01 = User.objects.create_user(
+            username='james01', email='james@nrc.org', is_active=True
+        )
+        SocialAccount.objects.create(
+            user=james01, provider=self.social_app.provider_id, uid='james-sso-uid'
+        )
+
+        james02 = User.objects.create_user(
+            username='james02', email='james@nrc.org', is_active=True
+        )
+        james03 = User.objects.create_user(
+            username='james03', email='james@nrc.org', is_active=True
+        )
+
+        # Should deactivate all 3
+        response = self.client.delete(
+            f'{self.url}/{james01.id}', HTTP_ACCEPT='application/scim+json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        james01.refresh_from_db()
+        james02.refresh_from_db()
+        james03.refresh_from_db()
+        self.assertFalse(james01.is_active)
+        self.assertFalse(james02.is_active)
+        self.assertFalse(james03.is_active)
+
+        # Reactivate via PATCH
+        payload = {
+            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations': [{'op': 'replace', 'path': 'active', 'value': True}],
+        }
+        response = self.client.patch(
+            f'{self.url}/{james01.id}',
+            payload,
+            format='json',
+            HTTP_ACCEPT='application/scim+json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        james01.refresh_from_db()
+        james02.refresh_from_db()
+        james03.refresh_from_db()
+
+        self.assertTrue(james01.is_active)
+        self.assertFalse(james02.is_active)
+        self.assertFalse(james03.is_active)
+
+    def test_reprovisioning_reactivates_sso_linked_accounts_only(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
+
+        james01 = User.objects.create_user(
+            username='james01', email='james@nrc.org', is_active=False
+        )
+        SocialAccount.objects.create(
+            user=james01, provider=self.social_app.provider_id, uid='james-sso-uid-post'
+        )
+
+        james02 = User.objects.create_user(
+            username='james02', email='james@nrc.org', is_active=False
+        )
+        james03 = User.objects.create_user(
+            username='james03', email='james@nrc.org', is_active=False
+        )
+
+        # Reprovision via POST
+        payload = {
+            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+            'userName': 'james01',
+            'emails': [{'primary': True, 'value': 'james@nrc.org'}],
+            'active': True,
+            'externalId': 'james-sso-uid-post',
+        }
+        response = self.client.post(
+            self.url,
+            payload,
+            format='json',
+            HTTP_ACCEPT='application/scim+json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        james01.refresh_from_db()
+        james02.refresh_from_db()
+        james03.refresh_from_db()
+
+        self.assertTrue(james01.is_active)
+        self.assertFalse(james02.is_active)
+        self.assertFalse(james03.is_active)

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -542,6 +542,12 @@ class ScimUsersAPITests(APITestCase):
         james03 = User.objects.create_user(
             username='james03', email='james@test.org', is_active=True
         )
+        james04 = User.objects.create_user(
+            username='james04', email='james@test.org', is_active=True
+        )
+        SocialAccount.objects.create(
+            user=james04, provider='other-provider-id', uid='james-other-uid'
+        )
 
         # Should deactivate all 3
         response = self.client.delete(
@@ -552,9 +558,11 @@ class ScimUsersAPITests(APITestCase):
         james01.refresh_from_db()
         james02.refresh_from_db()
         james03.refresh_from_db()
+        james04.refresh_from_db()
         self.assertFalse(james01.is_active)
         self.assertFalse(james02.is_active)
         self.assertFalse(james03.is_active)
+        self.assertFalse(james04.is_active)
 
         # Reactivate via PATCH
         payload = {
@@ -572,10 +580,12 @@ class ScimUsersAPITests(APITestCase):
         james01.refresh_from_db()
         james02.refresh_from_db()
         james03.refresh_from_db()
+        james04.refresh_from_db()
 
         self.assertTrue(james01.is_active)
         self.assertFalse(james02.is_active)
         self.assertFalse(james03.is_active)
+        self.assertFalse(james04.is_active)
 
     def test_reprovisioning_reactivates_sso_linked_accounts_only(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
@@ -592,6 +602,12 @@ class ScimUsersAPITests(APITestCase):
         )
         james03 = User.objects.create_user(
             username='james03', email='james@test.org', is_active=False
+        )
+        james04 = User.objects.create_user(
+            username='james04', email='james@test.org', is_active=False
+        )
+        SocialAccount.objects.create(
+            user=james04, provider='other-provider-post', uid='james-other-uid-post'
         )
 
         # Reprovision via POST
@@ -613,7 +629,9 @@ class ScimUsersAPITests(APITestCase):
         james01.refresh_from_db()
         james02.refresh_from_db()
         james03.refresh_from_db()
+        james04.refresh_from_db()
 
         self.assertTrue(james01.is_active)
         self.assertFalse(james02.is_active)
         self.assertFalse(james03.is_active)
+        self.assertFalse(james04.is_active)

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -633,3 +633,28 @@ class ScimUsersAPITests(APITestCase):
         self.assertFalse(james02.is_active)
         self.assertFalse(james03.is_active)
         self.assertFalse(james04.is_active)
+
+    def test_reactivation_of_user_without_email_works(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
+        no_email_user = User.objects.create_user(
+            username='noemailuser', email='', is_active=False
+        )
+        SocialAccount.objects.create(
+            user=no_email_user, provider=self.social_app.provider_id, uid='no-email-uid'
+        )
+
+        # Reactivate via PATCH
+        payload = {
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
+            'Operations': [{'op': 'replace', 'path': 'active', 'value': True}],
+        }
+        response = self.client.patch(
+            f'{self.url}/{no_email_user.id}',
+            payload,
+            format='json',
+            HTTP_ACCEPT='application/scim+json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        no_email_user.refresh_from_db()
+        self.assertTrue(no_email_user.is_active)

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -1,5 +1,5 @@
-import re
 import json
+import re
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
@@ -190,9 +190,7 @@ class ScimUserViewSet(
             with transaction.atomic():
                 # First, check if user exists via SocialAccount linkage
                 social_account = (
-                    SocialAccount.objects.filter(
-                        provider=self.idp_provider_id, uid=uid
-                    )
+                    SocialAccount.objects.filter(provider=self.idp_provider_id, uid=uid)
                     .select_related('user')
                     .first()
                 )
@@ -305,9 +303,7 @@ class ScimUserViewSet(
 
         # Only include users that are linked to this IdP's SocialApp.
         if self.idp.social_app:
-            queryset = queryset.filter(
-                socialaccount__provider=self.idp_provider_id
-            )
+            queryset = queryset.filter(socialaccount__provider=self.idp_provider_id)
         else:
             # If the IdP doesn't have a SocialApp, it can't be mapped to any users
             return User.objects.none()
@@ -494,9 +490,7 @@ class ScimSchemasView(APIView):
                     'description': 'User Account',
                     'meta': {
                         'resourceType': 'Schema',
-                        'location': (
-                            f'{location}/{SCIM_SCHEMA_USER}'
-                        ),
+                        'location': (f'{location}/{SCIM_SCHEMA_USER}'),
                     },
                     'attributes': [
                         {
@@ -608,9 +602,7 @@ class ScimSchemasView(APIView):
                     'description': 'Group',
                     'meta': {
                         'resourceType': 'Schema',
-                        'location': (
-                            f'{location}/{SCIM_SCHEMA_GROUP}'
-                        ),
+                        'location': (f'{location}/{SCIM_SCHEMA_GROUP}'),
                     },
                     'attributes': [
                         {

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -282,11 +282,11 @@ class ScimUserViewSet(
     def _reactivate_sso_linked_accounts(self, email, current_user=None):
         # Handle users with the same email:
         if email:
-            targets = User.objects.filter(email__iexact=email, is_active=False)
-            if self.idp_provider_id:
-                targets = targets.filter(socialaccount__provider=self.idp_provider_id)
-            else:
-                targets = targets.filter(socialaccount__isnull=False)
+            targets = User.objects.filter(
+                email__iexact=email, 
+                is_active=False, 
+                socialaccount__provider=self.idp_provider_id
+            )
             
             for target in targets:
                 target.is_active = True

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -4,6 +4,7 @@ import json
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.db import IntegrityError, transaction
+from django.utils.functional import cached_property
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -127,6 +128,16 @@ class ScimUserViewSet(
     parser_classes = [SCIMParser, JSONParser]
     renderer_classes = [SCIMRenderer]
 
+    @cached_property
+    def idp(self):
+        return getattr(self.request, 'auth', None)
+
+    @cached_property
+    def idp_provider_id(self):
+        if self.idp and self.idp.social_app:
+            return self.idp.social_app.provider_id
+        return None
+
     @extend_schema(
         responses=scim_responses(
             {
@@ -140,8 +151,7 @@ class ScimUserViewSet(
         """
         Handle POST requests (user provisioning from IdP).
         """
-        idp = request.auth
-        if not idp or not idp.social_app:
+        if not self.idp or not self.idp.social_app:
             return Response(
                 {'detail': 'IdP not configured for user provisioning'},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -181,7 +191,7 @@ class ScimUserViewSet(
                 # First, check if user exists via SocialAccount linkage
                 social_account = (
                     SocialAccount.objects.filter(
-                        provider=idp.social_app.provider_id, uid=uid
+                        provider=self.idp_provider_id, uid=uid
                     )
                     .select_related('user')
                     .first()
@@ -215,12 +225,11 @@ class ScimUserViewSet(
                 # We catch IntegrityError here just in case another IdP already
                 # has this exact uid linked.
                 SocialAccount.objects.get_or_create(
-                    user=user, provider=idp.social_app.provider_id, uid=uid
+                    user=user, provider=self.idp_provider_id, uid=uid
                 )
 
                 if data.get('active', True):
-                    provider_id = idp.social_app.provider_id if idp.social_app else None
-                    self._reactivate_sso_linked_accounts(user.email, provider_id, user)
+                    self._reactivate_sso_linked_accounts(user.email, user)
 
                 serializer = self.get_serializer(user)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -270,15 +279,13 @@ class ScimUserViewSet(
         was_active = serializer.instance.is_active
         instance = serializer.save()
         if not was_active and instance.is_active:
-            idp = self.request.auth
-            provider_id = idp.social_app.provider_id if idp and idp.social_app else None
-            self._reactivate_sso_linked_accounts(instance.email, provider_id, instance)
+            self._reactivate_sso_linked_accounts(instance.email, instance)
 
-    def _reactivate_sso_linked_accounts(self, email, provider_id=None, current_user=None):
+    def _reactivate_sso_linked_accounts(self, email, current_user=None):
         if email:
             targets = User.objects.filter(email__iexact=email, is_active=False)
-            if provider_id:
-                targets = targets.filter(socialaccount__provider=provider_id)
+            if self.idp_provider_id:
+                targets = targets.filter(socialaccount__provider=self.idp_provider_id)
             else:
                 targets = targets.filter(socialaccount__isnull=False)
             targets.update(is_active=True)
@@ -289,8 +296,7 @@ class ScimUserViewSet(
 
     def get_queryset(self):
         # The idp_slug in the URL MUST match the authenticated IdP
-        idp = self.request.auth
-        if not idp or idp.slug != self.kwargs.get('idp_slug'):
+        if not self.idp or self.idp.slug != self.kwargs.get('idp_slug'):
             # Return empty if cross-tenant or missing
             return User.objects.none()
 
@@ -298,9 +304,9 @@ class ScimUserViewSet(
         queryset = super().get_queryset().exclude(id=settings.ANONYMOUS_USER_ID)
 
         # Only include users that are linked to this IdP's SocialApp.
-        if idp.social_app:
+        if self.idp.social_app:
             queryset = queryset.filter(
-                socialaccount__provider=idp.social_app.provider_id
+                socialaccount__provider=self.idp_provider_id
             )
         else:
             # If the IdP doesn't have a SocialApp, it can't be mapped to any users
@@ -393,9 +399,7 @@ class ScimUserViewSet(
                 self.perform_destroy(instance)
             else:
                 # Re-enabling the user
-                idp = self.request.auth
-                provider_id = idp.social_app.provider_id if idp and idp.social_app else None
-                self._reactivate_sso_linked_accounts(instance.email, provider_id, instance)
+                self._reactivate_sso_linked_accounts(instance.email, instance)
 
             # SCIM expects the updated resource returned on successful PATCH
             instance.refresh_from_db()

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -201,13 +201,6 @@ class ScimUserViewSet(
                         last_name=last_name,
                         is_active=data.get('active', True),
                     )
-                else:
-                    # If they exist, optionally reactivate them if the IdP sends
-                    # active=True. (A deprovisioned user in Kobo is not deleted
-                    # but deactivated).
-                    if not user.is_active and data.get('active', True):
-                        user.is_active = True
-                        user.save(update_fields=['is_active'])
 
                 # Ensure the SocialAccount link exists so SSO works flawlessly.
                 # We catch IntegrityError here just in case another IdP already
@@ -215,6 +208,9 @@ class ScimUserViewSet(
                 SocialAccount.objects.get_or_create(
                     user=user, provider=idp.social_app.provider_id, uid=uid
                 )
+
+                if data.get('active', True):
+                    self._reactivate_sso_linked_accounts(user.email, user)
 
                 serializer = self.get_serializer(user)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -259,6 +255,23 @@ class ScimUserViewSet(
                 },
                 status=status.HTTP_409_CONFLICT,
             )
+
+    def perform_update(self, serializer):
+        was_active = serializer.instance.is_active
+        instance = serializer.save()
+        if not was_active and instance.is_active:
+            self._reactivate_sso_linked_accounts(instance.email, instance)
+
+    def _reactivate_sso_linked_accounts(self, email, current_user=None):
+        if email:
+            targets = User.objects.filter(
+                email__iexact=email, socialaccount__isnull=False, is_active=False
+            )
+            targets.update(is_active=True)
+
+        if current_user and not current_user.is_active:
+            current_user.is_active = True
+            current_user.save(update_fields=['is_active'])
 
     def get_queryset(self):
         # The idp_slug in the URL MUST match the authenticated IdP
@@ -366,8 +379,7 @@ class ScimUserViewSet(
                 self.perform_destroy(instance)
             else:
                 # Re-enabling the user
-                instance.is_active = True
-                instance.save(update_fields=['is_active'])
+                self._reactivate_sso_linked_accounts(instance.email, instance)
 
             # SCIM expects the updated resource returned on successful PATCH
             instance.refresh_from_db()

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -283,15 +283,15 @@ class ScimUserViewSet(
         # Handle users with the same email:
         if email:
             targets = User.objects.filter(
-                email__iexact=email, 
-                is_active=False, 
+                email__iexact=email,
+                is_active=False,
                 socialaccount__provider=self.idp_provider_id
             )
-            
+
             for target in targets:
                 target.is_active = True
                 target.save(update_fields=['is_active'])
-                
+
                 # Update in-memory instance to prevent the fallback block below
                 # from firing an extra, redundant save() call.
                 if current_user and current_user.pk == target.pk:

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -17,6 +17,15 @@ from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import AuditLog, AuditType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.kobo_scim.authentication import IsAuthenticatedIdP, ScimAuthentication
+from kobo.apps.kobo_scim.constants import (
+    SCIM_SCHEMA_ERROR,
+    SCIM_SCHEMA_GROUP,
+    SCIM_SCHEMA_LIST_RESPONSE,
+    SCIM_SCHEMA_RESOURCE_TYPE,
+    SCIM_SCHEMA_SCHEMA,
+    SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG,
+    SCIM_SCHEMA_USER,
+)
 from kobo.apps.kobo_scim.models import ScimGroup
 from kobo.apps.kobo_scim.pagination import ScimPagination
 from kobo.apps.kobo_scim.renderers import SCIMParser, SCIMRenderer
@@ -219,7 +228,7 @@ class ScimUserViewSet(
             # This is a safe fallback for edge cases like duplicate SocialAccount UIDs
             return Response(
                 {
-                    'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error'],
+                    'schemas': [SCIM_SCHEMA_ERROR],
                     'detail': 'One or more attributes in the resource already exists.',
                     'status': '409',
                 },
@@ -249,7 +258,7 @@ class ScimUserViewSet(
             # return SCIM 409 format.
             return Response(
                 {
-                    'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error'],
+                    'schemas': [SCIM_SCHEMA_ERROR],
                     'detail': 'One or more attributes in the resource already exists.',
                     'status': '409',
                 },
@@ -414,7 +423,7 @@ class ScimServiceProviderConfigView(APIView):
     def get(self, request, *args, **kwargs):
         # We only support patch and basic filtering
         payload = {
-            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+            'schemas': [SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG],
             'patch': {'supported': True},
             'bulk': {'supported': False},
             'filter': {'supported': True, 'maxResults': 100},
@@ -462,20 +471,20 @@ class ScimSchemasView(APIView):
     def get(self, request, *args, **kwargs):
         location = request.build_absolute_uri().rstrip('/')
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'schemas': [SCIM_SCHEMA_LIST_RESPONSE],
             'totalResults': 2,
             'itemsPerPage': 2,
             'startIndex': 1,
             'Resources': [
                 {
-                    'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Schema'],
-                    'id': 'urn:ietf:params:scim:schemas:core:2.0:User',
+                    'schemas': [SCIM_SCHEMA_SCHEMA],
+                    'id': SCIM_SCHEMA_USER,
                     'name': 'User',
                     'description': 'User Account',
                     'meta': {
                         'resourceType': 'Schema',
                         'location': (
-                            f'{location}/urn:ietf:params:scim:schemas:core:2.0:User'
+                            f'{location}/{SCIM_SCHEMA_USER}'
                         ),
                     },
                     'attributes': [
@@ -582,14 +591,14 @@ class ScimSchemasView(APIView):
                     ],
                 },
                 {
-                    'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Schema'],
-                    'id': 'urn:ietf:params:scim:schemas:core:2.0:Group',
+                    'schemas': [SCIM_SCHEMA_SCHEMA],
+                    'id': SCIM_SCHEMA_GROUP,
                     'name': 'Group',
                     'description': 'Group',
                     'meta': {
                         'resourceType': 'Schema',
                         'location': (
-                            f'{location}/urn:ietf:params:scim:schemas:core:2.0:Group'
+                            f'{location}/{SCIM_SCHEMA_GROUP}'
                         ),
                     },
                     'attributes': [
@@ -682,18 +691,18 @@ class ScimResourceTypesView(APIView):
     def get(self, request, *args, **kwargs):
         location = request.build_absolute_uri().rstrip('/')
         payload = {
-            'schemas': ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+            'schemas': [SCIM_SCHEMA_LIST_RESPONSE],
             'totalResults': 2,
             'itemsPerPage': 2,
             'startIndex': 1,
             'Resources': [
                 {
-                    'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+                    'schemas': [SCIM_SCHEMA_RESOURCE_TYPE],
                     'id': 'User',
                     'name': 'User',
                     'endpoint': '/Users',
                     'description': 'User Account',
-                    'schema': 'urn:ietf:params:scim:schemas:core:2.0:User',
+                    'schema': SCIM_SCHEMA_USER,
                     'schemaExtensions': [],
                     'meta': {
                         'resourceType': 'ResourceType',
@@ -701,12 +710,12 @@ class ScimResourceTypesView(APIView):
                     },
                 },
                 {
-                    'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+                    'schemas': [SCIM_SCHEMA_RESOURCE_TYPE],
                     'id': 'Group',
                     'name': 'Group',
                     'endpoint': '/Groups',
                     'description': 'Group',
-                    'schema': 'urn:ietf:params:scim:schemas:core:2.0:Group',
+                    'schema': SCIM_SCHEMA_GROUP,
                     'schemaExtensions': [],
                     'meta': {
                         'resourceType': 'ResourceType',

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -280,13 +280,22 @@ class ScimUserViewSet(
             self._reactivate_sso_linked_accounts(instance.email, instance)
 
     def _reactivate_sso_linked_accounts(self, email, current_user=None):
+        # Handle users with the same email:
         if email:
             targets = User.objects.filter(email__iexact=email, is_active=False)
             if self.idp_provider_id:
                 targets = targets.filter(socialaccount__provider=self.idp_provider_id)
             else:
                 targets = targets.filter(socialaccount__isnull=False)
-            targets.update(is_active=True)
+            
+            for target in targets:
+                target.is_active = True
+                target.save(update_fields=['is_active'])
+                
+                # Update in-memory instance to prevent the fallback block below
+                # from firing an extra, redundant save() call.
+                if current_user and current_user.pk == target.pk:
+                    current_user.is_active = True
 
         if current_user and not current_user.is_active:
             current_user.is_active = True

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -219,7 +219,8 @@ class ScimUserViewSet(
                 )
 
                 if data.get('active', True):
-                    self._reactivate_sso_linked_accounts(user.email, user)
+                    provider_id = idp.social_app.provider_id if idp.social_app else None
+                    self._reactivate_sso_linked_accounts(user.email, provider_id, user)
 
                 serializer = self.get_serializer(user)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -269,13 +270,17 @@ class ScimUserViewSet(
         was_active = serializer.instance.is_active
         instance = serializer.save()
         if not was_active and instance.is_active:
-            self._reactivate_sso_linked_accounts(instance.email, instance)
+            idp = self.request.auth
+            provider_id = idp.social_app.provider_id if idp and idp.social_app else None
+            self._reactivate_sso_linked_accounts(instance.email, provider_id, instance)
 
-    def _reactivate_sso_linked_accounts(self, email, current_user=None):
+    def _reactivate_sso_linked_accounts(self, email, provider_id=None, current_user=None):
         if email:
-            targets = User.objects.filter(
-                email__iexact=email, socialaccount__isnull=False, is_active=False
-            )
+            targets = User.objects.filter(email__iexact=email, is_active=False)
+            if provider_id:
+                targets = targets.filter(socialaccount__provider=provider_id)
+            else:
+                targets = targets.filter(socialaccount__isnull=False)
             targets.update(is_active=True)
 
         if current_user and not current_user.is_active:
@@ -388,7 +393,9 @@ class ScimUserViewSet(
                 self.perform_destroy(instance)
             else:
                 # Re-enabling the user
-                self._reactivate_sso_linked_accounts(instance.email, instance)
+                idp = self.request.auth
+                provider_id = idp.social_app.provider_id if idp and idp.social_app else None
+                self._reactivate_sso_linked_accounts(instance.email, provider_id, instance)
 
             # SCIM expects the updated resource returned on successful PATCH
             instance.refresh_from_db()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
This PR extends the SCIM provisioning flow to handle account reactivation only for SSO accounts. When a deprovisioned user is re-provisioned via SCIM (POST, PUT, or PATCH), the system will isolate and reactivate only the accounts linked to the SSO Identity Provider (SocialAccount) specified by the slug, while leaving any standard password-authenticated accounts safely disabled. 

### 📖 Description
In this PR we:
* Introduced the _reactivate_sso_linked_accounts helper method in ScimUserViewSet. This method queries for users matching the target email that also possess a SocialAccount association, setting them to is_active=True.
* POST (create): Ensures new re-provisioning requests from the IdP correctly reactivate existing SSO-linked accounts.
* PUT (perform_update): Intercepts is_active state changes to apply selective reactivation when a user's active status is toggled.
* PATCH (partial_update): Routes active=True patch operations to the new helper method that isolates the action to the SSO accounts linked to the given provider.
* Constants Refactoring (using constants instead of schema strings).

### 👀 Preview steps
1. Set up a SCIM-compliant Identity Provider (e.g., Authentik or Keycloak + SCIM extension).
2. Manually create three user accounts in Kobo that all share the exact same email address (e.g., james@example.org).
3. Link one of those accounts to the Identity Provider (simulating an SSO-linked account). Leave the other two as standard password-authenticated accounts.
4. Deprovision the user from the Identity Provider.
5. Expected behavior: The SCIM service should deactivate all three Kobo accounts linked to that email (is_active=False).
6. Re-provision / Reactivate the user in the Identity Provider.
7. Check the Django Admin or database to verify the account statuses. Only the SSO-linked account should be flipped back to is_active=True. The two password-authenticated accounts must remain is_active=False.