### PR TITLE
fix(nlp): remove region selector from translation step DEV-2331

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
@@ -77,7 +77,6 @@ export default function StepCreateAutomated({
 
   // TODO: HACK-FIX: We should rely on passing Language instead of LanguageCode throughout the single processing view to avoid
   // using the languages hook here, but this involves dealing with time consuming type handling for LanguageSelector.
-  // For now, we can rely on react-query's caching to not repeat a call and complete the RegionSelector refactor
   const { data, isLoading: isLoadingLanguages } = useLanguagesRetrieve(languageCode, {
     query: {
       queryKey: getLanguagesRetrieveQueryKey(languageCode),

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { Flex, Group, TextInput } from '@mantine/core'
 import { IconLanguage, IconX } from '@tabler/icons-react'
@@ -18,8 +18,7 @@ import KoboIcon from '#/components/common/KoboIcon'
 import Alert from '#/components/common/alert'
 import Button from '#/components/common/button'
 import LoadingSpinner from '#/components/common/loadingSpinner'
-import RegionSelector from '#/components/languages/RegionSelector'
-import type { LanguageCode, LocaleCode } from '#/components/languages/languagesStore'
+import type { LanguageCode } from '#/components/languages/languagesStore'
 import { SUBSEQUENCES_SCHEMA_VERSION } from '#/components/processing/common/constants'
 import { getLatestAutomaticTranslationVersionItem } from '#/components/processing/common/utils'
 import type { AssetResponse } from '#/dataInterface'
@@ -47,8 +46,6 @@ export default function StepCreateAutomated({
   onCreate,
   advancedFeatures,
 }: Props) {
-  const [locale, setLocale] = useState<null | string>(null)
-
   const advancedFeature = advancedFeatures.find(
     (af) => af.action === ActionEnum.automatic_google_translation && af.question_xpath === questionXpath,
   )
@@ -83,7 +80,6 @@ export default function StepCreateAutomated({
   // For now, we can rely on react-query's caching to not repeat a call and complete the RegionSelector refactor
   const { data, isLoading: isLoadingLanguages } = useLanguagesRetrieve(languageCode, {
     query: {
-      // Same key as the RegionSelector hook
       queryKey: getLanguagesRetrieveQueryKey(languageCode),
       enabled: languageCode !== '',
     },
@@ -109,10 +105,6 @@ export default function StepCreateAutomated({
     mutationPatchAF.isPending ||
     mutationCreateAutomaticTranslation.isPending ||
     isLoadingLanguages
-
-  function handleChangeLocale(newVal: LocaleCode | null) {
-    setLocale(newVal)
-  }
 
   function handleClickBack() {
     onBack()
@@ -154,7 +146,7 @@ export default function StepCreateAutomated({
         data: {
           _version: SUBSEQUENCES_SCHEMA_VERSION,
           [questionXpath]: {
-            automatic_google_translation: { language: languageCode, locale },
+            automatic_google_translation: { language: languageCode },
           },
         },
       })
@@ -206,15 +198,6 @@ export default function StepCreateAutomated({
                 icon={IconX}
               />
             }
-          />
-
-          <RegionSelector
-            rootLanguage={languageCode}
-            disabled={anyPending}
-            serviceCode='goog'
-            serviceType='translation'
-            onRegionChange={handleChangeLocale}
-            size='sm'
           />
         </Group>
       </Flex>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Remove region selector from the translate step in the single processing view.

### 👀 Preview steps
1. ℹ️ have an account and a project with an audio submission
2. Create a transcript and go to the translations tab
3. Click "automatic"
4. 🔴 [on main] notice that there is a region selector that doesn't do anything
5. 🟢 [on PR] notice that the region selector is gone