### PR TITLE
feat(frontend): enable filtering for hidden question type DEV-2222

### DIFF
--- a/jsapp/js/components/submissions/tableConstants.ts
+++ b/jsapp/js/components/submissions/tableConstants.ts
@@ -83,6 +83,7 @@ export const TEXT_FILTER_QUESTION_TYPES: AnyRowTypeName[] = [
   QuestionTypeName.date,
   QuestionTypeName.datetime,
   QuestionTypeName.decimal,
+  QuestionTypeName.hidden,
   QuestionTypeName.integer,
   QuestionTypeName.range,
   QuestionTypeName.rank,

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -70,5 +70,10 @@ describe('tableUtils', () => {
       const test = isTableColumnFilterableByTextInput(QuestionTypeName.hidden, 'my_hidden_question')
       chai.expect(test).to.equal(true)
     })
+
+    it('should return false for a non-filterable question type', () => {
+      const test = isTableColumnFilterableByTextInput(QuestionTypeName.audio, 'my_audio_question')
+      chai.expect(test).to.equal(false)
+    })
   })
 })

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -1,4 +1,5 @@
-import { getColumnLabel } from './tableUtils'
+import { QuestionTypeName } from '#/constants'
+import { getColumnLabel, isTableColumnFilterableByTextInput } from './tableUtils'
 import { assetWithBgAudioAndNLP, assetWithNestedGroupsAndNLP } from './tableUtils.mocks'
 
 describe('tableUtils', () => {
@@ -62,5 +63,12 @@ describe('tableUtils', () => {
     // TODO: write more tests here… I haven't got enough time to go over all
     // possible cases, just added one that I was fixing a bug for and a couple
     // that came to my mind.
+  })
+
+  describe('isTableColumnFilterableByTextInput', () => {
+    it('should return true for hidden question type', () => {
+      const test = isTableColumnFilterableByTextInput(QuestionTypeName.hidden, 'my_hidden_question')
+      chai.expect(test).to.equal(true)
+    })
   })
 })


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Make it possible to filter `hidden` questions in Project → Data → Table.

### 💭 Notes

Enable it in the list of filterable questions and add a silly test just for funs.

### 👀 Preview steps

1. ℹ️ Have an account and a project with `hidden` question, ideally with some calculation (so it has some response content).
2. Make few submissions.
3. Go to Project → Data → Table.
4. 🟢 Notice that hidden question now has a filter text input.
5. Use filtering to filter out submissions.
7. 🟢 Notice it works correctly.
