### PR TITLE
fix(account): delete button disabled check DEV-2445

### DIFF
--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import { http, HttpResponse } from 'msw'
 import { withRouter } from 'storybook-addon-remix-react-router'
 import { expect, waitFor, within } from 'storybook/test'
+import { endpoints } from '#/api.endpoints'
 import assetsMock from '#/endpoints/assets.mocks'
 import organizationMock from '#/endpoints/organization.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
@@ -91,5 +93,42 @@ export const UserOwnsMMO: Story = {
     const deleteButton = await canvas.findByRole('button', { name: /delete account/i })
     expect(canvas.getByText(/transfer ownership of your organization/i)).toBeInTheDocument()
     expect(deleteButton).toBeDisabled()
+  },
+}
+
+export const UserHasOnlyNonProjectAssets: Story = {
+  parameters: {
+    msw: {
+      handlers: {
+        assets: http.get(endpoints.ASSETS_URL, (info) => {
+          const query = new URL(info.request.url).searchParams.get('q')
+
+          if (query?.includes('asset_type:survey')) {
+            return HttpResponse.json({
+              count: 0,
+              next: null,
+              previous: null,
+              results: [],
+            })
+          }
+
+          return HttpResponse.json({
+            count: 2,
+            next: null,
+            previous: null,
+            results: [],
+          })
+        }),
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await canvas.findByRole('button', { name: /delete account/i })
+    await waitFor(() => expect(canvas.queryByText('…')).not.toBeInTheDocument())
+
+    expect(canvas.getByText(/delete your account and all your account data/i)).toBeInTheDocument()
+    expect(canvas.getByRole('button', { name: /delete account/i })).toBeEnabled()
   },
 }

--- a/jsapp/js/account/DeleteAccountBanner.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.tsx
@@ -18,7 +18,7 @@ export default function DeleteAccountBanner() {
 
   const username = session.currentLoggedAccount.username
   const { data: assetsData, isPending } = useAssetsList({
-    q: `(owner__username:${username})`,
+    q: `(owner__username:${username} AND asset_type:survey)`,
     limit: 1,
   })
 

--- a/jsapp/js/constants.ts
+++ b/jsapp/js/constants.ts
@@ -150,6 +150,8 @@ export enum AssetTypeName {
   template = 'template',
   survey = 'survey',
   collection = 'collection',
+  // Sometimes an empty asset is possible to be created by some funky import flows
+  // empty = 'empty'
 }
 
 export interface AssetTypeDefinition {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed an issue where users who deleted all their projects could still be blocked from deleting their account because non-project assets were counted by mistake.

### 💭 Notes

Changes here:

- `DeleteAccountBanner.tsx` updated the asset lookup query to only count projects by filtering with asset_type:survey.
  - This aligns the logic with the banner copy, which refers to projects, not all asset types.
- `DeleteAccountBanner.stories.tsx` - Added a regression story-test `UserHasOnlyNonProjectAssets`

### 👀 Preview steps

1. ℹ️ Have an account with a template and a project
2. ℹ️ Have `ALLOW_SELF_ACCOUNT_DELETION` enabled in `/admin` Constance → Config
3. Go to Account Settings → Profile and scroll down
4. 🟢 Notice that "Delete account" button is disabled
5. Go to My Library
6. 🟢 Notice that user owns some library items (at least one is enough)
7. Go to My Projects
8. Delete all your projects
9. Go to Account Settings → Profile and scroll down
10. 🔴 On main: "Delete account" button is disabled
13. 🟢 On this PR: "Delete account" button is enabled and the message confirms you can delete your account