### PR TITLE
fix(supplement): add UUID query fallback to supplement view DEV-2320

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -69,18 +69,18 @@ def _process_batch(docs: list):
     doc_ids = [doc['_id'] for doc in docs]
 
     # Only fetch Postgres records that actually have a root_uuid populated
-    instances = Instance.objects.only('pk', 'root_uuid').filter(
-        pk__in=doc_ids, root_uuid__isnull=False
+    instances_map = dict(
+        Instance.objects.filter(
+            pk__in=doc_ids, root_uuid__isnull=False
+        ).values_list('pk', 'root_uuid')
     )
-    instances_map = {inst.pk: inst.root_uuid for inst in instances}
 
     mongo_updates = [
         UpdateOne(
-            {'_id': doc_id},
-            {'$set': {'meta/rootUuid': add_uuid_prefix(instances_map[doc_id])}},
+            {'_id': pk},
+            {'$set': {'meta/rootUuid': add_uuid_prefix(root_uuid)}},
         )
-        for doc_id in doc_ids
-        if doc_id in instances_map
+        for pk, root_uuid in instances_map.items()
     ]
 
     if mongo_updates:

--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -1,0 +1,86 @@
+from django.conf import settings
+from django.db.models import Q
+from pymongo import UpdateOne
+
+from kobo.apps.long_running_migrations.exceptions import (
+    LongRunningMigrationDependencyError,
+)
+from kobo.apps.long_running_migrations.models import LongRunningMigration
+from kobo.apps.openrosa.apps.logger.models import Instance
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
+from kpi.utils.log import logging
+
+CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
+
+
+def run():
+    """
+    Syncs `meta/rootUuid` to MongoDB for submissions that had it backfilled in
+    Postgres by LRM 0027 but experienced a partial sync failure to MongoDB.
+    """
+    _check_lrm_0027_is_completed()
+
+    last_id = 0
+    while True:
+        query = {
+            '_id': {'$gt': last_id},
+            '$or': [
+                {'meta/rootUuid': {'$exists': False}},
+                {'meta/rootUuid': None},
+                {'meta/rootUuid': ''},
+            ],
+        }
+
+        # Paginate forward by _id to guarantee no infinite loops
+        # even if a record is intentionally left un-patched.
+        cursor = (
+            settings.MONGO_DB.instances.find(query, {'_id': 1})
+            .sort('_id', 1)
+            .limit(CHUNK_SIZE)
+        )
+        docs = list(cursor)
+
+        if not docs:
+            break
+
+        logging.info(
+            f'[LRM 0028] - Processing batch from _id {docs[0]["_id"]} to {docs[-1]["_id"]}'
+        )
+        _process_batch(docs)
+        last_id = docs[-1]['_id']
+
+
+def _check_lrm_0027_is_completed():
+    """
+    Raises `LongRunningMigrationDependencyError` if LRM 0027 has not yet
+    reached a terminal state (completed or failed).
+    """
+    if not LongRunningMigration.objects.filter(
+        Q(status='completed') | Q(status='failed'),
+        name__startswith='0027',
+    ).exists():
+        raise LongRunningMigrationDependencyError(
+            'LRM 0027 has not reached a terminal state yet'
+        )
+
+
+def _process_batch(docs: list):
+    doc_ids = [doc['_id'] for doc in docs]
+
+    # Only fetch Postgres records that actually have a root_uuid populated
+    instances = Instance.objects.only('pk', 'root_uuid').filter(
+        pk__in=doc_ids, root_uuid__isnull=False
+    )
+    instances_map = {inst.pk: inst.root_uuid for inst in instances}
+
+    mongo_updates = [
+        UpdateOne(
+            {'_id': doc_id},
+            {'$set': {'meta/rootUuid': add_uuid_prefix(instances_map[doc_id])}},
+        )
+        for doc_id in doc_ids
+        if doc_id in instances_map
+    ]
+
+    if mongo_updates:
+        settings.MONGO_DB.instances.bulk_write(mongo_updates, ordered=False)

--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -10,6 +10,7 @@ from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kpi.utils.log import logging
 
+
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
 
 
@@ -44,7 +45,7 @@ def run():
             break
 
         logging.info(
-            f'[LRM 0028] - Processing batch from _id {docs[0]["_id"]} to {docs[-1]["_id"]}'
+            f'[LRM 0028] - Processing batch _id {docs[0]["_id"]} to {docs[-1]["_id"]}'
         )
         _process_batch(docs)
         last_id = docs[-1]['_id']

--- a/kobo/apps/long_running_migrations/migrations/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/migrations/0028_sync_mongo_root_uuid.py
@@ -1,5 +1,3 @@
-# Generated on 2026-07-08
-
 from django.db import migrations
 
 

--- a/kobo/apps/long_running_migrations/migrations/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/migrations/0028_sync_mongo_root_uuid.py
@@ -1,0 +1,27 @@
+# Generated on 2026-07-08
+
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.get_or_create(
+        name='0028_sync_mongo_root_uuid',
+    )
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0027_backfill_remaining_root_uuid'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, noop),
+    ]

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1313,6 +1313,58 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
         assert response.data[META_ROOT_UUID] == root_uuid
         assert response.data['_validation_status'] == {}
 
+    def test_supplement_fallback_to_instance_id(self):
+        """
+        If a submission is missing `meta/rootUuid` in MongoDB, the `supplement`
+        endpoint should fallback to `meta/instanceID` (`_uuid`) and still retrieve the
+        supplement.
+        """
+        submission = self.submissions_submitted_by_someuser[0]
+        QuestionAdvancedFeature.objects.create(
+            asset=self.asset,
+            question_xpath='q1',
+            action='manual_transcription',
+            params=[{'language': 'en'}],
+        )
+
+        mongo_document = settings.MONGO_DB.instances.find_one(
+            {'_id': submission['_id']}
+        )
+        root_uuid = mongo_document.pop(META_ROOT_UUID)
+        settings.MONGO_DB.instances.update_one(
+            {'_id': submission['_id']},
+            {'$unset': {META_ROOT_UUID: root_uuid}},
+        )
+
+        supplement_data = {
+            'q1': {
+                'manual_transcription': {
+                    '_versions': [
+                        {
+                            '_data': {'language': 'en', 'value': 'Bonjour'},
+                        }
+                    ],
+                },
+            },
+            '_version': '20250820',
+        }
+        SubmissionSupplement.objects.create(
+            asset=self.asset,
+            submission_uuid=remove_uuid_prefix(submission['_uuid']),
+            content=supplement_data,
+        )
+
+        url = reverse(
+            self._get_endpoint('submission-supplement'),
+            kwargs={
+                'uid_asset': self.asset.uid,
+                'root_uuid': submission['_uuid'],
+            },
+        )
+        response = self.client.get(url, {'format': 'json'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['_version'], '20250820')
+
     def test_submitted_by_persists_after_user_deletion(self):
         # Simulate old submissions that don't have `submitted_by`
         ParsedInstance.objects.filter(instance__user=self.anotheruser).update(

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -570,7 +570,7 @@ class DataViewSet(
         # TODO remove the block below when LRM 0028 has completed
         root_uuid_key = OpenRosaDeploymentBackend.SUBMISSION_ROOT_UUID_XPATH
         instance_id_key = OpenRosaDeploymentBackend.SUBMISSION_CURRENT_UUID_XPATH
-        if root_uuid_key not in submission:
+        if not submission.get(root_uuid_key):
             submission[root_uuid_key] = submission[instance_id_key]
 
         submission_root_uuid = remove_uuid_prefix(submission[root_uuid_key])

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -562,31 +562,21 @@ class DataViewSet(
         if request.method == 'PATCH' and is_automatic_qa_request(request.data):
             check_automatic_qa_throttle(request, self)
 
-        deployment = self._get_deployment()
-        try:
-            submission_root_uuid_prefixed = add_uuid_prefix(submission_root_uuid)
-            # Fallback to meta/instanceID
-            uuid_query = {
-                '$or': [
-                    {'meta/rootUuid': submission_root_uuid_prefixed},
-                    {'meta/instanceID': submission_root_uuid_prefixed},
-                ]
-            }
-            submission = list(
-                deployment.get_submissions(
-                    user=request.user,
-                    query=uuid_query,
-                )
-            )[0]
-        except IndexError:
-            raise Http404
+        submission = self._get_submission_by_id_or_root_uuid(
+            submission_root_uuid, request
+        )
 
-        submission_root_uuid = submission.get(deployment.SUBMISSION_ROOT_UUID_XPATH)
-        if not submission_root_uuid:
-            submission_root_uuid = submission_root_uuid_prefixed
-            submission[deployment.SUBMISSION_ROOT_UUID_XPATH] = (
-                submission_root_uuid_prefixed
+        deployment = self._get_deployment()
+        fetched_root_uuid = submission.get(deployment.SUBMISSION_ROOT_UUID_XPATH)
+
+        if not fetched_root_uuid:
+            fetched_root_uuid = submission.get('meta/instanceID') or submission.get(
+                '_uuid'
             )
+            fetched_root_uuid = add_uuid_prefix(fetched_root_uuid)
+            submission[deployment.SUBMISSION_ROOT_UUID_XPATH] = fetched_root_uuid
+
+        submission_root_uuid = fetched_root_uuid
 
         if request.method == 'GET':
             return Response(

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -52,6 +52,7 @@ from kpi.constants import (
     SUBMISSION_FORMAT_TYPE_JSON,
     SUBMISSION_FORMAT_TYPE_XML,
 )
+from kpi.deployment_backends.openrosa_backend import OpenRosaDeploymentBackend
 from kpi.exceptions import (
     InvalidXFormException,
     MissingXFormException,
@@ -566,17 +567,13 @@ class DataViewSet(
             submission_root_uuid, request
         )
 
-        deployment = self._get_deployment()
-        fetched_root_uuid = submission.get(deployment.SUBMISSION_ROOT_UUID_XPATH)
+        # TODO remove the block below when LRM 0028 has completed
+        root_uuid_key = OpenRosaDeploymentBackend.SUBMISSION_ROOT_UUID_XPATH
+        instance_id_key = OpenRosaDeploymentBackend.SUBMISSION_CURRENT_UUID_XPATH
+        if root_uuid_key not in submission:
+            submission[root_uuid_key] = submission[instance_id_key]
 
-        if not fetched_root_uuid:
-            fetched_root_uuid = submission.get('meta/instanceID') or submission.get(
-                '_uuid'
-            )
-            fetched_root_uuid = add_uuid_prefix(fetched_root_uuid)
-            submission[deployment.SUBMISSION_ROOT_UUID_XPATH] = fetched_root_uuid
-
-        submission_root_uuid = fetched_root_uuid
+        submission_root_uuid = remove_uuid_prefix(submission[root_uuid_key])
 
         if request.method == 'GET':
             return Response(

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -564,16 +564,29 @@ class DataViewSet(
 
         deployment = self._get_deployment()
         try:
+            submission_root_uuid_prefixed = add_uuid_prefix(submission_root_uuid)
+            # Fallback to meta/instanceID
+            uuid_query = {
+                '$or': [
+                    {'meta/rootUuid': submission_root_uuid_prefixed},
+                    {'meta/instanceID': submission_root_uuid_prefixed},
+                ]
+            }
             submission = list(
                 deployment.get_submissions(
                     user=request.user,
-                    query={'meta/rootUuid': add_uuid_prefix(submission_root_uuid)},
+                    query=uuid_query,
                 )
             )[0]
         except IndexError:
             raise Http404
 
-        submission_root_uuid = submission[deployment.SUBMISSION_ROOT_UUID_XPATH]
+        submission_root_uuid = submission.get(deployment.SUBMISSION_ROOT_UUID_XPATH)
+        if not submission_root_uuid:
+            submission_root_uuid = submission_root_uuid_prefixed
+            submission[deployment.SUBMISSION_ROOT_UUID_XPATH] = (
+                submission_root_uuid_prefixed
+            )
 
         if request.method == 'GET':
             return Response(


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Use the fallback query in the supplement view to avoid throwing a 404 error for submissions that didn't get the rootUuid backfilled in mongo.

### 📖 Description
In `kpi/views/v2/data.py`, the method `DataViewSet.supplement` I replaced the strict `meta/rootUuid` MongoDB query  with the method `_get_submission_by_id_or_root_uuid` that searches both `meta/rootUuid` and `meta/instanceID` as a fallback. Also added logic to safely inject the matched uuid into `submission['meta/rootUuid']` if it was missing.

### 👀 Preview steps
Hard to preview, but you could manually remove the `meta/rootUuid` from a mongodb instance record and then request the supplement endpoint to test the fallback: 

1. Have a deployed asset and submit a record to it.

2. Execute in shell_plus the following snippet to manually strip the `meta/rootUuid` from MongoDB for that submission:

```
   from django.conf import settings
   
   asset = Asset.objects.get(uid='ASSET_UID')
   submission = list(asset.deployment.get_submissions(asset.owner))[0]
   instance_id = submission['_uuid']
   mongo_id = submission['_id']

   settings.MONGO_DB.instances.update_one(
       {'_id': mongo_id}, 
       {'$unset': {'meta/rootUuid': ""}}
   )
   
   print(f"Use this Instance ID for the URL: {instance_id}")
```
3. Request the supplement endpoint using the instanceID printed above. You can do this via curl, or by navigating in the browser to: `https://kf.local.kbtdev.org/api/v2/assets/{YOUR_ASSET_UID}/data/{INSTANCE_ID}/supplement/`. 

5. Before this PR the endpoint would return a 404 Not Found because it strictly queried meta/rootUuid. After this PR it will return a 200 OK because it successfully falls back to matching the provided UUID against `meta/instanceID`