### PR TITLE
fix(billing): use metadata to identify community plan DEV-2185

### DIFF
--- a/jsapp/js/account/plans/plan.component.tsx
+++ b/jsapp/js/account/plans/plan.component.tsx
@@ -262,7 +262,7 @@ export default function Plan() {
 
   const isSubscribedProduct = useCallback(
     (product: SinglePricedProduct) => {
-      if (!product.price?.unit_amount && !hasActiveSubscription) {
+      if (product.metadata?.default_free_plan === 'true' && !hasActiveSubscription) {
         return true
       }
 


### PR DESCRIPTION
### 📣 Summary
Adjusts plans page logic to identify only products marked as "default_free_plan" as the default community plan for users without a subscription.

### 💭 Notes
We added this metadata field a while back and reference it in a few places on the backend and frontend. We just missed this spot where we were still only checking that a product was free.


### 👀 Preview steps

1. On a Stripe-enabled instance, sync products and prices (do it again for this PR as the relevant product is new). 
2. Have an account with no subscription (so on the default community plan)
3. navigate to `/account/plan?type=custom_teams` and click on the "annual" view
4. 🔴 [on main] notice that you are shown as subscribed to a Team plan
5. 🟢 [on PR] Verify that you are no longer shown as subscribed to this plan
6. Check `/account/plan` on the monthly view to verify you are correctly shown as being under the community plan
