### PR TITLE
test(KMLExport): add permission test for KML export DEV‑1594

### DIFF
--- a/kpi/tests/api/v2/test_api_exports.py
+++ b/kpi/tests/api/v2/test_api_exports.py
@@ -428,6 +428,35 @@ class AssetExportTaskTestV2(MockDataExportsBase, BaseTestCase):
         )
         assert export_content_response.status_code == status.HTTP_200_OK
 
+    def test_export_task_create_kml_requires_view_data_permission(self):
+        list_url = reverse(
+            self._get_endpoint('asset-export-list'),
+            kwargs={'format': 'json', 'uid_asset': self.asset.uid},
+        )
+        data = {
+            'type': 'kml',
+            'lang': '_default',
+            'group_sep': '/',
+            'hierarchy_in_labels': False,
+            'fields_from_all_versions': False,
+            'multiple_select': 'both',
+        }
+
+        self.client.logout()
+        self.client.login(username='anotheruser', password='anotheruser')
+        response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        anotheruser = User.objects.get(username='anotheruser')
+        self.asset.assign_perm(anotheruser, PERM_VIEW_ASSET)
+        response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        self.asset.assign_perm(anotheruser, PERM_VIEW_SUBMISSIONS)
+        with immediate_on_commit():
+            response = self.client.post(list_url, data=data, format='json')
+        assert response.status_code == status.HTTP_201_CREATED
+
     def test_export_task_create_kml_includes_geo_fields_when_fields_filtered(self):
         geo_asset = Asset()
         geo_asset.owner = self.asset.owner


### PR DESCRIPTION
### 📣 Summary
Add a test ensuring KML exports behave consistently with all other export types--requiring “view data” permission and generating project history logs.

### 💭 Notes

- KML export creation already uses `SubmissionExportTask` and inherited permission checks from `ExportTaskPermission`.
- Audit logging was already handled by `AuditLoggedNoUpdateModelViewSet`.
- This test simply codifies the expected permissions behavior and protect against regressions. There is already a test for export logs in kobo/apps/audit_log/tests/test_project_history_logs.py: `test_export_creates_log`

### 👀 Preview steps

1. ℹ️ Have an account, a project, and a deployed survey with at least one of each geo type question (geopoint, geotrace, and geoshape).
2. Submit at least one response containing geo data.
3. Navigate to `/api/v2/docs` and create an export task `/api/v2/assets/{uid_asset}/exports/` with payload:
```
{
  "type": "kml",
  "lang": "_default",
  "group_sep": "/",
  "hierarchy_in_labels": false,
  "fields_from_all_versions": false,
  "multiple_select": "both"
}
```
4. Should succeed with HTTP 201 Created. Navigate to {Project Name} > Data > Downloads you should see an export generated in the export list.
5. 🟢 Check out the Settings > Activity and you should see a log that your user exported data. 
6. 🟢 Try creating an export task again through the api but now logged in as a user without "view-submissions" permissions on the project and receive a 404 Not Found error. 
