### PR TITLE
fix(accounts): avoid IntegrityError on SSO reconnect DEV-2226

### DIFF
--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -23,7 +23,16 @@ def update_email(*args, **kwargs):
     emails, primary = cleanup_email_addresses(request, all_email_addresses)
 
     # cleanup_email_addresses doesn't actually call set_as_primary on the primary
-    # email so do that now
+    # email so do that now.
+    # If primary has no pk, a matching record may already exist in the DB
+    # (e.g. reconnecting an SSO account whose email is already stored).
+    # In that case we must reuse the existing row; otherwise set_as_primary()
+    # would attempt an INSERT and hit the unique(user_id, email) constraint.
+    if not primary.pk:
+        try:
+            primary = EmailAddress.objects.get(user=social_user, email=primary.email)
+        except EmailAddress.DoesNotExist:
+            pass
     primary.set_as_primary()
 
     # update existing emails to reflect that they are no longer primary

--- a/kobo/apps/accounts/tests/test_signals.py
+++ b/kobo/apps/accounts/tests/test_signals.py
@@ -17,6 +17,60 @@ class TestAccountSignals(TestCase):
             primary=True
         )
 
+    def test_reconnect_sso_with_existing_email_does_not_raise(self):
+        """
+        Reconnecting SSO when the email already exists in EmailAddress must
+        not raise IntegrityError on the unique(user_id, email) constraint.
+        """
+        request = RequestFactory().get('/')
+        same_address = EmailAddress(
+            email=self.user.email,
+            verified=True,
+            primary=True,
+        )
+        social_login = SocialLogin(email_addresses=[same_address], user=self.user)
+        update_email(request=request, sociallogin=social_login)
+
+        assert EmailAddress.objects.filter(user=self.user).count() == 1
+        addr = EmailAddress.objects.get(user=self.user)
+        assert addr.email == self.user.email
+        assert addr.primary
+
+    def test_reconnect_sso_does_not_affect_other_user_with_same_email(self):
+        """
+        When two users share an email address and one reconnects via SSO,
+        the other user's EmailAddress must remain untouched.
+        """
+        shared_email = self.user.email
+        other_user = User.objects.create_user(
+            username='otheruser',
+            email=shared_email,
+            password='password',
+        )
+        other_address = EmailAddress.objects.create(
+            user=other_user,
+            email=shared_email,
+            verified=True,
+            primary=True,
+        )
+
+        request = RequestFactory().get('/')
+        same_address = EmailAddress(
+            email=shared_email,
+            verified=True,
+            primary=True,
+        )
+        social_login = SocialLogin(email_addresses=[same_address], user=self.user)
+        update_email(request=request, sociallogin=social_login)
+
+        self_addr = EmailAddress.objects.get(user=self.user)
+        assert self_addr.primary
+        assert self_addr.email == shared_email
+
+        refreshed_other = EmailAddress.objects.get(pk=other_address.pk)
+        assert refreshed_other.user == other_user
+        assert refreshed_other.primary
+
     def test_social_login_connect_updates_primary_email(self):
         request = RequestFactory().get('/')
         new_address = EmailAddress(


### PR DESCRIPTION
### 📣 Summary

Reconnecting a social (SSO) account failed with a database error when the user's email address was already stored.

### 💭 Notes

- The crash occurred in `update_email` (signal on `social_account_added`) at `primary.set_as_primary()`, which called `save()` on an unsaved `EmailAddress` instance — triggering an INSERT that violated the `unique(user_id, email)` constraint.
- Fix: before calling `set_as_primary()`, if `primary.pk` is `None`, we attempt `EmailAddress.objects.get(user=social_user, email=primary.email)`. If the row already exists, we reuse that instance (with its pk) so `save()` does an UPDATE instead of INSERT.
- The lookup is scoped to `user=social_user`, so two users sharing the same email address cannot interfere with each other.
- Two new tests cover: (1) reconnecting SSO with an already-stored email, (2) isolation between users who share an email.

### 👀 Preview steps

1. ℹ️ Have an account whose email is already stored as an `EmailAddress` (e.g. previously connected via SSO)
2. Connect a social/SSO account from the Account Settings → Security page
3. Disconnect it
4. 🔴 [on main] Reconnecting the SSO account raises a 500 error (`IntegrityError: duplicate key value violates unique constraint`)
5. 🟢 [on PR] Reconnecting the SSO account succeeds without error