### PR TITLE
refactor(deleteAccountBanner): make stories more stable DEV-2264

### DIFF
--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import type { DecoratorFunction } from '@storybook/types'
+import { expect, waitFor, within } from 'storybook/test'
 import { withRouter } from 'storybook-addon-remix-react-router'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
@@ -28,9 +29,49 @@ const meta: Meta<typeof DeleteAccountBanner> = {
 export default meta
 type Story = StoryObj<typeof DeleteAccountBanner>
 
-export const Default: Story = {}
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
 
-export const UserHasAssets: Story = {}
+    // Wait for the delete account button to appear (means auth and data loading complete)
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
+
+    // Wait for loading state to complete (ellipsis should disappear)
+    await waitFor(
+      () => {
+        const ellipsisText = canvas.queryByText('…')
+        expect(ellipsisText).not.toBeInTheDocument()
+      },
+      { timeout: 5000 }
+    )
+
+    // Delete button should be disabled when user has assets
+    expect(deleteButton).toBeDisabled()
+  },
+}
+
+export const UserHasAssets: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for the delete account button to appear
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
+
+    // Wait for loading to complete (ellipsis disappears)
+    await waitFor(
+      () => {
+        expect(canvas.queryByText('…')).not.toBeInTheDocument()
+      },
+      { timeout: 5000 }
+    )
+
+    // Should show message about deleting/transferring projects
+    expect(canvas.getByText(/need to delete or transfer ownership/i)).toBeInTheDocument()
+
+    // Delete button should be disabled
+    expect(deleteButton).toBeDisabled()
+  },
+}
 
 export const UserHasNoAssets: Story = {
   parameters: {
@@ -39,6 +80,26 @@ export const UserHasNoAssets: Story = {
         assets: assetsMock({ count: 0 }),
       },
     },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for the delete account button to appear
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
+
+    // Wait for loading to complete (ellipsis disappears)
+    await waitFor(
+      () => {
+        expect(canvas.queryByText('…')).not.toBeInTheDocument()
+      },
+      { timeout: 5000 }
+    )
+
+    // Should show message about deleting account
+    expect(canvas.getByText(/delete your account and all your account data/i)).toBeInTheDocument()
+
+    // Delete button should be enabled
+    expect(deleteButton).toBeEnabled()
   },
 }
 
@@ -49,5 +110,17 @@ export const UserOwnsMMO: Story = {
         organization: organizationMock({ is_mmo: true }),
       },
     },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Wait for the delete account button to appear
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
+
+    // For organization owners, message should appear (checking for asset loading isn't necessary since it's blocked)
+    expect(canvas.getByText(/transfer ownership of your organization/i)).toBeInTheDocument()
+
+    // Delete button should be disabled
+    expect(deleteButton).toBeDisabled()
   },
 }

--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { withRouter } from 'storybook-addon-remix-react-router'
-import { expect, within } from 'storybook/test'
+import { expect, waitFor, within } from 'storybook/test'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
@@ -38,9 +38,10 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // MSW mocks respond instantly, just wait for React Query to update
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
-    expect(canvas.queryByText('…')).not.toBeInTheDocument()
+    await canvas.findByRole('button', { name: /delete account/i })
+    await waitFor(() => expect(canvas.queryByText('…')).not.toBeInTheDocument())
+
+    const deleteButton = canvas.getByRole('button', { name: /delete account/i })
     expect(deleteButton).toBeDisabled()
   },
 }
@@ -49,10 +50,11 @@ export const UserHasAssets: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
-    expect(canvas.queryByText('…')).not.toBeInTheDocument()
+    await canvas.findByRole('button', { name: /delete account/i })
+    await waitFor(() => expect(canvas.queryByText('…')).not.toBeInTheDocument())
+
     expect(canvas.getByText(/need to delete or transfer ownership/i)).toBeInTheDocument()
-    expect(deleteButton).toBeDisabled()
+    expect(canvas.getByRole('button', { name: /delete account/i })).toBeDisabled()
   },
 }
 
@@ -67,10 +69,11 @@ export const UserHasNoAssets: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
-    expect(canvas.queryByText('…')).not.toBeInTheDocument()
+    await canvas.findByRole('button', { name: /delete account/i })
+    await waitFor(() => expect(canvas.queryByText('…')).not.toBeInTheDocument())
+
     expect(canvas.getByText(/delete your account and all your account data/i)).toBeInTheDocument()
-    expect(deleteButton).toBeEnabled()
+    expect(canvas.getByRole('button', { name: /delete account/i })).toBeEnabled()
   },
 }
 

--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { withRouter } from 'storybook-addon-remix-react-router'
-import { expect, waitFor, within } from 'storybook/test'
+import { expect, within } from 'storybook/test'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
@@ -38,19 +38,9 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Wait for the delete account button to appear (means auth and data loading complete)
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
-
-    // Wait for loading state to complete (ellipsis should disappear)
-    await waitFor(
-      () => {
-        const ellipsisText = canvas.queryByText('…')
-        expect(ellipsisText).not.toBeInTheDocument()
-      },
-      { timeout: 5000 },
-    )
-
-    // Delete button should be disabled when user has assets
+    // MSW mocks respond instantly, just wait for React Query to update
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
+    expect(canvas.queryByText('…')).not.toBeInTheDocument()
     expect(deleteButton).toBeDisabled()
   },
 }
@@ -59,21 +49,9 @@ export const UserHasAssets: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Wait for the delete account button to appear
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
-
-    // Wait for loading to complete (ellipsis disappears)
-    await waitFor(
-      () => {
-        expect(canvas.queryByText('…')).not.toBeInTheDocument()
-      },
-      { timeout: 5000 },
-    )
-
-    // Should show message about deleting/transferring projects
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
+    expect(canvas.queryByText('…')).not.toBeInTheDocument()
     expect(canvas.getByText(/need to delete or transfer ownership/i)).toBeInTheDocument()
-
-    // Delete button should be disabled
     expect(deleteButton).toBeDisabled()
   },
 }
@@ -89,21 +67,9 @@ export const UserHasNoAssets: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Wait for the delete account button to appear
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
-
-    // Wait for loading to complete (ellipsis disappears)
-    await waitFor(
-      () => {
-        expect(canvas.queryByText('…')).not.toBeInTheDocument()
-      },
-      { timeout: 5000 },
-    )
-
-    // Should show message about deleting account
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
+    expect(canvas.queryByText('…')).not.toBeInTheDocument()
     expect(canvas.getByText(/delete your account and all your account data/i)).toBeInTheDocument()
-
-    // Delete button should be enabled
     expect(deleteButton).toBeEnabled()
   },
 }
@@ -119,13 +85,8 @@ export const UserOwnsMMO: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Wait for the delete account button to appear
-    const deleteButton = await canvas.findByRole('button', { name: /delete account/i }, { timeout: 5000 })
-
-    // For organization owners, message should appear (checking for asset loading isn't necessary since it's blocked)
+    const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
     expect(canvas.getByText(/transfer ownership of your organization/i)).toBeInTheDocument()
-
-    // Delete button should be disabled
     expect(deleteButton).toBeDisabled()
   },
 }

--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,14 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
-import type { DecoratorFunction } from '@storybook/types'
 import { withRouter } from 'storybook-addon-remix-react-router'
 import { expect, waitFor, within } from 'storybook/test'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
-import RequireAuth from '#/router/requireAuth'
+import { RequireOrg } from '#/router/RequireOrg'
 import DeleteAccountBanner from './DeleteAccountBanner'
-
-const RequireAuthDecorator: DecoratorFunction = (Story) => <RequireAuth>{Story()}</RequireAuth>
 
 const meta: Meta<typeof DeleteAccountBanner> = {
   title: 'Components/DeleteAccountBanner',
@@ -23,7 +20,15 @@ const meta: Meta<typeof DeleteAccountBanner> = {
     },
     a11y: { test: 'todo' },
   },
-  decorators: [RequireAuthDecorator, withRouter, queryClientDecorator],
+  decorators: [
+    (Story) => (
+      <RequireOrg>
+        <Story />
+      </RequireOrg>
+    ),
+    withRouter,
+    queryClientDecorator,
+  ],
 }
 
 export default meta

--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import type { DecoratorFunction } from '@storybook/types'
-import { expect, waitFor, within } from 'storybook/test'
 import { withRouter } from 'storybook-addon-remix-react-router'
+import { expect, waitFor, within } from 'storybook/test'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
@@ -42,7 +42,7 @@ export const Default: Story = {
         const ellipsisText = canvas.queryByText('…')
         expect(ellipsisText).not.toBeInTheDocument()
       },
-      { timeout: 5000 }
+      { timeout: 5000 },
     )
 
     // Delete button should be disabled when user has assets
@@ -62,7 +62,7 @@ export const UserHasAssets: Story = {
       () => {
         expect(canvas.queryByText('…')).not.toBeInTheDocument()
       },
-      { timeout: 5000 }
+      { timeout: 5000 },
     )
 
     // Should show message about deleting/transferring projects
@@ -92,7 +92,7 @@ export const UserHasNoAssets: Story = {
       () => {
         expect(canvas.queryByText('…')).not.toBeInTheDocument()
       },
-      { timeout: 5000 }
+      { timeout: 5000 },
     )
 
     // Should show message about deleting account

--- a/jsapp/js/account/DeleteAccountBanner.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.tsx
@@ -1,12 +1,9 @@
 import { Box, Group, Stack, Text, Title } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { fetchGet } from '#/api'
-import { endpoints } from '#/api.endpoints'
+import { useAssetsList } from '#/api/react-query/manage-projects-and-library-content'
 import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import Button from '#/components/common/ButtonNew'
-import type { AssetResponse, PaginatedResponse } from '#/dataInterface'
 import { PROJECTS_ROUTES } from '#/router/routerConstants'
 import { useSession } from '#/stores/useSession'
 import styles from './DeleteAccountBanner.module.scss'
@@ -17,17 +14,15 @@ export default function DeleteAccountBanner() {
   const navigate = useNavigate()
   const session = useSession()
   const [organization] = useOrganizationAssumed()
-  const [isAccountWithoutAssets, setIsAccountWithoutAssets] = useState<boolean | undefined>(undefined)
   const isAccountOrganizationOwner = organization.is_mmo && organization.is_owner
 
-  useEffect(() => {
-    const username = session.currentLoggedAccount.username
-    // We are fetching all user assets, but we are only interested in wheter user has at least one asset
-    const singleAssetEndpoint = endpoints.ASSETS_URL + `?q=(owner__username:${username})&limit=1`
-    fetchGet<PaginatedResponse<AssetResponse>>(singleAssetEndpoint).then((data: PaginatedResponse<AssetResponse>) => {
-      setIsAccountWithoutAssets(data.count === 0)
-    })
-  }, [])
+  const username = session.currentLoggedAccount.username
+  const { data: assetsData, isPending } = useAssetsList({
+    q: `(owner__username:${username})`,
+    limit: 1,
+  })
+
+  const isAccountWithoutAssets = assetsData?.status === 200 ? assetsData.data.count === 0 : undefined
 
   function goToProjectsList() {
     navigate(PROJECTS_ROUTES.MY_PROJECTS)
@@ -42,28 +37,32 @@ export default function DeleteAccountBanner() {
           )}
         </Text>
       )
-    } else if (isAccountWithoutAssets === true) {
-      return <Text>{t('Delete your account and all your account data.')}</Text>
-    } else if (isAccountWithoutAssets === false) {
-      return (
-        <Group gap='4px'>
-          <Text>
-            {t(
-              'You need to delete or transfer ownership of all projects owned by your user before you can delete your account.',
-            )}
-          </Text>
+    }
 
-          <Button p='0' size='sm' onClick={goToProjectsList} rightIcon='arrow-right' variant='transparent'>
-            {t('Go to project list')}
-          </Button>
-        </Group>
-      )
-    } else {
+    if (isPending || isAccountWithoutAssets === undefined) {
       return <Text>…</Text>
     }
+
+    if (isAccountWithoutAssets) {
+      return <Text>{t('Delete your account and all your account data.')}</Text>
+    }
+
+    return (
+      <Group gap='4px'>
+        <Text>
+          {t(
+            'You need to delete or transfer ownership of all projects owned by your user before you can delete your account.',
+          )}
+        </Text>
+
+        <Button p='0' size='sm' onClick={goToProjectsList} rightIcon='arrow-right' variant='transparent'>
+          {t('Go to project list')}
+        </Button>
+      </Group>
+    )
   }
 
-  const isAllowedToDelete = isAccountWithoutAssets && !isAccountOrganizationOwner
+  const isAllowedToDelete = !isPending && isAccountWithoutAssets === true && !isAccountOrganizationOwner
 
   return (
     <Box className={styles.wrapper}>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Fixed flaky Storybook test for DeleteAccountBanner that randomly failed in CI.

Changes here:
- `DeleteAccountBanner.tsx`
  - Swapped out the manual `useEffect` + `fetchGet` pattern for Orval/react-query `useAssetsList` hook (works better with MSW in Storybook)
  - Fixes the race condition where tests would sometimes run before the mock API responded
  - Added proper `isPending` handling so the button's disabled state is consistent
- `DeleteAccountBanner.stories.tsx`
  - Added `play` functions to all 4 stories (Default, UserHasAssets, UserHasNoAssets, UserOwnsMMO)
  - Each one waits for auth AND data loading before running assertions
  - Actually tests the UI behavior (button states, messages) instead of just "did it render?"

AI joke: No more Schrödinger's test – it's either passing or failing, never both! 🐱

The bug: the component fetched user assets async, but tests could run before that finished. Sometimes the mock was fast, sometimes slow. React Query + explicit waits = no more flaky tests.

### 👀 Preview steps

1. Run `npm run test:storybook` locally
2. 🟢 All DeleteAccountBanner stories pass consistently across chromium, firefox, and webkit
3. 🟢 No more random CI failures on this component (try rerunning the successful job?)
