### PR TITLE
fix(import): forbid bad names in import DEV-2415

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -58,6 +58,7 @@ from kpi.constants import (
 from kpi.exceptions import ConcurrentExportException, XlsFormatException
 from kpi.fields import KpiUidField
 from kpi.models import Asset
+from kpi.utils.autoname import _is_group_end
 from kpi.utils.data_exports import (
     ACCESS_LOGS_EXPORT_FIELDS,
     ASSET_FIELDS,
@@ -76,6 +77,7 @@ from kpi.utils.rename_xls_sheet import (
     rename_xls_sheet,
     rename_xlsx_sheet,
 )
+from kpi.utils.sluggify import is_valid_node_name
 from kpi.utils.storage import is_filesystem_storage
 from kpi.utils.strings import to_str
 from kpi.zip_importer import HttpContentParse
@@ -362,6 +364,11 @@ class ImportTask(ImportExportTask):
                     kontent = xlsx_to_dict(item.readable)
                 except InvalidFileException:
                     kontent = xls_to_dict(item.readable)
+                survey_list = kontent.get('survey')
+                for node in survey_list:
+                    name = node.get('name')
+                    if not _is_group_end(node) and not is_valid_node_name(name):
+                        raise ValueError(f'Invalid node name: {name}')
 
                 if not destination:
                     extra_args['content'] = _strip_header_keys(kontent)
@@ -405,6 +412,11 @@ class ImportTask(ImportExportTask):
         library = kwargs.get('library')
         survey_dict = _b64_xls_to_dict(base64_encoded_upload)
         survey_dict_keys = survey_dict.keys()
+        survey_list = survey_dict.get('survey', [])
+        for node in survey_list:
+            name = node.get('name')
+            if not _is_group_end(node) and not is_valid_node_name(name):
+                raise ValueError(f'Invalid node name: {name}')
 
         destination = kwargs.get('destination', False)
         has_necessary_perm = kwargs.get('has_necessary_perm', False)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -364,10 +364,14 @@ class ImportTask(ImportExportTask):
                     kontent = xlsx_to_dict(item.readable)
                 except InvalidFileException:
                     kontent = xls_to_dict(item.readable)
-                survey_list = kontent.get('survey')
+                survey_list = kontent.get('survey', [])
                 for node in survey_list:
                     name = node.get('name')
-                    if not _is_group_end(node) and not is_valid_node_name(name):
+                    if (
+                        bool(name)
+                        and not _is_group_end(node)
+                        and not is_valid_node_name(name)
+                    ):
                         raise ValueError(f'Invalid node name: {name}')
 
                 if not destination:
@@ -415,7 +419,7 @@ class ImportTask(ImportExportTask):
         survey_list = survey_dict.get('survey', [])
         for node in survey_list:
             name = node.get('name')
-            if not _is_group_end(node) and not is_valid_node_name(name):
+            if bool(name) and not _is_group_end(node) and not is_valid_node_name(name):
                 raise ValueError(f'Invalid node name: {name}')
 
         destination = kwargs.get('destination', False)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -364,15 +364,7 @@ class ImportTask(ImportExportTask):
                     kontent = xlsx_to_dict(item.readable)
                 except InvalidFileException:
                     kontent = xls_to_dict(item.readable)
-                survey_list = kontent.get('survey', [])
-                for node in survey_list:
-                    name = node.get('name')
-                    if (
-                        bool(name)
-                        and not _is_group_end(node)
-                        and not is_valid_node_name(name)
-                    ):
-                        raise ValueError(f'Invalid node name: {name}')
+                self._ensure_valid_node_names(kontent)
 
                 if not destination:
                     extra_args['content'] = _strip_header_keys(kontent)
@@ -405,6 +397,14 @@ class ImportTask(ImportExportTask):
             orm_obj.parent = parent_item
             orm_obj.save()
 
+    @staticmethod
+    def _ensure_valid_node_names(survey_dict):
+        survey_list = survey_dict.get('survey', [])
+        for node in survey_list:
+            name = node.get('name')
+            if bool(name) and not _is_group_end(node) and not is_valid_node_name(name):
+                raise ValueError(f'Invalid node name: {name}')
+
     def _parse_b64_upload(self, base64_encoded_upload, messages, **kwargs):
         filename = kwargs.get('filename', False)
         desired_type = kwargs.get('desired_type')
@@ -415,12 +415,8 @@ class ImportTask(ImportExportTask):
             filename = ''
         library = kwargs.get('library')
         survey_dict = _b64_xls_to_dict(base64_encoded_upload)
+        self._ensure_valid_node_names(survey_dict)
         survey_dict_keys = survey_dict.keys()
-        survey_list = survey_dict.get('survey', [])
-        for node in survey_list:
-            name = node.get('name')
-            if bool(name) and not _is_group_end(node) and not is_valid_node_name(name):
-                raise ValueError(f'Invalid node name: {name}')
 
         destination = kwargs.get('destination', False)
         has_necessary_perm = kwargs.get('has_necessary_perm', False)

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -1107,7 +1107,7 @@ class AssetImportTaskTest(BaseTestCase):
 
         task_data = self._construct_xls_for_import(content, name='Bad file')
         encoded_str = task_data['base64Encoded']
-        encoded_substr = encoded_str[encoded_str.index('base64') + 7 :]
+        encoded_substr = encoded_str[encoded_str.index('base64') + 7:]
         task_data['base64Encoded'] = encoded_substr
         task = ImportTask.objects.create(user=self.asset.owner, data=task_data)
         result = task.run()

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -13,6 +13,7 @@ from rest_framework.reverse import reverse
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.constants import ASSET_TYPE_BLOCK, ASSET_TYPE_QUESTION
 from kpi.models import Asset, ImportTask
+from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.tests.base_test_case import BaseTestCase
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.strings import to_str
@@ -1087,3 +1088,29 @@ class AssetImportTaskTest(BaseTestCase):
                 'project_owner': self.asset.owner.username,
             },
         )
+
+    def test_import_raises_error_with_invalid_names(self):
+        survey_sheet_content = [
+            ['type', 'name', 'label::English (en)'],
+            ['today', 'today', ''],
+            ['begin group', 'this is a bad group name', 'Bad bad bad, no donut'],
+            ['note', 'note_1', 'Hi there 👋'],
+            ['end group', '', ''],
+        ]
+        choices_sheet_content = [
+            ['list_name', 'name', 'label::English (en)'],
+        ]
+        content = (
+            ('survey', survey_sheet_content),
+            ('choices', choices_sheet_content),
+        )
+
+        task_data = self._construct_xls_for_import(content, name='Bad file')
+        encoded_str = task_data['base64Encoded']
+        encoded_substr = encoded_str[encoded_str.index('base64') + 7 :]
+        task_data['base64Encoded'] = encoded_substr
+        task = ImportTask.objects.create(user=self.asset.owner, data=task_data)
+        result = task.run()
+        assert result.status == ImportExportStatusChoices.ERROR
+        error_message = result.messages['error']
+        assert 'this is a bad group name' in error_message


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Forbid uploading assets with bad node names


### 📖 Description
Previously we allowed users to upload assets with spaces or other non-xml-compliant characters in the node names, then sanitized those names when we deployed, resulting in a mismatch between the asset content and what was in submissions and breaking the data table in some cases.

### 👀 Preview steps
Make sure to restart the kpi_worker when changing branches

1. ℹ️ have an account 
2. Upload the attached xlsx to the project: 
[test_upload_with_space.xlsx](https://github.com/user-attachments/files/29808168/test_upload_with_space.xlsx)
3. 🔴 [on main] Upload succeeds
4. [on main] Deploy
5. [on main] Add a submission with an audio response
6. [on main] Navigate to data table and click `Open` on the audio file
7. 🔴 [on main] `path not found / recognized`
8. 🟢 [on PR] upload is forbidden

