### PR TITLE
feat(accountSettings): add UI for token regeneration DEV-2243

### DIFF
--- a/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
+++ b/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
@@ -49,14 +49,23 @@ export default function ApiTokenDisplay() {
 
   const regenerateToken = async () => {
     setIsRegenerating(true)
+    // Clear any displayed token up front so a now-stale value is never shown
+    // while we work (or if the user dismisses the modal mid-flight).
+    setToken(null)
     try {
-      // Revoke the existing token first, and immediately clear it from local
-      // state so a now-invalid token is never displayed.
+      // The whole sequence is best-effort and self-verifying: if any step
+      // fails we simply start over on the next attempt. We don't trust the
+      // DELETE's own response to confirm the rotation; instead we (1) read the
+      // current token, (2) delete it, then (3) read again and require a
+      // different value. A concurrent session rotating the token in between is
+      // fine — we only care that the final token differs from our baseline.
+      const before = await dataInterface.apiToken()
       await dataInterface.deleteApiToken()
-      setToken(null)
-      // Fetching the token triggers the backend to generate a new one.
-      const result = await dataInterface.apiToken()
-      setToken(result.token)
+      const after = await dataInterface.apiToken()
+      if (after.token === before.token) {
+        throw new Error('API key was not rotated')
+      }
+      setToken(after.token)
       notify(t('API key regenerated successfully'))
       regenerateModal.close()
     } catch {

--- a/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
+++ b/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
@@ -50,15 +50,10 @@ export default function ApiTokenDisplay() {
   const regenerateToken = async () => {
     setIsRegenerating(true)
     // Clear any displayed token up front so a now-stale value is never shown
-    // while we work (or if the user dismisses the modal mid-flight).
     setToken(null)
     try {
-      // The whole sequence is best-effort and self-verifying: if any step
-      // fails we simply start over on the next attempt. We don't trust the
-      // DELETE's own response to confirm the rotation; instead we (1) read the
-      // current token, (2) delete it, then (3) read again and require a
-      // different value. A concurrent session rotating the token in between is
-      // fine — we only care that the final token differs from our baseline.
+      // The true test of success is whether a new (i.e. different) token was
+      // generated and returned by the API
       const before = await dataInterface.apiToken()
       await dataInterface.deleteApiToken()
       const after = await dataInterface.apiToken()
@@ -70,10 +65,8 @@ export default function ApiTokenDisplay() {
       regenerateModal.close()
     } catch {
       notify.error(t('Failed to regenerate API key'))
-      // We cleared `token` above but left no replacement. Reset to the hidden
-      // state so the field stops showing a masked-but-"revealed" value and a
-      // single Display click re-fetches the still-valid token (the fetch
-      // effect only runs when `isVisible` transitions).
+      // Handle the case where "Display" had already been clicked before
+      // attempting (and failing) to regenerate the token
       setIsVisible(false)
     } finally {
       setIsRegenerating(false)
@@ -109,7 +102,7 @@ export default function ApiTokenDisplay() {
       >
         <Stack>
           <Text>
-            {t('All access through your existing API key will be revoked, and a new one will be generated randomly.')}
+            {t('All access through your existing API key will be revoked, and a new key will be generated randomly.')}
           </Text>
 
           <Group justify='flex-end'>

--- a/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
+++ b/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useEffect } from 'react'
 
+import { Group, Stack, Text } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
 import cx from 'classnames'
 import securityStyles from '#/account/security/securityRoute.module.scss'
+import ButtonNew from '#/components/common/ButtonNew'
+import ModalNew from '#/components/common/ModalNew'
 import Button from '#/components/common/button'
 import TextBox from '#/components/common/textBox'
 import { dataInterface } from '#/dataInterface'
@@ -18,6 +22,8 @@ export default function ApiTokenDisplay() {
   const [token, setToken] = useState(null)
   const [isFetching, setIsFetching] = useState(false)
   const [isVisible, setIsVisible] = useState(false)
+  const [isRegenerateModalOpen, regenerateModal] = useDisclosure(false)
+  const [isRegenerating, setIsRegenerating] = useState(false)
 
   const toggleTokenVisibility = () => {
     setIsVisible(!isVisible)
@@ -41,6 +47,25 @@ export default function ApiTokenDisplay() {
     }
   }, [isVisible])
 
+  const regenerateToken = async () => {
+    setIsRegenerating(true)
+    try {
+      // Revoke the existing token first, and immediately clear it from local
+      // state so a now-invalid token is never displayed.
+      await dataInterface.deleteApiToken()
+      setToken(null)
+      // Fetching the token triggers the backend to generate a new one.
+      const result = await dataInterface.apiToken()
+      setToken(result.token)
+      notify(t('API key regenerated successfully'))
+      regenerateModal.close()
+    } catch {
+      notify.error(t('Failed to regenerate API key'))
+    } finally {
+      setIsRegenerating(false)
+    }
+  }
+
   return (
     <section className={securityStyles.securitySection}>
       <div className={securityStyles.securitySectionTitle}>
@@ -57,8 +82,33 @@ export default function ApiTokenDisplay() {
       </div>
 
       <div className={styles.options}>
+        <Button label={t('Regenerate key')} size='m' type='text' onClick={regenerateModal.open} />
+
         <Button label={t('Display')} size='m' type='primary' onClick={toggleTokenVisibility} />
       </div>
+
+      <ModalNew
+        opened={isRegenerateModalOpen}
+        onClose={regenerateModal.close}
+        title={t('Regenerate API key')}
+        size='md'
+      >
+        <Stack>
+          <Text>
+            {t('All access through your existing API key will be revoked, and a new one will be generated randomly.')}
+          </Text>
+
+          <Group justify='flex-end'>
+            <ButtonNew size='md' onClick={regenerateModal.close} variant='light' disabled={isRegenerating}>
+              {t('Cancel')}
+            </ButtonNew>
+
+            <ButtonNew size='md' onClick={regenerateToken} variant='danger' loading={isRegenerating}>
+              {t('Regenerate')}
+            </ButtonNew>
+          </Group>
+        </Stack>
+      </ModalNew>
     </section>
   )
 }

--- a/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
+++ b/jsapp/js/account/security/apiToken/apiTokenSection.component.tsx
@@ -70,6 +70,11 @@ export default function ApiTokenDisplay() {
       regenerateModal.close()
     } catch {
       notify.error(t('Failed to regenerate API key'))
+      // We cleared `token` above but left no replacement. Reset to the hidden
+      // state so the field stops showing a masked-but-"revealed" value and a
+      // single Display click re-fetches the still-valid token (the fetch
+      // effect only runs when `isVisible` transitions).
+      setIsVisible(false)
     } finally {
       setIsRegenerating(false)
     }

--- a/jsapp/js/account/security/apiToken/apiTokenSection.module.scss
+++ b/jsapp/js/account/security/apiToken/apiTokenSection.module.scss
@@ -15,5 +15,6 @@
 .options {
   flex: 3;
   display: flex;
+  gap: 10px;
   justify-content: flex-end;
 }

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -1159,6 +1159,12 @@ export const dataInterface: DataInterface = {
       url: `${ROOT_URL}/token/?format=json`,
     }),
 
+  deleteApiToken: (): JQuery.jqXHR<void> =>
+    $ajax({
+      url: `${ROOT_URL}/token/?format=json`,
+      method: 'DELETE',
+    }),
+
   getUser: (userUrl: string): JQuery.jqXHR<UserResponse> =>
     $ajax({
       url: userUrl,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
3. [x] [(done)](https://chat.kobotoolbox.org/#narrow/channel/81-Support-Docs-Updates/topic/API.20key.20regeneration.2C.20self-service.20edition/with/848705) for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [x] delete this checklist section from the final squash commit before merging

### 📣 Summary

Allow regenerating the API Key (token) in the "Security" section of the "Account Settings" UI.

### 👀 Preview steps

1. Go to the "Security" section of the "Account Settings" UI
2. Notice "Regenerate key" appears next to the "Display" button for "API Key"
3. Click this
4. Confirm in the modal that appears
5. Verify that the token has changed in the UI
6. Refresh to ensure the new token indeed came from the server
7. Try again, but decline in the confirmation modal and verify nothing changes