### PR TITLE
ci(openapi): fail CI job on drf-spectacular error DEV-2135 DEV-2182

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Install Python dev dependencies
         run: uv pip sync --system dependencies/pip/dev_requirements.txt
 
+      - name: Run Django migrations
+        # Required so that constance (DatabaseBackend) and other apps queried
+        # during schema generation can read their tables.
+        run: python manage.py migrate --noinput
+
       - name: Generate OpenAPI with drf-spectacular
         # GitHub Actions run without a TTY device. This is a workaround to get one,
         # based on https://github.com/actions/runner/issues/241#issuecomment-2019042651

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -74,13 +74,15 @@ jobs:
         #   > FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting
         #   > in new releases of google.cloud.translate_v3 once it reaches its end of life (2026-10-04).
         run: |
-          if ./scripts/generate_api.sh --skip-orval 2>&1 | tee /dev/tty | grep -qP "(?<!\bFuture)Warning"; then
+          # run the script on its own line so if it crashes, bash will instantly kill the step with exit 1.
+          OUTPUT=$(./scripts/generate_api.sh --skip-orval 2>&1 | tee /dev/tty)
+
+          if echo "$OUTPUT" | grep -qP "(?<!\bFuture)Warning"; then
             echo ""
             echo "A warning found, aborted! Please treat drf-spectacular warnings as errors and resolve them."
             echo "P.S. This is only the first warning. You may want to run the script locally to see all warnings at once."
             exit 2
           fi
-
       - name: Fail on uncommitted OpenAPI changes
         run: |
           git diff


### PR DESCRIPTION
### 💭 Notes

Note for myself: when a command is put inside an `if` condition, Bash temporarily suspends `set -e`. It assumes you are manually handling the failure.

### 👀 Preview steps

See the [job](https://github.com/kobotoolbox/kpi/actions/runs/25922120403/job/76193612232?pr=7026) of actual unhandled failure here at https://github.com/kobotoolbox/kpi/pull/7026:
> Locally, this script is expected to be run from a container, for example like this:
   cd kobo-install
   ./run.py -cf run --rm kpi ./scripts/generate_api.sh
Enabling Stripe for schema generation…
Stripe enabled: true
Generating v2 OpenAPI JSON schema with drf-spectacular…
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/constance/base.py", line 123, in __getattr__
    asyncio.get_running_loop()
RuntimeError: no running event loop

See the [job](https://github.com/kobotoolbox/kpi/actions/runs/26575268831/job/78292784599?pr=7097) of a WIP commit that fails and is handled, and job of this PR that succeeds.