### PR TITLE
fix(assets): fix deletion of projects with long names DEV-2248

### DIFF
--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -127,7 +127,7 @@ def move_to_trash(
     max_char = PeriodicTask._meta.get_field('name').max_length
 
     def shorten_name(name):
-        if len(name) < max_char:
+        if len(name) <= max_char:
             return name
         return f'{name[0:max_char-3]}...'
 

--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -375,7 +375,7 @@ def _get_settings(trash_type: str, retain_placeholder: bool = True) -> tuple:
             Attachment,
             'attachment_uid',
             'empty_attachment',
-            f'{DELETE_ATTACHMENT_STR_PREFIX} ({{attachment_uid}}) {{attachment_basename}} ',  # noqa E501
+            f'{DELETE_ATTACHMENT_STR_PREFIX} ({{attachment_uid}}) {{attachment_basename}}',  # noqa E501
         )
 
     raise TrashNotImplementedError

--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -124,6 +124,13 @@ def move_to_trash(
             )
         )
 
+    max_char = PeriodicTask._meta.get_field('name').max_length
+
+    def shorten_name(name):
+        if len(name) < max_char:
+            return name
+        return f'{name[0:max_char-3]}...'
+
     with temporarily_disconnect_signals(save=True):
         clocked_time = timezone.now() + timedelta(days=grace_period)
         clocked = ClockedSchedule.objects.create(clocked_time=clocked_time)
@@ -134,7 +141,7 @@ def move_to_trash(
                 [
                     PeriodicTask(
                         clocked=clocked,
-                        name=task_name_placeholder.format(**ato.metadata),
+                        name=shorten_name(task_name_placeholder.format(**ato.metadata)),
                         task=f'kobo.apps.trash_bin.tasks.{python_file}.{task}',
                         args=json.dumps([ato.id]),
                         one_off=True,
@@ -344,7 +351,7 @@ def _get_settings(trash_type: str, retain_placeholder: bool = True) -> tuple:
             Asset,
             'asset_uid',
             'empty_project',
-            f'{DELETE_PROJECT_STR_PREFIX} {{asset_name}} ({{asset_uid}})',
+            f'{DELETE_PROJECT_STR_PREFIX} ({{asset_uid}}) {{asset_name}}',
         )
 
     if trash_type == 'user':

--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -375,7 +375,7 @@ def _get_settings(trash_type: str, retain_placeholder: bool = True) -> tuple:
             Attachment,
             'attachment_uid',
             'empty_attachment',
-            f'{DELETE_ATTACHMENT_STR_PREFIX} {{attachment_basename}} ({{attachment_uid}})',  # noqa E501
+            f'{DELETE_ATTACHMENT_STR_PREFIX} ({{attachment_uid}}) {{attachment_basename}} ',  # noqa E501
         )
 
     raise TrashNotImplementedError


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fixes a bug that was causing errors when users tried to delete a project with a particularly long name.

### Notes
Also preemptively handles long attachment names, even though those have not yet caused an issue.


### 👀 Preview steps
Make sure to restart the kpi_worker after switching branches

1. ℹ️ have an account 
2. Create a project with a name >= 200 characters (eg `P2.1.4_Nombre d'infrastructures ou d'installations réhabilitées, améliorées ou construites avec le soutien de l'intervention financée par l'UE, ventilé par type de soutien, ventilé par typologie`)
3. Delete the project
4. 🔴 [on main] 500 error
5. 🟢 [on PR] Project is successfully deleted

