### PR TITLE
fix(bulkProcessing): skip already-accepted versions in bulk-accept DEV-2385

### DIFF
--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -473,6 +473,10 @@ class BulkAcceptSerializer(serializers.Serializer):
                 if version_data.get('value') is None:
                     continue
 
+                # Skip versions that are already accepted
+                if latest_version.get('_dateAccepted'):
+                    continue
+
                 latest_version['_dateAccepted'] = now_str
                 target['_dateModified'] = now_str
 

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
@@ -297,13 +297,13 @@ class BulkAcceptAPITestCase(SubsequenceBaseTestCase):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['accepted_count'] == 0
 
-    def test_bulk_accept_already_accepted_updates_date(self):
+    def test_bulk_accept_already_accepted_returns_zero(self):
         """
-        Test that Re-accepting an already-accepted version overwrites
-        `_dateAccepted` with the current timestamp and is counted
+        Test that re-accepting an already-accepted version must be a no-op:
+        `accepted_count` should be 0 and `_dateAccepted` must remain unchanged
         """
         self._create_transcription_supplements()
-        # Accept once
+        # First accept - stamps _dateAccepted
         self._post_accept(
             {
                 'submission_uids': [self.submission_uuid],
@@ -318,8 +318,9 @@ class BulkAcceptAPITestCase(SubsequenceBaseTestCase):
         first_date = supp_before.content['q1']['automatic_google_transcription'][
             '_versions'
         ][0].get('_dateAccepted')
+        assert first_date is not None
 
-        # Accept again
+        # Second accept: version is already accepted, so no action is taken
         response = self._post_accept(
             {
                 'submission_uids': [self.submission_uuid],
@@ -328,16 +329,18 @@ class BulkAcceptAPITestCase(SubsequenceBaseTestCase):
                 'operation': 'accept',
             }
         )
-        assert response.data['accepted_count'] == 1
+        assert response.status_code == status.HTTP_200_OK
+        # No new records accepted, the submission was already accepted
+        assert response.data['accepted_count'] == 0
+
+        # _dateAccepted must be unchanged (not overwritten)
         supp_after = SubmissionSupplement.objects.get(
             asset=self.asset, submission_uuid=self.submission_uuid
         )
         second_date = supp_after.content['q1']['automatic_google_transcription'][
             '_versions'
         ][0].get('_dateAccepted')
-        # Both dates are present; second may equal or be later than first
-        assert first_date is not None
-        assert second_date is not None
+        assert second_date == first_date
 
     def test_bulk_accept_empty_submission_uids_returns_400(self):
         response = self._post_accept(


### PR DESCRIPTION
### 📣 Summary
The bulk-accept endpoint (`POST /api/v2/assets/{uid_asset}/data/supplements/bulk/`) was re-stamping `_dateAccepted` and counting already-accepted submissions on every call, making `accepted_count` misleading. Added a guard in `BulkAcceptSerializer.accept()` to skip versions where `_dateAccepted` is already set.

### 📖 Description
Calling the bulk-accept endpoint multiple times for the same submission always returned `accepted_count: 1` (or more), even though no new acceptance action was performed. The caller had no way to distinguish "just accepted" from "already accepted".

This PR adds an early continue in the per-supplement loop when latest_version.get(`_dateAccepted`) is already truthy. Already-accepted versions are now silently skipped `_dateAccepted` is not modified and the supplement is excluded from `to_update`, so `accepted_count` correctly reflects only newly accepted records.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Have an account with a project that contains audio submissions.
2. Create a transcription for an audio submission, but do not accept it from the UI. Instead, use the `POST /api/v2/assets/{uid_asset}/data/supplements/bulk/` endpoint from `/api/v2/docs` to accept it. Verify that the response contains `accepted_count: 1`, and confirm in the UI that the transcription is marked as accepted.
3. Send the same API request again using the exact same payload.
4. 🔴 On main: Notice that the API still returns `accepted_count: 1`.
5. 🟢 On this PR: Notice that the API now returns `accepted_count: 0` and does not update the `dateAccepted` timestamp.
6. Repeat the same steps for translations.

