### PR TITLE
fix(frontend): unnamed language fix DEV-2242

### DIFF
--- a/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
@@ -323,6 +323,43 @@ describe('translations hack', () => {
       })
       expect(unnullifyTranslations(test.surveyDataJSON, test.assetContent)).to.deep.equal(target)
     })
+
+    it('should omit translated label key for empty theme-grid begin_group label', () => {
+      const test = {
+        surveyDataJSON: JSON.stringify({
+          survey: [
+            {
+              type: 'begin_group',
+              label: null,
+            },
+          ],
+          settings: [
+            {
+              default_language: 'English (en)',
+              style: 'theme-grid',
+            },
+          ],
+        }),
+        assetContent: {
+          translated: ['label'],
+          translations_0: 'English (en)',
+        },
+      }
+      const target = JSON.stringify({
+        survey: [
+          {
+            type: 'begin_group',
+          },
+        ],
+        settings: [
+          {
+            default_language: 'English (en)',
+            style: 'theme-grid',
+          },
+        ],
+      })
+      expect(unnullifyTranslations(test.surveyDataJSON, test.assetContent)).to.deep.equal(target)
+    })
   })
 })
 

--- a/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.tests.js
@@ -275,6 +275,54 @@ describe('translations hack', () => {
       })
       expect(unnullifyTranslations(test.surveyDataJSON, test.assetContent)).to.deep.equal(target)
     })
+
+    it('should use first array item when restoring default language value', () => {
+      // Defensive behavior for malformed/nullified input:
+      // this code path only restores the default-language value from `label`.
+      // Extra array entries are ambiguous unless they are explicit
+      // `label::Language` keys, so we intentionally keep index 0 only.
+      const test = {
+        surveyDataJSON: JSON.stringify({
+          survey: [
+            {
+              label: ['Cheese?', 'Queso?'],
+            },
+          ],
+          choices: [
+            {
+              label: ['Yes', 'Si'],
+            },
+          ],
+          settings: [
+            {
+              default_language: 'English (en)',
+            },
+          ],
+        }),
+        assetContent: {
+          translated: ['label'],
+          translations_0: 'English (en)',
+        },
+      }
+      const target = JSON.stringify({
+        survey: [
+          {
+            'label::English (en)': 'Cheese?',
+          },
+        ],
+        choices: [
+          {
+            'label::English (en)': 'Yes',
+          },
+        ],
+        settings: [
+          {
+            default_language: 'English (en)',
+          },
+        ],
+      })
+      expect(unnullifyTranslations(test.surveyDataJSON, test.assetContent)).to.deep.equal(target)
+    })
   })
 })
 

--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -55,8 +55,14 @@ export function unnullifyTranslations(surveyDataJSON: string, surveyInitialParam
       surveyData.choices.forEach((choice) => {
         translatedProps.forEach((translatedProp) => {
           if (typeof choice[translatedProp] !== 'undefined') {
-            choice[`${translatedProp}::${defaultLang}`] = choice[translatedProp]
-            delete choice[translatedProp]
+            const translatedValue = choice[translatedProp]
+            // Some legacy or race-condition flows can leave translated values
+            // as arrays at this stage. We only want the default-language slot
+            // when writing `prop::defaultLang`.
+            choice[`${translatedProp}::${defaultLang}`] = Array.isArray(translatedValue)
+              ? translatedValue[0]
+              : translatedValue
+            choice[translatedProp] = undefined
           }
         })
       })
@@ -65,17 +71,22 @@ export function unnullifyTranslations(surveyDataJSON: string, surveyInitialParam
       surveyData.survey.forEach((surveyRow) => {
         translatedProps.forEach((translatedProp) => {
           if (typeof surveyRow[translatedProp] !== 'undefined') {
+            const translatedValue = surveyRow[translatedProp]
             if (
               typeof surveyData.settings[0] !== 'undefined' &&
               typeof surveyData.settings[0].style === 'string' &&
               surveyData.settings[0].style.includes('theme-grid') &&
               surveyRow.type === 'begin_group' &&
-              (surveyRow[translatedProp] === null || surveyRow[translatedProp] === '')
+              (translatedValue === null || translatedValue === '')
             ) {
-              delete surveyRow[translatedProp]
+              surveyRow[translatedProp] = undefined
             }
-            surveyRow[`${translatedProp}::${defaultLang}`] = surveyRow[translatedProp]
-            delete surveyRow[translatedProp]
+            // Match choices behavior: only map the default-language value,
+            // never the whole translation array.
+            surveyRow[`${translatedProp}::${defaultLang}`] = Array.isArray(translatedValue)
+              ? translatedValue[0]
+              : translatedValue
+            surveyRow[translatedProp] = undefined
           }
         })
       })
@@ -169,14 +180,21 @@ export function nullifyTranslations(
       data.translations.unshift(formDefaultLang)
       data.survey.forEach((row: FlatRow) => {
         translatedProps.forEach((translatedProp) => {
-          if (row[translatedProp]) {
+          const translatedValue = row[translatedProp]
+          if (translatedValue) {
             let propVal = null
             if (row.name) {
               propVal = row.name
             } else if (row.$autoname) {
               propVal = row.$autoname
             }
-            row[translatedProp].unshift(propVal)
+            if (Array.isArray(translatedValue)) {
+              translatedValue.unshift(propVal)
+            } else {
+              // Keep shape consistent for downstream code that expects
+              // translated props to be arrays indexed by language.
+              row[translatedProp] = [propVal, translatedValue]
+            }
           }
         })
       })

--- a/jsapp/js/components/formBuilder/formBuilderUtils.ts
+++ b/jsapp/js/components/formBuilder/formBuilderUtils.ts
@@ -79,7 +79,10 @@ export function unnullifyTranslations(surveyDataJSON: string, surveyInitialParam
               surveyRow.type === 'begin_group' &&
               (translatedValue === null || translatedValue === '')
             ) {
+              // Keep old behavior for empty theme-grid group labels: omit the
+              // translated key entirely instead of writing null/empty.
               surveyRow[translatedProp] = undefined
+              return
             }
             // Match choices behavior: only map the default-language value,
             // never the whole translation array.

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -195,6 +195,12 @@ export default function EditableForm(props: EditableFormProps) {
 
   useEffect(() => {
     const assetData = assetQuery.data?.data
+    if (assetQuery.isFetching) {
+      // Wait for the fetch to settle before seeding local state.
+      // Otherwise Form Builder can initialize from stale cached content and
+      // carry outdated translation metadata into save payloads.
+      return
+    }
     if (assetData && 'uid' in assetData) {
       // TODO: stop casting this as AssetResponse after backend openAPI task DEV-1727 is done
       const assetDataCast = assetData as unknown as AssetResponse
@@ -205,7 +211,7 @@ export default function EditableForm(props: EditableFormProps) {
         asset: assetDataCast,
       }))
     }
-  }, [assetQuery.data?.data])
+  }, [assetQuery.data?.data, assetQuery.isFetching])
 
   useEffect(() => {
     if (state.asset) {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixes a regression where adding a new question in Form Builder could create an unnamed language and break the Manage Languages UI.

### 📖 Description

After editing a form with translations, saving a new question in Form Builder could corrupt the language list and leave the form with an unnamed language. This patch keeps translation metadata consistent when forms are reopened and saved again.

### 💭 Notes

Changes here:
- Form Builder translation helpers
  - `nullifyTranslations` now keeps translated values in a shape that downstream code can safely save.
  - `unnullifyTranslations` now restores only the default-language value when translating back to XLSForm-style keys.
  - Added regression tests for both paths.
- Form Builder bootstrap
  - `EditableForm` now waits for the asset fetch to settle before seeding local state.
  - This avoids reusing stale translation metadata during reopen/save cycles.

Small AI pun for the road: the unnamed language has been politely asked to stop freeloading.

### 👀 Preview steps

1. ℹ️ Create a new form and add one question.
2. Save the form and exit Formbuilder.
3. Open Project → Form and use "Manage" button
4. Set the default language to English (en).
5. Click "Update translations" and confirm the table is not empty.
6. Close the modal.
7. Reopen Formbuilder and add another question.
8. Save the form and exit Formbuilder again.
9. Open Project → Form and use "Manage" button.
10. 🟢 No unnamed language should appear.
11. 🟢 Update translations should still show populated rows for the selected language.