### PR TITLE
fix(longRunningMigrations): do not tag XForm as failed on Celery timeout DEV-2450

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -1,5 +1,6 @@
 # Generated on 2026-06-23
 
+from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
 from django.core.management import call_command
 from django.db import IntegrityError
@@ -145,6 +146,12 @@ def _process_instances_batch(
                     xform=xform.id_string,
                     verbosity=2,
                 )
+            except (SoftTimeLimitExceeded, TimeLimitExceeded):
+                # Celery interrupted the command mid-run: this is not an
+                # unrecoverable data error, so do not tag the XForm as failed.
+                # Let it propagate to `execute()`, which resumes on the next
+                # Celery beat cycle.
+                raise
             except Exception as e:
                 logging.error(
                     f'[LRM 0027] - Failed to clean duplicated submissions: {str(e)}'

--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -118,6 +118,25 @@ def _check_lrm_0005_is_completed():
         )
 
 
+def _find_timeout_in_chain(exc: BaseException) -> BaseException | None:
+    """
+    Walk the exception's cause/context chain and return the first Celery
+    timeout found, or `None`. A lower layer may catch a timeout and re-raise it
+    wrapped in another exception type, which would otherwise be mistaken for an
+    unrecoverable data error.
+    """
+
+    seen = set()
+    current = exc
+    while current is not None and id(current) not in seen:
+        if isinstance(current, (SoftTimeLimitExceeded, TimeLimitExceeded)):
+            return current
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+
+    return None
+
+
 def _process_instances_batch(
     xform: XForm, instance_queryset: QuerySet, first_try=True
 ) -> bool:
@@ -140,6 +159,10 @@ def _process_instances_batch(
         Instance.objects.bulk_update(instance_batch, fields=['root_uuid'])
     except IntegrityError:
         if first_try:
+            logging.info(
+                f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - '
+                f'Cleaning duplicated submissions'
+            )
             try:
                 call_command(
                     'clean_duplicated_submissions_root_uuid',
@@ -153,11 +176,21 @@ def _process_instances_batch(
                 # Celery beat cycle.
                 raise
             except Exception as e:
+                # A lower layer may have caught a Celery timeout and re-raised
+                # it wrapped in another exception type (e.g. CommandError).
+                # Treat it as a timeout, not an unrecoverable data error.
+                if timeout := _find_timeout_in_chain(e):
+                    raise timeout
                 logging.error(
                     f'[LRM 0027] - Failed to clean duplicated submissions: {str(e)}'
                 )
                 xform.tags.add(FAILED_TAG)
                 return False
+
+            logging.info(
+                f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - '
+                f'Cleaned duplicated submissions!'
+            )
 
             # Need to reload instance_batch to get updated root_uuids
             instance_batch_retry = Instance.objects.only(

--- a/kobo/apps/long_running_migrations/tests/test_backfill_root_uuid.py
+++ b/kobo/apps/long_running_migrations/tests/test_backfill_root_uuid.py
@@ -1,0 +1,107 @@
+import importlib
+from unittest.mock import MagicMock, patch
+
+from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
+from django.core.management.base import CommandError
+from django.db import IntegrityError
+from django.test import SimpleTestCase
+
+job = importlib.import_module(
+    'kobo.apps.long_running_migrations.jobs.0027_backfill_remaining_root_uuid'
+)
+
+
+class BackfillRemainRootUuidTestCase(SimpleTestCase):
+
+    def test_direct_timeout_propagates_without_tagging(self):
+        xform = self._mock_xform()
+        with patch.object(job, 'call_command', side_effect=SoftTimeLimitExceeded()):
+            with patch.object(
+                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+            ):
+                with self.assertRaises(SoftTimeLimitExceeded):
+                    job._process_instances_batch(xform, self._mock_queryset())
+        xform.tags.add.assert_not_called()
+
+    def test_finds_timeout_nested_deep(self):
+        timeout = SoftTimeLimitExceeded()
+        inner = ValueError('inner')
+        inner.__context__ = timeout
+        outer = CommandError('outer')
+        outer.__context__ = inner
+        assert job._find_timeout_in_chain(outer) is timeout
+
+    def test_finds_timeout_wrapped_in_cause(self):
+        timeout = TimeLimitExceeded()
+        exc = CommandError('wrapped')
+        exc.__cause__ = timeout
+        assert job._find_timeout_in_chain(exc) is timeout
+
+    def test_finds_timeout_wrapped_in_context(self):
+        timeout = SoftTimeLimitExceeded()
+        try:
+            try:
+                raise timeout
+            except SoftTimeLimitExceeded:
+                raise CommandError('wrapped')
+        except CommandError as exc:
+            assert job._find_timeout_in_chain(exc) is timeout
+
+    def test_returns_direct_soft_time_limit(self):
+        exc = SoftTimeLimitExceeded()
+        assert job._find_timeout_in_chain(exc) is exc
+
+    def test_returns_direct_time_limit(self):
+        exc = TimeLimitExceeded()
+        assert job._find_timeout_in_chain(exc) is exc
+
+    def test_returns_none_when_no_timeout(self):
+        exc = CommandError('just a data error')
+        assert job._find_timeout_in_chain(exc) is None
+
+    def test_stops_on_context_cycle(self):
+        first = ValueError('first')
+        second = ValueError('second')
+        first.__context__ = second
+        second.__context__ = first
+        assert job._find_timeout_in_chain(first) is None
+
+    def test_unrecoverable_error_tags_failed(self):
+        xform = self._mock_xform()
+        with patch.object(
+            job, 'call_command', side_effect=CommandError('genuine data error')
+        ):
+            with patch.object(
+                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+            ):
+                result = job._process_instances_batch(xform, self._mock_queryset())
+        assert result is False
+        xform.tags.add.assert_called_once_with(job.FAILED_TAG)
+
+    def test_wrapped_timeout_propagates_without_tagging(self):
+        xform = self._mock_xform()
+        timeout = SoftTimeLimitExceeded()
+        wrapped = CommandError(
+            'command has completed with errors: SoftTimeLimitExceeded()'
+        )
+        wrapped.__cause__ = timeout
+        with patch.object(job, 'call_command', side_effect=wrapped):
+            with patch.object(
+                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+            ):
+                with self.assertRaises(SoftTimeLimitExceeded):
+                    job._process_instances_batch(xform, self._mock_queryset())
+        xform.tags.add.assert_not_called()
+
+    @staticmethod
+    def _mock_queryset():
+        queryset = MagicMock()
+        queryset.iterator.return_value = iter([MagicMock(pk=10)])
+        return queryset
+
+    @staticmethod
+    def _mock_xform():
+        xform = MagicMock()
+        xform.pk = 1
+        xform.id_string = 'a_form'
+        return xform

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -232,9 +232,21 @@ class Command(BaseCommand):
                     self.stdout.write(
                         f'\t\tOld UUID: {old_uuid}, New UUID: {instance.uuid}'
                     )
-                instance.xml = set_meta(instance.xml, 'instanceID', instance.uuid)
+                try:
+                    instance.xml = set_meta(
+                        instance.xml, 'instanceID', instance.uuid
+                    )
+                except ValueError:
+                    # Legacy submission without an instanceID node in its XML.
+                    # The DB `uuid` update above already resolves the collision.
+                    pass
                 instance.xml_hash = instance.get_hash(instance.xml)
-                instance._populate_root_uuid()  # noqa
+                try:
+                    instance._populate_root_uuid()  # noqa
+                except AssertionError:
+                    # No derivable root_uuid on this legacy submission; fall
+                    # back to its uuid, as LRM 0027 does.
+                    instance.root_uuid = instance.uuid
                 instances_to_update.append(instance)
 
                 # Save the parsed instance to sync MongoDB

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -1,5 +1,6 @@
 import time
 
+from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
@@ -43,6 +44,11 @@ class Command(BaseCommand):
                 verbosity=self._verbosity,
                 xform=xform_id_string,
             )
+        except (SoftTimeLimitExceeded, TimeLimitExceeded):
+            # A Celery timeout is not a data error. Let it propagate as-is
+            # instead of swallowing it into a CommandError, so the caller can
+            # tell a timeout apart from an unrecoverable failure.
+            raise
         except Exception as e:
             exit_code = 1
             error = str(e)


### PR DESCRIPTION
### 📣 Summary

A background data-repair task could permanently skip a form's submissions, either when it ran out of time or when it hit an old submission it did not know how to handle. It now resumes on the next cycle and handles those old submissions instead of giving up for good.

### 💭 Notes

Long-running migration `0027_backfill_remaining_root_uuid` calls the `clean_duplicated_submissions_root_uuid` management command when it hits an `IntegrityError` while backfilling `root_uuid`. If Celery interrupted that command (`SoftTimeLimitExceeded` / `TimeLimitExceeded`), the broad `except Exception` in `_process_instances_batch()` caught the timeout, logged it as a clean failure, and tagged the XForm with `FAILED_TAG` (`kobo-root-uuid-failed-0027`). That permanently skipped it on every subsequent run even though nothing was actually wrong with the data.

Both timeout exceptions are now re-raised before that handler so they propagate to `LongRunningMigration.execute()`, which already treats them as "took too long, resume on the next Celery beat cycle" without marking the migration as failed.

Production logs then showed the timeout was sometimes swallowed one layer deeper: `clean_duplicated_submissions_root_uuid` wrapped it into a `CommandError` (`command has completed with errors: SoftTimeLimitExceeded()`), which the direct re-raise did not catch, so the XForm was tagged failed anyway. Two changes close that gap. The wrapper command now re-raises `SoftTimeLimitExceeded` / `TimeLimitExceeded` instead of swallowing them into a `CommandError`. As defense in depth, `_process_instances_batch()` walks the exception `__cause__` / `__context__` chain (`_find_timeout_in_chain`) and, if it finds a timeout wrapped in any other exception type, re-raises the timeout instead of tagging the XForm. `FAILED_TAG` is now reserved for genuine, unrecoverable data errors.

A separate blocker also surfaced in production: `clean_duplicated_submissions._replace_duplicates()` crashed with `instanceID node not found` on legacy submissions whose XML has no `meta/instanceID` node, aborting the whole form's cleaning. `set_meta()` is now guarded (the DB `uuid` update already resolves the collision, so the missing node is fine) and `_populate_root_uuid()` falls back to the submission `uuid`, matching the tolerance already used by `_resolve_conflict_by_pk` and LRM 0027. This does not fabricate data into archived XML.

For visibility, LRM 0027 now logs when it starts and finishes cleaning duplicates for an XForm, so a long clean is no longer mistaken for a frozen task.

### 👀 Preview steps

Reproducing a real Celery timeout mid-command is contrived, so this needs a forced timeout.

1. ℹ️ have a form whose submissions still have a null `root_uuid` and at least one duplicate that makes `clean_duplicated_submissions_root_uuid` raise, so LRM 0027 enters the clean path
2. force the clean command to be interrupted, for example by setting `CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT` very low so Celery raises `SoftTimeLimitExceeded` while it runs
3. run the long-running migrations and let LRM 0027 process that form
4. check the form's tags and the migration status
5. 🔴 [on main] the form gets tagged `kobo-root-uuid-failed-0027` and is skipped on every later run
6. 🟢 [on PR] the form is not tagged, the migration stays `in_progress` and resumes on the next cycle
