### PR TITLE
refactor(libraryUploadModal): reorganise files DEV-2058

### DIFF
--- a/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.tsx
+++ b/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
-
 import { Checkbox, Group, Stack, Text } from '@mantine/core'
-import { modals } from '@mantine/modals'
 import { IconFileTypeXls } from '@tabler/icons-react'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import orvalFetchWithAuth from '#/api/orval.mutator'
 import { importsRetrieve } from '#/api/react-query/manage-projects-and-library-content'
 import ButtonNew from '#/components/common/ButtonNew'
@@ -88,43 +86,6 @@ function readFileAsDataURL(file: File): Promise<string | ArrayBuffer | null> {
 
     reader.readAsDataURL(file)
   })
-}
-
-export function openLibraryUploadModal(
-  params: Partial<Omit<LibraryUploadModalParams, 'type'>> & { type?: LibraryUploadModalParams['type'] } = {},
-) {
-  const initialType = params.type ?? MODAL_TYPES.LIBRARY_UPLOAD
-  const initialTitle = initialType === MODAL_TYPES.UPLOADING_XLS ? t('Uploading XLS file') : t('Upload file')
-  let modalId = ''
-
-  modalId = modals.open({
-    title: initialTitle,
-    size: 'lg',
-    children: (
-      <LibraryUploadModal
-        params={{
-          type: initialType,
-          file: params.file,
-          filename: params.filename,
-          onBack: params.onBack,
-        }}
-        onTitleChange={(title) => {
-          modals.updateModal({
-            modalId,
-            title,
-          })
-        }}
-        onRequestClose={() => {
-          modals.close(modalId)
-        }}
-      />
-    ),
-  })
-
-  return {
-    modalId,
-    close: () => modals.close(modalId),
-  }
 }
 
 export default function LibraryUploadModal(props: LibraryUploadModalProps) {

--- a/jsapp/js/components/library/LibraryUploadModal/index.ts
+++ b/jsapp/js/components/library/LibraryUploadModal/index.ts
@@ -1,0 +1,3 @@
+export { default } from './LibraryUploadModal'
+export type { LibraryUploadModalParams } from './LibraryUploadModal'
+export { openLibraryUploadModal } from './openLibraryUploadModal'

--- a/jsapp/js/components/library/LibraryUploadModal/openLibraryUploadModal.tsx
+++ b/jsapp/js/components/library/LibraryUploadModal/openLibraryUploadModal.tsx
@@ -4,6 +4,9 @@ import { MODAL_TYPES } from '#/constants'
 import LibraryUploadModal from './LibraryUploadModal'
 import type { LibraryUploadModalParams } from './LibraryUploadModal'
 
+// We use `modals.open` way for handling this modal, as `LibraryNewItemForm` has a flow that requires using such opener
+// function. We would need to refactor that component to make it possible to use `LibraryUploadModal` directly (as
+// a controllable wrapper of Mantine Modal)
 export function openLibraryUploadModal(
   params: Partial<Omit<LibraryUploadModalParams, 'type'>> & { type?: LibraryUploadModalParams['type'] } = {},
 ) {

--- a/jsapp/js/components/library/LibraryUploadModal/openLibraryUploadModal.tsx
+++ b/jsapp/js/components/library/LibraryUploadModal/openLibraryUploadModal.tsx
@@ -1,0 +1,42 @@
+import { modals } from '@mantine/modals'
+import React from 'react'
+import { MODAL_TYPES } from '#/constants'
+import LibraryUploadModal from './LibraryUploadModal'
+import type { LibraryUploadModalParams } from './LibraryUploadModal'
+
+export function openLibraryUploadModal(
+  params: Partial<Omit<LibraryUploadModalParams, 'type'>> & { type?: LibraryUploadModalParams['type'] } = {},
+) {
+  const initialType = params.type ?? MODAL_TYPES.LIBRARY_UPLOAD
+  const initialTitle = initialType === MODAL_TYPES.UPLOADING_XLS ? t('Uploading XLS file') : t('Upload file')
+  let modalId = ''
+
+  modalId = modals.open({
+    title: initialTitle,
+    size: 'lg',
+    children: (
+      <LibraryUploadModal
+        params={{
+          type: initialType,
+          file: params.file,
+          filename: params.filename,
+          onBack: params.onBack,
+        }}
+        onTitleChange={(title) => {
+          modals.updateModal({
+            modalId,
+            title,
+          })
+        }}
+        onRequestClose={() => {
+          modals.close(modalId)
+        }}
+      />
+    ),
+  })
+
+  return {
+    modalId,
+    close: () => modals.close(modalId),
+  }
+}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

This is a no-change change that spun from a discussion about code architecture.

Changes here:
- LibraryUploadModal.tsx: keeps only the LibraryUploadModal component logic.
- openLibraryUploadModal.tsx: moves helper logic into its own module.
- index.ts: acts as folder entry point and re-exports both default LibraryUploadModal and named openLibraryUploadModal.
- Public API is preserved, so existing imports from index.ts continue to work.
- This is a structural refactor only, with no intended user-facing behavior change.

### 👀 Preview steps

1. Log in and open Project → Library → My Library.
2. Drag and drop one valid XLSForm file.
3. Confirm the upload modal opens as before and can complete upload.
4. Drag and drop multiple valid XLSForm files.
5. Confirm batch upload feedback behaves as before for multi-file import in this route.
6. Open Project → Library and trigger Create Library Item → Upload.
7. Confirm the upload modal opens from that flow, and Back returns you to the Create Library Item modal as before.
8. Confirm no visible UI/UX difference versus main branch for these paths (refactor only).