### PR TITLE
feat(longRunningMigrations): keep migration lock fresh with a heartbeat DEV-2427

### DIFF
--- a/kobo/apps/long_running_migrations/tasks.py
+++ b/kobo/apps/long_running_migrations/tasks.py
@@ -36,6 +36,12 @@ def async_execute(migration_id: int):
             migration.execute()
         finally:
             stop_event.set()
+            # Cap the wait so a stuck cache or DB call in the heartbeat can
+            # never hang the worker here. If the thread is mid cache.set when
+            # the wait elapses, the lock may be re-set right after we delete it
+            # and linger until HEARTBEAT_TTL expires. That is harmless: a
+            # re-dispatch is blocked by the lock, and execute() skips a
+            # COMPLETED migration anyway.
             heartbeat.join(timeout=5)
             cache.delete(lock_key)
 

--- a/kobo/apps/long_running_migrations/tasks.py
+++ b/kobo/apps/long_running_migrations/tasks.py
@@ -1,27 +1,42 @@
+import threading
+
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.cache import cache
+from django.db import close_old_connections
 from django.db.models import Q
 from django.utils import timezone
 
 from kobo.celery import celery_app
+from kpi.utils.log import logging
 from .models import LongRunningMigration, LongRunningMigrationStatus
 
 
 @celery_app.task(
     queue='kpi_long_running_tasks_queue',
-    soft_time_limit=settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT,
-    time_limit=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT,
+    soft_time_limit=settings.CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT,
+    time_limit=settings.CELERY_LONG_RUNNING_MIGRATION_TASK_TIME_LIMIT,
 )
 def async_execute(migration_id: int):
     migration = LongRunningMigration.objects.get(pk=migration_id)
     lock_key = f'execute_long_running_migrations:{migration.name}'
     if cache.add(
-        lock_key, 'true', timeout=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT
+        lock_key,
+        'true',
+        timeout=settings.CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL,
     ):
+        stop_event = threading.Event()
+        heartbeat = threading.Thread(
+            target=_heartbeat,
+            args=(stop_event, lock_key, migration_id),
+            daemon=True,
+        )
+        heartbeat.start()
         try:
             migration.execute()
         finally:
+            stop_event.set()
+            heartbeat.join(timeout=5)
             cache.delete(lock_key)
 
 
@@ -29,17 +44,56 @@ def async_execute(migration_id: int):
 def execute_long_running_migrations():
     # Adding an offset to account for potential delays in task execution and
     # clock drift between the Celery workers and the database, ensuring tasks
-    # are not prematurely skipped.
+    # are not prematurely re-dispatched.
     offset = 5 * 60
+    # A running migration refreshes `date_modified` on every heartbeat, so a
+    # stale timestamp means the worker died (e.g. a Kubernetes pod eviction)
+    # without releasing its lock. We base the re-dispatch on the short heartbeat
+    # TTL instead of the full task time limit, so a dead migration is retried
+    # within minutes instead of hours.
     task_expiry_time = timezone.now() - relativedelta(
-        seconds=settings.CELERY_LONG_RUNNING_TASK_TIME_LIMIT + offset
+        seconds=settings.CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL + offset
     )
-    # Run tasks that were just created or are in progress but have exceeded
-    # the maximum runtime allowed for a Celery task, causing Celery to terminate
-    # them and raise a SoftTimeLimitExceeded exception.
+    # Run tasks that were just created or are in progress but whose worker died
+    # without refreshing the heartbeat.
     for migration in LongRunningMigration.objects.filter(
         Q(status=LongRunningMigrationStatus.CREATED)
         | Q(status=LongRunningMigrationStatus.IN_PROGRESS)
         & Q(date_modified__lte=task_expiry_time)
     ).order_by('date_created'):
         async_execute.delay(migration.pk)
+
+
+def _heartbeat(stop_event: threading.Event, lock_key: str, migration_id: int):
+    """
+    Keep the migration's lock and `date_modified` fresh while it runs.
+
+    Runs in a background thread so migration jobs never have to call anything
+    themselves (a job author cannot forget it). Refreshing the lock with a short
+    TTL - instead of holding it for the whole task time limit - means a
+    hard-killed worker releases the lock within a few heartbeats rather than
+    blocking re-execution for hours. Bumping `date_modified` lets
+    `execute_long_running_migrations` tell a live task apart from a dead one.
+    """
+
+    interval = settings.CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL
+    ttl = settings.CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL
+    while not stop_event.wait(interval):
+        # Recycle any connection that outlived `CONN_MAX_AGE` or was dropped
+        # server-side: over a 24h lifetime a persistent connection cannot be
+        # trusted, and a broken one would fail every subsequent heartbeat.
+        close_old_connections()
+        try:
+            cache.set(lock_key, 'true', timeout=ttl)
+            LongRunningMigration.objects.filter(pk=migration_id).update(
+                date_modified=timezone.now()
+            )
+        except Exception as e:
+            # A transient failure here only risks a spurious re-dispatch, which
+            # the lock guards against. Never let it kill the heartbeat.
+            logging.warning(
+                f'LongRunningMigration #{migration_id} heartbeat failed: {e}'
+            )
+
+    # Release this thread's connection on exit.
+    close_old_connections()

--- a/kobo/apps/long_running_migrations/tasks.py
+++ b/kobo/apps/long_running_migrations/tasks.py
@@ -36,12 +36,6 @@ def async_execute(migration_id: int):
             migration.execute()
         finally:
             stop_event.set()
-            # Cap the wait so a stuck cache or DB call in the heartbeat can
-            # never hang the worker here. If the thread is mid cache.set when
-            # the wait elapses, the lock may be re-set right after we delete it
-            # and linger until HEARTBEAT_TTL expires. That is harmless: a
-            # re-dispatch is blocked by the lock, and execute() skips a
-            # COMPLETED migration anyway.
             heartbeat.join(timeout=5)
             cache.delete(lock_key)
 
@@ -64,8 +58,10 @@ def execute_long_running_migrations():
     # without refreshing the heartbeat.
     for migration in LongRunningMigration.objects.filter(
         Q(status=LongRunningMigrationStatus.CREATED)
-        | Q(status=LongRunningMigrationStatus.IN_PROGRESS)
-        & Q(date_modified__lte=task_expiry_time)
+        | (
+            Q(status=LongRunningMigrationStatus.IN_PROGRESS)
+            & Q(date_modified__lte=task_expiry_time)
+        )
     ).order_by('date_created'):
         async_execute.delay(migration.pk)
 

--- a/kobo/apps/long_running_migrations/tasks.py
+++ b/kobo/apps/long_running_migrations/tasks.py
@@ -85,20 +85,27 @@ def _heartbeat(stop_event: threading.Event, lock_key: str, migration_id: int):
         # server-side: over a 24h lifetime a persistent connection cannot be
         # trusted, and a broken one would fail every subsequent heartbeat.
         close_old_connections()
+        # The lock and the timestamp guard against a premature re-dispatch
+        # through two independent backends, so refresh them independently. If
+        # the cache is down the lock may expire, but a fresh `date_modified`
+        # still keeps `execute_long_running_migrations` from re-dispatching us.
+        # If the DB is down the lock is still held, so `cache.add` blocks it.
+        # Never let one bad iteration kill the heartbeat.
         try:
             cache.set(lock_key, 'true', timeout=ttl)
+        except Exception as e:
+            logging.warning(
+                f'LongRunningMigration #{migration_id} heartbeat '
+                f'cache refresh failed: {e}'
+            )
+        try:
             LongRunningMigration.objects.filter(pk=migration_id).update(
                 date_modified=timezone.now()
             )
         except Exception as e:
-            # A failed DB write is harmless: the lock is still refreshed, so a
-            # premature re-dispatch is blocked by `cache.add`. A failed cache
-            # write is worse: the lock can expire and the migration may run a
-            # second time in parallel. We accept that because migrations are
-            # written to be safe to re-run. Either way, never let one bad
-            # iteration kill the heartbeat.
             logging.warning(
-                f'LongRunningMigration #{migration_id} heartbeat failed: {e}'
+                f'LongRunningMigration #{migration_id} heartbeat '
+                f'DB update failed: {e}'
             )
 
     # Release this thread's connection on exit.

--- a/kobo/apps/long_running_migrations/tasks.py
+++ b/kobo/apps/long_running_migrations/tasks.py
@@ -89,8 +89,12 @@ def _heartbeat(stop_event: threading.Event, lock_key: str, migration_id: int):
                 date_modified=timezone.now()
             )
         except Exception as e:
-            # A transient failure here only risks a spurious re-dispatch, which
-            # the lock guards against. Never let it kill the heartbeat.
+            # A failed DB write is harmless: the lock is still refreshed, so a
+            # premature re-dispatch is blocked by `cache.add`. A failed cache
+            # write is worse: the lock can expire and the migration may run a
+            # second time in parallel. We accept that because migrations are
+            # written to be safe to re-run. Either way, never let one bad
+            # iteration kill the heartbeat.
             logging.warning(
                 f'LongRunningMigration #{migration_id} heartbeat failed: {e}'
             )

--- a/kobo/apps/long_running_migrations/tests/fixtures/sample_task_2.py
+++ b/kobo/apps/long_running_migrations/tests/fixtures/sample_task_2.py
@@ -1,0 +1,2 @@
+def run():
+    print('hello from a second long running migration')

--- a/kobo/apps/long_running_migrations/tests/test_case.py
+++ b/kobo/apps/long_running_migrations/tests/test_case.py
@@ -1,12 +1,21 @@
 import os
+import threading
 from unittest.mock import MagicMock, patch
 
+from django.core.cache import cache
 from django.core.exceptions import SuspiciousOperation
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from freezegun import freeze_time
 
 from ..models import LongRunningMigration, LongRunningMigrationStatus
-from ..tasks import execute_long_running_migrations
+from ..tasks import _heartbeat, async_execute, execute_long_running_migrations
+
+FIXTURES_DIR = os.path.join(
+    'kobo', 'apps', 'long_running_migrations', 'tests', 'fixtures'
+)
+LOCMEM_CACHE = {
+    'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+}
 
 
 @override_settings(
@@ -125,3 +134,80 @@ class LongRunningMigrationPeriodicTaskTestCase(TestCase):
         execute_long_running_migrations()
         self.migration.refresh_from_db()
         self.assertEqual(self.migration.status, LongRunningMigrationStatus.COMPLETED)
+
+    def test_multiple_migrations_all_run(self):
+        second_migration = LongRunningMigration.objects.create(name='sample_task_2')
+        execute_long_running_migrations()
+        self.migration.refresh_from_db()
+        second_migration.refresh_from_db()
+        assert self.migration.status == LongRunningMigrationStatus.COMPLETED
+        assert second_migration.status == LongRunningMigrationStatus.COMPLETED
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+@patch.object(LongRunningMigration, 'LONG_RUNNING_MIGRATIONS_DIR', FIXTURES_DIR)
+class LongRunningMigrationLockTestCase(TestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_lock_prevents_duplicate_execution(self):
+        migration = LongRunningMigration.objects.create(name='sample_task')
+        lock_key = f'execute_long_running_migrations:{migration.name}'
+        # Simulate the migration already running on another worker.
+        cache.add(lock_key, 'true', timeout=300)
+        with patch.object(LongRunningMigration, 'execute') as mocked_execute:
+            async_execute(migration.pk)
+        mocked_execute.assert_not_called()
+
+    def test_lock_released_after_execution(self):
+        migration = LongRunningMigration.objects.create(name='sample_task')
+        lock_key = f'execute_long_running_migrations:{migration.name}'
+        async_execute(migration.pk)
+        assert cache.get(lock_key) is None
+
+    def test_distinct_migrations_use_distinct_locks(self):
+        first = LongRunningMigration.objects.create(name='sample_task')
+        second = LongRunningMigration.objects.create(name='sample_task_2')
+        # Hold the lock of the first migration only.
+        cache.add(
+            f'execute_long_running_migrations:{first.name}', 'true', timeout=300
+        )
+        async_execute(first.pk)
+        async_execute(second.pk)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        # First is blocked by its lock, second runs on its own lock.
+        assert first.status == LongRunningMigrationStatus.CREATED
+        assert second.status == LongRunningMigrationStatus.COMPLETED
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+@patch.object(LongRunningMigration, 'LONG_RUNNING_MIGRATIONS_DIR', FIXTURES_DIR)
+class LongRunningMigrationHeartbeatTestCase(TransactionTestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_heartbeat_refreshes_lock_and_timestamp(self):
+        migration = LongRunningMigration.objects.create(name='sample_task')
+        lock_key = f'execute_long_running_migrations:{migration.name}'
+        original_date_modified = migration.date_modified
+
+        # Make wait() return False once so the body runs a single time, then
+        # True so the loop exits. The thread stops on its own, so we don't need
+        # to sleep. We use a real thread so the DB write happens on its own
+        # connection, like in production.
+        stop_event = MagicMock()
+        stop_event.wait.side_effect = [False, True]
+        heartbeat = threading.Thread(
+            target=_heartbeat, args=(stop_event, lock_key, migration.pk)
+        )
+        heartbeat.start()
+        heartbeat.join(timeout=5)
+
+        assert not heartbeat.is_alive()
+        migration.refresh_from_db()
+        # `date_modified` moved forward and the lock is still held.
+        assert migration.date_modified > original_date_modified
+        assert cache.get(lock_key) == 'true'

--- a/kobo/apps/long_running_migrations/tests/test_case.py
+++ b/kobo/apps/long_running_migrations/tests/test_case.py
@@ -13,9 +13,7 @@ from ..tasks import _heartbeat, async_execute, execute_long_running_migrations
 FIXTURES_DIR = os.path.join(
     'kobo', 'apps', 'long_running_migrations', 'tests', 'fixtures'
 )
-LOCMEM_CACHE = {
-    'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
-}
+LOCMEM_CACHE = {'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}}
 
 
 @override_settings(
@@ -170,9 +168,7 @@ class LongRunningMigrationLockTestCase(TestCase):
         first = LongRunningMigration.objects.create(name='sample_task')
         second = LongRunningMigration.objects.create(name='sample_task_2')
         # Hold the lock of the first migration only.
-        cache.add(
-            f'execute_long_running_migrations:{first.name}', 'true', timeout=300
-        )
+        cache.add(f'execute_long_running_migrations:{first.name}', 'true', timeout=300)
         async_execute(first.pk)
         async_execute(second.pk)
         first.refresh_from_db()

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1733,14 +1733,16 @@ CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT = int(
 # the interval to tolerate a briefly stalled worker without expiring the lock of
 # a task that is still alive.
 CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL = int(
-    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL', 60)  # seconds
+    os.environ.get(
+        'CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL', 60  # 60 seconds
+    )
 )
 
 CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL = int(
-    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL', 300)  # seconds
+    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL', 300)  # 300 sec
 )
 
-CELERY_BEAT_RELOAD_INTERVAL = env.int('CELERY_BEAT_RELOAD_INTERVAL', 15)  # seconds
+CELERY_BEAT_RELOAD_INTERVAL = env.int('CELERY_BEAT_RELOAD_INTERVAL', 15)  # 15 seconds
 
 """ Django allauth configuration """
 # User.email should continue to be used instead of the EmailAddress model

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1714,6 +1714,32 @@ CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT = int(
     os.environ.get('CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT', 4200)  # seconds
 )
 
+# Dedicated, much longer limits for long-running migrations only. Unlike the
+# generic limits above (shared by many tasks), a single migration run may need
+# to churn through a whole table, so it is allowed up to ~24h in one pass.
+CELERY_LONG_RUNNING_MIGRATION_TASK_TIME_LIMIT = int(
+    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_TIME_LIMIT', 86460)  # 24h + 1min
+)
+
+CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT = int(
+    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT', 86400)  # 24h
+)
+
+# Heartbeat that keeps a running migration's lock and `date_modified` fresh from
+# a background thread. The lock TTL is tied to this heartbeat, not to the task
+# time limit, so a hard-killed worker (e.g. a Kubernetes pod eviction that skips
+# the `finally` cleanup) releases the lock within a few heartbeats instead of
+# blocking re-execution for the whole 24h. The TTL is deliberately a few times
+# the interval to tolerate a briefly stalled worker without expiring the lock of
+# a task that is still alive.
+CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL = int(
+    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL', 60)  # seconds
+)
+
+CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL = int(
+    os.environ.get('CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL', 300)  # seconds
+)
+
 CELERY_BEAT_RELOAD_INTERVAL = env.int('CELERY_BEAT_RELOAD_INTERVAL', 15)  # seconds
 
 """ Django allauth configuration """


### PR DESCRIPTION
### 📣 Summary

Background data migrations can now run for up to 24 hours per pass and recover on their own if a server is restarted, so they finish more reliably.

### 📖 Description

Some database maintenance tasks run in the background over a very large amount of data. Until now each pass was capped at about 71 minutes, and if the server running one was restarted it could stay stuck for a long time before another server picked it up. These tasks now get up to 24 hours per pass and are retried within minutes if their server goes away, so they complete without manual intervention.

### 👷 Description for instance maintainers

Long-running migrations now get a dedicated, much longer time budget, up to about 24 hours per run, separate from the shared limits used by other background tasks (those keep their current values). New environment variables let you tune this: `CELERY_LONG_RUNNING_MIGRATION_TASK_TIME_LIMIT`, `CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT`, `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL` and `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL`.

While a migration runs, a background heartbeat keeps its lock alive with a short lease and records that it is still making progress. If the worker running it dies (for example a Kubernetes pod eviction), the lease expires within a few minutes and the migration is picked up again automatically, instead of being blocked until the old time limit elapsed.

No database schema change and no new migration to run. The defaults are safe, so no configuration change is required.

### 💭 Notes

New dedicated settings for migrations only, so we can give them a much longer budget without touching the shared limits used by many other tasks (`CELERY_LONG_RUNNING_TASK_*`, still 4260 / 4200):
- `CELERY_LONG_RUNNING_MIGRATION_TASK_TIME_LIMIT` = 86460 (24h + 1min)
- `CELERY_LONG_RUNNING_MIGRATION_TASK_SOFT_TIME_LIMIT` = 86400 (24h)
- `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL` = 60
- `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL` = 300

`async_execute` now starts a background heartbeat thread while `migration.execute()` runs. Every `HEARTBEAT_INTERVAL` seconds it refreshes the cache lock with a short `HEARTBEAT_TTL` and bumps the migration's `date_modified`. The lock TTL is now tied to the heartbeat, not to the task time limit, so a hard-killed worker releases it within a few heartbeats instead of hours. Migration jobs call nothing, so a job author cannot forget it.

A premature re-dispatch is guarded twice, through two independent backends: the cache lock (`cache.add` fails while it is held) and the fresh `date_modified` (the beat skips a recently updated migration). The heartbeat refreshes each in its own `try` so one backend failing does not skip the other. A cache-only outage lets the lock expire but keeps `date_modified` fresh, so the beat still does not re-dispatch. A DB-only outage keeps the lock held, so `cache.add` still blocks it. A bad iteration never kills the heartbeat.

`execute_long_running_migrations` now decides a task is dead using `HEARTBEAT_TTL + offset` instead of `TIME_LIMIT + offset`, so a crashed migration is retried within minutes.

Thread safety: the heartbeat gets `migration_id` (not the shared model instance) and only writes the `date_modified` column via `.update()`, so it never touches `status`, which stays owned by the main thread. Django DB connections are per thread. The heartbeat recycles its connection each loop with `close_old_connections()` since it can live up to 24h. The lock is per migration name, so different migrations run in parallel while a duplicate dispatch of the same one is a no-op.

Tests cover the lock (duplicate blocked, released after run, distinct locks per migration), the heartbeat (refreshes lock and `date_modified`, driven deterministically without sleeps), and several migrations dispatched together.

### 👀 Preview steps

It's easier to refer to unit tests.

To watch the lock and recovery behavior manually:
1. create a dummy job under `jobs/`, e.g. `run()` does `print('foo')` then `time.sleep(180)`
2. create a `LongRunningMigration` row pointing to that job
3. to make the timings observable, set `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_INTERVAL=5` and `CELERY_LONG_RUNNING_MIGRATION_TASK_HEARTBEAT_TTL=15`, then trigger it with `async_execute.delay(<id>)`
4. while it runs, watch the lock TTL in Redis (`TTL execute_long_running_migrations:<name>`) and the migration `date_modified` via `lrm.refresh_from_db()` (or the Django admin)
5. 🔴 [on main] the lock TTL is close to `CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT` and `date_modified` never moves until the run ends
6. 🟢 [on PR] the lock TTL stays near the heartbeat TTL and is refreshed each interval, and `date_modified` advances every interval
7. kill the worker process mid-run to simulate a pod eviction
8. 🔴 [on main] the lock stays held for the whole time limit, blocking any re-execution
9. 🟢 [on PR] the lock is gone within the heartbeat TTL and the next `long-running-migrations` beat cycle re-runs the migration
