### PR TITLE
fix(constance): add new default DEV-2178

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -220,7 +220,7 @@ CONSTANCE_CONFIG = {
     ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
     'LAST_TOS_UPDATE': (
-        '1970-01-01',
+        '1970-01-01T00:00:00Z',
         'Date of the most recent update to the terms of service. '
         "DO NOT EDIT HERE. Instead, use the 'Require "
         "all users to reaccept the Terms of Service' action in "

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -220,7 +220,7 @@ CONSTANCE_CONFIG = {
     ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
     'LAST_TOS_UPDATE': (
-        '',
+        '1970-01-01',
         'Date of the most recent update to the terms of service. '
         "DO NOT EDIT HERE. Instead, use the 'Require "
         "all users to reaccept the Terms of Service' action in "

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -220,7 +220,7 @@ CONSTANCE_CONFIG = {
     ),
     'TERMS_OF_SERVICE_URL': ('', 'URL for terms of service document'),
     'LAST_TOS_UPDATE': (
-        '1970-01-01T00:00:00Z',
+        '',
         'Date of the most recent update to the terms of service. '
         "DO NOT EDIT HERE. Instead, use the 'Require "
         "all users to reaccept the Terms of Service' action in "
@@ -740,7 +740,10 @@ CONSTANCE_ADDITIONAL_FIELDS = {
             ),
         },
     ],
-    'disabled': ['django.forms.fields.CharField', {'disabled': True}],
+    'disabled': [
+        'django.forms.fields.CharField',
+        {'disabled': True, 'required': False},
+    ],
 }
 
 CONSTANCE_CONFIG_FIELDSETS = {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fixes a bug that was preventing constance from being updated when there was no initial TOS update date.


### 👀 Preview steps

1. ℹ️ have a superuser account
2. In a django shell, set `constance.config.LAST_TOS_UPDATE` to None
3. Go to constance in admin and change something
4. 🔴 [on main] Error
5. 🟢 [on PR] Success

