### PR TITLE
perf(asset): fetch permissions once in Asset detail endpoint DEV-1833

### DIFF
--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -870,28 +870,6 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context.get('request')
         return reverse('paired-data-list', args=(asset.uid,), request=request)
 
-    def _get_object_permission_assignments(self, asset):
-        """
-        Fetch the asset's non-denied assignments once per request (memoized), so
-        get_permissions and get_access_types share one query in the detail view.
-        """
-        cache = self.__dict__.setdefault(
-            '_object_permission_assignments_cache', {}
-        )
-        if asset.pk not in cache:
-            cache[asset.pk] = list(
-                asset.permissions.filter(deny=False)
-                .values(
-                    'uid',
-                    'user_id',
-                    'user__username',
-                    'user__is_active',
-                    'permission__codename',
-                )
-                .order_by('user__username', 'permission__codename')
-            )
-        return cache[asset.pk]
-
     @extend_schema_field(PermissionsField)
     def get_permissions(self, asset):
         context = self.context
@@ -1159,6 +1137,26 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     def _content(self, obj):
         # FIXME: Is this dead code?
         return json.dumps(obj.content)
+
+    def _get_object_permission_assignments(self, asset):
+        """
+        Fetch the asset's non-denied assignments once per request (memoized), so
+        get_permissions and get_access_types share one query in the detail view.
+        """
+        cache = self.__dict__.setdefault('_object_permission_assignments_cache', {})
+        if asset.pk not in cache:
+            cache[asset.pk] = list(
+                asset.permissions.filter(deny=False)
+                .values(
+                    'uid',
+                    'user_id',
+                    'user__username',
+                    'user__is_active',
+                    'permission__codename',
+                )
+                .order_by('user__username', 'permission__codename')
+            )
+        return cache[asset.pk]
 
     def _get_status(self, perm_assignments):
         """

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -872,13 +872,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
     def _get_object_permission_assignments(self, asset):
         """
-        Fetch this asset's non-denied permission assignments once per request,
-        memoized on the serializer instance, so `get_permissions` and
-        `get_access_types` share a single query in the detail endpoint.
-
-        The dicts are a superset: `get_permissions` further filters on
-        `user__is_active`. Shape mirrors the list view's
-        `object_permissions_per_asset` cache.
+        Fetch the asset's non-denied assignments once per request (memoized), so
+        get_permissions and get_access_types share one query in the detail view.
         """
         cache = self.__dict__.setdefault(
             '_object_permission_assignments_cache', {}

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -870,6 +870,33 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
         request = self.context.get('request')
         return reverse('paired-data-list', args=(asset.uid,), request=request)
 
+    def _get_object_permission_assignments(self, asset):
+        """
+        Fetch this asset's non-denied permission assignments once per request,
+        memoized on the serializer instance, so `get_permissions` and
+        `get_access_types` share a single query in the detail endpoint.
+
+        The dicts are a superset: `get_permissions` further filters on
+        `user__is_active`. Shape mirrors the list view's
+        `object_permissions_per_asset` cache.
+        """
+        cache = self.__dict__.setdefault(
+            '_object_permission_assignments_cache', {}
+        )
+        if asset.pk not in cache:
+            cache[asset.pk] = list(
+                asset.permissions.filter(deny=False)
+                .values(
+                    'uid',
+                    'user_id',
+                    'user__username',
+                    'user__is_active',
+                    'permission__codename',
+                )
+                .order_by('user__username', 'permission__codename')
+            )
+        return cache[asset.pk]
+
     @extend_schema_field(PermissionsField)
     def get_permissions(self, asset):
         context = self.context
@@ -877,16 +904,13 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
         self._set_asset_ids_cache(asset)
 
-        all_permissions = list(
-            asset.permissions.filter(deny=False, user__is_active=True)
-            .values(
-                'uid',
-                'user_id',
-                'user__username',
-                'permission__codename',
-            )
-            .order_by('user__username', 'permission__codename')
-        )
+        # Reuse the per-request assignments (shared with get_access_types);
+        # keep only active users, as this field did before.
+        all_permissions = [
+            assignment
+            for assignment in self._get_object_permission_assignments(asset)
+            if assignment['user__is_active']
+        ]
         # Users who have view_asset via a project view can see all permission
         # assignments, even without manage_asset on the asset directly.
         # Org admins are handled by `has_perm()` which checks `is_admin_only()`.
@@ -966,9 +990,10 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 'object_permissions_per_asset'
             ].get(asset.pk, [])
         except KeyError:
-            # Detail view fallback: use .values() to return dicts like the cache
-            asset_permission_assignments = asset.permissions.filter(deny=False).values(
-                'user_id', 'permission__codename'
+            # Detail view fallback: reuse the assignments fetched by
+            # get_permissions instead of issuing a second query.
+            asset_permission_assignments = self._get_object_permission_assignments(
+                asset
             )
 
         # Check if the asset is public (anonymous has discover_asset).

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -6,6 +6,9 @@ from datetime import datetime
 import dateutil.parser
 from ddt import data, ddt, unpack
 from django.conf import settings
+from django.db import connection
+from django.test import RequestFactory
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from model_bakery import baker
@@ -17,6 +20,7 @@ from kobo.apps.project_views.models.project_view import ProjectView
 from kobo.apps.subsequences.constants import Action
 from kobo.apps.subsequences.models import QuestionAdvancedFeature
 from kpi.constants import (
+    ASSET_TYPE_COLLECTION,
     ASSET_TYPE_EMPTY,
     ASSET_TYPE_SURVEY,
     PERM_ADD_SUBMISSIONS,
@@ -32,7 +36,7 @@ from kpi.constants import (
 )
 from kpi.models import Asset, AssetFile, AssetVersion
 from kpi.models.asset import AssetDeploymentStatus
-from kpi.serializers.v2.asset import AssetListSerializer
+from kpi.serializers.v2.asset import AssetListSerializer, AssetSerializer
 from kpi.tests.base_test_case import (
     BaseAssetDetailTestCase,
     BaseAssetTestCase,
@@ -2191,6 +2195,37 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
         usernames = self._get_perm_usernames(response.data['permissions'])
         self.assertIn('someuser', usernames)
         self.assertIn(self.thirduser.username, usernames)
+
+    def test_detail_access_types_reuses_permission_fetch(self):
+        """
+        On the detail endpoint, get_access_types reuses the per-request
+        permission-assignment fetch that get_permissions also uses, instead of
+        issuing its own query (DEV-1833): once the fetch is primed, it triggers
+        no further object-permission query.
+        """
+        collection = Asset.objects.create(
+            asset_type=ASSET_TYPE_COLLECTION,
+            owner=self.asset.owner,
+            name='shared-fetch collection',
+        )
+        collection.assign_perm(self.thirduser, PERM_VIEW_ASSET)
+
+        request = RequestFactory().get('/')
+        request.user = self.asset.owner
+        serializer = AssetSerializer(collection, context={'request': request})
+
+        # Prime the shared, memoized fetch (the same one get_permissions reads).
+        serializer._get_object_permission_assignments(collection)
+        with CaptureQueriesContext(connection) as context:
+            access_types = serializer.get_access_types(collection)
+
+        object_permission_queries = [
+            q['sql']
+            for q in context.captured_queries
+            if 'kpi_objectpermission' in q['sql']
+        ]
+        self.assertEqual(object_permission_queries, [])
+        self.assertEqual(access_types, ['owned'])
 
 
 class AssetsXmlExportApiTests(KpiTestCase):


### PR DESCRIPTION
### 📣 Summary

Opening a single project or collection is a bit faster — the server does less redundant work per request.

### 📖 Description

When you open a project or collection, the server was preparing its permission information twice. It now does that once, so detail pages load slightly faster. Nothing changes in what you see.

### 💭 Notes

- The Asset **detail** endpoint fetched permission assignments **twice** — once in `get_permissions()`, once in the `get_access_types()` fallback. Added a per-request memoized helper so both share **one** query (verified 2→1 with `CaptureQueriesContext`).
- Output is unchanged: the shared fetch is a superset each method narrows in-memory. The list path is untouched (it uses the viewset cache).

Added a regression test (`test_detail_access_types_reuses_permission_fetch`) that fails if the fields stop sharing the fetch. Green on both settings axes, darker clean, no schema drift.

### 👀 Preview steps

1. ℹ️ have an account with a project or collection, and turn on SQL query logging (Django debug toolbar, or log `django.db.backends`)
2. `GET /api/v2/assets/<uid>/` for that asset
3. 🔴 [on main] the object-permission table is queried **twice** for that request
4. 🟢 [on PR] it is queried **once**, and the response body is identical
