### PR TITLE
fix(qual): export qual questions correctly DEV-2233

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -265,7 +265,7 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@0b20c04f957638df2caca3777419a933e53d9f4f#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
     # via -r dependencies/pip/requirements.in
 freezegun==1.5.5
     # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
-git+https://github.com/kobotoolbox/formpack.git@0b20c04f957638df2caca3777419a933e53d9f4f#egg=formpack
+git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -210,7 +210,7 @@ fido2==2.2.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@0b20c04f957638df2caca3777419a933e53d9f4f#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
     # via -r dependencies/pip/requirements.in
 frozenlist==1.8.0
     # via

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -44,10 +44,7 @@ from kobo.apps.reports.report_data import build_formpack
 from kobo.apps.storage_backends.base import default_kpi_private_storage
 from kobo.apps.subsequences.exceptions import SupplementMigrationInProgress
 from kobo.apps.subsequences.models import SubmissionSupplement
-from kobo.apps.subsequences.utils.supplement_data import (
-    get_analysis_form_json,
-    stream_with_supplements,
-)
+from kobo.apps.subsequences.utils.supplement_data import get_analysis_form_json
 from kpi.constants import (
     ASSET_TYPE_COLLECTION,
     ASSET_TYPE_EMPTY,
@@ -1079,9 +1076,6 @@ class SubmissionExportTaskBase(ImportExportTask):
                 raise SupplementMigrationInProgress(
                     'Supplement data migration in progress, please retry later.'
                 )
-            submission_stream = stream_with_supplements(
-                source, submission_stream, for_output=True
-            )
 
         pack, submission_stream = build_formpack(
             source, submission_stream, self._fields_from_all_versions

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -1061,13 +1061,6 @@ class SubmissionExportTaskBase(ImportExportTask):
         # Include the group name in `fields` for Mongo to correctly filter
         # for repeat groups
         fields = self._get_fields_and_groups(fields)
-        submission_stream = source.deployment.get_submissions(
-            user=self.user,
-            fields=fields,
-            submission_ids=submission_ids,
-            query=query,
-            for_output=True,
-        )
 
         if source.has_advanced_features:
             # Use a cheap EXISTS query before the expensive full prefetch in
@@ -1083,6 +1076,13 @@ class SubmissionExportTaskBase(ImportExportTask):
                     'Supplement data migration in progress, please retry later.'
                 )
 
+        submission_stream = source.deployment.get_submissions(
+            user=self.user,
+            fields=fields,
+            submission_ids=submission_ids,
+            query=query,
+            for_output=True,
+        )
         pack, submission_stream = build_formpack(
             source, submission_stream, self._fields_from_all_versions
         )

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -902,7 +902,12 @@ class SubmissionExportTaskBase(ImportExportTask):
 
         # Some fields are attached to the submission and must be included in
         # addition to the user-selected fields
-        additional_fields = ['_attachments', '_supplementalDetails']
+        additional_fields = [
+            '_attachments',
+            '_supplementalDetails',
+            '_uuid',
+            'meta/rootUuid',
+        ]
 
         field_groups = set()
         for field in fields:
@@ -1061,6 +1066,7 @@ class SubmissionExportTaskBase(ImportExportTask):
             fields=fields,
             submission_ids=submission_ids,
             query=query,
+            for_output=True,
         )
 
         if source.has_advanced_features:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fixes the qualitative manual multiple select data export

### 📖 Description
The one hot data export for manual qualitative multiple select data was [fixed on formpack](https://github.com/kobotoolbox/formpack/pull/347). In `import_export_task.py`, the `SubmissionExportTaskBase.get_export_object`  we pass for_output=True down to `get_submissions`  in order to resolve the choice UUIDs into their corresponding human-readable labels. We have also added `_uuid` and `meta/rootUuid` to the additional_fields list in `_get_fields_and_groups()` to retrieve the qualitative payload correctly. 

### 👀 Preview steps
1. Create a project with an active qualSelectMultiple question and ensure there are submissions with multiple tags/options selected (You can achieve this by having an audio question, then clicking on "Open", in the Data view, in the audio cell, and then in the "Analysis" tab you can add a multiple choice question and select a few options)
3. Go to the project's Data > Downloads
4. Select an export format (e.g., XLS) and check the "Single and separate columns" advanced option
5. Generate and download the export
6. Open the export file and verify that the Qual multiple-choice field has successfully expanded into multiple binary columns, and that the single column version displays the selected labels separated by spaces instead of commas
