### PR TITLE
fix(admin): fix adding users in Django Admin DEV-2180

### DIFF
--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -6,9 +6,9 @@ from django.contrib import admin, messages
 from django.contrib.admin import SimpleListFilter
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import (
-    UserChangeForm as DjangoUserChangeForm,
     AdminUserCreationForm,
 )
+from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
 from django.core.exceptions import ValidationError
 from django.db.models import Count, Sum
 from django.forms import CharField
@@ -82,6 +82,10 @@ class UserCreationForm(AdminUserCreationForm):
         validators=username_validators,
     )
 
+    def clean(self):
+        self.cleaned_data['usable_password'] = 'true'
+        super().clean()
+
 
 class OrgInline(admin.StackedInline):
     model = OrganizationUser
@@ -114,7 +118,6 @@ class OrgInline(admin.StackedInline):
 
     def has_add_permission(self, request, obj=OrganizationUser):
         return False
-
 
 
 class InactiveUsersAsOfFilter(SimpleListFilter):

--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -193,6 +193,9 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
         'deployed_forms_count',
         'monthly_submission_count',
     )
+    # same add_fieldsets as UserAdmin but without the 'usable_password' field, which
+    # we don't want. Admins should not be able to enable/disable password access on
+    # a per-user basis
     add_fieldsets = (
         (
             None,

--- a/hub/admin/extend_user.py
+++ b/hub/admin/extend_user.py
@@ -5,8 +5,10 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin import SimpleListFilter
 from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.forms import UserChangeForm as DjangoUserChangeForm
-from django.contrib.auth.forms import UserCreationForm as DjangoUserCreationForm
+from django.contrib.auth.forms import (
+    UserChangeForm as DjangoUserChangeForm,
+    AdminUserCreationForm,
+)
 from django.core.exceptions import ValidationError
 from django.db.models import Count, Sum
 from django.forms import CharField
@@ -71,7 +73,7 @@ class UserChangeForm(DjangoUserChangeForm):
         return cleaned_data
 
 
-class UserCreationForm(DjangoUserCreationForm):
+class UserCreationForm(AdminUserCreationForm):
 
     username = CharField(
         label='username',
@@ -190,6 +192,15 @@ class ExtendedUserAdmin(AdvancedSearchMixin, UserAdmin):
     readonly_fields = UserAdmin.readonly_fields + (
         'deployed_forms_count',
         'monthly_submission_count',
+    )
+    add_fieldsets = (
+        (
+            None,
+            {
+                'classes': ('wide',),
+                'fields': ('username', 'password1', 'password2'),
+            },
+        ),
     )
     fieldsets = UserAdmin.fieldsets + (
         (


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] delete this section before merging

### 📣 Summary
Fixes a bug in Django admin that was preventing admins from adding users.

### 💭 Notes
The Django 5 upgrade introduced a new concept of `usable_password`, which is a setting that can allow/forbid users to authenticate with a password (as opposed to SSO or LDAP or something). This field is included by default in the UserAdmin, but not present on the model. Instead, it is created by a mixin that is present in `AdminUserCreationForm` but not regular `UserCreationForm.` 
The solution is to update our `UserCreationForm` to use `AdminCreationUserForm` as a base and just hide the `usable_password` field by overriding the `fieldsets`.


### 👀 Preview steps

1. ℹ️ have a superuser account
2. Go to Django admin -> Users
3. Add user
4. 🔴 [on release] 500
5. 🟢 [on PR] you are able to successfully add a new user

