### PR TITLE
fix(constance): add new setting to fieldsets DEV-2178

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -219,7 +219,14 @@ CONSTANCE_CONFIG = {
         'if field is not blank'
     ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
-    'LAST_TOS_UPDATE': ('', 'Date of the most recent update to the terms of service'),
+    'LAST_TOS_UPDATE': (
+        '',
+        'Date of the most recent update to the terms of service. '
+        "DO NOT EDIT HERE. Instead, use the 'Require "
+        "all users to reaccept the Terms of Service' action in "
+        'Sitewide messages',
+        'disabled',
+    ),
     'PRIVACY_POLICY_URL': ('', 'URL for privacy policy'),
     'SOURCE_CODE_URL': (
         'https://github.com/kobotoolbox/',
@@ -711,21 +718,11 @@ CONSTANCE_ADDITIONAL_FIELDS = {
     ],
     'long_metadata_fields_jsonschema': [
         'kpi.fields.jsonschema_form_field.UserMetadataFieldsListField',
-        {
-            'widget': 'django.forms.Textarea',
-            'widget_kwargs': {
-                'attrs': {'rows': 45}
-            }
-        },
+        {'widget': 'django.forms.Textarea', 'widget_kwargs': {'attrs': {'rows': 45}}},
     ],
     'long_textfield': [
         'django.forms.fields.CharField',
-        {
-            'widget': 'django.forms.Textarea',
-            'widget_kwargs': {
-                'attrs': {'rows': 30}
-            }
-        },
+        {'widget': 'django.forms.Textarea', 'widget_kwargs': {'attrs': {'rows': 30}}},
     ],
     'metadata_fields_jsonschema': [
         'kpi.fields.jsonschema_form_field.MetadataFieldsListField',
@@ -743,6 +740,7 @@ CONSTANCE_ADDITIONAL_FIELDS = {
             ),
         },
     ],
+    'disabled': ['django.forms.fields.CharField', {'disabled': True}],
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {
@@ -753,6 +751,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'REGISTRATION_BLACKLIST_EMAIL_DOMAINS',
         'REGISTRATION_BLACKLIST_ERROR_MESSAGE',
         'TERMS_OF_SERVICE_URL',
+        'LAST_TOS_UPDATE',
         'PRIVACY_POLICY_URL',
         'SOURCE_CODE_URL',
         'SUPPORT_EMAIL',


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fixes an error that was preventing saves to Constance.

### 💭 Notes
Constance throws an error if a field is present in the config but not present in fieldsets. We don't actually want people editing the TOS last update field, so we disable it and make a note that it should not be edited manually. It would be nice to remove the 'reset to default' option but that's more work than this small fix requires, and it's only for admins so it's not a huge deal. 



### 👀 Preview steps

1. ℹ️ have an admin account
2. In admin, attempt to change a constance config variable
3. 🔴 [on main] Error
4. 🟢 [on PR] update is successful

