### PR TITLE
refactor(settings): standardize Constance env overrides to CONSTANCE_ prefix DEV-1976

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -190,6 +190,24 @@ if os.environ.get('DEFAULT_FROM_EMAIL'):
 # must use `constance.config.THE_SETTING` instead of
 # `django.conf.settings.THE_SETTING`
 
+
+def _constance_env(getter, new_key, deprecated_key, default):
+    """
+    Read a Constance override from the `CONSTANCE_`-prefixed environment
+    variable, falling back to its deprecated (unprefixed / `KOBO_`) name.
+
+    Emit a `DeprecationWarning` when the deprecated name is still set so
+    deployments know to migrate to the `CONSTANCE_` prefix.
+    """
+    if deprecated_key in os.environ:
+        warnings.warn(
+            f'{deprecated_key} is renamed {new_key}, '
+            f'update the environment variable.',
+            DeprecationWarning,
+        )
+    return getter(new_key, getter(deprecated_key, default))
+
+
 CONSTANCE_CONFIG = {
     'REGISTRATION_OPEN': (
         True,
@@ -225,24 +243,39 @@ CONSTANCE_CONFIG = {
         'in the user interface',
     ),
     'SUPPORT_EMAIL': (
-        env.str(
+        _constance_env(
+            env.str,
             'CONSTANCE_SUPPORT_EMAIL',
+            'KOBO_SUPPORT_EMAIL',
             env.str('DEFAULT_FROM_EMAIL', 'help@kobotoolbox.org'),
         ),
         'Email address for users to contact, e.g. when they encounter '
         'unhandled errors in the application',
     ),
     'SUPPORT_URL': (
-        env.str('CONSTANCE_SUPPORT_URL', 'https://support.kobotoolbox.org/'),
+        _constance_env(
+            env.str,
+            'CONSTANCE_SUPPORT_URL',
+            'KOBO_SUPPORT_URL',
+            'https://support.kobotoolbox.org/',
+        ),
         'URL for "KoboToolbox Help Center"',
     ),
     'ACADEMY_URL': (
-        env.str('CONSTANCE_ACADEMY_URL', 'https://academy.kobotoolbox.org/'),
+        _constance_env(
+            env.str,
+            'CONSTANCE_ACADEMY_URL',
+            'KOBO_ACADEMY_URL',
+            'https://academy.kobotoolbox.org/',
+        ),
         'URL for "KoboToolbox Community Forum"',
     ),
     'COMMUNITY_URL': (
-        env.str(
-            'CONSTANCE_COMMUNITY_URL', 'https://community.kobotoolbox.org/'
+        _constance_env(
+            env.str,
+            'CONSTANCE_COMMUNITY_URL',
+            'KOBO_COMMUNITY_URL',
+            'https://community.kobotoolbox.org/',
         ),
         'URL for "KoboToolbox Community Forum"',
     ),
@@ -331,7 +364,12 @@ CONSTANCE_CONFIG = {
         'Require MFA for superusers with a usable password',
     ),
     'USAGE_LIMIT_ENFORCEMENT': (
-        env.bool('CONSTANCE_USAGE_LIMIT_ENFORCEMENT', False),
+        _constance_env(
+            env.bool,
+            'CONSTANCE_USAGE_LIMIT_ENFORCEMENT',
+            'USAGE_LIMIT_ENFORCEMENT',
+            False,
+        ),
         'For Stripe-enabled instances, determines whether usage limits will be enforced'
         'by blocking submissions/NLP actions or deleting stored files.',
     ),

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -18,6 +18,7 @@ from pymongo import MongoClient
 
 from kpi.constants import PERM_DELETE_ASSET, PERM_MANAGE_ASSET
 from ..static_lists import EXTRA_LANG_INFO, SECTOR_CHOICE_DEFAULTS
+from .utils import constance_env, dj_stripe_request_callback_method
 
 env = environ.Env()
 
@@ -190,24 +191,6 @@ if os.environ.get('DEFAULT_FROM_EMAIL'):
 # must use `constance.config.THE_SETTING` instead of
 # `django.conf.settings.THE_SETTING`
 
-
-def _constance_env(getter, new_key, deprecated_key, default):
-    """
-    Read a Constance override from the `CONSTANCE_`-prefixed environment
-    variable, falling back to its deprecated (unprefixed / `KOBO_`) name.
-
-    Emit a `DeprecationWarning` when the deprecated name is still set so
-    deployments know to migrate to the `CONSTANCE_` prefix.
-    """
-    if deprecated_key in os.environ:
-        warnings.warn(
-            f'{deprecated_key} is renamed {new_key}, '
-            f'update the environment variable.',
-            DeprecationWarning,
-        )
-    return getter(new_key, getter(deprecated_key, default))
-
-
 CONSTANCE_CONFIG = {
     'REGISTRATION_OPEN': (
         True,
@@ -243,7 +226,7 @@ CONSTANCE_CONFIG = {
         'in the user interface',
     ),
     'SUPPORT_EMAIL': (
-        _constance_env(
+        constance_env(
             env.str,
             'CONSTANCE_SUPPORT_EMAIL',
             'KOBO_SUPPORT_EMAIL',
@@ -253,7 +236,7 @@ CONSTANCE_CONFIG = {
         'unhandled errors in the application',
     ),
     'SUPPORT_URL': (
-        _constance_env(
+        constance_env(
             env.str,
             'CONSTANCE_SUPPORT_URL',
             'KOBO_SUPPORT_URL',
@@ -262,7 +245,7 @@ CONSTANCE_CONFIG = {
         'URL for "KoboToolbox Help Center"',
     ),
     'ACADEMY_URL': (
-        _constance_env(
+        constance_env(
             env.str,
             'CONSTANCE_ACADEMY_URL',
             'KOBO_ACADEMY_URL',
@@ -271,7 +254,7 @@ CONSTANCE_CONFIG = {
         'URL for "KoboToolbox Community Forum"',
     ),
     'COMMUNITY_URL': (
-        _constance_env(
+        constance_env(
             env.str,
             'CONSTANCE_COMMUNITY_URL',
             'KOBO_COMMUNITY_URL',
@@ -364,7 +347,7 @@ CONSTANCE_CONFIG = {
         'Require MFA for superusers with a usable password',
     ),
     'USAGE_LIMIT_ENFORCEMENT': (
-        _constance_env(
+        constance_env(
             env.bool,
             'CONSTANCE_USAGE_LIMIT_ENFORCEMENT',
             'USAGE_LIMIT_ENFORCEMENT',
@@ -1290,16 +1273,6 @@ Stripe configuration intended for kf.kobotoolbox.org only,
 tracks usage limit exceptions
 """
 STRIPE_ENABLED = env.bool('STRIPE_ENABLED', False)
-
-
-def dj_stripe_request_callback_method():
-    # This method exists because dj-stripe's documentation doesn't reflect reality.
-    # It claims that DJSTRIPE_SUBSCRIBER_MODEL no longer needs a request callback but
-    # this error occurs without it: `DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must
-    # be implemented if a DJSTRIPE_SUBSCRIBER_MODEL is defined`
-    # It doesn't need to do anything other than exist
-    # https://github.com/dj-stripe/dj-stripe/issues/1900
-    pass
 
 
 BULK_ACTION_RATE_LIMITS = {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -225,21 +225,24 @@ CONSTANCE_CONFIG = {
         'in the user interface',
     ),
     'SUPPORT_EMAIL': (
-        env.str('KOBO_SUPPORT_EMAIL', env.str('DEFAULT_FROM_EMAIL', 'help@kobotoolbox.org')),
+        env.str(
+            'CONSTANCE_SUPPORT_EMAIL',
+            env.str('DEFAULT_FROM_EMAIL', 'help@kobotoolbox.org'),
+        ),
         'Email address for users to contact, e.g. when they encounter '
         'unhandled errors in the application',
     ),
     'SUPPORT_URL': (
-        env.str('KOBO_SUPPORT_URL', 'https://support.kobotoolbox.org/'),
+        env.str('CONSTANCE_SUPPORT_URL', 'https://support.kobotoolbox.org/'),
         'URL for "KoboToolbox Help Center"',
     ),
     'ACADEMY_URL': (
-        env.str('KOBO_ACADEMY_URL', 'https://academy.kobotoolbox.org/'),
+        env.str('CONSTANCE_ACADEMY_URL', 'https://academy.kobotoolbox.org/'),
         'URL for "KoboToolbox Community Forum"',
     ),
     'COMMUNITY_URL': (
         env.str(
-            'KOBO_COMMUNITY_URL', 'https://community.kobotoolbox.org/'
+            'CONSTANCE_COMMUNITY_URL', 'https://community.kobotoolbox.org/'
         ),
         'URL for "KoboToolbox Community Forum"',
     ),
@@ -328,7 +331,7 @@ CONSTANCE_CONFIG = {
         'Require MFA for superusers with a usable password',
     ),
     'USAGE_LIMIT_ENFORCEMENT': (
-        env.bool('USAGE_LIMIT_ENFORCEMENT', False),
+        env.bool('CONSTANCE_USAGE_LIMIT_ENFORCEMENT', False),
         'For Stripe-enabled instances, determines whether usage limits will be enforced'
         'by blocking submissions/NLP actions or deleting stored files.',
     ),
@@ -345,10 +348,6 @@ CONSTANCE_CONFIG = {
             ' the operations API. '
         )
     ),
-    # We are adopting the `CONSTANCE_` prefix as the new standard for all env
-    # variables that override Constance defaults. Legacy variables (e.g., KOBO_*)
-    # will be deprecated and migrated to this new pattern after the upcoming
-    # migration to Constance 4.x
     'ASR_MT_GOOGLE_PROJECT_ID': (
         env.str('CONSTANCE_ASR_MT_GOOGLE_PROJECT_ID', 'kobo-asr-mt'),
         'ID of the Google Cloud project used to access ASR/MT APIs',

--- a/kobo/settings/utils.py
+++ b/kobo/settings/utils.py
@@ -1,0 +1,35 @@
+import os
+import warnings
+from typing import Any, Callable
+
+
+def constance_env(
+    getter: Callable,
+    new_key: str,
+    deprecated_key: str,
+    default: Any,
+) -> Any:
+    """
+    Read a Constance override from the `CONSTANCE_`-prefixed environment
+    variable, falling back to its deprecated (unprefixed / `KOBO_`) name.
+
+    Emit a `DeprecationWarning` when the deprecated name is still set so
+    deployments know to migrate to the `CONSTANCE_` prefix.
+    """
+    if deprecated_key in os.environ:
+        warnings.warn(
+            f'{deprecated_key} is renamed {new_key}, '
+            f'update the environment variable.',
+            DeprecationWarning,
+        )
+    return getter(new_key, getter(deprecated_key, default))
+
+
+def dj_stripe_request_callback_method():
+    # This method exists because dj-stripe's documentation doesn't reflect reality.
+    # It claims that DJSTRIPE_SUBSCRIBER_MODEL no longer needs a request callback but
+    # this error occurs without it: `DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK must
+    # be implemented if a DJSTRIPE_SUBSCRIBER_MODEL is defined`
+    # It doesn't need to do anything other than exist
+    # https://github.com/dj-stripe/dj-stripe/issues/1900
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,11 @@ testpaths = [
     'kpi',
     'hub',
 ]
-# Add USAGE_LIMIT_ENFORCEMENT here because setting it in
+# Add CONSTANCE_USAGE_LIMIT_ENFORCEMENT here because setting it in
 # test module doesn't get registered by constance
 env = [
     'DJANGO_SETTINGS_MODULE=kobo.settings.testing',
-    'USAGE_LIMIT_ENFORCEMENT=True',
+    'CONSTANCE_USAGE_LIMIT_ENFORCEMENT=True',
 ]
 addopts = [
     '-m not performance',


### PR DESCRIPTION
### 🔗 Related PRs
Part of a 3-repo Constance env-var standardization:
- **kobotoolbox/kobo-install#279** — same rename in the kobo-install env template
- **kobotoolbox/kobo-docker#373** — same rename in the kobo-docker default env file

Backward compatibility is preserved (see below), so these can land independently — the deploy-repo PRs simply complete the migration to the new names.

### 📣 Summary
Standardize all Constance override env vars on a single `CONSTANCE_` prefix.

### 📖 Description
The env vars that override Constance defaults used three conventions (bare, `KOBO_`, `CONSTANCE_`). This unifies them on `CONSTANCE_`, matching the existing `CONSTANCE_ASR_MT_GOOGLE_*` precedent.

Renamed:
- `KOBO_SUPPORT_EMAIL` → `CONSTANCE_SUPPORT_EMAIL`
- `KOBO_SUPPORT_URL` → `CONSTANCE_SUPPORT_URL`
- `KOBO_ACADEMY_URL` → `CONSTANCE_ACADEMY_URL`
- `KOBO_COMMUNITY_URL` → `CONSTANCE_COMMUNITY_URL`
- `USAGE_LIMIT_ENFORCEMENT` → `CONSTANCE_USAGE_LIMIT_ENFORCEMENT` (env fallback in `base.py` + pytest `env` in `pyproject.toml`)

**Backward compatible:** each override reads the new `CONSTANCE_`-prefixed variable and falls back to the deprecated name (`KOBO_*` / bare) when it's unset, emitting a `DeprecationWarning` so deployments know to migrate. Old env vars keep working — no hard break.

The fallback logic lives in a new `constance_env` helper in `kobo/settings/utils.py`, moved out of `base.py` along with `dj_stripe_request_callback_method`.

### ✅ Test plan
- [x] `test_api_environment.py` — both settings axes
- [x] usage-limit-enforcement tests (KPI submissions, OpenRosa, subsequences)
- [x] deprecated env var still read + `DeprecationWarning` fired