### PR TITLE
fix(subsequences): make translation _dependency optional in schema DEV-1721

### DIFF
--- a/jsapp/js/api/models/supplementalDataVersionItemAutomaticWithDep.ts
+++ b/jsapp/js/api/models/supplementalDataVersionItemAutomaticWithDep.ts
@@ -16,6 +16,6 @@ export interface SupplementalDataVersionItemAutomaticWithDep {
   _dateCreated: string
   _uuid: string
   _dateAccepted?: string
-  _dependency: SupplementalDataDependency
+  _dependency?: SupplementalDataDependency
   _data: SupplementalDataContentAutomatic
 }

--- a/jsapp/js/api/models/supplementalDataVersionItemManualWithDep.ts
+++ b/jsapp/js/api/models/supplementalDataVersionItemManualWithDep.ts
@@ -16,6 +16,6 @@ export interface SupplementalDataVersionItemManualWithDep {
   _dateCreated: string
   _uuid: string
   _dateAccepted: string
-  _dependency: SupplementalDataDependency
+  _dependency?: SupplementalDataDependency
   _data: SupplementalDataContentManual
 }

--- a/jsapp/js/api/react-query/survey-data/msw.ts
+++ b/jsapp/js/api/react-query/survey-data/msw.ts
@@ -654,10 +654,10 @@ export const getApiV2AssetsDataListResponseMock = (
                   _dateCreated: `${faker.date.past().toISOString().split('.')[0]}Z`,
                   _uuid: faker.string.uuid(),
                   _dateAccepted: `${faker.date.past().toISOString().split('.')[0]}Z`,
-                  _dependency: {
-                    _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    _uuid: faker.string.uuid(),
-                  },
+                  _dependency: faker.helpers.arrayElement([
+                    { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                    undefined,
+                  ]),
                   _data: {
                     language: faker.string.alpha({ length: { min: 10, max: 20 } }),
                     locale: faker.helpers.arrayElement([
@@ -706,10 +706,10 @@ export const getApiV2AssetsDataListResponseMock = (
                     `${faker.date.past().toISOString().split('.')[0]}Z`,
                     undefined,
                   ]),
-                  _dependency: {
-                    _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    _uuid: faker.string.uuid(),
-                  },
+                  _dependency: faker.helpers.arrayElement([
+                    { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                    undefined,
+                  ]),
                   _data: faker.helpers.arrayElement([
                     { ...getApiV2AssetsDataListResponseSupplementalDataContentAutomaticInProgressMock() },
                     { ...getApiV2AssetsDataListResponseSupplementalDataContentAutomaticFailedMock() },
@@ -1012,10 +1012,10 @@ export const getApiV2AssetsDataRetrieveResponseMock = (overrideResponse: Partial
                 _dateCreated: `${faker.date.past().toISOString().split('.')[0]}Z`,
                 _uuid: faker.string.uuid(),
                 _dateAccepted: `${faker.date.past().toISOString().split('.')[0]}Z`,
-                _dependency: {
-                  _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                  _uuid: faker.string.uuid(),
-                },
+                _dependency: faker.helpers.arrayElement([
+                  { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                  undefined,
+                ]),
                 _data: {
                   language: faker.string.alpha({ length: { min: 10, max: 20 } }),
                   locale: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
@@ -1061,10 +1061,10 @@ export const getApiV2AssetsDataRetrieveResponseMock = (overrideResponse: Partial
                   `${faker.date.past().toISOString().split('.')[0]}Z`,
                   undefined,
                 ]),
-                _dependency: {
-                  _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                  _uuid: faker.string.uuid(),
-                },
+                _dependency: faker.helpers.arrayElement([
+                  { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                  undefined,
+                ]),
                 _data: faker.helpers.arrayElement([
                   { ...getApiV2AssetsDataRetrieveResponseSupplementalDataContentAutomaticInProgressMock() },
                   { ...getApiV2AssetsDataRetrieveResponseSupplementalDataContentAutomaticFailedMock() },
@@ -1370,10 +1370,10 @@ export const getApiV2AssetsDataDuplicateCreateResponseMock = (
                 _dateCreated: `${faker.date.past().toISOString().split('.')[0]}Z`,
                 _uuid: faker.string.uuid(),
                 _dateAccepted: `${faker.date.past().toISOString().split('.')[0]}Z`,
-                _dependency: {
-                  _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                  _uuid: faker.string.uuid(),
-                },
+                _dependency: faker.helpers.arrayElement([
+                  { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                  undefined,
+                ]),
                 _data: {
                   language: faker.string.alpha({ length: { min: 10, max: 20 } }),
                   locale: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
@@ -1419,10 +1419,10 @@ export const getApiV2AssetsDataDuplicateCreateResponseMock = (
                   `${faker.date.past().toISOString().split('.')[0]}Z`,
                   undefined,
                 ]),
-                _dependency: {
-                  _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }),
-                  _uuid: faker.string.uuid(),
-                },
+                _dependency: faker.helpers.arrayElement([
+                  { _actionId: faker.string.alpha({ length: { min: 10, max: 20 } }), _uuid: faker.string.uuid() },
+                  undefined,
+                ]),
                 _data: faker.helpers.arrayElement([
                   { ...getApiV2AssetsDataDuplicateCreateResponseSupplementalDataContentAutomaticInProgressMock() },
                   { ...getApiV2AssetsDataDuplicateCreateResponseSupplementalDataContentAutomaticFailedMock() },

--- a/kpi/schema_extensions/v2/data/mixins.py
+++ b/kpi/schema_extensions/v2/data/mixins.py
@@ -154,11 +154,11 @@ class SupplementalDataComponentsRegistrationMixin(ComponentRegistrationMixin):
                     '_dependency': references['dependency'],
                     '_data': references['content_manual'],
                 },
+                # `_dependency` is optional: deleted versions omit it
                 required=[
                     '_dateCreated',
                     '_uuid',
                     '_dateAccepted',
-                    '_dependency',
                     '_data',
                 ],
             ),
@@ -193,7 +193,8 @@ class SupplementalDataComponentsRegistrationMixin(ComponentRegistrationMixin):
                     '_dependency': references['dependency'],
                     '_data': references['content_automatic'],
                 },
-                required=['_dateCreated', '_uuid', '_dependency', '_data'],
+                # `_dependency` is optional: deleted versions omit it
+                required=['_dateCreated', '_uuid', '_data'],
             ),
         )
 

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -32775,7 +32775,6 @@
                 "required": [
                     "_data",
                     "_dateCreated",
-                    "_dependency",
                     "_uuid"
                 ]
             },
@@ -32833,7 +32832,6 @@
                     "_data",
                     "_dateAccepted",
                     "_dateCreated",
-                    "_dependency",
                     "_uuid"
                 ]
             },

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -23426,7 +23426,6 @@ components:
       required:
       - _data
       - _dateCreated
-      - _dependency
       - _uuid
     SupplementalDataVersionItemManual:
       type: object
@@ -23469,7 +23468,6 @@ components:
       - _data
       - _dateAccepted
       - _dateCreated
-      - _dependency
       - _uuid
     SupplementalDataVersionItemQual:
       type: object


### PR DESCRIPTION
### 📣 Summary

Corrects the data API documentation so it no longer claims that every translation always has a linked source transcript.

### 📖 Description

In the API, each translation records which transcript it was based on. Deleted translations don't have one. The documentation wrongly listed that link as always present — it's now marked optional, matching what the API actually returns.

### 💭 Notes

- Drops `_dependency` from the `required` list of `SupplementalDataVersionItemAutomaticWithDep` and `SupplementalDataVersionItemManualWithDep` (still in `properties`); the generated orval type becomes `_dependency?`.
- No serializer/runtime change — `_dependency` is still returned for every non-deleted revision. Brings these two components in line with `SupplementalDataVersionItemQualAutomatic`, which was already optional.
- `static/openapi/*` + `jsapp/js/api/*` are regenerated artifacts. Branch sits a few commits behind `main` because the local dev container needs an older `formpack` than the current `main` tip; regeneration is unaffected.

### 👀 Preview steps

1. ℹ️ have an asset with a translation that has a deleted revision
2. `GET /api/v2/assets/<uid>/data/<submission>/supplemental/`
3. 🔴 [on main] the generated type marks `_dependency` as required, so a client assumes it is always present — even on a deleted revision where it is absent
4. 🟢 [on PR] the generated type marks `_dependency?` as optional, matching the actual response
