### PR TITLE
feat(bulkProcessing): poll activity logs if bulk processing is in progress DEV-2381

### DIFF
--- a/jsapp/js/UniversalTable/index.tsx
+++ b/jsapp/js/UniversalTable/index.tsx
@@ -63,6 +63,12 @@ interface UniversalTableProps<Datum, TError = Error | ErrorDetail | ErrorObject>
   maxHeight?: number | string
   /** Used to inject infinite scroll observers or footer info into the table. */
   bottomContent?: React.ReactNode
+  /**
+   * Controls when spinner overlay is shown.
+   * - `fetching` shows spinner for all fetches, including background refetches.
+   * - `loading` shows spinner only while there is no data yet.
+   */
+  spinnerVisibility?: 'fetching' | 'loading'
 }
 
 export const PAGE_SIZES = [10, 30, 50, 100]
@@ -104,6 +110,7 @@ export default function UniversalTable<Datum, TError = Error>({
   setPagination,
   maxHeight,
   bottomContent,
+  spinnerVisibility = 'fetching',
 }: UniversalTableProps<Datum, TError>) {
   const availablePages = useMemo(
     () => (queryResult.data?.status === 200 ? Math.ceil(queryResult.data?.data?.count / pagination.limit) : 0),
@@ -112,13 +119,15 @@ export default function UniversalTable<Datum, TError = Error>({
 
   const currentPageIndex = useMemo(() => Math.ceil(pagination.start / pagination.limit), [pagination])
 
+  const isSpinnerVisible = spinnerVisibility === 'loading' ? queryResult.isLoading : queryResult.isFetching
+
   if (queryResult.data?.status !== 200) return null
 
   return (
     <UniversalTableCore<Datum>
       columns={columns}
       data={queryResult.data?.data.results ?? []}
-      isSpinnerVisible={queryResult.isFetching}
+      isSpinnerVisible={isSpinnerVisible}
       maxHeight={maxHeight}
       bottomContent={bottomContent}
       pageIndex={currentPageIndex}

--- a/jsapp/js/components/activity/FormActivity.tsx
+++ b/jsapp/js/components/activity/FormActivity.tsx
@@ -76,9 +76,9 @@ export default function FormActivity() {
         return false
       }
 
-      // Poll every 10 seconds when there are ongoing items
+      // Poll every 5 seconds when there are ongoing items
       // This is a reasonable interval that balances responsiveness with server load
-      return 10000
+      return 5000
     },
     // Only poll while the tab is foregrounded
     refetchIntervalInBackground: false,

--- a/jsapp/js/components/activity/FormActivity.tsx
+++ b/jsapp/js/components/activity/FormActivity.tsx
@@ -55,6 +55,33 @@ export default function FormActivity() {
         start: pagination.start,
       }),
     placeholderData: keepPreviousData,
+    refetchInterval: (query) => {
+      // Poll only when there are ongoing bulk processing items
+      const data = query.state.data?.status === 200 ? query.state.data.data : null
+      if (!data?.results) {
+        return false
+      }
+
+      // Check if there are any ongoing bulk processing activities
+      const hasOngoingBulkProcessing = data.results.some((item) => {
+        if (item.action !== 'bulk-processing') {
+          return false
+        }
+        const bulkAction = item.metadata.bulk_action
+        return bulkAction?.status === 'in_progress' || bulkAction?.status === 'pending'
+      })
+
+      // If no ongoing items, stop polling
+      if (!hasOngoingBulkProcessing) {
+        return false
+      }
+
+      // Poll every 10 seconds when there are ongoing items
+      // This is a reasonable interval that balances responsiveness with server load
+      return 10000
+    },
+    // Only poll while the tab is foregrounded
+    refetchIntervalInBackground: false,
   })
 
   const columns: Array<UniversalTableColumn<ActivityLogsItem>> = [

--- a/jsapp/js/components/activity/FormActivity.tsx
+++ b/jsapp/js/components/activity/FormActivity.tsx
@@ -138,6 +138,7 @@ export default function FormActivity() {
           setPagination={setPagination}
           columns={columns}
           queryResult={queryResult}
+          spinnerVisibility='loading'
         />
       </div>
     </div>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Activity log now automatically updates bulk processing counters while jobs are running.

### 💭 Notes

Changes here:
- **FormActivity.tsx**: Added polling to the activity logs query. When there's an ongoing bulk transcription or translation job in the activity log, the page refreshes every 10 seconds to update the progress counter. Once all jobs finish (or if there aren't any running), polling stops automatically.

The polling follows the same pattern we use in the data table for bulk actions, adapted for the activity log context where we have less detailed info available.

### 👀 Preview steps

1. ℹ️ Have a project with audio questions and some submissions
2. Go to Project → Data → Table
3. Start a bulk transcription job on a few submissions
4. Navigate to Project → Settings → Activity
5. 🔴 [on main] The bulk processing activity shows up but the counter (e.g., "0/10") never updates unless you refresh the page
6. 🟢 [on PR] The counter updates automatically every 5 seconds showing progress (e.g., "3/10" → "5/10" → "10/10")
7. 🟢 Once the job completes, the activity log shows the final state and stops polling