### PR TITLE
fix(KMLExport): add simplekml to requirements DEV-2437

### DIFF
--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -81,6 +81,7 @@ requests
 regex
 responses
 shortuuid
+simplekml
 sqlparse
 static3
 tabulate

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -474,6 +474,10 @@ setuptools-git==1.2
     # via django-author
 shortuuid==1.0.13
     # via -r dependencies/pip/requirements.in
+simplekml==1.3.6
+    # via
+    #   -r dependencies/pip/requirements.in
+    #   geojson2kml
 six==1.17.0
     # via python-dateutil
 smsapi-client==2.9.7


### PR DESCRIPTION
### 📣 Summary
Fixes deployment issue where the build failed due to a missing python dependency required for KML export.

### 💭 Notes
This failure is triggered during collectstatic because Django loads all models, which imports Formpack → reporting → geojson2kml → simplekml.
Formpack does not declare `simplekml` in its own `setup.py`, so KPI must declare it explicitly.

### 👀 Preview steps

1. Build kpi image
2. 🔴 [on main] build fails at ` RUN python manage.py collectstatic --noinput --ignore rest_framework` with `ModuleNotFoundError: simplekml`
3. [on PR] rebuild kpi
4. 🟢 [on PR] build succeeds; collectstatic completes normally
5. Optionally verify imports in kpi shell, this should succeed:
```
from formpack.reporting.export import Export
```