### PR TITLE
fix(project-views): return asset_count for users list DEV-2438

### DIFF
--- a/kobo/apps/project_views/tests/test_project_views_api.py
+++ b/kobo/apps/project_views/tests/test_project_views_api.py
@@ -119,6 +119,19 @@ class ProjectViewsApiTestCase(BaseTestCase):
         self.assertNotIn(self.asset_org_fra.uid, uids)
         self.assertNotIn(self.asset_ext_esp.uid, uids)
 
+    def test_project_view_users_list(self):
+        self.client.force_login(self.regular_user)
+        url = reverse(
+            self._get_endpoint('projectview-users'),
+            kwargs={'uid_project_view': self.pv_org.uid},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # `asset_count` is serialized without the precomputed attribute the
+        # `/api/v2/users/` list injects (regression from #6447)
+        self.assertTrue(all('asset_count' in user for user in response.data['results']))
+
     def test_asset_permissions(self):
         # We test that get_project_view_user_permissions_for_asset correctly returns
         # permissions. Regular user should have PERM_VIEW_ASSET for asset_org_esp

--- a/kpi/serializers/v2/user.py
+++ b/kpi/serializers/v2/user.py
@@ -87,7 +87,12 @@ class UserListSerializer(UserSerializer):
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_asset_count(self, user):
-        return user.assets_count
+        # `assets_count` is precomputed per page by `UserViewSet`; other
+        # consumers (e.g. project-views) don't inject it, so fall back to a
+        # direct count.
+        if (assets_count := getattr(user, 'assets_count', None)) is not None:
+            return assets_count
+        return user.assets.count()
 
     @extend_schema_field(MetadataField)
     def get_metadata(self, user):


### PR DESCRIPTION
### 📣 Summary

Fixes a server error when listing the users of a project view.

### 📖 Description

Opening the **Users** tab of a project view failed with a server error and showed no one. The list now loads correctly again, including each user's project count.

### 💭 Notes

- `UserListSerializer` is shared by `/api/v2/users/` and `/api/v2/project-views/{uid}/users/`. A perf change (DEV-1236, #6447) switched `get_asset_count` to read a `user.assets_count` attribute that only `UserViewSet` precomputes per page — the project-views endpoint never sets it, so the serializer raised `AttributeError: 'User' object has no attribute 'assets_count'` → 500.
- Fix: `get_asset_count` falls back to a direct `user.assets.count()` when the attribute isn't precomputed. Keeps the optimized path for `/api/v2/users/`, restores the pre-#6447 behavior for project-views.
- Added a regression test for the previously-uncovered `users` action.

### 👀 Preview steps

1. ℹ️ be a superuser with a project view configured (region/organization)
2. `GET /api/v2/project-views/{uid}/users/`
3. 🔴 [on main] the request returns `500` (`AttributeError: 'User' object has no attribute 'assets_count'`)
4. 🟢 [on PR] the request returns `200` with the user list, each entry carrying `asset_count`
