### PR TITLE
feat(auditLogs): util for getting max lookback days DEV-1466

### DIFF
--- a/kobo/apps/audit_log/tests/test_utils.py
+++ b/kobo/apps/audit_log/tests/test_utils.py
@@ -12,7 +12,7 @@ class LookbackUtilsTestCase(TestCase):
 
     fixtures = ['test_data']
 
-    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     def test_lookback_with_stripe(self):
         someuser = User.objects.get(username='someuser')
         from kobo.apps.stripe.tests.utils import generate_plan_subscription
@@ -29,7 +29,7 @@ class LookbackUtilsTestCase(TestCase):
         generate_plan_subscription(someuser.organization, product_metadata)
         assert get_max_lookback_days(someuser) == 60
 
-    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     def test_lookback_with_stripe_default_subscription(self):
         someuser = User.objects.get(username='someuser')
         from kobo.apps.stripe.tests.utils import generate_free_plan
@@ -38,14 +38,14 @@ class LookbackUtilsTestCase(TestCase):
         lookback_days = plan.metadata.get('log_lookback_days_limit')
         assert get_max_lookback_days(someuser) == int(lookback_days)
 
-    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     @override_settings(PROJECT_HISTORY_LOG_LIFESPAN=10)
     @override_settings(ACCESS_LOG_LIFESPAN=5)
     def test_lookback_if_subscription_missing_log_lookback_days_limit(self):
         someuser = User.objects.get(username='someuser')
         assert get_max_lookback_days(someuser) == 5
 
-    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     def test_lookback_with_anonymous_user(self):
         anon_user = get_anonymous_user()
         assert get_max_lookback_days(anon_user) == 0

--- a/kobo/apps/audit_log/tests/test_utils.py
+++ b/kobo/apps/audit_log/tests/test_utils.py
@@ -1,0 +1,51 @@
+import pytest
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+import kpi.tests.utils.baker_generators  # noqa F401
+from kobo.apps.audit_log.utils import get_max_lookback_days
+from kobo.apps.kobo_auth.shortcuts import User
+from kpi.utils.object_permission import get_anonymous_user
+
+
+class LookbackUtilsTestCase(TestCase):
+
+    fixtures = ['test_data']
+
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    def test_lookback_with_stripe(self):
+        someuser = User.objects.get(username='someuser')
+        from kobo.apps.stripe.tests.utils import generate_plan_subscription
+
+        product_metadata = {
+            'mmo_enabled': 'true',
+            'plan_type': 'enterprise',
+            'asr_seconds_limit': 1,
+            'mt_characters_limit': 1,
+            'submission_limit': 1,
+            'storage_bytes_limit': 1,
+            'log_lookback_days_limit': 60,
+        }
+        generate_plan_subscription(someuser.organization, product_metadata)
+        assert get_max_lookback_days(someuser) == 60
+
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    def test_lookback_with_stripe_default_subscription(self):
+        someuser = User.objects.get(username='someuser')
+        from kobo.apps.stripe.tests.utils import generate_free_plan
+
+        plan = generate_free_plan()
+        lookback_days = plan.metadata.get('log_lookback_days_limit')
+        assert get_max_lookback_days(someuser) == int(lookback_days)
+
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    @override_settings(PROJECT_HISTORY_LOG_LIFESPAN=10)
+    @override_settings(ACCESS_LOG_LIFESPAN=5)
+    def test_lookback_if_subscription_missing_log_lookback_days_limit(self):
+        someuser = User.objects.get(username='someuser')
+        assert get_max_lookback_days(someuser) == 5
+
+    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason="Stripe is not enabled")
+    def test_lookback_with_anonymous_user(self):
+        anon_user = get_anonymous_user()
+        assert get_max_lookback_days(anon_user) == 0

--- a/kobo/apps/audit_log/tests/test_utils.py
+++ b/kobo/apps/audit_log/tests/test_utils.py
@@ -29,6 +29,15 @@ class LookbackUtilsTestCase(TestCase):
         generate_plan_subscription(someuser.organization, product_metadata)
         assert get_max_lookback_days(someuser) == 60
 
+    @pytest.mark.skipif(
+        settings.STRIPE_ENABLED, reason='Tests non-stripe functionality'
+    )
+    @override_settings(PROJECT_HISTORY_LOG_LIFESPAN=10)
+    @override_settings(ACCESS_LOG_LIFESPAN=5)
+    def test_lookback_if_subscription_missing_log_lookback_days_limit(self):
+        someuser = User.objects.get(username='someuser')
+        assert get_max_lookback_days(someuser) == 5
+
     @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     def test_lookback_with_stripe_default_subscription(self):
         someuser = User.objects.get(username='someuser')
@@ -41,11 +50,10 @@ class LookbackUtilsTestCase(TestCase):
     @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     @override_settings(PROJECT_HISTORY_LOG_LIFESPAN=10)
     @override_settings(ACCESS_LOG_LIFESPAN=5)
-    def test_lookback_if_subscription_missing_log_lookback_days_limit(self):
+    def test_lookback_if_no_default_plan(self):
         someuser = User.objects.get(username='someuser')
         assert get_max_lookback_days(someuser) == 5
 
-    @pytest.mark.skipif(not settings.STRIPE_ENABLED, reason='Stripe is not enabled')
     def test_lookback_with_anonymous_user(self):
         anon_user = get_anonymous_user()
         assert get_max_lookback_days(anon_user) == 0

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -31,8 +31,4 @@ def get_max_lookback_days(user, **kwargs) -> int:
     limit = get_organization_subscription_limit(
         organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
     )
-    # this should only happen if the default subscription is missing a log lookback
-    # limit for some reason, just default to the minimum lifespan of a log
-    if limit == inf:
-        return min(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
     return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -34,8 +34,4 @@ def get_max_lookback_days(user, **kwargs) -> int:
     # this really shouldn't happen, but handle it just in case
     if limit == inf:
         return max(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
-    return int(
-        get_organization_subscription_limit(
-            organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
-        )
-    )
+    return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -31,7 +31,8 @@ def get_max_lookback_days(user, **kwargs) -> int:
     limit = get_organization_subscription_limit(
         organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
     )
-    # this really shouldn't happen, but handle it just in case
+    # this should only happen if the default subscription is missing a log lookback
+    # limit for some reason, just default to the minimum lifespan of a log
     if limit == inf:
-        return max(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
+        return min(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
     return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -1,4 +1,13 @@
 from dataclasses import dataclass
+from math import inf
+
+import settings
+from kobo.apps.organizations.constants import UsageType
+from kobo.apps.stripe.utils.import_management import requires_stripe
+from kobo.apps.stripe.utils.subscription_limits import (
+    get_organization_subscription_limit,
+)
+from kpi.utils.permissions import is_user_anonymous
 
 
 @dataclass
@@ -11,3 +20,18 @@ class SubmissionUpdate:
 
     def __post_init__(self):
         self.username = 'AnonymousUser' if self.username is None else self.username
+
+
+@requires_stripe
+def get_max_lookback_days(user, **kwargs) -> int:
+    if is_user_anonymous(user):
+        return 0
+    user_org = user.organization
+    limit = get_organization_subscription_limit(organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS)
+    if limit == inf:
+        return max(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
+    return int(
+        get_organization_subscription_limit(
+            organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
+        )
+    )

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -31,4 +31,6 @@ def get_max_lookback_days(user, **kwargs) -> int:
     limit = get_organization_subscription_limit(
         organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
     )
+    if limit == inf:
+        return min(settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_LOG_LIFESPAN)
     return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -4,9 +4,9 @@ from math import inf
 from django.conf import settings
 
 from kobo.apps.organizations.constants import UsageType
-from kobo.apps.stripe.utils.import_management import requires_stripe
 from kobo.apps.stripe.utils.subscription_limits import (
-    get_organization_subscription_limit,
+    get_limit_key,
+    get_organizations_effective_limits,
 )
 from kpi.utils.permissions import is_user_anonymous
 
@@ -23,14 +23,14 @@ class SubmissionUpdate:
         self.username = 'AnonymousUser' if self.username is None else self.username
 
 
-@requires_stripe
 def get_max_lookback_days(user, **kwargs) -> int:
     if is_user_anonymous(user):
         return 0
     user_org = user.organization
-    limit = get_organization_subscription_limit(
-        organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
-    )
+    limits = get_organizations_effective_limits(
+        [user_org], include_onetime_addons=False, include_storage_addons=False
+    )[user_org.id]
+    limit = limits[get_limit_key(UsageType.LOG_LOOKBACK_DAYS)]
     if limit == inf:
-        return min(settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_LOG_LIFESPAN)
+        limit = min(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
     return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -1,7 +1,4 @@
 from dataclasses import dataclass
-from math import inf
-
-from django.conf import settings
 
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.stripe.utils.subscription_limits import (
@@ -31,6 +28,4 @@ def get_max_lookback_days(user, **kwargs) -> int:
         [user_org], include_onetime_addons=False, include_storage_addons=False
     )[user_org.id]
     limit = limits[get_limit_key(UsageType.LOG_LOOKBACK_DAYS)]
-    if limit == inf:
-        limit = min(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
     return int(limit)

--- a/kobo/apps/audit_log/utils.py
+++ b/kobo/apps/audit_log/utils.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from math import inf
 
-import settings
+from django.conf import settings
+
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.stripe.utils.import_management import requires_stripe
 from kobo.apps.stripe.utils.subscription_limits import (
@@ -27,7 +28,10 @@ def get_max_lookback_days(user, **kwargs) -> int:
     if is_user_anonymous(user):
         return 0
     user_org = user.organization
-    limit = get_organization_subscription_limit(organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS)
+    limit = get_organization_subscription_limit(
+        organization=user_org, usage_type=UsageType.LOG_LOOKBACK_DAYS
+    )
+    # this really shouldn't happen, but handle it just in case
     if limit == inf:
         return max(settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN)
     return int(

--- a/kobo/apps/organizations/constants.py
+++ b/kobo/apps/organizations/constants.py
@@ -7,7 +7,12 @@ class UsageType(models.TextChoices):
     MT_CHARACTERS = 'mt_characters'
     ASR_SECONDS = 'asr_seconds'
     LLM_REQUESTS = 'llm_requests'
+    LOG_LOOKBACK_DAYS = 'log_lookback_days'
 
+
+USAGE_TYPES_WITH_COUNTERS = [
+    choice for choice in UsageType.choices if choice[0] != UsageType.LOG_LOOKBACK_DAYS
+]
 
 INVITE_OWNER_ERROR = (
     'This account is already the owner of ##organization_name##. '

--- a/kobo/apps/organizations/tests/test_organizations_service_usage_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_service_usage_api.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kobo.apps.organizations.constants import UsageType
+from kobo.apps.organizations.constants import UsageType, USAGE_TYPES_WITH_COUNTERS
 from kobo.apps.trash_bin.utils import move_to_trash
 from kpi.models import Asset
 from kpi.tests.test_usage_calculator import BaseServiceUsageTestCase
@@ -90,7 +90,7 @@ class OrganizationServiceUsageAPITestCase(BaseServiceUsageTestCase):
 
         # Without stripe, there are no usage limits and
         # therefore balances should all be empty
-        for usage_type, _ in UsageType.choices:
+        for usage_type, _ in USAGE_TYPES_WITH_COUNTERS:
             assert response.data['balances'][usage_type] is None
 
     @pytest.mark.skipif(

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -15,24 +15,19 @@ from freezegun import freeze_time
 from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kobo.apps.organizations.constants import UsageType
+from kobo.apps.organizations.constants import USAGE_TYPES_WITH_COUNTERS, UsageType
 from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.utils import get_billing_dates
+from kobo.apps.stripe.exceptions import (
+    DefaultCommunityPlanNotFoundError,
+    ManualSubscriptionExistsError,
+)
 from kobo.apps.stripe.models import ExceededLimitCounter
 from kobo.apps.stripe.tests.utils import (
     _create_one_time_addon_product,
     _create_payment,
     generate_free_plan,
     generate_plan_subscription,
-)
-from kobo.apps.stripe.exceptions import (
-    DefaultCommunityPlanNotFoundError,
-    ManualSubscriptionExistsError,
-)
-from kobo.apps.stripe.utils.manual_subscription import (
-    create_manual_subscription,
-    get_default_community_plan_price,
-    organization_can_start_manual_subscription,
 )
 from kobo.apps.stripe.utils.billing_dates import (
     get_billing_dates_after_canceled_subscription,
@@ -43,6 +38,11 @@ from kobo.apps.stripe.utils.billing_dates import (
 from kobo.apps.stripe.utils.limit_enforcement import (
     check_exceeded_limit,
     update_or_remove_limit_counter,
+)
+from kobo.apps.stripe.utils.manual_subscription import (
+    create_manual_subscription,
+    get_default_community_plan_price,
+    organization_can_start_manual_subscription,
 )
 from kobo.apps.stripe.utils.subscription_limits import (
     determine_limit,
@@ -83,6 +83,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
             f'{UsageType.LLM_REQUESTS}_limit': '300',
             f'{UsageType.SUBMISSION}_limit': '400',
             f'{UsageType.STORAGE_BYTES}_limit': '500',
+            f'{UsageType.LOG_LOOKBACK_DAYS}_limit': '60',
         }
         # second plan for org2 where we append (not add) 1 to all the limits
         second_paid_plan_limits = {
@@ -130,6 +131,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
             f'{UsageType.LLM_REQUESTS}_limit': '1',
             f'{UsageType.SUBMISSION}_limit': '1',
             f'{UsageType.STORAGE_BYTES}_limit': '1',
+            f'{UsageType.LOG_LOOKBACK_DAYS}_limit': '1',
             'product_type': 'plan',
             'plan_type': 'enterprise',
         }
@@ -139,6 +141,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
             f'{UsageType.LLM_REQUESTS}_limit': '2',
             f'{UsageType.SUBMISSION}_limit': '2',
             f'{UsageType.STORAGE_BYTES}_limit': '2',
+            f'{UsageType.LOG_LOOKBACK_DAYS}_limit': '2',
         }
         generate_plan_subscription(
             self.organization, metadata=product_metadata, price_metadata=price_metadata
@@ -694,7 +697,7 @@ class ExceededLimitsTestCase(BaseServiceUsageTestCase):
         ):
             self.add_submissions(count=2, asset=self.asset, username='someuser')
         self.add_nlp_trackers()
-        for usage_type, _ in UsageType.choices:
+        for usage_type, _ in USAGE_TYPES_WITH_COUNTERS:
             check_exceeded_limit(self.someuser, usage_type)
             assert (
                 ExceededLimitCounter.objects.filter(
@@ -705,7 +708,7 @@ class ExceededLimitsTestCase(BaseServiceUsageTestCase):
 
     def test_check_exceeded_limit_updates_counters(self):
         today = timezone.now()
-        for usage_type, _ in UsageType.choices:
+        for usage_type, _ in USAGE_TYPES_WITH_COUNTERS:
             baker.make(
                 ExceededLimitCounter,
                 user=self.anotheruser,
@@ -722,7 +725,7 @@ class ExceededLimitsTestCase(BaseServiceUsageTestCase):
         ):
             self.add_submissions(count=2, asset=self.asset, username='someuser')
         self.add_nlp_trackers()
-        for usage_type, _ in UsageType.choices:
+        for usage_type, _ in USAGE_TYPES_WITH_COUNTERS:
             check_exceeded_limit(self.someuser, usage_type)
             counter = ExceededLimitCounter.objects.get(
                 user_id=self.anotheruser.id, limit_type=usage_type

--- a/kobo/apps/stripe/tests/utils.py
+++ b/kobo/apps/stripe/tests/utils.py
@@ -26,6 +26,7 @@ def generate_free_plan():
         f'{UsageType.LLM_REQUESTS}_limit': '20',
         f'{UsageType.MT_CHARACTERS}_limit': '6000',
         f'{UsageType.STORAGE_BYTES}_limit': '1000',
+        f'{UsageType.LOG_LOOKBACK_DAYS}_limit': '30',
         'default_free_plan': 'true',
     }
 

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -35,6 +35,7 @@ def get_default_add_on_limits():
         f'{UsageType.ASR_SECONDS}_limit': 0,
         f'{UsageType.MT_CHARACTERS}_limit': 0,
         f'{UsageType.LLM_REQUESTS}_limit': 0,
+        f'{UsageType.LOG_LOOKBACK_DAYS}_limit': 0,
     }
 
 
@@ -126,6 +127,7 @@ def get_organizations_subscription_limits(
     characters_limit = _get_limit_key(UsageType.MT_CHARACTERS)
     seconds_limit = _get_limit_key(UsageType.ASR_SECONDS)
     requests_limit = _get_limit_key(UsageType.LLM_REQUESTS)
+    log_access_limit = _get_limit_key(UsageType.LOG_LOOKBACK_DAYS)
     # Anyone who does not have a subscription is on the free tier plan by default
     default_plan = (
         Product.objects.filter(metadata__default_free_plan='true')
@@ -135,6 +137,7 @@ def get_organizations_subscription_limits(
             mt_characters_limit=F(f'metadata__{characters_limit}'),
             asr_seconds_limit=F(f'metadata__{seconds_limit}'),
             llm_requests_limit=F(f'metadata__{requests_limit}'),
+            log_lookback_days_limit=F(f'metadata__{log_access_limit}'),
         )
         .first()
     ) or {}
@@ -241,6 +244,9 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
     price_requests_key, product_requests_key = (
         _get_subscription_metadata_fields_for_usage_type(UsageType.LLM_REQUESTS)
     )
+    price_lookback_days_key, product_lookback_days_key = (
+        _get_subscription_metadata_fields_for_usage_type(UsageType.LOG_LOOKBACK_DAYS)
+    )
 
     # Get organizations we care about (either those in the 'organizations' param or all)
     org_filter = Q(customer__subscriber_id__in=[org_id for org_id in organization_ids])
@@ -263,6 +269,9 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
                 F(price_characters_key), F(product_characters_key)
             ),
             llm_requests_limit=Coalesce(F(price_requests_key), F(product_requests_key)),
+            log_lookback_days_limit=Coalesce(
+                F(price_lookback_days_key), F(product_lookback_days_key)
+            ),
             sub_start_date=F('start_date'),
             product_type=F('items__price__product__metadata__product_type'),
         )

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -16,7 +16,7 @@ from kobo.apps.stripe.utils.import_management import requires_stripe
 def _get_default_usage_limits():
     limits = {f'{usage_type}_limit': inf for usage_type in USAGE_TYPES_WITH_COUNTERS}
     limits['log_lookback_days_limit'] = min(
-        settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_HISTORY_LOG_LIFESPAN
+        settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_LOG_LIFESPAN
     )
     return limits
 

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -21,12 +21,12 @@ def _get_default_usage_limits():
     return limits
 
 
-def _get_limit_key(usage_type: UsageType):
+def get_limit_key(usage_type: UsageType) -> str:
     return f'{usage_type}_limit'
 
 
 def _get_subscription_metadata_fields_for_usage_type(usage_type: UsageType):
-    limit_key = _get_limit_key(usage_type)
+    limit_key = get_limit_key(usage_type)
     return (
         f'items__price__metadata__{limit_key}',
         f'items__price__product__metadata__{limit_key}',
@@ -126,12 +126,12 @@ def get_organizations_subscription_limits(
             row_limits['addon_storage_limit'] = row[f'{UsageType.STORAGE_BYTES}_limit']
         subscription_limits_by_org_id[row['org_id']] = row_limits
 
-    storage_limit = _get_limit_key(UsageType.STORAGE_BYTES)
-    submission_limit = _get_limit_key(UsageType.SUBMISSION)
-    characters_limit = _get_limit_key(UsageType.MT_CHARACTERS)
-    seconds_limit = _get_limit_key(UsageType.ASR_SECONDS)
-    requests_limit = _get_limit_key(UsageType.LLM_REQUESTS)
-    log_access_limit = _get_limit_key(UsageType.LOG_LOOKBACK_DAYS)
+    storage_limit = get_limit_key(UsageType.STORAGE_BYTES)
+    submission_limit = get_limit_key(UsageType.SUBMISSION)
+    characters_limit = get_limit_key(UsageType.MT_CHARACTERS)
+    seconds_limit = get_limit_key(UsageType.ASR_SECONDS)
+    requests_limit = get_limit_key(UsageType.LLM_REQUESTS)
+    log_access_limit = get_limit_key(UsageType.LOG_LOOKBACK_DAYS)
     # Anyone who does not have a subscription is on the free tier plan by default
     default_plan = (
         Product.objects.filter(metadata__default_free_plan='true')

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -14,7 +14,7 @@ from kobo.apps.stripe.utils.import_management import requires_stripe
 
 
 def _get_default_usage_limits():
-    limits = {f'{usage_type}_limit': inf for usage_type in USAGE_TYPES_WITH_COUNTERS}
+    limits = {f'{usage_type}_limit': inf for usage_type, _ in USAGE_TYPES_WITH_COUNTERS}
     limits['log_lookback_days_limit'] = min(
         settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_LOG_LIFESPAN
     )

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import F, Max, Q, QuerySet, Window
 from django.db.models.functions import Coalesce
 
-from kobo.apps.organizations.constants import UsageType
+from kobo.apps.organizations.constants import USAGE_TYPES_WITH_COUNTERS, UsageType
 from kobo.apps.organizations.models import Organization, OrganizationUser
 from kobo.apps.organizations.types import UsageLimits
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
@@ -14,7 +14,10 @@ from kobo.apps.stripe.utils.import_management import requires_stripe
 
 
 def _get_default_usage_limits():
-    return {f'{usage_type}_limit': inf for usage_type, _ in UsageType.choices}
+    limits = {f'{usage_type}_limit': inf for usage_type in USAGE_TYPES_WITH_COUNTERS}
+    limits['log_lookback_days_limit'] = min(
+        settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_HISTORY_LOG_LIFESPAN
+    )
 
 
 def _get_limit_key(usage_type: UsageType):

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -149,8 +149,12 @@ def get_organizations_subscription_limits(
     for usage_type, _ in UsageType.choices:
         limit_key = f'{usage_type}_limit'
         default_limit = default_plan.get(limit_key)
-        if default_limit is None:
+        if default_limit is None and usage_type != UsageType.LOG_LOOKBACK_DAYS:
             default_plan_limits[limit_key] = 'unlimited'
+        elif default_limit is None and usage_type == UsageType.LOG_LOOKBACK_DAYS:
+            default_plan_limits[limit_key] = min(
+                settings.ACCESS_LOG_LIFESPAN, settings.PROJECT_HISTORY_LOG_LIFESPAN
+            )
         else:
             default_plan_limits[limit_key] = default_limit
 

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -18,6 +18,7 @@ def _get_default_usage_limits():
     limits['log_lookback_days_limit'] = min(
         settings.PROJECT_HISTORY_LOG_LIFESPAN, settings.ACCESS_HISTORY_LOG_LIFESPAN
     )
+    return limits
 
 
 def _get_limit_key(usage_type: UsageType):

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from model_bakery import baker
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kobo.apps.organizations.constants import UsageType
+from kobo.apps.organizations.constants import UsageType, USAGE_TYPES_WITH_COUNTERS
 from kobo.apps.organizations.models import Organization
 from kobo.apps.trackers.models import NLPUsageCounter
 from kpi.models import Asset
@@ -556,5 +556,5 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
 
         usage_balances = calculator.get_usage_balances()
 
-        for usage_type, _ in UsageType.choices:
+        for usage_type, _ in USAGE_TYPES_WITH_COUNTERS:
             assert usage_balances[usage_type] is None


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging


### 💭 Notes
Dev-only change to add a util that will calculate the maximum number of days a user can look back for audit logs according to their subscription. 

On stripe-enabled instances, this will be part of the subscription plans. On non-stripe instances, the maximum lookback is however long we retain audit logs for.

### 👀 Preview steps
Make sure to have stripe enabled and sync the most recent test Stripe data

1. ℹ️ have an account on the community/default plan
2. Open a django shell
3. 
```
from kobo.apps.audit_log.utils import get_max_lookback_days
u = User.objects.get(username='<username>')
get_max_lookback_days(u)
```
4. 🟢 [on PR] should return 60
5. Upgrade your user's subscription to the Professional plan (make sure to resync using sync_subscriber so the local db gets updated)
7. ```get_max_lookback_days(u)```
8. 🟢 should now return 90
