### PR TITLE
fix(myLibrary): popover menu items not working 2nd time DEV-2302

### DIFF
--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -116,7 +116,7 @@ class AssetActionButtons extends React.Component<AssetActionButtonsProps, AssetA
   }
 
   onPopoverSetVisible() {
-    this.setState({ isPopoverVisible: true })
+    this.setState({ isPopoverVisible: true, shouldHidePopover: false })
   }
 
   // Methods for managing the asset

--- a/jsapp/js/popoverMenu.tsx
+++ b/jsapp/js/popoverMenu.tsx
@@ -36,6 +36,9 @@ type HTMLElementEvent<T extends HTMLElement> = Event & {
   relatedTarget: T
 }
 
+/**
+ * @deprecated please use `js/components/common/Menu`
+ */
 export default class PopoverMenu extends React.Component<PopoverMenuProps, PopoverMenuState> {
   _mounted: boolean
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fix issue with My Library "…" ("More actions") dropdown options not working after trying to use them 2nd time.

### 💭 Notes

Turned out our (now deprecated) `PopoverMenu` component (which has a very weird complex logic) was misconfigured (again, weird complex logic) and thus having that weird bug. One liner was all it took to fix it 🤷

An outcome of this bug is me creating a migration task to get rid of `PopoverMenu` https://linear.app/kobotoolbox/issue/DEV-2303/migrate-all-popovermenu-instances-to-common-menu

### 👀 Preview steps

1. Go to My Library
2. Create a collection (and end up on collection page)
3. Go back to My Library
4. Hover over new collection and choose "…" ("More actions") → Delete
5. A prompt appears
6. Click "Cancel"
7. Hover over same collection and choose "…" ("More actions") → Delete
8. [on main] 🔴 🐛 Nothing happens
9. [on PR] 🟢 Wow, yay, fixed! 🌈✨💖