### PR TITLE
fix(assets): fix 500 when parent uid is wrong DEV-1742

### DIFF
--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -341,7 +341,7 @@ class KpiObjectPermissionsFilter(filters.BaseFilterBackend):
         # but we should only search with one parent uid
         try:
             parent_obj = queryset.get(uid=parent_uids[0])
-        except ObjectDoesNotExist:
+        except (ObjectDoesNotExist, Asset.MultipleObjectsReturned):
             return queryset
 
         if not isinstance(parent_obj, Asset):

--- a/kpi/filters.py
+++ b/kpi/filters.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import FieldError
+from django.core.exceptions import FieldError, ObjectDoesNotExist
 from django.db.models import Case, Count, F, IntegerField, Q, Value, When
 from django.db.models.query import QuerySet
 from django.utils.datastructures import MultiValueDictKeyError
@@ -33,7 +33,6 @@ from kpi.utils.object_permission import (
 )
 from kpi.utils.permissions import is_user_anonymous
 from kpi.utils.query_parser import ParseError, get_parsed_parameters, parse
-
 from .models import Asset, ObjectPermission
 
 
@@ -338,9 +337,12 @@ class KpiObjectPermissionsFilter(filters.BaseFilterBackend):
         except KeyError:
             return queryset
 
-        # `self.__get_parsed_parameters()` returns a list for each parameters
-        # but we should only search only with one parent uid
-        parent_obj = queryset.get(uid=parent_uids[0])
+        # `self.__get_parsed_parameters()` returns a list for each parameter
+        # but we should only search with one parent uid
+        try:
+            parent_obj = queryset.get(uid=parent_uids[0])
+        except ObjectDoesNotExist:
+            return queryset
 
         if not isinstance(parent_obj, Asset):
             return queryset

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -331,6 +331,11 @@ class AssetListApiTests(PermissionsTestMixin, BaseAssetTestCase):
         result_uids_float = [r['uid'] for r in resp_float.data.get('results', [])]
         self.assertIn(asset_float.uid, result_uids_float)
 
+    def test_nonexistent_parent(self):
+        res = self.client.get(self.list_url, data={'q': 'parent__uid:bad'})
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data['results'] == []
+
     def test_assets_ordering(self):
 
         someuser = User.objects.get(username='someuser')


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Return an empty list instead of an error when an invalid parent id is passed to the asset list filter query.


### 👀 Preview steps

1. ℹ️ have an account and a project
2. Navigate to `/api/v2/assets/?q=parent__uid:bad`
3. 🔴 [on main] 500
4. 🟢 [on PR] empty result list

