### PR TITLE
fix(supplement): include null value for deleting automatic transcription/translation DEV-1722

### DIFF
--- a/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranscription.ts
+++ b/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranscription.ts
@@ -9,9 +9,12 @@ The endpoints are grouped by area of intended use. Each category contains relate
 **General note**: All projects (whether deployed or draft), as well as all library content (questions, blocks, templates, and collections) in the user-facing application are represented in the API as "assets".
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
+import type { PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue } from './patchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue'
 
 export type PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscription = {
   language: string
   locale?: string
   accepted?: boolean
+  /** @nullable */
+  value?: PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue
 }

--- a/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue.ts
+++ b/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue.ts
@@ -9,12 +9,13 @@ The endpoints are grouped by area of intended use. Each category contains relate
 **General note**: All projects (whether deployed or draft), as well as all library content (questions, blocks, templates, and collections) in the user-facing application are represented in the API as "assets".
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
-import type { PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue } from './patchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue'
 
-export type PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslation = {
-  language: string
-  locale?: string
-  accepted?: boolean
-  /** @nullable */
-  value?: PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue
-}
+/**
+ * @nullable
+ */
+export type PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue =
+  | (typeof PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue)[keyof typeof PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue]
+  | null
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PatchedDataSupplementPayloadOneOfAutomaticGoogleTranscriptionValue = {} as const

--- a/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue.ts
+++ b/jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue.ts
@@ -9,12 +9,13 @@ The endpoints are grouped by area of intended use. Each category contains relate
 **General note**: All projects (whether deployed or draft), as well as all library content (questions, blocks, templates, and collections) in the user-facing application are represented in the API as "assets".
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
-import type { PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue } from './patchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue'
 
-export type PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslation = {
-  language: string
-  locale?: string
-  accepted?: boolean
-  /** @nullable */
-  value?: PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue
-}
+/**
+ * @nullable
+ */
+export type PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue =
+  | (typeof PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue)[keyof typeof PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue]
+  | null
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PatchedDataSupplementPayloadOneOfAutomaticGoogleTranslationValue = {} as const

--- a/jsapp/js/api/mutation-defaults/survey-data.ts
+++ b/jsapp/js/api/mutation-defaults/survey-data.ts
@@ -266,8 +266,7 @@ export function applySurveyDataMutationDefaults(client: QueryClient): void {
                   if (response?.status !== 200) return response // just a typeguard, UI shouldn't allow to mutate if error.
                   let _versions = response?.data?.[questionXpath]?.[action]?._versions ?? []
 
-                  // TODO OpenAPI: see DEV-1722
-                  if ((datumTyped as any).value === null) {
+                  if (datumTyped.value === null) {
                     // If discarding/deleting (value: null), clear all versions for this language
                     _versions = []
                   } else if (datumTyped.accepted === true) {
@@ -327,8 +326,7 @@ export function applySurveyDataMutationDefaults(client: QueryClient): void {
                   if (response?.status !== 200) return response // just a typeguard, UI shouldn't allow to mutate if error.
                   let _versions = response?.data?.[questionXpath]?.[action]?.[language]?._versions ?? []
 
-                  // TODO OpenAPI: see DEV-1722
-                  if ((datumTyped as any).value === null) {
+                  if (datumTyped.value === null) {
                     // If discarding/deleting (value: null), clear all versions for this language
                     _versions = []
                   } else if (datumTyped.accepted === true) {

--- a/kpi/schema_extensions/v2/data/extensions.py
+++ b/kpi/schema_extensions/v2/data/extensions.py
@@ -209,6 +209,9 @@ class DataSupplementPayloadExtension(
                 'language': GENERIC_STRING_SCHEMA,
                 'locale': GENERIC_STRING_SCHEMA,
                 'accepted': {'type': 'boolean'},
+                # `value` is only ever null: passing `{value: null}` deletes the
+                # automatic transcription/translation (see DEV-1722).
+                'value': {'enum': [None], 'nullable': True},
             },
             required=['language'],
         )

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -28654,6 +28654,12 @@
                             },
                             "accepted": {
                                 "type": "boolean"
+                            },
+                            "value": {
+                                "enum": [
+                                    null
+                                ],
+                                "nullable": true
                             }
                         },
                         "additionalProperties": false,
@@ -28672,6 +28678,12 @@
                             },
                             "accepted": {
                                 "type": "boolean"
+                            },
+                            "value": {
+                                "enum": [
+                                    null
+                                ],
+                                "nullable": true
                             }
                         },
                         "additionalProperties": false,

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -20498,6 +20498,10 @@ components:
               type: string
             accepted:
               type: boolean
+            value:
+              enum:
+              - null
+              nullable: true
           additionalProperties: false
           required:
           - language
@@ -20510,6 +20514,10 @@ components:
               type: string
             accepted:
               type: boolean
+            value:
+              enum:
+              - null
+              nullable: true
           additionalProperties: false
           required:
           - language


### PR DESCRIPTION
### 📣 Summary

API-schema fix

### 📖 Description

The API reference for automatic transcription and translation now documents that a result can be deleted by sending an empty (null) value. This only affects the API documentation and generated API client; the delete itself already worked.

### 💭 Notes

- `_nlp_automatic_action_schema` now includes an optional, null-only `value` (`{enum: [null], nullable: true}` — drf-spectacular's NullEnum idiom, since OpenAPI 3.0.3 has no `type: null`). Deleting already worked server-side (`actions/base.py`: "Deletion is triggered by passing `{value: null}`").
- Regenerated `static/openapi/*` + the orval client. The two automatic `Patched…` types now carry `value?: null`, so the `as any` casts and `TODO … DEV-1722` markers in `survey-data.ts` are gone.
- No runtime/behavior change, no migration.

### 👀 Preview steps

Observable via the API docs / generated types (no user-facing UI change):

1. ℹ️ Open the automatic transcription PATCH schema — Swagger at `/api/v2/docs/`, or `jsapp/js/api/models/patchedDataSupplementPayloadOneOfAutomaticGoogleTranscription.ts`.
2. 🔴 [on main] `value` is absent from the type/schema.
3. 🟢 [on PR] the type/schema includes `value?: null`.
