### PR TITLE
fix(submissions): resolve form without UUID for permitted collectors

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -71,7 +71,7 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
             request = self.factory.post('/submission', data, format='json')
             auth = DigestAuth('bob', 'bobbob')
             request.META.update(auth(request.META, response))
-            expected_queries = FuzzyInt(40, 45)
+            expected_queries = FuzzyInt(39, 45)
             # In stripe-enabled environments usage limit enforcement
             # requires additional queries
             # TODO: Constance adds three extra queries when checking
@@ -79,7 +79,7 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
             # so should find a way to keep that out of this count
             if settings.STRIPE_ENABLED:
                 # But because of cache, sometimes goes down to 58
-                expected_queries = FuzzyInt(58, 90)
+                expected_queries = FuzzyInt(57, 90)
             with self.assertNumQueries(expected_queries):
                 self.view(request)
 

--- a/kobo/apps/openrosa/apps/logger/tests/test_get_xform_from_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_get_xform_from_submission.py
@@ -1,0 +1,191 @@
+from django.http import Http404
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.models import XForm
+from kobo.apps.openrosa.libs.utils.logger_tools import (
+    _exclude_common_paths,
+    _get_submission_field_paths,
+    _get_xform_template_field_paths,
+    get_xform_from_submission,
+)
+
+# Both forms deliberately share the same `id_string` (`shared_id`) but belong to
+# different owners and expose different schemas, reproducing the cross-owner
+# `id_string` collision that the disambiguation logic must resolve.
+SHARED_ID = 'shared_id'
+
+
+def _xform_xml(title: str, instance_body: str) -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<h:html xmlns="http://www.w3.org/2002/xforms"'
+        ' xmlns:h="http://www.w3.org/1999/xhtml"'
+        ' xmlns:jr="http://openrosa.org/javarosa">'
+        '<h:head>'
+        f'<h:title>{title}</h:title>'
+        '<model>'
+        '<instance>'
+        f'<{SHARED_ID} id="{SHARED_ID}" version="1">'
+        '<formhub><uuid/></formhub>'
+        f'{instance_body}'
+        '<__version__/>'
+        '<meta><instanceID/></meta>'
+        f'</{SHARED_ID}>'
+        '</instance>'
+        f'<bind nodeset="/{SHARED_ID}/meta/instanceID" type="string"/>'
+        '</model>'
+        '</h:head>'
+        '<h:body/>'
+        '</h:html>'
+    )
+
+
+def _submission_xml(instance_body: str) -> str:
+    return (
+        f'<{SHARED_ID} id="{SHARED_ID}" version="1">'
+        '<formhub><uuid>7117fdf814234f5ea0c9f5801b022293</uuid></formhub>'
+        f'{instance_body}'
+        '<__version__>v1</__version__>'
+        '<meta><instanceID>uuid:55d873b2-3a25-4370-8cd9-c41ed4156d07'
+        '</instanceID></meta>'
+        f'</{SHARED_ID}>'
+    )
+
+
+# Flat schema: top-level fields only.
+FORM_A_XML = _xform_xml('Form A', '<name/><note1/><note2/>')
+SUBMISSION_A_XML = _submission_xml('<name>Bob</name><note1/><note2/>')
+
+# Grouped schema: nested groups + ODK preload fields.
+FORM_B_XML = _xform_xml(
+    'Form B',
+    '<start/><end/><today/><deviceid/>'
+    '<demographic><name/><nationality/></demographic>'
+    '<weather><temp/></weather>'
+    '<observation><bird/></observation>',
+)
+SUBMISSION_B_XML = _submission_xml(
+    '<start>t</start><end>t</end><today>d</today><deviceid>x</deviceid>'
+    '<demographic><name>Bob</name></demographic>'
+    '<weather><temp>20</temp></weather>'
+    '<observation><bird>eagle</bird></observation>'
+)
+
+
+class TestFieldPathHelpers(TestCase):
+    """
+    Unit tests for the schema-fingerprinting helpers (no database access).
+    """
+
+    def test_submission_paths_strip_common_metadata(self):
+        # `formhub`, `meta`, `__version__` are dropped: only real questions remain
+        assert _get_submission_field_paths(SUBMISSION_A_XML) == {
+            'name',
+            'note1',
+            'note2',
+        }
+
+    def test_submission_paths_use_full_xpaths_for_nested_groups(self):
+        # Nested groups are compared by full path, not by bare tag name, and the
+        # `jr:preload` fields (start/end/today/deviceid) are treated as common.
+        assert _get_submission_field_paths(SUBMISSION_B_XML) == {
+            'demographic',
+            'demographic/name',
+            'weather',
+            'weather/temp',
+            'observation',
+            'observation/bird',
+        }
+
+    def test_template_paths_match_submission_paths(self):
+        # A form template exposes every field, empty or not, so the submission's
+        # paths must be a subset of the template's.
+        template_a = _get_xform_template_field_paths(FORM_A_XML)
+        assert template_a == {'name', 'note1', 'note2'}
+        assert _get_submission_field_paths(SUBMISSION_A_XML) <= template_a
+
+        template_b = _get_xform_template_field_paths(FORM_B_XML)
+        assert 'demographic/nationality' in template_b
+        assert _get_submission_field_paths(SUBMISSION_B_XML) <= template_b
+
+    def test_preload_fields_excluded_from_template(self):
+        template_b = _get_xform_template_field_paths(FORM_B_XML)
+        assert {'start', 'end', 'today', 'deviceid'}.isdisjoint(template_b)
+
+    def test_exclude_common_paths_drops_metadata_and_descendants(self):
+        paths = {
+            'formhub',
+            'formhub/uuid',
+            'meta',
+            'meta/instanceID',
+            '__version__',
+            'start',
+            'name',
+            'demographic/name',
+        }
+        assert _exclude_common_paths(paths) == {'name', 'demographic/name'}
+
+
+class TestGetXFormFromSubmissionCollision(TestCase):
+    """
+    Integration tests for `id_string` collisions across different owners.
+    """
+
+    def setUp(self):
+        self.alice = User.objects.create(username='alice')
+        self.bob = User.objects.create(username='bob')
+        # `uuid` is left blank so the UUID lookup misses and the code falls back
+        # to `id_string` resolution, which then hits `MultipleObjectsReturned`.
+        self.xform_a = XForm.objects.create(
+            xml=FORM_A_XML, user=self.alice, require_auth=False
+        )
+        self.xform_b = XForm.objects.create(
+            xml=FORM_B_XML, user=self.bob, require_auth=False
+        )
+        assert self.xform_a.id_string == SHARED_ID
+        assert self.xform_b.id_string == SHARED_ID
+
+    def test_routes_submission_to_form_matching_its_schema(self):
+        resolved = get_xform_from_submission(SUBMISSION_A_XML, self.alice.username)
+        assert resolved.pk == self.xform_a.pk
+
+        resolved = get_xform_from_submission(SUBMISSION_B_XML, self.bob.username)
+        assert resolved.pk == self.xform_b.pk
+
+    def test_ownership_does_not_influence_routing(self):
+        # Even when the submitter owns the *other* colliding form, routing is
+        # decided purely by schema conformance.
+        resolved = get_xform_from_submission(SUBMISSION_B_XML, self.alice.username)
+        assert resolved.pk == self.xform_b.pk
+
+    def test_ambiguous_submission_fails_closed(self):
+        # A submission with no distinguishing fields (only common metadata) is a
+        # subset of every candidate template. When the submitter owns none of the
+        # colliding forms, there is no way to disambiguate -> refuse.
+        carol = User.objects.create(username='carol')
+        empty_submission = _submission_xml('')
+        with self.assertRaises(Http404):
+            get_xform_from_submission(empty_submission, carol.username)
+
+    def test_identical_schema_disambiguated_by_ownership(self):
+        # Two forms sharing the same `id_string` AND the same schema (e.g. the
+        # same form published by two accounts) cannot be told apart by content;
+        # ownership breaks the tie so a submitter reaches their own form.
+        carol = User.objects.create(username='carol')
+        xform_a_clone = XForm.objects.create(
+            xml=FORM_A_XML, user=carol, require_auth=False
+        )
+
+        resolved = get_xform_from_submission(SUBMISSION_A_XML, carol.username)
+        assert resolved.pk == xform_a_clone.pk
+
+        resolved = get_xform_from_submission(SUBMISSION_A_XML, self.alice.username)
+        assert resolved.pk == self.xform_a.pk
+
+    def test_submission_matching_no_form_raises_404(self):
+        unknown_submission = _submission_xml(
+            '<totally_unknown_field>x</totally_unknown_field>'
+        )
+        with self.assertRaises(Http404):
+            get_xform_from_submission(unknown_submission, self.alice.username)

--- a/kobo/apps/openrosa/apps/logger/tests/test_get_xform_from_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_get_xform_from_submission.py
@@ -16,7 +16,7 @@ from kobo.apps.openrosa.libs.utils.logger_tools import (
 SHARED_ID = 'shared_id'
 
 
-def _xform_xml(title: str, instance_body: str) -> str:
+def _xform_xml(title: str, instance_body: str, id_string: str = SHARED_ID) -> str:
     return (
         '<?xml version="1.0" encoding="utf-8"?>'
         '<h:html xmlns="http://www.w3.org/2002/xforms"'
@@ -26,14 +26,14 @@ def _xform_xml(title: str, instance_body: str) -> str:
         f'<h:title>{title}</h:title>'
         '<model>'
         '<instance>'
-        f'<{SHARED_ID} id="{SHARED_ID}" version="1">'
+        f'<{id_string} id="{id_string}" version="1">'
         '<formhub><uuid/></formhub>'
         f'{instance_body}'
         '<__version__/>'
         '<meta><instanceID/></meta>'
-        f'</{SHARED_ID}>'
+        f'</{id_string}>'
         '</instance>'
-        f'<bind nodeset="/{SHARED_ID}/meta/instanceID" type="string"/>'
+        f'<bind nodeset="/{id_string}/meta/instanceID" type="string"/>'
         '</model>'
         '</h:head>'
         '<h:body/>'
@@ -41,15 +41,15 @@ def _xform_xml(title: str, instance_body: str) -> str:
     )
 
 
-def _submission_xml(instance_body: str) -> str:
+def _submission_xml(instance_body: str, id_string: str = SHARED_ID) -> str:
     return (
-        f'<{SHARED_ID} id="{SHARED_ID}" version="1">'
+        f'<{id_string} id="{id_string}" version="1">'
         '<formhub><uuid>7117fdf814234f5ea0c9f5801b022293</uuid></formhub>'
         f'{instance_body}'
         '<__version__>v1</__version__>'
         '<meta><instanceID>uuid:55d873b2-3a25-4370-8cd9-c41ed4156d07'
         '</instanceID></meta>'
-        f'</{SHARED_ID}>'
+        f'</{id_string}>'
     )
 
 
@@ -189,3 +189,36 @@ class TestGetXFormFromSubmissionCollision(TestCase):
         )
         with self.assertRaises(Http404):
             get_xform_from_submission(unknown_submission, self.alice.username)
+
+
+class TestGetXFormFromSubmissionSingleMatch(TestCase):
+    """
+    The common path: a uniquely-named form resolves for any authorized
+    submitter, including non-owners (the core fix — the fallback no longer
+    filters on the submitter's username).
+    """
+
+    UNIQUE_ID = 'unique_form_id'
+
+    def setUp(self):
+        self.owner = User.objects.create(username='owner_user')
+        self.collector = User.objects.create(username='collector_user')
+        self.xform = XForm.objects.create(
+            xml=_xform_xml('Unique', '<name/>', id_string=self.UNIQUE_ID),
+            user=self.owner,
+            require_auth=False,
+        )
+        assert self.xform.id_string == self.UNIQUE_ID
+
+    def test_non_owner_resolves_uniquely_named_form(self):
+        # Before the fix, filtering on `user__username=<submitter>` made this
+        # 404 for a non-owner. Authorization is now left to
+        # `check_submission_permissions`, so resolution succeeds.
+        submission = _submission_xml('<name>Bob</name>', id_string=self.UNIQUE_ID)
+        resolved = get_xform_from_submission(submission, self.collector.username)
+        assert resolved.pk == self.xform.pk
+
+    def test_owner_resolves_uniquely_named_form(self):
+        submission = _submission_xml('<name>Bob</name>', id_string=self.UNIQUE_ID)
+        resolved = get_xform_from_submission(submission, self.owner.username)
+        assert resolved.pk == self.xform.pk

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -34,7 +34,6 @@ from django.http import (
     HttpResponseNotFound,
     StreamingHttpResponse,
 )
-from django.shortcuts import get_object_or_404
 from django.utils import timezone as dj_timezone
 from django.utils.encoding import DjangoUnicodeDecodeError, smart_str
 from django.utils.translation import gettext as t
@@ -433,17 +432,58 @@ def get_xform_from_submission(xml, username, uuid=None):
     if uuid:
         # try to find the form by its uuid which is the ideal condition
         try:
-            xform = XForm.objects.get(uuid=uuid)
+            xform = XForm.objects.select_related('user').get(uuid=uuid)
         except XForm.DoesNotExist:
             pass
         else:
             return xform
 
+    # Fallback: resolve the form by its `id_string` (the root node's `id=""`).
+    # We deliberately do NOT filter by the submitter's username here: the
+    # submitter is not necessarily the owner (they may only hold
+    # `add_submissions`). On the common single-match path, authorization is
+    # enforced right after by `check_submission_permissions()`, so this function
+    # only has to locate the form.
     id_string = get_id_string_from_xml_str(xml)
+    try:
+        return XForm.objects.select_related('user').get(id_string=id_string)
+    except XForm.DoesNotExist:
+        raise Http404
+    except MultipleObjectsReturned:
+        # `id_string` is unique per owner (`unique_together = (user, id_string)`)
+        # but NOT globally, so several accounts can share the same value. The
+        # submission XML carries no owner information, so routing it to an
+        # arbitrary match would risk silently attaching it to the wrong project
+        # and corrupting its data.
+        #
+        # Instead, route by content: a submission belongs to the form whose
+        # instance template it conforms to (its fields are a subset of the
+        # template's).
+        submission_paths = _get_submission_field_paths(xml)
+        xforms = XForm.objects.filter(id_string=id_string).select_related('user')
+        conforming = [
+            xform
+            for xform in xforms
+            if submission_paths <= _get_xform_template_field_paths(xform.xml)
+        ]
+        if len(conforming) == 1:
+            return conforming[0]
 
-    return get_object_or_404(
-        XForm, id_string__exact=id_string, user__username=username
-    )
+        # Several conforming candidates share an equivalent schema (e.g. the very
+        # same form published under different accounts). Fall back to ownership as
+        # a tie-breaker: a submitter posting to their own form is unambiguous.
+        if len(conforming) > 1:
+            owned = [
+                xform
+                for xform in conforming
+                if username and xform.user.username == username
+            ]
+            if len(owned) == 1:
+                return owned[0]
+
+        # No conforming form, or still ambiguous with no ownership tie-breaker:
+        # fail closed rather than guess and risk corrupting another project.
+        raise Http404
 
 
 @contextmanager
@@ -916,12 +956,20 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
 
     # FIXME Temporary hack to leave background-audio files and audit files alone
     #  Bug comes from `get_xform_media_question_xpaths()`
-    queryset = Attachment.objects.filter(instance=instance).exclude(
-        Q(media_file_basename__endswith='.enc')
-        | Q(media_file_basename='audit.csv')
-        | Q(media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$') # background audio file by Collect
-        | Q(media_file_basename__regex=r'^background-audio-\d{8}_\d{6}\.webm$') # background audio file by Enketo
-    ).order_by('-id')
+    queryset = (
+        Attachment.objects.filter(instance=instance)
+        .exclude(
+            Q(media_file_basename__endswith='.enc')
+            | Q(media_file_basename='audit.csv')
+            | Q(
+                media_file_basename__regex=r'^\d{10,}\.(m4a|amr)$'
+            )  # background audio file by Collect
+            | Q(
+                media_file_basename__regex=r'^background-audio-\d{8}_\d{6}\.webm$'
+            )  # background audio file by Enketo
+        )
+        .order_by('-id')
+    )
 
     latest_attachments, remaining_attachments_ids = [], []
     basename_set = set(basenames)
@@ -947,6 +995,55 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     )
 
     return soft_deleted_attachments
+
+
+# Metadata nodes (form-level bookkeeping and ODK `jr:preload` fields) that carry
+# no distinguishing power when routing a submission to the right form, so they
+# are stripped before comparing schemas. Matching is done on the first path
+# segment, which also drops their descendants (e.g. `formhub/uuid`,
+# `meta/instanceID`).
+_COMMON_INSTANCE_FIELDS = frozenset(
+    {
+        'formhub',
+        'meta',
+        '__version__',
+        'start',
+        'end',
+        'today',
+        'deviceid',
+    }
+)
+
+
+def _collect_element_paths(node, prefix: str = '') -> set:
+    """
+    Recursively collect the relative XPaths of every descendant element of
+    `node` (e.g. `demographic/name`).
+
+    Using full paths rather than bare tag names lets nested groups be compared
+    by their exact position in the tree, so two forms that happen to reuse the
+    same field name under different groups are not treated as identical.
+    """
+
+    paths = set()
+    for child in node.childNodes:
+        if child.nodeType != Node.ELEMENT_NODE:
+            continue
+        path = f'{prefix}{child.tagName}'
+        paths.add(path)
+        paths |= _collect_element_paths(child, f'{path}/')
+
+    return paths
+
+
+def _exclude_common_paths(paths: set) -> set:
+    """
+    Drop the common metadata nodes that do not help tell two forms apart.
+    """
+
+    return {
+        path for path in paths if path.split('/', 1)[0] not in _COMMON_INSTANCE_FIELDS
+    }
 
 
 def _get_instance(
@@ -1052,6 +1149,54 @@ def _get_instance_from_deprecated_id(
             )
 
     return instance, old_uuid
+
+
+def _get_submission_field_paths(xml: str) -> set:
+    """
+    Return a submission's field XPaths, relative to its root node, with the
+    common metadata paths excluded.
+    """
+
+    root = clean_and_parse_xml(xml).documentElement
+
+    return _exclude_common_paths(_collect_element_paths(root))
+
+
+def _get_xform_template_field_paths(xform_xml: str) -> set:
+    """
+    Return an XForm's primary instance template field XPaths, with the common
+    metadata paths excluded.
+
+    The primary instance is the `<instance>` node without an `id` attribute
+    (secondary instances used for choices, e.g. `<instance id="birds">`, are
+    ignored). Its single child element is the survey root, whose own tag is the
+    `id_string` (shared by colliding forms), so we compare the paths of its
+    descendants relative to it — matching how submissions are collected.
+    """
+
+    doc = clean_and_parse_xml(xform_xml)
+
+    model_node = None
+    for node in doc.getElementsByTagName('model'):
+        parent = getattr(node, 'parentNode', None)
+        if parent is not None and parent.tagName == 'h:head':
+            model_node = node
+            break
+
+    if model_node is None:
+        return set()
+
+    for node in model_node.childNodes:
+        if (
+            node.nodeType == Node.ELEMENT_NODE
+            and node.tagName.lower() == 'instance'
+            and not node.hasAttribute('id')
+        ):
+            for child in node.childNodes:
+                if child.nodeType == Node.ELEMENT_NODE:
+                    return _exclude_common_paths(_collect_element_paths(child))
+
+    return set()
 
 
 def _has_edit_xform_permission(

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -997,11 +997,19 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     return soft_deleted_attachments
 
 
-# Metadata nodes (form-level bookkeeping and ODK `jr:preload` fields) that carry
-# no distinguishing power when routing a submission to the right form, so they
-# are stripped before comparing schemas. Matching is done on the first path
-# segment, which also drops their descendants (e.g. `formhub/uuid`,
-# `meta/instanceID`).
+# Metadata nodes that carry no distinguishing power when routing a submission to
+# the right form, so they are stripped before comparing schemas. Matching is done
+# on the first path segment, which also drops their descendants (e.g.
+# `formhub/uuid`, `meta/instanceID`).
+#
+# The list is intentionally limited to structural nodes (`formhub`, `meta`,
+# `__version__`) and the `jr:preload` names that pyxform reserves as metadata
+# types (`start`, `end`, `today`, `deviceid`) — none of which can be a
+# user-defined question, so stripping them cannot hide a real field. Other
+# preload fields (e.g. `username`, `email`, `phonenumber`) are deliberately NOT
+# listed: they are plausible question names, and keeping them is harmless since a
+# node shared by every form appears in both the template and the submission and
+# therefore never affects the subset comparison.
 _COMMON_INSTANCE_FIELDS = frozenset(
     {
         'formhub',


### PR DESCRIPTION
### 📣 Summary

Fix a 404 (No XForm matches the given query) when submitting to a form whose XML does not include the form UUID, for collectors who have submission permission but are not the form owner.

### 📖 Description

Submissions are matched to their form by UUID first, then by `id_string`. When the UUID is missing from the submission XML, the fallback could not find the form for a collector who is not the owner, so the submission was rejected with a 404.

### 👷 Description for instance maintainers

The `id_string` fallback in `get_xform_from_submission` no longer scopes the lookup to the submitter's username; authorization is left to `check_submission_permissions`.

### 💭 Notes

The previous fallback filtered on `user__username=<submitter>` while `user` is the form **owner**, so it only matched when the submitter was the owner and returned a 404 otherwise (it never misrouted). Dropping that filter means a bare `id_string` lookup can now match several forms when different accounts share the same `id_string`, so we disambiguate safely:

- resolve by form UUID first (unchanged),
- otherwise a single `id_string` match, no username filter,
- on an `id_string` collision, route to the form whose instance template the submission conforms to (full field XPaths, common metadata excluded),
- ownership is used only as a tie-breaker between schema-equivalent candidates,
- fail closed (404) when no form conforms or the match stays ambiguous.

New `test_get_xform_from_submission.py` covers the path helpers and the collision routing.

### 👀 Preview steps

1. ℹ️ have two accounts: an owner and a collector
2. owner deploys a form and shares it with the collector, granting "Add submissions"
3. as the collector, submit an instance whose XML has no `<formhub><uuid>`
4. 🔴 [on main] the submission is rejected with 404 "No XForm matches the given query"
5. 🟢 [on PR] the submission is accepted
