### PR TITLE
refactor(formMap): hide map tiles to avoid uncontrollable chromatic test failures

### DIFF
--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -142,8 +142,32 @@ const meta: Meta<typeof FormMapWrapper> = {
       routing: { path: ROUTES.FORM_DATA },
     }),
     a11y: { test: 'todo' },
+    chromatic: {
+      delay: 1000,
+    },
   },
-  decorators: [withRouter, queryClientDecorator, withMinHeightWrapper(400, { height: 400 })],
+  decorators: [
+    withRouter,
+    queryClientDecorator,
+    withMinHeightWrapper(400, { height: 400 }),
+    // Hide map tiles for Chromatic tests - prevents flakiness from map images rendering differently (we had tiny
+    // differences causing tests to fail)
+    (Story) => (
+      <>
+        <style>
+          {`
+            .leaflet-tile-pane {
+              opacity: 0 !important;
+            }
+            #data-map {
+              background: #a8e4f0 !important;
+            }
+          `}
+        </style>
+        <Story />
+      </>
+    ),
+  ],
 }
 
 export default meta


### PR DESCRIPTION
### 💭 Notes

The map Storybook tests kept failing Chromatic checks because OpenStreetMap tiles would render with tiny pixel differences between runs. A few dozen pixels would shift around, causing false positive failures.

Changes here:
- `FormMapWrapper.stories.tsx`: Added a decorator that hides the tile layer with CSS (makes `.leaflet-tile-pane` invisible) and replaces it with a solid light blue background. Also added 1000ms delay in Chromatic config so the map has time to initialize before snapshots.

### 👀 Preview steps

1. ℹ️ Open Storybook locally: `npm run storybook`
2. Navigate to Features → FormMap → WithOnlyStartGeopoint or WithBothGeopointTypes
3. 🟢 Notice the map background is now solid light blue instead of showing OpenStreetMap tiles
4. 🟢 Confirm all UI elements still work: settings button, layer toggle, fullscreen, markers, legend