### PR TITLE
fix(bulkProcessing): fix bulk action re-processing after deletion and language switching DEV-2346 DEV-2338

### DIFF
--- a/kobo/apps/subsequences/exceptions.py
+++ b/kobo/apps/subsequences/exceptions.py
@@ -108,7 +108,14 @@ class SupplementMigrationInProgress(Exception):
 
 
 class TranscriptionNotFound(DependencyNotFound):
-    pass
+    def __init__(
+        self,
+        message=(
+            'No accepted transcription found. '
+            'Accept the transcription before running translation.'
+        )
+    ):
+        super().__init__(message)
 
 
 class TranslationAsyncResultAvailable(Exception):

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -365,8 +365,9 @@ class BulkActionCreateSerializer(serializers.Serializer):
             return
 
         action = feature.to_action()
+        params_before_update = list(feature.params)
         action.update_params(feature_params)
-        if action.params != feature.params:
+        if action.params != params_before_update:
             feature.params = action.params
             feature.save(update_fields=['params'])
 

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -1,4 +1,5 @@
 import jsonschema.exceptions
+from copy import deepcopy
 from django.db import IntegrityError, transaction
 from rest_framework import serializers
 
@@ -369,7 +370,7 @@ class BulkActionCreateSerializer(serializers.Serializer):
             return
 
         action = feature.to_action()
-        params_before_update = list(feature.params)
+        params_before_update = deepcopy(feature.params)
         action.update_params(feature_params)
         if action.params != params_before_update:
             feature.params = action.params

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -264,7 +264,11 @@ class BulkActionCreateSerializer(serializers.Serializer):
                 continue
             requested_locale = params.get('locale')
             if requested_locale and data.get('locale') != requested_locale:
-                continue
+                # Deleted versions may have no locale; always include them so a
+                # deletion can clear eligibility regardless of which locale was
+                # originally stored
+                if data.get('status') != 'deleted':
+                    continue
             matching_versions.append(version)
 
         if not matching_versions:

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
@@ -507,3 +507,160 @@ class BulkActionAPITestCase(SubsequenceBaseTestCase):
         assert response.status_code == status.HTTP_201_CREATED
         assert self.submission_uuid in response.data['submission_uuids']
         assert response.data['skipped_uuids'] == []
+
+
+class EnsureQuestionAdvancedFeatureTestCase(SubsequenceBaseTestCase):
+    """
+    Tests that bulk transcription and translation actions correctly remember
+    every language a user has requested, even when different languages are used
+    across separate bulk runs.
+
+    Previously, when a user ran a bulk action with one language and then ran
+    another bulk action with a different language, the system failed to save the
+    new language, so the second request would be rejected. These tests verify
+    that each language is properly recorded and that switching languages between
+    bulk runs always succeeds.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.list_url = reverse(
+            self._get_endpoint('advanced-features-bulk-actions-list'),
+            args=[self.asset.uid],
+        )
+
+    def _call_ensure_feature(self, action_id, question_xpath, params):
+        from kobo.apps.subsequences.serializers import BulkActionCreateSerializer
+
+        serializer = BulkActionCreateSerializer(
+            context={'asset': self.asset, 'request': self.client}
+        )
+        serializer._ensure_question_advanced_feature(
+            asset=self.asset,
+            action_id=action_id,
+            question_xpath=question_xpath,
+            params=params,
+        )
+
+    def test_first_language_creates_feature_with_correct_params(self):
+        """
+        Test that calling _ensure_question_advanced_feature for the first time
+        creates a QuestionAdvancedFeature row with the requested language in params
+        """
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'en'},
+        )
+
+        feature = QuestionAdvancedFeature.objects.get(
+            asset=self.asset,
+            question_xpath='q1',
+            action='automatic_google_transcription',
+        )
+        assert feature.params == [{'language': 'en'}]
+
+    def test_second_language_is_persisted_to_db(self):
+        """
+        Test that calling _ensure_question_advanced_feature with a second
+        language saves both languages to the DB so subsequent bulk jobs have
+        an up-to-date schema that accepts the new language
+        """
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'en'},
+        )
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'fr'},
+        )
+
+        feature = QuestionAdvancedFeature.objects.get(
+            asset=self.asset,
+            question_xpath='q1',
+            action='automatic_google_transcription',
+        )
+        languages = [p['language'] for p in feature.params]
+        assert 'en' in languages
+        assert 'fr' in languages
+
+    def test_duplicate_language_does_not_add_extra_entry(self):
+        """
+        Test that calling _ensure_question_advanced_feature twice with the same
+        language does not create duplicate entries in the feature params list
+        """
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'en'},
+        )
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'en'},
+        )
+
+        feature = QuestionAdvancedFeature.objects.get(
+            asset=self.asset,
+            question_xpath='q1',
+            action='automatic_google_transcription',
+        )
+        assert feature.params == [{'language': 'en'}]
+
+    def test_bulk_action_succeeds_after_switching_language(self):
+        """
+        Test that a bulk transcription request succeeds after a previous bulk
+        action was created with a different language, verifying that the feature
+        params are correctly updated in the DB so the new language is accepted
+        """
+        self._call_ensure_feature(
+            action_id='automatic_google_transcription',
+            question_xpath='q1',
+            params={'language': 'en'},
+        )
+
+        payload = {
+            'action_id': 'automatic_google_transcription',
+            'question_xpath': 'q1',
+            'submission_uuids': [self.submission_uuid],
+            'params': {'language': 'fr', 'locale': 'fr-FR'},
+        }
+        response = self.client.post(self.list_url, data=payload, format='json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+        feature = QuestionAdvancedFeature.objects.get(
+            asset=self.asset,
+            question_xpath='q1',
+            action='automatic_google_transcription',
+        )
+        languages = [p['language'] for p in feature.params]
+        assert 'en' in languages
+        assert 'fr' in languages
+
+    def test_translation_second_language_persisted_to_db(self):
+        """
+        Test that calling _ensure_question_advanced_feature twice with different
+        translation target languages saves both languages, confirming the fix
+        applies equally to translation actions
+        """
+        self._call_ensure_feature(
+            action_id='automatic_google_translation',
+            question_xpath='q1',
+            params={'language': 'de'},
+        )
+        self._call_ensure_feature(
+            action_id='automatic_google_translation',
+            question_xpath='q1',
+            params={'language': 'fr'},
+        )
+
+        feature = QuestionAdvancedFeature.objects.get(
+            asset=self.asset,
+            question_xpath='q1',
+            action='automatic_google_translation',
+        )
+        languages = [p['language'] for p in feature.params]
+        assert 'de' in languages
+        assert 'fr' in languages

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
@@ -452,3 +452,58 @@ class BulkActionAPITestCase(SubsequenceBaseTestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['skipped_uuids'] == []
+
+    def test_create_bulk_action_allowed_after_deleting_transcription_with_locale(self):
+        """
+        Test that a deleted transcription does not prevent creating a new
+        bulk transcription, even when the deleted transcription history
+        contains locale-specific versions
+        """
+        SubmissionSupplement.objects.create(
+            asset=self.asset,
+            submission_uuid=self.submission_uuid,
+            content={
+                '_version': '20250820',
+                'q1': {
+                    'automatic_google_transcription': {
+                        '_dateCreated': '2026-05-14T10:00:00Z',
+                        '_dateModified': '2026-05-14T10:01:00Z',
+                        '_versions': [
+                            {
+                                # The deletion version: no locale, newer timestamp
+                                '_dateCreated': '2026-05-14T10:01:00Z',
+                                '_uuid': '22222222-2222-2222-2222-222222222222',
+                                '_data': {
+                                    'language': 'en',
+                                    'status': 'deleted',
+                                    'value': None,
+                                },
+                            },
+                            {
+                                # The original complete version with locale
+                                '_dateCreated': '2026-05-14T10:00:00Z',
+                                '_uuid': '11111111-1111-1111-1111-111111111111',
+                                '_data': {
+                                    'language': 'en',
+                                    'locale': 'en-US',
+                                    'status': 'complete',
+                                    'value': 'hello world',
+                                },
+                            },
+                        ],
+                    }
+                },
+            },
+        )
+
+        response = self.client.post(
+            self.list_url,
+            data=self._build_payload(
+                submission_uuids=[self.submission_uuid]
+            ),
+            format='json',
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert self.submission_uuid in response.data['submission_uuids']
+        assert response.data['skipped_uuids'] == []


### PR DESCRIPTION
### 📣 Summary
This PR fixes two bugs in the bulk transcription and translation feature that prevented users from re-processing audio submissions after they had already interacted with them.

### 📖 Description
(DEV-2346): When a user switched the interface language and then tried to run a bulk transcription or translation on their submissions, the entire batch would fail with an error. This happened because the language-switching caused an internal mismatch that broke the bulk processing request before it even started.

(DEV-2338): When a user transcribed a submission, then deleted that transcription (via the "Discard" button in the Single Processing view), and then tried to transcribe the same submission again using the same language, they would get a "400 - All submissions are already processed or currently being processed" error. The system was not correctly recognising that the previous transcription had been deleted and was treating the submission as if it was still processed.

What was fixed?                                                                                                                                                                                     Both bugs have been resolved so that users can now:                                                                                                                               
- Switch languages freely without disrupting bulk processing requests.                                                                                                            
- Delete a transcription and immediately re-transcribe the same submission in the same language without errors.


### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Have an account and a project with a few audio submissions.
2. Enable bulk actions in the UI using the `bulkProcessingEnabled` feature flag.
3. Select an audio submission and click "Transcribe selected audio files" to generate a transcription. Use the "Open" button to access the Single Processing view, then click "Discard" on the generated transcription. Finally, click "Done" to return to the Data Table.
4. Request a bulk transcription again for the same submission.
5. 🔴 [On main] Notice that the request fails with a `400` error and the notification "All submissions are already processed or currently being processed." appears.
6. 🟢 [On PR] Notice that the bulk transcription proceeds successfully.
7. Repeat steps 3 and 4, but select a different language for the second transcription request.
8. 🔴 [On main] Notice that the transcription fails (visible in the GET API response).
9. 🟢 [On PR] Notice that the transcription is successfully generated in the requested language.

