### PR TITLE
fix(bulkProcessing): update copy and fix aggressive css DEV-1400

### DIFF
--- a/jsapp/js/components/common/alert.stories.tsx
+++ b/jsapp/js/components/common/alert.stories.tsx
@@ -1,3 +1,4 @@
+import { Stack } from '@mantine/core'
 import Alert from './alert'
 
 export default { title: 'Design system/Alert' }
@@ -6,7 +7,7 @@ export function Demo() {
   const message =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam'
   return (
-    <div>
+    <Stack gap='md'>
       <Alert type='default'>{message}</Alert>
       <Alert iconName='alert' type='default'>
         {message}
@@ -23,6 +24,6 @@ export function Demo() {
       <Alert iconName='alert' type='warning'>
         {message}
       </Alert>
-    </div>
+    </Stack>
   )
 }

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
@@ -215,7 +215,7 @@ export default function StepCreateAutomated({
 
       {errorMessage && (
         <div>
-          <Alert iconName='alert' type='error'>
+          <Alert iconName='alert' type='error' mt='md'>
             {errorMessage}
           </Alert>
         </div>

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
@@ -113,6 +113,11 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
 
   const eligibleSubmissionUuids = eligibleSubmissions.map((s) => s._uuid)
 
+  // Allow language selection even when the only error is 'no-eligible-submissions'
+  // since changing the language might reveal eligible submissions
+  const hasBlockingError =
+    hasErrors && activeAlerts.some((alert) => alert.type === 'error' && alert.id !== 'no-eligible-submissions')
+
   const handleLanguageChange = (language: LanguageCode | null) => {
     setSelectedLanguage(language)
     setSelectedRegion(null)
@@ -171,7 +176,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>
             <LanguageSelector
-              disabled={hasExceededLimit || isLoadingUsage || hasErrors}
+              disabled={hasExceededLimit || isLoadingUsage || hasBlockingError}
               onLanguageChange={handleLanguageChange}
               value={selectedLanguage}
               required
@@ -180,7 +185,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
               nothingFoundMessage={t('I cannot find my language')}
             />
             <RegionSelector
-              disabled={!selectedLanguage || hasExceededLimit || isLoadingUsage || hasErrors}
+              disabled={!selectedLanguage || hasExceededLimit || isLoadingUsage || hasBlockingError}
               rootLanguage={selectedLanguage || ''}
               serviceCode={serviceCode}
               serviceType='transcription'

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
@@ -101,7 +101,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
   const advancedFeatures = advancedFeaturesData?.status === 200 ? advancedFeaturesData.data : []
   const suggestedLanguages = getSuggestedLanguages(advancedFeatures)
 
-  const { activeAlerts, hasErrors, eligibleSubmissions } = useBulkProcessingAlerts({
+  const { activeAlerts, hasErrors, hasBlockingError, eligibleSubmissions } = useBulkProcessingAlerts({
     actionType: 'transcript',
     selectedSubmissions: props.selectedSubmissions,
     selectedLanguage: selectedLanguage || undefined,
@@ -112,11 +112,6 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
   })
 
   const eligibleSubmissionUuids = eligibleSubmissions.map((s) => s._uuid)
-
-  // Allow language selection even when the only error is 'no-eligible-submissions'
-  // since changing the language might reveal eligible submissions
-  const hasBlockingError =
-    hasErrors && activeAlerts.some((alert) => alert.type === 'error' && alert.id !== 'no-eligible-submissions')
 
   const handleLanguageChange = (language: LanguageCode | null) => {
     setSelectedLanguage(language)

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
@@ -161,7 +161,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
         <Stack gap='md'>
           <Text size='sm'>
             {t(
-              'Your ##total_files## audio files is a total of ##total_length##. This should take approximately ##estimated_time## to complete.',
+              'Your ##total_files## audio files is a total of ##total_length##. This may take longer to complete than the total duration of your files.',
             )
               .replace('##total_files##', String(eligibleSubmissions.length))
               // TODO: this will be done after DEV-2255 is done
@@ -171,7 +171,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>
             <LanguageSelector
-              disabled={hasExceededLimit}
+              disabled={hasExceededLimit || isLoadingUsage || hasErrors}
               onLanguageChange={handleLanguageChange}
               value={selectedLanguage}
               required
@@ -180,7 +180,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
               nothingFoundMessage={t('I cannot find my language')}
             />
             <RegionSelector
-              disabled={!selectedLanguage || hasExceededLimit}
+              disabled={!selectedLanguage || hasExceededLimit || isLoadingUsage || hasErrors}
               rootLanguage={selectedLanguage || ''}
               serviceCode={serviceCode}
               serviceType='transcription'

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
@@ -170,8 +170,7 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
             )
               .replace('##total_files##', String(eligibleSubmissions.length))
               // TODO: this will be done after DEV-2255 is done
-              .replace('##total_length##', t('some time'))
-              .replace('##estimated_time##', t('some time'))}
+              .replace('##total_length##', t('some time'))}
           </Text>
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -151,7 +151,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
         <Stack gap='md'>
           <Text size='sm'>
             {t(
-              'Your ##total_selected## transcripts is a total of ##total_characters## characters. This should take ##estimated_time## to complete.',
+              'Your ##total_selected## transcripts is a total of ##total_characters## characters. This may take some time to complete.',
             )
               .replace('##total_selected##', String(eligibleSubmissions.length))
               .replace('##total_characters##', String(totalCharacters))
@@ -161,7 +161,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>
             <LanguageSelector
-              disabled={hasExceededLimit}
+              disabled={hasExceededLimit || isLoadingUsage || hasErrors}
               onLanguageChange={handleLanguageChange}
               value={selectedLanguage}
               required

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -93,7 +93,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const suggestedLanguages = getSuggestedLanguages(advancedFeatures)
 
   // Use bulk processing alerts hook
-  const { activeAlerts, hasErrors, eligibleSubmissions } = useBulkProcessingAlerts({
+  const { activeAlerts, hasErrors, hasBlockingError, eligibleSubmissions } = useBulkProcessingAlerts({
     actionType: 'translation',
     selectedSubmissions: props.selectedSubmissions,
     selectedLanguage: selectedLanguage || undefined,
@@ -101,11 +101,6 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
     serviceUsageData: serviceUsageData || undefined,
     activeBulkActions: props.activeBulkActions,
   })
-
-  // Allow language selection even when the only error is 'no-eligible-submissions'
-  // since changing the language might reveal eligible submissions
-  const hasBlockingError =
-    hasErrors && activeAlerts.some((alert) => alert.type === 'error' && alert.id !== 'no-eligible-submissions')
 
   const handleLanguageChange = (language: LanguageCode | null) => {
     setSelectedLanguage(language)

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -159,9 +159,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
               'Your ##total_selected## transcripts is a total of ##total_characters## characters. This may take some time to complete.',
             )
               .replace('##total_selected##', String(eligibleSubmissions.length))
-              .replace('##total_characters##', String(totalCharacters))
-              // TODO: this will be done after DEV-2255 is done
-              .replace('##estimated_time##', t('some time'))}
+              .replace('##total_characters##', String(totalCharacters))}
           </Text>
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -102,6 +102,11 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
     activeBulkActions: props.activeBulkActions,
   })
 
+  // Allow language selection even when the only error is 'no-eligible-submissions'
+  // since changing the language might reveal eligible submissions
+  const hasBlockingError =
+    hasErrors && activeAlerts.some((alert) => alert.type === 'error' && alert.id !== 'no-eligible-submissions')
+
   const handleLanguageChange = (language: LanguageCode | null) => {
     setSelectedLanguage(language)
   }
@@ -161,7 +166,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
 
           <Group gap='sm' align='flex-start' wrap='nowrap' grow>
             <LanguageSelector
-              disabled={hasExceededLimit || isLoadingUsage || hasErrors}
+              disabled={hasExceededLimit || isLoadingUsage || hasBlockingError}
               onLanguageChange={handleLanguageChange}
               value={selectedLanguage}
               required

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertDefinitions.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertDefinitions.ts
@@ -80,7 +80,7 @@ export function getAlertDefinitions(actionType: BulkActionType): AlertDefinition
       id: 'no-eligible-submissions',
       type: 'error',
       evaluator: evaluateNoEligibleSubmissions,
-      messageTemplate: () => t('There are no submissions to process.'),
+      messageTemplate: () => t('There are no eligible submissions to process.'),
     },
   ]
 }

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertDefinitions.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertDefinitions.ts
@@ -80,7 +80,7 @@ export function getAlertDefinitions(actionType: BulkActionType): AlertDefinition
       id: 'no-eligible-submissions',
       type: 'error',
       evaluator: evaluateNoEligibleSubmissions,
-      messageTemplate: () => t('No submissions to process, see alerts above.'),
+      messageTemplate: () => t('There are no submissions to process.'),
     },
   ]
 }

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
@@ -73,15 +73,8 @@ export function evaluateAlreadyTranslated(context: AlertEvaluationContext): Aler
  */
 export function evaluateNoEligibleSubmissions(context: AlertEvaluationContext): AlertEvaluationResult {
   const eligibleCount = context.submissions.length - context.previouslyFilteredSubmissionUuids.size
-
-  const shouldShow = eligibleCount === 0
-
-  if (shouldShow) {
-    console.info('[BulkProcessingAlerts] Alert "no-eligible-submissions": All submissions filtered out')
-  }
-
   return {
-    shouldShow,
+    shouldShow: eligibleCount === 0,
     type: 'error',
     filteredSubmissionUuids: [],
     computedValues: {

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/useBulkProcessingAlerts.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/useBulkProcessingAlerts.ts
@@ -74,12 +74,6 @@ export function useBulkProcessingAlerts(props: UseBulkProcessingAlertsProps): Us
         // Add filtered submission uuids to the set (for warnings)
         if (result.type === 'warning') {
           result.filteredSubmissionUuids.forEach((uuid) => filteredSubmissionUuids.add(uuid))
-
-          // Debug logging
-          console.info(
-            `[BulkProcessingAlerts] Alert "${alertDef.id}" filtered ${result.filteredSubmissionUuids.length} submissions:`,
-            result.filteredSubmissionUuids,
-          )
         }
 
         // Create active alert

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/useBulkProcessingAlerts.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/useBulkProcessingAlerts.ts
@@ -21,6 +21,8 @@ interface UseBulkProcessingAlertsReturn {
   activeAlerts: ActiveAlert[]
   hasErrors: boolean
   hasWarnings: boolean
+  /** True if there are errors other than 'no-eligible-submissions' */
+  hasBlockingError: boolean
   /** Submissions eligible after filtering */
   eligibleSubmissions: SubmissionResponse[]
   /** UUIDs of eligible submissions */
@@ -97,11 +99,16 @@ export function useBulkProcessingAlerts(props: UseBulkProcessingAlertsProps): Us
     // Compute evaluation state
     const hasErrors = activeAlerts.some((alert) => alert.type === 'error')
     const hasWarnings = activeAlerts.some((alert) => alert.type === 'warning')
+    // This allows language selection even when only no-eligible-submissions error is present. We want users to be able
+    // to select different language, as it could mean there will be eligible submissions.
+    const hasBlockingError =
+      hasErrors && activeAlerts.some((alert) => alert.type === 'error' && alert.id !== 'no-eligible-submissions')
 
     return {
       activeAlerts,
       hasErrors,
       hasWarnings,
+      hasBlockingError,
       eligibleSubmissions,
       eligibleSubmissionUuids,
     }

--- a/jsapp/js/project/FormMedia/index.tsx
+++ b/jsapp/js/project/FormMedia/index.tsx
@@ -210,7 +210,7 @@ export default function FormMedia(props: FormMediaProps) {
     <div className='form-view form-view--form-media'>
       <div className='form-media'>
         {props.asset.deployment__active && (
-          <Alert iconName='alert' type='warning'>
+          <Alert iconName='alert' type='warning' mb='md'>
             {t('You must redeploy this form to see media changes.')}
           </Alert>
         )}

--- a/jsapp/js/theme/kobo/Alert.module.css
+++ b/jsapp/js/theme/kobo/Alert.module.css
@@ -1,13 +1,5 @@
 .root {
   padding: 12px 24px;
-
-  &:not(:last-child) {
-    margin-bottom: 24px;
-  }
-
-  &:not(:first-child) {
-    margin-top: 24px;
-  }
 }
 
 .message {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Changes here:
- Some copy changes in bulk processing modals
- Disabling LanguageSelector and RegionSelector when there are error alerts
- Removing aggressive css margin from Alert component, rather relying on parents to set spacing
- Dropped some console logging