### PR TITLE
fix(auth): handle user names from IdP and metadata refactor DEV-2394

### DIFF
--- a/kobo/apps/kobo_scim/exceptions.py
+++ b/kobo/apps/kobo_scim/exceptions.py
@@ -47,7 +47,7 @@ def scim_exception_handler(exc, context):
         reason = exc.reason
     elif isinstance(exc, IntegrityError):
         status_code = status.HTTP_409_CONFLICT
-        detail = f'One or more attributes in the resource already exists. Details: {str(exc)}'
+        detail = f'One or more attributes in the resource already exists.'
         error_code = 'integrity_error'
 
     if status_code is not None:

--- a/kobo/apps/kobo_scim/exceptions.py
+++ b/kobo/apps/kobo_scim/exceptions.py
@@ -47,7 +47,7 @@ def scim_exception_handler(exc, context):
         reason = exc.reason
     elif isinstance(exc, IntegrityError):
         status_code = status.HTTP_409_CONFLICT
-        detail = 'One or more attributes in the resource already exists.'
+        detail = f'One or more attributes in the resource already exists. Details: {str(exc)}'
         error_code = 'integrity_error'
 
     if status_code is not None:

--- a/kobo/apps/kobo_scim/exceptions.py
+++ b/kobo/apps/kobo_scim/exceptions.py
@@ -3,9 +3,9 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 
-from kpi.utils.drf_exceptions import custom_exception_handler
 from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_ERROR
+from kpi.utils.drf_exceptions import custom_exception_handler
 
 
 class ScimException(APIException):
@@ -47,7 +47,7 @@ def scim_exception_handler(exc, context):
         reason = exc.reason
     elif isinstance(exc, IntegrityError):
         status_code = status.HTTP_409_CONFLICT
-        detail = f'One or more attributes in the resource already exists.'
+        detail = 'One or more attributes in the resource already exists.'
         error_code = 'integrity_error'
 
     if status_code is not None:

--- a/kobo/apps/kobo_scim/serializers.py
+++ b/kobo/apps/kobo_scim/serializers.py
@@ -31,8 +31,15 @@ class ScimUserSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_name(self, obj):
+        formatted = obj.get_full_name() or obj.username
+
+        if hasattr(obj, 'extra_details') and obj.extra_details.data:
+            metadata_name = obj.extra_details.data.get('name')
+            if metadata_name:
+                formatted = metadata_name
+
         return {
-            'formatted': obj.get_full_name() or obj.username,
+            'formatted': formatted,
             'familyName': obj.last_name,
             'givenName': obj.first_name,
         }

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -15,7 +15,6 @@ from kobo.apps.kobo_scim.constants import (
     SCIM_SCHEMA_USER,
 )
 from kobo.apps.kobo_scim.models import IdentityProvider
-from kobo.apps.openrosa.apps.main.models import UserProfile
 
 
 class ScimUsersAPITests(APITestCase):
@@ -973,7 +972,6 @@ class ScimUsersAPITests(APITestCase):
             }
         ]
     )
-
     def test_custom_metadata_mapping_validation_failure(self):
         # We removed strict validation against UserProfile, so we now assert
         # that invalid fields like 3-letter country codes are accepted and
@@ -1041,7 +1039,7 @@ class ScimUsersAPITests(APITestCase):
 
         user = User.objects.get(username='partial_sync_user')
         extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
-        
+
         # Now asserts that both are retained in ExtraUserDetail because UserProfile validation is removed
         self.assertEqual(extra_user_detail.data.get('country'), 'USA')
         self.assertEqual(extra_user_detail.data.get('organization'), 'Valid Org')

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -549,6 +549,27 @@ class ScimUsersAPITests(APITestCase):
         self.user1.refresh_from_db()
         self.assertEqual(self.user1.last_name, 'Smith')
 
+    def test_patch_unsupported_operation(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
+
+        payload = {
+            'schemas': [SCIM_SCHEMA_PATCH_OP],
+            'Operations': [
+                {'op': 'replace', 'path': 'unknownField', 'value': 'x'}
+            ],
+        }
+
+        response = self.client.patch(
+            f'{self.url}/{self.user1.id}',
+            payload,
+            format='json',
+            HTTP_ACCEPT='application/scim+json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data.get('detail'), 'Operation not supported or invalid')
+
     def test_put_name_operation(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -120,7 +120,11 @@ class ScimUsersAPITests(APITestCase):
         payload = {
             'schemas': [SCIM_SCHEMA_USER],
             'userName': 'newscimuser',
-            'name': {'givenName': 'New', 'familyName': 'Scim'},
+            'name': {
+                'givenName': 'New',
+                'familyName': 'Scim',
+                'formatted': 'New Scim User',
+            },
             'emails': [
                 {'primary': True, 'value': 'newscimuser@example.com', 'type': 'work'}
             ],
@@ -139,11 +143,18 @@ class ScimUsersAPITests(APITestCase):
         )
         data = response.json()
         self.assertEqual(data['userName'], 'newscimuser')
+        self.assertEqual(data['name']['formatted'], 'New Scim User')
+        self.assertEqual(data['name']['givenName'], 'New')
+        self.assertEqual(data['name']['familyName'], 'Scim')
 
         # Verify in DB
         user = User.objects.get(username='newscimuser')
         self.assertEqual(user.email, 'newscimuser@example.com')
         self.assertEqual(user.first_name, 'New')
+        self.assertEqual(user.last_name, 'Scim')
+
+        extra_user_detail = ExtraUserDetail.objects.get(user=user)
+        self.assertEqual(extra_user_detail.data.get('name'), 'New Scim User')
 
         # Verify SocialAccount link
         social_account = SocialAccount.objects.get(
@@ -516,7 +527,7 @@ class ScimUsersAPITests(APITestCase):
         self.assertFalse(self.user1.is_active)
         self.assertFalse(user3.is_active)
 
-    def test_patch_unsupported_operation(self):
+    def test_patch_name_operation(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
 
         payload = {
@@ -533,10 +544,41 @@ class ScimUsersAPITests(APITestCase):
             HTTP_ACCEPT='application/scim+json',
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.user1.refresh_from_db()
-        self.assertTrue(self.user1.is_active)
+        self.assertEqual(self.user1.last_name, 'Smith')
+
+    def test_put_name_operation(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
+
+        payload = {
+            'schemas': [SCIM_SCHEMA_USER],
+            'userName': 'jdoe',
+            'name': {
+                'givenName': 'Johnny',
+                'familyName': 'Doeseph',
+                'formatted': 'Johnny Doeseph',
+            },
+            'emails': [{'primary': True, 'value': 'jdoe@example.com', 'type': 'work'}],
+            'active': True,
+        }
+
+        response = self.client.put(
+            f'{self.url}/{self.user1.id}',
+            payload,
+            format='json',
+            HTTP_ACCEPT='application/scim+json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.first_name, 'Johnny')
+        self.assertEqual(self.user1.last_name, 'Doeseph')
+
+        extra_user_detail = ExtraUserDetail.objects.get(user=self.user1)
+        self.assertEqual(extra_user_detail.data.get('name'), 'Johnny Doeseph')
 
     def test_manual_reactivation_after_scim_deprovisioning(self):
         """
@@ -1031,9 +1073,7 @@ class ScimUsersAPITests(APITestCase):
             'Operations': [
                 {
                     'op': 'replace',
-                    'value': {
-                        SCIM_SCHEMA_EXTENSION_USER: {'country': 'USA'}
-                    },
+                    'value': {SCIM_SCHEMA_EXTENSION_USER: {'country': 'USA'}},
                 }
             ],
         }

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -852,12 +852,6 @@ class ScimUsersAPITests(APITestCase):
         self.assertEqual(extra.data.get('bio'), 'Test bio')
         self.assertEqual(extra.data.get('organization'), 'Acme Corp')
 
-        # Check UserProfile
-        profile, _ = UserProfile.objects.get_or_create(user=user)
-        self.assertEqual(profile.country, 'US')
-        self.assertEqual(profile.description, 'Test bio')  # bio maps to description
-        self.assertEqual(profile.organization, 'Acme Corp')
-
     @override_config(
         USER_METADATA_FIELDS=[
             {
@@ -889,8 +883,8 @@ class ScimUsersAPITests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        profile, _ = UserProfile.objects.get_or_create(user=self.user1)
-        self.assertEqual(profile.country, 'CA')
+        extra, _ = ExtraUserDetail.objects.get_or_create(user=self.user1)
+        self.assertEqual(extra.data.get('country'), 'CA')
 
         # Test value-based update
         payload2 = {
@@ -910,8 +904,8 @@ class ScimUsersAPITests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        profile.refresh_from_db()
-        self.assertEqual(profile.country, 'GB')
+        extra.refresh_from_db()
+        self.assertEqual(extra.data.get('country'), 'GB')
 
     @override_config(
         USER_METADATA_FIELDS=[
@@ -943,8 +937,8 @@ class ScimUsersAPITests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        profile, _ = UserProfile.objects.get_or_create(user=self.user1)
-        self.assertEqual(profile.country, 'CA')
+        extra, _ = ExtraUserDetail.objects.get_or_create(user=self.user1)
+        self.assertEqual(extra.data.get('country'), 'CA')
 
     def test_reactivation_of_user_without_email_works(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
@@ -979,7 +973,11 @@ class ScimUsersAPITests(APITestCase):
             }
         ]
     )
+
     def test_custom_metadata_mapping_validation_failure(self):
+        # We removed strict validation against UserProfile, so we now assert
+        # that invalid fields like 3-letter country codes are accepted and
+        # stored directly in ExtraUserDetail.data without returning 400.
         self.idp.enforce_strict_metadata_validation = True
         self.idp.save()
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.idp.scim_api_key}')
@@ -989,7 +987,7 @@ class ScimUsersAPITests(APITestCase):
             'emails': [{'primary': True, 'value': 'bad_country@example.com'}],
             'active': True,
             SCIM_SCHEMA_EXTENSION_USER: {
-                'country': 'USA',  # Country max length is 2
+                'country': 'USA',  # Country max length is 2 in UserProfile, but we ignore UserProfile now
             },
         }
 
@@ -999,10 +997,11 @@ class ScimUsersAPITests(APITestCase):
             format='json',
             HTTP_ACCEPT='application/scim+json',
         )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        # Verify user was not created
-        self.assertFalse(User.objects.filter(username='bad_country_user').exists())
+        user = User.objects.get(username='bad_country_user')
+        extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
+        self.assertEqual(extra_user_detail.data.get('country'), 'USA')
 
     @override_config(
         USER_METADATA_FIELDS=[
@@ -1027,7 +1026,7 @@ class ScimUsersAPITests(APITestCase):
             'emails': [{'primary': True, 'value': 'partial_sync@example.com'}],
             'active': True,
             SCIM_SCHEMA_EXTENSION_USER: {
-                'country': 'USA',  # Invalid, max length is 2
+                'country': 'USA',  # Invalid in UserProfile, but valid in ExtraUserDetail
                 'organization': 'Valid Org',  # Valid
             },
         }
@@ -1041,17 +1040,10 @@ class ScimUsersAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user = User.objects.get(username='partial_sync_user')
-        profile, _ = UserProfile.objects.get_or_create(user=user)
-
-        # Invalid field should be gracefully discarded
-        self.assertEqual(profile.country, '')
-
-        # Valid field should be successfully saved
-        self.assertEqual(profile.organization, 'Valid Org')
-
-        # Assert ExtraUserDetail metadata is also scrubbed of the invalid field
         extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
-        self.assertNotIn('country', extra_user_detail.data)
+        
+        # Now asserts that both are retained in ExtraUserDetail because UserProfile validation is removed
+        self.assertEqual(extra_user_detail.data.get('country'), 'USA')
         self.assertEqual(extra_user_detail.data.get('organization'), 'Valid Org')
 
     @override_config(
@@ -1088,7 +1080,7 @@ class ScimUsersAPITests(APITestCase):
 
         user_id = response1.json()['id']
 
-        # Step 2: Patch user with invalid country
+        # Step 2: Patch user with "invalid" country
         payload2 = {
             'schemas': [SCIM_SCHEMA_PATCH_OP],
             'Operations': [
@@ -1107,11 +1099,7 @@ class ScimUsersAPITests(APITestCase):
         self.assertEqual(response2.status_code, status.HTTP_200_OK)
 
         user = User.objects.get(username='existing_metadata_user')
-        profile, _ = UserProfile.objects.get_or_create(user=user)
 
-        # Profile country should still be US
-        self.assertEqual(profile.country, 'US')
-
-        # ExtraUserDetail metadata should still have US
+        # ExtraUserDetail metadata should now have USA
         extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
-        self.assertEqual(extra_user_detail.data.get('country'), 'US')
+        self.assertEqual(extra_user_detail.data.get('country'), 'USA')

--- a/kobo/apps/kobo_scim/tests/test_scim_users_api.py
+++ b/kobo/apps/kobo_scim/tests/test_scim_users_api.py
@@ -985,7 +985,7 @@ class ScimUsersAPITests(APITestCase):
             'emails': [{'primary': True, 'value': 'bad_country@example.com'}],
             'active': True,
             SCIM_SCHEMA_EXTENSION_USER: {
-                'country': 'USA',  # Country max length is 2 in UserProfile, but we ignore UserProfile now
+                'country': 'USA',
             },
         }
 
@@ -1024,7 +1024,7 @@ class ScimUsersAPITests(APITestCase):
             'emails': [{'primary': True, 'value': 'partial_sync@example.com'}],
             'active': True,
             SCIM_SCHEMA_EXTENSION_USER: {
-                'country': 'USA',  # Invalid in UserProfile, but valid in ExtraUserDetail
+                'country': 'USA',
                 'organization': 'Valid Org',  # Valid
             },
         }
@@ -1040,7 +1040,6 @@ class ScimUsersAPITests(APITestCase):
         user = User.objects.get(username='partial_sync_user')
         extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
 
-        # Now asserts that both are retained in ExtraUserDetail because UserProfile validation is removed
         self.assertEqual(extra_user_detail.data.get('country'), 'USA')
         self.assertEqual(extra_user_detail.data.get('organization'), 'Valid Org')
 

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -1,14 +1,11 @@
 from constance import config
-from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework import status
-from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from hub.models.extra_user_detail import ExtraUserDetail
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.kobo_scim.constants import SCIM_SCHEMA_SCHEMA
 from kobo.apps.kobo_scim.exceptions import ScimException
-from kobo.apps.openrosa.apps.main.models import UserProfile
 
 
 def get_scim_value(data, path):

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -88,10 +88,10 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     if first_name is not None or last_name is not None or formatted is not None:
         matched_any = True
         update_fields = []
-        if first_name is not None:
+        if first_name is not None and user.first_name != first_name:
             user.first_name = first_name
             update_fields.append('first_name')
-        if last_name is not None:
+        if last_name is not None and user.last_name != last_name:
             user.last_name = last_name
             update_fields.append('last_name')
         if update_fields:

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -72,7 +72,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     extra_details_updated = False
     extra_user_detail = None
     metadata = {}
-    original_metadata = {}
 
     first_name = get_scim_value(scim_data, 'name.givenName')
     last_name = get_scim_value(scim_data, 'name.familyName')
@@ -98,7 +97,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         if formatted is not None:
             extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
             metadata = extra_user_detail.data or {}
-            original_metadata = dict(metadata)
             metadata['name'] = formatted
             extra_details_updated = True
 
@@ -130,8 +128,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         if extra_user_detail is None:
             extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
             metadata = extra_user_detail.data or {}
-            # Snapshot original metadata to safely recover previously valid fields
-            original_metadata = dict(metadata)
 
         # Apply value mapping if defined
         value_mapping = field_def.get('scim_value_mapping')

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -85,6 +85,11 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     last_name = get_scim_value(scim_data, 'name.familyName')
     formatted = get_scim_value(scim_data, 'name.formatted')
 
+    if not formatted and (first_name is not None or last_name is not None):
+        _first = first_name if first_name is not None else user.first_name
+        _last = last_name if last_name is not None else user.last_name
+        formatted = f"{_first or ''} {_last or ''}".strip()
+
     if first_name is not None or last_name is not None or formatted is not None:
         matched_any = True
         update_fields = []

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -113,7 +113,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     extra_details_updated = False
     profile_updates = {}
     profile_field_to_metadata_key = {}
-    matched_any = False
 
     extra_user_detail = None
     metadata = {}

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -11,15 +11,94 @@ from kobo.apps.kobo_scim.exceptions import ScimException
 from kobo.apps.openrosa.apps.main.models import UserProfile
 
 
+def get_scim_value(data, path):
+    """
+    Extracts a value from a SCIM data dictionary using a dotted path.
+    Handles SCIM extension URNs which may contain periods.
+    """
+    if not path or not data:
+        return None
+
+    # First check if exact path string is a key in data
+    # (useful for flat patch operations)
+    if path in data:
+        return data[path]
+
+    # Try to match a top-level key first (like an extension URN)
+    matched_key = None
+    if isinstance(data, dict):
+        for key in data.keys():
+            if (
+                path == key
+                or path.startswith(f'{key}.')
+                or path.startswith(f'{key}:')
+            ):
+                # Ensure we match the longest prefix to avoid partial matches
+                if matched_key is None or len(key) > len(matched_key):
+                    matched_key = key
+
+    if matched_key:
+        remainder = path[len(matched_key):]
+        if remainder.startswith('.') or remainder.startswith(':'):
+            remainder = remainder[1:]
+
+        value = data[matched_key]
+        if remainder:
+            keys = remainder.replace(':', '.').split('.')
+            for k in keys:
+                if isinstance(value, dict):
+                    value = value.get(k)
+                else:
+                    return None
+        return value
+
+    # Fallback to simple dot splitting if no top-level key matched
+    keys = path.split('.')
+    value = data
+    for key in keys:
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            return None
+
+    return value
+
+
 def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     """
     Applies custom IdP metadata from the SCIM payload to the Kobo user profile.
     It reads `constance.config.USER_METADATA_FIELDS` for mapping definitions.
+    It also natively maps standard SCIM core schema attributes.
     """
+    matched_any = False
+
+    first_name = get_scim_value(scim_data, 'name.givenName')
+    last_name = get_scim_value(scim_data, 'name.familyName')
+    formatted = get_scim_value(scim_data, 'name.formatted')
+
+    if first_name is not None or last_name is not None or formatted is not None:
+        matched_any = True
+        update_fields = []
+        if first_name is not None:
+            user.first_name = first_name
+            update_fields.append('first_name')
+        if last_name is not None:
+            user.last_name = last_name
+            update_fields.append('last_name')
+        if update_fields:
+            user.save(update_fields=update_fields)
+
+        if formatted is not None:
+            extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
+            metadata = extra_user_detail.data or {}
+            metadata['name'] = formatted
+            extra_user_detail.data = metadata
+            extra_user_detail.save(update_fields=['data'])
+
     metadata_fields = getattr(config, 'USER_METADATA_FIELDS', None)
 
     if not isinstance(metadata_fields, list):
-        return False
+        return matched_any
 
     # Fields that map directly to UserProfile model attributes
     user_profile_fields = {
@@ -48,49 +127,7 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         if not field_name or not scim_mapping:
             continue
 
-        # First check if exact scim_mapping string is a key in scim_data
-        # (useful for flat patch operations)
-        if scim_mapping in scim_data:
-            value = scim_data[scim_mapping]
-        else:
-            value = None
-            # Try to match a top-level key first (like an extension URN)
-            matched_key = None
-            if isinstance(scim_data, dict):
-                for key in scim_data.keys():
-                    if (
-                        scim_mapping == key
-                        or scim_mapping.startswith(f'{key}.')
-                        or scim_mapping.startswith(f'{key}:')
-                    ):
-                        # Ensure we match the longest prefix to avoid partial matches
-                        if matched_key is None or len(key) > len(matched_key):
-                            matched_key = key
-
-            if matched_key:
-                remainder = scim_mapping[len(matched_key):]
-                if remainder.startswith('.') or remainder.startswith(':'):
-                    remainder = remainder[1:]
-
-                value = scim_data[matched_key]
-                if remainder:
-                    keys = remainder.replace(':', '.').split('.')
-                    for k in keys:
-                        if isinstance(value, dict):
-                            value = value.get(k)
-                        else:
-                            value = None
-                            break
-            else:
-                # Fallback to simple dot splitting if no top-level key matched
-                keys = scim_mapping.split('.')
-                value = scim_data
-                for key in keys:
-                    if isinstance(value, dict):
-                        value = value.get(key)
-                    else:
-                        value = None
-                        break
+        value = get_scim_value(scim_data, scim_mapping)
 
         if value is None:
             continue

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -107,7 +107,7 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     metadata_fields = getattr(config, 'USER_METADATA_FIELDS', None)
 
     if not isinstance(metadata_fields, list):
-        return matched_any
+        metadata_fields = []
 
     # Fields that map directly to UserProfile model attributes
     user_profile_fields = {

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -73,13 +73,9 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     matched_any = False
 
     extra_details_updated = False
-    profile_updates = {}
-    profile_field_to_metadata_key = {}
-
     extra_user_detail = None
     metadata = {}
     original_metadata = {}
-    profile = None
 
     first_name = get_scim_value(scim_data, 'name.givenName')
     last_name = get_scim_value(scim_data, 'name.familyName')
@@ -114,16 +110,7 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     if not isinstance(metadata_fields, list):
         metadata_fields = []
 
-    # Fields that map directly to UserProfile model attributes
-    user_profile_fields = {
-        'name',
-        'city',
-        'country',
-        'organization',
-        'twitter',
-        'address',
-    }
-
+    # Fields that map to SCIM values
     for field_def in metadata_fields:
         field_name = field_def.get('name')
         scim_mapping = field_def.get('scim_mapping')
@@ -149,69 +136,19 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
             # Snapshot original metadata to safely recover previously valid fields
             original_metadata = dict(metadata)
 
-        if profile is None:
-            profile, _ = UserProfile.objects.get_or_create(user=user)
-
         # Apply value mapping if defined
         value_mapping = field_def.get('scim_value_mapping')
         if isinstance(value_mapping, dict) and str(value) in value_mapping:
             value = value_mapping[str(value)]
 
-        # Determine where to save the field in UserProfile
-        if field_name == 'bio':
-            profile.description = value
-            profile_updates['description'] = value
-            profile_field_to_metadata_key['description'] = field_name
-        elif field_name == 'organization_website':
-            profile.home_page = value
-            profile_updates['home_page'] = value
-            profile_field_to_metadata_key['home_page'] = field_name
-        elif field_name == 'phone_number':
-            profile.phonenumber = value
-            profile_updates['phonenumber'] = value
-            profile_field_to_metadata_key['phonenumber'] = field_name
-        elif field_name in user_profile_fields:
-            setattr(profile, field_name, value)
-            profile_updates[field_name] = value
-            profile_field_to_metadata_key[field_name] = field_name
-
         # Always save to ExtraUserDetail.data for a complete metadata source
         metadata[field_name] = value
         extra_details_updated = True
 
-    if extra_details_updated or profile_updates:
+    if extra_details_updated:
         with transaction.atomic():
-            if profile_updates:
-                try:
-                    profile.full_clean()
-                    profile.save(update_fields=list(profile_updates.keys()))
-                except DjangoValidationError as e:
-                    if enforce_strict_validation:
-                        raise DRFValidationError(e.message_dict)
-                    else:
-                        # Gracefully discard invalid fields and save the rest
-                        profile.refresh_from_db()
-                        valid_fields = []
-                        for field, val in profile_updates.items():
-                            if field not in e.error_dict:
-                                setattr(profile, field, val)
-                                valid_fields.append(field)
-                            else:
-                                metadata_key = profile_field_to_metadata_key.get(field)
-                                if metadata_key and metadata_key in metadata:
-                                    if metadata_key in original_metadata:
-                                        metadata[metadata_key] = original_metadata[
-                                            metadata_key
-                                        ]
-                                    else:
-                                        del metadata[metadata_key]
-
-                        if valid_fields:
-                            profile.save(update_fields=valid_fields)
-
-            if extra_details_updated:
-                extra_user_detail.data = metadata
-                extra_user_detail.save(update_fields=['data'])
+            extra_user_detail.data = metadata
+            extra_user_detail.save(update_fields=['data'])
 
     return matched_any
 

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -119,7 +119,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         'address',
     }
 
-
     for field_def in metadata_fields:
         field_name = field_def.get('name')
         scim_mapping = field_def.get('scim_mapping')
@@ -133,7 +132,7 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
             continue
 
         if field_name == 'name' and formatted is not None:
-            # Skip if name.formatted was natively provided, because standard core 
+            # Skip if name.formatted was natively provided, because standard core
             # schemas take precedence over custom extension configurations
             continue
 

--- a/kobo/apps/kobo_scim/utils.py
+++ b/kobo/apps/kobo_scim/utils.py
@@ -72,6 +72,15 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
     """
     matched_any = False
 
+    extra_details_updated = False
+    profile_updates = {}
+    profile_field_to_metadata_key = {}
+
+    extra_user_detail = None
+    metadata = {}
+    original_metadata = {}
+    profile = None
+
     first_name = get_scim_value(scim_data, 'name.givenName')
     last_name = get_scim_value(scim_data, 'name.familyName')
     formatted = get_scim_value(scim_data, 'name.formatted')
@@ -91,9 +100,9 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         if formatted is not None:
             extra_user_detail, _ = ExtraUserDetail.objects.get_or_create(user=user)
             metadata = extra_user_detail.data or {}
+            original_metadata = dict(metadata)
             metadata['name'] = formatted
-            extra_user_detail.data = metadata
-            extra_user_detail.save(update_fields=['data'])
+            extra_details_updated = True
 
     metadata_fields = getattr(config, 'USER_METADATA_FIELDS', None)
 
@@ -110,14 +119,6 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         'address',
     }
 
-    extra_details_updated = False
-    profile_updates = {}
-    profile_field_to_metadata_key = {}
-
-    extra_user_detail = None
-    metadata = {}
-    original_metadata = {}
-    profile = None
 
     for field_def in metadata_fields:
         field_name = field_def.get('name')
@@ -129,6 +130,11 @@ def apply_scim_user_metadata(user, scim_data, enforce_strict_validation=False):
         value = get_scim_value(scim_data, scim_mapping)
 
         if value is None:
+            continue
+
+        if field_name == 'name' and formatted is not None:
+            # Skip if name.formatted was natively provided, because standard core 
+            # schemas take precedence over custom extension configurations
             continue
 
         matched_any = True

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -26,6 +26,7 @@ from kobo.apps.kobo_scim.constants import (
     SCIM_SCHEMA_SERVICE_PROVIDER_CONFIG,
     SCIM_SCHEMA_USER,
 )
+from kobo.apps.kobo_scim.exceptions import ScimException, scim_exception_handler
 from kobo.apps.kobo_scim.models import IdentityProvider, ScimGroup
 from kobo.apps.kobo_scim.pagination import ScimPagination
 from kobo.apps.kobo_scim.renderers import SCIMParser, SCIMRenderer
@@ -38,7 +39,6 @@ from kobo.apps.kobo_scim.utils import (
     generate_unique_scim_username,
     get_scim_extension_schemas,
 )
-from kobo.apps.kobo_scim.exceptions import ScimException, scim_exception_handler
 
 
 class ScimExceptionHandlerMixin:
@@ -246,9 +246,7 @@ class ScimUserViewSet(
                     )
 
                 # Create the user natively
-                unique_username = generate_unique_scim_username(
-                    username, self.idp.slug
-                )
+                unique_username = generate_unique_scim_username(username, self.idp.slug)
                 user = User.objects.create_user(
                     username=unique_username,
                     email=email,
@@ -302,6 +300,7 @@ class ScimUserViewSet(
 
                 self.perform_destroy(user)
 
+                user.refresh_from_db()
                 serializer = self.get_serializer(user)
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -348,6 +347,7 @@ class ScimUserViewSet(
                     reason='Automated account provisioning via Identity Provider',
                 )
 
+            user.refresh_from_db()
             serializer = self.get_serializer(user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/kobo/apps/kobo_scim/views.py
+++ b/kobo/apps/kobo_scim/views.py
@@ -38,6 +38,7 @@ from kobo.apps.kobo_scim.utils import (
     apply_scim_user_metadata,
     generate_unique_scim_username,
     get_scim_extension_schemas,
+    get_scim_value,
 )
 
 
@@ -197,9 +198,8 @@ class ScimUserViewSet(
         if not email and '@' in username:
             email = username
 
-        name_dict = data.get('name', {})
-        first_name = name_dict.get('givenName', '')
-        last_name = name_dict.get('familyName', '')
+        first_name = get_scim_value(data, 'name.givenName') or ''
+        last_name = get_scim_value(data, 'name.familyName') or ''
         uid = data.get('externalId') or username
         active = str(data.get('active', True)).lower() == 'true'
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Map standard SCIM name attributes (givenName, familyName, and formatted) natively to Kobo user fields (User.first_name, User.last_name, and ExtraUserDetail.data['name']) during SCIM provisioning.

### 📖 Description
Previously, Kobo's SCIM implementation did not natively capture standard name payload attributes from the IdP when creating or updating users. This resulted in new users appearing with empty full names inside the Kobo frontend. This PR resolves the issue by intercepting the standard SCIM core schema attributes for names and mapping them to their appropriate Kobo storage locations:

* `name.givenName` → `User.first_name`
* `name.familyName` → `User.last_name`
* `name.formatted` → `ExtraUserDetail.data['name']`

- Refactored the core extraction logic inside kobo/apps/kobo_scim/utils.py. Created a helper function `get_scim_value()` that parses both nested JSON dictionaries and SCIM extension URN paths
- Unified Metadata Application: Updated `apply_scim_user_metadata()` to natively process standard SCIM core fields alongside the configurable custom metadata mappings (`USER_METADATA_FIELDS`). Because this utility handles all mapping, POST, PUT, and PATCH API requests automatically receive this behavior without duplicating code in the view layer
- Updated `ScimUserSerializer.get_name()` to fetch the formatted name from ExtraUserDetail so the SCIM API returns the correct data. It safely falls back to concatenating first_name and last_name if formatted is omitted

### 👀 Preview steps
1. Simulate the IdP pushing a brand-new user with a full `name` payload.

```bash
curl -X POST http://kf.local.kbtdev.org/scim/v2/<IDP_SLUG>/Users \
  -H "Authorization: Bearer <SCIM_API_KEY>" \
  -H "Content-Type: application/scim+json" \
  -d '{
    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
    "userName": "curltestuser",
    "active": true,
    "emails": [
      {
        "primary": true,
        "value": "curltestuser@example.com",
        "type": "work"
      }
    ],
    "name": {
      "givenName": "Perencejo",
      "familyName": "Lopez",
      "formatted": "Perencejo Lopez"
    }
  }'
```
The response should return `201 Created` and the payload should reflect `"name": {"givenName": "Perencejo", "familyName": "Lopez", "formatted": "Perencejo Lopez"}`.

2. Simulate the IdP doing a targeted update to just the user's family name. Take note of the `id` returned from the `POST` response in the previous step and use it here

```bash
curl -X PATCH http://kf.local.kbtdev.org/scim/v2/<IDP_SLUG>/Users/<USER_ID> \
  -H "Authorization: Bearer <SCIM_API_KEY>" \
  -H "Content-Type: application/scim+json" \
  -d '{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [
      {
        "op": "replace",
        "path": "name.familyName",
        "value": "Cerati"
      }
    ]
  }'
```
The response should return `200 OK`. The payload's name dictionary should now reflect `"familyName": "Cerati"`. 

3. Simulate the IdP doing a full payload overwrite. It changes both the first and last names entirely.
```bash
curl -X PUT http://kf.local.kbtdev.org/scim/v2/<IDP_SLUG>/Users/<USER_ID> \
  -H "Authorization: Bearer <YOUR_SCIM_API_KEY>" \
  -H "Content-Type: application/scim+json" \
  -d '{
    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
    "userName": "curltestuser",
    "active": true,
    "emails": [
      {
        "primary": true,
        "value": "curltestuser@example.com",
        "type": "work"
      }
    ],
    "name": {
      "givenName": "Gustavo",
      "familyName": "Cerati",
      "formatted": "Gustavo Cerati"
    }
  }'
```
The response should return `200 OK`. If you log into Django Admin, Kobo's `User.first_name` will be Gustavo and `User.last_name` will be Cerati