### PR TITLE
fix(urls): register v1_api_gone patterns first to avoid catch-all interception DEV-1383

### DIFF
--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -36,8 +36,6 @@ REMOVED_V1_API_PREFIXES = [
     'users',
     'formUpload',
     'upload',
-    'view/downloadSubmission',
-    'view/submissionList',
 ]
 
 urlpatterns = [

--- a/kobo/urls.py
+++ b/kobo/urls.py
@@ -20,7 +20,37 @@ from kpi.views.v2.swagger_ui import ExtendedSwaggerUIView
 admin.autodiscover()
 admin.site.login = staff_member_required(admin.site.login, login_url=settings.LOGIN_URL)
 
+# V1 API fall-through route. This ensures removed V1 routes return a 410
+# instructing users to read the API migration guide.
+REMOVED_V1_API_PREFIXES = [
+    'api/v1',
+    'asset_snapshots',
+    'asset_subscriptions',
+    'assets',
+    'authorized_application',
+    'exports',
+    'imports',
+    'permissions',
+    'sitewide_messages',
+    'tags',
+    'users',
+    'formUpload',
+    'upload',
+    'view/downloadSubmission',
+    'view/submissionList',
+]
+
 urlpatterns = [
+    # Must stay first: main.urls has a catch-all path('<str:username>/')
+    # that would intercept single-segment paths before these can match.
+    *[
+        re_path(
+            rf'^{prefix}(/.*)?$',
+            v1_api_gone_view,
+            name=f'v1_api_gone-{prefix.replace("/", "-")}',
+        )
+        for prefix in REMOVED_V1_API_PREFIXES
+    ],
     path(
         'api/v2/schema/',
         SpectacularAPIView.as_view(
@@ -72,36 +102,6 @@ urlpatterns = [
     path('markdownx-uploader/', include('kobo.apps.markdownx_uploader.urls')),
     path('help/', include('kobo.apps.help.urls')),
 ]
-
-# V1 API fall-through route. This ensures removed V1 routes return a 404
-# instructing users to read the API migration guide.
-REMOVED_V1_API_PREFIXES = [
-    'api/v1',
-    'asset_snapshots',
-    'asset_subscriptions',
-    'assets',
-    'authorized_application',
-    'exports',
-    'imports',
-    'permissions',
-    'sitewide_messages',
-    'tags',
-    'users',
-    'formUpload',
-    'upload',
-    'view/downloadSubmission',
-    'view/submissionList',
-]
-
-for prefix in REMOVED_V1_API_PREFIXES:
-    prefix_name = prefix.replace('/', '-')
-    urlpatterns.append(
-        re_path(
-            rf'^{prefix}(/.*)?$',
-            v1_api_gone_view,
-            name=f'v1_api_gone-{prefix_name}'
-        )
-    )
 
 if settings.ENABLE_METRICS:
     urlpatterns.append(

--- a/kpi/tests/test_v1_api_gone.py
+++ b/kpi/tests/test_v1_api_gone.py
@@ -16,7 +16,7 @@ class V1APIGoneViewTest(SimpleTestCase):
     def setUp(self):
         self.client = APIClient()
 
-    @data('get', 'post', 'put', 'patch', 'delete', 'options')
+    @data('get', 'post', 'put', 'patch', 'delete', 'head', 'options')
     def test_returns_410_for_any_method(self, method):
         response = getattr(self.client, method)('/api/v1/')
         assert response.status_code == status.HTTP_410_GONE

--- a/kpi/tests/test_v1_api_gone.py
+++ b/kpi/tests/test_v1_api_gone.py
@@ -1,0 +1,44 @@
+from ddt import data, ddt
+from django.test import SimpleTestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from kobo.urls import REMOVED_V1_API_PREFIXES
+
+
+@ddt
+class V1APIGoneViewTest(SimpleTestCase):
+    """
+    Tests for V1APIGoneView: all removed V1 API routes must return 410 Gone
+    for every HTTP method, with proper content negotiation.
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+
+    @data('get', 'post', 'put', 'patch', 'delete', 'options')
+    def test_returns_410_for_any_method(self, method):
+        response = getattr(self.client, method)('/api/v1/')
+        assert response.status_code == status.HTTP_410_GONE
+
+    def test_response_detail_contains_migration_url(self):
+        response = self.client.get('/api/v1/', format='json')
+        assert 'detail' in response.data
+        assert 'migrating_api.html' in response.data['detail']
+
+    def test_json_content_negotiation(self):
+        response = self.client.get('/api/v1/', HTTP_ACCEPT='application/json')
+        assert response['Content-Type'].startswith('application/json')
+
+    def test_xml_content_negotiation(self):
+        response = self.client.get('/api/v1/', HTTP_ACCEPT='application/xml')
+        assert response['Content-Type'].startswith('application/xml')
+
+    def test_html_content_negotiation(self):
+        response = self.client.get('/api/v1/', HTTP_ACCEPT='text/html')
+        assert response['Content-Type'].startswith('text/html')
+
+    @data(*REMOVED_V1_API_PREFIXES)
+    def test_all_removed_prefixes_return_410(self, prefix):
+        response = self.client.get(f'/{prefix}/')
+        assert response.status_code == status.HTTP_410_GONE


### PR DESCRIPTION
### 📣 Summary

Removed V1 API paths (e.g. `/assets/`, `/users/`) were silently redirected to the home page instead of returning 410 Gone.

### 💭 Notes

`kobo/urls.py` had a `path('<str:username>/')` catch-all in `kobo.apps.openrosa.apps.main.urls` that matched single-segment removed V1 paths before the `v1_api_gone` patterns had a chance to run. Fix: the `REMOVED_V1_API_PREFIXES` patterns are now registered at the top of `urlpatterns`. A comment guards the ordering.

Unit tests cover: all HTTP methods return 410, JSON/XML/HTML content negotiation, and every prefix in `REMOVED_V1_API_PREFIXES`.

### 👀 Preview steps

1. Hit any removed V1 path, e.g. `GET /assets/`
2. 🔴 [on target] returns 302 redirect to home
3. 🟢 [on PR] returns 410 Gone with migration article link