### PR TITLE
refactor(formLanguagesManager): reorganise files DEV-2063

### DIFF
--- a/jsapp/js/project/FormLanguagesManager/FormLanguagesManager.tsx
+++ b/jsapp/js/project/FormLanguagesManager/FormLanguagesManager.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { Box, CloseButton, Group, Text } from '@mantine/core'
-import { modals } from '@mantine/modals'
+import { Box, Group, Text } from '@mantine/core'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import cloneDeep from 'lodash.clonedeep'
 import type { PaginatedListResponse } from '#/UniversalTable'
@@ -20,67 +19,13 @@ import TranslationsEditor from './TranslationsEditor'
 import type { TranslationRowItem } from './types'
 import { SAVE_BUTTON_LABEL, buildTranslationRows, deleteTranslations, prepareTranslations } from './utils'
 
-type FormLanguagesManagerView = 'languages' | 'translations'
+export type FormLanguagesManagerView = 'languages' | 'translations'
 
-interface FormLanguagesManagerProps {
+export interface FormLanguagesManagerProps {
   asset: AssetResponse
   onRequestClose: () => void
   registerOnRequestClose?: (closeHandler: () => void) => void
   onActiveViewChange?: (view: FormLanguagesManagerView) => void
-}
-
-export function openFormLanguagesModal(asset: AssetResponse) {
-  let requestModalClose = () => {}
-  const modalSizeByView: Record<FormLanguagesManagerView, string> = {
-    languages: 'lg',
-    translations: '80%',
-  }
-
-  const modalId = modals.open({
-    title: (
-      <Group justify='space-between' wrap='nowrap'>
-        <Box>{t('Manage Languages')}</Box>
-        <CloseButton aria-label={t('Close')} onClick={() => requestModalClose()} />
-      </Group>
-    ),
-    size: modalSizeByView.languages,
-    // Keep default close button disabled and render a controlled one in title,
-    // so close requests always go through FormLanguagesManager.requestClose.
-    withCloseButton: false,
-    // closeOnEscape and closeOnClickOutside are kept disabled because the
-    // modals manager calls closeModal() directly, bypassing any guard logic.
-    // Instead we intercept both events manually and route them through
-    // FormLanguagesManager.requestClose (unsaved-changes confirmation):
-    //   - Escape key: handled via onKeyDown on the content root Box
-    //   - Overlay click: handled via overlayProps.onClick below
-    closeOnEscape: false,
-    closeOnClickOutside: false,
-    overlayProps: {
-      ...KOBO_MODAL_OVERLAY_PROPS,
-      onClick: () => requestModalClose(),
-    },
-    children: (
-      <FormLanguagesManager
-        asset={asset}
-        registerOnRequestClose={(closeHandler) => {
-          requestModalClose = closeHandler
-        }}
-        onActiveViewChange={(view) => {
-          modals.updateModal({
-            modalId,
-            size: modalSizeByView[view],
-          })
-        }}
-        onRequestClose={() => {
-          modals.close(modalId)
-        }}
-      />
-    ),
-  })
-
-  requestModalClose = () => {
-    modals.close(modalId)
-  }
 }
 
 export default function FormLanguagesManager(props: FormLanguagesManagerProps) {

--- a/jsapp/js/project/FormLanguagesManager/index.ts
+++ b/jsapp/js/project/FormLanguagesManager/index.ts
@@ -1,0 +1,3 @@
+export { default as FormLanguagesManager } from './FormLanguagesManager'
+export * from './FormLanguagesManager'
+export * from './openFormLanguagesModal'

--- a/jsapp/js/project/FormLanguagesManager/openFormLanguagesModal.tsx
+++ b/jsapp/js/project/FormLanguagesManager/openFormLanguagesModal.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+
+import { Box, CloseButton, Group } from '@mantine/core'
+import { modals } from '@mantine/modals'
+import type { AssetResponse } from '#/dataInterface'
+import { KOBO_MODAL_OVERLAY_PROPS } from '#/theme/kobo/Modal'
+import FormLanguagesManager, { type FormLanguagesManagerView } from './FormLanguagesManager'
+
+export function openFormLanguagesModal(asset: AssetResponse) {
+  let requestModalClose = () => {}
+  const modalSizeByView: Record<FormLanguagesManagerView, string> = {
+    languages: 'lg',
+    translations: '80%',
+  }
+
+  const modalId = modals.open({
+    title: (
+      <Group justify='space-between' wrap='nowrap'>
+        <Box>{t('Manage Languages')}</Box>
+        <CloseButton aria-label={t('Close')} onClick={() => requestModalClose()} />
+      </Group>
+    ),
+    size: modalSizeByView.languages,
+    // Keep default close button disabled and render a controlled one in title,
+    // so close requests always go through FormLanguagesManager.requestClose.
+    withCloseButton: false,
+    // closeOnEscape and closeOnClickOutside are kept disabled because the
+    // modals manager calls closeModal() directly, bypassing any guard logic.
+    // Instead we intercept both events manually and route them through
+    // FormLanguagesManager.requestClose (unsaved-changes confirmation):
+    //   - Escape key: handled via onKeyDown on the content root Box
+    //   - Overlay click: handled via overlayProps.onClick below
+    closeOnEscape: false,
+    closeOnClickOutside: false,
+    overlayProps: {
+      ...KOBO_MODAL_OVERLAY_PROPS,
+      onClick: () => requestModalClose(),
+    },
+    children: (
+      <FormLanguagesManager
+        asset={asset}
+        registerOnRequestClose={(closeHandler) => {
+          requestModalClose = closeHandler
+        }}
+        onActiveViewChange={(view) => {
+          modals.updateModal({
+            modalId,
+            size: modalSizeByView[view],
+          })
+        }}
+        onRequestClose={() => {
+          modals.close(modalId)
+        }}
+      />
+    ),
+  })
+
+  requestModalClose = () => {
+    modals.close(modalId)
+  }
+}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

This is a no-change change that spun from a discussion about code architecture. Similar to #7131

### 👀 Preview steps

1. ℹ️ Have a deployed project with more than 10 questions
2. Navigate to Project → Form tab
3. Click "Manage <globe icon>" button (under the "Redeploy" button)
4. 🔴 [on main] Observe the old-style language management modal
5. 🟢 [on PR] Notice the new Mantine-styled modal
6. Try: adding new default language, new additional language, changing default language, editing a language → all these should still work
7. For a non-default language click "Update translations" button (the globe with small star icon)
8. 🔴 [on main] Observe the old-style translations table
9. 🟢 [on PR] Notice the new table
10. Try: changing translation, eiditing the language, changing page, closing with unsaved changes → all these should still work
11. Also notice that after adding a language an closing a modal, the "Languages: …" to the left of the "Manage <globe icon>" button updates correctly (this is the bridge from #7040 doing its magic)