### PR TITLE
fix(datatable): filter duplicate options for select dropdown DEV-2449

### DIFF
--- a/jsapp/js/components/submissions/TableDropdownFilter.tsx
+++ b/jsapp/js/components/submissions/TableDropdownFilter.tsx
@@ -26,10 +26,17 @@ const TableDropdownFilter: FilterRender = (props: TableDropdownFilterProps) => {
   const selectFromListName = 'selectFromListName' in props.column ? props.column.selectFromListName : undefined
   const translationIndex = 'translationIndex' in props.column ? props.column.translationIndex || 0 : 0
 
+  // Duplicate values can exist in the choices array, so we use a Set to filter them out
+  const seenValues = new Set<string>()
   const data = [
     { value: SHOW_ALL_VALUE, label: t('Show All') },
     ...choices
       .filter((choiceItem) => choiceItem.list_name === selectFromListName)
+      .filter((item) => {
+        if (seenValues.has(item.name)) return false
+        seenValues.add(item.name)
+        return true
+      })
       .map((item) => {
         return {
           value: item.name,


### PR DESCRIPTION
### 📣 Summary
Fixes a bug that prevented data table from rendering when a form has a select question with multiple options.

### 👀 Preview steps
1. Import and deploy this form:
[duplicate-options.xlsx](https://github.com/user-attachments/files/30095310/duplicate-options.xlsx)
2. Make a few submissions 
3. Load the data table
4. 🔴 [on 2.026.27] notice that data table throws error and doesn't render
5. 🟢 [on PR] verify that table renders and option list for relevant question is appropriately filtered
