### PR TITLE
refactor(assetTagsModal): make stories more stable DEV-2267

### DIFF
--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
@@ -98,6 +98,12 @@ export const UpdateTagsFlow: Story = {
       await waitFor(async () => {
         await expect(canvas.getByRole('dialog', { name: 'Edit tags' })).toBeInTheDocument()
       })
+
+      // Wait for the session store to load and the form to become interactive.
+      // The modal shows a loading spinner until sessionStore.isInitialLoadComplete is true.
+      await waitFor(async () => {
+        await expect(canvas.getByRole('textbox')).toBeInTheDocument()
+      })
     })
 
     await step('Submit new tags', async () => {
@@ -106,9 +112,13 @@ export const UpdateTagsFlow: Story = {
       await userEvent.type(tagsInput, 'gamma{enter}')
       await userEvent.click(canvas.getByRole('button', { name: 'Update' }))
 
-      await waitFor(async () => {
-        await expect(canvas.queryByRole('dialog', { name: 'Edit tags' })).not.toBeInTheDocument()
-      })
+      // Wait for the modal to close after the successful PATCH request
+      await waitFor(
+        async () => {
+          await expect(canvas.queryByRole('dialog', { name: 'Edit tags' })).not.toBeInTheDocument()
+        },
+        { timeout: 3000 },
+      )
     })
 
     await step('Verify payload', async () => {

--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
@@ -113,12 +113,9 @@ export const UpdateTagsFlow: Story = {
       await userEvent.click(canvas.getByRole('button', { name: 'Update' }))
 
       // Wait for the modal to close after the successful PATCH request
-      await waitFor(
-        async () => {
-          await expect(canvas.queryByRole('dialog', { name: 'Edit tags' })).not.toBeInTheDocument()
-        },
-        { timeout: 3000 },
-      )
+      await waitFor(async () => {
+        await expect(canvas.queryByRole('dialog', { name: 'Edit tags' })).not.toBeInTheDocument()
+      })
     })
 
     await step('Verify payload', async () => {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Fixed flaky Storybook test for AssetTagsModal that randomly failed in CI.

Changes here:
- `AssetTagsModal.stories.tsx`
  - Introduce more waiting in stories to make sure sessionStore is ready

Root cause of bug: The test didn't wait for `sessionStore.isInitialLoadComplete`, so the modal sometimes showed a loading spinner instead of the interactive form, causing test interactions to fail.

### 👀 Preview steps

1. Run `npm run test:storybook` locally
2. 🟢 All AssetTagsModal stories pass consistently across chromium, firefox, and webkit
3. 🟢 No more random CI failures on this component (try rerunning the successful job?)