### PR TITLE
fix(gallery): heic images not being displayed DEV-2105

### DIFF
--- a/jsapp/js/components/formGallery/formGallery.component.tsx
+++ b/jsapp/js/components/formGallery/formGallery.component.tsx
@@ -233,7 +233,7 @@ export default function FormGallery(props: FormGalleryProps) {
             {/* Current image */}
             <Box style={{ flexGrow: 1, minWidth: 0 }}>
               <Image
-                src={currentAttachment.download_url}
+                src={currentAttachment.download_large_url || currentAttachment.download_url}
                 alt={currentAttachment.filename}
                 fit='contain'
                 style={{ maxHeight: '70vh', width: '100%' }}

--- a/jsapp/js/components/formGallery/formGallery.selectors.ts
+++ b/jsapp/js/components/formGallery/formGallery.selectors.ts
@@ -3,7 +3,14 @@ import type { Json } from '#/components/common/common.interfaces'
 import type { MongoQuery, SubmissionAttachment, SubmissionResponse } from '#/dataInterface'
 import { createDateQuery } from '#/utils'
 
-const IMAGE_MIMETYPES = ['image/png', 'image/gif', 'image/jpeg', 'image/svg+xml']
+const IMAGE_MIMETYPES = [
+  'image/png',
+  'image/gif',
+  'image/jpeg',
+  'image/svg+xml',
+  'image/heic',
+  'image/heif',
+]
 
 /**
  * Data api does not return the exact file name

--- a/jsapp/js/components/formGallery/formGallery.selectors.ts
+++ b/jsapp/js/components/formGallery/formGallery.selectors.ts
@@ -3,14 +3,7 @@ import type { Json } from '#/components/common/common.interfaces'
 import type { MongoQuery, SubmissionAttachment, SubmissionResponse } from '#/dataInterface'
 import { createDateQuery } from '#/utils'
 
-const IMAGE_MIMETYPES = [
-  'image/png',
-  'image/gif',
-  'image/jpeg',
-  'image/svg+xml',
-  'image/heic',
-  'image/heif',
-]
+const IMAGE_MIMETYPES = ['image/png', 'image/gif', 'image/jpeg', 'image/svg+xml', 'image/heic', 'image/heif']
 
 /**
  * Data api does not return the exact file name


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

HEIC images now show up in the Project → Data → Gallery view.

### 💭 Notes

Changes here:
- **`formGallery.selectors.ts`** — Added `image/heic` and `image/heif` to the allowed image types so they pass the frontend filter
- **`formGallery.component.tsx`** — Modal now uses `download_large_url` (1280px JPEG thumbnail) instead of `download_url` (the original file) to display images

The backend already converts HEIC/HEIF to JPEG thumbnails (small: 240px, medium: 640px, large: 1280px) while keeping the original file intact. The gallery grid was fine because it uses `download_small_url`, but the modal was trying to show the original HEIC file, which browsers can't render. Now it shows the large JPEG version instead.

### 👀 Preview steps

1. ℹ️ You'll need a project with image question and file question
2. Make a submission with heic image https://heic.digital/samples/ and heif file https://convertico.com/samples/heif/
3. Go to Project → Data → Gallery
4. 🔴 [on main] HEIC and HEIF images don't appear in the gallery grid at all
5. 🟢 [on PR] Both images appears as thumbnails in the gallery grid
6. Click on the HEIC/HEIF image thumbnail
7. 🔴 [on main] N/A
8. 🟢 [on PR] The image displays properly in the modal at 1280px resolution
9. Navigate between images with the arrow buttons to confirm everything still works

HEIF images are unfortunately not testable through `image` question, as Enketo doesn't allow uploading them to `image` questions. Thus we use the `file` question hack/feature.