### PR TITLE
feat(frontend): add Mantine notifications DEV-2211

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 import '@mantine/core/styles.css'
+// ‼️ import notifications styles after core package styles
+import '@mantine/notifications/styles.css';
 import '@mantine/dropzone/styles.css'
 import '../jsapp/js/fonts'
 import '../jsapp/scss/main.scss'

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import '../jsapp/scss/main.scss'
 import '#/bemComponents'
 import { FeatureFlag } from '../jsapp/js/featureFlags'
 import { MantineProvider, useMantineColorScheme } from '@mantine/core'
+import { Notifications } from '@mantine/notifications';
 import type { Preview } from '@storybook/react'
 import * as mswAddon from 'msw-storybook-addon'
 import { useEffect } from 'react'
@@ -48,7 +49,7 @@ window.t = (str) => str
 const preview: Preview = {
   decorators: [
     (Story) => <ColorSchemeWrapper>{Story()}</ColorSchemeWrapper>,
-    (Story) => <MantineProvider theme={themeKobo}>{Story()}</MantineProvider>,
+    (Story) => <MantineProvider theme={themeKobo}><Notifications />{Story()}</MantineProvider>,
   ],
   loaders: [mswAddon.mswLoader],
   tags: ['autodocs'],

--- a/jsapp/js/app.jsx
+++ b/jsapp/js/app.jsx
@@ -8,6 +8,7 @@ import React, { useEffect, useState } from 'react'
 
 import { MantineProvider } from '@mantine/core'
 import { ModalsProvider } from '@mantine/modals'
+import { Notifications } from '@mantine/notifications'
 import { QueryClientProvider } from '@tanstack/react-query'
 import DocumentTitle from 'react-document-title'
 import reactMixin from 'react-mixin'
@@ -155,6 +156,7 @@ class App extends React.Component {
       <DocumentTitle title='KoboToolbox'>
         <QueryClientProvider client={queryClient}>
           <MantineProvider theme={themeKobo} cssVariablesResolver={cssVariablesResolverKobo}>
+            <Notifications />
             <ModalsProvider modalProps={KOBO_MODAL_SHARED_PROPS}>
               <RootContextProvider>
                 <Tracking />

--- a/jsapp/js/components/common/ButtonNew.stories.tsx
+++ b/jsapp/js/components/common/ButtonNew.stories.tsx
@@ -1,13 +1,12 @@
 import type { MantineSize, TooltipProps } from '@mantine/core'
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { IconChevronDown, IconSearch, IconX } from '@tabler/icons-react'
+import type { ForwardRefExoticComponent } from 'react'
 import { expect, fn, userEvent, within } from 'storybook/test'
 import { type IconName, IconNames } from '#/k-icons'
-import Button, { type ButtonProps } from './ButtonNew'
-import '@mantine/core/styles.css'
-import type { ForwardRefExoticComponent } from 'react'
 import type { StoryArgsFromPolymorphic } from '#/storybookUtils'
 import { recordValues } from '#/utils'
+import Button, { type ButtonProps } from './ButtonNew'
 
 const buttonVariants: Array<ButtonProps['variant']> = [
   'filled',

--- a/jsapp/js/components/common/Menu.stories.tsx
+++ b/jsapp/js/components/common/Menu.stories.tsx
@@ -2,10 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import type { ComponentProps } from 'react'
 import { expect, fn, userEvent, within } from 'storybook/test'
 import ActionIcon from './ActionIcon'
+import ButtonNew from './ButtonNew'
 import Menu from './Menu'
 import Icon from './icon'
-import '@mantine/core/styles.css'
-import ButtonNew from './ButtonNew'
 
 type StoryArgs = ComponentProps<typeof Menu> & {
   onDeleteClick?: () => void

--- a/jsapp/js/components/common/Notification.stories.tsx
+++ b/jsapp/js/components/common/Notification.stories.tsx
@@ -1,7 +1,9 @@
 import type { MantineSize } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import * as TablerIcons from '@tabler/icons-react'
 import type { TablerIcon } from '@tabler/icons-react'
+import Button from './ButtonNew'
 import KoboIcon from './KoboIcon'
 import Notification, { type NotificationProps } from './Notification'
 
@@ -59,6 +61,31 @@ export const Default: Story = {
       >
         <a href='#'>Click here</a> to monitor your progress or to cancel this job
       </Notification>
+    )
+  },
+}
+
+export const NotificationsShowApi: Story = {
+  args: {
+    title: 'Your transcripts are on their way!',
+    icon: 'IconCheckFilled',
+    iconSize: 'xs',
+  },
+  render: (args) => {
+    const selectedTablerIcon = typeof args.icon === 'string' ? tablerIconMapping[args.icon] : undefined
+
+    return (
+      <Button
+        onClick={() => {
+          notifications.show({
+            title: args.title,
+            message: 'Click here to monitor your progress or to cancel this job',
+            icon: selectedTablerIcon ? <KoboIcon icon={selectedTablerIcon} size={args.iconSize} /> : undefined,
+          })
+        }}
+      >
+        Show notification
+      </Button>
     )
   },
 }

--- a/jsapp/js/components/common/Notification.stories.tsx
+++ b/jsapp/js/components/common/Notification.stories.tsx
@@ -1,4 +1,4 @@
-import type { MantineSize } from '@mantine/core'
+import { type MantineSize, Text } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import * as TablerIcons from '@tabler/icons-react'
@@ -75,17 +75,26 @@ export const NotificationsShowApi: Story = {
     const selectedTablerIcon = typeof args.icon === 'string' ? tablerIconMapping[args.icon] : undefined
 
     return (
-      <Button
-        onClick={() => {
-          notifications.show({
-            title: args.title,
-            message: 'Click here to monitor your progress or to cancel this job',
-            icon: selectedTablerIcon ? <KoboIcon icon={selectedTablerIcon} size={args.iconSize} /> : undefined,
-          })
-        }}
-      >
-        Show notification
-      </Button>
+      <>
+        <Text mb='lg'>
+          This story shows how the notifications system works and mostly relies on defaults. To see all the available
+          options for <code>notifications.show</code>, check out{' '}
+          <a href='https://mantine.dev/x/notifications/#notification-props'>Mantine documentation</a>.
+        </Text>
+
+        <Button
+          onClick={() => {
+            notifications.show({
+              title: args.title,
+              message: 'Click here to monitor your progress or to cancel this job',
+              icon: selectedTablerIcon ? <KoboIcon icon={selectedTablerIcon} size={args.iconSize} /> : undefined,
+              position: 'bottom-center',
+            })
+          }}
+        >
+          Show notification
+        </Button>
+      </>
     )
   },
 }

--- a/jsapp/js/main.js
+++ b/jsapp/js/main.js
@@ -10,6 +10,8 @@
  */
 import 'jquery-ui/ui/widgets/sortable'
 import '@mantine/core/styles.css'
+// ‼️ import notifications styles after core package styles
+import '@mantine/notifications/styles.css'
 import '@mantine/dropzone/styles.css'
 // We import all the weights and styles we actually use here to avoid unnecessary weight (pun intended).
 import './fonts'

--- a/jsapp/js/router/basicLayout.component.tsx
+++ b/jsapp/js/router/basicLayout.component.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { MantineProvider } from '@mantine/core'
 import { ModalsProvider } from '@mantine/modals'
+import { Notifications } from '@mantine/notifications'
 import { QueryClientProvider } from '@tanstack/react-query'
 import DocumentTitle from 'react-document-title'
 import { queryClient } from '#/api/queryClient'
@@ -29,6 +30,7 @@ export default function BasicLayout(props: BasicLayoutProps) {
     <DocumentTitle title='KoboToolbox'>
       <QueryClientProvider client={queryClient}>
         <MantineProvider theme={themeKobo} cssVariablesResolver={cssVariablesResolverKobo}>
+          <Notifications />
           <ModalsProvider modalProps={KOBO_MODAL_SHARED_PROPS}>
             <Tracking />
             <ToasterConfig />

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mantine/form": "^8.3.18",
         "@mantine/hooks": "^8.3.18",
         "@mantine/modals": "^8.3.18",
+        "@mantine/notifications": "^8.3.18",
         "@mapbox/leaflet-omnivore": "^0.3.4",
         "@placemarkio/check-geojson": "^0.1.14",
         "@sentry/react": "^10.51.0",
@@ -5938,6 +5939,31 @@
         "@mantine/hooks": "8.3.18",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/notifications": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.18.tgz",
+      "integrity": "sha512-IpQ0lmwbigTBbZCR6iSYWqIOKEx1tlcd7PcEJ5M5X1qeVSY/N3mmDQt1eJmObvcyDeL5cTJMbSA9UPqhRqo9jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mantine/store": "8.3.18",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "8.3.18",
+        "@mantine/hooks": "8.3.18",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.18.tgz",
+      "integrity": "sha512-i+QRTLmZzLldea0egtUVnGALd6UMIu8jd44nrNWBSNIXJU/8B6rMlC6gyX+l4szopZSuOaaNJIXkqRdC1gQsVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@mapbox/leaflet-omnivore": {
@@ -37292,6 +37318,21 @@
       "version": "8.3.18",
       "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-8.3.18.tgz",
       "integrity": "sha512-JfPDS4549L314SxFPC1x6CbKwzh82OdnIzwgMxPCVNsWLKV2vEHHUH/fzUYj4Wli6IBrsW4cufjMj9BTj3hm3Q==",
+      "requires": {}
+    },
+    "@mantine/notifications": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.18.tgz",
+      "integrity": "sha512-IpQ0lmwbigTBbZCR6iSYWqIOKEx1tlcd7PcEJ5M5X1qeVSY/N3mmDQt1eJmObvcyDeL5cTJMbSA9UPqhRqo9jw==",
+      "requires": {
+        "@mantine/store": "8.3.18",
+        "react-transition-group": "4.4.5"
+      }
+    },
+    "@mantine/store": {
+      "version": "8.3.18",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.18.tgz",
+      "integrity": "sha512-i+QRTLmZzLldea0egtUVnGALd6UMIu8jd44nrNWBSNIXJU/8B6rMlC6gyX+l4szopZSuOaaNJIXkqRdC1gQsVg==",
       "requires": {}
     },
     "@mapbox/leaflet-omnivore": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mantine/form": "^8.3.18",
     "@mantine/hooks": "^8.3.18",
     "@mantine/modals": "^8.3.18",
+    "@mantine/notifications": "^8.3.18",
     "@mapbox/leaflet-omnivore": "^0.3.4",
     "@placemarkio/check-geojson": "^0.1.14",
     "@sentry/react": "^10.51.0",


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Enabled Mantine notifications across the app and Storybook, and added a Design System story that demonstrates triggering a notification with notifications.show.

### 💭 Notes

Changes here:
- Added dependency and lockfile updates for Mantine notifications:
  - `package.json`
  - `package-lock.json`
- Imported notifications styles globally (after Mantine core styles) so notifications render correctly:
  - `main.js`
  - `preview.tsx`
- Mounted the Notifications container at app roots so `notifications.show` can render in real UI contexts:
  - `app.jsx`
  - `basicLayout.component.tsx`
- Mounted Notifications in Storybook Mantine decorator so notification APIs work in stories:
  - `preview.tsx`
- Added an interactive Notification story that uses `notifications.show` on button click:
  - `Notification.stories.tsx`
- Removed redundant local Mantine core style imports from stories now that styles are globally loaded in Storybook:
  - `Menu.stories.tsx`
  - `ButtonNew.stories.tsx`

### 👀 Preview steps

1. Open Storybook for this branch.
2. Navigate to Design system → Notification.
3. Open story NotificationsShowApi.
4. Click Show notification.
5. 🔴 On main: this story does not exist.
6. 🟢 On this branch: a Mantine notification appears with title/message/icon.
7. Optional sanity check: open Design system → Menu and Design system → Button stories and confirm styles still render correctly after removing local style imports.
