### PR TITLE
fix(longRunningMigrations): backfill root_uuid missed by LRM 0005 DEV-2320

### DIFF
--- a/kobo/apps/long_running_migrations/exceptions.py
+++ b/kobo/apps/long_running_migrations/exceptions.py
@@ -1,0 +1,7 @@
+class LongRunningMigrationDependencyError(Exception):
+    """
+    Raised when a long-running migration cannot start because a required
+    predecessor migration has not yet reached a terminal state
+    (completed or failed). The current migration will be retried on the
+    next Celery beat cycle without being marked as failed.
+    """

--- a/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
@@ -104,6 +104,8 @@ def _process_instances_batch(
             if 'root_uuid should not be empty' in str(e):
                 # fallback on `uuid` to back-fill `root_uuid`
                 instance.root_uuid = instance.uuid
+            else:
+                raise from e
 
         instance_batch_ids.append(instance.pk)
         instance_batch.append(instance)

--- a/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0005_backfill_logger_instance_root_uuid.py
@@ -105,7 +105,7 @@ def _process_instances_batch(
                 # fallback on `uuid` to back-fill `root_uuid`
                 instance.root_uuid = instance.uuid
             else:
-                raise from e
+                raise
 
         instance_batch_ids.append(instance.pk)
         instance_batch.append(instance)

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -1,4 +1,4 @@
-# Generated on 2025-01-16 11:58
+# Generated on 2026-06-23
 from django.conf import settings
 from django.core.management import call_command
 from django.db import IntegrityError, connections
@@ -11,14 +11,21 @@ from kpi.utils.database import use_db
 from kpi.utils.log import logging
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
+FAILED_TAG = 'kobo-root-uuid-failed-0026'
 
 
 def run():
     """
-    Backfills the `root_uuid` field on all `Instance` records that are missing
-    it, processing xforms in batches.
-    """
+    Backfills `root_uuid` and `meta/rootUuid` for any Instance records missed
+    by LRM 0005 (e.g. due to the taggit multi-DB routing bug).
 
+    Tracking strategy:
+    - No success tag: the absence of null `root_uuid` instances proves completion.
+    - A `kobo-root-uuid-failed` tag (written directly to the kobocat DB) marks
+      XForms with unrecoverable errors so they are permanently skipped.
+
+    Safe to run concurrently with or after LRM 0005.
+    """
     _check_root_uuid_unique_index_ready()
 
     last_xform_id = 0
@@ -26,7 +33,7 @@ def run():
         while xforms := get_xforms_queryset(last_xform_id):
             for xform in xforms:
                 logging.info(
-                    f'[LRM 0005] - XForm #{xform.pk} ({xform.id_string}) - In Progress'
+                    f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - In Progress'
                 )
                 error = False
                 while instances := get_instances_queryset(xform.pk):
@@ -35,11 +42,10 @@ def run():
                         break
 
                 if not error:
-                    xform.tags.add('kobo-root-uuid-success')
+                    logging.info(
+                        f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - Done'
+                    )
 
-                logging.info(
-                    f'[LRM 0005] - XForm #{xform.pk} ({xform.id_string}) - Done'
-                )
                 last_xform_id = xform.pk
 
         # Clean up tags while retaining failed entries for future manual review
@@ -58,13 +64,24 @@ def get_instances_queryset(xform_id: int) -> QuerySet:
 
 
 def get_xforms_queryset(xform_id: int) -> QuerySet:
-    # `order_by('pk')` is inexpensive here because `pk` is the primary key and
-    # already indexed. Combined with the `CHUNK_SIZE` limit, each batch is
-    # fetched quickly without scanning the full table.
+    """
+    Returns up to CHUNK_SIZE XForm pks that still have null root_uuid instances
+    and have not been permanently marked as failed.
+
+    Both the null-check and the failed-tag exclusion run within the kobocat DB
+    connection, avoiding cross-DB routing issues.
+    """
+    xform_ids = list(
+        Instance.objects.filter(root_uuid__isnull=True)
+        .values_list('xform_id', flat=True)
+        .filter(xform_id__gt=xform_id)
+        .distinct().order_by('xform_id')[:CHUNK_SIZE]
+    )
+
     return (
         XForm.objects.only('pk', 'id_string')
-        .filter(pk__gt=xform_id)
-        .exclude(tags__name__contains='kobo-root-uuid')
+        .filter(pk__in=xform_ids)
+        .exclude(tags__name__contains=FAILED_TAG)
         .order_by('pk')[:CHUNK_SIZE]
     )
 
@@ -78,17 +95,15 @@ def _check_root_uuid_unique_index_ready():
             JOIN pg_class c ON c.relname = i.indexname
             JOIN pg_index ix ON ix.indexrelid = c.oid
             WHERE i.tablename = %s AND i.indexname = %s
-        """,
+            """,
             ['logger_instance', 'unique_root_uuid_per_xform'],
         )
         row = cursor.fetchone()
         if not (row is not None and row[0]):
             raise RootUUIDConstraintNotEnforced(
-                'The unique index on "root_uuid" is missing or invalid.\n'
-                'Make sure the migration `logger.0041_add_root_uuid_field_to_instance` '
-                'has been applied and that the constraint was successfully created. '
-                'Once that is done, re-run this migration (by setting its status back '
-                'to "CREATED" in the admin interface).'
+                'The unique index on "root_uuid" is missing or invalid. '
+                'Make sure migration `logger.0041_add_root_uuid_field_to_instance` '
+                'has been applied before running this migration.'
             )
 
 
@@ -120,9 +135,9 @@ def _process_instances_batch(
                 )
             except Exception as e:
                 logging.error(
-                    f'[LRM 0005] - Failed to clean duplicated submissions: {str(e)}'
+                    f'[LRM 0027] - Failed to clean duplicated submissions: {str(e)}'
                 )
-                xform.tags.add('kobo-root-uuid-failed')
+                xform.tags.add(FAILED_TAG)
                 return False
 
             # Need to reload instance_batch to get new uuids
@@ -133,7 +148,7 @@ def _process_instances_batch(
                 xform, instance_batch_retry, first_try=False
             )
         else:
-            xform.tags.add('kobo-root-uuid-failed')
+            xform.tags.add(FAILED_TAG)
             return False
     else:
         return True

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -1,11 +1,17 @@
 # Generated on 2026-06-23
+import time
+
 from django.conf import settings
 from django.core.management import call_command
-from django.db import IntegrityError, connections
+from django.db import IntegrityError
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from pymongo import UpdateOne
 
-from kobo.apps.openrosa.apps.logger.exceptions import RootUUIDConstraintNotEnforced
+from kobo.apps.long_running_migrations.exceptions import (
+    LongRunningMigrationDependencyError,
+)
+from kobo.apps.long_running_migrations.models import LongRunningMigration
 from kobo.apps.openrosa.apps.logger.models import Instance, XForm
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kpi.utils.database import use_db
@@ -20,15 +26,16 @@ def run():
     Backfills `root_uuid` and `meta/rootUuid` for any Instance records missed
     by LRM 0005 (e.g. due to the taggit multi-DB routing bug).
 
+    Requires LRM 0005 to be in a terminal state (completed or failed) before
+    starting; retries on the next Celery beat cycle otherwise.
+
     Tracking strategy:
     - No success tag: the absence of null `root_uuid` instances proves completion.
-    - A `kobo-root-uuid-failed` tag (written directly to the kobocat DB) marks
-      XForms with unrecoverable errors so they are permanently skipped.
-
-    Safe to run concurrently with or after LRM 0005.
+    - A `kobo-root-uuid-failed-0026` tag (written directly to the KoboCAT DB)
+      marks XForms with unrecoverable errors so they are permanently skipped.
     """
 
-    _check_root_uuid_unique_index_ready()
+    _check_lrm_0005_is_completed()
 
     last_xform_id = 0
     with use_db(settings.OPENROSA_DB_ALIAS):
@@ -70,6 +77,7 @@ def get_xforms_queryset(xform_id: int) -> QuerySet:
     Both the null-check and the failed-tag exclusion run within the kobocat DB
     connection, avoiding cross-DB routing issues.
     """
+
     xform_ids = list(
         Instance.objects.filter(root_uuid__isnull=True)
         .values_list('xform_id', flat=True)
@@ -85,25 +93,21 @@ def get_xforms_queryset(xform_id: int) -> QuerySet:
     )
 
 
-def _check_root_uuid_unique_index_ready():
-    with connections[settings.OPENROSA_DB_ALIAS].cursor() as cursor:
-        cursor.execute(
-            """
-            SELECT ix.indisvalid
-            FROM pg_indexes i
-            JOIN pg_class c ON c.relname = i.indexname
-            JOIN pg_index ix ON ix.indexrelid = c.oid
-            WHERE i.tablename = %s AND i.indexname = %s
-            """,
-            ['logger_instance', 'unique_root_uuid_per_xform'],
+def _check_lrm_0005_is_completed():
+    """
+    Raises `LongRunningMigrationDependencyError` if LRM 0005 has not yet
+    reached a terminal state (completed or failed). The caller's `execute()`
+    catches this exception and retries on the next Celery beat cycle instead
+    of marking this migration as failed.
+    """
+
+    if not LongRunningMigration.objects.filter(
+        Q(status='completed') | Q(status='failed'),
+        name__startswith='0005',
+    ).exists():
+        raise LongRunningMigrationDependencyError(
+            'LRM 0005 has not reached a terminal state yet'
         )
-        row = cursor.fetchone()
-        if not (row is not None and row[0]):
-            raise RootUUIDConstraintNotEnforced(
-                'The unique index on "root_uuid" is missing or invalid. '
-                'Make sure migration `logger.0041_add_root_uuid_field_to_instance` '
-                'has been applied before running this migration.'
-            )
 
 
 def _process_instances_batch(
@@ -139,7 +143,7 @@ def _process_instances_batch(
                 xform.tags.add(FAILED_TAG)
                 return False
 
-            # Need to reload instance_batch to get new uuids
+            # Need to reload instance_batch to get updated root_uuids
             instance_batch_retry = Instance.objects.only(
                 'pk', 'uuid', 'xml', 'root_uuid'
             ).filter(pk__in=instance_batch_ids)

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -121,6 +121,8 @@ def _process_instances_batch(
             if 'root_uuid should not be empty' in str(e):
                 # fallback on `uuid` to back-fill `root_uuid`
                 instance.root_uuid = instance.uuid
+            else:
+                raise from e
 
         instance_batch_ids.append(instance.pk)
         instance_batch.append(instance)

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -3,10 +3,11 @@ from django.conf import settings
 from django.core.management import call_command
 from django.db import IntegrityError, connections
 from django.db.models.query import QuerySet
-from taggit.models import TaggedItem
+from pymongo import UpdateOne
 
 from kobo.apps.openrosa.apps.logger.exceptions import RootUUIDConstraintNotEnforced
 from kobo.apps.openrosa.apps.logger.models import Instance, XForm
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kpi.utils.database import use_db
 from kpi.utils.log import logging
 
@@ -26,6 +27,7 @@ def run():
 
     Safe to run concurrently with or after LRM 0005.
     """
+
     _check_root_uuid_unique_index_ready()
 
     last_xform_id = 0
@@ -47,9 +49,6 @@ def run():
                     )
 
                 last_xform_id = xform.pk
-
-        # Clean up tags while retaining failed entries for future manual review
-        TaggedItem.objects.filter(tag__name='kobo-root-uuid-success').delete()
 
 
 def get_instances_queryset(xform_id: int) -> QuerySet:
@@ -151,4 +150,17 @@ def _process_instances_batch(
             xform.tags.add(FAILED_TAG)
             return False
     else:
+        _update_mongo_batch(instance_batch)
         return True
+
+
+def _update_mongo_batch(instances: list):
+    mongo_updates = [
+        UpdateOne(
+            {'_id': instance.pk},
+            {'$set': {'meta/rootUuid': add_uuid_prefix(instance.root_uuid)}},
+        )
+        for instance in instances
+    ]
+    if mongo_updates:
+        settings.MONGO_DB.instances.bulk_write(mongo_updates, ordered=False)

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -17,7 +17,7 @@ from kpi.utils.database import use_db
 from kpi.utils.log import logging
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
-FAILED_TAG = 'kobo-root-uuid-failed-0026'
+FAILED_TAG = 'kobo-root-uuid-failed-0027'
 
 
 def run():

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -122,7 +122,7 @@ def _process_instances_batch(
                 # fallback on `uuid` to back-fill `root_uuid`
                 instance.root_uuid = instance.uuid
             else:
-                raise from e
+                raise
 
         instance_batch_ids.append(instance.pk)
         instance_batch.append(instance)

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -1,5 +1,4 @@
 # Generated on 2026-06-23
-import time
 
 from django.conf import settings
 from django.core.management import call_command
@@ -63,10 +62,9 @@ def get_instances_queryset(xform_id: int) -> QuerySet:
     # `xform_id` filter can be applied, making each batch extremely slow.
     # Since we just need to exhaust all instances with a null `root_uuid` for a
     # given xform, their retrieval order does not matter.
-    return (
-        Instance.objects.only('pk', 'uuid', 'xml', 'root_uuid')
-        .filter(root_uuid__isnull=True, xform_id=xform_id)[:CHUNK_SIZE]
-    )
+    return Instance.objects.only('pk', 'uuid', 'xml', 'root_uuid').filter(
+        root_uuid__isnull=True, xform_id=xform_id
+    )[:CHUNK_SIZE]
 
 
 def get_xforms_queryset(xform_id: int) -> QuerySet:
@@ -82,7 +80,8 @@ def get_xforms_queryset(xform_id: int) -> QuerySet:
         Instance.objects.filter(root_uuid__isnull=True)
         .values_list('xform_id', flat=True)
         .filter(xform_id__gt=xform_id)
-        .distinct().order_by('xform_id')[:CHUNK_SIZE]
+        .distinct()
+        .order_by('xform_id')[:CHUNK_SIZE]
     )
 
     return (

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -38,7 +38,10 @@ def run():
 
     last_xform_id = 0
     with use_db(settings.OPENROSA_DB_ALIAS):
-        while xforms := get_xforms_queryset(last_xform_id):
+        while True:
+            xforms, last_xform_id = get_xforms_queryset(last_xform_id)
+            if last_xform_id == -1:
+                break
             for xform in xforms:
                 logging.info(
                     f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - In Progress'
@@ -54,8 +57,6 @@ def run():
                         f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - Done'
                     )
 
-                last_xform_id = xform.pk
-
 
 def get_instances_queryset(xform_id: int) -> QuerySet:
     # No `order_by` here: ordering would force a full table scan before the
@@ -67,10 +68,13 @@ def get_instances_queryset(xform_id: int) -> QuerySet:
     )[:CHUNK_SIZE]
 
 
-def get_xforms_queryset(xform_id: int) -> QuerySet:
+def get_xforms_queryset(xform_id: int) -> tuple[QuerySet, int]:
     """
-    Returns up to CHUNK_SIZE XForm pks that still have null root_uuid instances
-    and have not been permanently marked as failed.
+    Returns `(queryset, next_xform_id)` where `next_xform_id` is the highest
+    candidate XForm PK seen (including failed ones), or -1 if there is no more
+    work. The caller must use `next_xform_id` — not `queryset` results — to
+    advance the pagination cursor, so that permanently-failed XForms at lower
+    PKs never block XForms with higher PKs.
 
     Both the null-check and the failed-tag exclusion run within the kobocat DB
     connection, avoiding cross-DB routing issues.
@@ -84,11 +88,15 @@ def get_xforms_queryset(xform_id: int) -> QuerySet:
         .order_by('xform_id')[:CHUNK_SIZE]
     )
 
+    if not xform_ids:
+        return XForm.objects.none(), -1
+
     return (
         XForm.objects.only('pk', 'id_string')
         .filter(pk__in=xform_ids)
         .exclude(tags__name__contains=FAILED_TAG)
-        .order_by('pk')[:CHUNK_SIZE]
+        .order_by('pk')[:CHUNK_SIZE],
+        max(xform_ids),
     )
 
 

--- a/kobo/apps/long_running_migrations/migrations/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/migrations/0027_backfill_remaining_root_uuid.py
@@ -1,0 +1,27 @@
+# Generated on 2026-06-23
+
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.get_or_create(
+        name='0027_backfill_remaining_root_uuid',
+    )
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0026_backfill_extra_user_detail_last_activity'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, noop),
+    ]

--- a/kobo/apps/long_running_migrations/models.py
+++ b/kobo/apps/long_running_migrations/models.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.db import models
 
+from kobo.apps.long_running_migrations.exceptions import (
+    LongRunningMigrationDependencyError,
+)
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.log import logging
 
@@ -67,6 +70,11 @@ class LongRunningMigration(AbstractTimeStampedModel):
         except (SoftTimeLimitExceeded, TimeLimitExceeded):
             # Let's continue in the next round — this task took too long to
             # complete in a single run.
+            return
+        except LongRunningMigrationDependencyError as e:
+            # A required predecessor migration is not yet complete; retry on
+            # the next Celery beat cycle without marking this one as failed.
+            logging.warning(f'LongRunningMigration.execute(): dependency not met — {e}')
             return
         except Exception as e:
             # Log the error and update the status to 'failed'

--- a/kobo/apps/long_running_migrations/models.py
+++ b/kobo/apps/long_running_migrations/models.py
@@ -75,6 +75,8 @@ class LongRunningMigration(AbstractTimeStampedModel):
             # A required predecessor migration is not yet complete; retry on
             # the next Celery beat cycle without marking this one as failed.
             logging.warning(f'LongRunningMigration.execute(): dependency not met — {e}')
+            self.attempts -= 1
+            self.save(update_fields=['attempts', 'date_modified'])
             return
         except Exception as e:
             # Log the error and update the status to 'failed'

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -55,9 +55,8 @@ class Command(BaseCommand):
                 f'with errors: {error}'
             )
 
-        queryset = (
-            Instance.objects.only('pk', 'uuid', 'xml')
-            .filter(xform__id_string=xform_id_string, root_uuid__isnull=True)
+        queryset = Instance.objects.only('pk', 'uuid', 'xml').filter(
+            xform__id_string=xform_id_string, root_uuid__isnull=True
         )
 
         while True:
@@ -85,8 +84,7 @@ class Command(BaseCommand):
                 break
 
             stubs = [
-                Instance(pk=pk, root_uuid=root_uuid)
-                for pk, root_uuid in update_data
+                Instance(pk=pk, root_uuid=root_uuid) for pk, root_uuid in update_data
             ]
             try:
                 Instance.objects.bulk_update(stubs, ['root_uuid'])
@@ -95,9 +93,7 @@ class Command(BaseCommand):
                 for pk, root_uuid in update_data:
                     self._resolve_conflict_by_pk(pk, root_uuid, xform_id_string)
 
-    def _resolve_conflict_by_pk(
-        self, pk: int, root_uuid: str, xform_id_string: str
-    ):
+    def _resolve_conflict_by_pk(self, pk: int, root_uuid: str, xform_id_string: str):
         try:
             Instance.objects.filter(pk=pk).update(root_uuid=root_uuid)
             settings.MONGO_DB.instances.update_one(
@@ -135,8 +131,7 @@ class Command(BaseCommand):
             instance.xml_hash = instance.get_hash(instance.xml)
             if self._verbosity >= 2:
                 self.stdout.write(
-                    f'\tOld root_uuid: {old_uuid}, '
-                    f'New root_uuid: {new_root_uuid}'
+                    f'\tOld root_uuid: {old_uuid}, ' f'New root_uuid: {new_root_uuid}'
                 )
             Instance.objects.filter(pk=pk).update(
                 xml=instance.xml,

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -4,12 +4,15 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.db.utils import IntegrityError
+from pymongo import UpdateOne
 
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     add_uuid_prefix,
     set_meta,
 )
+
+CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
 
 
 class Command(BaseCommand):
@@ -34,7 +37,6 @@ class Command(BaseCommand):
         if not (xform_id_string := options.get('xform')):
             raise CommandError("XForm's `id_string` must be specified")
 
-        # First
         try:
             exit_code = call_command(
                 'clean_duplicated_submissions',
@@ -53,75 +55,106 @@ class Command(BaseCommand):
                 f'with errors: {error}'
             )
 
-        # Retrieve all instances with the same `uuid`
-        queryset = Instance.objects.filter(
-            xform__id_string=xform_id_string, root_uuid__isnull=True
+        queryset = (
+            Instance.objects.only('pk', 'uuid', 'xml')
+            .filter(xform__id_string=xform_id_string, root_uuid__isnull=True)
         )
 
-        for instance in queryset.iterator():
-            try:
-                instance._populate_root_uuid()  # noqa
+        while True:
+            # Accumulate lightweight (pk, root_uuid) pairs — no xml kept in memory.
+            # iterator(chunk_size=CHUNK_SIZE) fetches CHUNK_SIZE rows per cursor
+            # batch from PostgreSQL, but only one Instance object is live in Python
+            # at a time: the previous one is dereferenced (and its xml GC'd) before
+            # the next is assigned to `instance`.
+            update_data = []
+            for instance in queryset[:CHUNK_SIZE].iterator(chunk_size=CHUNK_SIZE):
+                try:
+                    instance._populate_root_uuid()  # noqa
+                except AssertionError:
+                    # Fallback: use uuid so this instance exits the null filter
+                    # and does not block the loop indefinitely.
+                    instance.root_uuid = instance.uuid
+
                 if self._verbosity >= 1:
                     self.stdout.write(
                         f'Processing root_uuid `{instance.root_uuid}`…'
                     )
-                # Bypass Instance.save() mechanism
-                Instance.objects.filter(pk=instance.pk).update(
-                    root_uuid=instance.root_uuid
+                update_data.append((instance.pk, instance.root_uuid))
+
+            if not update_data:
+                break
+
+            stubs = [
+                Instance(pk=pk, root_uuid=root_uuid)
+                for pk, root_uuid in update_data
+            ]
+            try:
+                Instance.objects.bulk_update(stubs, ['root_uuid'])
+                self._update_mongo_batch(update_data)
+            except IntegrityError:
+                for pk, root_uuid in update_data:
+                    self._resolve_conflict_by_pk(pk, root_uuid, xform_id_string)
+
+    def _resolve_conflict_by_pk(
+        self, pk: int, root_uuid: str, xform_id_string: str
+    ):
+        try:
+            Instance.objects.filter(pk=pk).update(root_uuid=root_uuid)
+            settings.MONGO_DB.instances.update_one(
+                {'_id': pk},
+                {'$set': {'meta/rootUuid': add_uuid_prefix(root_uuid)}},
+            )
+        except IntegrityError:
+            if self._verbosity >= 2:
+                self.stdout.write(f'\tConflict detected on instance #{pk}!')
+
+            # Load XML only now, when we actually need it for conflict resolution
+            instance = Instance.objects.only('pk', 'uuid', 'xml', 'xml_hash').get(pk=pk)
+
+            conflicting_xml_hash = Instance.objects.values_list(
+                'xml_hash', flat=True
+            ).get(root_uuid=root_uuid)
+
+            # Same hash means clean_duplicated_submissions should have handled it
+            if conflicting_xml_hash == instance.xml_hash:
+                return
+
+            old_uuid = instance.uuid
+            now = int(time.time() * 1000)
+            new_root_uuid = f'CONFLICT-{now}-{xform_id_string}-{old_uuid}'
+            try:
+                instance.xml = set_meta(
+                    instance.xml,
+                    'rootUuid',
+                    add_uuid_prefix(new_root_uuid),
                 )
-            except IntegrityError as e:
-                if 'unique_root_uuid_per_xform' not in str(e):
-                    self.stderr.write(
-                        f'Could not update instance #{instance.pk} '
-                        f'- uuid: {instance.uuid}'
-                    )
+            except ValueError:
+                # instance has never been edited
+                pass
 
-                if self._verbosity >= 2:
-                    self.stdout.write('\tConflict detected!')
-
-                xml_hash = Instance.objects.values_list(
-                    'xml_hash', flat=True
-                ).get(root_uuid=instance.root_uuid)
-                # Only consider different hashes, because if there are the
-                # same, they should have been handled by clean_duplicated_submissions
-                # management command
-                if xml_hash != instance.xml_hash:
-                    old_uuid = instance.uuid
-                    now = int(time.time() * 1000)
-                    instance.root_uuid = (
-                        f'CONFLICT-{now}-{xform_id_string}-{old_uuid}'
-                    )
-                    try:
-                        instance.xml = set_meta(
-                            instance.xml,
-                            'rootUuid',
-                            add_uuid_prefix(instance.root_uuid),
-                        )
-                    except ValueError:
-                        # instance has never been edited
-                        pass
-
-                    instance.xml_hash = instance.get_hash(instance.xml)
-                    if self._verbosity >= 2:
-                        self.stdout.write(
-                            f'\tOld root_uuid: {old_uuid}, '
-                            f'New UUID: {instance.root_uuid}'
-                        )
-                    # Bypass Instance.save() mechanism
-                    Instance.objects.filter(pk=instance.pk).update(
-                        xml=instance.xml,
-                        xml_hash=instance.xml_hash,
-                        root_uuid=instance.root_uuid
-                    )
-                    doc = settings.MONGO_DB.instances.find_one(
-                        {'_id': instance.pk}
-                    )
-                    doc['meta/rootUuid'] = add_uuid_prefix(instance.root_uuid)
-                    settings.MONGO_DB.instances.replace_one(
-                        {'_id': instance.pk}, doc, upsert=True
-                    )
-            except AssertionError:
-                self.stderr.write(
-                    f'Could not update root_uuid of instance #{instance.pk} '
-                    f'- uuid: {instance.uuid}'
+            instance.xml_hash = instance.get_hash(instance.xml)
+            if self._verbosity >= 2:
+                self.stdout.write(
+                    f'\tOld root_uuid: {old_uuid}, '
+                    f'New root_uuid: {new_root_uuid}'
                 )
+            Instance.objects.filter(pk=pk).update(
+                xml=instance.xml,
+                xml_hash=instance.xml_hash,
+                root_uuid=new_root_uuid,
+            )
+            doc = settings.MONGO_DB.instances.find_one({'_id': pk})
+            doc['meta/rootUuid'] = add_uuid_prefix(new_root_uuid)
+            settings.MONGO_DB.instances.replace_one({'_id': pk}, doc, upsert=True)
+
+    @staticmethod
+    def _update_mongo_batch(update_data: list):
+        mongo_updates = [
+            UpdateOne(
+                {'_id': pk},
+                {'$set': {'meta/rootUuid': add_uuid_prefix(root_uuid)}},
+            )
+            for pk, root_uuid in update_data
+        ]
+        if mongo_updates:
+            settings.MONGO_DB.instances.bulk_write(mongo_updates, ordered=False)

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -107,14 +107,6 @@ class Command(BaseCommand):
             # Load XML only now, when we actually need it for conflict resolution
             instance = Instance.objects.only('pk', 'uuid', 'xml', 'xml_hash').get(pk=pk)
 
-            conflicting_xml_hash = Instance.objects.values_list(
-                'xml_hash', flat=True
-            ).get(root_uuid=root_uuid)
-
-            # Same hash means clean_duplicated_submissions should have handled it
-            if conflicting_xml_hash == instance.xml_hash:
-                return
-
             old_uuid = instance.uuid
             now = int(time.time() * 1000)
             new_root_uuid = f'CONFLICT-{now}-{xform_id_string}-{old_uuid}'

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -139,8 +139,9 @@ class Command(BaseCommand):
                 root_uuid=new_root_uuid,
             )
             doc = settings.MONGO_DB.instances.find_one({'_id': pk})
-            doc['meta/rootUuid'] = add_uuid_prefix(new_root_uuid)
-            settings.MONGO_DB.instances.replace_one({'_id': pk}, doc, upsert=True)
+            if doc is not None:
+                doc['meta/rootUuid'] = add_uuid_prefix(new_root_uuid)
+                settings.MONGO_DB.instances.replace_one({'_id': pk}, doc)
 
     @staticmethod
     def _update_mongo_batch(update_data: list):

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 from django.conf import settings
-from django.db import transaction
+from django.db import DEFAULT_DB_ALIAS, transaction
 from django.db.models.signals import post_delete, pre_delete
 from django_celery_beat.models import PeriodicTask
 from django_userforeignkey.request import get_current_request
@@ -142,7 +142,7 @@ def delete_instances(xform: XForm, request_data: dict) -> int:
                                     get_optimized_image_path(media_file, suffix)
                                 )
 
-                att_trash_qs = AttachmentTrash.objects.filter(
+                att_trash_qs = AttachmentTrash.objects.using(DEFAULT_DB_ALIAS).filter(
                     attachment_id__in=attachment_ids
                 )
                 periodic_task_ids = list(
@@ -152,7 +152,9 @@ def delete_instances(xform: XForm, request_data: dict) -> int:
                 )
                 att_trash_qs.delete()
                 if periodic_task_ids:
-                    PeriodicTask.objects.filter(pk__in=periodic_task_ids).delete()
+                    PeriodicTask.objects.using(DEFAULT_DB_ALIAS).filter(
+                        pk__in=periodic_task_ids
+                    ).delete()
 
             Attachment.all_objects.filter(instance_id__in=instance_ids).delete()
             Note.objects.filter(instance_id__in=instance_ids).delete()


### PR DESCRIPTION
### 📣 Summary

Some submissions returned a 404 on the supplementary data endpoint because their \`root_uuid\` was never backfilled by LRM 0005 due to a taggit multi-DB routing bug that silently skipped affected XForms.

### 💭 Notes

- LRM 0005 had a taggit multi-DB routing bug that caused some XForms to be silently skipped. LRM 0027 is data-driven (`root_uuid IS NULL`) so it picks up everything missed without relying on tags.
- LRM 0027 waits for LRM 0005 to reach a terminal state via the new `LongRunningMigrationDependencyError`, caught in `execute()` to retry on the next beat cycle without failing.
- `clean_duplicated_submissions_root_uuid` now processes batches without keeping XML in RAM and updates MongoDB in all cases, not only on conflict.
- `delete_instances()` now pins `AttachmentTrash` and `PeriodicTask` to the default DB to avoid a crash when called within a `use_db(settings.OPENROSA_DB_ALIAS)` context.
- LRM 0005 was calling the wrong command on `IntegrityError`; fixed.

### 👀 Preview steps

1. ℹ️ Set up an instance with LRM 0005 `completed` but with XForms that still have `root_uuid IS NULL` instances (simulating the skipped XForms) and MongoDB documents without `meta/rootUuid`. 
2. 🔴 Confirm affected submissions return 404 on `/api/v2/assets/<uid>/data/<uuid>/supplement/`.
3. Apply this PR and run `manage.py migrate` to register LRM 0027.
4. Wait for Celery beat to pick it up, or trigger it from Django admin.
5. 🟢 Confirm `root_uuid` is now populated on all previously null instances.
6. 🟢 Confirm the same submissions no longer 404 on `/supplement/`.