### PR TITLE
fix(mfa): enforce 2FA when an authenticated user logs in as another account DEV-2111

### DIFF
--- a/kobo/apps/accounts/mfa/tests/test_login.py
+++ b/kobo/apps/accounts/mfa/tests/test_login.py
@@ -47,6 +47,116 @@ class LoginTests(KpiTestCase):
         response = self.client.post(reverse('kobo_login'), data=data)
         self.assertRedirects(response, reverse('mfa_authenticate'))
 
+    def test_login_while_authenticated_as_other_user_still_enforces_mfa(self):
+        """
+        Regression: navigating somewhere that bounces to the login form (e.g.
+        `/admin/`) while already logged in as a user without MFA, then
+        submitting credentials for an MFA-enabled account, must present the
+        2FA challenge instead of silently redirecting back to the landing page
+        still logged in as the original user.
+        """
+        # `anotheruser` has no MFA enabled; authenticate as them first
+        self.client.force_login(self.anotheruser)
+        # Attempt to log in as `someuser` (MFA enabled) without logging out.
+        # Follow the whole redirect chain: the bug is that the login POST
+        # correctly redirects to `mfa_authenticate`, but that view then bounces
+        # the still-authenticated `anotheruser` back to the landing page
+        # without ever completing (or challenging) the `someuser` login.
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(reverse('kobo_login'), data=data, follow=True)
+        # The 2FA challenge must be reached and rendered, not skipped
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.request['PATH_INFO'], reverse('mfa_authenticate'))
+        # The stale `anotheruser` session must not remain authenticated
+        self.assertFalse(response.context['user'].is_authenticated)
+
+    def test_failed_login_while_authenticated_keeps_existing_session(self):
+        """
+        A failed login attempt (wrong password) while already authenticated
+        must not drop the existing session: the current user stays logged in.
+        """
+        self.client.force_login(self.anotheruser)
+        data = {
+            'login': 'someuser',
+            'password': 'wrong-password',
+        }
+        response = self.client.post(reverse('kobo_login'), data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['user'].pk, self.anotheruser.pk)
+
+    def test_relogin_as_same_mfa_user_keeps_session(self):
+        """
+        Re-submitting your own credentials while already authenticated must not
+        drop the session: the guard only logs out a *different* user, so an
+        MFA-enabled user re-logging in as themselves stays authenticated and
+        lands on the usual redirect target (no spurious 2FA challenge, no
+        lockout).
+        """
+        self.client.force_login(self.someuser)
+        data = {
+            'login': 'someuser',
+            'password': 'someuser',
+        }
+        response = self.client.post(reverse('kobo_login'), data=data, follow=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.request['PATH_INFO'],
+            resolve_url(settings.LOGIN_REDIRECT_URL),
+        )
+        self.assertTrue(response.context['user'].is_authenticated)
+        self.assertEqual(response.context['user'].pk, self.someuser.pk)
+
+    def test_switch_to_other_non_superuser_with_next_admin_is_not_redirected(self):
+        """
+        Regression: a non-superuser switching into another non-superuser
+        account while `?next=/admin/` is in the POST must not be redirected to
+        the admin panel (which would immediately bounce them with a permission
+        error). The admin-redirect guard must key off the account being
+        authenticated, not `request.user` — which allauth evaluates before the
+        login completes, and which the stale-session logout sets to anonymous.
+        """
+        admin_url = reverse('admin:index')
+        # Logged in as `someuser` (non-superuser); switch to `anotheruser`
+        # (another non-superuser, no MFA) with `next=/admin/`
+        self.client.force_login(self.someuser)
+        data = {
+            'login': 'anotheruser',
+            'password': 'anotheruser',
+            'next': admin_url,
+        }
+        response = self.client.post(reverse('kobo_login'), data=data, follow=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Must land on the normal redirect target, never the admin panel
+        self.assertEqual(
+            response.request['PATH_INFO'],
+            resolve_url(settings.LOGIN_REDIRECT_URL),
+        )
+        self.assertNotEqual(response.request['PATH_INFO'], admin_url)
+        self.assertEqual(response.context['user'].pk, self.anotheruser.pk)
+
+    def test_superuser_with_next_admin_is_redirected_to_admin(self):
+        """
+        The admin-redirect guard must only suppress the redirect for
+        non-superusers: a superuser logging in with `?next=/admin/` must still
+        be sent to the admin panel.
+        """
+        admin_url = reverse('admin:index')
+        self.anotheruser.is_staff = True
+        self.anotheruser.is_superuser = True
+        self.anotheruser.save()
+        data = {
+            'login': 'anotheruser',
+            'password': 'anotheruser',
+            'next': admin_url,
+        }
+        response = self.client.post(reverse('kobo_login'), data=data)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertTrue(response.url.startswith(admin_url))
+
     @override_config(MFA_ENABLED=False)
     def test_mfa_globally_disabled(self):
         data = {

--- a/kobo/apps/accounts/mfa/views.py
+++ b/kobo/apps/accounts/mfa/views.py
@@ -2,7 +2,11 @@ from allauth.account.views import LoginView
 from allauth.mfa.adapter import get_adapter
 from allauth.mfa.internal.flows.add import validate_can_add_authenticator
 from allauth.mfa.totp.internal import auth as totp_auth
+from django.conf import settings
+from django.contrib.auth import logout
 from django.db.models import QuerySet
+from django.http import HttpResponse
+from django.shortcuts import resolve_url
 from django.urls import reverse
 from rest_framework.generics import ListAPIView
 from rest_framework.request import Request
@@ -15,12 +19,28 @@ from kpi.utils.log import logging
 from ..forms import LoginForm
 from .flows import activate_totp, deactivate_totp, regenerate_codes
 from .models import MfaMethodsWrapper
-from .permissions import IsMfaEnabled, EnforceSuperuserMFA
+from .permissions import EnforceSuperuserMFA, IsMfaEnabled
 from .serializers import MfaCodeSerializer, UserMfaMethodSerializer
 
 
 class MfaLoginView(LoginView):
     form_class = LoginForm
+
+    def form_valid(self, form) -> HttpResponse:
+        """
+        Overload parent method to drop a stale session before logging in.
+        """
+        # `form.user` is the account being authenticated. Remember it before
+        # anything else: allauth calls `get_success_url()` before the login
+        # completes, and the `logout()` below clears `request.user`, so
+        # `request.user` is not a reliable reference to the target user there.
+        self._login_user = form.user
+
+        user = self.request.user
+        if user.is_authenticated and user.pk != form.user.pk:
+            logout(self.request)
+
+        return super().form_valid(form)
 
     def get_success_url(self):
         """
@@ -37,15 +57,17 @@ class MfaLoginView(LoginView):
         # We do not want to redirect a regular user to `/admin/` if they
         # are not a superuser. Otherwise, they are successfully authenticated,
         # redirected to the admin platform, then disconnected because of the
-        # lack of permissions.
-        user = self.request.user
+        # lack of permissions. Check the account being authenticated
+        # (`self._login_user`), not `request.user`: this runs before the login
+        # completes, and a stale session may have just been logged out.
+        user = getattr(self, '_login_user', self.request.user)
         if (
             user.is_authenticated
             and self.redirect_field_name in self.request.POST
             and not user.is_superuser
             and redirect_to.startswith(reverse('admin:index'))
         ):
-            return ''
+            return resolve_url(settings.LOGIN_REDIRECT_URL)
 
         return redirect_to
 


### PR DESCRIPTION
### 📣 Summary

Signing in with a second account's credentials while already logged in now signs you into that account (prompting for 2FA when enabled) instead of silently ignoring the new credentials.

### 📖 Description

Previously, if you were already logged in and submitted a different account's credentials on the login form, the new login was silently discarded. You stayed logged in as your original account and never saw a 2FA prompt. Now the stale session is dropped so the new login completes normally, including its two-factor challenge.

### 💭 Notes

- Root cause: `ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS` is disabled, so an already-authenticated user can POST the login form for a *different* account. When that account has MFA enabled, allauth defers the login to its 2FA stage, but the `mfa_authenticate` view redirects any already-authenticated request away (allauth's `login_stage_required` decorator), silently abandoning the pending login and leaving the original user signed in. `MfaLoginView.form_valid` now logs the current user out (only when the submitted credentials resolve to a different account, and only after they validate) so the new login and its 2FA challenge run on a clean, anonymous session.
- Two regression tests added in `kobo/apps/accounts/mfa/tests/test_login.py`: one reproducing the bounce (asserts the 2FA challenge is reached and the stale session is dropped), and one guarding that a *failed* login attempt does not drop the existing session.

### 👀 Preview steps

1. ℹ️ have two accounts: a regular one, and a superuser with 2FA (TOTP) enabled
2. log in as the regular (non-superuser) account
3. navigate to `/admin/` — you get the login screen
4. enter the superuser's username and password
5. 🔴 [on main] you're bounced straight to the projects list, still logged in as the regular user, with no 2FA prompt
6. 🟢 [on PR] you're taken to the 2FA challenge (`/accounts/2fa/authenticate/`); entering a valid code logs you into the admin as the superuser
