### PR TITLE
feat(map): improve settings modal tabs logic DEV-2224

### DIFF
--- a/jsapp/js/components/map/MapSettings.tests.ts
+++ b/jsapp/js/components/map/MapSettings.tests.ts
@@ -5,6 +5,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
     const tabs = buildMapSettingsTabsToDisplay({
       hasMultipleGeopointQuestions: false,
       hasLargeQueryCount: false,
+      hasChangeAssetPermission: true,
     })
 
     chai.expect(tabs).to.deep.equal(['colors', 'overlays'])
@@ -14,6 +15,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
     const tabs = buildMapSettingsTabsToDisplay({
       hasMultipleGeopointQuestions: false,
       hasLargeQueryCount: true,
+      hasChangeAssetPermission: true,
     })
 
     chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'overlays'])
@@ -23,6 +25,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
     const tabs = buildMapSettingsTabsToDisplay({
       hasMultipleGeopointQuestions: true,
       hasLargeQueryCount: false,
+      hasChangeAssetPermission: true,
     })
 
     chai.expect(tabs).to.deep.equal(['colors', 'geoquestion', 'overlays'])
@@ -32,8 +35,19 @@ describe('buildMapSettingsTabsToDisplay', () => {
     const tabs = buildMapSettingsTabsToDisplay({
       hasMultipleGeopointQuestions: true,
       hasLargeQueryCount: true,
+      hasChangeAssetPermission: true,
     })
 
     chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion', 'overlays'])
+  })
+
+  it('hides overlays when user has no permission to edit project', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasMultipleGeopointQuestions: true,
+      hasLargeQueryCount: true,
+      hasChangeAssetPermission: false,
+    })
+
+    chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion'])
   })
 })

--- a/jsapp/js/components/map/MapSettings.tests.ts
+++ b/jsapp/js/components/map/MapSettings.tests.ts
@@ -36,13 +36,4 @@ describe('buildMapSettingsTabsToDisplay', () => {
 
     chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion', 'overlays'])
   })
-
-  it('still keeps overlays tab when the user cannot change the asset', () => {
-    const tabs = buildMapSettingsTabsToDisplay({
-      hasMultipleGeopointQuestions: true,
-      hasLargeQueryCount: true,
-    })
-
-    chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion', 'overlays'])
-  })
 })

--- a/jsapp/js/components/map/MapSettings.tests.ts
+++ b/jsapp/js/components/map/MapSettings.tests.ts
@@ -7,7 +7,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
       hasLargeQueryCount: false,
     })
 
-    chai.expect(tabs).to.deep.equal(['overlays', 'colors'])
+    chai.expect(tabs).to.deep.equal(['colors', 'overlays'])
   })
 
   it('includes query limit without removing overlays', () => {
@@ -16,7 +16,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
       hasLargeQueryCount: true,
     })
 
-    chai.expect(tabs).to.deep.equal(['querylimit', 'overlays', 'colors'])
+    chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'overlays'])
   })
 
   it('includes geopoint question without removing overlays', () => {
@@ -25,7 +25,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
       hasLargeQueryCount: false,
     })
 
-    chai.expect(tabs).to.deep.equal(['geoquestion', 'overlays', 'colors'])
+    chai.expect(tabs).to.deep.equal(['colors', 'geoquestion', 'overlays'])
   })
 
   it('includes query limit and geopoint question together without removing overlays', () => {
@@ -34,7 +34,7 @@ describe('buildMapSettingsTabsToDisplay', () => {
       hasLargeQueryCount: true,
     })
 
-    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'overlays', 'colors'])
+    chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion', 'overlays'])
   })
 
   it('still keeps overlays tab when the user cannot change the asset', () => {
@@ -43,6 +43,6 @@ describe('buildMapSettingsTabsToDisplay', () => {
       hasLargeQueryCount: true,
     })
 
-    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'overlays', 'colors'])
+    chai.expect(tabs).to.deep.equal(['colors', 'querylimit', 'geoquestion', 'overlays'])
   })
 })

--- a/jsapp/js/components/map/MapSettings.tests.ts
+++ b/jsapp/js/components/map/MapSettings.tests.ts
@@ -3,7 +3,6 @@ import { buildMapSettingsTabsToDisplay } from './MapSettings'
 describe('buildMapSettingsTabsToDisplay', () => {
   it('keeps baseline tabs when no extra tab conditions are met', () => {
     const tabs = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: true,
       hasMultipleGeopointQuestions: false,
       hasLargeQueryCount: false,
     })
@@ -13,7 +12,6 @@ describe('buildMapSettingsTabsToDisplay', () => {
 
   it('includes query limit without removing overlays', () => {
     const tabs = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: true,
       hasMultipleGeopointQuestions: false,
       hasLargeQueryCount: true,
     })
@@ -23,7 +21,6 @@ describe('buildMapSettingsTabsToDisplay', () => {
 
   it('includes geopoint question without removing overlays', () => {
     const tabs = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: true,
       hasMultipleGeopointQuestions: true,
       hasLargeQueryCount: false,
     })
@@ -33,7 +30,6 @@ describe('buildMapSettingsTabsToDisplay', () => {
 
   it('includes query limit and geopoint question together without removing overlays', () => {
     const tabs = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: true,
       hasMultipleGeopointQuestions: true,
       hasLargeQueryCount: true,
     })
@@ -41,13 +37,12 @@ describe('buildMapSettingsTabsToDisplay', () => {
     chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'overlays', 'colors'])
   })
 
-  it('omits overlays if the user cannot change the asset', () => {
+  it('still keeps overlays tab when the user cannot change the asset', () => {
     const tabs = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: false,
       hasMultipleGeopointQuestions: true,
       hasLargeQueryCount: true,
     })
 
-    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'colors'])
+    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'overlays', 'colors'])
   })
 })

--- a/jsapp/js/components/map/MapSettings.tests.ts
+++ b/jsapp/js/components/map/MapSettings.tests.ts
@@ -1,0 +1,53 @@
+import { buildMapSettingsTabsToDisplay } from './MapSettings'
+
+describe('buildMapSettingsTabsToDisplay', () => {
+  it('keeps baseline tabs when no extra tab conditions are met', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: true,
+      hasMultipleGeopointQuestions: false,
+      hasLargeQueryCount: false,
+    })
+
+    chai.expect(tabs).to.deep.equal(['overlays', 'colors'])
+  })
+
+  it('includes query limit without removing overlays', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: true,
+      hasMultipleGeopointQuestions: false,
+      hasLargeQueryCount: true,
+    })
+
+    chai.expect(tabs).to.deep.equal(['querylimit', 'overlays', 'colors'])
+  })
+
+  it('includes geopoint question without removing overlays', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: true,
+      hasMultipleGeopointQuestions: true,
+      hasLargeQueryCount: false,
+    })
+
+    chai.expect(tabs).to.deep.equal(['geoquestion', 'overlays', 'colors'])
+  })
+
+  it('includes query limit and geopoint question together without removing overlays', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: true,
+      hasMultipleGeopointQuestions: true,
+      hasLargeQueryCount: true,
+    })
+
+    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'overlays', 'colors'])
+  })
+
+  it('omits overlays if the user cannot change the asset', () => {
+    const tabs = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: false,
+      hasMultipleGeopointQuestions: true,
+      hasLargeQueryCount: true,
+    })
+
+    chai.expect(tabs).to.deep.equal(['querylimit', 'geoquestion', 'colors'])
+  })
+})

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -1,24 +1,17 @@
 import alertify from 'alertifyjs'
 import cx from 'classnames'
-// Libraries
 import React from 'react'
 import Dropzone, { type Accept, type FileRejection } from 'react-dropzone'
-
-// Partial components
-import bem from '../../../js/bem'
-import Button from '../../../js/components/common/button'
-import Modal from '../../../js/components/common/modal'
-import MapColorPicker from '../../../js/components/map/MapColorPicker'
-
-// Stores, hooks and utilities
-import { actions } from '../../../js/actions'
-import { getQuestionOrChoiceDisplayName, getRowName } from '../../../js/assetUtils'
-import { userCan } from '../../../js/components/permissions/utils'
-import { dataInterface } from '../../../js/dataInterface'
-import { findFirstGeopoint, notify } from '../../../js/utils'
-
-// Constants and types
-import { ASSET_FILE_TYPES, QUERY_LIMIT_DEFAULT } from '../../../js/constants'
+import { actions } from '#/actions'
+import { getQuestionOrChoiceDisplayName, getRowName } from '#/assetUtils'
+import bem from '#/bem'
+import Alert from '#/components/common/alert'
+import Button from '#/components/common/button'
+import Modal from '#/components/common/modal'
+import MapColorPicker from '#/components/map/MapColorPicker'
+import { userCan } from '#/components/permissions/utils'
+import { ASSET_FILE_TYPES, QUERY_LIMIT_DEFAULT } from '#/constants'
+import { dataInterface } from '#/dataInterface'
 import type {
   AssetFileResponse,
   AssetMapStyles,
@@ -27,7 +20,8 @@ import type {
   FailResponse,
   LabelValuePair,
   PaginatedResponse,
-} from '../../../js/dataInterface'
+} from '#/dataInterface'
+import { findFirstGeopoint, notify } from '#/utils'
 
 enum MapSettingsTabNames {
   colors = 'colors',
@@ -37,21 +31,16 @@ enum MapSettingsTabNames {
 }
 
 export interface MapSettingsTabsConditions {
-  hasChangeAssetPermission: boolean
   hasMultipleGeopointQuestions: boolean
   hasLargeQueryCount: boolean
 }
 
 export function buildMapSettingsTabsToDisplay({
-  hasChangeAssetPermission,
   hasMultipleGeopointQuestions,
   hasLargeQueryCount,
 }: MapSettingsTabsConditions): MapSettingsTabNames[] {
-  const enabledTabs = new Set<MapSettingsTabNames>([MapSettingsTabNames.colors])
+  const enabledTabs = new Set<MapSettingsTabNames>([MapSettingsTabNames.colors, MapSettingsTabNames.overlays])
 
-  if (hasChangeAssetPermission) {
-    enabledTabs.add(MapSettingsTabNames.overlays)
-  }
   if (hasMultipleGeopointQuestions) {
     enabledTabs.add(MapSettingsTabNames.geoquestion)
   }
@@ -59,12 +48,7 @@ export function buildMapSettingsTabsToDisplay({
     enabledTabs.add(MapSettingsTabNames.querylimit)
   }
 
-  return [
-    MapSettingsTabNames.querylimit,
-    MapSettingsTabNames.geoquestion,
-    MapSettingsTabNames.overlays,
-    MapSettingsTabNames.colors,
-  ].filter((tabId) => enabledTabs.has(tabId))
+  return Array.from(TABS.keys()).filter((tabId) => enabledTabs.has(tabId))
 }
 
 interface MapSettingsTabDefinition {
@@ -83,6 +67,7 @@ const MAP_LAYER_DROPZONE_ACCEPT: Accept = {
   'application/wkt': ['.wkt'],
 }
 
+// FYI the order here matters
 const TABS = new Map<MapSettingsTabNames, MapSettingsTabDefinition>([
   [MapSettingsTabNames.colors, { id: MapSettingsTabNames.colors, label: t('Marker Colors') }],
   [MapSettingsTabNames.querylimit, { id: MapSettingsTabNames.querylimit, label: t('Query Limit') }],
@@ -125,15 +110,6 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
 
     const queryCount = props.asset.deployment__submission_count
 
-    let defaultActiveTab = MapSettingsTabNames.colors
-    if (queryCount > QUERY_LIMIT_MINIMUM) {
-      defaultActiveTab = MapSettingsTabNames.querylimit
-    } else if (geoQuestions.length > 1) {
-      defaultActiveTab = MapSettingsTabNames.geoquestion
-    } else if (userCan('change_asset', this.props.asset)) {
-      defaultActiveTab = MapSettingsTabNames.overlays
-    }
-
     const mapStyles = Object.assign({}, this.props.asset.map_styles)
     if (this.props.overridenStyles) {
       Object.assign(mapStyles, this.props.overridenStyles)
@@ -151,7 +127,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
     }
 
     this.state = {
-      activeModalTab: defaultActiveTab,
+      activeModalTab: MapSettingsTabNames.colors,
       geoQuestions: geoQuestions,
       mapSettings: mapStyles,
       files: [],
@@ -292,6 +268,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
 
   render() {
     let queryLimit = this.state.mapSettings.querylimit || QUERY_LIMIT_DEFAULT
+    const hasChangeAssetPermission = userCan('change_asset', this.props.asset)
 
     // This case can only happen if somehow the queryLimit in map_styles is using the old slider values
     if (Number(queryLimit) > this.props.queryLimit) {
@@ -299,7 +276,6 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
     }
 
     const tabsToDisplay = buildMapSettingsTabsToDisplay({
-      hasChangeAssetPermission: userCan('change_asset', this.props.asset),
       hasMultipleGeopointQuestions: this.state.geoQuestions.length > 1,
       hasLargeQueryCount: this.state.queryCount > QUERY_LIMIT_MINIMUM,
     })
@@ -344,46 +320,53 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
             )}
             {activeTab === MapSettingsTabNames.overlays && (
               <div className='map-settings__overlay'>
-                {this.state.files.length > 0 && (
-                  <bem.FormModal__item m='list-files'>
-                    <label>{t('Uploaded layers')}</label>
-                    {this.state.files.map((file, i) => (
-                      <div className='list-file-row' key={i}>
-                        <span className='file-type'>{file.metadata.type}</span>
-                        <span className='file-layer-name'>{file.description}</span>
-                        <span
-                          className='file-delete'
-                          onClick={() => this.deleteFile(file.uid)}
-                          data-tip={t('Delete layer')}
-                        >
-                          <i className='k-icon k-icon-trash' />
-                        </span>
-                      </div>
-                    ))}
-                  </bem.FormModal__item>
+                {!hasChangeAssetPermission && (
+                  <Alert type='info'>{t('Managing overlay layers requires permission to edit this project.')}</Alert>
                 )}
-                <bem.FormModal__item m='layer-upload'>
-                  <label htmlFor='name'>
-                    {t(
-                      'Use the form below to upload files with map data in one of these formats: CSV, KML, KMZ, WKT or GEOJSON. The data will be made available as layers for display on the map.',
+                {hasChangeAssetPermission && (
+                  <>
+                    {this.state.files.length > 0 && (
+                      <bem.FormModal__item m='list-files'>
+                        <label>{t('Uploaded layers')}</label>
+                        {this.state.files.map((file, i) => (
+                          <div className='list-file-row' key={i}>
+                            <span className='file-type'>{file.metadata.type}</span>
+                            <span className='file-layer-name'>{file.description}</span>
+                            <span
+                              className='file-delete'
+                              onClick={() => this.deleteFile(file.uid)}
+                              data-tip={t('Delete layer')}
+                            >
+                              <i className='k-icon k-icon-trash' />
+                            </span>
+                          </div>
+                        ))}
+                      </bem.FormModal__item>
                     )}
-                  </label>
-                  <input
-                    type='text'
-                    id='name'
-                    placeholder={t('Layer name')}
-                    value={this.state.layerName}
-                    onChange={this.onLayerNameChange.bind(this)}
-                  />
-                  <Dropzone onDrop={this.dropFiles.bind(this)} multiple={false} accept={MAP_LAYER_DROPZONE_ACCEPT}>
-                    {({ getRootProps, getInputProps }) => (
-                      <div {...getRootProps({ className: 'dropzone' })}>
-                        <input {...getInputProps()} />
-                        <Button type='primary' size='l' label={t('Upload')} isFullWidth />
-                      </div>
-                    )}
-                  </Dropzone>
-                </bem.FormModal__item>
+                    <bem.FormModal__item m='layer-upload'>
+                      <label htmlFor='name'>
+                        {t(
+                          'Use the form below to upload files with map data in one of these formats: CSV, KML, KMZ, WKT or GEOJSON. The data will be made available as layers for display on the map.',
+                        )}
+                      </label>
+                      <input
+                        type='text'
+                        id='name'
+                        placeholder={t('Layer name')}
+                        value={this.state.layerName}
+                        onChange={this.onLayerNameChange.bind(this)}
+                      />
+                      <Dropzone onDrop={this.dropFiles.bind(this)} multiple={false} accept={MAP_LAYER_DROPZONE_ACCEPT}>
+                        {({ getRootProps, getInputProps }) => (
+                          <div {...getRootProps({ className: 'dropzone' })}>
+                            <input {...getInputProps()} />
+                            <Button type='primary' size='l' label={t('Upload')} isFullWidth />
+                          </div>
+                        )}
+                      </Dropzone>
+                    </bem.FormModal__item>
+                  </>
+                )}
               </div>
             )}
             {activeTab === MapSettingsTabNames.colors && (
@@ -428,7 +411,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
           activeTab,
         ) && (
           <bem.Modal__footer>
-            {userCan('change_asset', this.props.asset) && queryLimit !== QUERY_LIMIT_DEFAULT && (
+            {hasChangeAssetPermission && queryLimit !== QUERY_LIMIT_DEFAULT && (
               <Button type='danger' size='l' onClick={this.resetMapSettings.bind(this)} label={t('Reset')} />
             )}
 

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -127,7 +127,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
     }
 
     this.state = {
-      activeModalTab: Array.from(TABS.keys())[0],
+      activeModalTab: MapSettingsTabNames.colors,
       geoQuestions: geoQuestions,
       mapSettings: mapStyles,
       files: [],

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -67,7 +67,7 @@ const MAP_LAYER_DROPZONE_ACCEPT: Accept = {
   'application/wkt': ['.wkt'],
 }
 
-// FYI the order here matters and inflences the order of tabs in UI
+// FYI the order here matters and influences the order of tabs in UI
 const TABS = new Map<MapSettingsTabNames, MapSettingsTabDefinition>([
   [MapSettingsTabNames.colors, { id: MapSettingsTabNames.colors, label: t('Marker Colors') }],
   [MapSettingsTabNames.querylimit, { id: MapSettingsTabNames.querylimit, label: t('Query Limit') }],

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -36,6 +36,37 @@ enum MapSettingsTabNames {
   overlays = 'overlays',
 }
 
+export interface MapSettingsTabsConditions {
+  hasChangeAssetPermission: boolean
+  hasMultipleGeopointQuestions: boolean
+  hasLargeQueryCount: boolean
+}
+
+export function buildMapSettingsTabsToDisplay({
+  hasChangeAssetPermission,
+  hasMultipleGeopointQuestions,
+  hasLargeQueryCount,
+}: MapSettingsTabsConditions): MapSettingsTabNames[] {
+  const enabledTabs = new Set<MapSettingsTabNames>([MapSettingsTabNames.colors])
+
+  if (hasChangeAssetPermission) {
+    enabledTabs.add(MapSettingsTabNames.overlays)
+  }
+  if (hasMultipleGeopointQuestions) {
+    enabledTabs.add(MapSettingsTabNames.geoquestion)
+  }
+  if (hasLargeQueryCount) {
+    enabledTabs.add(MapSettingsTabNames.querylimit)
+  }
+
+  return [
+    MapSettingsTabNames.querylimit,
+    MapSettingsTabNames.geoquestion,
+    MapSettingsTabNames.overlays,
+    MapSettingsTabNames.colors,
+  ].filter((tabId) => enabledTabs.has(tabId))
+}
+
 interface MapSettingsTabDefinition {
   id: MapSettingsTabNames
   label: string
@@ -267,25 +298,22 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
       queryLimit = this.props.queryLimit.toString()
     }
 
-    const tabsToDisplay = [MapSettingsTabNames.colors]
-    if (userCan('change_asset', this.props.asset)) {
-      tabsToDisplay.unshift(MapSettingsTabNames.overlays)
-    }
-    if (this.state.geoQuestions.length > 1) {
-      tabsToDisplay.unshift(MapSettingsTabNames.geoquestion)
-    }
-    if (this.state.queryCount > QUERY_LIMIT_MINIMUM) {
-      tabsToDisplay.unshift(MapSettingsTabNames.querylimit)
-    }
+    const tabsToDisplay = buildMapSettingsTabsToDisplay({
+      hasChangeAssetPermission: userCan('change_asset', this.props.asset),
+      hasMultipleGeopointQuestions: this.state.geoQuestions.length > 1,
+      hasLargeQueryCount: this.state.queryCount > QUERY_LIMIT_MINIMUM,
+    })
 
-    var modalTabs = tabsToDisplay.map((tabId, i) => (
+    const activeTab = tabsToDisplay.includes(this.state.activeModalTab) ? this.state.activeModalTab : tabsToDisplay[0]
+
+    var modalTabs = tabsToDisplay.map((tabId) => (
       <button
         className={cx({
           'legacy-modal-tab-button': true,
-          'legacy-modal-tab-button--active': this.state.activeModalTab === tabId,
+          'legacy-modal-tab-button--active': activeTab === tabId,
         })}
         onClick={() => this.switchTab(tabId)}
-        key={i}
+        key={tabId}
       >
         {TABS.get(tabId)?.label || '??'}
       </button>
@@ -296,7 +324,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
         <Modal.Tabs>{modalTabs}</Modal.Tabs>
         <Modal.Body>
           <div className='tabs-content map-settings'>
-            {this.state.activeModalTab === MapSettingsTabNames.geoquestion && (
+            {activeTab === MapSettingsTabNames.geoquestion && (
               <div className='map-settings__GeoQuestions'>
                 <p>{t('Choose the Geopoint question you would like to display on the map:')}</p>
                 {this.state.geoQuestions.map((question, i) => (
@@ -314,7 +342,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
                 ))}
               </div>
             )}
-            {this.state.activeModalTab === MapSettingsTabNames.overlays && (
+            {activeTab === MapSettingsTabNames.overlays && (
               <div className='map-settings__overlay'>
                 {this.state.files.length > 0 && (
                   <bem.FormModal__item m='list-files'>
@@ -358,7 +386,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
                 </bem.FormModal__item>
               </div>
             )}
-            {this.state.activeModalTab === MapSettingsTabNames.colors && (
+            {activeTab === MapSettingsTabNames.colors && (
               <bem.FormModal__item>
                 <div className='map-settings__colors'>
                   {t('Choose the color set for the disaggregated map markers.')}
@@ -366,7 +394,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
                 </div>
               </bem.FormModal__item>
             )}
-            {this.state.activeModalTab === MapSettingsTabNames.querylimit && (
+            {activeTab === MapSettingsTabNames.querylimit && (
               <bem.FormModal__item>
                 <div className='map-settings__querylimit'>
                   {t(
@@ -397,7 +425,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
         </Modal.Body>
 
         {[MapSettingsTabNames.geoquestion, MapSettingsTabNames.colors, MapSettingsTabNames.querylimit].includes(
-          this.state.activeModalTab,
+          activeTab,
         ) && (
           <bem.Modal__footer>
             {userCan('change_asset', this.props.asset) && queryLimit !== QUERY_LIMIT_DEFAULT && (

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -5,7 +5,6 @@ import Dropzone, { type Accept, type FileRejection } from 'react-dropzone'
 import { actions } from '#/actions'
 import { getQuestionOrChoiceDisplayName, getRowName } from '#/assetUtils'
 import bem from '#/bem'
-import Alert from '#/components/common/alert'
 import Button from '#/components/common/button'
 import Modal from '#/components/common/modal'
 import MapColorPicker from '#/components/map/MapColorPicker'
@@ -33,13 +32,19 @@ enum MapSettingsTabNames {
 export interface MapSettingsTabsConditions {
   hasMultipleGeopointQuestions: boolean
   hasLargeQueryCount: boolean
+  hasChangeAssetPermission: boolean
 }
 
 export function buildMapSettingsTabsToDisplay({
   hasMultipleGeopointQuestions,
   hasLargeQueryCount,
+  hasChangeAssetPermission,
 }: MapSettingsTabsConditions): MapSettingsTabNames[] {
-  const enabledTabs = new Set<MapSettingsTabNames>([MapSettingsTabNames.colors, MapSettingsTabNames.overlays])
+  const enabledTabs = new Set<MapSettingsTabNames>([MapSettingsTabNames.colors])
+
+  if (hasChangeAssetPermission) {
+    enabledTabs.add(MapSettingsTabNames.overlays)
+  }
 
   if (hasMultipleGeopointQuestions) {
     enabledTabs.add(MapSettingsTabNames.geoquestion)
@@ -278,6 +283,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
     const tabsToDisplay = buildMapSettingsTabsToDisplay({
       hasMultipleGeopointQuestions: this.state.geoQuestions.length > 1,
       hasLargeQueryCount: this.state.queryCount > QUERY_LIMIT_MINIMUM,
+      hasChangeAssetPermission,
     })
 
     const activeTab = tabsToDisplay.includes(this.state.activeModalTab) ? this.state.activeModalTab : tabsToDisplay[0]
@@ -320,53 +326,46 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
             )}
             {activeTab === MapSettingsTabNames.overlays && (
               <div className='map-settings__overlay'>
-                {!hasChangeAssetPermission && (
-                  <Alert type='info'>{t('Managing overlay layers requires permission to edit this project.')}</Alert>
+                {this.state.files.length > 0 && (
+                  <bem.FormModal__item m='list-files'>
+                    <label>{t('Uploaded layers')}</label>
+                    {this.state.files.map((file, i) => (
+                      <div className='list-file-row' key={i}>
+                        <span className='file-type'>{file.metadata.type}</span>
+                        <span className='file-layer-name'>{file.description}</span>
+                        <span
+                          className='file-delete'
+                          onClick={() => this.deleteFile(file.uid)}
+                          data-tip={t('Delete layer')}
+                        >
+                          <i className='k-icon k-icon-trash' />
+                        </span>
+                      </div>
+                    ))}
+                  </bem.FormModal__item>
                 )}
-                {hasChangeAssetPermission && (
-                  <>
-                    {this.state.files.length > 0 && (
-                      <bem.FormModal__item m='list-files'>
-                        <label>{t('Uploaded layers')}</label>
-                        {this.state.files.map((file, i) => (
-                          <div className='list-file-row' key={i}>
-                            <span className='file-type'>{file.metadata.type}</span>
-                            <span className='file-layer-name'>{file.description}</span>
-                            <span
-                              className='file-delete'
-                              onClick={() => this.deleteFile(file.uid)}
-                              data-tip={t('Delete layer')}
-                            >
-                              <i className='k-icon k-icon-trash' />
-                            </span>
-                          </div>
-                        ))}
-                      </bem.FormModal__item>
+                <bem.FormModal__item m='layer-upload'>
+                  <label htmlFor='name'>
+                    {t(
+                      'Use the form below to upload files with map data in one of these formats: CSV, KML, KMZ, WKT or GEOJSON. The data will be made available as layers for display on the map.',
                     )}
-                    <bem.FormModal__item m='layer-upload'>
-                      <label htmlFor='name'>
-                        {t(
-                          'Use the form below to upload files with map data in one of these formats: CSV, KML, KMZ, WKT or GEOJSON. The data will be made available as layers for display on the map.',
-                        )}
-                      </label>
-                      <input
-                        type='text'
-                        id='name'
-                        placeholder={t('Layer name')}
-                        value={this.state.layerName}
-                        onChange={this.onLayerNameChange.bind(this)}
-                      />
-                      <Dropzone onDrop={this.dropFiles.bind(this)} multiple={false} accept={MAP_LAYER_DROPZONE_ACCEPT}>
-                        {({ getRootProps, getInputProps }) => (
-                          <div {...getRootProps({ className: 'dropzone' })}>
-                            <input {...getInputProps()} />
-                            <Button type='primary' size='l' label={t('Upload')} isFullWidth />
-                          </div>
-                        )}
-                      </Dropzone>
-                    </bem.FormModal__item>
-                  </>
-                )}
+                  </label>
+                  <input
+                    type='text'
+                    id='name'
+                    placeholder={t('Layer name')}
+                    value={this.state.layerName}
+                    onChange={this.onLayerNameChange.bind(this)}
+                  />
+                  <Dropzone onDrop={this.dropFiles.bind(this)} multiple={false} accept={MAP_LAYER_DROPZONE_ACCEPT}>
+                    {({ getRootProps, getInputProps }) => (
+                      <div {...getRootProps({ className: 'dropzone' })}>
+                        <input {...getInputProps()} />
+                        <Button type='primary' size='l' label={t('Upload')} isFullWidth />
+                      </div>
+                    )}
+                  </Dropzone>
+                </bem.FormModal__item>
               </div>
             )}
             {activeTab === MapSettingsTabNames.colors && (

--- a/jsapp/js/components/map/MapSettings.tsx
+++ b/jsapp/js/components/map/MapSettings.tsx
@@ -67,7 +67,7 @@ const MAP_LAYER_DROPZONE_ACCEPT: Accept = {
   'application/wkt': ['.wkt'],
 }
 
-// FYI the order here matters
+// FYI the order here matters and inflences the order of tabs in UI
 const TABS = new Map<MapSettingsTabNames, MapSettingsTabDefinition>([
   [MapSettingsTabNames.colors, { id: MapSettingsTabNames.colors, label: t('Marker Colors') }],
   [MapSettingsTabNames.querylimit, { id: MapSettingsTabNames.querylimit, label: t('Query Limit') }],
@@ -127,7 +127,7 @@ export default class MapSettings extends React.Component<MapSettingsProps, MapSe
     }
 
     this.state = {
-      activeModalTab: MapSettingsTabNames.colors,
+      activeModalTab: Array.from(TABS.keys())[0],
       geoQuestions: geoQuestions,
       mapSettings: mapStyles,
       files: [],


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Map display settings modal now has a consistent and tested tab display behaviour. The order of the tabs is now enforced and kept the same.

### 💭 Notes

Changes here:
- jsapp/js/components/map/MapSettings.tsx: 
  - Extracted tab visibility rules into buildMapSettingsTabsToDisplay to keep tab logic in one place.
  - Stabilized tab rendering with tab-id keys and active-tab fallback when needed.
  - Default active tab is now always Colors.
- jsapp/js/components/map/MapSettings.tests.ts: 
  - Added unit tests for tab composition across combinations (baseline, query limit, multiple geopoints, both together, and read-only case).

Tiny map pun for morale from AI: no tabs were harmed in this navigation.

### 👀 Preview steps

Please verify that tab appearance is working correctly:
1. "Marker Colors" - always there
2. "Query Limit" - if more than 1000 submissions
3. "Geopoint question" - whether has at least 2 `geopoint` type question
4. "Overlays" - user has `change_asset` permission