### PR TITLE
feat(bulkProcessing): add OpenAPI schema documentation for bulk actions APIs DEV-1501

### DIFF
--- a/jsapp/js/api/models/bulkActionResponse.ts
+++ b/jsapp/js/api/models/bulkActionResponse.ts
@@ -24,6 +24,11 @@ export interface BulkActionResponse {
   submission_uuids: string[]
   submission_statuses: BulkActionSubmissionStatusResponse[]
   params: BulkActionParamsResponse
+  /**
+   * @minimum 0
+   * @maximum 100
+   */
+  progress: number
   created_by: BulkActionUserResponse
   date_created: string
   date_modified: string

--- a/jsapp/js/api/models/bulkActionSubmissionStatusResponse.ts
+++ b/jsapp/js/api/models/bulkActionSubmissionStatusResponse.ts
@@ -14,4 +14,6 @@ import type { BulkActionSubmissionStatusResponseStatusEnum } from './bulkActionS
 export interface BulkActionSubmissionStatusResponse {
   uuid: string
   status: BulkActionSubmissionStatusResponseStatusEnum
+  /** @nullable */
+  error: string | null
 }

--- a/jsapp/js/api/react-query/survey-data.ts
+++ b/jsapp/js/api/react-query/survey-data.ts
@@ -558,8 +558,28 @@ export const useAssetsAdvancedFeaturesPartialUpdate = <
 /**
  * ## List bulk processing jobs on an asset
 
-Returns all bulk processing jobs associated with the specified asset. Each job
-is organized around one question and many submissions.
+Returns paginated bulk processing jobs associated with the specified asset. Each
+job is organized around one action, one question, and many submissions.
+
+Use this endpoint to monitor recently-created bulk transcription and translation
+jobs. Each result includes the parent job status, per-submission statuses, the
+original deterministic params, the user who created the job, cancellation
+metadata, and integer `progress` from `0` to `100`.
+
+Job statuses:
+
+* `pending`: the job exists but has not started.
+* `in_progress`: one or more child submissions are still active.
+* `complete`: every child submission has reached a terminal state.
+* `cancelled`: the job was cancelled.
+
+Child submission statuses:
+
+* `pending`
+* `in_progress`
+* `complete`
+* `failed`
+* `cancelled`
 
  */
 export type assetsAdvancedFeaturesBulkActionsListResponse200 = {
@@ -673,8 +693,25 @@ export function useAssetsAdvancedFeaturesBulkActionsList<
 /**
  * ## Create a bulk processing job
 
-Creates a placeholder bulk transcription or bulk translation job for a single
-question across multiple submissions.
+Creates and starts a bulk processing job for one question across multiple
+submissions.
+
+Supported actions:
+
+* `automatic_google_transcription`
+* `automatic_google_translation`
+
+The request must include the target `question_xpath`, the submission root UUIDs
+to process, and deterministic `params`. `params.language` is required. For
+transcription, `params.locale` may also be supplied when a more specific Google
+Speech locale is needed.
+
+Creation is atomic. If any selected submission is unknown, already has matching
+results, or already has an active matching bulk action, no job or child items are
+created.
+
+The response is the created job. Its initial status is `in_progress` because
+creation immediately starts background processing.
 
  */
 export type assetsAdvancedFeaturesBulkActionsCreateResponse201 = {
@@ -784,10 +821,11 @@ export const useAssetsAdvancedFeaturesBulkActionsCreate = <
  * ## Retrieve a bulk processing job
 
 Returns detailed information about a single bulk processing job, including its
-current status and processing metadata.
+current status, per-submission status, processing params, creator, cancellation
+metadata, timestamps, and integer `progress` from `0` to `100`.
 
 The response shape is identical to the item returned by the bulk job creation
-endpoint.
+endpoint and to each item in the paginated list response.
 
  */
 export type assetsAdvancedFeaturesBulkActionsRetrieveResponse200 = {
@@ -884,11 +922,23 @@ export function useAssetsAdvancedFeaturesBulkActionsRetrieve<
 /**
  * ## Update a bulk processing job
 
-Cancels a single bulk processing job for an asset.
+Cancels a single bulk processing job for an asset. This endpoint currently only
+supports cancellation.
 
-The `PATCH` endpoint is used for bulk action cancellation.
+Request body:
 
-The request body sets the job status to `cancelled`.
+```json
+{
+  "status": "cancelled"
+}
+```
+
+Cancellation is idempotent. Cancelling an already-cancelled job returns the
+current cancelled job. Completed jobs cannot be cancelled.
+
+When a job is cancelled, pending and in-progress child items are marked
+`cancelled`; terminal child items are not modified. The response is the updated
+job, including `cancelled_by`.
 
  */
 export type assetsAdvancedFeaturesBulkActionsPartialUpdateResponse200 = {

--- a/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
@@ -22,11 +22,13 @@ describe('bulkProcessingUtils', () => {
         {
           uuid: submission._uuid,
           status: BulkActionSubmissionStatusResponseStatusEnum.in_progress,
+          error: null,
         },
       ],
       params: {
         language: 'fr',
       },
+      progress: 50,
       created_by: {
         username: 'leszek',
       },
@@ -71,6 +73,7 @@ describe('bulkProcessingUtils', () => {
             {
               uuid: submission._uuid,
               status: BulkActionSubmissionStatusResponseStatusEnum.complete,
+              error: null,
             },
           ],
         }),

--- a/jsapp/js/endpoints/bulkAction.factory.ts
+++ b/jsapp/js/endpoints/bulkAction.factory.ts
@@ -9,6 +9,8 @@ export default function bulkActionFactory(
   languageCode: LanguageCode,
   overrides: Partial<BulkActionResponse> = {},
 ): BulkActionResponse {
+  const { progress = 0, ...restOverrides } = overrides
+
   return {
     uid: 'bulk-action-uid',
     status: BulkActionResponseStatusEnum.in_progress,
@@ -19,16 +21,18 @@ export default function bulkActionFactory(
       {
         uuid: submissionUuid,
         status: BulkActionSubmissionStatusResponseStatusEnum.in_progress,
+        error: null,
       },
     ],
     params: {
       language: languageCode,
     },
+    progress,
     created_by: {
       username: 'zefir',
     },
     date_created: '2026-01-01T00:00:00Z',
     date_modified: '2026-01-01T00:00:00Z',
-    ...overrides,
+    ...restOverrides,
   }
 }

--- a/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_create.md
+++ b/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_create.md
@@ -1,4 +1,21 @@
 ## Create a bulk processing job
 
-Creates a placeholder bulk transcription or bulk translation job for a single
-question across multiple submissions.
+Creates and starts a bulk processing job for one question across multiple
+submissions.
+
+Supported actions:
+
+* `automatic_google_transcription`
+* `automatic_google_translation`
+
+The request must include the target `question_xpath`, the submission root UUIDs
+to process, and deterministic `params`. `params.language` is required. For
+transcription, `params.locale` may also be supplied when a more specific Google
+Speech locale is needed.
+
+Creation is atomic. If any selected submission is unknown, already has matching
+results, or already has an active matching bulk action, no job or child items are
+created.
+
+The response is the created job. Its initial status is `in_progress` because
+creation immediately starts background processing.

--- a/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_list.md
+++ b/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_list.md
@@ -1,4 +1,24 @@
 ## List bulk processing jobs on an asset
 
-Returns all bulk processing jobs associated with the specified asset. Each job
-is organized around one question and many submissions.
+Returns paginated bulk processing jobs associated with the specified asset. Each
+job is organized around one action, one question, and many submissions.
+
+Use this endpoint to monitor recently-created bulk transcription and translation
+jobs. Each result includes the parent job status, per-submission statuses, the
+original deterministic params, the user who created the job, cancellation
+metadata, and integer `progress` from `0` to `100`.
+
+Job statuses:
+
+* `pending`: the job exists but has not started.
+* `in_progress`: one or more child submissions are still active.
+* `complete`: every child submission has reached a terminal state.
+* `cancelled`: the job was cancelled.
+
+Child submission statuses:
+
+* `pending`
+* `in_progress`
+* `complete`
+* `failed`
+* `cancelled`

--- a/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_retrieve.md
+++ b/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_retrieve.md
@@ -1,7 +1,8 @@
 ## Retrieve a bulk processing job
 
 Returns detailed information about a single bulk processing job, including its
-current status and processing metadata.
+current status, per-submission status, processing params, creator, cancellation
+metadata, timestamps, and integer `progress` from `0` to `100`.
 
 The response shape is identical to the item returned by the bulk job creation
-endpoint.
+endpoint and to each item in the paginated list response.

--- a/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_update.md
+++ b/kobo/apps/subsequences/docs/api/v2/subsequences/bulk_actions_update.md
@@ -1,7 +1,19 @@
 ## Update a bulk processing job
 
-Cancels a single bulk processing job for an asset.
+Cancels a single bulk processing job for an asset. This endpoint currently only
+supports cancellation.
 
-The `PATCH` endpoint is used for bulk action cancellation.
+Request body:
 
-The request body sets the job status to `cancelled`.
+```json
+{
+  "status": "cancelled"
+}
+```
+
+Cancellation is idempotent. Cancelling an already-cancelled job returns the
+current cancelled job. Completed jobs cannot be cancelled.
+
+When a job is cancelled, pending and in-progress child items are marked
+`cancelled`; terminal child items are not modified. The response is the updated
+job, including `cancelled_by`.

--- a/kpi/schema_extensions/v2/subsequences/examples.py
+++ b/kpi/schema_extensions/v2/subsequences/examples.py
@@ -545,38 +545,48 @@ def _bulk_action_response_value(
     submission_uuids = [
         '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
         '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
+        '5d4958d6-b2e8-4d4b-a51f-63f91b459e26',
     ]
     submission_statuses = [
         {
             'uuid': '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
             'status': 'complete',
+            'error': None,
         },
         {
             'uuid': '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
             'status': 'in_progress',
+            'error': None,
+        },
+        {
+            'uuid': '5d4958d6-b2e8-4d4b-a51f-63f91b459e26',
+            'status': 'failed',
+            'error': 'Google quota exceeded',
         },
     ]
     status = 'in_progress'
-    progress = 50
+    progress = 66
     cancelled_by = None
 
     if cancelled:
         status = 'cancelled'
         progress = 100
         cancelled_by = {'username': 'someuser'}
-        submission_uuids.append('5d4958d6-b2e8-4d4b-a51f-63f91b459e26')
         submission_statuses = [
             {
                 'uuid': '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
                 'status': 'complete',
+                'error': None,
             },
             {
                 'uuid': '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
                 'status': 'cancelled',
+                'error': None,
             },
             {
                 'uuid': '5d4958d6-b2e8-4d4b-a51f-63f91b459e26',
-                'status': 'cancelled',
+                'status': 'failed',
+                'error': 'Google quota exceeded',
             },
         ]
 

--- a/kpi/schema_extensions/v2/subsequences/examples.py
+++ b/kpi/schema_extensions/v2/subsequences/examples.py
@@ -492,7 +492,7 @@ def get_bulk_actions_create_examples() -> list[OpenApiExample]:
             'Bulk transcription job',
             value={
                 'action_id': 'automatic_google_transcription',
-                'question_xpath': 'q1',
+                'question_xpath': 'q1_audio',
                 'submission_uuids': [
                     '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
                     '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
@@ -512,7 +512,7 @@ def get_bulk_actions_create_examples() -> list[OpenApiExample]:
             'Bulk translation job',
             value={
                 'action_id': 'automatic_google_translation',
-                'question_xpath': 'q1',
+                'question_xpath': 'q1_transcript',
                 'submission_uuids': [
                     '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
                     '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
@@ -532,41 +532,69 @@ def get_bulk_actions_create_examples() -> list[OpenApiExample]:
 
 def _bulk_action_response_value(
     *,
-    action_id: str = 'automatic_google_transcription',
+    action_id: str,
+    cancelled: bool = False,
 ) -> dict:
-    params = {'language': 'fr'}
-    question_xpath = 'q1'
     if action_id == 'automatic_google_transcription':
+        question_xpath = 'q1_audio'
         params = {'language': 'en', 'locale': 'en-US'}
-        question_xpath = 'q1'
+    else:
+        question_xpath = 'q1_transcript'
+        params = {'language': 'fr'}
 
-    return {
-        'uid': 'ba123456789AbCdEfGhIjklm',
-        'status': 'in_progress',
-        'action_id': action_id,
-        'question_xpath': question_xpath,
-        'submission_uuids': [
-            '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
-            '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
-        ],
-        'submission_statuses': [
+    submission_uuids = [
+        '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
+        '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
+    ]
+    submission_statuses = [
+        {
+            'uuid': '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
+            'status': 'complete',
+        },
+        {
+            'uuid': '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
+            'status': 'in_progress',
+        },
+    ]
+    status = 'in_progress'
+    progress = 50
+    cancelled_by = None
+
+    if cancelled:
+        status = 'cancelled'
+        progress = 100
+        cancelled_by = {'username': 'someuser'}
+        submission_uuids.append('5d4958d6-b2e8-4d4b-a51f-63f91b459e26')
+        submission_statuses = [
             {
                 'uuid': '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
                 'status': 'complete',
             },
             {
                 'uuid': '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
-                'status': 'in_progress',
+                'status': 'cancelled',
             },
-        ],
+            {
+                'uuid': '5d4958d6-b2e8-4d4b-a51f-63f91b459e26',
+                'status': 'cancelled',
+            },
+        ]
+
+    return {
+        'uid': 'ba123456789AbCdEfGhIjklm',
+        'status': status,
+        'action_id': action_id,
+        'question_xpath': question_xpath,
+        'submission_uuids': submission_uuids,
+        'submission_statuses': submission_statuses,
         'params': params,
-        'progress': 50,
+        'progress': progress,
         'created_by': {
             'username': 'someuser',
         },
         'date_created': '2026-05-05T09:00:00Z',
         'date_modified': '2026-05-05T09:02:00Z',
-        'cancelled_by': None,
+        'cancelled_by': cancelled_by,
     }
 
 
@@ -606,7 +634,7 @@ def get_bulk_action_list_response_examples() -> list[OpenApiExample]:
     )
     return [
         OpenApiExample(
-            'Bulk transcription job response',
+            'Bulk transcription job list response',
             value={
                 'count': 1,
                 'next': None,
@@ -616,7 +644,7 @@ def get_bulk_action_list_response_examples() -> list[OpenApiExample]:
             response_only=True,
         ),
         OpenApiExample(
-            'Bulk translation job response',
+            'Bulk translation job list response',
             value={
                 'count': 1,
                 'next': None,
@@ -637,5 +665,28 @@ def get_bulk_action_patch_examples() -> list[OpenApiExample]:
             },
             request_only=True,
         ),
-        *get_bulk_action_response_examples(),
+        OpenApiExample(
+            'Cancelled bulk transcription job response',
+            value=_bulk_action_response_value(
+                action_id='automatic_google_transcription',
+                cancelled=True,
+            ),
+            description=(
+                'The cancelled response shows active child items moved to '
+                '`cancelled`; terminal child items remain unchanged.'
+            ),
+            response_only=True,
+        ),
+        OpenApiExample(
+            'Cancelled bulk translation job response',
+            value=_bulk_action_response_value(
+                action_id='automatic_google_translation',
+                cancelled=True,
+            ),
+            description=(
+                'The cancelled response includes the user who cancelled the '
+                'job in `cancelled_by`.'
+            ),
+            response_only=True,
+        ),
     ]

--- a/kpi/schema_extensions/v2/subsequences/examples.py
+++ b/kpi/schema_extensions/v2/subsequences/examples.py
@@ -502,6 +502,10 @@ def get_bulk_actions_create_examples() -> list[OpenApiExample]:
                     'locale': 'en-US',
                 },
             },
+            description=(
+                'Starts Google transcription for the selected audio question '
+                'across the listed submissions. `locale` is optional.'
+            ),
             request_only=True,
         ),
         OpenApiExample(
@@ -517,17 +521,30 @@ def get_bulk_actions_create_examples() -> list[OpenApiExample]:
                     'language': 'fr',
                 },
             },
+            description=(
+                'Starts Google translation for the selected question across '
+                'the listed submissions. `language` is the target language.'
+            ),
             request_only=True,
         ),
     ]
 
 
-def _bulk_action_response_value() -> dict:
+def _bulk_action_response_value(
+    *,
+    action_id: str = 'automatic_google_transcription',
+) -> dict:
+    params = {'language': 'fr'}
+    question_xpath = 'q1'
+    if action_id == 'automatic_google_transcription':
+        params = {'language': 'en', 'locale': 'en-US'}
+        question_xpath = 'q1'
+
     return {
         'uid': 'ba123456789AbCdEfGhIjklm',
         'status': 'in_progress',
-        'action_id': 'automatic_google_transcription',
-        'question_xpath': 'q1',
+        'action_id': action_id,
+        'question_xpath': question_xpath,
         'submission_uuids': [
             '3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f',
             '0ca3624a-6f22-451e-8d0a-c40978fd6fe2',
@@ -542,10 +559,8 @@ def _bulk_action_response_value() -> dict:
                 'status': 'in_progress',
             },
         ],
-        'params': {
-            'language': 'en',
-            'locale': 'en-US',
-        },
+        'params': params,
+        'progress': 50,
         'created_by': {
             'username': 'someuser',
         },
@@ -558,23 +573,55 @@ def _bulk_action_response_value() -> dict:
 def get_bulk_action_response_examples() -> list[OpenApiExample]:
     return [
         OpenApiExample(
-            'Bulk action response',
-            value=_bulk_action_response_value(),
+            'Bulk transcription job response',
+            value=_bulk_action_response_value(
+                action_id='automatic_google_transcription',
+            ),
+            description=(
+                'Bulk transcription responses include the action params used '
+                'to start the job. `locale` appears when it was supplied.'
+            ),
+            response_only=True,
+        ),
+        OpenApiExample(
+            'Bulk translation job response',
+            value=_bulk_action_response_value(
+                action_id='automatic_google_translation',
+            ),
+            description=(
+                'Bulk translation responses use the same job shape. '
+                '`params.language` is the target translation language.'
+            ),
             response_only=True,
         ),
     ]
 
 
 def get_bulk_action_list_response_examples() -> list[OpenApiExample]:
-    response_value = _bulk_action_response_value()
+    transcription_response = _bulk_action_response_value(
+        action_id='automatic_google_transcription',
+    )
+    translation_response = _bulk_action_response_value(
+        action_id='automatic_google_translation',
+    )
     return [
         OpenApiExample(
-            'Bulk action list response',
+            'Bulk transcription job response',
             value={
                 'count': 1,
                 'next': None,
                 'previous': None,
-                'results': [response_value],
+                'results': [transcription_response],
+            },
+            response_only=True,
+        ),
+        OpenApiExample(
+            'Bulk translation job response',
+            value={
+                'count': 1,
+                'next': None,
+                'previous': None,
+                'results': [translation_response],
             },
             response_only=True,
         ),

--- a/kpi/schema_extensions/v2/subsequences/serializers.py
+++ b/kpi/schema_extensions/v2/subsequences/serializers.py
@@ -90,6 +90,7 @@ BulkActionSubmissionStatusResponse = inline_serializer_class(
     fields={
         'uuid': serializers.CharField(),
         'status': BulkActionSubmissionStatusField(),
+        'error': serializers.CharField(allow_null=True),
     },
 )
 

--- a/kpi/schema_extensions/v2/subsequences/serializers.py
+++ b/kpi/schema_extensions/v2/subsequences/serializers.py
@@ -119,6 +119,7 @@ BulkActionResponse = inline_serializer_class(
         'submission_uuids': serializers.ListField(child=serializers.CharField()),
         'submission_statuses': BulkActionSubmissionStatusResponse(many=True),
         'params': BulkActionParamsResponse(),
+        'progress': serializers.IntegerField(min_value=0, max_value=100),
         'created_by': BulkActionUserResponse(),
         'date_created': serializers.DateTimeField(),
         'date_modified': serializers.DateTimeField(),

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -2899,7 +2899,7 @@
                                     "$ref": "#/components/schemas/BulkActionListResponse"
                                 },
                                 "examples": {
-                                    "BulkTranscriptionJobResponse": {
+                                    "BulkTranscriptionJobListResponse": {
                                         "value": {
                                             "count": 1,
                                             "next": null,
@@ -2909,7 +2909,7 @@
                                                     "uid": "ba123456789AbCdEfGhIjklm",
                                                     "status": "in_progress",
                                                     "action_id": "automatic_google_transcription",
-                                                    "question_xpath": "q1",
+                                                    "question_xpath": "q1_audio",
                                                     "submission_uuids": [
                                                         "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                         "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -2938,9 +2938,9 @@
                                                 }
                                             ]
                                         },
-                                        "summary": "Bulk transcription job response"
+                                        "summary": "Bulk transcription job list response"
                                     },
-                                    "BulkTranslationJobResponse": {
+                                    "BulkTranslationJobListResponse": {
                                         "value": {
                                             "count": 1,
                                             "next": null,
@@ -2950,7 +2950,7 @@
                                                     "uid": "ba123456789AbCdEfGhIjklm",
                                                     "status": "in_progress",
                                                     "action_id": "automatic_google_translation",
-                                                    "question_xpath": "q1",
+                                                    "question_xpath": "q1_transcript",
                                                     "submission_uuids": [
                                                         "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                         "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -2978,7 +2978,7 @@
                                                 }
                                             ]
                                         },
-                                        "summary": "Bulk translation job response"
+                                        "summary": "Bulk translation job list response"
                                     }
                                 }
                             }
@@ -3032,7 +3032,7 @@
                                 "BulkTranscriptionJob": {
                                     "value": {
                                         "action_id": "automatic_google_transcription",
-                                        "question_xpath": "q1",
+                                        "question_xpath": "q1_audio",
                                         "submission_uuids": [
                                             "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                             "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3048,7 +3048,7 @@
                                 "BulkTranslationJob": {
                                     "value": {
                                         "action_id": "automatic_google_translation",
-                                        "question_xpath": "q1",
+                                        "question_xpath": "q1_transcript",
                                         "submission_uuids": [
                                             "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                             "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3086,7 +3086,7 @@
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
                                             "action_id": "automatic_google_transcription",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_audio",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                 "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3121,7 +3121,7 @@
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
                                             "action_id": "automatic_google_translation",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_transcript",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                 "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3246,7 +3246,7 @@
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
                                             "action_id": "automatic_google_transcription",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_audio",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                 "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3281,7 +3281,7 @@
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
                                             "action_id": "automatic_google_translation",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_transcript",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
                                                 "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
@@ -3394,15 +3394,16 @@
                                     "$ref": "#/components/schemas/BulkActionResponse"
                                 },
                                 "examples": {
-                                    "BulkTranscriptionJobResponse": {
+                                    "CancelledBulkTranscriptionJobResponse": {
                                         "value": {
                                             "uid": "ba123456789AbCdEfGhIjklm",
-                                            "status": "in_progress",
+                                            "status": "cancelled",
                                             "action_id": "automatic_google_transcription",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_audio",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
@@ -3411,33 +3412,40 @@
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "cancelled"
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "cancelled"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
-                                            "progress": 50,
+                                            "progress": 100,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
                                             "date_created": "2026-05-05T09:00:00Z",
                                             "date_modified": "2026-05-05T09:02:00Z",
-                                            "cancelled_by": null
+                                            "cancelled_by": {
+                                                "username": "someuser"
+                                            }
                                         },
-                                        "summary": "Bulk transcription job response",
-                                        "description": "Bulk transcription responses include the action params used to start the job. `locale` appears when it was supplied."
+                                        "summary": "Cancelled bulk transcription job response",
+                                        "description": "The cancelled response shows active child items moved to `cancelled`; terminal child items remain unchanged."
                                     },
-                                    "BulkTranslationJobResponse": {
+                                    "CancelledBulkTranslationJobResponse": {
                                         "value": {
                                             "uid": "ba123456789AbCdEfGhIjklm",
-                                            "status": "in_progress",
+                                            "status": "cancelled",
                                             "action_id": "automatic_google_translation",
-                                            "question_xpath": "q1",
+                                            "question_xpath": "q1_transcript",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
@@ -3446,22 +3454,28 @@
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "cancelled"
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "cancelled"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "fr"
                                             },
-                                            "progress": 50,
+                                            "progress": 100,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
                                             "date_created": "2026-05-05T09:00:00Z",
                                             "date_modified": "2026-05-05T09:02:00Z",
-                                            "cancelled_by": null
+                                            "cancelled_by": {
+                                                "username": "someuser"
+                                            }
                                         },
-                                        "summary": "Bulk translation job response",
-                                        "description": "Bulk translation responses use the same job shape. `params.language` is the target translation language."
+                                        "summary": "Cancelled bulk translation job response",
+                                        "description": "The cancelled response includes the user who cancelled the job in `cancelled_by`."
                                     }
                                 }
                             }

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -2841,7 +2841,7 @@
         "/api/v2/assets/{uid_asset}/advanced-features/bulk-actions/": {
             "get": {
                 "operationId": "api_v2_assets_advanced_features_bulk_actions_list",
-                "description": "## List bulk processing jobs on an asset\n\nReturns all bulk processing jobs associated with the specified asset. Each job\nis organized around one question and many submissions.\n",
+                "description": "## List bulk processing jobs on an asset\n\nReturns paginated bulk processing jobs associated with the specified asset. Each\njob is organized around one action, one question, and many submissions.\n\nUse this endpoint to monitor recently-created bulk transcription and translation\njobs. Each result includes the parent job status, per-submission statuses, the\noriginal deterministic params, the user who created the job, cancellation\nmetadata, and integer `progress` from `0` to `100`.\n\nJob statuses:\n\n* `pending`: the job exists but has not started.\n* `in_progress`: one or more child submissions are still active.\n* `complete`: every child submission has reached a terminal state.\n* `cancelled`: the job was cancelled.\n\nChild submission statuses:\n\n* `pending`\n* `in_progress`\n* `complete`\n* `failed`\n* `cancelled`\n",
                 "parameters": [
                     {
                         "name": "limit",
@@ -2899,7 +2899,7 @@
                                     "$ref": "#/components/schemas/BulkActionListResponse"
                                 },
                                 "examples": {
-                                    "BulkActionListResponse": {
+                                    "BulkTranscriptionJobResponse": {
                                         "value": {
                                             "count": 1,
                                             "next": null,
@@ -2928,6 +2928,7 @@
                                                         "language": "en",
                                                         "locale": "en-US"
                                                     },
+                                                    "progress": 50,
                                                     "created_by": {
                                                         "username": "someuser"
                                                     },
@@ -2937,7 +2938,47 @@
                                                 }
                                             ]
                                         },
-                                        "summary": "Bulk action list response"
+                                        "summary": "Bulk transcription job response"
+                                    },
+                                    "BulkTranslationJobResponse": {
+                                        "value": {
+                                            "count": 1,
+                                            "next": null,
+                                            "previous": null,
+                                            "results": [
+                                                {
+                                                    "uid": "ba123456789AbCdEfGhIjklm",
+                                                    "status": "in_progress",
+                                                    "action_id": "automatic_google_translation",
+                                                    "question_xpath": "q1",
+                                                    "submission_uuids": [
+                                                        "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                        "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                    ],
+                                                    "submission_statuses": [
+                                                        {
+                                                            "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                            "status": "complete"
+                                                        },
+                                                        {
+                                                            "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                            "status": "in_progress"
+                                                        }
+                                                    ],
+                                                    "params": {
+                                                        "language": "fr"
+                                                    },
+                                                    "progress": 50,
+                                                    "created_by": {
+                                                        "username": "someuser"
+                                                    },
+                                                    "date_created": "2026-05-05T09:00:00Z",
+                                                    "date_modified": "2026-05-05T09:02:00Z",
+                                                    "cancelled_by": null
+                                                }
+                                            ]
+                                        },
+                                        "summary": "Bulk translation job response"
                                     }
                                 }
                             }
@@ -2966,7 +3007,7 @@
             },
             "post": {
                 "operationId": "api_v2_assets_advanced_features_bulk_actions_create",
-                "description": "## Create a bulk processing job\n\nCreates a placeholder bulk transcription or bulk translation job for a single\nquestion across multiple submissions.\n",
+                "description": "## Create a bulk processing job\n\nCreates and starts a bulk processing job for one question across multiple\nsubmissions.\n\nSupported actions:\n\n* `automatic_google_transcription`\n* `automatic_google_translation`\n\nThe request must include the target `question_xpath`, the submission root UUIDs\nto process, and deterministic `params`. `params.language` is required. For\ntranscription, `params.locale` may also be supplied when a more specific Google\nSpeech locale is needed.\n\nCreation is atomic. If any selected submission is unknown, already has matching\nresults, or already has an active matching bulk action, no job or child items are\ncreated.\n\nThe response is the created job. Its initial status is `in_progress` because\ncreation immediately starts background processing.\n",
                 "parameters": [
                     {
                         "in": "path",
@@ -3001,7 +3042,8 @@
                                             "locale": "en-US"
                                         }
                                     },
-                                    "summary": "Bulk transcription job"
+                                    "summary": "Bulk transcription job",
+                                    "description": "Starts Google transcription for the selected audio question across the listed submissions. `locale` is optional."
                                 },
                                 "BulkTranslationJob": {
                                     "value": {
@@ -3015,7 +3057,8 @@
                                             "language": "fr"
                                         }
                                     },
-                                    "summary": "Bulk translation job"
+                                    "summary": "Bulk translation job",
+                                    "description": "Starts Google translation for the selected question across the listed submissions. `language` is the target language."
                                 }
                             }
                         }
@@ -3038,7 +3081,7 @@
                                     "$ref": "#/components/schemas/BulkActionResponse"
                                 },
                                 "examples": {
-                                    "BulkActionResponse": {
+                                    "BulkTranscriptionJobResponse": {
                                         "value": {
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
@@ -3062,6 +3105,7 @@
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
+                                            "progress": 50,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3069,7 +3113,42 @@
                                             "date_modified": "2026-05-05T09:02:00Z",
                                             "cancelled_by": null
                                         },
-                                        "summary": "Bulk action response"
+                                        "summary": "Bulk transcription job response",
+                                        "description": "Bulk transcription responses include the action params used to start the job. `locale` appears when it was supplied."
+                                    },
+                                    "BulkTranslationJobResponse": {
+                                        "value": {
+                                            "uid": "ba123456789AbCdEfGhIjklm",
+                                            "status": "in_progress",
+                                            "action_id": "automatic_google_translation",
+                                            "question_xpath": "q1",
+                                            "submission_uuids": [
+                                                "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                            ],
+                                            "submission_statuses": [
+                                                {
+                                                    "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                    "status": "complete"
+                                                },
+                                                {
+                                                    "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                    "status": "in_progress"
+                                                }
+                                            ],
+                                            "params": {
+                                                "language": "fr"
+                                            },
+                                            "progress": 50,
+                                            "created_by": {
+                                                "username": "someuser"
+                                            },
+                                            "date_created": "2026-05-05T09:00:00Z",
+                                            "date_modified": "2026-05-05T09:02:00Z",
+                                            "cancelled_by": null
+                                        },
+                                        "summary": "Bulk translation job response",
+                                        "description": "Bulk translation responses use the same job shape. `params.language` is the target translation language."
                                     }
                                 }
                             }
@@ -3122,7 +3201,7 @@
         "/api/v2/assets/{uid_asset}/advanced-features/bulk-actions/{action_uid}/": {
             "get": {
                 "operationId": "api_v2_assets_advanced_features_bulk_actions_retrieve",
-                "description": "## Retrieve a bulk processing job\n\nReturns detailed information about a single bulk processing job, including its\ncurrent status and processing metadata.\n\nThe response shape is identical to the item returned by the bulk job creation\nendpoint.\n",
+                "description": "## Retrieve a bulk processing job\n\nReturns detailed information about a single bulk processing job, including its\ncurrent status, per-submission status, processing params, creator, cancellation\nmetadata, timestamps, and integer `progress` from `0` to `100`.\n\nThe response shape is identical to the item returned by the bulk job creation\nendpoint and to each item in the paginated list response.\n",
                 "parameters": [
                     {
                         "in": "path",
@@ -3162,7 +3241,7 @@
                                     "$ref": "#/components/schemas/BulkActionResponse"
                                 },
                                 "examples": {
-                                    "BulkActionResponse": {
+                                    "BulkTranscriptionJobResponse": {
                                         "value": {
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
@@ -3186,6 +3265,7 @@
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
+                                            "progress": 50,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3193,7 +3273,42 @@
                                             "date_modified": "2026-05-05T09:02:00Z",
                                             "cancelled_by": null
                                         },
-                                        "summary": "Bulk action response"
+                                        "summary": "Bulk transcription job response",
+                                        "description": "Bulk transcription responses include the action params used to start the job. `locale` appears when it was supplied."
+                                    },
+                                    "BulkTranslationJobResponse": {
+                                        "value": {
+                                            "uid": "ba123456789AbCdEfGhIjklm",
+                                            "status": "in_progress",
+                                            "action_id": "automatic_google_translation",
+                                            "question_xpath": "q1",
+                                            "submission_uuids": [
+                                                "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                            ],
+                                            "submission_statuses": [
+                                                {
+                                                    "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                    "status": "complete"
+                                                },
+                                                {
+                                                    "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                    "status": "in_progress"
+                                                }
+                                            ],
+                                            "params": {
+                                                "language": "fr"
+                                            },
+                                            "progress": 50,
+                                            "created_by": {
+                                                "username": "someuser"
+                                            },
+                                            "date_created": "2026-05-05T09:00:00Z",
+                                            "date_modified": "2026-05-05T09:02:00Z",
+                                            "cancelled_by": null
+                                        },
+                                        "summary": "Bulk translation job response",
+                                        "description": "Bulk translation responses use the same job shape. `params.language` is the target translation language."
                                     }
                                 }
                             }
@@ -3222,7 +3337,7 @@
             },
             "patch": {
                 "operationId": "api_v2_assets_advanced_features_bulk_actions_partial_update",
-                "description": "## Update a bulk processing job\n\nCancels a single bulk processing job for an asset.\n\nThe `PATCH` endpoint is used for bulk action cancellation.\n\nThe request body sets the job status to `cancelled`.\n",
+                "description": "## Update a bulk processing job\n\nCancels a single bulk processing job for an asset. This endpoint currently only\nsupports cancellation.\n\nRequest body:\n\n```json\n{\n  \"status\": \"cancelled\"\n}\n```\n\nCancellation is idempotent. Cancelling an already-cancelled job returns the\ncurrent cancelled job. Completed jobs cannot be cancelled.\n\nWhen a job is cancelled, pending and in-progress child items are marked\n`cancelled`; terminal child items are not modified. The response is the updated\njob, including `cancelled_by`.\n",
                 "parameters": [
                     {
                         "in": "path",
@@ -3279,7 +3394,7 @@
                                     "$ref": "#/components/schemas/BulkActionResponse"
                                 },
                                 "examples": {
-                                    "BulkActionResponse": {
+                                    "BulkTranscriptionJobResponse": {
                                         "value": {
                                             "uid": "ba123456789AbCdEfGhIjklm",
                                             "status": "in_progress",
@@ -3303,6 +3418,7 @@
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
+                                            "progress": 50,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3310,7 +3426,42 @@
                                             "date_modified": "2026-05-05T09:02:00Z",
                                             "cancelled_by": null
                                         },
-                                        "summary": "Bulk action response"
+                                        "summary": "Bulk transcription job response",
+                                        "description": "Bulk transcription responses include the action params used to start the job. `locale` appears when it was supplied."
+                                    },
+                                    "BulkTranslationJobResponse": {
+                                        "value": {
+                                            "uid": "ba123456789AbCdEfGhIjklm",
+                                            "status": "in_progress",
+                                            "action_id": "automatic_google_translation",
+                                            "question_xpath": "q1",
+                                            "submission_uuids": [
+                                                "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                            ],
+                                            "submission_statuses": [
+                                                {
+                                                    "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
+                                                    "status": "complete"
+                                                },
+                                                {
+                                                    "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                    "status": "in_progress"
+                                                }
+                                            ],
+                                            "params": {
+                                                "language": "fr"
+                                            },
+                                            "progress": 50,
+                                            "created_by": {
+                                                "username": "someuser"
+                                            },
+                                            "date_created": "2026-05-05T09:00:00Z",
+                                            "date_modified": "2026-05-05T09:02:00Z",
+                                            "cancelled_by": null
+                                        },
+                                        "summary": "Bulk translation job response",
+                                        "description": "Bulk translation responses use the same job shape. `params.language` is the target translation language."
                                     }
                                 }
                             }
@@ -22302,6 +22453,11 @@
                     "params": {
                         "$ref": "#/components/schemas/BulkActionParamsResponse"
                     },
+                    "progress": {
+                        "type": "integer",
+                        "maximum": 100,
+                        "minimum": 0
+                    },
                     "created_by": {
                         "$ref": "#/components/schemas/BulkActionUserResponse"
                     },
@@ -22328,6 +22484,7 @@
                     "date_created",
                     "date_modified",
                     "params",
+                    "progress",
                     "question_xpath",
                     "status",
                     "submission_statuses",

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -2912,23 +2912,31 @@
                                                     "question_xpath": "q1_audio",
                                                     "submission_uuids": [
                                                         "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                        "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                        "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                        "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                                     ],
                                                     "submission_statuses": [
                                                         {
                                                             "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                            "status": "complete"
+                                                            "status": "complete",
+                                                            "error": null
                                                         },
                                                         {
                                                             "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                            "status": "in_progress"
+                                                            "status": "in_progress",
+                                                            "error": null
+                                                        },
+                                                        {
+                                                            "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                            "status": "failed",
+                                                            "error": "Google quota exceeded"
                                                         }
                                                     ],
                                                     "params": {
                                                         "language": "en",
                                                         "locale": "en-US"
                                                     },
-                                                    "progress": 50,
+                                                    "progress": 66,
                                                     "created_by": {
                                                         "username": "someuser"
                                                     },
@@ -2953,22 +2961,30 @@
                                                     "question_xpath": "q1_transcript",
                                                     "submission_uuids": [
                                                         "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                        "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                        "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                        "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                                     ],
                                                     "submission_statuses": [
                                                         {
                                                             "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                            "status": "complete"
+                                                            "status": "complete",
+                                                            "error": null
                                                         },
                                                         {
                                                             "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                            "status": "in_progress"
+                                                            "status": "in_progress",
+                                                            "error": null
+                                                        },
+                                                        {
+                                                            "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                            "status": "failed",
+                                                            "error": "Google quota exceeded"
                                                         }
                                                     ],
                                                     "params": {
                                                         "language": "fr"
                                                     },
-                                                    "progress": 50,
+                                                    "progress": 66,
                                                     "created_by": {
                                                         "username": "someuser"
                                                     },
@@ -3089,23 +3105,31 @@
                                             "question_xpath": "q1_audio",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "in_progress",
+                                                    "error": null
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
-                                            "progress": 50,
+                                            "progress": 66,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3124,22 +3148,30 @@
                                             "question_xpath": "q1_transcript",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "in_progress",
+                                                    "error": null
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "fr"
                                             },
-                                            "progress": 50,
+                                            "progress": 66,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3249,23 +3281,31 @@
                                             "question_xpath": "q1_audio",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "in_progress",
+                                                    "error": null
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "en",
                                                 "locale": "en-US"
                                             },
-                                            "progress": 50,
+                                            "progress": 66,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3284,22 +3324,30 @@
                                             "question_xpath": "q1_transcript",
                                             "submission_uuids": [
                                                 "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2"
+                                                "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
+                                                "5d4958d6-b2e8-4d4b-a51f-63f91b459e26"
                                             ],
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "in_progress"
+                                                    "status": "in_progress",
+                                                    "error": null
+                                                },
+                                                {
+                                                    "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
                                                 "language": "fr"
                                             },
-                                            "progress": 50,
+                                            "progress": 66,
                                             "created_by": {
                                                 "username": "someuser"
                                             },
@@ -3408,15 +3456,18 @@
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "cancelled"
+                                                    "status": "cancelled",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
-                                                    "status": "cancelled"
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
@@ -3450,15 +3501,18 @@
                                             "submission_statuses": [
                                                 {
                                                     "uuid": "3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f",
-                                                    "status": "complete"
+                                                    "status": "complete",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "0ca3624a-6f22-451e-8d0a-c40978fd6fe2",
-                                                    "status": "cancelled"
+                                                    "status": "cancelled",
+                                                    "error": null
                                                 },
                                                 {
                                                     "uuid": "5d4958d6-b2e8-4d4b-a51f-63f91b459e26",
-                                                    "status": "cancelled"
+                                                    "status": "failed",
+                                                    "error": "Google quota exceeded"
                                                 }
                                             ],
                                             "params": {
@@ -22524,9 +22578,14 @@
                     },
                     "status": {
                         "$ref": "#/components/schemas/BulkActionSubmissionStatusResponseStatusEnum"
+                    },
+                    "error": {
+                        "type": "string",
+                        "nullable": true
                     }
                 },
                 "required": [
+                    "error",
                     "status",
                     "uuid"
                 ]

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -2008,7 +2008,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionListResponse'
               examples:
-                BulkTranscriptionJobResponse:
+                BulkTranscriptionJobListResponse:
                   value:
                     count: 1
                     next: null
@@ -2017,7 +2017,7 @@ paths:
                     - uid: ba123456789AbCdEfGhIjklm
                       status: in_progress
                       action_id: automatic_google_transcription
-                      question_xpath: q1
+                      question_xpath: q1_audio
                       submission_uuids:
                       - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2035,8 +2035,8 @@ paths:
                       date_created: '2026-05-05T09:00:00Z'
                       date_modified: '2026-05-05T09:02:00Z'
                       cancelled_by: null
-                  summary: Bulk transcription job response
-                BulkTranslationJobResponse:
+                  summary: Bulk transcription job list response
+                BulkTranslationJobListResponse:
                   value:
                     count: 1
                     next: null
@@ -2045,7 +2045,7 @@ paths:
                     - uid: ba123456789AbCdEfGhIjklm
                       status: in_progress
                       action_id: automatic_google_translation
-                      question_xpath: q1
+                      question_xpath: q1_transcript
                       submission_uuids:
                       - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2062,7 +2062,7 @@ paths:
                       date_created: '2026-05-05T09:00:00Z'
                       date_modified: '2026-05-05T09:02:00Z'
                       cancelled_by: null
-                  summary: Bulk translation job response
+                  summary: Bulk translation job list response
           description: null
         '404':
           content:
@@ -2117,7 +2117,7 @@ paths:
               BulkTranscriptionJob:
                 value:
                   action_id: automatic_google_transcription
-                  question_xpath: q1
+                  question_xpath: q1_audio
                   submission_uuids:
                   - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                   - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2130,7 +2130,7 @@ paths:
               BulkTranslationJob:
                 value:
                   action_id: automatic_google_translation
-                  question_xpath: q1
+                  question_xpath: q1_transcript
                   submission_uuids:
                   - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                   - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2155,7 +2155,7 @@ paths:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
                     action_id: automatic_google_transcription
-                    question_xpath: q1
+                    question_xpath: q1_audio
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2181,7 +2181,7 @@ paths:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
                     action_id: automatic_google_translation
-                    question_xpath: q1
+                    question_xpath: q1_transcript
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2268,7 +2268,7 @@ paths:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
                     action_id: automatic_google_transcription
-                    question_xpath: q1
+                    question_xpath: q1_audio
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2294,7 +2294,7 @@ paths:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
                     action_id: automatic_google_translation
-                    question_xpath: q1
+                    question_xpath: q1_transcript
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
@@ -2383,57 +2383,65 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionResponse'
               examples:
-                BulkTranscriptionJobResponse:
+                CancelledBulkTranscriptionJobResponse:
                   value:
                     uid: ba123456789AbCdEfGhIjklm
-                    status: in_progress
+                    status: cancelled
                     action_id: automatic_google_transcription
-                    question_xpath: q1
+                    question_xpath: q1_audio
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
-                      status: in_progress
+                      status: cancelled
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: cancelled
                     params:
                       language: en
                       locale: en-US
-                    progress: 50
+                    progress: 100
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
                     date_modified: '2026-05-05T09:02:00Z'
-                    cancelled_by: null
-                  summary: Bulk transcription job response
-                  description: Bulk transcription responses include the action params
-                    used to start the job. `locale` appears when it was supplied.
-                BulkTranslationJobResponse:
+                    cancelled_by:
+                      username: someuser
+                  summary: Cancelled bulk transcription job response
+                  description: The cancelled response shows active child items moved
+                    to `cancelled`; terminal child items remain unchanged.
+                CancelledBulkTranslationJobResponse:
                   value:
                     uid: ba123456789AbCdEfGhIjklm
-                    status: in_progress
+                    status: cancelled
                     action_id: automatic_google_translation
-                    question_xpath: q1
+                    question_xpath: q1_transcript
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
-                      status: in_progress
+                      status: cancelled
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: cancelled
                     params:
                       language: fr
-                    progress: 50
+                    progress: 100
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
                     date_modified: '2026-05-05T09:02:00Z'
-                    cancelled_by: null
-                  summary: Bulk translation job response
-                  description: Bulk translation responses use the same job shape.
-                    `params.language` is the target translation language.
+                    cancelled_by:
+                      username: someuser
+                  summary: Cancelled bulk translation job response
+                  description: The cancelled response includes the user who cancelled
+                    the job in `cancelled_by`.
           description: null
         '404':
           content:

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -2021,15 +2021,21 @@ paths:
                       submission_uuids:
                       - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                       submission_statuses:
                       - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                         status: complete
+                        error: null
                       - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                         status: in_progress
+                        error: null
+                      - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                        status: failed
+                        error: Google quota exceeded
                       params:
                         language: en
                         locale: en-US
-                      progress: 50
+                      progress: 66
                       created_by:
                         username: someuser
                       date_created: '2026-05-05T09:00:00Z'
@@ -2049,14 +2055,20 @@ paths:
                       submission_uuids:
                       - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                       submission_statuses:
                       - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                         status: complete
+                        error: null
                       - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                         status: in_progress
+                        error: null
+                      - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                        status: failed
+                        error: Google quota exceeded
                       params:
                         language: fr
-                      progress: 50
+                      progress: 66
                       created_by:
                         username: someuser
                       date_created: '2026-05-05T09:00:00Z'
@@ -2159,15 +2171,21 @@ paths:
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: in_progress
+                      error: null
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: en
                       locale: en-US
-                    progress: 50
+                    progress: 66
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
@@ -2185,14 +2203,20 @@ paths:
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: in_progress
+                      error: null
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: fr
-                    progress: 50
+                    progress: 66
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
@@ -2272,15 +2296,21 @@ paths:
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: in_progress
+                      error: null
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: en
                       locale: en-US
-                    progress: 50
+                    progress: 66
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
@@ -2298,14 +2328,20 @@ paths:
                     submission_uuids:
                     - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                     - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    - 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: in_progress
+                      error: null
+                    - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: fr
-                    progress: 50
+                    progress: 66
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
@@ -2396,10 +2432,13 @@ paths:
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: cancelled
+                      error: null
                     - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
-                      status: cancelled
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: en
                       locale: en-US
@@ -2426,10 +2465,13 @@ paths:
                     submission_statuses:
                     - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
                       status: complete
+                      error: null
                     - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
                       status: cancelled
+                      error: null
                     - uuid: 5d4958d6-b2e8-4d4b-a51f-63f91b459e26
-                      status: cancelled
+                      status: failed
+                      error: Google quota exceeded
                     params:
                       language: fr
                     progress: 100
@@ -16063,7 +16105,11 @@ components:
           type: string
         status:
           $ref: '#/components/schemas/BulkActionSubmissionStatusResponseStatusEnum'
+        error:
+          type: string
+          nullable: true
       required:
+      - error
       - status
       - uuid
     BulkActionSubmissionStatusResponseStatusEnum:

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -1948,8 +1948,28 @@ paths:
       description: |
         ## List bulk processing jobs on an asset
 
-        Returns all bulk processing jobs associated with the specified asset. Each job
-        is organized around one question and many submissions.
+        Returns paginated bulk processing jobs associated with the specified asset. Each
+        job is organized around one action, one question, and many submissions.
+
+        Use this endpoint to monitor recently-created bulk transcription and translation
+        jobs. Each result includes the parent job status, per-submission statuses, the
+        original deterministic params, the user who created the job, cancellation
+        metadata, and integer `progress` from `0` to `100`.
+
+        Job statuses:
+
+        * `pending`: the job exists but has not started.
+        * `in_progress`: one or more child submissions are still active.
+        * `complete`: every child submission has reached a terminal state.
+        * `cancelled`: the job was cancelled.
+
+        Child submission statuses:
+
+        * `pending`
+        * `in_progress`
+        * `complete`
+        * `failed`
+        * `cancelled`
       parameters:
       - name: limit
         required: false
@@ -1988,7 +2008,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionListResponse'
               examples:
-                BulkActionListResponse:
+                BulkTranscriptionJobResponse:
                   value:
                     count: 1
                     next: null
@@ -2009,12 +2029,40 @@ paths:
                       params:
                         language: en
                         locale: en-US
+                      progress: 50
                       created_by:
                         username: someuser
                       date_created: '2026-05-05T09:00:00Z'
                       date_modified: '2026-05-05T09:02:00Z'
                       cancelled_by: null
-                  summary: Bulk action list response
+                  summary: Bulk transcription job response
+                BulkTranslationJobResponse:
+                  value:
+                    count: 1
+                    next: null
+                    previous: null
+                    results:
+                    - uid: ba123456789AbCdEfGhIjklm
+                      status: in_progress
+                      action_id: automatic_google_translation
+                      question_xpath: q1
+                      submission_uuids:
+                      - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                      - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      submission_statuses:
+                      - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                        status: complete
+                      - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                        status: in_progress
+                      params:
+                        language: fr
+                      progress: 50
+                      created_by:
+                        username: someuser
+                      date_created: '2026-05-05T09:00:00Z'
+                      date_modified: '2026-05-05T09:02:00Z'
+                      cancelled_by: null
+                  summary: Bulk translation job response
           description: null
         '404':
           content:
@@ -2032,8 +2080,25 @@ paths:
       description: |
         ## Create a bulk processing job
 
-        Creates a placeholder bulk transcription or bulk translation job for a single
-        question across multiple submissions.
+        Creates and starts a bulk processing job for one question across multiple
+        submissions.
+
+        Supported actions:
+
+        * `automatic_google_transcription`
+        * `automatic_google_translation`
+
+        The request must include the target `question_xpath`, the submission root UUIDs
+        to process, and deterministic `params`. `params.language` is required. For
+        transcription, `params.locale` may also be supplied when a more specific Google
+        Speech locale is needed.
+
+        Creation is atomic. If any selected submission is unknown, already has matching
+        results, or already has an active matching bulk action, no job or child items are
+        created.
+
+        The response is the created job. Its initial status is `in_progress` because
+        creation immediately starts background processing.
       parameters:
       - in: path
         name: uid_asset
@@ -2060,6 +2125,8 @@ paths:
                     language: en
                     locale: en-US
                 summary: Bulk transcription job
+                description: Starts Google transcription for the selected audio question
+                  across the listed submissions. `locale` is optional.
               BulkTranslationJob:
                 value:
                   action_id: automatic_google_translation
@@ -2070,6 +2137,8 @@ paths:
                   params:
                     language: fr
                 summary: Bulk translation job
+                description: Starts Google translation for the selected question across
+                  the listed submissions. `language` is the target language.
         required: true
       security:
       - BasicAuth: []
@@ -2081,7 +2150,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionResponse'
               examples:
-                BulkActionResponse:
+                BulkTranscriptionJobResponse:
                   value:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
@@ -2098,12 +2167,40 @@ paths:
                     params:
                       language: en
                       locale: en-US
+                    progress: 50
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
                     date_modified: '2026-05-05T09:02:00Z'
                     cancelled_by: null
-                  summary: Bulk action response
+                  summary: Bulk transcription job response
+                  description: Bulk transcription responses include the action params
+                    used to start the job. `locale` appears when it was supplied.
+                BulkTranslationJobResponse:
+                  value:
+                    uid: ba123456789AbCdEfGhIjklm
+                    status: in_progress
+                    action_id: automatic_google_translation
+                    question_xpath: q1
+                    submission_uuids:
+                    - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                    - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    submission_statuses:
+                    - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                      status: complete
+                    - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      status: in_progress
+                    params:
+                      language: fr
+                    progress: 50
+                    created_by:
+                      username: someuser
+                    date_created: '2026-05-05T09:00:00Z'
+                    date_modified: '2026-05-05T09:02:00Z'
+                    cancelled_by: null
+                  summary: Bulk translation job response
+                  description: Bulk translation responses use the same job shape.
+                    `params.language` is the target translation language.
           description: null
         '404':
           content:
@@ -2136,10 +2233,11 @@ paths:
         ## Retrieve a bulk processing job
 
         Returns detailed information about a single bulk processing job, including its
-        current status and processing metadata.
+        current status, per-submission status, processing params, creator, cancellation
+        metadata, timestamps, and integer `progress` from `0` to `100`.
 
         The response shape is identical to the item returned by the bulk job creation
-        endpoint.
+        endpoint and to each item in the paginated list response.
       parameters:
       - in: path
         name: action_uid
@@ -2165,7 +2263,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionResponse'
               examples:
-                BulkActionResponse:
+                BulkTranscriptionJobResponse:
                   value:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
@@ -2182,12 +2280,40 @@ paths:
                     params:
                       language: en
                       locale: en-US
+                    progress: 50
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
                     date_modified: '2026-05-05T09:02:00Z'
                     cancelled_by: null
-                  summary: Bulk action response
+                  summary: Bulk transcription job response
+                  description: Bulk transcription responses include the action params
+                    used to start the job. `locale` appears when it was supplied.
+                BulkTranslationJobResponse:
+                  value:
+                    uid: ba123456789AbCdEfGhIjklm
+                    status: in_progress
+                    action_id: automatic_google_translation
+                    question_xpath: q1
+                    submission_uuids:
+                    - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                    - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    submission_statuses:
+                    - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                      status: complete
+                    - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      status: in_progress
+                    params:
+                      language: fr
+                    progress: 50
+                    created_by:
+                      username: someuser
+                    date_created: '2026-05-05T09:00:00Z'
+                    date_modified: '2026-05-05T09:02:00Z'
+                    cancelled_by: null
+                  summary: Bulk translation job response
+                  description: Bulk translation responses use the same job shape.
+                    `params.language` is the target translation language.
           description: null
         '404':
           content:
@@ -2205,11 +2331,23 @@ paths:
       description: |
         ## Update a bulk processing job
 
-        Cancels a single bulk processing job for an asset.
+        Cancels a single bulk processing job for an asset. This endpoint currently only
+        supports cancellation.
 
-        The `PATCH` endpoint is used for bulk action cancellation.
+        Request body:
 
-        The request body sets the job status to `cancelled`.
+        ```json
+        {
+          "status": "cancelled"
+        }
+        ```
+
+        Cancellation is idempotent. Cancelling an already-cancelled job returns the
+        current cancelled job. Completed jobs cannot be cancelled.
+
+        When a job is cancelled, pending and in-progress child items are marked
+        `cancelled`; terminal child items are not modified. The response is the updated
+        job, including `cancelled_by`.
       parameters:
       - in: path
         name: action_uid
@@ -2245,7 +2383,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BulkActionResponse'
               examples:
-                BulkActionResponse:
+                BulkTranscriptionJobResponse:
                   value:
                     uid: ba123456789AbCdEfGhIjklm
                     status: in_progress
@@ -2262,12 +2400,40 @@ paths:
                     params:
                       language: en
                       locale: en-US
+                    progress: 50
                     created_by:
                       username: someuser
                     date_created: '2026-05-05T09:00:00Z'
                     date_modified: '2026-05-05T09:02:00Z'
                     cancelled_by: null
-                  summary: Bulk action response
+                  summary: Bulk transcription job response
+                  description: Bulk transcription responses include the action params
+                    used to start the job. `locale` appears when it was supplied.
+                BulkTranslationJobResponse:
+                  value:
+                    uid: ba123456789AbCdEfGhIjklm
+                    status: in_progress
+                    action_id: automatic_google_translation
+                    question_xpath: q1
+                    submission_uuids:
+                    - 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                    - 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                    submission_statuses:
+                    - uuid: 3c3f8e07-d660-4f5d-bb0d-7f7a54f02f8f
+                      status: complete
+                    - uuid: 0ca3624a-6f22-451e-8d0a-c40978fd6fe2
+                      status: in_progress
+                    params:
+                      language: fr
+                    progress: 50
+                    created_by:
+                      username: someuser
+                    date_created: '2026-05-05T09:00:00Z'
+                    date_modified: '2026-05-05T09:02:00Z'
+                    cancelled_by: null
+                  summary: Bulk translation job response
+                  description: Bulk translation responses use the same job shape.
+                    `params.language` is the target translation language.
           description: null
         '404':
           content:
@@ -15842,6 +16008,10 @@ components:
             $ref: '#/components/schemas/BulkActionSubmissionStatusResponse'
         params:
           $ref: '#/components/schemas/BulkActionParamsResponse'
+        progress:
+          type: integer
+          maximum: 100
+          minimum: 0
         created_by:
           $ref: '#/components/schemas/BulkActionUserResponse'
         date_created:
@@ -15860,6 +16030,7 @@ components:
       - date_created
       - date_modified
       - params
+      - progress
       - question_xpath
       - status
       - submission_statuses


### PR DESCRIPTION
### 📣 Summary
This PR implements the OpenAPI specifications for the `SubsequenceBulkAction` ViewSet using `drf-spectacular`.

### 📖 Description
This PR also adds the `progress` and `failure_error` fields to the API response schemas, allowing clients to track the progress of background bulk tasks and inspect failure details when errors occur.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Navigate to the docs endpoint: `/api/v1/docs`
2. 🟢 [on PR] Notice the new `advanced-features/bulk-actions/` endpoints are populated.
3. Expand the `POST` and `PATCH` endpoints.
4. 🟢 [on PR] Verify that the descriptions correctly format the Markdown files, and the request/response payloads strictly match the expected structures with the provided examples (including the `progress` tracking field).
