### PR TITLE
feat(auditLogs): filter list endpoints by lookback DEV-1461

### DIFF
--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -735,6 +735,30 @@ class ApiProjectHistoryLogsTestCase(
         response = self.client.get(f'{self.url}actions/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @override_settings(ACCESS_LOG_LIFESPAN=60, PROJECT_HISTORY_LOG_LIFESPAN=60)
+    def test_list_actions_filters_by_max_lookback(self):
+        if settings.STRIPE_ENABLED:
+            self.create_plan_for_user(self.user, lookback_days=60)
+        today = timezone.now()
+        out_of_range_date = today - timedelta(days=70)
+
+        ProjectHistoryLog.objects.create(
+            user=self.user,
+            object_id=self.asset.id,
+            action=AuditAction.DELETE,
+            metadata={**self.default_metadata, 'asset_uid': self.asset.uid},
+            date_created=out_of_range_date,
+        )
+        ProjectHistoryLog.objects.create(
+            user=self.user,
+            object_id=self.asset.id,
+            action=AuditAction.MODIFY_SHARING,
+            metadata={**self.default_metadata, 'asset_uid': self.asset.uid},
+        )
+        response = self.client.get(f'{self.url}actions/')
+        # older DELETE action should not show up
+        assert response.data['actions'] == [AuditAction.MODIFY_SHARING]
+
     def test_show_project_history_logs_filters_to_project(self):
         asset2 = Asset.objects.get(pk=2)
         ProjectHistoryLog.objects.create(

--- a/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
+++ b/kobo/apps/audit_log/tests/api/v2/test_api_audit_log.py
@@ -1,13 +1,17 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.utils import timezone
+from model_bakery import baker
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import AccessLog, AuditLog, AuditType, ProjectHistoryLog
 from kobo.apps.audit_log.tests.test_signals import skip_login_access_log
+from kobo.apps.audit_log.utils import get_max_lookback_days
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import (
     ACCESS_LOG_SUBMISSION_AUTH_TYPE,
@@ -23,6 +27,45 @@ from kpi.models.import_export_task import (
 )
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
+
+
+class LookbackTestMixin:
+
+    def create_plan_for_user(self, user, lookback_days):
+        from kobo.apps.stripe.tests.utils import generate_plan_subscription
+
+        product_metadata = {
+            'mmo_enabled': 'true',
+            'plan_type': 'enterprise',
+            'asr_seconds_limit': 1,
+            'mt_characters_limit': 1,
+            'submission_limit': 1,
+            'storage_bytes_limit': 1,
+            'log_lookback_days_limit': lookback_days,
+        }
+        return generate_plan_subscription(user.organization, product_metadata)
+
+    def get_baker_defaults(self):
+        return {}
+
+    @override_settings(ACCESS_LOG_LIFESPAN=60, PROJECT_HISTORY_LOG_LIFESPAN=60)
+    def test_results_limited_by_subscription_date(self):
+        if settings.STRIPE_ENABLED:
+            self.create_plan_for_user(self.user, lookback_days=60)
+        today = timezone.now()
+        baker_defaults = self.get_baker_defaults()
+        out_of_range_date = today - timedelta(days=70)
+        baker.make(self.model, date_created=out_of_range_date, **baker_defaults)
+        baker.make(self.model, date_created=today, **baker_defaults)
+        with skip_login_access_log():
+            self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(len(response.data['results']), 1)
+        # only allow maximum lookback even if the search filter asks for more
+        longer_out_of_range_date = timezone.now() - timedelta(days=160)
+        as_str = longer_out_of_range_date.date().strftime('%Y-%m-%d')
+        response = self.client.get(f'{self.url}?q=date_created__gt:{as_str}')
+        self.assertEqual(len(response.data['results']), 1)
 
 
 class BaseAuditLogTestCase(BaseTestCase):
@@ -52,6 +95,8 @@ class ProjectHistoryLogTestCaseMixin:
     """
     Common tests for /project-history-logs and asset/<uid>/history
     """
+
+    model = ProjectHistoryLog
 
     def test_results_have_expected_fields(self):
         now = timezone.now()
@@ -198,7 +243,13 @@ class ProjectHistoryLogTestCaseMixin:
         self.assertIn(task.status, ['created', 'processing', 'complete'])
 
 
-class ApiAuditLogTestCase(BaseAuditLogTestCase):
+class ApiAuditLogTestCase(BaseAuditLogTestCase, LookbackTestMixin):
+
+    model = AuditLog
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.get(username='adminuser')
 
     def get_endpoint_basename(self):
         return 'audit-log-list'
@@ -316,7 +367,20 @@ class ApiAuditLogTestCase(BaseAuditLogTestCase):
         assert response.data['results'][0]['user'] is None
 
 
-class ApiAccessLogTestCase(BaseAuditLogTestCase):
+class ApiAccessLogTestCase(BaseAuditLogTestCase, LookbackTestMixin):
+
+    model = AccessLog
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.get(username='someuser')
+
+    def get_baker_defaults(self):
+        return {
+            'user': self.user,
+            'log_type': AuditType.ACCESS,
+            'user_uid': self.user.extra_details.uid,
+        }
 
     def get_endpoint_basename(self):
         return 'access-log-list'
@@ -371,22 +435,24 @@ class ApiAccessLogTestCase(BaseAuditLogTestCase):
         # the logic of grouping submissions is tested more thoroughly in test_models,
         # this is just to ensure that we're using the grouping query
         user = User.objects.get(username='someuser')
+        min_date = timezone.now() - timedelta(days=get_max_lookback_days(user))
+        min_date_1_30_am = min_date.replace(
+            hour=1, minute=30, second=25, microsecond=123456
+        )
+        min_date_1_45_am = min_date.replace(
+            hour=1, minute=45, second=25, microsecond=123456
+        )
+
         self.force_login_user(user)
-        jan_1_1_30_am = datetime.fromisoformat(
-            '2024-01-01T01:30:25.123456+00:00'
-        )
-        jan_1_1_45_am = datetime.fromisoformat(
-            '2024-01-01T01:45:25.123456+00:00'
+        AccessLog.objects.create(
+            user=user,
+            metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
+            date_created=min_date_1_30_am,
         )
         AccessLog.objects.create(
             user=user,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_30_am,
-        )
-        AccessLog.objects.create(
-            user=user,
-            metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_45_am,
+            date_created=min_date_1_45_am,
         )
         response = self.client.get(self.url)
         # should return 1 submission group with 2 submissions
@@ -399,7 +465,16 @@ class ApiAccessLogTestCase(BaseAuditLogTestCase):
         self.assertEqual(result['count'], 2)
 
 
-class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
+class AllApiAccessLogsTestCase(BaseAuditLogTestCase, LookbackTestMixin):
+
+    model = AccessLog
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.get(username='adminuser')
+
+    def get_baker_defaults(self):
+        return {'log_type': AuditType.ACCESS}
 
     def get_endpoint_basename(self):
         return 'all-access-logs-list'
@@ -439,20 +514,27 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
         admin = User.objects.get(username='adminuser')
 
         self.force_login_user(admin)
-        jan_1_1_30_am = datetime.fromisoformat('2024-01-01T01:30:25.123456+00:00')
-        jan_1_1_45_am = datetime.fromisoformat('2024-01-01T01:45:25.123456+00:00')
-        jan_1_1_50_am = datetime.fromisoformat('2024-01-01T01:50:25.123456+00:00')
+        min_date = timezone.now() - timedelta(days=get_max_lookback_days(admin))
+        min_date_1_30_am = min_date.replace(
+            hour=1, minute=30, second=25, microsecond=123456
+        )
+        min_date_1_45_am = min_date.replace(
+            hour=1, minute=45, second=25, microsecond=123456
+        )
+        min_date_1_50_am = min_date.replace(
+            hour=1, minute=50, second=25, microsecond=123456
+        )
 
         # create 2 submissions for user1
         AccessLog.objects.create(
             user=user1,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_30_am,
+            date_created=min_date_1_30_am,
         )
         AccessLog.objects.create(
             user=user1,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_45_am,
+            date_created=min_date_1_45_am,
         )
 
         # 2 submissions for user2, after the ones for user1 so we know the expected
@@ -460,12 +542,12 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
         AccessLog.objects.create(
             user=user2,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_45_am,
+            date_created=min_date_1_45_am,
         )
         AccessLog.objects.create(
             user=user2,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_50_am,
+            date_created=min_date_1_50_am,
         )
         response = self.client.get(self.url)
         # should return 2 submission group with 2 submissions each
@@ -512,17 +594,22 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
 
         # create two submissions that will be grouped together
         # these are the only two logs for user admin
-        jan_1_1_30_am = datetime.fromisoformat('2024-01-01T01:30:25.123456+00:00')
-        jan_1_1_45_am = datetime.fromisoformat('2024-01-01T01:45:25.123456+00:00')
-        AccessLog.objects.create(
-            user=user1,
-            metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_30_am,
+        min_date = timezone.now() - timedelta(days=get_max_lookback_days(admin))
+        min_date_1_30_am = min_date.replace(
+            hour=1, minute=30, second=25, microsecond=123456
+        )
+        min_date_1_45_am = min_date.replace(
+            hour=1, minute=45, second=25, microsecond=123456
         )
         AccessLog.objects.create(
             user=user1,
             metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
-            date_created=jan_1_1_45_am,
+            date_created=min_date_1_30_am,
+        )
+        AccessLog.objects.create(
+            user=user1,
+            metadata={'auth_type': ACCESS_LOG_SUBMISSION_AUTH_TYPE},
+            date_created=min_date_1_45_am,
         )
 
         # create an extra log for user2 so we know it gets filtered out
@@ -602,7 +689,9 @@ class AllApiAccessLogsTestCase(BaseAuditLogTestCase):
         )
 
 
-class ApiProjectHistoryLogsTestCase(BaseTestCase, ProjectHistoryLogTestCaseMixin):
+class ApiProjectHistoryLogsTestCase(
+    BaseTestCase, ProjectHistoryLogTestCaseMixin, LookbackTestMixin
+):
 
     fixtures = ['test_data']
 
@@ -619,6 +708,14 @@ class ApiProjectHistoryLogsTestCase(BaseTestCase, ProjectHistoryLogTestCaseMixin
             'project_owner': 'someuser',
         }
         self.client.force_login(self.user)
+
+    def get_baker_defaults(self):
+        return {
+            'user': self.user,
+            'log_type': AuditType.PROJECT_HISTORY,
+            'metadata': {**self.default_metadata, 'asset_uid': self.asset.uid},
+            'object_id': self.asset.uid,
+        }
 
     def test_list_without_permissions_returns_forbidden(self):
         user2 = User.objects.get(username='anotheruser')
@@ -711,8 +808,21 @@ class ApiProjectHistoryLogsTestCase(BaseTestCase, ProjectHistoryLogTestCaseMixin
 
 
 class ApiAllProjectHistoryLogsTestCase(
-    BaseAuditLogTestCase, ProjectHistoryLogTestCaseMixin
+    BaseAuditLogTestCase, ProjectHistoryLogTestCaseMixin, LookbackTestMixin
 ):
+
+    def get_baker_defaults(self):
+        return {
+            'user': self.user,
+            'log_type': AuditType.PROJECT_HISTORY,
+            'metadata': {
+                'asset_uid': self.asset.uid,
+                'ip_address': '1.2.3.4',
+                'source': 'source',
+                'log_subtype': 'project',
+                'project_owner': 'someuser',
+            },
+        }
 
     def get_endpoint_basename(self):
         return 'all-project-history-logs-list'

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -99,7 +99,9 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     def get_lookback_date(self):
         user = self.request.user
         lookback_days = get_max_lookback_days(user)
-        min_date = timezone.now().date() - timedelta(days=lookback_days)
+        now = timezone.now()
+        now_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        min_date = now_midnight - timedelta(days=lookback_days)
         return min_date
 
     def get_queryset(self):
@@ -340,8 +342,11 @@ class ProjectHistoryLogViewSet(
 
     @action(detail=False, methods=['GET'])
     def actions(self, request, *args, **kwargs):
+        min_date = self.get_lookback_date()
         actions = (
-            self.model.objects.filter(metadata__asset_uid=self.asset_uid)
+            self.model.objects.filter(
+                metadata__asset_uid=self.asset_uid, date_created__gte=min_date
+            )
             .values_list('action')
             .distinct()
         )

--- a/kobo/apps/audit_log/views.py
+++ b/kobo/apps/audit_log/views.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 from django.db import transaction
+from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -47,6 +50,7 @@ from .serializers import (
     AuditLogSerializer,
     ProjectHistoryLogSerializer,
 )
+from .utils import get_max_lookback_days
 
 
 @extend_schema(
@@ -92,6 +96,20 @@ class AuditLogViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     ]
     pagination_class = NoCountPagination
 
+    def get_lookback_date(self):
+        user = self.request.user
+        lookback_days = get_max_lookback_days(user)
+        min_date = timezone.now().date() - timedelta(days=lookback_days)
+        return min_date
+
+    def get_queryset(self):
+        min_date = self.get_lookback_date()
+        return (
+            AuditLog.objects.select_related('user')
+            .filter(date_created__gte=min_date)
+            .order_by('-date_created')
+        )
+
 
 @extend_schema_view(
     list=extend_schema(
@@ -115,8 +133,15 @@ class AllAccessLogViewSet(AuditLogViewSet):
     Documentation:
     - docs/api/v2/access_logs/list.md
     """
-    queryset = AccessLog.objects.with_submissions_grouped().order_by('-date_created')
     serializer_class = AccessLogSerializer
+
+    def get_queryset(self):
+        min_date = self.get_lookback_date()
+        return (
+            AccessLog.objects.with_submissions_grouped()
+            .filter(date_created__gte=min_date)
+            .order_by('-date_created')
+        )
 
 
 @extend_schema_view(
@@ -131,7 +156,7 @@ class AllAccessLogViewSet(AuditLogViewSet):
         ),
     )
 )
-class AccessLogViewSet(AuditLogViewSet):
+class AccessLogViewSet(AllAccessLogViewSet):
     """
     ViewSet for listing a user's access logs
 
@@ -142,7 +167,6 @@ class AccessLogViewSet(AuditLogViewSet):
     - docs/api/v2/access_logs/me/list.md
     """
 
-    queryset = AccessLog.objects.with_submissions_grouped().order_by('-date_created')
     permission_classes = (IsAuthenticated,)
     filter_backends = (AccessLogPermissionsFilter,)
     serializer_class = AccessLogSerializer
@@ -177,6 +201,12 @@ class AllProjectHistoryLogViewSet(AuditLogViewSet):
 
     queryset = ProjectHistoryLog.objects.all().order_by('-date_created')
     serializer_class = ProjectHistoryLogSerializer
+
+    def get_queryset(self):
+        min_date = self.get_lookback_date()
+        return ProjectHistoryLog.objects.filter(date_created__gte=min_date).order_by(
+            '-date_created'
+        )
 
     @extend_schema(
         methods=['GET'],
@@ -303,9 +333,10 @@ class ProjectHistoryLogViewSet(
     pagination_class = FastPagination
 
     def get_queryset(self):
-        return self.model.objects.filter(metadata__asset_uid=self.asset_uid).order_by(
-            '-date_created'
-        )
+        min_date = self.get_lookback_date()
+        return self.model.objects.filter(
+            metadata__asset_uid=self.asset_uid, date_created__gte=min_date
+        ).order_by('-date_created')
 
     @action(detail=False, methods=['GET'])
     def actions(self, request, *args, **kwargs):

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -450,7 +450,6 @@ class SearchFilter(filters.BaseFilterBackend):
     """
 
     def filter_queryset(self, request, queryset, view):
-
         try:
             q = request.query_params['q']
         except AttributeError:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Restrict API endpoints for audit logs to only look back the number of days allowed by the user's subscription.


### 📖 Description
Restricts the following endpoints:
- audit logs
- access logs (personal and global)
- project history logs (project-specific and global)
If stripe is not enabled, the number of days allowed is set based on the log retention settings of the server.

### Notes
One small inheritance change, AccessLogViewSet now inherits from AllAccessLogViewSet to avoid having to write the same queryset twice. The unit testing around the access log view set is quite comprehensive so there is not much fear of regression, and it was also tested locally.


### 👀 Preview steps

1. ℹ️ have an admin account and a project
2. ℹ️ Ensure you have access logs and project history logs that are at least 3 days old
3. In Django admin, update the default plan (or whatever plan you admin user is on) to have `"log_lookback_days_limit": "2"` in the metadata
4. 🟢 For each of the following endpoints, ensure there are no logs older than 2 days old:
  * /api/v2/audit-logs/
  * /api/v2/access-logs/me/
  * /api/v2/access-logs/
  * /api/v2/project-history-logs/
  * /api/v2/assets/<asset_uid>/history/ 

