### PR TITLE
feat(asset): add created by to API DEV-1990

### DIFF
--- a/jsapp/js/api/models/asset.ts
+++ b/jsapp/js/api/models/asset.ts
@@ -95,9 +95,6 @@ export interface Asset {
   readonly owner_label: string
   /** @nullable */
   readonly last_modified_by: string | null
-  /**
-   * @maxLength 150
-   * @nullable
-   */
-  created_by?: string | null
+  /** @nullable */
+  readonly created_by: string | null
 }

--- a/jsapp/js/api/models/asset.ts
+++ b/jsapp/js/api/models/asset.ts
@@ -95,4 +95,9 @@ export interface Asset {
   readonly owner_label: string
   /** @nullable */
   readonly last_modified_by: string | null
+  /**
+   * @maxLength 150
+   * @nullable
+   */
+  created_by?: string | null
 }

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -476,7 +476,7 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             'last_modified_by',
             'created_by',
         )
-        read_only_fields = ('last_modified_by', 'uid')
+        read_only_fields = ('last_modified_by', 'created_by', 'uid')
         extra_kwargs = {
             'parent': {
                 'lookup_field': 'uid',

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -473,7 +473,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
             'paired_data',
             'project_ownership',
             'owner_label',
-            'last_modified_by'
+            'last_modified_by',
+            'created_by',
         )
         read_only_fields = ('last_modified_by', 'uid')
         extra_kwargs = {
@@ -1156,6 +1157,7 @@ class AssetListSerializer(AssetSerializer):
             'data_sharing',
             'owner_label',
             'last_modified_by',
+            'created_by'
         )
 
     def get_permissions(self, asset):

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -1268,6 +1268,7 @@ class AssetMetadataListSerializer(AssetListSerializer):
             'downloads',
             'owner_label',
             'last_modified_by',
+            'created_by',
         )
 
     def get_deployment__submission_count(self, obj: Asset) -> int:

--- a/kpi/tests/api/v1/test_api_assets.py
+++ b/kpi/tests/api/v1/test_api_assets.py
@@ -56,6 +56,10 @@ class AssetListApiTests(test_api_assets.AssetListApiTests):
     def test_last_modified_by_field_not_assigned(self):
         pass
 
+    @unittest.skip(reason='`created_by` field only exists in v2 endpoint')
+    def test_created_by_field_not_assigned(self):
+        pass
+
     @unittest.skip(reason='`date_deployed` field only exists in v2 endpoint')
     def test_list_can_load_with_desynchronized_assets(self):
         pass
@@ -116,6 +120,10 @@ class AssetDetailApiTests(test_api_assets.AssetDetailApiTests):
 
     @unittest.skip(reason='`last_modified_by` property only exists in v2 endpoint')
     def test_cannot_modified_last_modified_by(self):
+        pass
+
+    @unittest.skip(reason='`created_by` property only exists in v2 endpoint')
+    def test_cannot_modify_created_by(self):
         pass
 
     @unittest.skip(reason='`last_modified_by` property only exists in v2 endpoint')

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -95,6 +95,11 @@ class AssetListApiTests(PermissionsTestMixin, BaseAssetTestCase):
         assert response.data['last_modified_by'] == response.data['owner__username']
         assert response.data['last_modified_by'] != 'anotheruser'
 
+    def test_created_by_field_not_assigned(self):
+        extra_data = {'created_by': 'anotheruser'}
+        response = self.create_asset(**extra_data)
+        assert response.data['created_by'] == 'someuser'
+
     def test_delete_asset(self):
         self.client.logout()
         self.client.login(username='anotheruser', password='anotheruser')
@@ -2006,6 +2011,16 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
         self.asset.refresh_from_db()
         assert response.data['last_modified_by'] == anotheruser.username
         assert self.asset.last_modified_by == anotheruser.username
+
+    def test_cannot_modify_created_by(self):
+        assert self.asset.created_by == self.asset.owner.username
+        payload = {'created_by': 'bob'}
+        self.client.force_login(self.asset.owner)
+        response = self.client.patch(self.asset_url, data=payload, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        self.asset.refresh_from_db()
+        assert response.data['created_by'] == self.asset.owner.username
+        assert self.asset.created_by == self.asset.owner.username
 
     def test_analysis_form_json_with_nlp_actions(self):
         for action in [

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -21139,6 +21139,11 @@
                         "type": "string",
                         "readOnly": true,
                         "nullable": true
+                    },
+                    "created_by": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 150
                     }
                 },
                 "required": [

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -21142,8 +21142,8 @@
                     },
                     "created_by": {
                         "type": "string",
-                        "nullable": true,
-                        "maxLength": 150
+                        "readOnly": true,
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -21152,6 +21152,7 @@
                     "asset_type",
                     "assignable_permissions",
                     "children",
+                    "created_by",
                     "data",
                     "deployed_version_id",
                     "deployed_versions",

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -15026,14 +15026,15 @@ components:
           nullable: true
         created_by:
           type: string
+          readOnly: true
           nullable: true
-          maxLength: 150
       required:
       - access_types
       - analysis_form_json
       - asset_type
       - assignable_permissions
       - children
+      - created_by
       - data
       - deployed_version_id
       - deployed_versions

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -15024,6 +15024,10 @@ components:
           type: string
           readOnly: true
           nullable: true
+        created_by:
+          type: string
+          nullable: true
+          maxLength: 150
       required:
       - access_types
       - analysis_form_json


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Add `created_by` to the asset API responses.


### 📖 Description
Update the asset list and detail endpoints with a new `created_by` field containing the username of the asset's creator.


### 💭 Notes
`created_by` is set to just the username rather than the user URL to match `last_modified_by`.


### 👀 Preview steps

1. ℹ️ have an account and a project
2. Add the account to an MMO
3. Create a project view for the account
4. GET `api/v2/assets/<asset_uid>/`
5. 🟢 [on PR] Notice `created_by` is now in the response
6. GET `api/v2/project-views/<project_view_uid>/assets/`
7. 🟢 [on PR] Notice `created_by` is now in the response for each asset
8. GET `api/v2/organizations/<org_uid>/assets/`
9. 🟢 [on PR] Notice `created_by` is now in the response for each asset

