### PR TITLE
feat(deleteAsset): handle API errors gracefully DEV-1996

### DIFF
--- a/jsapp/js/actions.js
+++ b/jsapp/js/actions.js
@@ -1,7 +1,7 @@
 import alertify from 'alertifyjs'
 import Reflux from 'reflux'
 import { replaceSupportEmail } from '#/textUtils'
-import { notify } from '#/utils'
+import { getErrorMessage, notify } from '#/utils'
 import exportsActions from './actions/exportsActions'
 import libraryActions from './actions/library'
 import { permissionsActions } from './actions/permissions'
@@ -156,19 +156,9 @@ actions.resources.deployAsset.failed.listen((data, redeployment) => {
 
   if (!data.responseJSON || (!data.responseJSON.xform_id_string && !data.responseJSON.detail)) {
     // failed to retrieve a valid response from the server
-    // setContent() removes the input box, but the value is retained
-    var msg
-    const has_error_code = data.status == 500 || data.status == 400
-    if (has_error_code && data.responseJSON && data.responseJSON.error) {
-      msg = `<pre>${data.responseJSON.error}</pre>`
-    } else if (has_error_code && data.responseText) {
-      msg = `<pre>${data.responseText}</pre>`
-    } else {
-      msg = t('please check your connection and try again.')
-    }
     failure_message = `
       <p>${replaceSupportEmail(t('if this problem persists, contact help@kobotoolbox.org'))}</p>
-      <p>${msg}</p>
+      <p>${getErrorMessage(data)}</p>
     `
   } else if (!!data.responseJSON.xform_id_string) {
     // TODO: now that the id_string is automatically generated, this failure
@@ -313,10 +303,10 @@ actions.resources.deleteAsset.listen((details, params = {}) => {
     })
     .fail((err) => {
       actions.resources.deleteAsset.failed(details)
-      alertify.alert(
-        t('Unable to delete asset!'),
-        `<p>${t('Error details:')}</p><pre style='max-height: 200px;'>${err.responseText}</pre>`,
-      )
+      alertify.alert(t('Unable to delete asset!'), `<p>${t('Error details:')}</p>${getErrorMessage(err)}`)
+      if (typeof params.onFail === 'function') {
+        params.onFail(err)
+      }
     })
 })
 

--- a/jsapp/js/api.endpoints.ts
+++ b/jsapp/js/api.endpoints.ts
@@ -9,6 +9,7 @@ export const endpoints = {
   ASSET_HISTORY_ACTIONS: '/api/v2/assets/:asset_uid/history/actions',
   ASSET_HISTORY_EXPORT: '/api/v2/assets/:asset_uid/history/export/',
   ASSET_ADVANCED_FEATURES_BULK_ACTIONS: '/api/v2/assets/:uid/advanced-features/bulk-actions/',
+  ASSETS_BULK_URL: '/api/v2/assets/bulk/',
   ASSETS_URL: '/api/v2/assets/',
   ASSET_URL: '/api/v2/assets/:uid/',
   ASSET_DATA_URL: '/api/v2/assets/:uid/data/',

--- a/jsapp/js/components/DeleteAssetModal/DeleteAssetModal.tsx
+++ b/jsapp/js/components/DeleteAssetModal/DeleteAssetModal.tsx
@@ -12,11 +12,12 @@ export interface DeleteAssetModalProps {
   asset: AssetResponse | ProjectViewAsset
   name: string
   onDeleted?: (deletedAssetUid: string) => void
+  onFailed?: () => void
   modalId: string
   onRequestClose: () => void
 }
 
-export function DeleteAssetModal({ asset, name, onDeleted, modalId, onRequestClose }: DeleteAssetModalProps) {
+export function DeleteAssetModal({ asset, name, onDeleted, onFailed, modalId, onRequestClose }: DeleteAssetModalProps) {
   const assetTypeLabel = ASSET_TYPES[asset.asset_type].label
   const [isDataChecked, setIsDataChecked] = useState(false)
   const [isFormChecked, setIsFormChecked] = useState(false)
@@ -45,6 +46,7 @@ export function DeleteAssetModal({ asset, name, onDeleted, modalId, onRequestClo
       },
       () => {
         setIsConfirmDeletePending(false)
+        onFailed?.()
         onRequestClose()
       },
     )

--- a/jsapp/js/components/DeleteAssetModal/openDeleteAssetModal.tsx
+++ b/jsapp/js/components/DeleteAssetModal/openDeleteAssetModal.tsx
@@ -10,6 +10,7 @@ export function openDeleteAssetModal(
   asset: AssetResponse | ProjectViewAsset,
   name: string,
   onDeleted?: (deletedAssetUid: string) => void,
+  onFailed?: () => void,
 ) {
   const modalId = `delete-asset-${generateUuid()}`
   const [deleteCheck] = userCanDeleteAssets([asset])
@@ -26,6 +27,7 @@ export function openDeleteAssetModal(
           asset={asset}
           name={name}
           onDeleted={onDeleted}
+          onFailed={onFailed}
           modalId={modalId}
           onRequestClose={() => modals.close(modalId)}
         />

--- a/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
+++ b/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Group, Stack, Text } from '@mantine/core'
 import { modals } from '@mantine/modals'
 import { fetchPost, handleApiFail } from '#/api'
+import { endpoints } from '#/api.endpoints'
 import ButtonNew from '#/components/common/ButtonNew'
 import Checkbox from '#/components/common/checkbox'
 import customViewStore from '#/projects/customViewStore'
@@ -42,7 +43,7 @@ export function BulkDeleteModal({ assetUids, modalId, onRequestClose }: BulkDele
 
     // Using notifyAboutError = false to avoid double toast.
     // Calling handleApiFail in catch block to handle all errors unconditionally (error 400 is excluded by default in fetchPost)
-    fetchPost<AssetsBulkResponse>('/api/v2/assets/bulk/', { payload: payload }, { notifyAboutError: false })
+    fetchPost<AssetsBulkResponse>(endpoints.ASSETS_BULK_URL, { payload: payload }, { notifyAboutError: false })
       .then((response) => {
         // Ensure sidebar will refresh after bulk deletion is done.
         // In future we will use react-query for bulk deletion and then this invalidation will be done elsewhere.

--- a/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
+++ b/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import { Group, Stack, Text } from '@mantine/core'
 import { modals } from '@mantine/modals'
-import { fetchPost } from '#/api'
+import { fetchPost, handleApiFail } from '#/api'
 import ButtonNew from '#/components/common/ButtonNew'
 import Checkbox from '#/components/common/checkbox'
 import customViewStore from '#/projects/customViewStore'
@@ -40,7 +40,9 @@ export function BulkDeleteModal({ assetUids, modalId, onRequestClose }: BulkDele
       action: 'delete',
     }
 
-    fetchPost<AssetsBulkResponse>('/api/v2/assets/bulk/', { payload: payload })
+    // Using notifyAboutError = false to avoid double toast.
+    // Calling handleApiFail in catch block to handle all errors unconditionally (error 400 is excluded by default in fetchPost)
+    fetchPost<AssetsBulkResponse>('/api/v2/assets/bulk/', { payload: payload }, { notifyAboutError: false })
       .then((response) => {
         // Ensure sidebar will refresh after bulk deletion is done.
         // In future we will use react-query for bulk deletion and then this invalidation will be done elsewhere.
@@ -48,7 +50,8 @@ export function BulkDeleteModal({ assetUids, modalId, onRequestClose }: BulkDele
         customViewStore.handleAssetsDeleted(assetUids)
         notify(response.detail)
       })
-      .catch(() => {
+      .catch((err) => {
+        handleApiFail(err)
         invalidateSidebarQueries(orgUid)
         customViewStore.fetchAssets()
       })

--- a/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
+++ b/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import { Group, Stack, Text } from '@mantine/core'
 import { modals } from '@mantine/modals'
-import { fetchPost, handleApiFail } from '#/api'
+import { fetchPost } from '#/api'
 import ButtonNew from '#/components/common/ButtonNew'
 import Checkbox from '#/components/common/checkbox'
 import customViewStore from '#/projects/customViewStore'
@@ -48,8 +48,9 @@ export function BulkDeleteModal({ assetUids, modalId, onRequestClose }: BulkDele
         customViewStore.handleAssetsDeleted(assetUids)
         notify(response.detail)
       })
-      .catch((error) => {
-        handleApiFail(error)
+      .catch(() => {
+        invalidateSidebarQueries(orgUid)
+        customViewStore.fetchAssets()
       })
       .finally(() => {
         setIsConfirmDeletePending(false)

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -47,6 +47,8 @@ const ProjectQuickActions = ({ asset }: ProjectQuickActionsProps) => {
         customViewStore.handleAssetsDeleted([deletedAssetUid])
       },
       () => {
+        // On fail, lets update project list so the user has a feedback of fail reason.
+        // e.g: a last minute submission, or the project was deleted by someone else.
         customViewStore.fetchAssets()
       },
     )

--- a/jsapp/js/projects/projectsTable/projectQuickActions.tsx
+++ b/jsapp/js/projects/projectsTable/projectQuickActions.tsx
@@ -40,9 +40,16 @@ const ProjectQuickActions = ({ asset }: ProjectQuickActionsProps) => {
   const canOpenDeleteFlow = isAdmin || (isMmoMember ? userCan('manage_asset', asset) : userCan('delete_asset', asset))
 
   function handleDelete() {
-    openDeleteAssetModal(asset, getAssetDisplayName(asset).final, (deletedAssetUid: string) => {
-      customViewStore.handleAssetsDeleted([deletedAssetUid])
-    })
+    openDeleteAssetModal(
+      asset,
+      getAssetDisplayName(asset).final,
+      (deletedAssetUid: string) => {
+        customViewStore.handleAssetsDeleted([deletedAssetUid])
+      },
+      () => {
+        customViewStore.fetchAssets()
+      },
+    )
   }
 
   return (

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -16,7 +16,7 @@ import type { Toast, ToastOptions } from 'react-hot-toast'
 import { toast } from 'react-hot-toast'
 import type { DataResponse } from '#/api/models/dataResponse'
 import { isMapDisplayableGeopointType } from './constants'
-import type { MongoQuery, SurveyRow } from './dataInterface'
+import type { FailResponse, MongoQuery, SurveyRow } from './dataInterface'
 
 /**
  * Type `Record<string, unknown>` raises problems down the road when using with interfaces without index signature.
@@ -650,3 +650,20 @@ export function createDateQuery(startDate: string, endDate: string): MongoQuery[
 }
 
 export const sleep = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(() => resolve(), ms))
+
+/**
+ * Parses a jQuery XHR / FailResponse error and returns an HTML snippet
+ * describing the error, suitable for embedding in an alertify message.
+ */
+export function getErrorMessage(err: FailResponse): string {
+  if (err.responseJSON?.detail) {
+    return `<pre>${err.responseJSON.detail}</pre>`
+  }
+  if (err.responseJSON?.error) {
+    return `<pre>${err.responseJSON.error}</pre>`
+  }
+  if (err.responseText) {
+    return `<pre style='max-height: 200px;'>${err.responseText}</pre>`
+  }
+  return t('please check your connection and try again.')
+}

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -665,5 +665,5 @@ export function getErrorMessage(err: FailResponse): string {
   if (err.responseText) {
     return `<pre style='max-height: 200px;'>${err.responseText}</pre>`
   }
-  return t('please check your connection and try again.')
+  return t('Please check your connection and try again.')
 }

--- a/jsapp/js/utils.ts
+++ b/jsapp/js/utils.ts
@@ -665,5 +665,5 @@ export function getErrorMessage(err: FailResponse): string {
   if (err.responseText) {
     return `<pre style='max-height: 200px;'>${err.responseText}</pre>`
   }
-  return t('Please check your connection and try again.')
+  return t('please check your connection and try again.')
 }


### PR DESCRIPTION
### 📣 Summary

API errors are handled properly now when deleting an asset.


### 💭 Notes
For single asset deletion:
- A helper function was created to handle API responses that may contain either JSON or text. The function is now used on asset deploy and delete
- Fail callback was added so the project list could be reloaded
- Action fail callback calling fixed
- Deletion modal closes so the error message can be displayed properly

For bulk deletion:
- Removed duplicated toast on fail
- Added project list refresh on fail

### 👀 Preview steps

For single submission:

1. ℹ️ have an account and some projects as an MMO member (not admin)
2. Create a new project and deploy it
2. Open the project in a new tab
2. On the first tab, open the project list, select the project and press delete action
2. Leave deletion modal opened and, on the second tab, open the form on Enketo em submit data
2. Go back to the first tab and go on with the deletion
4. 🔴 [on main] A json error appears on a modal behind the deletion modal. Deletion modal is locked in a loading state.
5. 🟢 [on PR] Deletion modal closes, error appears with the proper information, project list updates, so submission counts are updated

For bulk delete:
1. ℹ️ have an account and some projects as an MMO member (not admin)
2. Create **2** new projects and deploy them
2. Open one of the projects in a new tab
2. On the first tab, open the project list, select the 2 projects and press delete action
2. Leave deletion modal opened and, on the second tab, open the form on Enketo em submit data
2. Go back to the first tab and go on with the deletion
4. 🔴 [on main] 2 toasts with an error message will appear. Project list with submission count are not updated.
5. 🟢 [on PR] Only 1 toast with the error is displayes. Project list is updated.