### PR TITLE
fix(dataTable): bulk processing stories not working DEV-2251

### DIFF
--- a/jsapp/js/endpoints/environment.mocks.ts
+++ b/jsapp/js/endpoints/environment.mocks.ts
@@ -424,7 +424,8 @@ const environmentResponse: EnvironmentResponse = {
     },
   ],
   social_apps: [],
-  asr_mt_features_enabled: false,
+  // Note: this is needed to be `true` for all bulk processing related stories to work
+  asr_mt_features_enabled: true,
   submission_placeholder: '%SUBMISSION%',
   project_history_log_lifespan: 60,
   stripe_public_key: 'pk_test_qliDXQRyVGPWmsYR69tB1NPx00ndTrJfVM',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Fixed Storybook bulk-processing scenarios by enabling ASR/MT in the mocked environment, so “Processing” table behavior is visible in stories that depend on it.

Changes here:
- Storybook environment mock:
  - switched ASR/MT mocked capability to enabled for Storybook runs
  - added an inline note explaining why this must stay enabled for bulk-processing stories

### 👀 Preview steps

1. Open Storybook.
2. Go to Components → DataTableWrapper.
3. Open the Processing Column story.
4. 🔴 On main: bulk-processing-dependent table behavior can be missing because ASR/MT is mocked as disabled (i.e. no column with "Processing" cells).
5. 🟢 On this PR: bulk-processing-dependent behavior appears as expected because Storybook mock env has ASR/MT enabled.