### PR TITLE
feat(projectSettings): enable delete button for MMO members DEV-2350

### DIFF
--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -314,7 +314,7 @@ class ProjectSettings extends React.Component {
     openDeleteAssetModal(this.state.formAsset, this.state.formAsset.name, this.goToProjectsList.bind(this))
   }
 
-  isMMOOrganization() {
+  isMMO() {
     const account = sessionStore.currentAccount
     const orgUid = 'organization' in account ? account.organization?.uid : undefined
     if (orgUid) {
@@ -326,8 +326,8 @@ class ProjectSettings extends React.Component {
     return false
   }
 
-  canOpenDeleteFlow() {
-    return this.isMMOOrganization() || userCan('delete_asset', this.state.formAsset)
+  userCanViewDeleteButton() {
+    return this.isMMO() || userCan('delete_asset', this.state.formAsset)
   }
 
   // archive flow
@@ -1123,7 +1123,7 @@ class ProjectSettings extends React.Component {
               </div>
             )}
 
-          {this.canOpenDeleteFlow() && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING && (
+          {this.userCanViewDeleteButton() && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING && (
             <div className={styles.input}>
               <Button
                 type='danger'

--- a/jsapp/js/components/modalForms/projectSettings.js
+++ b/jsapp/js/components/modalForms/projectSettings.js
@@ -9,6 +9,8 @@ import reactMixin from 'react-mixin'
 import Reflux from 'reflux'
 import { actions } from '#/actions'
 import { handleApiFail } from '#/api'
+import { queryClient } from '#/api/queryClient'
+import { getOrganizationsRetrieveQueryKey } from '#/api/react-query/user-team-organization-usage'
 import { archiveAsset, unarchiveAsset } from '#/assetQuickActions'
 import assetUtils from '#/assetUtils'
 import { openDeleteAssetModal } from '#/components/DeleteAssetModal/openDeleteAssetModal'
@@ -310,6 +312,22 @@ class ProjectSettings extends React.Component {
     evt.preventDefault()
 
     openDeleteAssetModal(this.state.formAsset, this.state.formAsset.name, this.goToProjectsList.bind(this))
+  }
+
+  isMMOOrganization() {
+    const account = sessionStore.currentAccount
+    const orgUid = 'organization' in account ? account.organization?.uid : undefined
+    if (orgUid) {
+      const orgResponse = queryClient.getQueryData(getOrganizationsRetrieveQueryKey(orgUid))
+      if (orgResponse?.status === 200 && orgResponse.data?.is_mmo) {
+        return true
+      }
+    }
+    return false
+  }
+
+  canOpenDeleteFlow() {
+    return this.isMMOOrganization() || userCan('delete_asset', this.state.formAsset)
   }
 
   // archive flow
@@ -1105,21 +1123,20 @@ class ProjectSettings extends React.Component {
               </div>
             )}
 
-          {userCan('delete_asset', this.state.formAsset) &&
-            this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING && (
-              <div className={styles.input}>
-                <Button
-                  type='danger'
-                  size='l'
-                  label={
-                    this.state.formAsset.deployment__submission_count > 0
-                      ? t('Delete Project and Data')
-                      : t('Delete Project')
-                  }
-                  onClick={this.deleteProject}
-                />
-              </div>
-            )}
+          {this.canOpenDeleteFlow() && this.props.context === PROJECT_SETTINGS_CONTEXTS.EXISTING && (
+            <div className={styles.input}>
+              <Button
+                type='danger'
+                size='l'
+                label={
+                  this.state.formAsset.deployment__submission_count > 0
+                    ? t('Delete Project and Data')
+                    : t('Delete Project')
+                }
+                onClick={this.deleteProject}
+              />
+            </div>
+          )}
         </div>
       </form>
     )


### PR DESCRIPTION
### 📣 Summary
Now the delete project button in project settnigs is always visible to MMO members

### 💭 Notes
Even if the project is not deletable by the current combination of user, project having data or ownership, the button needs to always be visible so the user can click and see the error that explain why they cannot delete that project.

### 👀 Preview steps
1. ℹ️ have an account and a project
2. be an mmo member (not admin)
3. Go to the project settings tab in a project
4. 🔴 [on main] no delete button is visible
5. 🟢 [on PR] delete button is visible and, when clicking on it, same behavior of project quick action should be triggered