### PR TITLE
fix(assets): do not create version on all changes DEV-2432

### DIFF
--- a/kobo/apps/data_collectors/admin.py
+++ b/kobo/apps/data_collectors/admin.py
@@ -82,9 +82,7 @@ class DataCollectorGroupAdmin(admin.ModelAdmin):
             if old_asset.uid not in new_asset_uids:
                 old_asset.data_collector_group = None
                 old_asset.save(
-                    update_fields=['data_collector_group'],
-                    adjust_content=False,
-                    create_version=False,
+                    update_fields=['data_collector_group'], adjust_content=False
                 )
 
         # link new assets
@@ -92,9 +90,7 @@ class DataCollectorGroupAdmin(admin.ModelAdmin):
             if new_asset.data_collector_group_id != obj.pk:
                 new_asset.data_collector_group = obj
                 new_asset.save(
-                    update_fields=['data_collector_group'],
-                    adjust_content=False,
-                    create_version=False,
+                    update_fields=['data_collector_group'], adjust_content=False
                 )
 
     def get_form(self, request, obj=..., change=..., **kwargs):

--- a/kobo/apps/data_collectors/signals.py
+++ b/kobo/apps/data_collectors/signals.py
@@ -54,10 +54,9 @@ def remove_enketo_links_on_permission_removed(sender, instance, *args, **kwargs)
 
     if group is not None and group.owner_id == instance.user_id:
         # we have to do this manually instead of using obj.assets.remove()
-        # so we can call save() with adjust_content=False
+        # so we can call save() with parameters
         asset.data_collector_group = None
         asset.save(
             update_fields=['data_collector_group'],
             adjust_content=False,
-            create_version=False,
         )

--- a/kobo/apps/data_collectors/tests/test_models.py
+++ b/kobo/apps/data_collectors/tests/test_models.py
@@ -161,3 +161,15 @@ class TestDataCollector(BaseTestCase):
         )
         self.data_collector_group.delete()
         patched_remove.assert_called_once_with(data_collector_0.token)
+
+    @patch('kobo.apps.data_collectors.signals.set_data_collector_enketo_links')
+    def test_change_group_does_not_produce_new_version(self, *_):
+        someuser = User.objects.get(username='someuser')
+        asset = Asset.objects.filter(owner=someuser).last()
+        initial_version_count = asset.asset_versions.count()
+        group = DataCollectorGroup.objects.create(
+            name='DCG1', owner=User.objects.get(username='someuser')
+        )
+        group.assets.add(asset)
+        asset.refresh_from_db()
+        assert asset.asset_versions.count() == initial_version_count

--- a/kobo/apps/project_ownership/models/transfer.py
+++ b/kobo/apps/project_ownership/models/transfer.py
@@ -232,7 +232,6 @@ class Transfer(AbstractTimeStampedModel):
 
         self.asset.save(
             update_fields=['owner', '_deployment_data', 'search_field'],
-            create_version=False,
             adjust_content=False,
         )
         self.asset.assign_perm(
@@ -364,9 +363,7 @@ class Transfer(AbstractTimeStampedModel):
         if self.asset.is_excluded_from_projects_list != is_excluded:
             self.asset.is_excluded_from_projects_list = is_excluded
             self.asset.save(
-                update_fields=['is_excluded_from_projects_list'],
-                adjust_content=False,
-                create_version=False
+                update_fields=['is_excluded_from_projects_list'], adjust_content=False
             )
 
 

--- a/kobo/apps/project_ownership/tests/test_transfer_status.py
+++ b/kobo/apps/project_ownership/tests/test_transfer_status.py
@@ -139,3 +139,11 @@ class ProjectOwnershipTransferStatusTestCase(TestCase):
         assert (
             error.error == 'Updating status of previously successful transfer to failed'
         )
+
+    def test_transfer_does_not_produce_new_version(self):
+        asset = self.transfer.asset
+        initial_version_count = asset.asset_versions.count()
+        with immediate_on_commit():
+            self.transfer.transfer_project()
+        asset.refresh_from_db()
+        assert asset.asset_versions.count() == initial_version_count

--- a/kobo/apps/project_ownership/tests/test_transfer_status.py
+++ b/kobo/apps/project_ownership/tests/test_transfer_status.py
@@ -142,6 +142,8 @@ class ProjectOwnershipTransferStatusTestCase(TestCase):
 
     def test_transfer_does_not_produce_new_version(self):
         asset = self.transfer.asset
+        # save to create an initial version
+        asset.save()
         initial_version_count = asset.asset_versions.count()
         with immediate_on_commit():
             self.transfer.transfer_project()

--- a/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
+++ b/kobo/apps/subsequences/management/commands/migrate_submission_supplements.py
@@ -272,7 +272,6 @@ class Command(BaseCommand):
                         asset.advanced_features['_version'] = SCHEMA_VERSIONS[0]
                         asset.save(
                             update_fields=['advanced_features'],
-                            create_version=False,
                             adjust_content=False,
                         )
             except Exception as e:

--- a/kobo/apps/subsequences/tests/api/v2/test_api.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_api.py
@@ -478,9 +478,7 @@ class SubmissionSupplementAPITestCase(SubsequenceBaseTestCase):
 
         # Simulate old data
         self.asset.save(
-            update_fields=['advanced_features', 'known_cols'],
-            create_version=False,
-            adjust_content=False,
+            update_fields=['advanced_features', 'known_cols'], adjust_content=False
         )
 
         SubmissionSupplement.objects.create(

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -401,6 +401,12 @@ class TestVersioning(TestCase):
         self.asset.refresh_from_db()
         assert self.asset.advanced_features.get('_version') is None
 
+    def test_migrate_does_not_produce_new_version(self):
+        initial_version_count = self.asset.asset_versions.count()
+        migrate_advanced_features(self.asset)
+        self.asset.refresh_from_db()
+        assert self.asset.asset_versions.count() == initial_version_count
+
     def test_convert_nlp_action(self):
         transcript_dict = {'languages': ['en', 'es']}
         known_cols_list = ['Audio_q_1', 'Audio_q_2']

--- a/kobo/apps/subsequences/tests/test_versioning.py
+++ b/kobo/apps/subsequences/tests/test_versioning.py
@@ -49,7 +49,7 @@ from kobo.apps.subsequences.utils.versioning import (
     migrate_advanced_features,
     migrate_submission_supplementals,
 )
-from kpi.models import Asset
+from kpi.models import Asset, AssetVersion
 
 
 @ddt
@@ -402,6 +402,13 @@ class TestVersioning(TestCase):
         assert self.asset.advanced_features.get('_version') is None
 
     def test_migrate_does_not_produce_new_version(self):
+        # hack: manually create an initial version since we won't be calling this
+        # on a brand new asset but save() will trigger the migration prematurely
+        AssetVersion.objects.create(
+            asset=self.asset,
+            version_content=self.asset.content,
+            name=self.asset.name
+        )
         initial_version_count = self.asset.asset_versions.count()
         migrate_advanced_features(self.asset)
         self.asset.refresh_from_db()

--- a/kobo/apps/subsequences/utils/versioning.py
+++ b/kobo/apps/subsequences/utils/versioning.py
@@ -162,11 +162,7 @@ def migrate_advanced_features(
     if advanced_features is None:
         asset.advanced_features = {'_version': SCHEMA_VERSIONS[0]}
         if save_asset:
-            asset.save(
-                update_fields=['advanced_features'],
-                create_version=False,
-                adjust_content=False,
-            )
+            asset.save(update_fields=['advanced_features'], adjust_content=False)
         return
 
     if asset.advanced_features.get('_version') == SCHEMA_VERSIONS[0]:
@@ -212,11 +208,7 @@ def migrate_advanced_features(
         asset.advanced_features = copied
         asset.advanced_features['_version'] = SCHEMA_VERSIONS[0]
         if save_asset:
-            asset.save(
-                update_fields=['advanced_features'],
-                create_version=False,
-                adjust_content=False,
-            )
+            asset.save(update_fields=['advanced_features'], adjust_content=False)
 
 
 def migrate_qual_data(supplemental_data: dict) -> dict | None:

--- a/kpi/deployment_backends/mixin.py
+++ b/kpi/deployment_backends/mixin.py
@@ -20,7 +20,7 @@ class DeployableMixin:
         if always or self.asset_files.filter(
             file_type=AssetFile.FORM_MEDIA, synced_with_backend=False
         ).exists():
-            self.save(create_version=False, adjust_content=False)
+            self.save(adjust_content=False)
             # Not using .delay() due to circular import in tasks.py
             celery.current_app.send_task('kpi.tasks.sync_media_files', (self.uid,))
 
@@ -92,7 +92,6 @@ class DeployableMixin:
         if save:
             self.save(
                 update_fields=['date_deployed'],
-                create_version=False,
                 adjust_content=False,
             )
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -867,6 +867,17 @@ class Asset(
         elif not isinstance(extra_metadata, dict):
             self.settings['extra_metadata'] = {}
 
+    def new_version_required(self):
+        if not self.latest_version:
+            return True
+        current_content = self.content
+        current_name = self.name
+        previous_version_content = self.latest_version.version_content
+        previous_version_name = self.latest_version.name
+        return current_name != previous_version_name or hash(
+            previous_version_content
+        ) != hash(current_content)
+
     @staticmethod
     def optimize_queryset_for_list(queryset):
         """Used by serializers to improve performance when listing assets"""
@@ -933,10 +944,9 @@ class Asset(
         force_update=False,
         update_fields=None,
         adjust_content=True,
-        create_version=False,
         update_parent_languages=True,
         *args,
-        **kwargs
+        **kwargs,
     ):
         is_new = self.pk is None
 
@@ -973,7 +983,6 @@ class Asset(
         # If `content` is part of the updated fields, `summary` and
         # `report_styles` must be too.
         if update_content_field:
-            create_version = True
             update_fields += ['summary', 'report_styles']
             # Avoid duplicates
             update_fields = list(set(update_fields))
@@ -992,10 +1001,7 @@ class Asset(
         # in certain circumstances, we don't want content to
         # be altered on save. (e.g. on asset.deploy())
         if adjust_content:
-            before_adjust = copy.deepcopy(self.content)
             self.adjust_content_on_save()
-            if before_adjust != self.content:
-                create_version = True
 
         if not update_fields or update_fields and 'advanced_features' in update_fields:
             migrate_advanced_features(self, save_asset=False)
@@ -1098,7 +1104,7 @@ class Asset(
         if self.has_deployment:
             self.deployment.sync_media_files(AssetFile.PAIRED_DATA)
 
-        if create_version:
+        if self.new_version_required():
             self.create_version()
 
     def set_deployment_status(self):

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -869,8 +869,10 @@ class Asset(
             self.settings['extra_metadata'] = {}
 
     def new_version_required(self):
+        # don't use self.latest_version or self.version__content_hash to avoid
+        # loading potentially large version_content field
         latest_version = (
-            self.asset_versions.defer('version_content')
+            self.asset_versions.only('name', '_content_hash')
             .order_by('-date_created')
             .first()
         )

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -933,7 +933,7 @@ class Asset(
         force_update=False,
         update_fields=None,
         adjust_content=True,
-        create_version=True,
+        create_version=False,
         update_parent_languages=True,
         *args,
         **kwargs
@@ -973,6 +973,7 @@ class Asset(
         # If `content` is part of the updated fields, `summary` and
         # `report_styles` must be too.
         if update_content_field:
+            create_version = True
             update_fields += ['summary', 'report_styles']
             # Avoid duplicates
             update_fields = list(set(update_fields))
@@ -991,7 +992,10 @@ class Asset(
         # in certain circumstances, we don't want content to
         # be altered on save. (e.g. on asset.deploy())
         if adjust_content:
+            before_adjust = copy.deepcopy(self.content)
             self.adjust_content_on_save()
+            if before_adjust != self.content:
+                create_version = True
 
         if not update_fields or update_fields and 'advanced_features' in update_fields:
             migrate_advanced_features(self, save_asset=False)

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -1110,7 +1110,6 @@ class Asset(
 
         if self.has_deployment:
             self.deployment.sync_media_files(AssetFile.PAIRED_DATA)
-
         if self.new_version_required():
             self.create_version()
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -65,6 +65,7 @@ from kpi.models.asset_snapshot import AssetSnapshot
 from kpi.models.asset_user_partial_permission import AssetUserPartialPermission
 from kpi.models.asset_version import AssetVersion
 from kpi.utils.asset_content_analyzer import AssetContentAnalyzer
+from kpi.utils.hash import calculate_content_hash
 from kpi.utils.object_permission import (
     get_cached_code_names,
     post_assign_partial_perm,
@@ -868,15 +869,19 @@ class Asset(
             self.settings['extra_metadata'] = {}
 
     def new_version_required(self):
-        if not self.latest_version:
+        latest_version = (
+            self.asset_versions.defer('version_content')
+            .order_by('-date_created')
+            .first()
+        )
+        if not latest_version:
             return True
-        current_content = self.content
-        current_name = self.name
-        previous_version_content = self.latest_version.version_content
-        previous_version_name = self.latest_version.name
-        return current_name != previous_version_name or hash(
-            previous_version_content
-        ) != hash(current_content)
+        current_content_hash = calculate_content_hash(self.content)
+        previous_version_name = latest_version.name
+        return (
+            self.name != previous_version_name
+            or latest_version.content_hash != current_content_hash
+        )
 
     @staticmethod
     def optimize_queryset_for_list(queryset):

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -1,13 +1,12 @@
 # coding: utf-8
 import datetime
-import json
 
 from django.db import models
 
 from formpack.utils.expand_content import expand_content
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
-from kpi.utils.hash import calculate_hash
+from kpi.utils.hash import calculate_content_hash
 from kpi.utils.kobo_to_xlsform import to_xlsform_structure
 
 DEFAULT_DATETIME = datetime.datetime(2010, 1, 1)
@@ -71,10 +70,8 @@ class AssetVersion(AbstractTimeStampedModel):
         disappear once all records have been backfilled via the long-running
         migration 0020
         """
-
         if not self._content_hash:
-            _json_string = json.dumps(self.version_content, sort_keys=True)
-            self._content_hash = calculate_hash(_json_string, 'sha1')
+            self._content_hash = calculate_content_hash(self.version_content)
 
         return self._content_hash
 

--- a/kpi/models/paired_data.py
+++ b/kpi/models/paired_data.py
@@ -145,11 +145,7 @@ class PairedData(OpenRosaManifestInterface,
 
         # Update asset
         del self.asset.paired_data[self.source_uid]
-        self.asset.save(
-            update_fields=['paired_data'],
-            adjust_content=False,
-            create_version=False,
-        )
+        self.asset.save(update_fields=['paired_data'], adjust_content=False)
 
     @property
     def deleted_at(self):
@@ -287,11 +283,7 @@ class PairedData(OpenRosaManifestInterface,
             'paired_data_uid': self.paired_data_uid,
         }
 
-        self.asset.save(
-            update_fields=['paired_data'],
-            adjust_content=False,
-            create_version=False,
-        )
+        self.asset.save(update_fields=['paired_data'], adjust_content=False)
 
     def void_external_xml_cache(self):
         # We delete the content of `self.asset_file` to force its regeneration

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1543,7 +1543,7 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
         }
         self.client.patch(self.asset_url, data, format='json')
         self.asset.refresh_from_db()
-        assert self.asset.versions.count() == initial_version_count
+        assert self.asset.asset_versions.count() == initial_version_count
 
     def test_asset_has_deployment_data(self):
         response = self.client.get(self.asset_url, format='json')

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -1534,6 +1534,17 @@ class AssetDetailApiTests(PermissionsTestMixin, BaseAssetDetailTestCase):
         }
         self.assertEqual(resp.data['settings'], expected)
 
+    def test_update_settings_does_not_produce_new_version(self):
+        initial_version_count = self.asset.asset_versions.count()
+        data = {
+            'settings': json.dumps({
+                'mysetting': 'value'
+            }),
+        }
+        self.client.patch(self.asset_url, data, format='json')
+        self.asset.refresh_from_db()
+        assert self.asset.versions.count() == initial_version_count
+
     def test_asset_has_deployment_data(self):
         response = self.client.get(self.asset_url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -2138,7 +2138,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         # redeploy the asset to create a new deployment version
         self.asset.deploy(active=True)
         self.asset.save()
-        assert self.asset.asset_versions.count() == original_versions_count + 2
+        assert self.asset.asset_versions.count() == original_versions_count + 1
         assert (
             self.asset.deployed_versions.count()
             == original_deployed_versions_count + 1

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -84,7 +84,7 @@ class AssetVersionTestCase(TestCase):
         self.assertEqual(self.template_asset.asset_versions.count(), 1)
         self.assertEqual(self.template_asset.latest_version.deployed, False)
         self.template_asset.save()
-        self.assertEqual(self.template_asset.asset_versions.count(), 2)
+        self.assertEqual(self.template_asset.asset_versions.count(), 1)
         self.assertEqual(self.template_asset.latest_version.deployed, False)
 
         def _bad_deployment():

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -71,7 +71,7 @@ class AssetVersionTestCase(TestCase):
         self.assertEqual(self.asset.latest_version.deployed, False)
 
         self.asset.deploy(backend='mock', active=True)
-        self.asset.save(create_version=False, adjust_content=False)
+        self.asset.save(adjust_content=False)
         # version did not increment
         self.assertEqual(self.asset.asset_versions.count(), 2)
 

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -162,6 +162,19 @@ class CreateAssetVersions(AssetsTestCase):
         anon_asset = Asset.objects.create(content=self.asset.content)
         self.assertEqual(anon_asset.owner, None)
 
+    def test_asset_versions_only_created_when_necessary(self):
+        asset = Asset.objects.create(name='Asset', content=self.asset.content)
+        assert asset.asset_versions.count() == 1
+        asset.name = 'New name'
+        asset.save()
+        assert asset.asset_versions.count() == 2
+        asset.content = {}
+        asset.save()
+        assert asset.asset_versions.count() == 3
+        asset.settings = {}
+        asset.save()
+        assert asset.asset_versions.count() == 3
+
 
 class AssetContentTests(AssetsTestCase):
     def _wrap_field(self, field_name, value):

--- a/kpi/tests/test_mock_data.py
+++ b/kpi/tests/test_mock_data.py
@@ -502,7 +502,7 @@ class MockDataReports(BaseSubmissionTestCase):
         )
 
     def test_has_version_and_submissions(self):
-        self.assertEqual(self.asset.asset_versions.count(), 2)
+        self.assertTrue(self.asset.asset_versions.exists())
         self.assertTrue(self.asset.has_deployment)
         self.asset.deployment.xform.refresh_from_db()
         self.assertEqual(self.asset.deployment.submission_count, 4)

--- a/kpi/utils/hash.py
+++ b/kpi/utils/hash.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import time
 from typing import BinaryIO, Optional, Union
 
@@ -134,3 +135,7 @@ def calculate_hash(
         return _finalize_hash(f'{content_type}:{content_length}', 'length')
 
     return _finalize_hash(source, 'url')
+
+
+def calculate_content_hash(asset_content: dict) -> str:
+    return calculate_hash(json.dumps(asset_content, sort_keys=True), 'sha1')


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Only add entries to form history when the form content or name changes.


### 💭 Notes
Previously, the decision to not create a new version of an asset on save was left to the caller. We now know we only want to create new versions when either the asset content or the asset name has changed from the previous version, so the responsibility of determining whether a version has changed is moved to the `.save()` logic. 

This does mean that every save requires one more query to get the latest version. We could in theory keep the `create_version` flag to allow callers to short-circuit this but we run the risk of missing content or name changes if something in `.save()` changes the content in ways the caller does not expect. This is not unlikely given how much additional processing the `save()` method does. Ultimately if we want to make sure we capture every content or name change, the responsibility needs to be on the asset.

As noted in the comment, we don't use `asset.latest_version` because that loads the whole version object, including the `version_content` dictionary, which can be very large. Since we only need the name and the hash, that's all we load.

In places where we previously called save with create_version = False, adds a unit test to make sure we're still not creating new versions.


### 👀 Preview steps

1. ℹ️ have an account and a project with at least 2 submissions
2. Navigate to the data table and sort by _id
3. Navigate to the `Form` tab and `Show full history`
4. 🔴 [on main] notice there is a new Form change entry
5. 🟢 [on PR] no new entry

