### PR TITLE
feat(bulkProcessing): use proper xpath for bulk translation DEV-2379

### DIFF
--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -1,4 +1,5 @@
 import { Anchor, Group, Stack, Text } from '@mantine/core'
+import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ACCOUNT_ROUTES } from '#/account/routes.constants'
@@ -6,6 +7,7 @@ import type { ServerError } from '#/api/ServerError'
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import {
+  getAssetsAdvancedFeaturesBulkActionsListQueryKey,
   useAssetsAdvancedFeaturesBulkActionsCreate,
   useAssetsAdvancedFeaturesList,
 } from '#/api/react-query/survey-data'
@@ -44,12 +46,19 @@ export interface BulkTranslationModalProps {
 export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const [showWarningModal, setShowWarningModal] = useState<boolean>(props.showWarningModal)
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageCode | null>(null)
+  const queryClient = useQueryClient()
+
   const { mutate: createBulkTranslation, isPending } = useAssetsAdvancedFeaturesBulkActionsCreate({
     mutation: {
       onSuccess: () => {
         notify.success(t('Bulk translation request submitted successfully'))
 
-        // TODO: implement @mantine/notifications system, see DEV-2211
+        // Invalidate the bulk actions list so React Query refetches it.
+        // This triggers BulkProcessingBanner to appear (or update its count if already visible).
+        queryClient.invalidateQueries({
+          queryKey: getAssetsAdvancedFeaturesBulkActionsListQueryKey(props.assetUid),
+        })
+
         props.onRequestClose()
         props.onSuccess()
       },

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -13,17 +13,18 @@ import {
   getOrganizationsServiceUsageRetrieveQueryKey,
   useOrganizationsServiceUsageRetrieve,
 } from '#/api/react-query/user-team-organization-usage'
+import ButtonNew from '#/components/common/ButtonNew'
 import Alert from '#/components/common/alert'
+import LanguageSelector from '#/components/languages/LanguageSelector'
+import type { LanguageCode } from '#/components/languages/languagesStore'
+import { getSuggestedLanguages } from '#/components/processing/common/utils'
+import { getSupplementalPathParts } from '#/components/processing/processingUtils'
+import { BulkProcessingWarningModal } from '#/components/submissions/BulkProcessingModals/BulkProcessingWarningModal'
+import { getSupplementalDetailsContent } from '#/components/submissions/submissionUtils'
 import type { SubmissionResponse } from '#/dataInterface'
 import envStore from '#/envStore'
 import { useSession } from '#/stores/useSession'
 import { notify } from '#/utils'
-import ButtonNew from '../../../common/ButtonNew'
-import LanguageSelector from '../../../languages/LanguageSelector'
-import type { LanguageCode } from '../../../languages/languagesStore'
-import { getSuggestedLanguages } from '../../../processing/common/utils'
-import { BulkProcessingWarningModal } from '../../BulkProcessingModals/BulkProcessingWarningModal'
-import { getSupplementalDetailsContent } from '../../submissionUtils'
 import BulkProcessingAlerts from '../alerts/BulkProcessingAlerts'
 import { useBulkProcessingAlerts } from '../alerts/useBulkProcessingAlerts'
 
@@ -113,13 +114,17 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const eligibleSubmissionUuids = eligibleSubmissions.map((submission) => submission._uuid)
 
   const handleStartTranslation = () => {
+    // Extract the source row path from the transcript column path
+    // e.g., "_supplementalDetails/q1/transcript_en" -> "q1"
+    const { sourceRowPath } = getSupplementalPathParts(props.fieldXpath)
+
     // Use eligibleSubmissionUuids from the alerts hook to filter out submissions
     // that have been flagged by warning evaluators (e.g., already translated, no source)
     createBulkTranslation({
       uidAsset: props.assetUid,
       data: {
         action_id: ActionIdEnum.automatic_google_translation,
-        question_xpath: props.fieldXpath,
+        question_xpath: sourceRowPath,
         submission_uuids: eligibleSubmissionUuids,
         params: {
           language: selectedLanguage!,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed bulk translation requests that were failing due to incorrect question path being sent to the backend.

### 💭 Notes

Changes here:
- **BulkTranslationModal.tsx**: 
  - Extract the actual question path from the full supplemental details path before sending to API (turns `_supplementalDetails/q1/transcript_en` into just `q1` like the backend expects)
  - Add query invalidation after successful submission so the BulkProcessingBanner appears and cells show "Processing" status (transcription modal had this, translation modal didn't)

### 👀 Preview steps

1. ℹ️ Have a project with an audio question and some submissions with completed transcripts
2. Go to Project → Data → Table
3. Select one or more rows that have transcripts (but not translations yet)
4. Click the transcript column header menu
5. Choose "Translate selected transcripts"
6. Pick a target language and click "Create translations"
7. 🔴 [on main] Request fails silently or with error, no processing banner appears, cells stay empty
8. 🟢 [on PR] Success toast appears, BulkProcessingBanner shows up at the top, and the selected cells show "Processing" status
