### PR TITLE
fix(admin): fix timeout when viewing tokens DEV-2149

### DIFF
--- a/kpi/admin.py
+++ b/kpi/admin.py
@@ -63,11 +63,13 @@ class ExtraProjectMetadataFieldAdmin(admin.ModelAdmin):
 
 
 class TokenAdmin(DRFTokenAdmin):
+    autocomplete_fields = ['user']
     def get_readonly_fields(self, request, obj=...):
         if obj is None:
             return ()
         else:
             return ('user',)
+
 
 # Register your models here.
 admin.site.register(AuthorizedApplication)

--- a/kpi/admin.py
+++ b/kpi/admin.py
@@ -65,7 +65,7 @@ class ExtraProjectMetadataFieldAdmin(admin.ModelAdmin):
 class TokenAdmin(DRFTokenAdmin):
     def get_readonly_fields(self, request, obj=...):
         if obj is None:
-            return ('',)
+            return ()
         else:
             return ('user',)
 

--- a/kpi/admin.py
+++ b/kpi/admin.py
@@ -1,10 +1,13 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
+from rest_framework.authtoken.admin import TokenAdmin as DRFTokenAdmin
+from rest_framework.authtoken.models import TokenProxy
 
 from kpi.constants import ASSET_TYPE_SURVEY
 from kpi.forms.extra_metadata_form import ExtraProjectMetadataFieldForm
 from kpi.models import ExtraProjectMetadataField
 from .models import Asset, AuthorizedApplication
+
 
 # We need to register Asset to use `autocomplete_fields` (with Asset) in
 # Django Admin.
@@ -58,5 +61,15 @@ class ExtraProjectMetadataFieldAdmin(admin.ModelAdmin):
 
     label_display.short_description = _('Default Label')
 
+
+class TokenAdmin(DRFTokenAdmin):
+    def get_readonly_fields(self, request, obj=...):
+        if obj is None:
+            return ('',)
+        else:
+            return ('user',)
+
 # Register your models here.
 admin.site.register(AuthorizedApplication)
+admin.site.unregister(TokenProxy)
+admin.site.register(TokenProxy, TokenAdmin)

--- a/kpi/admin.py
+++ b/kpi/admin.py
@@ -63,7 +63,9 @@ class ExtraProjectMetadataFieldAdmin(admin.ModelAdmin):
 
 
 class TokenAdmin(DRFTokenAdmin):
+
     autocomplete_fields = ['user']
+
     def get_readonly_fields(self, request, obj=...):
         if obj is None:
             return ()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fix a timeout error when attempting to view individual user tokens in Django admin.


### 💭 Notes
The built in TokenAdmin has `user` as an editable field, which requires loading all users to create the selection dropdown. The PR makes the `user` field read-only except on creation. 
Since the original TokenAdmin is registered in DRF app code, we have to unregister it before re-registering it with our edited version.


### 👀 Preview steps
Regression test only. Best to test with `--print-sql` running

1. ℹ️ have a superuser account
2. Go to django admin -> Auth Token -> Token
3. Select an arbitrary token to open the editing view
4. 🔴 [on release] notice there is a query that queries the entire auth_user table (using a cursor)
5. :red_circle: [on release] notice you are able to change the user
6. 🟢 [on PR] notice all queries to auth_user are filtered
7. Delete the token
8. Create a new token for the same user
9. 🟢 Ensure new token is created successfully
