### PR TITLE
fix(processing): enable processing view for questions in renamed groups DEV-2345

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -449,6 +449,21 @@ export function findRowByXpath(assetContent: AssetContent, xpath: string) {
   return assetContent?.survey?.find((row) => row.$xpath === xpath)
 }
 
+/**
+ * Like `findRowByXpath`, but falls back to matching by leaf name when the
+ * xpath doesn't exist in the current schema (e.g. after a group rename).
+ * Note that this will return the first match by leaf name,
+ * which may not be the correct one.
+ */
+export function findRowByXpathOrLeafName(assetContent: AssetContent, xpath: string) {
+  const exactMatch = findRowByXpath(assetContent, xpath)
+  if (exactMatch) {
+    return exactMatch
+  }
+  const leafName = xpath.includes('/') ? xpath.split('/').at(-1) : xpath
+  return leafName ? findRow(assetContent, leafName) : undefined
+}
+
 export function getRowType(assetContent: AssetContent, rowName: string) {
   const foundRow = findRow(assetContent, rowName)
   return foundRow?.type

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/index.tsx
@@ -43,7 +43,7 @@ export default function TranscriptCreate({
     '##type##',
     getProcessedFileLabel(getQuestionType(asset, questionXpath)),
   )
-  const attachment = getAttachmentForProcessing(asset, questionXpath, submission)
+  const attachment = getAttachmentForProcessing(questionXpath, submission)
 
   function goBackToLanguageStep() {
     // Clear the selected language when returning to the language selection step

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptPoll.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptPoll.tsx
@@ -68,7 +68,7 @@ export default function AutomaticTranscriptionInProgress({ asset, questionXpath,
   }, [querySupplement, mutationPending])
 
   useEffect(() => {
-    const attachment = getAttachmentForProcessing(asset, questionXpath, submission)
+    const attachment = getAttachmentForProcessing(questionXpath, submission)
     if (typeof attachment !== 'string') {
       getAudioDuration(attachment.download_url).then((length: number) => {
         setEstimate(secondsToTranscriptionEstimate(length))

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/common/utils.ts
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/common/utils.ts
@@ -1,16 +1,16 @@
-import { findRowByXpath, getRowName } from '#/assetUtils'
+import { findRowByXpathOrLeafName, getRowName } from '#/assetUtils'
 import { type AnyRowTypeName, QUESTION_TYPES } from '#/constants'
 import type { AssetResponse } from '#/dataInterface'
 
 export function getQuestionName(asset: AssetResponse, questionXpath: string) {
   if (!asset?.content) return undefined
-  const foundRow = findRowByXpath(asset.content, questionXpath)
+  const foundRow = findRowByXpathOrLeafName(asset.content, questionXpath)
   return foundRow ? getRowName(foundRow) : undefined
 }
 
 export function getQuestionType(asset: AssetResponse, questionXpath: string): AnyRowTypeName | undefined {
   if (!asset?.content) return undefined
-  const foundRow = findRowByXpath(asset.content, questionXpath)
+  const foundRow = findRowByXpathOrLeafName(asset.content, questionXpath)
   return foundRow?.type
 }
 

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/transcript.utils.ts
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/transcript.utils.ts
@@ -1,40 +1,26 @@
+import type { _DataResponseAttachmentsItem } from '#/api/models/_dataResponseAttachmentsItem'
 import type { DataResponse } from '#/api/models/dataResponse'
-import { findRowByXpath, getRowName } from '#/assetUtils'
-import { getMediaAttachment, getRowData } from '#/components/submissions/submissionUtils'
-import type { AssetResponse, SubmissionAttachment } from '#/dataInterface'
+import { getMediaAttachment } from '#/components/submissions/submissionUtils'
+import type { SubmissionAttachment } from '#/dataInterface'
 import { convertSecondsToMinutes } from '#/utils'
-
-function getQuestionName(asset: AssetResponse, xpath: string) {
-  if (!asset?.content) return undefined
-  const foundRow = findRowByXpath(asset.content, xpath)
-  return foundRow ? getRowName(foundRow) : undefined
-}
 
 /**
  * Returns an error string or the attachment. It's basically a wrapper function
  * over `getMediaAttachment` for DRY purposes.
  */
 export function getAttachmentForProcessing(
-  asset: AssetResponse,
   questionXPath: string,
   submissionData?: DataResponse,
 ): string | SubmissionAttachment {
   const errorMessage = 'Insufficient data'
-
-  const currentQuestionName = getQuestionName(asset, questionXPath)
-  // We need `assetContent` with survey, submission data, and question name to
-  // go further.
-  if (!asset?.content?.survey || !submissionData || !currentQuestionName) {
+  const fileName = submissionData?._attachments?.find(
+    (attachment: _DataResponseAttachmentsItem) => attachment.question_xpath === questionXPath,
+  )?.filename
+  if (!fileName) {
     return errorMessage
   }
 
-  const rowData = getRowData(currentQuestionName, asset.content.survey, submissionData)
-  // We need row data to go further. And we are expecting a string (filename).
-  if (!rowData || typeof rowData !== 'string') {
-    return errorMessage
-  }
-
-  return getMediaAttachment(submissionData, rowData, questionXPath)
+  return getMediaAttachment(submissionData, fileName, questionXPath)
 }
 
 /**

--- a/jsapp/js/components/processing/SingleProcessingHeader/SelectQuestion.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/SelectQuestion.tsx
@@ -1,7 +1,14 @@
 import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
-import { getLanguageIndex, getRowName, getRowTypeIcon, getTranslatedRowLabel } from '#/assetUtils'
+import type { DataResponse } from '#/api/models/dataResponse'
+import {
+  findRowByXpathOrLeafName,
+  getLanguageIndex,
+  getRowName,
+  getRowTypeIcon,
+  getTranslatedRowLabel,
+} from '#/assetUtils'
 import KoboSelect from '#/components/common/koboSelect'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import { goToProcessing } from '#/components/processing/routes.utils'
@@ -13,6 +20,7 @@ import styles from './index.module.scss'
 interface Props {
   currentSubmissionUid: string
   asset: AssetResponse
+  submission: DataResponse
   questionLabelLanguage: LanguageCode | string
   xpath: string
   hasUnsavedWork: boolean
@@ -25,6 +33,7 @@ interface Props {
  */
 export default function SelectQuestion({
   asset,
+  submission,
   currentSubmissionUid,
   questionLabelLanguage,
   xpath,
@@ -49,18 +58,38 @@ export default function SelectQuestion({
       return []
     }
 
-    return assetContent.survey
+    const isAudioRow = (type: string) =>
+      type === QUESTION_TYPES.audio.id || type === QUESTION_TYPES['background-audio'].id
+
+    const buildOption = (optionXpath: string, row: SurveyRow) => {
+      const rowName = getRowName(row)
+      return {
+        value: optionXpath,
+        label: getTranslatedRowLabel(rowName, assetContent.survey, languageIndex) ?? rowName,
+        icon: getRowTypeIcon(row.type),
+      }
+    }
+
+    const result = assetContent.survey
       .filter((question): question is SurveyRow & { $xpath: NonNullable<SurveyRow['$xpath']> } => !!question.$xpath)
-      .filter(({ type }) => type === QUESTION_TYPES.audio.id || type === QUESTION_TYPES['background-audio'].id)
-      .map((question) => {
-        const rowName = getRowName(question)
-        return {
-          value: question.$xpath,
-          label: getTranslatedRowLabel(rowName, assetContent.survey, languageIndex) ?? rowName,
-          icon: getRowTypeIcon(question.type),
-        }
-      })
-  }, [asset.content, questionLabelLanguage])
+      .filter(({ type }) => isAudioRow(type))
+      .map((question) => buildOption(question.$xpath, question))
+
+    // Add entries for audio questions answered in this submission but missing
+    // from the current schema (e.g. after a group rename).
+    for (const submissionXpath of Object.keys(submission)) {
+      if (result.some((o) => o.value === submissionXpath)) {
+        continue
+      }
+      const foundRow = findRowByXpathOrLeafName(assetContent, submissionXpath)
+      if (!foundRow || !isAudioRow(foundRow.type)) {
+        continue
+      }
+      result.push(buildOption(submissionXpath, foundRow))
+    }
+
+    return result
+  }, [asset.content, questionLabelLanguage, submission])
 
   return (
     <section className={classNames(styles.column, styles.columnMain)}>

--- a/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingHeader/index.tsx
@@ -34,6 +34,7 @@ export default function SingleProcessingHeader({
     <header className={styles.root}>
       <SelectQuestion
         asset={asset}
+        submission={submission}
         xpath={xpath}
         currentSubmissionUid={currentSubmissionUid}
         questionLabelLanguage={questionLabelLanguage}

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionData.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionData.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 
 import type { DataResponse } from '#/api/models/dataResponse'
-import { getRowNameByXpath } from '#/assetUtils'
+import { findRowByXpathOrLeafName, getRowName } from '#/assetUtils'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import SubmissionDataList from '#/components/submissions/submissionDataList'
 import { ADDITIONAL_SUBMISSION_PROPS, META_QUESTION_TYPES } from '#/constants'
@@ -35,8 +35,9 @@ export default function SidebarSubmissionData({
 
   /** We want only the processing related data (the actual form questions) */
   const questionsToHide = useMemo(() => {
+    const foundRow = findRowByXpathOrLeafName(asset.content!, xpath)
     const metaQuestions = [
-      getRowNameByXpath(asset.content!, xpath) || '',
+      foundRow ? getRowName(foundRow) : '',
       ...recordKeys(ADDITIONAL_SUBMISSION_PROPS),
       ...recordKeys(META_QUESTION_TYPES),
     ]

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionMedia.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionMedia.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import cx from 'classnames'
 import type { DataResponse } from '#/api/models/dataResponse'
-import { findRowByXpath } from '#/assetUtils'
+import { findRowByXpathOrLeafName } from '#/assetUtils'
 import AttachmentActionsDropdown from '#/attachments/AttachmentActionsDropdown'
 import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import AudioPlayer from '#/components/common/audioPlayer'
@@ -23,7 +23,7 @@ export default function SidebarSubmissionMedia({ asset, xpath, submission }: Sid
     return null
   }
 
-  const attachment = getAttachmentForProcessing(asset, xpath, submission)
+  const attachment = getAttachmentForProcessing(xpath, submission)
   if (typeof attachment === 'string') {
     return null
   }
@@ -35,7 +35,7 @@ export default function SidebarSubmissionMedia({ asset, xpath, submission }: Sid
     )
   }
 
-  switch (findRowByXpath(asset.content, xpath)?.type) {
+  switch (findRowByXpathOrLeafName(asset.content, xpath)?.type) {
     case QUESTION_TYPES.audio.id:
     case QUESTION_TYPES['background-audio'].id:
       return (

--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -71,10 +71,12 @@ export default function DataTableCell(props: DataTableCellProps) {
         props.question.type === QUESTION_TYPES['background-audio'].id
       ) {
         if (mediaAttachment !== null && props.question.$xpath !== undefined) {
+          const audioXpath =
+            typeof mediaAttachment === 'string' ? props.question.$xpath : mediaAttachment.question_xpath
           return (
             <AudioCell
               assetUid={props.asset.uid}
-              xpath={props.question.$xpath}
+              xpath={audioXpath}
               submissionData={submission}
               mediaAttachment={mediaAttachment}
             />


### PR DESCRIPTION
### 📣 Summary
Enables users to view/process answers to audio questions that are included in groups that have been renamed after the relevant submission.

### 💭 Notes
The data table has all of the information it needs to display the audio response for a question with a changed group name based on submission data rather than the current shape of the asset. But the processing view has previously been more conservative, generally choosing to render nothing rather than display submission data that doesn't fit the current shape of the asset. This PR brings the data table's more flexible approach into the processing view. 

#### Changes

**`DataTableCell/index.tsx`**
- `AudioCell` now receives `attachment.question_xpath` instead of `props.question.$xpath`, so the "open in processing" button uses the xpath recorded at submission time rather than the "likely xpath" from the current asset version.

**`transcript.utils.ts`**
- `getAttachmentForProcessing` no longer resolves through the asset schema; it looks up the attachment directly by `question_xpath` on `submission._attachments`. `asset` parameter removed.

**`jsapp/js/assetUtils.ts`**
- Added `findRowByXpathOrLeafName` — like `findRowByXpath` but falls back to matching by leaf question name when the xpath doesn't exist in the current schema (e.g. after a group rename)

**`TabTranscript/common/utils.ts`**
- `getQuestionName` and `getQuestionType` now use `findRowByXpathOrLeafName` instead of `findRowByXpath`

**`sidebarSubmissionMedia.tsx`**
- `getAttachmentForProcessing` call updated; `findRowByXpathOrLeafName` used for the question type switch

**`sidebarSubmissionData.tsx`**
- `questionsToHide` now uses `findRowByXpathOrLeafName` so the current question is still suppressed from the data list after a group rename

**`SelectQuestion.tsx` + `SingleProcessingHeader/index.tsx`**
- Selector now includes entries for audio questions present in the submission but missing from the current schema, so navigation between questions still works after a group rename. `submission` prop added and threaded through from `SingleProcessingHeader`.


### 👀 Preview steps
1. On an NLP-enabled instance, upload this form as a project:
[audio-rename-test.xlsx](https://github.com/user-attachments/files/29351681/audio-rename-test.xlsx)
2. Make at least one submission to the project
3. Change the name of the first group **from** `first_group_name_v1` **to** `first_group_name_v2`
4. Navigate to data table
5. 🔴 [on target branch] notice that the audio file is displayed, along with a button for opening the processing view. But if you click the button, you will not see any data in the processing view (because it is opening for the wrong xpath). To save time, manually edit the url with the correct xpath so you can see what it looks like before switching back to the PR.
6. 🟢 [on PR] See that the processing view opens to the correct question, displaying the correct audio file and allowing you to transcribe/translate/analyze it as usual.

