### PR TITLE
fix(library): use full metadata flow when creating project from template DEV-2278

### DIFF
--- a/jsapp/js/assetQuickActions.tsx
+++ b/jsapp/js/assetQuickActions.tsx
@@ -278,13 +278,12 @@ export function cloneAssetAsTemplate(sourceUid: string, sourceName: string) {
 }
 
 /** To be used when creating a project from template. */
-export function cloneAssetAsSurvey(sourceUid: string, sourceName: string) {
-  _cloneAssetAsNewType({
-    sourceUid: sourceUid,
-    sourceName: sourceName,
-    targetType: ASSET_TYPES.survey.id,
-    promptTitle: t('Create new project from this template'),
-    promptMessage: t('Enter the name of the new project.'),
+export function cloneAssetAsSurvey(sourceUid: string) {
+  // Open the NEW_FORM modal with the template pre-selected
+  // This ensures that metadata is properly collected during project creation
+  pageState.showModal({
+    type: MODAL_TYPES.NEW_FORM,
+    initialTemplateUid: sourceUid,
   })
 }
 

--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -178,7 +178,7 @@ class AssetActionButtons extends React.Component<AssetActionButtonsProps, AssetA
   }
 
   cloneAsSurvey() {
-    cloneAssetAsSurvey(this.props.asset.uid, assetUtils.getAssetDisplayName(this.props.asset).final)
+    cloneAssetAsSurvey(this.props.asset.uid)
   }
 
   cloneAsTemplate() {

--- a/jsapp/js/components/bigModal/bigModal.js
+++ b/jsapp/js/components/bigModal/bigModal.js
@@ -233,7 +233,11 @@ class BigModal extends React.Component {
         <Modal.Body>
           {this.props.params.type === MODAL_TYPES.SHARING && <SharingForm assetUid={uid} />}
           {this.props.params.type === MODAL_TYPES.NEW_FORM && (
-            <ProjectSettings context={PROJECT_SETTINGS_CONTEXTS.NEW} onSetModalTitle={this.setModalTitle} />
+            <ProjectSettings
+              context={PROJECT_SETTINGS_CONTEXTS.NEW}
+              onSetModalTitle={this.setModalTitle}
+              initialTemplateUid={this.props.params.initialTemplateUid}
+            />
           )}
           {this.props.params.type === MODAL_TYPES.LIBRARY_NEW_ITEM && (
             <LibraryNewItemForm onSetModalTitle={this.setModalTitle} />

--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -87,6 +87,7 @@ class ProjectSettings extends React.Component {
       isApplyTemplatePending: false,
       applyTemplateButton: t('Next'),
       chosenTemplateUid: this.props.initialTemplateUid || null,
+      pendingTemplateCloneUid: null,
       // upload files
       isUploadFilePending: false,
       // archive flow
@@ -105,14 +106,7 @@ class ProjectSettings extends React.Component {
     this.setInitialStep()
     // If an initial template is provided, apply it immediately
     if (this.props.initialTemplateUid && this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW) {
-      this.setState({
-        isApplyTemplatePending: true,
-        applyTemplateButton: t('Please wait…'),
-      })
-      actions.resources.cloneAsset({
-        uid: this.props.initialTemplateUid,
-        new_asset_type: 'survey',
-      })
+      this.cloneTemplateAsSurvey(this.props.initialTemplateUid)
     }
     when(
       () => sessionStore.isInitialLoadComplete,
@@ -124,8 +118,6 @@ class ProjectSettings extends React.Component {
       actions.resources.loadAsset.completed.listen(this.onLoadAssetCompleted.bind(this)),
       actions.resources.updateAsset.completed.listen(this.onUpdateAssetCompleted.bind(this)),
       actions.resources.updateAsset.failed.listen(this.onUpdateAssetFailed.bind(this)),
-      actions.resources.cloneAsset.completed.listen(this.onCloneAssetCompleted.bind(this)),
-      actions.resources.cloneAsset.failed.listen(this.onCloneAssetFailed.bind(this)),
       actions.resources.setDeploymentActive.failed.listen(this.onSetDeploymentActiveFailed.bind(this)),
       actions.resources.setDeploymentActive.completed.listen(this.onSetDeploymentActiveCompleted.bind(this)),
       router.subscribe(this.onRouteChange.bind(this)),
@@ -181,10 +173,10 @@ class ProjectSettings extends React.Component {
     switch (this.props.context) {
       case PROJECT_SETTINGS_CONTEXTS.NEW:
       case PROJECT_SETTINGS_CONTEXTS.REPLACE:
-        // If an initial template is provided, skip directly to template loading
-        // The actual PROJECT_DETAILS step will be shown after the template is cloned
+        // If an initial template is provided, keep currentStep null to show spinner
+        // until the clone completes, then onCloneAssetCompleted will show PROJECT_DETAILS
         if (this.props.initialTemplateUid && this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW) {
-          return this.displayStep(this.STEPS.CHOOSE_TEMPLATE)
+          return
         }
         return this.displayStep(this.STEPS.FORM_SOURCE)
       case PROJECT_SETTINGS_CONTEXTS.EXISTING:
@@ -476,29 +468,6 @@ class ProjectSettings extends React.Component {
     }
   }
 
-  onCloneAssetCompleted(asset) {
-    if (
-      (this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE ||
-        this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW) &&
-      this.state.currentStep === this.STEPS.CHOOSE_TEMPLATE
-    ) {
-      this.setState({
-        formAsset: asset,
-        fields: this.getInitialFieldsFromAsset(asset),
-      })
-      this.resetApplyTemplateButton()
-      this.displayStep(this.STEPS.PROJECT_DETAILS)
-    }
-  }
-
-  onCloneAssetFailed() {
-    if (
-      this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE ||
-      this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW
-    ) {
-      this.resetApplyTemplateButton()
-    }
-  }
 
   getOrCreateFormAsset() {
     const assetPromise = new Promise((resolve, reject) => {
@@ -555,24 +524,56 @@ class ProjectSettings extends React.Component {
     })
   }
 
-  applyTemplate(evt) {
-    evt.preventDefault()
-
+  cloneTemplateAsSurvey(templateUid) {
     this.setState({
       isApplyTemplatePending: true,
       applyTemplateButton: t('Please wait…'),
+      pendingTemplateCloneUid: templateUid,
     })
 
+    // Use dataInterface directly with promise to avoid race with global listeners
+    dataInterface
+      .cloneAsset({
+        uid: templateUid,
+        new_asset_type: 'survey',
+      })
+      .done((asset) => {
+        // Only process if we're still waiting for this specific template
+        if (this.state.pendingTemplateCloneUid === templateUid) {
+          this.setState({
+            formAsset: asset,
+            fields: this.getInitialFieldsFromAsset(asset),
+            pendingTemplateCloneUid: null,
+          })
+          this.resetApplyTemplateButton()
+          this.displayStep(this.STEPS.PROJECT_DETAILS)
+        }
+      })
+      .fail(() => {
+        if (this.state.pendingTemplateCloneUid === templateUid) {
+          this.setState({ pendingTemplateCloneUid: null })
+          this.resetApplyTemplateButton()
+          notify.error(t('Failed to apply template.'))
+        }
+      })
+  }
+
+  applyTemplate(evt) {
+    evt.preventDefault()
+
+    const templateUid = this.state.chosenTemplateUid
+
     if (this.props.context === PROJECT_SETTINGS_CONTEXTS.REPLACE) {
+      this.setState({
+        isApplyTemplatePending: true,
+        applyTemplateButton: t('Please wait…'),
+      })
       actions.resources.updateAsset(this.state.formAsset.uid, {
-        clone_from: this.state.chosenTemplateUid,
+        clone_from: templateUid,
         name: this.state.formAsset.name,
       })
     } else {
-      actions.resources.cloneAsset({
-        uid: this.state.chosenTemplateUid,
-        new_asset_type: 'survey',
-      })
+      this.cloneTemplateAsSurvey(templateUid)
     }
   }
 

--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -468,7 +468,6 @@ class ProjectSettings extends React.Component {
     }
   }
 
-
   getOrCreateFormAsset() {
     const assetPromise = new Promise((resolve, reject) => {
       if (this.state.formAsset) {

--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -553,6 +553,11 @@ class ProjectSettings extends React.Component {
           this.setState({ pendingTemplateCloneUid: null })
           this.resetApplyTemplateButton()
           notify.error(t('Failed to apply template.'))
+          // If auto-cloning from initialTemplateUid failed, close the modal
+          // since the user was sent here specifically for that template
+          if (this.props.initialTemplateUid === templateUid) {
+            pageState.hideModal()
+          }
         }
       })
   }

--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -40,9 +40,10 @@ const VIA_URL_SUPPORT_URL = 'xlsform_with_kobotoolbox.html#importing-an-xlsform-
 /**
  * This is used for multiple different purposes:
  *
- * 1. When creating new project
- * 2. When replacing project with new one
- * 3. When editing project in /settings
+ * 1. When creating new project from scratch
+ * 2. When creating new project from template
+ * 3. When replacing project with new one
+ * 4. When editing project in /settings
  *
  * Identifying the purpose is done by checking `context` and `formAsset`.
  *
@@ -85,7 +86,7 @@ class ProjectSettings extends React.Component {
       // template
       isApplyTemplatePending: false,
       applyTemplateButton: t('Next'),
-      chosenTemplateUid: null,
+      chosenTemplateUid: this.props.initialTemplateUid || null,
       // upload files
       isUploadFilePending: false,
       // archive flow
@@ -102,6 +103,17 @@ class ProjectSettings extends React.Component {
 
   componentDidMount() {
     this.setInitialStep()
+    // If an initial template is provided, apply it immediately
+    if (this.props.initialTemplateUid && this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW) {
+      this.setState({
+        isApplyTemplatePending: true,
+        applyTemplateButton: t('Please wait…'),
+      })
+      actions.resources.cloneAsset({
+        uid: this.props.initialTemplateUid,
+        new_asset_type: 'survey',
+      })
+    }
     when(
       () => sessionStore.isInitialLoadComplete,
       () => {
@@ -169,6 +181,11 @@ class ProjectSettings extends React.Component {
     switch (this.props.context) {
       case PROJECT_SETTINGS_CONTEXTS.NEW:
       case PROJECT_SETTINGS_CONTEXTS.REPLACE:
+        // If an initial template is provided, skip directly to template loading
+        // The actual PROJECT_DETAILS step will be shown after the template is cloned
+        if (this.props.initialTemplateUid && this.props.context === PROJECT_SETTINGS_CONTEXTS.NEW) {
+          return this.displayStep(this.STEPS.CHOOSE_TEMPLATE)
+        }
         return this.displayStep(this.STEPS.FORM_SOURCE)
       case PROJECT_SETTINGS_CONTEXTS.EXISTING:
         return this.displayStep(this.STEPS.PROJECT_DETAILS)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed bug where creating a project from a template in My Library skipped the metadata prompt, leaving required fields blank.

### 💭 Notes

Changes here:
- **projectSettings.js** — Added support for `initialTemplateUid` prop to pre-select a template. When provided, the modal automatically clones the template and shows the `PROJECT_DETAILS` step where metadata is collected.
- **assetQuickActions.tsx** — Changed `cloneAssetAsSurvey()` from using a simple name prompt to opening the full `NEW_FORM` modal flow.
- **assetActionButtons.tsx** — Updated the call site to match the new signature.
- **bigModal.js** — Passes `initialTemplateUid` through to `ProjectSettings` when opening NEW_FORM modal.

Both creation paths (My Library "Create project" button and My Projects "NEW" → "Use a template") now use the same multi-step modal that collects metadata.

### 👀 Preview steps

1. ℹ️ Have an account with at least one template in your library
2. ℹ️ Make sure your server has some required metadata fields configured
3. Go to "My Library"
4. Hover over a template and click the clipboard icon ("Create project")
5. 🔴 [on main] You only get a name prompt, then the project is created with blank metadata
6. 🟢 [on PR] The NEW_FORM modal opens and automatically begins cloning the template
7. 🟢 You see the "Project details" step with fields for Project Name, Sector, Country, Description, and any custom metadata
8. Fill in the metadata fields and click "Create"
9. 🟢 The project is created with all metadata properly filled in

**Bonus verification:** Try the same flow from Projects → NEW → "Use a template" to confirm both paths still work identically.