### PR TITLE
feat(bulkProcessing): hide feature based on admin setting DEV-2212

### DIFF
--- a/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
+++ b/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
@@ -10,6 +10,7 @@ import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
 import { userCan } from '#/components/permissions/utils'
 import { SortValues } from '#/components/submissions/tableConstants'
 import type { AssetResponse } from '#/dataInterface'
+import envStore from '#/envStore'
 import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 
 interface TableColumnSortDropdownProps {
@@ -40,11 +41,13 @@ interface TableColumnSortDropdownProps {
 export default function TableColumnSortDropdown(props: TableColumnSortDropdownProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const isBulkProcessingFeatureEnabled = useFeatureFlag(FeatureFlag.bulkProcessingEnabled)
+  const isAsrMtFeaturesEnabled = envStore.data.asr_mt_features_enabled
+  const isBulkProcessingEnabled = isBulkProcessingFeatureEnabled && isAsrMtFeaturesEnabled
 
   const canTranscribeSelectedAudioFiles =
-    isBulkProcessingFeatureEnabled && props.isAudioQuestionColumn && Boolean(props.onTranscribeSelectedAudioFiles)
+    isBulkProcessingEnabled && props.isAudioQuestionColumn && Boolean(props.onTranscribeSelectedAudioFiles)
   const canTranslateSelectedTranscriptions =
-    isBulkProcessingFeatureEnabled && props.isTranscriptColumn && Boolean(props.onTranslateSelectedTranscriptions)
+    isBulkProcessingEnabled && props.isTranscriptColumn && Boolean(props.onTranslateSelectedTranscriptions)
   const shouldRenderBulkProcessingButtons = canTranscribeSelectedAudioFiles || canTranslateSelectedTranscriptions
 
   function renderTrigger() {

--- a/jsapp/js/components/submissions/useDataTableBulkActions.tests.ts
+++ b/jsapp/js/components/submissions/useDataTableBulkActions.tests.ts
@@ -28,6 +28,17 @@ jest.mock('#/stores/useSession', () => {
   }
 })
 
+jest.mock('#/envStore', () => {
+  return {
+    __esModule: true,
+    default: {
+      data: {
+        asr_mt_features_enabled: true,
+      },
+    },
+  }
+})
+
 function buildBulkAction(
   status: BulkActionResponseStatusEnum,
   createdByUsername: string,
@@ -48,6 +59,7 @@ describe('useDataTableBulkActions', () => {
   const useBulkActionsListMock = useAssetsAdvancedFeaturesBulkActionsList as jest.MockedFunction<
     typeof useAssetsAdvancedFeaturesBulkActionsList
   >
+  const envStore = require('#/envStore').default as { data: { asr_mt_features_enabled: boolean } }
 
   function mockSession(username: string | undefined, isPending = false) {
     // Hook only needs username and pending state; the remaining methods are stubbed.
@@ -75,10 +87,26 @@ describe('useDataTableBulkActions', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
+    envStore.data.asr_mt_features_enabled = true
   })
 
   it('returns no active actions and false when feature flag is disabled', () => {
     useFeatureFlagMock.mockReturnValue(false)
+    mockSession('zefir')
+    mockBulkActions([
+      buildBulkAction(BulkActionResponseStatusEnum.in_progress, 'other-user'),
+      buildBulkAction(BulkActionResponseStatusEnum.pending, 'other-user'),
+    ])
+
+    const { result } = renderHook(() => useDataTableBulkActions('asset-123'))
+
+    chai.expect(result.current.activeBulkActions).to.deep.equal([])
+    chai.expect(result.current.hasActiveBulkActionsCreatedByAnotherUser).to.equal(false)
+  })
+
+  it('returns no active actions and false when ASR/MT features are disabled in env', () => {
+    useFeatureFlagMock.mockReturnValue(true)
+    envStore.data.asr_mt_features_enabled = false
     mockSession('zefir')
     mockBulkActions([
       buildBulkAction(BulkActionResponseStatusEnum.in_progress, 'other-user'),

--- a/jsapp/js/components/submissions/useDataTableBulkActions.ts
+++ b/jsapp/js/components/submissions/useDataTableBulkActions.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import { useAssetsAdvancedFeaturesBulkActionsList } from '#/api/react-query/survey-data'
+import envStore from '#/envStore'
 import { FeatureFlag, useFeatureFlag } from '#/featureFlags'
 import { useSession } from '#/stores/useSession'
 
@@ -18,15 +19,17 @@ interface UseDataTableBulkActionsResult {
 export function useDataTableBulkActions(assetUid: string): UseDataTableBulkActionsResult {
   // Feature flag keeps all bulk-processing logic disabled unless explicitly enabled.
   const isBulkProcessingFeatureEnabled = useFeatureFlag(FeatureFlag.bulkProcessingEnabled)
+  const isAsrMtFeaturesEnabled = envStore.data.asr_mt_features_enabled
+  const isBulkProcessingEnabled = isBulkProcessingFeatureEnabled && isAsrMtFeaturesEnabled
   const session = useSession()
   // While session is loading we avoid making user-specific decisions.
   const currentUsername = session.isPending ? undefined : session.currentLoggedAccount?.username
 
   // Empty uid disables the query in Orval/react-query options.
-  const bulkActionsListQuery = useAssetsAdvancedFeaturesBulkActionsList(isBulkProcessingFeatureEnabled ? assetUid : '')
+  const bulkActionsListQuery = useAssetsAdvancedFeaturesBulkActionsList(isBulkProcessingEnabled ? assetUid : '')
 
   const activeBulkActions = React.useMemo(() => {
-    if (!isBulkProcessingFeatureEnabled) {
+    if (!isBulkProcessingEnabled) {
       return []
     }
 
@@ -38,7 +41,7 @@ export function useDataTableBulkActions(assetUid: string): UseDataTableBulkActio
         bulkAction.status === BulkActionResponseStatusEnum.pending ||
         bulkAction.status === BulkActionResponseStatusEnum.in_progress,
     )
-  }, [bulkActionsListQuery.data, isBulkProcessingFeatureEnabled])
+  }, [bulkActionsListQuery.data, isBulkProcessingEnabled])
 
   const hasActiveBulkActionsCreatedByAnotherUser = React.useMemo(() => {
     if (!currentUsername) {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Only users with ASR/MT enabled can see or use bulk transcription and translation in the data table.

### 💭 Notes

This update adds the `asr_mt_features_enabled` environment gate to the bulk-processing UI, so the bulk transcription and translation actions stay hidden unless the feature is enabled for the instance. It also keeps the bulk-actions data hook from polling or exposing bulk-processing state when the feature is off.

Changes here:
- tableColumnSortDropdown.tsx
  - Added the environment gate alongside the existing feature flag check.
  - Bulk transcription / translation menu items now render only when both gates are on.
- useDataTableBulkActions.ts
  - Added the same gate to bulk-action loading and active-job derivation.
  - Prevents bulk-processing banners, polling, and table-side bulk-job state from showing when ASR/MT is disabled.
- useDataTableBulkActions.tests.ts
  - Added coverage for the new env-level gate.

### 👀 Preview steps

To disable ASR/MT go to `/admin` → Constance → Config and set `ASR_MT_INVITEE_USERNAMES` to empty. To enable it add usernames or `*` wildcard.

1. Open a KPI instance where ASR/MT is disabled in the environment.
2. Go to a project with audio questions and submissions.
3. Open the column menu on an audio question or transcript column.
4. Notice that bulk transcription / translation actions do not appear.
5. Enable ASR/MT for the instance.
6. Reload the data table and open the same column menu again.
7. Notice that the bulk actions are available again, and bulk-processing state can load normally.