### PR TITLE
feat(KMLExport): route KML exports through KPI export tasks DEV-1591

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -264,7 +264,7 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@3bf65b74fe876a514cff839fb10c24470dd63de2
     # via -r dependencies/pip/requirements.in
 freezegun==1.5.5
     # via -r dependencies/pip/dev_requirements.in
@@ -276,10 +276,14 @@ funcsigs==1.0.2
     # via begins
 future==1.0.0
     # via -r dependencies/pip/requirements.in
+geojson==3.3.0
+    # via geojson2kml
 geojson-rewind==1.2.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack
+geojson2kml==0.2.0
+    # via formpack
 google-api-core[grpc]==2.30.3
     # via
     #   google-api-python-client
@@ -639,6 +643,8 @@ shortuuid==1.0.13
     # via -r dependencies/pip/requirements.in
 simplejson==4.1.1
     # via -r dependencies/pip/dev_requirements.in
+simplekml==1.3.6
+    # via geojson2kml
 six==1.17.0
     # via python-dateutil
 smsapi-client==2.9.7

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
-git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
+git+https://github.com/kobotoolbox/formpack.git@3bf65b74fe876a514cff839fb10c24470dd63de2#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -210,7 +210,7 @@ fido2==2.2.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@7e92685993f76a14b7772363edd9882dc50da18f#egg=formpack
+formpack @ git+https://github.com/kobotoolbox/formpack.git@3bf65b74fe876a514cff839fb10c24470dd63de2
     # via -r dependencies/pip/requirements.in
 frozenlist==1.8.0
     # via
@@ -220,10 +220,14 @@ funcsigs==1.0.2
     # via begins
 future==1.0.0
     # via -r dependencies/pip/requirements.in
+geojson==3.3.0
+    # via geojson2kml
 geojson-rewind==1.2.1
     # via
     #   -r dependencies/pip/requirements.in
     #   formpack
+geojson2kml==0.2.0
+    # via formpack
 google-api-core[grpc]==2.30.3
     # via
     #   google-api-python-client

--- a/kobo/apps/openrosa/apps/viewer/tasks.py
+++ b/kobo/apps/openrosa/apps/viewer/tasks.py
@@ -62,9 +62,8 @@ def create_async_export(xform, export_type, query, force_xlsx, options=None):
         result = create_zip_export.apply_async(
             (), arguments, countdown=10)
     elif export_type == Export.KML_EXPORT:
-        # start async export
-        result = create_kml_export.apply_async(
-            (), arguments, countdown=10)
+        # KML exports must be created through KPI v2 export tasks.
+        raise Export.ExportTypeError
     else:
         raise Export.ExportTypeError
     if result:

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -983,6 +983,9 @@ class SubmissionExportTaskBase(ImportExportTask):
         if self.data.get('type', '').lower() != 'kml':
             return fields
 
+        if not fields:
+            return fields
+
         survey = source.content.get('survey', []) if source.content else []
         geo_fields = self._get_geo_fields_from_survey(survey)
         if not geo_fields:

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -50,6 +50,7 @@ from kpi.constants import (
     ASSET_TYPE_EMPTY,
     ASSET_TYPE_SURVEY,
     ASSET_TYPE_TEMPLATE,
+    GEO_QUESTION_TYPES,
     PERM_CHANGE_ASSET,
     PERM_MANAGE_ASSET,
     PERM_PARTIAL_SUBMISSIONS,
@@ -942,6 +943,61 @@ class SubmissionExportTaskBase(ImportExportTask):
         fields += list(field_groups) + additional_fields
         return fields
 
+    @staticmethod
+    def _get_geo_fields_from_survey(survey: list) -> List[str]:
+        """
+        Build full field paths for all geographic questions in the survey.
+        """
+        if not isinstance(survey, list):
+            return []
+
+        geo_fields = []
+        open_groups = []
+        for row in survey:
+            if not isinstance(row, dict):
+                continue
+
+            row_type = row.get('type')
+            row_name = row.get('name') or row.get('$autoname') or row.get('$xpath')
+
+            if row_type in ('begin_group', 'begin_repeat'):
+                if row_name:
+                    open_groups.append(row_name)
+                continue
+
+            if row_type in ('end_group', 'end_repeat'):
+                if open_groups:
+                    open_groups.pop()
+                continue
+
+            if row_type not in GEO_QUESTION_TYPES or not row_name:
+                continue
+
+            geo_fields.append('/'.join([*open_groups, row_name]))
+
+        return geo_fields
+
+    def _get_submission_fields(self, source: Asset, fields: List[str]) -> List[str]:
+        fields = self._get_fields_and_groups(fields)
+
+        if self.data.get('type', '').lower() != 'kml':
+            return fields
+
+        survey = source.content.get('survey', []) if source.content else []
+        geo_fields = self._get_geo_fields_from_survey(survey)
+        if not geo_fields:
+            return fields
+
+        ordered_fields = []
+        seen_fields = set()
+        for field in [*fields, *self._get_fields_and_groups(geo_fields)]:
+            if field in seen_fields:
+                continue
+            seen_fields.add(field)
+            ordered_fields.append(field)
+
+        return ordered_fields
+
     @property
     def _hierarchy_in_labels(self) -> bool:
         hierarchy_in_labels = self.data.get('hierarchy_in_labels', False)
@@ -986,9 +1042,9 @@ class SubmissionExportTaskBase(ImportExportTask):
             # Excel exports are always returned in XLSX format, but they're
             # referred to internally as `xls`
             export_type = 'xls'
-        if export_type not in ('xls', 'csv', 'geojson', 'spss_labels'):
+        if export_type not in ('xls', 'csv', 'geojson', 'kml', 'spss_labels'):
             raise NotImplementedError(
-                'only `xls`, `csv`, `geojson`, and `spss_labels` '
+                'only `xls`, `csv`, `geojson`, `kml`, and `spss_labels` '
                 'are valid export types'
             )
 
@@ -1001,8 +1057,12 @@ class SubmissionExportTaskBase(ImportExportTask):
                 for line in export.to_csv(submission_stream):
                     output_file.write((line + '\r\n').encode('utf-8'))
             elif export_type == 'geojson':
-                for line in export.to_geojson(
-                    submission_stream, flatten=flatten
+                for line in export.to_geojson(submission_stream, flatten=flatten):
+                    output_file.write(line.encode('utf-8'))
+            elif export_type == 'kml':
+                for line in export.to_kml(
+                    submission_stream,
+                    flatten=True,
                 ):
                     output_file.write(line.encode('utf-8'))
             elif export_type == 'xls':
@@ -1079,7 +1139,7 @@ class SubmissionExportTaskBase(ImportExportTask):
 
         # Include the group name in `fields` for Mongo to correctly filter
         # for repeat groups
-        fields = self._get_fields_and_groups(fields)
+        fields = self._get_submission_fields(source, fields)
 
         if source.has_advanced_features:
             # Use a cheap EXISTS query before the expensive full prefetch in

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -267,7 +267,10 @@ class ExportTaskSerializer(serializers.ModelSerializer):
             )
 
         # KML-specific validation
-        if export_type == EXPORT_TYPE_KML and data.get(EXPORT_SETTING_FLATTEN) is True:
+        if (
+            export_type == EXPORT_TYPE_KML
+            and EXPORT_SETTING_FLATTEN in data
+        ):
             raise serializers.ValidationError(
                 {
                     EXPORT_SETTING_FLATTEN: t(

--- a/kpi/serializers/v2/export_task.py
+++ b/kpi/serializers/v2/export_task.py
@@ -18,6 +18,7 @@ from formpack.constants import (
     EXPORT_SETTING_SUBMISSION_IDS,
     EXPORT_SETTING_TYPE,
     EXPORT_SETTING_XLS_TYPES_AS_TEXT,
+    EXPORT_TYPE_KML,
     REQUIRED_EXPORT_SETTINGS,
     VALID_DEFAULT_LANGUAGES,
     VALID_EXPORT_SETTINGS,
@@ -264,6 +265,17 @@ class ExportTaskSerializer(serializers.ModelSerializer):
                     )
                 }
             )
+
+        # KML-specific validation
+        if export_type == EXPORT_TYPE_KML and data.get(EXPORT_SETTING_FLATTEN) is True:
+            raise serializers.ValidationError(
+                {
+                    EXPORT_SETTING_FLATTEN: t(
+                        'The "flatten" option is not supported for KML exports.'
+                    )
+                }
+            )
+
         return export_type
 
     def get_url(self, obj: SubmissionExportTask) -> str:

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -428,6 +428,35 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         )
         assert export_content_response.status_code == status.HTTP_200_OK
 
+    def test_export_task_create_kml_requires_view_data_permission(self):
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': self.asset.uid},
+        )
+        data = {
+            'type': 'kml',
+            'lang': '_default',
+            'group_sep': '/',
+            'hierarchy_in_labels': False,
+            'fields_from_all_versions': False,
+            'multiple_select': 'both',
+        }
+
+        self.client.logout()
+        self.client.login(username='anotheruser', password='anotheruser')
+        response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        anotheruser = User.objects.get(username='anotheruser')
+        self.asset.assign_perm(anotheruser, PERM_VIEW_ASSET)
+        response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        self.asset.assign_perm(anotheruser, PERM_VIEW_SUBMISSIONS)
+        with immediate_on_commit():
+            response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
     def test_export_task_create_kml_includes_geo_fields_when_fields_filtered(self):
         geo_asset = Asset()
         geo_asset.owner = self.asset.owner

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -1,7 +1,9 @@
 # coding: utf-8
+import copy
 import os
 from collections import defaultdict
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.test import RequestFactory
 from django.utils import timezone
@@ -9,6 +11,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.models import XForm
 from kpi.constants import (
     PERM_PARTIAL_SUBMISSIONS,
     PERM_VIEW_ASSET,
@@ -384,6 +387,174 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         }
         response = self.client.post(list_url, data=data, format='json')
         assert response.status_code == status.HTTP_201_CREATED
+
+    def test_export_task_create_kml_with_full_payload(self):
+        self.client.login(username='someuser', password='someuser')
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': self.asset.uid},
+        )
+        data = {
+            'type': 'kml',
+            'lang': '_default',
+            'group_sep': '/',
+            'hierarchy_in_labels': False,
+            'fields_from_all_versions': False,
+            'multiple_select': 'both',
+        }
+
+        with immediate_on_commit():
+            response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_uid = response.json()['uid']
+        export_task = SubmissionExportTask.objects.get(uid=export_uid)
+        assert export_task.data['type'] == 'kml'
+        assert export_task.status == ImportExportStatusChoices.COMPLETE
+        assert export_task.result.name.endswith('.kml')
+        assert export_task.result.storage.exists(export_task.result.name)
+        assert SubmissionExportTask.objects.filter(
+            uid=export_uid, data__type='kml'
+        ).exists()
+
+        export_detail_response = self.client.get(
+            response.json()['url'], headers={'accept': 'application/json'}
+        )
+        assert export_detail_response.status_code == status.HTTP_200_OK
+        assert export_detail_response.json()['result'].endswith('.kml')
+
+        export_content_response = self.client.get(
+            export_detail_response.json()['result']
+        )
+        assert export_content_response.status_code == status.HTTP_200_OK
+
+    def test_export_task_create_kml_includes_geo_fields_when_fields_filtered(self):
+        geo_asset = Asset()
+        geo_asset.owner = self.asset.owner
+        geo_asset.content = copy.deepcopy(self.asset.content)
+        geo_asset.content['survey'].extend(
+            [
+                {
+                    'name': 'geo_point',
+                    '$autoname': 'geo_point',
+                    '$kuid': 'kml_geo_point',
+                    '$xpath': 'geo_point',
+                    'type': 'geopoint',
+                    'label': ['Geo point', 'Punto geo'],
+                },
+                {
+                    'name': 'geo_trace',
+                    '$autoname': 'geo_trace',
+                    '$kuid': 'kml_geo_trace',
+                    '$xpath': 'geo_trace',
+                    'type': 'geotrace',
+                    'label': ['Geo trace', 'Trazo geo'],
+                },
+                {
+                    'name': 'geo_shape',
+                    '$autoname': 'geo_shape',
+                    '$kuid': 'kml_geo_shape',
+                    '$xpath': 'geo_shape',
+                    'type': 'geoshape',
+                    'label': ['Geo shape', 'Area geo'],
+                },
+            ]
+        )
+        geo_asset.save()
+        geo_asset.deploy(backend='mock', active=True)
+        geo_asset.deployment.mock_submissions(
+            [
+                {
+                    '_attachments': [],
+                    '_status': 'submitted_via_web',
+                    '_submission_time': '2026-07-10T00:00:00',
+                    '_uuid': '7d6f8ce4-e2d6-4f75-a450-5f0a1e2d9c11',
+                    'meta/rootUuid': 'uuid:7d6f8ce4-e2d6-4f75-a450-5f0a1e2d9c11',
+                    'string': 'text value',
+                    'geo_point': '13.581921 17.858232 0 0',
+                    'geo_trace': '18.312811 0.269114 0 0;18.315724 0.274077 0 0',
+                    'geo_shape': (
+                        '22.268764 -1.841581 0 0;22.26791 -1.837273 0 0;'
+                        '22.266332 -1.841469 0 0;22.268764 -1.841581 0 0'
+                    ),
+                }
+            ]
+        )
+
+        self.client.login(username='someuser', password='someuser')
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': geo_asset.uid},
+        )
+
+        with immediate_on_commit():
+            response = self.client.post(
+                list_url,
+                data={
+                    'type': 'kml',
+                    'lang': '_default',
+                    'group_sep': '/',
+                    'hierarchy_in_labels': False,
+                    'fields_from_all_versions': False,
+                    'multiple_select': 'both',
+                    'fields': ['string'],
+                },
+                format='json',
+            )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_detail_response = self.client.get(
+            response.json()['url'], headers={'accept': 'application/json'}
+        )
+        assert export_detail_response.status_code == status.HTTP_200_OK
+
+        export_content_response = self.client.get(
+            export_detail_response.json()['result']
+        )
+        assert export_content_response.status_code == status.HTTP_200_OK
+
+        export_content = ''.join(
+            line.decode() for line in export_content_response.streaming_content
+        )
+        assert '<Placemark' in export_content
+        assert '<Point' in export_content
+
+    @patch('kobo.apps.openrosa.apps.viewer.tasks.create_async_export')
+    def test_export_task_create_kml_does_not_hit_legacy_openrosa_kml_new_endpoint(
+        self, create_async_export_mock
+    ):
+        self.client.login(username='someuser', password='someuser')
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': self.asset.uid},
+        )
+        data = {
+            'type': 'kml',
+            'lang': '_default',
+            'group_sep': '/',
+            'hierarchy_in_labels': False,
+            'fields_from_all_versions': False,
+            'multiple_select': 'both',
+        }
+
+        response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+        create_async_export_mock.assert_not_called()
+
+    def test_legacy_openrosa_kml_new_endpoint_is_blocked(self):
+        self.client.login(username='someuser', password='someuser')
+        xform = XForm.objects.get(kpi_asset_uid=self.asset.uid)
+        legacy_create_url = reverse(
+            'create_export',
+            kwargs={
+                'username': xform.user.username,
+                'id_string': xform.id_string,
+                'export_type': 'kml',
+            },
+        )
+
+        response = self.client.post(legacy_create_url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_export_task_create_with_name(self):
         self.client.login(username='someuser', password='someuser')

--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -502,6 +502,8 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
                 format='json',
             )
         assert response.status_code == status.HTTP_201_CREATED
+        export_task = SubmissionExportTask.objects.get(uid=response.json()['uid'])
+        assert export_task._get_submission_fields(geo_asset, []) == []
 
         export_detail_response = self.client.get(
             response.json()['url'], headers={'accept': 'application/json'}
@@ -518,6 +520,95 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         )
         assert '<Placemark' in export_content
         assert '<Point' in export_content
+
+    def test_export_task_create_kml_without_field_filter_keeps_non_geo_fields(self):
+        geo_asset = Asset()
+        geo_asset.owner = self.asset.owner
+        geo_asset.content = copy.deepcopy(self.asset.content)
+        geo_asset.content['survey'].extend(
+            [
+                {
+                    'name': 'geo_point',
+                    '$autoname': 'geo_point',
+                    '$kuid': 'kml_geo_point',
+                    '$xpath': 'geo_point',
+                    'type': 'geopoint',
+                    'label': ['Geo point', 'Punto geo'],
+                },
+                {
+                    'name': 'geo_trace',
+                    '$autoname': 'geo_trace',
+                    '$kuid': 'kml_geo_trace',
+                    '$xpath': 'geo_trace',
+                    'type': 'geotrace',
+                    'label': ['Geo trace', 'Trazo geo'],
+                },
+                {
+                    'name': 'geo_shape',
+                    '$autoname': 'geo_shape',
+                    '$kuid': 'kml_geo_shape',
+                    '$xpath': 'geo_shape',
+                    'type': 'geoshape',
+                    'label': ['Geo shape', 'Area geo'],
+                },
+            ]
+        )
+        geo_asset.save()
+        geo_asset.deploy(backend='mock', active=True)
+        geo_asset.deployment.mock_submissions(
+            [
+                {
+                    '_attachments': [],
+                    '_status': 'submitted_via_web',
+                    '_submission_time': '2026-07-10T00:00:00',
+                    '_uuid': '7d6f8ce4-e2d6-4f75-a450-5f0a1e2d9c11',
+                    'meta/rootUuid': 'uuid:7d6f8ce4-e2d6-4f75-a450-5f0a1e2d9c11',
+                    'string': 'text value',
+                    'geo_point': '13.581921 17.858232 0 0',
+                    'geo_trace': '18.312811 0.269114 0 0;18.315724 0.274077 0 0',
+                    'geo_shape': (
+                        '22.268764 -1.841581 0 0;22.26791 -1.837273 0 0;'
+                        '22.266332 -1.841469 0 0;22.268764 -1.841581 0 0'
+                    ),
+                }
+            ]
+        )
+
+        self.client.login(username='someuser', password='someuser')
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': geo_asset.uid},
+        )
+
+        with immediate_on_commit():
+            response = self.client.post(
+                list_url,
+                data={
+                    'type': 'kml',
+                    'lang': '_default',
+                    'group_sep': '/',
+                    'hierarchy_in_labels': False,
+                    'fields_from_all_versions': False,
+                    'multiple_select': 'both',
+                },
+                format='json',
+            )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_detail_response = self.client.get(
+            response.json()['url'], headers={'accept': 'application/json'}
+        )
+        assert export_detail_response.status_code == status.HTTP_200_OK
+
+        export_content_response = self.client.get(
+            export_detail_response.json()['result']
+        )
+        assert export_content_response.status_code == status.HTTP_200_OK
+
+        export_content = ''.join(
+            line.decode() for line in export_content_response.streaming_content
+        )
+        assert '<Placemark' in export_content
 
     @patch('kobo.apps.openrosa.apps.viewer.tasks.create_async_export')
     def test_export_task_create_kml_does_not_hit_legacy_openrosa_kml_new_endpoint(


### PR DESCRIPTION
### 📣 Summary
KML exports now run through KPI export tasks and no longer use the legacy OpenRosa KML export endpoint.

### 💭 Notes
- Updated formpack pin to the latest [commit] that implements kml exports (https://github.com/kobotoolbox/formpack/commit/3bf65b74fe876a514cff839fb10c24470dd63de2) 
- Added kml as a valid export type in SubmissionExportTask pipeline.
- Writes KML output via export.to_kml(..., flatten=True).
- Added geo-question field auto-inclusion logic for KML when fields filtering is used, so geometry columns are still fetched.

### 👀 Preview steps

1. ℹ️ Have an account, a project, and a deployed survey with at least one of each geo type question (geopoint, geotrace, and geoshape).
2. Submit at least one response containing geo data.
3. Navigate to `/api/v2/docs` and create an export task `/api/v2/assets/{uid_asset}/exports/` with payload:
```
{
  "type": "kml",
  "lang": "_default",
  "group_sep": "/",
  "hierarchy_in_labels": false,
  "fields_from_all_versions": false,
  "multiple_select": "both"
}
```
4. 🟢 Should succeed with HTTP 201 Created. Navigate to {Project Name} > Data > Downloads you should see an export generated in the export list with no type yet (as the frontend hasn't been implemented).
<img width="1208" height="734" alt="Screenshot 2026-07-10 at 2 11 27 PM" src="https://github.com/user-attachments/assets/8dcdd1d0-72d6-408c-a753-7b3cad6d464e" />
5. 🟢 Download the export and validate that the kml is correct by uploading the file to google earth. 
6. 🟢 Check that requests to the openRosa endpoint are bypassed by trying to generate a kml export through the legacy kml exports. You should get an error:
<img width="1210" height="730" alt="Screenshot 2026-07-10 at 2 09 28 PM" src="https://github.com/user-attachments/assets/c0178af4-0923-43ed-9235-2a85a31a4290" />