### PR TITLE
feat(nlp): ensure maximum language support with per-language STT routing and GLOBAL/EU toggle DEV-2277

### DIFF
--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -40,7 +40,7 @@ from ...exceptions import (
     TranscriptionResultNotFound
 )
 from .base import GoogleService
-from .locations import get_speech_location
+from .locations import get_speech_location, get_speech_location_for_model
 
 # https://cloud.google.com/speech-to-text/docs/quotas
 ASYNC_MAX_LENGTH = timedelta(minutes=479)
@@ -64,7 +64,6 @@ class GoogleTranscriptionService(GoogleService):
         class. It uses Google Cloud Speech-to-Text v2 batch API.
         """
         super().__init__(submission=submission, asset=asset, *args, **kwargs)
-        self.speech_location = get_speech_location()
 
     def adapt_response(self, response: Union[dict, list]) -> str:
         """
@@ -110,6 +109,7 @@ class GoogleTranscriptionService(GoogleService):
         content: Any,
         *,
         model_code: str | None = None,
+        speech_location: str | None = None,
     ) -> tuple[object, int]:
         """
         Set up a batch transcription operation
@@ -122,19 +122,19 @@ class GoogleTranscriptionService(GoogleService):
             )
 
         speech_model = model_code or DEFAULT_SPEECH_MODEL
-        speech_client = self._get_speech_client(self.speech_location)
+        speech_client = self._get_speech_client(speech_location)
         input_path, output_prefix = self._get_batch_paths(xpath, source_lang)
 
         logging.info(
             'Starting Google automatic transcription for '
             f'{self.submission_root_uuid=}, {xpath=}, {source_lang=}, '
-            f'{self.speech_location=}, {speech_model=}'
+            f'{speech_location=}, {speech_model=}'
         )
         self._cleanup_batch_files(xpath, source_lang)
         gcs_input_uri = self.store_file(flac_content, input_path)
 
         request = speech.BatchRecognizeRequest(
-            recognizer=self._get_recognizer_name(self.speech_location),
+            recognizer=self._get_recognizer_name(speech_location),
             config=speech.RecognitionConfig(
                 auto_decoding_config=speech.AutoDetectDecodingConfig(),
                 language_codes=[source_lang],
@@ -161,11 +161,6 @@ class GoogleTranscriptionService(GoogleService):
     @property
     def counter_name(self):
         return 'google_asr_seconds'
-
-    def get_client_options(self):
-        return client_options.ClientOptions(
-            api_endpoint=f'{self.speech_location}-speech.googleapis.com'
-        )
 
     def get_converted_audio(
         self, xpath: str, submission_uuid: int, user: object
@@ -213,6 +208,12 @@ class GoogleTranscriptionService(GoogleService):
             return {'status': 'failed', 'error': message}
 
         source_language = language_config.language_code
+        speech_location = (
+            get_speech_location_for_model(language_config.model_code)
+            or language_config.location_code
+            or get_speech_location()
+        )
+
         operation_name = self._get_operation_reference(
             xpath, source_language, bulk_action_uid
         )
@@ -243,6 +244,7 @@ class GoogleTranscriptionService(GoogleService):
                     target_lang=None,
                     content=converted_audio,
                     model_code=language_config.model_code,
+                    speech_location=speech_location,
                 )
             except AudioTooLongError as err:
                 return {'status': 'failed', 'error': str(err)}
@@ -320,6 +322,7 @@ class GoogleTranscriptionService(GoogleService):
             # read the batch result after Google reports completion
             operation_payload = self._get_operation_payload(
                 operation_name,
+                speech_location,
             )
             if not operation_payload.get('done'):
                 raise SubsequenceTimeoutError
@@ -481,11 +484,12 @@ class GoogleTranscriptionService(GoogleService):
     def _get_operation_payload(
         self,
         operation_name: str,
+        speech_location: str,
     ) -> dict:
         """
-        Poll the Google long-running operation backing the batch request.
+        Poll the Google long-running operation backing the batch request
         """
-        speech_client = self._get_speech_client(self.speech_location)
+        speech_client = self._get_speech_client(speech_location)
         operation = speech_client.transport.operations_client.get_operation(
             operation_name
         )

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -122,6 +122,8 @@ class GoogleTranscriptionService(GoogleService):
             )
 
         speech_model = model_code or DEFAULT_SPEECH_MODEL
+        if speech_location is None:
+            speech_location = get_speech_location()
         speech_client = self._get_speech_client(speech_location)
         input_path, output_prefix = self._get_batch_paths(xpath, source_lang)
 

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -40,7 +40,7 @@ from ...exceptions import (
     TranscriptionResultNotFound
 )
 from .base import GoogleService
-from .locations import get_speech_location, get_speech_location_for_model
+from .locations import get_speech_location_for_region, get_speech_location_for_model
 
 # https://cloud.google.com/speech-to-text/docs/quotas
 ASYNC_MAX_LENGTH = timedelta(minutes=479)
@@ -123,7 +123,7 @@ class GoogleTranscriptionService(GoogleService):
 
         speech_model = model_code or DEFAULT_SPEECH_MODEL
         if speech_location is None:
-            speech_location = get_speech_location()
+            speech_location = get_speech_location_for_region()
         speech_client = self._get_speech_client(speech_location)
         input_path, output_prefix = self._get_batch_paths(xpath, source_lang)
 
@@ -213,7 +213,7 @@ class GoogleTranscriptionService(GoogleService):
         speech_location = (
             get_speech_location_for_model(language_config.model_code)
             or language_config.location_code
-            or get_speech_location()
+            or get_speech_location_for_region()
         )
 
         operation_name = self._get_operation_reference(
@@ -495,7 +495,7 @@ class GoogleTranscriptionService(GoogleService):
             parts = operation_name.split('/')
             location = parts[parts.index('locations') + 1]
         except (ValueError, IndexError):
-            location = get_speech_location()
+            location = get_speech_location_for_region()
 
         speech_client = self._get_speech_client(location)
         speech_client.transport.operations_client.cancel_operation(name=operation_name)

--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -483,6 +483,23 @@ class GoogleTranscriptionService(GoogleService):
             f'locations/{location}/recognizers/_'
         )
 
+    def cancel_google_operation(self, operation_name: str) -> None:
+        """
+        Parse the GCP location from a long-running operation resource name and
+        cancel a previously started Google long-running operation
+
+        STT v2 operation names follow the pattern:
+            projects/{project}/locations/{location}/operations/{id}
+        """
+        try:
+            parts = operation_name.split('/')
+            location = parts[parts.index('locations') + 1]
+        except (ValueError, IndexError):
+            location = get_speech_location()
+
+        speech_client = self._get_speech_client(location)
+        speech_client.transport.operations_client.cancel_operation(name=operation_name)
+
     def _get_operation_payload(
         self,
         operation_name: str,

--- a/kobo/apps/subsequences/integrations/google/locations.py
+++ b/kobo/apps/subsequences/integrations/google/locations.py
@@ -10,8 +10,8 @@ from kpi.utils.log import logging
 # to whichever Google endpoint hosts that model.
 # EU - restrict all processing to EU-hosted Google endpoints for data residency
 # compliance; languages unavailable in EU become unsupported.
-GOOGLE_REGION_EU = 'EU'
-GOOGLE_REGION_GLOBAL = 'GLOBAL'
+GOOGLE_REGION_EU = 'eu'
+GOOGLE_REGION_GLOBAL = 'global'
 GOOGLE_REGION_CHOICES = (GOOGLE_REGION_GLOBAL, GOOGLE_REGION_EU)
 
 DEFAULT_GOOGLE_REGION = GOOGLE_REGION_GLOBAL
@@ -42,9 +42,9 @@ TRANSLATE_LOCATION_BY_REGION = {
 
 def get_google_region() -> str:
     """
-    Return the configured ASR/MT Google processing region ('GLOBAL' or 'EU')
+    Return the configured ASR/MT Google processing region ('global' or 'eu')
     """
-    region = str(constance.config.ASR_MT_GOOGLE_REGION).upper()
+    region = str(constance.config.ASR_MT_GOOGLE_REGION).lower()
     if region in GOOGLE_REGION_CHOICES:
         return region
 
@@ -66,7 +66,7 @@ def get_speech_location_for_model(model_code: str | None) -> str | None:
     return None
 
 
-def get_speech_location() -> str:
+def get_speech_location_for_region() -> str:
     return 'eu' if get_google_region() == GOOGLE_REGION_EU else 'us'
 
 

--- a/kobo/apps/subsequences/integrations/google/locations.py
+++ b/kobo/apps/subsequences/integrations/google/locations.py
@@ -5,44 +5,44 @@ import constance
 from kpi.utils.log import logging
 
 
-# The server-wide Google region is stored in Constance as either 'US' or 'EU'.
-# 'EU' must be used when EU data residency is required (all data must remain
-# within Europe). 'US' is the default for all other deployments
+# Server-wide Google region setting stored in Constance:
+# GLOBAL (default) - use the best model for every language, routing per-language
+# to whichever Google endpoint hosts that model.
+# EU - restrict all processing to EU-hosted Google endpoints for data residency
+# compliance; languages unavailable in EU become unsupported.
 GOOGLE_REGION_EU = 'EU'
-GOOGLE_REGION_US = 'US'
-GOOGLE_REGION_CHOICES = (GOOGLE_REGION_US, GOOGLE_REGION_EU)
+GOOGLE_REGION_GLOBAL = 'GLOBAL'
+GOOGLE_REGION_CHOICES = (GOOGLE_REGION_GLOBAL, GOOGLE_REGION_EU)
 
-DEFAULT_GOOGLE_REGION = GOOGLE_REGION_US
+DEFAULT_GOOGLE_REGION = GOOGLE_REGION_GLOBAL
 
-# 'us' and 'eu' are STT v2 multi-region endpoints with identical language
-# support and model availability
-SPEECH_LOCATION_BY_REGION = {
-    GOOGLE_REGION_EU: 'eu',
-    GOOGLE_REGION_US: 'us',
+# EU equivalents per model:
+#   chirp_3  → 'eu'            (us/eu multi-region, chirp_3 support)
+#   chirp_2  → 'europe-west4'  (EU sub-region with chirp_2 support)
+#   chirp    → 'europe-west4'  (EU sub-region with chirp support)
+#   long     → 'eu'            (us/eu multi-region, long model)
+EU_LOCATION_BY_MODEL = {
+    'chirp_3': 'eu',
+    'chirp_2': 'europe-west4',
+    'chirp':   'europe-west4',
+    'long':    'eu',
 }
 
-# Translation requests are routed through multi-region endpoints:
-# `translate-eu.googleapis.com` keeps TLS termination and processing within the EU
-# for EU data residency requirements, while `translate-us.googleapis.com` routes
-# requests through the US multi-region
+# MT (Translation v3) endpoint and location mapping
 TRANSLATE_ENDPOINT_BY_REGION = {
     GOOGLE_REGION_EU: 'translate-eu.googleapis.com',
-    GOOGLE_REGION_US: 'translate-us.googleapis.com',
+    GOOGLE_REGION_GLOBAL: 'translate-us.googleapis.com',
 }
 
 TRANSLATE_LOCATION_BY_REGION = {
     GOOGLE_REGION_EU: 'europe-west1',
-    GOOGLE_REGION_US: 'us-west1',
+    GOOGLE_REGION_GLOBAL: 'us-west1',
 }
 
 
 def get_google_region() -> str:
     """
-    Return the configured ASR/MT Google processing region ('US' or 'EU')
-
-    Reads ASR_MT_GOOGLE_REGION from constance at call time, so an admin can
-    change the region without restarting the server. Tolerates lower-case input
-    and falls back to 'US' with a warning if an unrecognised value is set
+    Return the configured ASR/MT Google processing region ('GLOBAL' or 'EU')
     """
     region = str(constance.config.ASR_MT_GOOGLE_REGION).upper()
     if region in GOOGLE_REGION_CHOICES:
@@ -56,8 +56,18 @@ def get_google_region() -> str:
     return DEFAULT_GOOGLE_REGION
 
 
+def get_speech_location_for_model(model_code: str | None) -> str | None:
+    """
+    Return the EU speech location for the given model, or None in GLOBAL mode,
+    in which case the caller must use location_code from the database
+    """
+    if get_google_region() == GOOGLE_REGION_EU:
+        return EU_LOCATION_BY_MODEL.get(model_code, 'eu')
+    return None
+
+
 def get_speech_location() -> str:
-    return SPEECH_LOCATION_BY_REGION[get_google_region()]
+    return 'eu' if get_google_region() == GOOGLE_REGION_EU else 'us'
 
 
 def get_translate_endpoint() -> str:

--- a/kobo/apps/subsequences/integrations/tests/test_google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_transcribe.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from google.api_core.exceptions import PermissionDenied
@@ -130,7 +130,11 @@ def test_process_data_returns_failed_for_missing_google_service_config():
     }
 
 
-def test_process_data_returns_failed_for_polling_auth_errors():
+@patch(
+    'kobo.apps.subsequences.integrations.google.google_transcribe.get_speech_location_for_model',  # noqa E501
+    return_value=None,
+)
+def test_process_data_returns_failed_for_polling_auth_errors(_mock_location):
     service = _get_service_for_process_data()
     service._get_google_language_config = MagicMock(
         return_value=MagicMock(language_code='en-US', location_code='global')
@@ -149,7 +153,11 @@ def test_process_data_returns_failed_for_polling_auth_errors():
     )
 
 
-def test_process_data_returns_failed_for_unexpected_polling_errors():
+@patch(
+    'kobo.apps.subsequences.integrations.google.google_transcribe.get_speech_location_for_model',  # noqa E501
+    return_value=None,
+)
+def test_process_data_returns_failed_for_unexpected_polling_errors(_mock_location):
     service = _get_service_for_process_data()
     service._get_google_language_config = MagicMock(
         return_value=MagicMock(language_code='en-US', location_code='global')

--- a/kobo/apps/subsequences/integrations/tests/test_google_translate.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_translate.py
@@ -56,7 +56,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_sync_translation_returns_failed_for_invalid_argument(self):
         """
@@ -86,7 +86,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_async_translation_returns_failed_timeout_and_saves_operation(self):
         """
@@ -130,7 +130,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_async_translation_reuses_cached_operation_and_returns_complete(self):
         """
@@ -169,7 +169,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_async_translation_reuses_cached_operation_and_returns_retry_later(self):
         """
@@ -209,7 +209,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_operation_payload_can_be_dict(self):
         """
@@ -228,7 +228,7 @@ class TestGoogleTranslate(TestCase):
 
     @override_config(
         ASR_MT_GOOGLE_PROJECT_ID='abc',
-        ASR_MT_GOOGLE_REGION='US',
+        ASR_MT_GOOGLE_REGION='global',
     )
     def test_bulk_action_uid_falls_back_to_cache_when_model_is_unavailable(self):
         """

--- a/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
+++ b/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
@@ -1,0 +1,75 @@
+import json
+from django.db import migrations
+
+
+def _read_constance_value(raw: str | None) -> str:
+    if not raw:
+        return ''
+    try:
+        return str(json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        return str(raw)
+
+
+def rename_us_to_global(apps, schema_editor):
+    """
+    Rename the legacy constance value 'US' to 'GLOBAL'.
+
+    Migration 0012 introduced ASR_MT_GOOGLE_REGION and wrote 'US' as the
+    default. The value is now 'GLOBAL' to reflect that non-EU servers use
+    per-language global routing rather than a fixed US endpoint.
+    EU deployments are unaffected.
+    """
+    try:
+        Constance = apps.get_model('constance', 'Constance')
+    except LookupError:
+        return
+
+    db_alias = schema_editor.connection.alias
+    try:
+        config = Constance.objects.using(db_alias).get(
+            key='ASR_MT_GOOGLE_REGION'
+        )
+    except Constance.DoesNotExist:
+        return
+
+    if _read_constance_value(config.value).upper() == 'US':
+        config.value = json.dumps('GLOBAL')
+        config.save(update_fields=['value'])
+
+
+def rename_global_to_us(apps, schema_editor):
+    """
+    Reverse: rename 'GLOBAL' back to 'US'
+    """
+    try:
+        Constance = apps.get_model('constance', 'Constance')
+    except LookupError:
+        return
+
+    db_alias = schema_editor.connection.alias
+    try:
+        config = Constance.objects.using(db_alias).get(
+            key='ASR_MT_GOOGLE_REGION'
+        )
+    except Constance.DoesNotExist:
+        return
+
+    if _read_constance_value(config.value).upper() == 'GLOBAL':
+        config.value = json.dumps('US')
+        config.save(update_fields=['value'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subsequences', '0012_migrate_google_region_constance_key'),
+        ('constance', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_us_to_global,
+            reverse_code=rename_global_to_us,
+        ),
+    ]

--- a/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
+++ b/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
@@ -11,52 +11,52 @@ def _read_constance_value(raw: str | None) -> str:
         return str(raw)
 
 
-def rename_us_to_global(apps, schema_editor):
-    """
-    Rename the legacy constance value 'US' to 'global'
-
-    Migration 0012 introduced ASR_MT_GOOGLE_REGION and wrote 'US' as the
-    default. The value is now 'global' to reflect that non-EU servers use
-    per-language global routing rather than a fixed US endpoint.
-    EU deployments are unaffected.
-    """
+def _get_constance_config(apps, schema_editor):
     try:
         Constance = apps.get_model('constance', 'Constance')
     except LookupError:
-        return
-
-    db_alias = schema_editor.connection.alias
+        return None
     try:
-        config = Constance.objects.using(db_alias).get(
+        return Constance.objects.using(schema_editor.connection.alias).get(
             key='ASR_MT_GOOGLE_REGION'
         )
     except Constance.DoesNotExist:
+        return None
+
+
+def normalise_to_lowercase(apps, schema_editor):
+    """
+    Normalise legacy uppercase region slugs to lowercase
+
+    Migration 0012 wrote 'US' as the default and 'EU' for EU deployments.
+    Both are now lowercase ('global' and 'eu') to match the updated slug
+    convention. Leaving 'EU' uppercase would cause the Django admin Constance
+    form to render the wrong selected option, risking a silent switch from EU
+    to GLOBAL data residency on save.
+    """
+    config = _get_constance_config(apps, schema_editor)
+    if config is None:
         return
 
-    if _read_constance_value(config.value).upper() == 'US':
-        config.value = json.dumps('global')
+    RENAMES = {'us': 'global', 'eu': 'eu'}
+    current = _read_constance_value(config.value).lower()
+    if current in RENAMES and config.value != json.dumps(RENAMES[current]):
+        config.value = json.dumps(RENAMES[current])
         config.save(update_fields=['value'])
 
 
-def rename_global_to_us(apps, schema_editor):
+def revert_to_uppercase(apps, schema_editor):
     """
-    Reverse: rename 'global' back to 'US'
+    Reverse: restore uppercase slugs written by migration 0012
     """
-    try:
-        Constance = apps.get_model('constance', 'Constance')
-    except LookupError:
+    config = _get_constance_config(apps, schema_editor)
+    if config is None:
         return
 
-    db_alias = schema_editor.connection.alias
-    try:
-        config = Constance.objects.using(db_alias).get(
-            key='ASR_MT_GOOGLE_REGION'
-        )
-    except Constance.DoesNotExist:
-        return
-
-    if _read_constance_value(config.value).lower() == 'global':
-        config.value = json.dumps('US')
+    RENAMES = {'global': 'US', 'eu': 'EU'}
+    current = _read_constance_value(config.value).lower()
+    if current in RENAMES:
+        config.value = json.dumps(RENAMES[current])
         config.save(update_fields=['value'])
 
 
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            rename_us_to_global,
-            reverse_code=rename_global_to_us,
+            normalise_to_lowercase,
+            reverse_code=revert_to_uppercase,
         ),
     ]

--- a/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
+++ b/kobo/apps/subsequences/migrations/0013_rename_google_region_us_to_global.py
@@ -13,10 +13,10 @@ def _read_constance_value(raw: str | None) -> str:
 
 def rename_us_to_global(apps, schema_editor):
     """
-    Rename the legacy constance value 'US' to 'GLOBAL'.
+    Rename the legacy constance value 'US' to 'global'
 
     Migration 0012 introduced ASR_MT_GOOGLE_REGION and wrote 'US' as the
-    default. The value is now 'GLOBAL' to reflect that non-EU servers use
+    default. The value is now 'global' to reflect that non-EU servers use
     per-language global routing rather than a fixed US endpoint.
     EU deployments are unaffected.
     """
@@ -34,13 +34,13 @@ def rename_us_to_global(apps, schema_editor):
         return
 
     if _read_constance_value(config.value).upper() == 'US':
-        config.value = json.dumps('GLOBAL')
+        config.value = json.dumps('global')
         config.save(update_fields=['value'])
 
 
 def rename_global_to_us(apps, schema_editor):
     """
-    Reverse: rename 'GLOBAL' back to 'US'
+    Reverse: rename 'global' back to 'US'
     """
     try:
         Constance = apps.get_model('constance', 'Constance')
@@ -55,7 +55,7 @@ def rename_global_to_us(apps, schema_editor):
     except Constance.DoesNotExist:
         return
 
-    if _read_constance_value(config.value).upper() == 'GLOBAL':
+    if _read_constance_value(config.value).lower() == 'global':
         config.value = json.dumps('US')
         config.save(update_fields=['value'])
 

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -365,12 +365,13 @@ CONSTANCE_CONFIG = {
         ),
     ),
     'ASR_MT_GOOGLE_REGION': (
-        env.str('CONSTANCE_ASR_MT_GOOGLE_REGION', 'US'),
+        env.str('CONSTANCE_ASR_MT_GOOGLE_REGION', 'GLOBAL'),
         (
-            'Google Cloud region for ASR/MT data residency. Use `US` for '
-            'Speech-to-Text location `us` and Translation location '
-            '`us-west1`; use `EU` for Speech-to-Text location `eu` and '
-            'Translation location `europe-west1`.'
+            'Google Cloud region for ASR/MT data residency. '
+            'GLOBAL (default): maximum language support, per-language routing '
+            'to the best available Google endpoint for each model. '
+            'EU: restrict all processing to EU-hosted Google endpoints; '
+            'languages only available outside the EU become unsupported.'
         ),
         'google_region_choice',
     ),
@@ -714,7 +715,7 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'django.forms.fields.ChoiceField',
         {
             'choices': (
-                ('US', 'US'),
+                ('GLOBAL', 'GLOBAL'),
                 ('EU', 'EU'),
             ),
         },

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -365,12 +365,12 @@ CONSTANCE_CONFIG = {
         ),
     ),
     'ASR_MT_GOOGLE_REGION': (
-        env.str('CONSTANCE_ASR_MT_GOOGLE_REGION', 'GLOBAL'),
+        env.str('CONSTANCE_ASR_MT_GOOGLE_REGION', 'global'),
         (
             'Google Cloud region for ASR/MT data residency. '
-            'GLOBAL (default): maximum language support, per-language routing '
+            'global (default): maximum language support, per-language routing '
             'to the best available Google endpoint for each model. '
-            'EU: restrict all processing to EU-hosted Google endpoints; '
+            'eu: restrict all processing to EU-hosted Google endpoints; '
             'languages only available outside the EU become unsupported.'
         ),
         'google_region_choice',
@@ -715,8 +715,8 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'django.forms.fields.ChoiceField',
         {
             'choices': (
-                ('GLOBAL', 'GLOBAL'),
-                ('EU', 'EU'),
+                ('global', 'global'),
+                ('eu', 'eu'),
             ),
         },
     ],

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -715,8 +715,8 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         'django.forms.fields.ChoiceField',
         {
             'choices': (
-                ('global', 'global'),
-                ('eu', 'eu'),
+                ('global', 'Global'),
+                ('eu', 'Europe'),
             ),
         },
     ],


### PR DESCRIPTION
### 📣 Summary
Extends the Google ASR/MT location handling from [kpi#7128](https://github.com/kobotoolbox/kpi/pull/7128) to support every language Google offers. Instead of a fixed `us`/`eu` endpoint for all languages, the code now routes each language to whichever Google endpoint hosts its best available model. A new `GLOBAL`/`EU` Constance toggle replaces the old `US`/`EU` toggle: `GLOBAL` (default) uses per-language routing for maximum coverage; `EU` restricts all processing to EU-hosted endpoints for data residency compliance.

### 📖 Description
[kpi#7128](https://github.com/kobotoolbox/kpi/pull/7128) re-implemented the server-wide Google ASR/MT region setting  (`ASR_MT_GOOGLE_REGION`) and simplified routing to use a single fixed  location: `us` for all languages on non-EU servers and `eu` on EU servers.

However, this caused 24 languages to lose ASR support, languages like Irish,  Belarusian, Bosnian, and Somali that only have `chirp_2` model support in specific Google sub-regions (`us-central1`, `europe-west4`) and no model at  all in the `us`/`eu` multi-region endpoints.

Because we cannot lose support for these 24 languages, we decided to implement the following approach instead:
1. Global mode (default): Support every language that Google supports by routing each language to the endpoint that provides the best available model.
2. EU mode: Use the best available model within EU-hosted endpoints only. Languages that are not available in any EU endpoint are considered unsupported on EU servers.

In `GLOBAL` mode, the code reads `location_code` per language from the  database (populated by the language spreadsheet, which stores the correct  global location for each model). In EU mode, the code overrides the DB  location at runtime using the table above via `EU_LOCATION_BY_MODEL` in `locations.py`.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Have an account with a project containing audio submissions.
2. Ensure `ASR_MT_GOOGLE_REGION` is set to `GLOBAL` in Django admin → Constance → Config.

Test GLOBAL mode with `chirp_3` language (e.g. French):
3. 🟢 Transcribe a French audio submission → should succeed.

Test GLOBAL mode with `chirp_2` language (e.g. Irish):
4. Transcribe an Irish audio submission → should succeed.

Test EU mode:
5. Change `ASR_MT_GOOGLE_REGION` to `EU`.
6. 🟢 Transcribe a French submission → should succeed using location `eu`.
7. 🟢 Transcribe an Irish submission → should succeed using location `europe-west4`.

NOTE: Import this updated language list through the Django admin [kobo-import.csv](https://github.com/user-attachments/files/28955677/kobo-import.csv)
