### PR TITLE
fix(dataTable): duplicate column and broken Open button DEV-2404

### DIFF
--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -72,7 +72,9 @@ export default function DataTableCell(props: DataTableCellProps) {
       ) {
         if (mediaAttachment !== null && props.question.$xpath !== undefined) {
           const audioXpath =
-            typeof mediaAttachment === 'string' ? props.question.$xpath : mediaAttachment.question_xpath
+            typeof mediaAttachment === 'string' || !mediaAttachment.question_xpath
+              ? props.question.$xpath
+              : mediaAttachment.question_xpath
           return (
             <AudioCell
               assetUid={props.asset.uid}

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -1,4 +1,5 @@
-import { getColumnLabel } from './tableUtils'
+import type { SubmissionResponse } from '#/dataInterface'
+import { getAllDataColumns, getColumnLabel } from './tableUtils'
 import { assetWithBgAudioAndNLP, assetWithNestedGroupsAndNLP } from './tableUtils.mocks'
 
 describe('tableUtils', () => {
@@ -62,5 +63,30 @@ describe('tableUtils', () => {
     // TODO: write more tests here… I haven't got enough time to go over all
     // possible cases, just added one that I was fixing a bug for and a couple
     // that came to my mind.
+  })
+  describe('getAllDataColumns', () => {
+    it('should keep current audio key and drop legacy path duplicate', () => {
+      // In this case, imagine we had a question with path
+      // `old_group/Secret_password_as_an_audio_file`, made a submission, and
+      // then and we've renamed it to `Secret_password_as_an_audio_file` and
+      // now we have both pieces in submission data
+      const submissions = [
+        {
+          _attachments: [
+            {
+              question_xpath: 'old_group/Secret_password_as_an_audio_file',
+              media_file_basename: 'secret_audio.mp3',
+            },
+          ],
+          Secret_password_as_an_audio_file: 'secret_audio.mp3',
+          'old_group/Secret_password_as_an_audio_file': 'secret_audio.mp3',
+        },
+      ] as unknown as SubmissionResponse[]
+
+      const columns = getAllDataColumns(assetWithBgAudioAndNLP, submissions)
+
+      chai.expect(columns).to.include('Secret_password_as_an_audio_file')
+      chai.expect(columns).to.not.include('old_group/Secret_password_as_an_audio_file')
+    })
   })
 })

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -88,5 +88,29 @@ describe('tableUtils', () => {
       chai.expect(columns).to.include('Secret_password_as_an_audio_file')
       chai.expect(columns).to.not.include('old_group/Secret_password_as_an_audio_file')
     })
+
+    it('should keep both columns when old and current paths are distinct fields', () => {
+      const submissions = [
+        {
+          _attachments: [
+            {
+              question_xpath: 'old_group/Secret_password_as_an_audio_file',
+              media_file_basename: 'legacy_audio.mp3',
+            },
+            {
+              question_xpath: 'Secret_password_as_an_audio_file',
+              media_file_basename: 'current_audio.mp3',
+            },
+          ],
+          Secret_password_as_an_audio_file: 'current_audio.mp3',
+          'old_group/Secret_password_as_an_audio_file': 'legacy_audio.mp3',
+        },
+      ] as unknown as SubmissionResponse[]
+
+      const columns = getAllDataColumns(assetWithBgAudioAndNLP, submissions)
+
+      chai.expect(columns).to.include('Secret_password_as_an_audio_file')
+      chai.expect(columns).to.include('old_group/Secret_password_as_an_audio_file')
+    })
   })
 })

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -215,6 +215,35 @@ export function getAllDataColumns(
   // exclude some technical non-data columns
   output = output.filter((key) => EXCLUDED_COLUMNS.includes(key) === false)
 
+  // Deduplicate stale audio keys from old submissions when current schema has
+  // the same question under a different (usually renamed-group) path.
+  // TODO DEV-2407: Evaluate extending this dedupe approach to other
+  // attachment question types (image/video/file) in main, with dedicated tests
+  // to avoid over-deduping distinct fields that share a leaf name.
+  const currentAudioPathsByLeaf = new Map<string, string>()
+  asset.content.survey.forEach((row) => {
+    if (row.type !== QUESTION_TYPES.audio.id && row.type !== QUESTION_TYPES['background-audio'].id) {
+      return
+    }
+    const rowName = getRowName(row)
+    const currentPath = flatPaths[rowName]
+    if (currentPath) {
+      currentAudioPathsByLeaf.set(rowName, currentPath)
+    }
+  })
+
+  output = output.filter((key) => {
+    const keyParts = key.split('/')
+    const leafName = keyParts[keyParts.length - 1]
+    const currentPath = currentAudioPathsByLeaf.get(leafName)
+
+    if (!currentPath || key === currentPath) {
+      return true
+    }
+
+    return !output.includes(currentPath)
+  })
+
   // exclude notes
   output = output.filter((key) => {
     const foundPathKey = recordKeys(flatPaths).find((pathKey) => flatPaths[pathKey] === key)

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -241,7 +241,37 @@ export function getAllDataColumns(
       return true
     }
 
-    return !output.includes(currentPath)
+    if (!output.includes(currentPath)) {
+      return true
+    }
+
+    // Only collapse legacy path if we can observe it mirroring current path in
+    // at least one submission (same non-empty value on both keys). This avoids
+    // hiding distinct historical columns that merely share a leaf name.
+    if (!submissions || submissions.length === 0) {
+      return true
+    }
+
+    let hasMatchingOverlap = false
+    for (const submission of submissions) {
+      const legacyValue = submission[key]
+      const currentValue = submission[currentPath]
+
+      const hasLegacyValue = legacyValue !== undefined && legacyValue !== null && legacyValue !== ''
+      const hasCurrentValue = currentValue !== undefined && currentValue !== null && currentValue !== ''
+
+      if (!hasLegacyValue || !hasCurrentValue) {
+        continue
+      }
+
+      if (legacyValue !== currentValue) {
+        return true
+      }
+
+      hasMatchingOverlap = true
+    }
+
+    return !hasMatchingOverlap
   })
 
   // exclude notes

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -220,7 +220,7 @@ export function getAllDataColumns(
   // TODO DEV-2407: Evaluate extending this dedupe approach to other
   // attachment question types (image/video/file) in main, with dedicated tests
   // to avoid over-deduping distinct fields that share a leaf name.
-  const currentAudioPathsByLeaf = new Map<string, string>()
+  const currentAudioPathsByLeaf = new Map<string, string[]>()
   asset.content.survey.forEach((row) => {
     if (row.type !== QUESTION_TYPES.audio.id && row.type !== QUESTION_TYPES['background-audio'].id) {
       return
@@ -228,20 +228,25 @@ export function getAllDataColumns(
     const rowName = getRowName(row)
     const currentPath = flatPaths[rowName]
     if (currentPath) {
-      currentAudioPathsByLeaf.set(rowName, currentPath)
+      const existingPaths = currentAudioPathsByLeaf.get(rowName) || []
+      if (!existingPaths.includes(currentPath)) {
+        currentAudioPathsByLeaf.set(rowName, [...existingPaths, currentPath])
+      }
     }
   })
 
   output = output.filter((key) => {
     const keyParts = key.split('/')
     const leafName = keyParts[keyParts.length - 1]
-    const currentPath = currentAudioPathsByLeaf.get(leafName)
+    const currentPaths = currentAudioPathsByLeaf.get(leafName)
 
-    if (!currentPath || key === currentPath) {
+    if (!currentPaths || currentPaths.includes(key)) {
       return true
     }
 
-    if (!output.includes(currentPath)) {
+    const matchingCurrentPaths = currentPaths.filter((currentPath) => output.includes(currentPath))
+
+    if (matchingCurrentPaths.length === 0) {
       return true
     }
 
@@ -255,20 +260,25 @@ export function getAllDataColumns(
     let hasMatchingOverlap = false
     for (const submission of submissions) {
       const legacyValue = submission[key]
-      const currentValue = submission[currentPath]
-
       const hasLegacyValue = legacyValue !== undefined && legacyValue !== null && legacyValue !== ''
-      const hasCurrentValue = currentValue !== undefined && currentValue !== null && currentValue !== ''
-
-      if (!hasLegacyValue || !hasCurrentValue) {
+      if (!hasLegacyValue) {
         continue
       }
 
-      if (legacyValue !== currentValue) {
-        return true
-      }
+      for (const currentPath of matchingCurrentPaths) {
+        const currentValue = submission[currentPath]
+        const hasCurrentValue = currentValue !== undefined && currentValue !== null && currentValue !== ''
 
-      hasMatchingOverlap = true
+        if (!hasCurrentValue) {
+          continue
+        }
+
+        if (legacyValue !== currentValue) {
+          return true
+        }
+
+        hasMatchingOverlap = true
+      }
     }
 
     return !hasMatchingOverlap


### PR DESCRIPTION
### 📣 Summary

Fixed Single Processing opening for audio responses when attachment metadata has an empty question path, and prevented duplicate audio columns in Project → Data → Table when old submission paths differ from the current form schema.

### 💭 Notes

Changes here:

- `index.tsx`: for audio cells, fallback to the schema xpath when attachment question path is empty, so Open does not navigate to a broken processing route.
- `tableUtils.ts`: in `getAllDataColumns`, dedupe stale audio keys from submissions when the current survey already contains the matching audio question path.
- `tableUtils.tests.ts`: added regression coverage to ensure current audio xpath is preferred and stale duplicate xpath is excluded.

### 👀 Preview steps

1. Open a project with audio questions and submissions where at least one attachment has an empty question path value (not sure how to achieve it yet).
2. Go to Project → Data → Table.
3. Find an audio response row and use "Open" button.
4. 🔴 On main: for affected attachments, "Open" may navigate to a broken processing URL.
5. 🟢 On this PR: Open navigates to the expected Single Processing route using a safe xpath fallback.
6. In the same table, check columns for an audio question that exists under an old submission path and a current schema path.
7. 🔴 On main: duplicate audio columns may appear.
8. 🟢 On this PR: only the current survey audio column is shown; stale duplicate path column is not shown.