### PR TITLE
feat(subsequences): background polling for async Google translations DEV-2090

### DIFF
--- a/kobo/apps/subsequences/actions/automatic_google_translation.py
+++ b/kobo/apps/subsequences/actions/automatic_google_translation.py
@@ -13,6 +13,7 @@ class AutomaticGoogleTranslationAction(TranslationActionMixin, BaseAutomaticNLPA
         automatic=True,
         action_data_key='language',
         review_type=ReviewType.ACCEPTANCE,
+        allow_async=True,
     )
 
     def get_nlp_service_class(self) -> NLPExternalServiceClass:

--- a/kobo/apps/subsequences/integrations/google/google_translate.py
+++ b/kobo/apps/subsequences/integrations/google/google_translate.py
@@ -44,10 +44,6 @@ class GoogleTranslationService(GoogleService):
     API_VERSION = 'v3'
     API_RESOURCE = 'projects.locations.operations'
     MAX_SYNC_CHARS = 30720
-    ASYNC_RETRY_LATER_ERROR = (
-        'Timed out waiting for translation results. Translation may still be '
-        'running. Try again in 5 minutes.'
-    )
 
     def __init__(self, submission: dict, asset: 'kpi.models.Asset', *args, **kwargs):
         """
@@ -159,10 +155,19 @@ class GoogleTranslationService(GoogleService):
         """
         Translate one submission value using either sync or async Google APIs
 
+        Returns:
+        - `in_progress` while Google is still processing an async batch job
+        - `complete` with a translated value when results are available
+        - `failed` with a user-facing error for expected failures
+
         `bulk_action_uid` is an optional identifier for the SubsequenceBulkActionItem
         that is being processed. It is only relevant for async translations and if no
         bulk action item is available, async translations fall back to the existing
         cache-based operation tracking.
+
+        When this returns `in_progress`, `BaseAutomaticNLPAction.run_external_process()`
+        schedules the `poll_run_external_process` Celery task, which calls this method
+        again in the background until the batch job finishes.
         """
         try:
             content = params['_dependency']['value']
@@ -352,10 +357,10 @@ class GoogleTranslationService(GoogleService):
             )
             return {'status': 'complete', 'value': value}
         except TimeoutError:
-            return {
-                'status': 'failed',
-                'error': self.ASYNC_RETRY_LATER_ERROR,
-            }
+            # Google is still working. The operation reference was already
+            # saved above, so `poll_run_external_process` will pick up this
+            # same batch job on its next attempt instead of starting a new one
+            return {'status': 'in_progress'}
         except TranslationResultNotFound as err:
             logging.error(f'No translation output found for {xpath=}: {err}')
             self._clear_operation_reference(
@@ -376,14 +381,14 @@ class GoogleTranslationService(GoogleService):
             )
             raise GoogleQuotaExceededError(retry_after=retry_after) from err
         except (GoogleAPIError, GoogleCloudError) as err:
+            # Unable to reach Google to check on the operation, but the batch
+            # job itself may still be running. Report 'in_progress' so
+            # background polling retries instead of surfacing a hard failure
             logging.error(
                 'Google infrastructure error while starting translation for '
                 f'{xpath=}: {err}'
             )
-            return {
-                'status': 'failed',
-                'error': self.ASYNC_RETRY_LATER_ERROR,
-            }
+            return {'status': 'in_progress'}
 
     def _poll_async_translation(
         self,
@@ -422,14 +427,14 @@ class GoogleTranslationService(GoogleService):
                 target_language_code,
             )
         except SubsequenceTimeoutError:
+            # The batch job is not done yet. Keep the operation reference so
+            # `poll_run_external_process` resumes this same job on the next
+            # background attempt
             logging.info(
                 'Google batch translation still running for '
                 f'{xpath=}, {self.submission_root_uuid=}'
             )
-            return {
-                'status': 'failed',
-                'error': self.ASYNC_RETRY_LATER_ERROR,
-            }
+            return {'status': 'in_progress'}
         except TranslationResultNotFound as err:
             logging.error(f'No translation output found for {xpath=}: {err}')
             self._clear_operation_reference(
@@ -450,16 +455,13 @@ class GoogleTranslationService(GoogleService):
             )
             raise GoogleQuotaExceededError(retry_after=retry_after) from err
         except (GoogleAPIError, GoogleCloudError) as err:
-            # Keep the operation reference so a later manual retry can resume
-            # instead of recreating the Google job.
+            # Keep the operation reference so a later polling attempt can
+            # resume instead of recreating the Google job
             logging.error(
                 'Google infrastructure error while polling translation for '
                 f'{xpath=}: {err}'
             )
-            return {
-                'status': 'failed',
-                'error': self.ASYNC_RETRY_LATER_ERROR,
-            }
+            return {'status': 'in_progress'}
 
         self._clear_operation_reference(
             xpath,

--- a/kobo/apps/subsequences/integrations/tests/test_google_translate.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_translate.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from constance.test import override_config
 from django.core.cache import cache
 from django.test import TestCase
-from google.api_core.exceptions import InvalidArgument
+from google.api_core.exceptions import GoogleAPIError, InvalidArgument
 
 from kobo.apps.subsequences.integrations.google.google_translate import (
     GoogleTranslationService,
@@ -92,10 +92,56 @@ class TestGoogleTranslate(TestCase):
         ASR_MT_GOOGLE_REGION='global',
     )
     def test_async_translation_returns_in_progress_timeout_and_saves_operation(self):
+        """
+        Start a large translation, return 'in_progress' on timeout so
+        background polling can resume it, and keep the Google operation name
+        in cache so the next poll resumes the same job instead of starting
+        a duplicate one
+        """
         service = self._build_service()
         operation = MagicMock()
         operation.operation.name = 'operations/translate-1'
         operation.result.side_effect = TimeoutError()
+
+        with patch.object(service, '_get_source_language_code', return_value='en-US'):
+            with patch.object(service, '_get_target_language_code', return_value='fr'):
+                with patch.object(
+                    service,
+                    'begin_google_operation',
+                    return_value=(operation, 40000),
+                ):
+                    with patch.object(service, 'update_counters'):
+                        response = service.process_data(
+                            'mock_xpath',
+                            {
+                                'language': 'fr',
+                                '_dependency': {
+                                    'language': 'en',
+                                    'value': 'Hello ' * 10000,
+                                },
+                            },
+                        )
+
+        cache_key = service._get_cache_key('mock_xpath', 'en-US', 'fr')
+        assert response == {'status': 'in_progress'}
+        assert cache.get(cache_key) == 'operations/translate-1'
+
+    @override_config(
+        ASR_MT_GOOGLE_PROJECT_ID='abc',
+        ASR_MT_GOOGLE_REGION='global',
+    )
+    def test_async_translation_returns_in_progress_on_infra_error_and_saves_operation(
+        self,
+    ):
+        """
+        When Google's infrastructure is unreachable while waiting on a newly
+        started batch job, return 'in_progress' instead of a hard failure and
+        keep the operation reference so background polling can resume it
+        """
+        service = self._build_service()
+        operation = MagicMock()
+        operation.operation.name = 'operations/translate-1'
+        operation.result.side_effect = GoogleAPIError('temporarily unavailable')
 
         with patch.object(service, '_get_source_language_code', return_value='en-US'):
             with patch.object(service, '_get_target_language_code', return_value='fr'):
@@ -178,6 +224,41 @@ class TestGoogleTranslate(TestCase):
                     service,
                     '_get_operation_payload',
                     return_value={'done': False},
+                ):
+                    response = service.process_data(
+                        'mock_xpath',
+                        {
+                            'language': 'fr',
+                            '_dependency': {
+                                'language': 'en',
+                                'value': 'Hello ' * 10000,
+                            },
+                        },
+                    )
+
+        assert response == {'status': 'in_progress'}
+        assert cache.get(cache_key) == 'operations/translate-1'
+
+    @override_config(
+        ASR_MT_GOOGLE_PROJECT_ID='abc',
+        ASR_MT_GOOGLE_REGION='global',
+    )
+    def test_async_translation_returns_in_progress_on_infra_error_while_polling(self):
+        """
+        When Google's infrastructure is unreachable while polling an existing
+        batch job, return 'in_progress' instead of a hard failure and keep the
+        cached operation so a later poll can resume it
+        """
+        service = self._build_service()
+        cache_key = service._get_cache_key('mock_xpath', 'en-US', 'fr')
+        cache.set(cache_key, 'operations/translate-1', timeout=300)
+
+        with patch.object(service, '_get_source_language_code', return_value='en-US'):
+            with patch.object(service, '_get_target_language_code', return_value='fr'):
+                with patch.object(
+                    service,
+                    '_get_operation_payload',
+                    side_effect=GoogleAPIError('temporarily unavailable'),
                 ):
                     response = service.process_data(
                         'mock_xpath',

--- a/kobo/apps/subsequences/integrations/tests/test_google_translate.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_translate.py
@@ -91,12 +91,7 @@ class TestGoogleTranslate(TestCase):
         ASR_MT_GOOGLE_PROJECT_ID='abc',
         ASR_MT_GOOGLE_REGION='global',
     )
-    def test_async_translation_returns_failed_timeout_and_saves_operation(self):
-        """
-        Start a large translation, return the retry-later failure on timeout,
-        and keep the Google operation name in cache so later manual
-        requests poll instead of starting a duplicate job
-        """
+    def test_async_translation_returns_in_progress_timeout_and_saves_operation(self):
         service = self._build_service()
         operation = MagicMock()
         operation.operation.name = 'operations/translate-1'
@@ -122,13 +117,7 @@ class TestGoogleTranslate(TestCase):
                         )
 
         cache_key = service._get_cache_key('mock_xpath', 'en-US', 'fr')
-        assert response == {
-            'status': 'failed',
-            'error': (
-                'Timed out waiting for translation results. Translation may still '
-                'be running. Try again in 5 minutes.'
-            ),
-        }
+        assert response == {'status': 'in_progress'}
         assert cache.get(cache_key) == 'operations/translate-1'
 
     @override_config(
@@ -174,10 +163,10 @@ class TestGoogleTranslate(TestCase):
         ASR_MT_GOOGLE_PROJECT_ID='abc',
         ASR_MT_GOOGLE_REGION='global',
     )
-    def test_async_translation_reuses_cached_operation_and_returns_retry_later(self):
+    def test_async_translation_reuses_cached_operation_and_returns_in_progress(self):
         """
-        When a cached async translation is still running, return the retry-later
-        failure and keep the cached operation for a later manual retry
+        When a cached async translation is still running, return 'in_progress'
+        and keep the cached operation so the next background poll resumes it
         """
         service = self._build_service()
         cache_key = service._get_cache_key('mock_xpath', 'en-US', 'fr')
@@ -201,13 +190,7 @@ class TestGoogleTranslate(TestCase):
                         },
                     )
 
-        assert response == {
-            'status': 'failed',
-            'error': (
-                'Timed out waiting for translation results. Translation may still '
-                'be running. Try again in 5 minutes.'
-            ),
-        }
+        assert response == {'status': 'in_progress'}
         assert cache.get(cache_key) == 'operations/translate-1'
 
     @override_config(
@@ -268,13 +251,7 @@ class TestGoogleTranslate(TestCase):
                             )
 
         cache_key = service._get_cache_key('mock_xpath', 'en-US', 'fr')
-        assert response == {
-            'status': 'failed',
-            'error': (
-                'Timed out waiting for translation results. Translation may still '
-                'be running. Try again in 5 minutes.'
-            ),
-        }
+        assert response == {'status': 'in_progress'}
         assert cache.get(cache_key) == 'operations/translate-2'
 
     @override_config(

--- a/kobo/apps/subsequences/tests/test_automatic_google_translation.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_translation.py
@@ -526,10 +526,11 @@ def test_find_the_most_recent_accepted_transcription():
     assert action_data == expected
 
 
-def test_async_translation_timeout_is_saved_as_failed():
+def test_async_translation_timeout_schedules_background_polling():
     """
-    Persist a failed result when async translation is still running so the user
-    must retry manually instead of relying on background polling
+    A still-running async translation is stored with status 'in_progress' and
+    schedules `poll_run_external_process` so the job finishes in the
+    background instead of requiring the user to manually retry
     """
     action = _get_action()
     mock_service = MagicMock()
@@ -539,13 +540,7 @@ def test_async_translation_timeout_is_saved_as_failed():
         'kobo.apps.subsequences.actions.automatic_google_translation.GoogleTranslationService',  # noqa
         return_value=mock_service,
     ):
-        mock_service.process_data.return_value = {
-            'status': 'failed',
-            'error': (
-                'Timed out waiting for translation results. Translation may still '
-                'be running. Try again in 5 minutes.'
-            ),
-        }
+        mock_service.process_data.return_value = {'status': 'in_progress'}
         with patch(
             'kobo.apps.subsequences.actions.base.poll_run_external_process'
         ) as task_mock:
@@ -555,14 +550,24 @@ def test_async_translation_timeout_is_saved_as_failed():
                 {'language': 'fr'},
             )
 
-        task_mock.apply_async.assert_not_called()
+        task_mock.apply_async.assert_called_once()
+        _, kwargs = task_mock.apply_async.call_args
+        assert kwargs['kwargs']['action_id'] == action.ID
+        assert kwargs['kwargs']['question_xpath'] == action.source_question_xpath
+        assert kwargs['kwargs']['submission'] == submission
+
         data = result['fr']['_versions'][0]['_data']
-        assert data['status'] == 'failed'
+        assert data['status'] == 'in_progress'
         assert data['language'] == 'fr'
-        assert 'Try again in 5 minutes.' in data['error']
 
 
-def test_google_quota_error_is_saved_as_failed_for_non_async_translation():
+def test_google_quota_error_schedules_background_polling_for_async_translation():
+    """
+    A quota-exceeded error during translation should not surface as a hard
+    failure. Since translation now allows async processing, it should be
+    stored as 'in_progress' and retried later via background polling, the
+    same way automatic transcription behaves
+    """
     action = _get_action()
     mock_service = MagicMock()
     submission = {'meta/rootUuid': '123-abdc'}
@@ -583,9 +588,10 @@ def test_google_quota_error_is_saved_as_failed_for_non_async_translation():
                 {'language': 'fr'},
             )
 
-    task_mock.apply_async.assert_not_called()
-    assert result['fr']['_versions'][0]['_data']['status'] == 'failed'
-    assert 'Retry after 123 seconds.' in result['fr']['_versions'][0]['_data']['error']
+    task_mock.apply_async.assert_called_once()
+    _, kwargs = task_mock.apply_async.call_args
+    assert kwargs['countdown'] == 123
+    assert result['fr']['_versions'][0]['_data']['status'] == 'in_progress'
 
 
 def test_transform_data_for_output():


### PR DESCRIPTION
### 📣 Summary
This PR enables background polling support for asynchronous automated Google Translate operations.

### 📖 Description
Enables `allow_async=True` on `AutomaticGoogleTranslationAction`, so long-running translation batch jobs now reuse the same `poll_run_external_process` Celery task already used for automatic transcription, instead of relying on the user to manually re-request the translation after a timeout.

`GoogleTranslationService` now returns status: `in_progress` (instead of status: `failed` with the `SYNC_RETRY_LATER_ERROR` message) whenever the batch translation job is still running or a transient Google infrastructure error occurs while starting/polling it. The Google operation reference is preserved in these cases so the next poll resumes the same job rather than starting a duplicate one.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Have an account and a project with audio submissions
2. Set `MAX_SYNC_CHARS` in `GoogleTranslationService` to a lower value to trigger the async operation with a small audio file.
3. Trigger an automatic Google translation.
4. 🔴 [on main] Notice that the request processes for some time and then returns a `failed` status, asking you to try again later.
5. 🟢 [on PR] Notice that the API returns an `in_progress` status and, after some time, returns the actual translated object.
6. Note that async support is not yet implemented on the frontend, so you will need to either revisit the page later to check whether the result is ready or call the API directly using curl or another API tool.

