### PR TITLE
fix(submissions): validate submission ids in bulk actions DEV-2258

### DIFF
--- a/kobo/apps/openrosa/apps/logger/exceptions.py
+++ b/kobo/apps/openrosa/apps/logger/exceptions.py
@@ -83,6 +83,16 @@ class InstanceParseError(Exception):
         super().__init__(message)
 
 
+class InvalidSubmissionIdsError(Exception):
+    """
+    Raised when a bulk action references submission ids that do not all belong
+    to the targeted XForm. The whole batch is rejected without revealing
+    whether those ids exist elsewhere.
+    """
+
+    pass
+
+
 class LockedSubmissionError(Exception):
     def __init__(self, message=t('Submission is currently being processed.')):
         super().__init__(message)

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -68,8 +68,6 @@ def delete_instances(xform: XForm, request_data: dict) -> int:
     holding it open during slow storage I/O.
     """
 
-    print('DELETE INSTANCES', request_data, flush=True)
-
     deleted_records_count = 0
     postgres_query, mongo_query = build_db_queries(xform, request_data)
 
@@ -245,6 +243,15 @@ def set_instance_validation_statuses(
 
     # Update Postgres & Mongo
     records_queryset = Instance.objects.filter(**postgres_query)
+
+    requested_ids = postgres_query.get('id__in')
+    if requested_ids is not None and (
+        records_queryset.count() != len(set(requested_ids))
+    ):
+        # At least one requested id does not belong to this XForm. Reject the
+        # whole batch without revealing whether those ids exist elsewhere.
+        raise InvalidSubmissionIdsError
+
     validation_status = new_validation_status.get('label', 'None')
     if get_current_request() is not None:
         get_current_request().instances = {

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -24,7 +24,10 @@ from kobo.apps.trash_bin.models.attachment import AttachmentTrash
 from kpi.deployment_backends.kc_access.storage import default_kobocat_storage
 from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 from kpi.utils.storage import bulk_delete_files
-from ..exceptions import MissingValidationStatusPayloadError
+from ..exceptions import (
+    InvalidSubmissionIdsError,
+    MissingValidationStatusPayloadError,
+)
 from ..models.instance import Instance
 from ..models.xform import XForm
 from .database_query import build_db_queries
@@ -65,6 +68,8 @@ def delete_instances(xform: XForm, request_data: dict) -> int:
     holding it open during slow storage I/O.
     """
 
+    print('DELETE INSTANCES', request_data, flush=True)
+
     deleted_records_count = 0
     postgres_query, mongo_query = build_db_queries(xform, request_data)
 
@@ -92,11 +97,15 @@ def delete_instances(xform: XForm, request_data: dict) -> int:
     post_delete.disconnect(add_instance_to_request_post_delete, sender=Instance)
 
     try:
-        instance_ids = postgres_query.get('id__in')
-        if not instance_ids:
-            instance_ids = list(
-                Instance.objects.values_list('id', flat=True).filter(**postgres_query)
-            )
+        requested_ids = postgres_query.get('id__in')
+        instance_ids = list(
+            Instance.objects.filter(**postgres_query).values_list('id', flat=True)
+        )
+        # Validate all submissions passed for deletion belong to the project.
+        if requested_ids is not None and len(instance_ids) != len(set(requested_ids)):
+            # Otherwise, reject the whole batch without revealing whether those ids
+            # exist elsewhere.
+            raise InvalidSubmissionIdsError
 
         total_storage_bytes = 0
         files_to_delete = set()

--- a/kpi/management/commands/restore_deleted_attachments.py
+++ b/kpi/management/commands/restore_deleted_attachments.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone as dj_timezone
+
+from kobo.apps.openrosa.apps.logger.models import Attachment, Instance
+from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
+from kpi.deployment_backends.kc_access.storage import (
+    default_kobocat_storage as default_storage,
+)
+from kpi.models import Asset
+
+
+class Command(BaseCommand):
+
+    help = (
+        'Restore Attachment rows of a project that were wrongly deleted by a '
+        'cross-project bulk deletion. The metadata is read back from MongoDB '
+        '(which still references the attachments) and the rows are recreated '
+        'only when the underlying file is still present on storage. MongoDB is '
+        'left untouched.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--asset-uid',
+            required=True,
+            help='UID of the project (Asset) to inspect and restore',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Only report what would be restored, without writing anything',
+        )
+
+    def handle(self, *args, **options):
+        asset_uid = options['asset_uid']
+        dry_run = options['dry_run']
+        self._verbosity = options['verbosity']
+
+        try:
+            asset = Asset.objects.defer('content').get(uid=asset_uid)
+        except Asset.DoesNotExist:
+            raise CommandError(f'Asset `{asset_uid}` does not exist')
+
+        if not asset.has_deployment:
+            raise CommandError(f'Asset `{asset_uid}` is not deployed')
+
+        deployment = asset.deployment
+        xform = deployment.xform
+
+        if dry_run:
+            self.stdout.write('⚠ Dry run: no change will be written')
+
+        restored = 0
+        already_present = 0
+        unrecoverable = 0
+
+        # MongoDB still holds the metadata of the deleted attachments, so we
+        # read the submissions from there (the owner has full access).
+        submissions = deployment.get_submissions(
+            user=asset.owner,
+            fields=['_id', '_attachments'],
+        )
+
+        for submission in submissions:
+            instance_id = submission['_id']
+            instance = None
+            affected = False
+            attachments = submission['_attachments'] or []
+
+            for attachment in attachments:
+                # Attachments flagged as deleted in MongoDB were removed on purpose;
+                #  never bring those back.
+                if attachment.get('is_deleted'):
+                    continue
+
+                media_file = attachment.get('filename')
+                if not media_file:
+                    continue
+
+                # `media_file` is the storage path and is unique; use it to tell
+                # whether the row is still there (including soft-deleted ones).
+                if Attachment.all_objects.filter(
+                    instance_id=instance_id, media_file=media_file
+                ).exists():
+                    already_present += 1
+                    continue
+
+                # The row is gone: this submission was hit by the bug.
+                affected = True
+
+                # Only restore when the original file is still present. We do not
+                # fall back to the surviving `<media_file>.mp3` transcode: it
+                # would leave the UI broken since MongoDB still references the
+                # original filename and is intentionally left untouched.
+                if not default_storage.exists(media_file):
+                    unrecoverable += 1
+                    self.stderr.write(
+                        f'\tInstance #{instance_id}: cannot restore '
+                        f'`{media_file}` (file missing from storage)'
+                    )
+                    continue
+
+                if self._verbosity > 0:
+                    prefix = 'Would restore' if dry_run else 'Restoring'
+                    self.stdout.write(
+                        f'\tInstance #{instance_id}: {prefix} `{media_file}`'
+                    )
+
+                if not dry_run:
+                    if instance is None:
+                        instance = Instance.objects.get(pk=instance_id)
+                    self._restore_attachment(instance, media_file, attachment, xform)
+
+                restored += 1
+
+            # The bug also deleted the ParsedInstance row of every affected
+            # submission; recreate it even when the file itself is lost.
+            if affected and not dry_run:
+                if instance is None:
+                    instance = Instance.objects.get(pk=instance_id)
+                self._ensure_parsed_instance(instance)
+
+        self.stdout.write(
+            'Done! '
+            f'{restored} attachment(s) {"to restore" if dry_run else "restored"}, '
+            f'{already_present} already present, '
+            f'{unrecoverable} unrecoverable (file missing).'
+        )
+        if not dry_run and restored:
+            self.stdout.write(
+                'Storage counters were left untouched. Run '
+                '`update_attachment_storage_bytes` if they need to be '
+                'recalculated.'
+            )
+
+    def _ensure_parsed_instance(self, instance: Instance):
+        """
+        Recreate the ParsedInstance row of `instance` if it is missing, without
+        writing to MongoDB. `ParsedInstance.save()` would resync Mongo, which
+        must be left untouched here.
+        """
+        if ParsedInstance.objects.filter(instance=instance).exists():
+            return
+
+        parsed_instance = ParsedInstance(instance=instance)
+        parsed_instance._set_geopoint()
+        parsed_instance.set_submitted_by()
+        # Bypass `ParsedInstance.save()` to avoid the MongoDB resync it performs.
+        super(ParsedInstance, parsed_instance).save()
+
+    def _restore_attachment(
+        self,
+        instance: Instance,
+        media_file: str,
+        attachment_data: dict,
+        xform: 'XForm',
+    ):
+        """
+        Recreate a single Attachment row pointing at the file already present on
+        storage. The file is not re-uploaded: assigning the stored path to the
+        `FileField` marks it as already committed.
+        """
+        attachment = Attachment(
+            instance=instance,
+            media_file=media_file,
+            media_file_basename=attachment_data.get('media_file_basename'),
+            mimetype=attachment_data.get('mimetype') or '',
+            xform_id=xform.id,
+            user_id=xform.user_id,
+            date_created=instance.date_created,
+            date_modified=dj_timezone.now(),
+        )
+        # Storage counters were not decremented for this project when the bug
+        # struck, so they must not be incremented again here.
+        attachment.defer_counting = True
+        attachment.save()

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -22,6 +22,7 @@ from django.urls import reverse
 from django_digest.test import Client as DigestClient
 from rest_framework import status
 
+from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import ProjectHistoryLog
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import InstanceIdMissingError
@@ -325,6 +326,11 @@ class BulkDeleteSubmissionsApiTests(
         assert (
             Instance.objects.filter(id__in=foreign_ids).count() == len(foreign_ids)
         )
+
+        # No phantom DELETE_SUBMISSION audit log entries for the rejected batch
+        assert not ProjectHistoryLog.objects.filter(
+            object_id=self.asset.id, action=AuditAction.DELETE_SUBMISSION
+        ).exists()
 
     def test_delete_all_allowed_submissions_with_partial_perms_as_anotheruser(self):
         """

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -151,6 +151,38 @@ class BaseSubmissionTestCase(BaseTestCase):
         self.submissions_submitted_by_anotheruser = submissions[4:6]
         self.submissions = submissions
 
+    def _create_other_project_with_submissions(self):
+        """
+        Create a second deployed project owned by `anotheruser` with its own
+        submissions and return the list of its PostgreSQL `Instance` ids.
+        """
+        content_source_asset = Asset.objects.get(id=1)
+        other_asset = Asset.objects.create(
+            content=content_source_asset.content,
+            owner=self.anotheruser,
+            asset_type='survey',
+        )
+        other_asset.deploy(backend='mock', active=True)
+        v_uid = other_asset.latest_deployed_version.uid
+        submissions = []
+        for i in range(2):
+            uuid_ = uuid.uuid4()
+            submissions.append(
+                {
+                    '__version__': v_uid,
+                    'q1': 'foreign',
+                    'meta/instanceID': f'uuid:{uuid_}',
+                    '_uuid': str(uuid_),
+                    '_submitted_by': 'anotheruser',
+                }
+            )
+        other_asset.deployment.mock_submissions(submissions)
+        return list(
+            Instance.objects.filter(
+                xform__kpi_asset_uid=other_asset.uid
+            ).values_list('id', flat=True)
+        )
+
 
 class BulkDeleteSubmissionsApiTests(
     SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase
@@ -244,38 +276,6 @@ class BulkDeleteSubmissionsApiTests(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = self.client.get(self.submission_list_url, {'format': 'json'})
         self.assertEqual(response.data['count'], 0)
-
-    def _create_other_project_with_submissions(self):
-        """
-        Create a second deployed project owned by `anotheruser` with its own
-        submissions and return the list of its PostgreSQL `Instance` ids.
-        """
-        content_source_asset = Asset.objects.get(id=1)
-        other_asset = Asset.objects.create(
-            content=content_source_asset.content,
-            owner=self.anotheruser,
-            asset_type='survey',
-        )
-        other_asset.deploy(backend='mock', active=True)
-        v_uid = other_asset.latest_deployed_version.uid
-        submissions = []
-        for i in range(2):
-            uuid_ = uuid.uuid4()
-            submissions.append(
-                {
-                    '__version__': v_uid,
-                    'q1': 'foreign',
-                    'meta/instanceID': f'uuid:{uuid_}',
-                    '_uuid': str(uuid_),
-                    '_submitted_by': 'anotheruser',
-                }
-            )
-        other_asset.deployment.mock_submissions(submissions)
-        return list(
-            Instance.objects.filter(
-                xform__kpi_asset_uid=other_asset.uid
-            ).values_list('id', flat=True)
-        )
 
     def test_cannot_delete_submissions_of_another_project(self):
         """
@@ -3435,6 +3435,31 @@ class SubmissionValidationStatusesApiTests(
             uid='validation_status_not_approved', username='someuser'
         )
 
+    def test_cannot_set_validation_statuses_of_another_project(self):
+        """
+        someuser must not be able to set the validation status of another
+        project's submissions by passing foreign ids to their own project
+        endpoint. The whole batch is rejected (400).
+        """
+        foreign_ids = self._create_other_project_with_submissions()
+        assert len(foreign_ids) == 2
+
+        self.client.force_login(self.someuser)
+        data = {
+            'payload': {
+                'validation_status.uid': 'validation_status_approved',
+                'submission_ids': foreign_ids,
+            }
+        }
+        response = self.client.patch(
+            self.validation_statuses_url, data=data, format='json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # The foreign submissions must not have been updated
+        for instance in Instance.objects.filter(id__in=foreign_ids):
+            assert instance.validation_status in ({}, None)
+
     def test_delete_all_statuses_as_owner(self):
         """
         someuser is the owner of the project.
@@ -3450,7 +3475,7 @@ class SubmissionValidationStatusesApiTests(
         someuser is the owner of the project.
         someuser can bulk delete the status of some of their submissions.
         """
-        submission_id = 1
+        submission_id = self.submissions_submitted_by_someuser[0]['_id']
         data = {
             'payload': {
                 'validation_status.uid': None,
@@ -3591,7 +3616,7 @@ class SubmissionValidationStatusesApiTests(
         someuser is the owner of the project.
         someuser can edit some validation statuses at once.
         """
-        submission_id = 1
+        submission_id = self.submissions_submitted_by_someuser[0]['_id']
         data = {
             'payload': {
                 'validation_status.uid': 'validation_status_approved',

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -245,6 +245,87 @@ class BulkDeleteSubmissionsApiTests(
         response = self.client.get(self.submission_list_url, {'format': 'json'})
         self.assertEqual(response.data['count'], 0)
 
+    def _create_other_project_with_submissions(self):
+        """
+        Create a second deployed project owned by `anotheruser` with its own
+        submissions and return the list of its PostgreSQL `Instance` ids.
+        """
+        content_source_asset = Asset.objects.get(id=1)
+        other_asset = Asset.objects.create(
+            content=content_source_asset.content,
+            owner=self.anotheruser,
+            asset_type='survey',
+        )
+        other_asset.deploy(backend='mock', active=True)
+        v_uid = other_asset.latest_deployed_version.uid
+        submissions = []
+        for i in range(2):
+            uuid_ = uuid.uuid4()
+            submissions.append(
+                {
+                    '__version__': v_uid,
+                    'q1': 'foreign',
+                    'meta/instanceID': f'uuid:{uuid_}',
+                    '_uuid': str(uuid_),
+                    '_submitted_by': 'anotheruser',
+                }
+            )
+        other_asset.deployment.mock_submissions(submissions)
+        return list(
+            Instance.objects.filter(
+                xform__kpi_asset_uid=other_asset.uid
+            ).values_list('id', flat=True)
+        )
+
+    def test_cannot_delete_submissions_of_another_project(self):
+        """
+        someuser owns `self.asset`. They must not be able to delete the
+        submissions of another project by passing foreign ids to their own
+        project bulk-delete endpoint. The request is rejected (400) and the
+        foreign data is left untouched.
+        """
+        foreign_ids = self._create_other_project_with_submissions()
+        assert len(foreign_ids) == 2
+
+        self.client.force_login(self.someuser)
+        data = {'payload': {'submission_ids': foreign_ids}}
+        response = self.client.delete(
+            self.submission_bulk_url, data=data, format='json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # The foreign submissions must still exist
+        assert (
+            Instance.objects.filter(id__in=foreign_ids).count() == len(foreign_ids)
+        )
+
+    def test_delete_submissions_rejects_whole_batch_if_one_id_is_foreign(self):
+        """
+        A batch mixing someuser's own ids with a foreign id must be rejected
+        entirely (strict): none of the submissions — own or foreign — are
+        deleted.
+        """
+        foreign_ids = self._create_other_project_with_submissions()
+        own_ids = list(
+            Instance.objects.filter(
+                xform__kpi_asset_uid=self.asset.uid
+            ).values_list('id', flat=True)
+        )
+        assert own_ids and foreign_ids
+
+        self.client.force_login(self.someuser)
+        data = {'payload': {'submission_ids': own_ids[:1] + foreign_ids[:1]}}
+        response = self.client.delete(
+            self.submission_bulk_url, data=data, format='json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        # Nothing was deleted: both the own and the foreign submissions remain
+        assert Instance.objects.filter(id__in=own_ids).count() == len(own_ids)
+        assert (
+            Instance.objects.filter(id__in=foreign_ids).count() == len(foreign_ids)
+        )
+
     def test_delete_all_allowed_submissions_with_partial_perms_as_anotheruser(self):
         """
         someuser is the project owner.

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -798,6 +798,11 @@ class DataViewSet(
                 bulk_actions_validator.data, request.user
             )
         except InvalidSubmissionIdsError:
+            # Raised before any deletion is attempted, so none of the
+            # pre-recorded instances were actually deleted. Clear them to
+            # avoid phantom DELETE_SUBMISSION audit log entries, which the
+            # middleware would otherwise create even for this 400 response.
+            request._request.instances = {}
             return {
                 'data': {'detail': t('One or more submission ids are invalid')},
                 'content_type': 'application/json',

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -20,6 +20,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from kobo.apps.audit_log.base_views import AuditLoggedViewSet
 from kobo.apps.audit_log.models import AuditType
 from kobo.apps.audit_log.utils import SubmissionUpdate
+from kobo.apps.openrosa.apps.logger.exceptions import InvalidSubmissionIdsError
 from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     add_uuid_prefix,
@@ -790,6 +791,12 @@ class DataViewSet(
             deleted = deployment.delete_submissions(
                 bulk_actions_validator.data, request.user
             )
+        except InvalidSubmissionIdsError:
+            return {
+                'data': {'detail': t('One or more submission ids are invalid')},
+                'content_type': 'application/json',
+                'status': status.HTTP_400_BAD_REQUEST,
+            }
         except (MissingXFormException, InvalidXFormException):
             return {
                 'data': {'detail': 'Could not delete submissions'},

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -749,8 +749,14 @@ class DataViewSet(
             perm=PERM_VALIDATE_SUBMISSIONS
         )
         bulk_actions_validator.is_valid(raise_exception=True)
-        json_response = deployment.set_validation_statuses(
-            request.user, bulk_actions_validator.data)
+        try:
+            json_response = deployment.set_validation_statuses(
+                request.user, bulk_actions_validator.data)
+        except InvalidSubmissionIdsError:
+            return Response(
+                {'detail': t('One or more submission ids are invalid')},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         return Response(**json_response)
 


### PR DESCRIPTION
### 📣 Summary

Strengthens validation of submission ids passed to bulk delete and bulk validation-status endpoints.

### 📖 Description

Bulk actions on submissions now verify that all provided ids belong to the target project before processing, rejecting the request otherwise. An administrative command (`restore_deleted_attachments`) is also included to help recover affected attachment records.

### 👀 Preview steps
