### PR TITLE
fix(auth): remove email verification contact links DEV-2162

### DIFF
--- a/kobo/apps/accounts/templates/account/email_confirm.html
+++ b/kobo/apps/accounts/templates/account/email_confirm.html
@@ -46,16 +46,6 @@
       {% trans "If you are trying to verify an email address change, please go to the security tab under your account settings, and click the 'resend' button to receive an activation link." %}
     </p>
 
-    {% url 'account_email' as email_url %}
-
-    <p class="registration__message">
-      {% trans "Need help?" %}
-      <a href="https://www.kobotoolbox.org/contact/?reason=support&support=account_support">
-        {% trans "Contact support" %}
-      </a>
-      {% trans "if you're having trouble accessing your account." %}
-    </p>
-
   {% endif %}
   </form>
 

--- a/kobo/apps/accounts/templates/account/verification_sent.html
+++ b/kobo/apps/accounts/templates/account/verification_sent.html
@@ -10,12 +10,5 @@
   <p class="registration__message registration__message--complete">
     {% trans "We have sent you an activation link. Please check your inbox (and spam folder) and click the link to activate your account." %}
   </p>
-  <p class="registration__message">
-    {% trans "Didn’t receive the email?" %}
-    <a href="https://www.kobotoolbox.org/contact/?reason=support&support=account_support">
-      {% trans "Contact support" %}
-    </a>
-    {% trans "if you're having trouble accessing your account." %}
-  </p>
 </form>
 {% endblock %}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Removes links inviting users to contact support on the verification_sent and email_confirm view templates.

### 👀 Preview steps

1. Create a new account
2. See that message indicating verification email has been sent no longer includes link for contacting support.
3. Don't confirm email. In admin, delete newly created email to force failure message on confirmation link
4. Navigate to email confirmation url
5. See that Activation Failed message no longer includes link for contacting support.
