### PR TITLE
fix(parsers): preserve raw filenames beyond 255 chars DEV-1856

### DIFF
--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -436,6 +436,42 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
                 self.assertEqual(response['Location'],
                                  'http://testserver/submission')
 
+    def test_post_submission_with_long_filename(self):
+        # KoboCollect names `xml_submission_file` after the form title, so a
+        # long title produces a long filename. It used to overflow the parser's
+        # base64-encoded filename past Django's 255-char cap on `file.name`,
+        # corrupting it and raising during decode -> HTTP 500 (DEV-1856).
+        s = self.surveys[0]
+        media_file = '1335783522563.jpg'
+        media_path = os.path.join(self.main_directory, 'fixtures',
+                                  'transportation', 'instances', s, media_file)
+        long_filename = 'a' * 220 + '.xml'
+        with open(media_path, 'rb') as mf:
+            mf = InMemoryUploadedFile(mf, 'media_file', media_file, 'image/jpg',
+                                      os.path.getsize(media_path), None)
+
+            submission_path = os.path.join(
+                self.main_directory, 'fixtures',
+                'transportation', 'instances', s, s + '.xml')
+
+            with open(submission_path, 'rb') as sf:
+                xml_file = InMemoryUploadedFile(
+                    sf, 'xml_submission_file', long_filename, 'text/xml',
+                    os.path.getsize(submission_path), None)
+                data = {'xml_submission_file': xml_file, 'media_file': mf}
+                request = self.factory.post('/submission', data)
+                response = self.view(request)
+                self.assertEqual(response.status_code, 401)
+
+                sf.seek(0)
+                mf.seek(0)
+                request = self.factory.post('/submission', data)
+                auth = DigestAuth('bob', 'bobbob')
+                request.META.update(auth(request.META, response))
+                response = self.view(request, username=self.user.username)
+                self.assertContains(response, 'Successful submission',
+                                    status_code=201)
+
     def test_post_submission_uuid_other_user_username_not_provided(self):
         alice_data = {
             'username': 'alice',

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -443,21 +443,43 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
         # corrupting it and raising during decode -> HTTP 500 (DEV-1856).
         s = self.surveys[0]
         media_file = '1335783522563.jpg'
-        media_path = os.path.join(self.main_directory, 'fixtures',
-                                  'transportation', 'instances', s, media_file)
+        media_path = os.path.join(
+            self.main_directory,
+            'fixtures',
+            'transportation',
+            'instances',
+            s,
+            media_file,
+        )
         long_filename = 'a' * 220 + '.xml'
         with open(media_path, 'rb') as mf:
-            mf = InMemoryUploadedFile(mf, 'media_file', media_file, 'image/jpg',
-                                      os.path.getsize(media_path), None)
+            mf = InMemoryUploadedFile(
+                mf,
+                'media_file',
+                media_file,
+                'image/jpg',
+                os.path.getsize(media_path),
+                None,
+            )
 
             submission_path = os.path.join(
-                self.main_directory, 'fixtures',
-                'transportation', 'instances', s, s + '.xml')
+                self.main_directory,
+                'fixtures',
+                'transportation',
+                'instances',
+                s,
+                s + '.xml',
+            )
 
             with open(submission_path, 'rb') as sf:
                 xml_file = InMemoryUploadedFile(
-                    sf, 'xml_submission_file', long_filename, 'text/xml',
-                    os.path.getsize(submission_path), None)
+                    sf,
+                    'xml_submission_file',
+                    long_filename,
+                    'text/xml',
+                    os.path.getsize(submission_path),
+                    None,
+                )
                 data = {'xml_submission_file': xml_file, 'media_file': mf}
                 request = self.factory.post('/submission', data)
                 response = self.view(request)
@@ -469,8 +491,7 @@ class TestXFormSubmissionApi(TestAbstractViewSet):
                 auth = DigestAuth('bob', 'bobbob')
                 request.META.update(auth(request.META, response))
                 response = self.view(request, username=self.user.username)
-                self.assertContains(response, 'Successful submission',
-                                    status_code=201)
+                self.assertContains(response, 'Successful submission', status_code=201)
 
     def test_post_submission_uuid_other_user_username_not_provided(self):
         alice_data = {

--- a/kpi/parsers.py
+++ b/kpi/parsers.py
@@ -1,5 +1,3 @@
-import base64
-
 from django.conf import settings
 from django.http.multipartparser import MultiPartParser as DjangoMultiPartParser
 from django.http.multipartparser import MultiPartParserError
@@ -8,35 +6,48 @@ from rest_framework.exceptions import ParseError
 from rest_framework.parsers import DataAndFiles
 from rest_framework.parsers import MultiPartParser as DRFMultiPartParser
 
+# Prefix for the short placeholder names returned by `sanitize_file_name`.
+# It only needs to survive `DjangoMultiPartParser` as an opaque lookup key, so
+# keep it well under Django's 255-char limit on `file.name`.
+RAW_FILENAME_TOKEN_PREFIX = '__kobo_raw_filename__'
+
 
 class MultiPartParserWithRawFilenames(DjangoMultiPartParser):
     """
     A parser that "smuggles" unsanitized filenames through
-    `DjangoMultiPartParser._parse()` by encoding them to base64. Then, after
-    the superclass is called, the base64-encoded filenames are decoded and
-    split into raw and sanitized attributes on each file.
+    `DjangoMultiPartParser._parse()`. Instead of storing the raw filename in
+    `file.name` (which Django silently truncates to 255 chars), it hands back a
+    short placeholder token and keeps the original filename in a side-channel
+    dict. After the superclass is called, each file's raw filename is recovered
+    from that dict, so it survives regardless of length.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Maps placeholder token -> original (unsanitized) filename.
+        self._raw_filenames = {}
 
     def sanitize_file_name(self, file_name: str) -> str:
         raw = force_str(file_name)
-        encoded = base64.urlsafe_b64encode(raw.encode('utf-8')).decode('ascii')
-        return encoded
+        token = f'{RAW_FILENAME_TOKEN_PREFIX}{len(self._raw_filenames)}'
+        self._raw_filenames[token] = raw
+        return token
 
     def parse(self):
         data, files = super().parse()
 
         for field_name, f in files.items():
-            decoded = base64.urlsafe_b64decode(f.name.encode('ascii')).decode('utf-8')
-            f._raw_filename = decoded
-            f.name = super().sanitize_file_name(decoded)
+            raw = self._raw_filenames.get(f.name, f.name)
+            f._raw_filename = raw
+            f.name = super().sanitize_file_name(raw)
 
         return data, files
 
 
 class RawFilenameMultiPartParser(DRFMultiPartParser):
     """
-    DRF-compatible MultiPartParser that intercepts the original filenames
-    via base64 encoding and stores the decoded version in ._raw_filename.
+    DRF-compatible MultiPartParser that intercepts the original filenames and
+    stores them, unsanitized, in ._raw_filename.
     """
 
     def parse(self, stream, media_type=None, parser_context=None):

--- a/kpi/tests/test_parsers.py
+++ b/kpi/tests/test_parsers.py
@@ -1,0 +1,36 @@
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from kpi.parsers import RawFilenameMultiPartParser
+
+
+class RawFilenameMultiPartParserTestCase(TestCase):
+    def _parse_single_file(self, filename: str):
+        upload = SimpleUploadedFile(filename, b'<data/>', content_type='text/xml')
+        request = APIRequestFactory().post(
+            '/', {'xml_submission_file': upload}, format='multipart'
+        )
+        parser = RawFilenameMultiPartParser()
+        result = parser.parse(
+            BytesIO(request.body),
+            request.META['CONTENT_TYPE'],
+            {'request': request, 'encoding': 'utf-8'},
+        )
+        return result.files['xml_submission_file']
+
+    def test_preserves_long_raw_filename(self):
+        # KoboCollect names the submission file after the form title. A long
+        # title used to overflow the base64-smuggled name past Django's
+        # 255-char cap on `file.name`, corrupting it and raising during decode
+        # (the production HTTP 500). The original filename must survive intact.
+        filename = 'a' * 220 + '.xml'
+        parsed = self._parse_single_file(filename)
+        assert parsed._raw_filename == filename
+
+    def test_preserves_short_raw_filename(self):
+        filename = 'submission.xml'
+        parsed = self._parse_single_file(filename)
+        assert parsed._raw_filename == filename

--- a/kpi/tests/test_parsers.py
+++ b/kpi/tests/test_parsers.py
@@ -8,19 +8,6 @@ from kpi.parsers import RawFilenameMultiPartParser
 
 
 class RawFilenameMultiPartParserTestCase(TestCase):
-    def _parse_single_file(self, filename: str):
-        upload = SimpleUploadedFile(filename, b'<data/>', content_type='text/xml')
-        request = APIRequestFactory().post(
-            '/', {'xml_submission_file': upload}, format='multipart'
-        )
-        parser = RawFilenameMultiPartParser()
-        result = parser.parse(
-            BytesIO(request.body),
-            request.META['CONTENT_TYPE'],
-            {'request': request, 'encoding': 'utf-8'},
-        )
-        return result.files['xml_submission_file']
-
     def test_preserves_long_raw_filename(self):
         # KoboCollect names the submission file after the form title. A long
         # title used to overflow the base64-smuggled name past Django's
@@ -34,3 +21,16 @@ class RawFilenameMultiPartParserTestCase(TestCase):
         filename = 'submission.xml'
         parsed = self._parse_single_file(filename)
         assert parsed._raw_filename == filename
+
+    def _parse_single_file(self, filename: str):
+        upload = SimpleUploadedFile(filename, b'<data/>', content_type='text/xml')
+        request = APIRequestFactory().post(
+            '/', {'xml_submission_file': upload}, format='multipart'
+        )
+        parser = RawFilenameMultiPartParser()
+        result = parser.parse(
+            BytesIO(request.body),
+            request.META['CONTENT_TYPE'],
+            {'request': request, 'encoding': 'utf-8'},
+        )
+        return result.files['xml_submission_file']


### PR DESCRIPTION
### 📣 Summary

Fixed a server error that blocked KoboCollect submissions for projects with very long names.

### 📖 Description

Submitting a form from KoboToolbox Collect could fail with a server error when the project name was very long. Submissions now succeed regardless of name length, so no data is lost.

### 💭 Notes

The submission filename is derived from the form title. Long titles overflowed the parser's base64-encoded filename past Django's 255-char cap on `file.name`, raising `binascii.Error` → HTTP 500. The parser now keeps the raw filename in a side-channel dict instead of `file.name`, so it survives any length. No limit change, no migration.

Tests: unit round-trip (`kpi/tests/test_parsers.py`) + e2e `test_post_submission_with_long_filename` (reproduces the 500 pre-fix). Submission and snapshot suites green on both settings axes.

### 👀 Preview steps

1. deploy a project and rename it to a 255+ character title
2. submit a form for it from KoboToolbox Collect
3. 🔴 [on main] submission fails with HTTP 500
4. 🟢 [on PR] submission succeeds
