### PR TITLE
test(frontend): make FormMedia tests more stable DEV-2175

### DIFF
--- a/jsapp/js/project/FormMedia/FormMedia.stories.tsx
+++ b/jsapp/js/project/FormMedia/FormMedia.stories.tsx
@@ -62,9 +62,11 @@ export const BasicFlow: Story = {
       await userEvent.click(canvas.getByRole('button', { name: 'Add' }))
 
       await waitFor(async () => {
-        // One seeded link + one newly created link.
-        const fileLinks = canvas.getAllByRole('link')
-        await expect(fileLinks.length).toBe(2)
+        // Count media rows via their delete buttons to avoid matching unrelated
+        // links (for example helper links rendered elsewhere in the component).
+        // One seeded item + one newly added item = 2 delete buttons.
+        const deleteButtons = canvas.getAllByRole('button', { name: 'Delete file' })
+        await expect(deleteButtons.length).toBe(2)
       })
     })
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Stabilize the FormMedia Storybook interaction test.

Changes here:
- FormMedia.stories.tsx: update the play test to count delete buttons after adding media by URL, instead of counting every link in the canvas.
- This avoids a flaky assertion when Storybook renders the support/help link alongside the uploaded media links.

### 👀 Preview steps

1. Start Storybook.
2. Open `Features/FormMedia → BasicFlow`.
3. Confirm the seeded media file is shown.
4. Paste `https://example.org/docs/reference.pdf` into the URL field and click `Add`.
5. Confirm there are now two media rows, each with a `Delete file` button.
6. Click one `Delete file` button and confirm only one row remains.