### PR TITLE
refactor(assetTagsModal): reorganise files DEV-2057

### DIFF
--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
@@ -7,7 +7,7 @@ import assetFactory from '#/endpoints/asset.factory'
 import { assetPatchMock } from '#/endpoints/asset.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
 import { KOBO_MODAL_SHARED_PROPS } from '#/theme/kobo/Modal'
-import { openAssetTagsModal } from '.'
+import { openAssetTagsModal } from './openAssetTagsModal'
 
 const mockAsset = assetFactory({
   uid: 'storyAssetTagsUid',

--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
 import { Group, Stack } from '@mantine/core'
-import { modals } from '@mantine/modals'
 import { when } from 'mobx'
 import { useAssetsPartialUpdate } from '#/api/react-query/manage-projects-and-library-content'
 import { cleanupAndUniqueTags } from '#/assetUtils'
@@ -12,35 +11,17 @@ import type { AssetResponse } from '#/dataInterface'
 import sessionStore from '#/stores/session'
 import { notify } from '#/utils'
 
-type AssetTagsModalAsset = Pick<AssetResponse, 'uid'> & Partial<Pick<AssetResponse, 'tag_string'>>
+export type AssetTagsModalAsset = Pick<AssetResponse, 'uid'> & Partial<Pick<AssetResponse, 'tag_string'>>
 
-interface AssetTagsModalProps {
+export interface AssetTagsModalProps {
   asset: AssetTagsModalAsset
   onRequestClose: () => void
 }
 
 /**
- * Opens the Mantine-based asset tags editor and returns imperative close helpers.
- */
-export function openAssetTagsModal(asset: AssetTagsModalAsset) {
-  let modalId = ''
-
-  modalId = modals.open({
-    title: t('Edit tags'),
-    size: 'lg',
-    children: <AssetTagsModal asset={asset} onRequestClose={() => modals.close(modalId)} />,
-  })
-
-  return {
-    modalId,
-    close: () => modals.close(modalId),
-  }
-}
-
-/**
  * Lets a user edit an asset's comma-separated tags and save them through Orval/react-query.
  */
-function AssetTagsModal({ asset, onRequestClose }: AssetTagsModalProps) {
+export function AssetTagsModal({ asset, onRequestClose }: AssetTagsModalProps) {
   const [isSessionLoaded, setIsSessionLoaded] = useState(!!sessionStore.isLoggedIn)
   const [tags, setTags] = useState<string[]>(() => (asset.tag_string ? asset.tag_string.split(',') : []))
 

--- a/jsapp/js/components/AssetTagsModal/index.ts
+++ b/jsapp/js/components/AssetTagsModal/index.ts
@@ -1,0 +1,2 @@
+export * from './AssetTagsModal'
+export * from './openAssetTagsModal'

--- a/jsapp/js/components/AssetTagsModal/openAssetTagsModal.tsx
+++ b/jsapp/js/components/AssetTagsModal/openAssetTagsModal.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { modals } from '@mantine/modals'
+import { AssetTagsModal, type AssetTagsModalAsset } from './AssetTagsModal'
+
+/**
+ * Opens the Mantine-based asset tags editor and returns imperative close helpers.
+ */
+export function openAssetTagsModal(asset: AssetTagsModalAsset) {
+  let modalId = ''
+
+  modalId = modals.open({
+    title: t('Edit tags'),
+    size: 'lg',
+    children: <AssetTagsModal asset={asset} onRequestClose={() => modals.close(modalId)} />,
+  })
+
+  return {
+    modalId,
+    close: () => modals.close(modalId),
+  }
+}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

This is a no-change change that spun from a discussion about code architecture. Similar to #7131

### 👀 Preview steps

1. ℹ️ Have an account with few Library items (assets)
2. Go to My Library and hover over one of the rows
3. Click "Edit tags" icon button
4. 🔴 [on main] Notice the old legacy modal flow/styling.
5. 🟢 [on PR] Notice the Mantine modal opens for tag editing.
6. Add a new tag and click "Update".
7. 🟢 Notice the modal closes successfully and tag changes are saved (re-open Edit tags to confirm persistence).

Also verify Storybook AssetTagsModal story works.