### PR TITLE
fix(pairedData): return null source for deleted parent projects DEV-2034

### DIFF
--- a/kpi/serializers/v2/paired_data.py
+++ b/kpi/serializers/v2/paired_data.py
@@ -3,6 +3,7 @@ import os
 import re
 
 from django.utils.translation import gettext as t
+from django_request_cache import cache_for_request
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.reverse import reverse
@@ -41,6 +42,9 @@ class PairedDataSerializer(serializers.Serializer):
         return self.__save(validated_data)
 
     def get_source__name(self, paired_data):
+        if self._source_is_deleted(paired_data):
+            return None
+
         # To avoid multiple calls to DB, try to retrieve source names from
         # the context.
         source__name = None
@@ -62,11 +66,8 @@ class PairedDataSerializer(serializers.Serializer):
         return source__name
 
     def to_representation(self, instance):
-        source_deleted = self._source_is_deleted(instance)
         return {
-            'source': (
-                None if source_deleted else self.__get_source_asset_url(instance)
-            ),
+            'source': self.__get_source_asset_url(instance),
             'source__name': self.get_source__name(instance),
             'fields': instance.fields,
             'filename': instance.filename,
@@ -123,6 +124,7 @@ class PairedDataSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         return self.__save(validated_data)
 
+    @cache_for_request
     def _source_is_deleted(self, instance) -> bool:
         """
         Return whether the source (parent) asset no longer exists.
@@ -132,7 +134,8 @@ class PairedDataSerializer(serializers.Serializer):
         keeps appearing here. Reuse the `source__names` mapping the viewset
         already built (uid absent means the row does not exist) to avoid an
         extra query per row on the list endpoint; fall back to a direct
-        existence check when the context is not populated.
+        existence check when the context is not populated. Cached per request
+        so `get_source__name()` and `__get_source_asset_url()` share one lookup.
         """
         source__names = self.context.get('source__names')
         if source__names is not None:
@@ -256,7 +259,9 @@ class PairedDataSerializer(serializers.Serializer):
             request=request,
         )
 
-    def __get_source_asset_url(self, instance: 'kpi.models.PairedData') -> str:
+    def __get_source_asset_url(self, instance: 'kpi.models.PairedData') -> str | None:
+        if self._source_is_deleted(instance):
+            return None
         request = self.context['request']
         return reverse('asset-detail',
                        args=[instance.source_uid],

--- a/kpi/serializers/v2/paired_data.py
+++ b/kpi/serializers/v2/paired_data.py
@@ -62,8 +62,11 @@ class PairedDataSerializer(serializers.Serializer):
         return source__name
 
     def to_representation(self, instance):
+        source_deleted = self._source_is_deleted(instance)
         return {
-            'source': self.__get_source_asset_url(instance),
+            'source': (
+                None if source_deleted else self.__get_source_asset_url(instance)
+            ),
             'source__name': self.get_source__name(instance),
             'fields': instance.fields,
             'filename': instance.filename,
@@ -119,6 +122,22 @@ class PairedDataSerializer(serializers.Serializer):
 
     def update(self, instance, validated_data):
         return self.__save(validated_data)
+
+    def _source_is_deleted(self, instance) -> bool:
+        """
+        Return whether the source (parent) asset no longer exists.
+
+        A deleted source is not cleaned up from the destination's
+        `paired_data` because there is no cascading FK (see DEV-2034), so it
+        keeps appearing here. Reuse the `source__names` mapping the viewset
+        already built (uid absent means the row does not exist) to avoid an
+        extra query per row on the list endpoint; fall back to a direct
+        existence check when the context is not populated.
+        """
+        source__names = self.context.get('source__names')
+        if source__names is not None:
+            return instance.source_uid not in source__names
+        return not Asset.objects.filter(uid=instance.source_uid).exists()
 
     def _validate_fields(self, attrs: dict):
 

--- a/kpi/tests/api/v2/test_api_paired_data.py
+++ b/kpi/tests/api/v2/test_api_paired_data.py
@@ -289,6 +289,27 @@ class PairedDataListApiTests(BasePairedDataTestCase):
         self.assertEqual('`paired_data` is already used',
                          str(response.data['filename'][0]))
 
+    def test_list_with_deleted_source(self):
+        # anotheruser pairs their form with someuser's source asset
+        self.toggle_source_sharing(enabled=True)
+        self.source_asset.assign_perm(self.anotheruser, PERM_VIEW_SUBMISSIONS)
+        response = self.paired_data()
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # someuser deletes the source (parent) project. There is no FK cascade,
+        # so the destination asset still references it in its `paired_data` dict.
+        self.source_asset.delete()
+
+        # The destination owner lists their paired data. The deleted source must
+        # be reported with a null `source` (not just a null `source__name`).
+        self.login_as_other_user('anotheruser', 'anotheruser')
+        response = self.client.get(self.destination_asset_paired_data_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        result = response.data['results'][0]
+        self.assertIsNone(result['source'])
+        self.assertIsNone(result['source__name'])
+
     def test_create_paired_data_anonymous(self):
         self.toggle_source_sharing(enabled=True)
         payload = {


### PR DESCRIPTION
### 📣 Summary
When a source project used for a connected (paired) dataset is deleted, it is now clearly reported as deleted rather than still appearing as a normal source.

### 📖 Description
Connected projects pull data from a "source" project. If that source project was deleted, the paired-data endpoint kept listing it as if it were a live source, which the connected-projects UI couldn't reliably detect. The deleted source's `source` link is now returned as `null`, giving the frontend a dependable signal.

### 💭 Notes
`paired_data` is stored as a JSON blob on the destination `Asset` keyed by source uid, with **no cascading FK**, so deleting a source asset leaves a dangling reference (DEV-2034). `PairedDataSerializer.to_representation` now emits `source: null` when the source Asset row no longer exists, detected by reusing the `source__names` mapping the viewset already builds (uid absent ⇒ row deleted) — no extra query on the list endpoint, with a direct `.exists()` fallback when context is absent. Runtime-only change: no OpenAPI schema drift, no migration.

### 👀 Preview steps
1. ℹ️ have an account with two projects; enable data sharing on project **A** (the source).
2. Connect project **B** to **A** (paired data) and `GET /api/v2/assets/<B_uid>/paired-data/`.
3. Delete project **A**.
4. `GET /api/v2/assets/<B_uid>/paired-data/` again.
5. 🔴 [on main] the deleted source still appears with a populated `"source"` URL (only `"source__name"` is null).
6. 🟢 [on PR] that entry's `"source"` is `null`.