### PR TITLE
feat(nlp): implement Google API US/EU region routing for Speech-to-Text and Translation DEV-2199

### DIFF
--- a/kobo/apps/languages/models/transcription.py
+++ b/kobo/apps/languages/models/transcription.py
@@ -28,11 +28,22 @@ class TranscriptionService(BaseLanguageService):
                 service__code=self.code, region__code=value
             )
         except TranscriptionServiceLanguageM2M.DoesNotExist as err:
-            # Fall back on language itself and let the service detect the region.
+            # Check if value is itself a language code (e.g. 'en')
             if self.language_set.filter(code=value).exists():
                 return value
-            else:
-                raise LanguageNotSupported from err
+
+            # `value` is a region code (e.g. 'fr-BE') not explicitly in
+            # the DB. Strip the region suffix to get the parent language code
+            # (e.g. 'fr') and check whether that base language is supported.
+            # If it is, return the original region code unchanged so that
+            # Google STT receives the correct regional hint
+            parent_code = value.split('-')[0]
+            if parent_code != value and self.language_set.filter(
+                code=parent_code
+            ).exists():
+                return value
+
+            raise LanguageNotSupported from err
         else:
             return (
                 through_obj.mapping_code if through_obj.mapping_code else value
@@ -61,16 +72,25 @@ class TranscriptionService(BaseLanguageService):
         if through_obj:
             return self._build_config(through_obj)
 
-        if not self.language_set.filter(code=value).exists():
+        # `value` is a language code (e.g. 'fr') or a region-specific code
+        # (e.g. 'fr-BE'). If the exact code is not configured, fall back to the
+        # parent language ('fr') and use its stored configuration (model, location,
+        # etc.), so region-specific variants inherit their parent language settings
+        parent_code = value.split('-')[0]
+        lang_code = value if self.language_set.filter(code=value).exists() else (
+            parent_code if self.language_set.filter(code=parent_code).exists()
+            else None
+        )
+        if lang_code is None:
             raise LanguageNotSupported
 
-        candidates = list(queryset.filter(language__code=value))
+        candidates = list(queryset.filter(language__code=lang_code))
         if len(candidates) == 1:
             return self._build_config(candidates[0])
 
         if len(candidates) > 1:
             return self._build_config(
-                self._get_default_candidate(value, candidates)
+                self._get_default_candidate(lang_code, candidates)
             )
 
         raise LanguageNotSupported

--- a/kobo/apps/subsequences/integrations/google/base.py
+++ b/kobo/apps/subsequences/integrations/google/base.py
@@ -7,6 +7,7 @@ from typing import Any
 import constance
 from django.conf import settings
 from django.core.cache import cache
+from google.api_core import client_options
 from google.api_core.operation import Operation
 from google.cloud import storage
 from googleapiclient import discovery
@@ -49,6 +50,9 @@ class GoogleService(ABC):
     def adapt_response(self, results: Any) -> str:
         pass
 
+    def get_client_options(self) -> Any:
+        return None
+
     @abstractmethod
     def begin_google_operation(
         self,
@@ -75,13 +79,8 @@ class GoogleService(ABC):
         # Fetch the latest update from Google API, but do not resend the same operation.
         cache_key = self._get_cache_key(xpath, source_lang, target_lang)
         if operation_name := cache.get(cache_key):
-            google_service = discovery.build(
-                self.API_NAME, self.API_VERSION, credentials=self.credentials
-            )
-            resource_path = self.API_RESOURCE.split('.')
-            for subresource in resource_path:
-                google_service = getattr(google_service, subresource)()
-            operation = google_service.get(name=operation_name).execute()
+            resource = self._get_discovery_resource()
+            operation = resource.get(name=operation_name).execute()
             if not (
                 operation.get('done') or operation.get('state') == 'SUCCEEDED'
             ):
@@ -117,15 +116,26 @@ class GoogleService(ABC):
         """
         Cancel a previously started Google long-running operation
         """
+        resource = self._get_discovery_resource()
+        resource.cancel(name=operation_name, body={}).execute()
+
+    def _get_discovery_resource(self):
+        opts = self.get_client_options()
+        if opts and opts.api_endpoint and not opts.api_endpoint.startswith('http'):
+            opts = client_options.ClientOptions(
+                api_endpoint=f'https://{opts.api_endpoint}'
+            )
+
         google_service = discovery.build(
             self.API_NAME,
             self.API_VERSION,
             credentials=self.credentials,
+            client_options=opts,
         )
         resource = google_service
         for subresource in self.API_RESOURCE.split('.'):
             resource = getattr(resource, subresource)()
-        resource.cancel(name=operation_name, body={}).execute()
+        return resource
 
     @abstractmethod
     def process_data(

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -40,11 +40,17 @@ from ...exceptions import (
     TranscriptionResultNotFound
 )
 from .base import GoogleService
+from .locations import get_speech_location
 
 # https://cloud.google.com/speech-to-text/docs/quotas
 ASYNC_MAX_LENGTH = timedelta(minutes=479)
-DEFAULT_SPEECH_LOCATION = 'global'
-DEFAULT_SPEECH_MODEL = 'long'
+
+# Fallback STT model used when a language has no `model_code` set in the
+# `TranscriptionServiceLanguageM2M` database table. 'chirp_3' is chosen over
+# 'long' because it is available for every language in the 'us' and 'eu'
+# multi-region endpoints, and it supports all recognition features
+# (e.g. enable_automatic_punctuation)
+DEFAULT_SPEECH_MODEL = 'chirp_3'
 
 
 class GoogleTranscriptionService(GoogleService):
@@ -102,7 +108,6 @@ class GoogleTranscriptionService(GoogleService):
         target_lang: str,
         content: Any,
         *,
-        location_code: str | None = None,
         model_code: str | None = None,
     ) -> tuple[object, int]:
         """
@@ -115,7 +120,7 @@ class GoogleTranscriptionService(GoogleService):
                 'Audio file of duration %s is too long.' % duration
             )
 
-        speech_location = location_code or DEFAULT_SPEECH_LOCATION
+        speech_location = get_speech_location()
         speech_model = model_code or DEFAULT_SPEECH_MODEL
         speech_client = self._get_speech_client(speech_location)
         input_path, output_prefix = self._get_batch_paths(xpath, source_lang)
@@ -151,6 +156,11 @@ class GoogleTranscriptionService(GoogleService):
     @property
     def counter_name(self):
         return 'google_asr_seconds'
+
+    def get_client_options(self):
+        return client_options.ClientOptions(
+            api_endpoint=f'{get_speech_location()}-speech.googleapis.com'
+        )
 
     def get_converted_audio(
         self, xpath: str, submission_uuid: int, user: object
@@ -227,7 +237,6 @@ class GoogleTranscriptionService(GoogleService):
                     source_lang=source_language,
                     target_lang=None,
                     content=converted_audio,
-                    location_code=language_config.location_code,
                     model_code=language_config.model_code,
                 )
             except AudioTooLongError as err:
@@ -306,7 +315,6 @@ class GoogleTranscriptionService(GoogleService):
             # read the batch result after Google reports completion
             operation_payload = self._get_operation_payload(
                 operation_name,
-                language_config.location_code,
             )
             if not operation_payload.get('done'):
                 raise SubsequenceTimeoutError
@@ -449,12 +457,12 @@ class GoogleTranscriptionService(GoogleService):
         """
         Create a Speech client bound to the configured regional endpoint
         """
-        client_kwargs = {'credentials': self.credentials}
-        if location != DEFAULT_SPEECH_LOCATION:
-            client_kwargs['client_options'] = client_options.ClientOptions(
+        return speech.SpeechClient(
+            credentials=self.credentials,
+            client_options=client_options.ClientOptions(
                 api_endpoint=f'{location}-speech.googleapis.com'
-            )
-        return speech.SpeechClient(**client_kwargs)
+            ),
+        )
 
     def _get_recognizer_name(self, location: str) -> str:
         """
@@ -468,14 +476,11 @@ class GoogleTranscriptionService(GoogleService):
     def _get_operation_payload(
         self,
         operation_name: str,
-        location_code: str | None = None,
     ) -> dict:
         """
         Poll the Google long-running operation backing the batch request.
         """
-        speech_client = self._get_speech_client(
-            location_code or DEFAULT_SPEECH_LOCATION
-        )
+        speech_client = self._get_speech_client(get_speech_location())
         operation = speech_client.transport.operations_client.get_operation(
             operation_name
         )

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -64,6 +64,7 @@ class GoogleTranscriptionService(GoogleService):
         class. It uses Google Cloud Speech-to-Text v2 batch API.
         """
         super().__init__(submission=submission, asset=asset, *args, **kwargs)
+        self.speech_location = get_speech_location()
 
     def adapt_response(self, response: Union[dict, list]) -> str:
         """
@@ -120,21 +121,20 @@ class GoogleTranscriptionService(GoogleService):
                 'Audio file of duration %s is too long.' % duration
             )
 
-        speech_location = get_speech_location()
         speech_model = model_code or DEFAULT_SPEECH_MODEL
-        speech_client = self._get_speech_client(speech_location)
+        speech_client = self._get_speech_client(self.speech_location)
         input_path, output_prefix = self._get_batch_paths(xpath, source_lang)
 
         logging.info(
             'Starting Google automatic transcription for '
             f'{self.submission_root_uuid=}, {xpath=}, {source_lang=}, '
-            f'{speech_location=}, {speech_model=}'
+            f'{self.speech_location=}, {speech_model=}'
         )
         self._cleanup_batch_files(xpath, source_lang)
         gcs_input_uri = self.store_file(flac_content, input_path)
 
         request = speech.BatchRecognizeRequest(
-            recognizer=self._get_recognizer_name(speech_location),
+            recognizer=self._get_recognizer_name(self.speech_location),
             config=speech.RecognitionConfig(
                 auto_decoding_config=speech.AutoDetectDecodingConfig(),
                 language_codes=[source_lang],
@@ -159,7 +159,7 @@ class GoogleTranscriptionService(GoogleService):
 
     def get_client_options(self):
         return client_options.ClientOptions(
-            api_endpoint=f'{get_speech_location()}-speech.googleapis.com'
+            api_endpoint=f'{self.speech_location}-speech.googleapis.com'
         )
 
     def get_converted_audio(
@@ -480,7 +480,7 @@ class GoogleTranscriptionService(GoogleService):
         """
         Poll the Google long-running operation backing the batch request.
         """
-        speech_client = self._get_speech_client(get_speech_location())
+        speech_client = self._get_speech_client(self.speech_location)
         operation = speech_client.transport.operations_client.get_operation(
             operation_name
         )

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -145,7 +145,7 @@ class GoogleTranscriptionService(GoogleService):
                     # languages, including the 6 legacy African languages
                     # (Kinyarwanda, Swati, Southern Sotho, Tswana, Tsonga, Venda),
                     # and will return a 400 error if enabled
-                    enable_automatic_punctuation = (speech_model != 'long'),
+                    enable_automatic_punctuation=(speech_model != 'long'),
                 ),
             ),
             files=[speech.BatchRecognizeFileMetadata(uri=gcs_input_uri)],

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -140,7 +140,12 @@ class GoogleTranscriptionService(GoogleService):
                 language_codes=[source_lang],
                 model=speech_model,
                 features=speech.RecognitionFeatures(
-                    enable_automatic_punctuation=True
+                    # chirp_3, chirp_2, and chirp support automatic punctuation
+                    # for all languages. 'long' does not support it for several
+                    # languages, including the 6 legacy African languages
+                    # (Kinyarwanda, Swati, Southern Sotho, Tswana, Tsonga, Venda),
+                    # and will return a 400 error if enabled
+                    enable_automatic_punctuation = (speech_model != 'long'),
                 ),
             ),
             files=[speech.BatchRecognizeFileMetadata(uri=gcs_input_uri)],

--- a/kobo/apps/subsequences/integrations/google/google_translate.py
+++ b/kobo/apps/subsequences/integrations/google/google_translate.py
@@ -9,6 +9,7 @@ import constance
 from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
+from google.api_core import client_options
 from google.api_core.exceptions import GoogleAPIError, InvalidArgument
 from google.cloud import translate_v3 as translate
 from google.cloud.exceptions import GoogleCloudError
@@ -22,6 +23,7 @@ from ...constants import GOOGLE_CACHE_TIMEOUT, GOOGLE_CODE
 from ...exceptions import SubsequenceTimeoutError, TranslationResultNotFound
 from ..utils.google import google_credentials_from_constance_config
 from .base import GoogleService
+from .locations import get_translate_endpoint, get_translate_location
 
 
 class GoogleTranslationService(GoogleService):
@@ -41,16 +43,17 @@ class GoogleTranslationService(GoogleService):
         super().__init__(submission, asset, *args, **kwargs)
 
         self.translate_client = translate.TranslationServiceClient(
-            credentials=google_credentials_from_constance_config()
+            credentials=google_credentials_from_constance_config(),
+            client_options=client_options.ClientOptions(
+                api_endpoint=get_translate_endpoint()
+            ),
         )
+        translate_location = get_translate_location()
         self.translate_parent = (
-            f'projects/{constance.config.ASR_MT_GOOGLE_PROJECT_ID}'
-        )
-        # Google batch translation requires a concrete regional location
-        self.translate_async_parent = (
             f'projects/{constance.config.ASR_MT_GOOGLE_PROJECT_ID}/'
-            f'locations/{constance.config.ASR_MT_GOOGLE_TRANSLATION_LOCATION}'
+            f'locations/{translate_location}'
         )
+        self.translate_async_parent = self.translate_parent
         self.bucket_prefix = (
             constance.config.ASR_MT_GOOGLE_STORAGE_BUCKET_PREFIX
         )
@@ -70,6 +73,9 @@ class GoogleTranslationService(GoogleService):
     @property
     def counter_name(self):
         return 'google_mt_characters'
+
+    def get_client_options(self):
+        return client_options.ClientOptions(api_endpoint=get_translate_endpoint())
 
     def begin_google_operation(
         self,

--- a/kobo/apps/subsequences/integrations/google/locations.py
+++ b/kobo/apps/subsequences/integrations/google/locations.py
@@ -14,44 +14,37 @@ GOOGLE_REGION_CHOICES = (GOOGLE_REGION_US, GOOGLE_REGION_EU)
 
 DEFAULT_GOOGLE_REGION = GOOGLE_REGION_US
 
+# 'us' and 'eu' are STT v2 multi-region endpoints with identical language
+# support and model availability
 SPEECH_LOCATION_BY_REGION = {
     GOOGLE_REGION_EU: 'eu',
     GOOGLE_REGION_US: 'us',
 }
 
-# To maintain strict EU data residency compliance, EU traffic is explicitly
-# routed through the dedicated 'translate-eu' multi-regional gateway. This
-# guarantees that TLS termination, data in transit, and processing
-# (in europe-west1) remain entirely within European borders.
-#
-# For the default/US region, we utilize the global endpoint to process in
-# us-central1, as there are no data residency restrictions and this allows for
-# more flexible failover and redundancy options across Google's global infrastructure
+# Translation requests are routed through multi-region endpoints:
+# `translate-eu.googleapis.com` keeps TLS termination and processing within the EU
+# for EU data residency requirements, while `translate-us.googleapis.com` routes
+# requests through the US multi-region
 TRANSLATE_ENDPOINT_BY_REGION = {
     GOOGLE_REGION_EU: 'translate-eu.googleapis.com',
-    GOOGLE_REGION_US: 'translate.googleapis.com',
+    GOOGLE_REGION_US: 'translate-us.googleapis.com',
 }
 
 TRANSLATE_LOCATION_BY_REGION = {
     GOOGLE_REGION_EU: 'europe-west1',
-    GOOGLE_REGION_US: 'us-central1',
+    GOOGLE_REGION_US: 'us-west1',
 }
 
 
 def get_google_region() -> str:
     """
-    Return the configured ASR/MT Google processing region
+    Return the configured ASR/MT Google processing region ('US' or 'EU')
 
-    Constance values are editable at runtime, so tolerate lower-case values and
-    fall back to the 'US' with a warning if an un-recognized value is set.
+    Reads ASR_MT_GOOGLE_REGION from constance at call time, so an admin can
+    change the region without restarting the server. Tolerates lower-case input
+    and falls back to 'US' with a warning if an unrecognised value is set
     """
-    region = str(
-        getattr(
-            constance.config,
-            'ASR_MT_GOOGLE_REGION',
-            DEFAULT_GOOGLE_REGION,
-        )
-    ).upper()
+    region = constance.config.ASR_MT_GOOGLE_REGION
     if region in GOOGLE_REGION_CHOICES:
         return region
 

--- a/kobo/apps/subsequences/integrations/google/locations.py
+++ b/kobo/apps/subsequences/integrations/google/locations.py
@@ -44,7 +44,7 @@ def get_google_region() -> str:
     change the region without restarting the server. Tolerates lower-case input
     and falls back to 'US' with a warning if an unrecognised value is set
     """
-    region = constance.config.ASR_MT_GOOGLE_REGION
+    region = str(constance.config.ASR_MT_GOOGLE_REGION).upper()
     if region in GOOGLE_REGION_CHOICES:
         return region
 

--- a/kobo/apps/subsequences/integrations/google/locations.py
+++ b/kobo/apps/subsequences/integrations/google/locations.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import constance
+
+from kpi.utils.log import logging
+
+
+# The server-wide Google region is stored in Constance as either 'US' or 'EU'.
+# 'EU' must be used when EU data residency is required (all data must remain
+# within Europe). 'US' is the default for all other deployments
+GOOGLE_REGION_EU = 'EU'
+GOOGLE_REGION_US = 'US'
+GOOGLE_REGION_CHOICES = (GOOGLE_REGION_US, GOOGLE_REGION_EU)
+
+DEFAULT_GOOGLE_REGION = GOOGLE_REGION_US
+
+SPEECH_LOCATION_BY_REGION = {
+    GOOGLE_REGION_EU: 'eu',
+    GOOGLE_REGION_US: 'us',
+}
+
+# To maintain strict EU data residency compliance, EU traffic is explicitly
+# routed through the dedicated 'translate-eu' multi-regional gateway. This
+# guarantees that TLS termination, data in transit, and processing
+# (in europe-west1) remain entirely within European borders.
+#
+# For the default/US region, we utilize the global endpoint to process in
+# us-central1, as there are no data residency restrictions and this allows for
+# more flexible failover and redundancy options across Google's global infrastructure
+TRANSLATE_ENDPOINT_BY_REGION = {
+    GOOGLE_REGION_EU: 'translate-eu.googleapis.com',
+    GOOGLE_REGION_US: 'translate.googleapis.com',
+}
+
+TRANSLATE_LOCATION_BY_REGION = {
+    GOOGLE_REGION_EU: 'europe-west1',
+    GOOGLE_REGION_US: 'us-central1',
+}
+
+
+def get_google_region() -> str:
+    """
+    Return the configured ASR/MT Google processing region
+
+    Constance values are editable at runtime, so tolerate lower-case values and
+    fall back to the 'US' with a warning if an un-recognized value is set.
+    """
+    region = str(
+        getattr(
+            constance.config,
+            'ASR_MT_GOOGLE_REGION',
+            DEFAULT_GOOGLE_REGION,
+        )
+    ).upper()
+    if region in GOOGLE_REGION_CHOICES:
+        return region
+
+    logging.warning(
+        'Invalid ASR_MT_GOOGLE_REGION=%s; defaulting to %s',
+        region,
+        DEFAULT_GOOGLE_REGION,
+    )
+    return DEFAULT_GOOGLE_REGION
+
+
+def get_speech_location() -> str:
+    return SPEECH_LOCATION_BY_REGION[get_google_region()]
+
+
+def get_translate_endpoint() -> str:
+    return TRANSLATE_ENDPOINT_BY_REGION[get_google_region()]
+
+
+def get_translate_location() -> str:
+    return TRANSLATE_LOCATION_BY_REGION[get_google_region()]

--- a/kobo/apps/subsequences/integrations/tests/test_google_translate.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_translate.py
@@ -56,7 +56,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_sync_translation_returns_failed_for_invalid_argument(self):
         """
@@ -86,7 +86,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_async_translation_returns_failed_timeout_and_saves_operation(self):
         """
@@ -130,7 +130,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_async_translation_reuses_cached_operation_and_returns_complete(self):
         """
@@ -169,7 +169,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_async_translation_reuses_cached_operation_and_returns_retry_later(self):
         """
@@ -209,7 +209,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_operation_payload_can_be_dict(self):
         """
@@ -228,7 +228,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_TRANSLATION_LOCATION='us-central1',
+        ASR_MT_GOOGLE_REGION='US',
     )
     def test_bulk_action_uid_falls_back_to_cache_when_model_is_unavailable(self):
         """

--- a/kobo/apps/subsequences/migrations/0012_migrate_google_region_constance_key.py
+++ b/kobo/apps/subsequences/migrations/0012_migrate_google_region_constance_key.py
@@ -1,6 +1,5 @@
 import json
 from django.db import migrations
-from constance.codecs import loads, dumps
 
 
 def _read_constance_value(raw: str | None) -> str:

--- a/kobo/apps/subsequences/migrations/0012_migrate_google_region_constance_key.py
+++ b/kobo/apps/subsequences/migrations/0012_migrate_google_region_constance_key.py
@@ -1,0 +1,100 @@
+import json
+from django.db import migrations
+from constance.codecs import loads, dumps
+
+
+def _read_constance_value(raw: str | None) -> str:
+    """
+    Safely decode a value read directly from the Constance DB column
+
+    Constance stores all values as plain JSON strings in the database. Reading
+    the ORM field directly gives the raw JSON, so we must decode it before
+    doing any string comparisons.
+    """
+    if not raw:
+        return ''
+    try:
+        return str(json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        return str(raw)
+
+
+def _get_region_from_legacy_location(raw_db_value: str | None) -> str:
+    """
+    Convert an old ASR_MT_GOOGLE_TRANSLATION_LOCATION DB value to the new
+    two-value region format
+    """
+    location = _read_constance_value(raw_db_value).lower()
+    if location == 'eu' or location.startswith('europe-'):
+        return 'EU'
+    return 'US'
+
+
+def migrate_google_region(apps, schema_editor):
+    try:
+        Constance = apps.get_model('constance', 'Constance')
+    except LookupError:
+        return
+
+    db_alias = schema_editor.connection.alias
+
+    try:
+        source_config = Constance.objects.using(db_alias).get(
+            key='ASR_MT_GOOGLE_TRANSLATION_LOCATION'
+        )
+    except Constance.DoesNotExist:
+        Constance.objects.using(db_alias).get_or_create(
+            key='ASR_MT_GOOGLE_REGION',
+            defaults={'value': json.dumps('US')},
+        )
+        return
+
+    new_region = _get_region_from_legacy_location(source_config.value)
+    Constance.objects.using(db_alias).update_or_create(
+        key='ASR_MT_GOOGLE_REGION',
+        defaults={'value': json.dumps(new_region)},
+    )
+    source_config.delete()
+
+
+def reverse_migrate_google_region(apps, schema_editor):
+    try:
+        Constance = apps.get_model('constance', 'Constance')
+    except LookupError:
+        return
+
+    db_alias = schema_editor.connection.alias
+
+    try:
+        source_config = Constance.objects.using(db_alias).get(
+            key='ASR_MT_GOOGLE_REGION'
+        )
+    except Constance.DoesNotExist:
+        Constance.objects.using(db_alias).get_or_create(
+            key='ASR_MT_GOOGLE_TRANSLATION_LOCATION',
+            defaults={'value': json.dumps('us-central1')},
+        )
+        return
+
+    region = _read_constance_value(source_config.value).upper()
+    old_location = 'europe-west1' if region == 'EU' else 'us-central1'
+    Constance.objects.using(db_alias).update_or_create(
+        key='ASR_MT_GOOGLE_TRANSLATION_LOCATION',
+        defaults={'value': json.dumps(old_location)},
+    )
+    source_config.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subsequences', '0011_add_cancelled_by_field_to_subsequencebulkaction'),
+        ('constance', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_google_region,
+            reverse_code=reverse_migrate_google_region,
+        ),
+    ]

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -364,12 +364,15 @@ CONSTANCE_CONFIG = {
             ' variable `GS_BUCKET_NAME`.'
         ),
     ),
-    'ASR_MT_GOOGLE_TRANSLATION_LOCATION': (
-        env.str('CONSTANCE_ASR_MT_GOOGLE_TRANSLATION_LOCATION', 'us-central1'),
+    'ASR_MT_GOOGLE_REGION': (
+        env.str('CONSTANCE_ASR_MT_GOOGLE_REGION', 'US'),
         (
-            'Google Cloud location to use for large translation tasks. It'
-            ' cannot be `global`, and Google only allows certain locations.'
+            'Google Cloud region for ASR/MT data residency. Use `US` for '
+            'Speech-to-Text location `us` and Translation location '
+            '`us-central1`; use `EU` for Speech-to-Text location `eu` and '
+            'Translation location `europe-west1`.'
         ),
+        'google_region_choice',
     ),
     'ASR_MT_GOOGLE_CREDENTIALS': (
         '',
@@ -707,6 +710,15 @@ CONSTANCE_ADDITIONAL_FIELDS = {
     'positive_int': ['django.forms.fields.IntegerField', {'min_value': 0}],
     'positive_int_minus_one': ['django.forms.fields.IntegerField', {'min_value': -1}],
     'natural_int': ['django.forms.fields.IntegerField', {'min_value': 1}],
+    'google_region_choice': [
+        'django.forms.fields.ChoiceField',
+        {
+            'choices': (
+                ('US', 'US'),
+                ('EU', 'EU'),
+            ),
+        },
+    ],
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
@@ -745,7 +757,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'ASR_MT_INVITEE_USERNAMES',
         'ASR_MT_GOOGLE_PROJECT_ID',
         'ASR_MT_GOOGLE_STORAGE_BUCKET_PREFIX',
-        'ASR_MT_GOOGLE_TRANSLATION_LOCATION',
+        'ASR_MT_GOOGLE_REGION',
         'ASR_MT_GOOGLE_CREDENTIALS',
         'ASR_MT_GOOGLE_REQUEST_TIMEOUT',
         'AUTOMATIC_QA_REQUESTS_PER_SECOND'

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -369,7 +369,7 @@ CONSTANCE_CONFIG = {
         (
             'Google Cloud region for ASR/MT data residency. Use `US` for '
             'Speech-to-Text location `us` and Translation location '
-            '`us-central1`; use `EU` for Speech-to-Text location `eu` and '
+            '`us-west1`; use `EU` for Speech-to-Text location `eu` and '
             'Translation location `europe-west1`.'
         ),
         'google_region_choice',


### PR DESCRIPTION
### 📣 Summary
This PR implements the server-wide Google ASR/MT location setting to enforce strict EU data residency or utilize global US infrastructure for Speech-to-Text (v2) and Translation (v3) APIs.

### 📖 Description
Following the parallel switch to Google Cloud Speech-to-Text v2 and Translation v3, the previous ASR/MT region control setting (from DEV-1943) was no longer functional. This PR re-establishes the server-wide US/EU location toggle and ensures requests are routed to the correct regional or global endpoints based on that configuration.

#### Speech-to-Text (ASR) Updates:
- The Google location is dynamically set to `us` or `eu` depending on the server-wide `ASR_MT_GOOGLE_REGION` setting.

#### Translation (MT) Updates:
- EU traffic is explicitly routed through the dedicated `translate-eu.googleapis.com` multi-regional gateway and processed in `europe-west1`. This guarantees that TLS termination, processing, and data-in-transit remain entirely within European borders.
- US traffic is routed through `translate-us.googleapis.com` + `us-west1`.

#### Constance setting:
- Consolidated the legacy `ASR_MT_GOOGLE_TRANSLATION_LOCATION` setting (which tracked granular locations like `us-central1` or `europe-west1`) into a new `ASR_MT_GOOGLE_REGION` Constance setting that provides a straightforward US or EU toggle.

#### Region code fallback fix (pre-existing bug):

- `TranscriptionService.get_language_code()` and `get_configuration()` previously raised `LanguageNotSupported` for any region code not explicitly listed in the database (e.g. `fr-BE`, `de-AT`). The check `language_set.filter(code='fr-BE')` always returned false because `fr-BE` is a region code, not a language code.
- Fixed: both methods now extract the parent language code (`fr` from `fr-BE`) as a fallback. If the parent language is supported, the original region code is passed through to Google STT unchanged, allowing it to apply the best available model for that regional variant.


### 👀 Preview steps
1. ℹ️ Have a KoboToolbox account with a project that has audio submissions
2. Set the `ASR_MT_GOOGLE_REGION` constance value to `US` (Django admin → Constance → Config)

**Spreadsheet**:
You can download the updated CSV from here: [kobo-import.csv](https://github.com/user-attachments/files/28942188/kobo-import.csv)
It contains the languages available in the `us` region along with their best available models, which I extracted using the scraper tool. I haven't updated the Kobo Google Spreadsheet yet. I'll do that once this PR is approved.

**Test US routing:**
4. Transcribe an audio submission, it should succeed
5. Translate a transcription, it should succeed
6. 🟢 [on PR] In Google Cloud Console → Cloud Speech-to-Text API → Metrics, confirm requests appear under location `us`. For translation, confirm requests appear under `us-central1`.

**Test EU routing:**
7. Change `ASR_MT_GOOGLE_REGION` constance value to `EU`
8. Transcribe another audio submission, it should succeed
9. Translate a transcription, it should succeed
10. 🟢 [on PR] In Google Cloud Console → Cloud Speech-to-Text API → Metrics, confirm requests now appear under location `eu` (not `us`). For translation, confirm requests appear under `europe-west1`.

Note: I have not yet confirmed the Metrics data in the Google Cloud Console with the sysadmin team, but if you have access, you may be able to see it there. Guillermo has added this screenshot in his PR:

<img width="1210" height="65" alt="image" src="https://github.com/user-attachments/assets/3dd9ea9b-58a4-4cb4-a038-0e3c2c661309" />

