### PR TITLE
fix(maps): overflow for lists in map disaggregation dropdown DEV-2388

### DIFF
--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -1275,7 +1275,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
                     </ButtonNew>
                   </Menu.Target>
 
-                  <Menu.Dropdown>
+                  <Menu.Dropdown style={{ maxHeight: 300, overflowY: 'auto' }}>
                     {langs.length > 1 && <Menu.Label>{t('Language')}</Menu.Label>}
                     {langs.map((l, i) => (
                       <Menu.Item


### PR DESCRIPTION
### 📣 Summary
Adds scrollable overflow for map disaggregation dropdown so long lists of questions can be displayed.

### 👀 Preview steps

1. Upload this form: 
[long-list-geopoint.xlsx](https://github.com/user-attachments/files/29561883/long-list-geopoint.xlsx)
2. Make a couple submissions
3. 🔴 [on main] notice that list takes up whole screen and can't be scrolled
4. 🟢 [on PR] notice that list height is capped and list can be scrolled
