### PR TITLE
feat(metadata): ensure extra metadata fields are returned on asset endpoint DEV-2161

### DIFF
--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import re
 from typing import Optional
@@ -508,20 +509,22 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
-        if 'settings' not in representation:
+        settings = representation.get('settings')
+        if not isinstance(settings, dict):
             return representation
 
-        settings = representation.setdefault('settings', {})
-        extra_metadata = settings.setdefault('extra_metadata', {})
+        settings = copy.deepcopy(settings)
+        representation['settings'] = settings
 
+        extra_metadata = settings.get('extra_metadata')
         if not isinstance(extra_metadata, dict):
             extra_metadata = {}
 
         defaults = self._get_extra_metadata_defaults()
 
         settings['extra_metadata'] = {
-            field_name: extra_metadata.get(field_name, default_value)
-            for field_name, default_value in defaults.items()
+            key: extra_metadata.get(key, default)
+            for key, default in defaults.items()
         }
 
         return representation

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -40,8 +40,14 @@ from kpi.constants import (
     PERM_VIEW_SUBMISSIONS,
 )
 from kpi.fields import WritableJSONField
-from kpi.models import Asset, ObjectPermission, UserAssetSubscription
+from kpi.models import (
+    Asset,
+    ExtraProjectMetadataField,
+    ObjectPermission,
+    UserAssetSubscription,
+)
 from kpi.models.asset import AssetDeploymentStatus
+from kpi.models.extra_project_metadata_field import ExtraProjectMetadataFieldType
 from kpi.utils.object_permission import (
     get_cached_code_names,
     get_database_user,
@@ -498,6 +504,27 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             instance = super().create(validated_data)
 
         return instance
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if 'settings' not in representation:
+            return representation
+
+        settings = representation.setdefault('settings', {})
+        extra_metadata = settings.setdefault('extra_metadata', {})
+
+        if not isinstance(extra_metadata, dict):
+            extra_metadata = {}
+
+        defaults = self._get_extra_metadata_defaults()
+
+        settings['extra_metadata'] = {
+            field_name: extra_metadata.get(field_name, default_value)
+            for field_name, default_value in defaults.items()
+        }
+
+        return representation
 
     def update(self, asset, validated_data):
         request = self.context['request']
@@ -1063,6 +1090,21 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def _content(self, obj):
         # FIXME: Is this dead code?
         return json.dumps(obj.content)
+
+    def _get_extra_metadata_defaults(self):
+        defaults = {}
+
+        fields = self.context.get('extra_project_metadata_fields')
+        if fields is None:
+            fields = ExtraProjectMetadataField.objects.all()
+
+        for field in fields:
+            if field.type == ExtraProjectMetadataFieldType.MULTI_SELECT:
+                defaults[field.name] = []
+            else:
+                defaults[field.name] = None
+
+        return defaults
 
     def _get_status(self, perm_assignments):
         """

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -32,6 +32,10 @@ from kpi.constants import (
 )
 from kpi.models import Asset, AssetFile, AssetVersion
 from kpi.models.asset import AssetDeploymentStatus
+from kpi.models.extra_project_metadata_field import (
+    ExtraProjectMetadataField,
+    ExtraProjectMetadataFieldType,
+)
 from kpi.serializers.v2.asset import AssetListSerializer
 from kpi.tests.base_test_case import (
     BaseAssetDetailTestCase,
@@ -1464,6 +1468,7 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
             'country_codes': [],
             'description': '',
             'mysetting': 'value',
+            'extra_metadata': {},
             'organization': '',
             'sector': {},
         }
@@ -2116,6 +2121,78 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
         usernames = self._get_perm_usernames(response.data['permissions'])
         self.assertIn('someuser', usernames)
         self.assertIn(self.thirduser.username, usernames)
+
+    def test_extra_metadata_defaults_are_returned(self):
+        """
+        Existing assets should include newly configured extra metadata fields
+        with default empty values in the detail response.
+        """
+        asset = Asset.objects.create(
+            owner=self.asset.owner,
+            name='Survey without extra metadata',
+            asset_type=ASSET_TYPE_SURVEY,
+        )
+
+        ExtraProjectMetadataField.objects.create(
+            name='Text',
+            type=ExtraProjectMetadataFieldType.TEXT,
+        )
+        ExtraProjectMetadataField.objects.create(
+            name='Select one',
+            type=ExtraProjectMetadataFieldType.SINGLE_SELECT,
+            options=[
+                {'name': 'one', 'label': '1st Option'},
+                {'name': 'two', 'label': '2nd Option'},
+                {'name': 'three', 'label': '3rd option'},
+            ],
+        )
+        ExtraProjectMetadataField.objects.create(
+            name='Select multiple',
+            type=ExtraProjectMetadataFieldType.MULTI_SELECT,
+            options=[
+                {'name': 'cat', 'label': 'Animal 1'},
+                {'name': 'dog', 'label': 'Animal 2'},
+                {'name': 'hamster', 'label': 'Animal 3'},
+            ],
+        )
+
+        response = self.client.get(
+            reverse('api_v2:asset-detail', kwargs={'uid_asset': asset.uid}),
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['settings']['extra_metadata'] == {
+            'Select multiple': [],
+            'Select one': None,
+            'Text': None,
+        }
+
+    def test_deleted_extra_metadata_fields_are_not_returned(self):
+        """
+        Deleted extra metadata field definitions should not appear in the
+        detail response, even if stale values remain in asset settings.
+        """
+        field = ExtraProjectMetadataField.objects.create(
+            name='Text',
+            type=ExtraProjectMetadataFieldType.TEXT,
+        )
+        asset = Asset.objects.create(
+            owner=self.asset.owner,
+            name='Old Name',
+            asset_type=ASSET_TYPE_SURVEY,
+            settings={'extra_metadata': {'Text': 'stale value'}},
+        )
+
+        field.delete()
+
+        response = self.client.get(
+            reverse('api_v2:asset-detail', kwargs={'uid_asset': asset.uid}),
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['settings']['extra_metadata'] == {}
 
 
 class AssetsXmlExportApiTests(KpiTestCase):

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -695,6 +695,19 @@ class AssetListApiTests(PermissionsTestMixin, BaseAssetTestCase):
         # Anotheruser's own asset must still appear
         assert own_asset.uid in result_uids
 
+    def test_extra_metadata_defaults_are_returned_on_list(self):
+        ExtraProjectMetadataField.objects.create(
+            name='Text',
+            type=ExtraProjectMetadataFieldType.TEXT,
+        )
+
+        response = self.client.get(reverse('api_v2:asset-list'), format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['results'][0]['settings']['extra_metadata'] == {
+            'Text': None,
+        }
+
     def _setup_current_user_permissions_only(self):
         """
         Create an asset owned by someuser, grant view_asset to anotheruser

--- a/kpi/views/v2/asset.py
+++ b/kpi/views/v2/asset.py
@@ -42,6 +42,7 @@ from kpi.highlighters import highlight_xform
 from kpi.mixins.asset import AssetViewSetListMixin
 from kpi.mixins.object_permission import ObjectPermissionViewSetMixin
 from kpi.models import Asset, AssetUserPartialPermission, UserAssetSubscription
+from kpi.models.extra_project_metadata_field import ExtraProjectMetadataField
 from kpi.models.object_permission import ObjectPermission
 from kpi.paginators import AssetPagination, NoCountPagination
 from kpi.permissions import (
@@ -910,6 +911,10 @@ class AssetViewSet(
                 context_['organizations_per_asset'] = (
                     self.get_organizations_per_asset_ids(asset_ids)
                 )
+
+            context_['extra_project_metadata_fields'] = list(
+                ExtraProjectMetadataField.objects.all()
+            )
 
         return context_
 


### PR DESCRIPTION
### 📣 Summary
Extra project metadata fields now appear consistently in the `/api/v2/assets` endpoint, including default empty values for newly added fields.

### 👀 Preview steps

1. ℹ️ Create a project before any extra metadata fields exist (and delete any extra metadata fields that you might have)
2. Then create several `ExtraProjectMetadataField` entries in the django admin 
3. 🔴 [on main] Open the `api/v2/assets/{uid_asset}/` endpoint for the project you made and notice that it omits the new metadata fields entirely and only has `"extra_metadata": {}`
4. 🟢 [on PR] Open the `api/v2/assets/{uid_asset}/` endpoint for the project you made and notice that the new metadata fields are present and listed with default values (null, [], etc.)
6. Create a project with metadata fields
8. 🟢 Verify that the metadata values are correctly displayed in the api response
9. Delete all of your `ExtraProjectMetadataField` entries
10. 🟢 [on PR] Notice deleted metadata fields are omitted from the api response and just `"extra_metadata": {}` is shown