### PR TITLE
feat(longRunningMigrations): reprocess XForms wrongly tagged by 0027 DEV-2427

### DIFF
--- a/kobo/apps/long_running_migrations/migrations/0030_reprocess_failed_root_uuid.py
+++ b/kobo/apps/long_running_migrations/migrations/0030_reprocess_failed_root_uuid.py
@@ -1,0 +1,83 @@
+from django.conf import settings
+from django.db import migrations
+from django.db.utils import OperationalError, ProgrammingError
+
+FAILED_TAG = 'kobo-root-uuid-failed-0027'
+DEPENDENT_MIGRATIONS = [
+    '0027_backfill_remaining_root_uuid',
+    '0028_sync_mongo_root_uuid',
+]
+
+
+def reprocess_failed_xforms(apps, schema_editor):
+    """
+    Remove the `kobo-root-uuid-failed-0027` tag from every XForm that LRM 0027
+    wrongly flagged, then reset LRM 0027 and 0028 to `created` so they run again
+    over those XForms.
+
+    Done here rather than in an LRM job so both steps land at deploy time,
+    before the workers restart. The order matters: if the tag were removed later
+    (by a job), 0027 would re-run and complete before the detag, leaving the
+    XForms excluded forever.
+
+    The tag lives in the KoboCAT DB while the `LongRunningMigration` rows live in
+    the default DB, so the two writes cannot share a transaction. The migration
+    is therefore non-atomic and the reset runs *before* the delete: whenever a
+    tag is removed, the matching reset has already been committed. If the process
+    dies in between, a re-run finds the tags already gone but 0027 and 0028
+    already reset, so the reprocessing is never silently lost.
+    """
+
+    TaggedItem = apps.get_model('taggit', 'TaggedItem')
+
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+
+    # Filtering by `content_type` app_label and model avoids `get_for_model()`
+    # and its per-connection cache.
+    tag_filter = dict(
+        tag__name__contains=FAILED_TAG,
+        content_type__app_label='logger',
+        content_type__model='xform',
+    )
+
+    try:
+        has_failed_xforms = (
+            TaggedItem.objects.using(settings.OPENROSA_DB_ALIAS)
+            .filter(**tag_filter)
+            .exists()
+        )
+    except (OperationalError, ProgrammingError):
+        # Fresh install: KPI migrations run before the KoboCAT ones, so the
+        # taggit tables (or the KoboCAT DB) may not exist yet. There are no
+        # submissions, hence nothing to reprocess.
+        return
+
+    if not has_failed_xforms:
+        # Nothing was skipped; leave 0027 and 0028 alone, so their (possibly
+        # expensive) re-run is not triggered for nothing.
+        return
+
+    LongRunningMigration.objects.filter(name__in=DEPENDENT_MIGRATIONS).update(
+        status='created', error=''
+    )
+
+    TaggedItem.objects.using(settings.OPENROSA_DB_ALIAS).filter(**tag_filter).delete()
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    atomic = False
+
+    dependencies = [
+        ('long_running_migrations', '0029_restart_failed_lrm_0024'),
+    ]
+
+    operations = [
+        migrations.RunPython(reprocess_failed_xforms, noop),
+    ]

--- a/kobo/apps/openrosa/apps/logger/migrations/0054_add_null_root_uuid_partial_index.py
+++ b/kobo/apps/openrosa/apps/logger/migrations/0054_add_null_root_uuid_partial_index.py
@@ -1,0 +1,68 @@
+# flake8: noqa: E501
+from django.conf import settings
+from django.db import migrations, models
+
+INDEX_NAME = 'xform_null_root_uuid_idx'
+
+
+def manually_create_index_instructions(apps, schema_editor):
+    print(
+        f"""
+        ⚠️ ATTENTION ⚠️
+        Run the SQL query below in PostgreSQL directly:
+
+        --
+        -- Create partial index {INDEX_NAME} on logger_instance
+        --
+        CREATE INDEX CONCURRENTLY "xform_null_root_uuid_idx"
+            ON "logger_instance" ("xform_id")
+            WHERE "root_uuid" IS NULL;
+        """
+    )
+
+
+def manually_drop_index_instructions(apps, schema_editor):
+    print(
+        f"""
+        ⚠️ ATTENTION ⚠️
+        Run the SQL query below in PostgreSQL directly:
+
+        --
+        -- Drop partial index {INDEX_NAME} on logger_instance
+        --
+        DROP INDEX CONCURRENTLY IF EXISTS "{INDEX_NAME}";
+        """
+    )
+
+
+class Migration(migrations.Migration):
+    """
+    Adds a partial index on (xform_id) WHERE root_uuid IS NULL.
+
+    LRM 0027 and the clean_duplicated_submissions_root_uuid command rely on it
+    to find instances still missing a root_uuid without scanning every NULL
+    row in the table.
+    """
+
+    dependencies = [
+        ('logger', '0053_merge_conflicting_0052'),
+    ]
+
+    if settings.SKIP_HEAVY_MIGRATIONS:
+        operations = [
+            migrations.RunPython(
+                manually_create_index_instructions,
+                manually_drop_index_instructions,
+            )
+        ]
+    else:
+        operations = [
+            migrations.AddIndex(
+                model_name='instance',
+                index=models.Index(
+                    fields=['xform'],
+                    name=INDEX_NAME,
+                    condition=models.Q(root_uuid__isnull=True),
+                ),
+            ),
+        ]

--- a/kobo/apps/openrosa/apps/logger/models/instance.py
+++ b/kobo/apps/openrosa/apps/logger/models/instance.py
@@ -118,6 +118,11 @@ class Instance(AbstractTimeStampedModel):
                 fields=['user_id', '-date_modified'],
                 name='instance_user_date_mod_idx',
             ),
+            models.Index(
+                fields=['xform'],
+                name='xform_null_root_uuid_idx',
+                condition=models.Q(root_uuid__isnull=True),
+            ),
         ]
 
     @property


### PR DESCRIPTION
### 📣 Summary

Some forms were skipped by a background data-repair task after it hit bugs that have since been fixed. This makes the task run over those forms again so they get repaired.

### 👷 Description for instance maintainers

Earlier bugs made long-running migration 0027 tag some forms as failed (`kobo-root-uuid-failed-0027`) and skip them for good, on a task timeout or on an old submission it could not clean. Those bugs are fixed in a separate change.

This adds a data migration that removes that tag from every affected form and resets migrations 0027 and 0028 back to pending, so they run again over the previously skipped forms. It runs at deploy time, before the workers restart. No database schema change and no new table.

Deploy order matters: the 0027 fixes must be present before this migration runs, otherwise the same forms get tagged again. Ship this together with, or after, those fixes.

### 💭 Notes

This is a plain Django data migration (`0030_reprocess_failed_root_uuid`), not an LRM job, matching the existing reset migrations (`0025_reset_lrm_0024`, `0029_restart_failed_lrm_0024`).

Both steps must happen at deploy time and in order. The tag (KoboCAT DB) and the reset (default DB) cannot share a transaction, so the migration is `atomic = False` and the reset runs before the delete. Whenever a tag is deleted, the matching reset is already committed, so a crash in between cannot leave the tags gone while 0027/0028 stay completed (which would silently drop the reprocessing). The go/no-go is an `exists()` check before the delete, not the delete count after, so an install with no failed XForms is a true no-op and does not trigger a pointless (and, for 0028, expensive) re-run.

Doing the detag and the reset together in the migration avoids a race: if the reset ran at deploy but the detag ran later in an LRM job, the beat would dispatch 0027 (older) before that job, so 0027 would re-run and complete while the XForms were still tagged, excluding them for good. Resetting both 0027 and 0028 at once is safe because 0028 waits on `_check_lrm_0027_is_completed`.

Idempotent and a no-op on a fresh install: if no XForm carries the tag, 0027 and 0028 are left untouched. Removing an already-removed tag and resetting an already-pending migration are both harmless.

### 👀 Preview steps

1. ℹ️ have a form tagged `kobo-root-uuid-failed-0027` and migrations 0027 and 0028 marked completed (the state the earlier bugs left behind)
2. run `manage.py migrate long_running_migrations`
3. 🟢 the tag is gone from the form, and 0027 and 0028 are back to `created`
4. 🟢 on the next beat cycles, 0027 re-runs and backfills the form, then 0028 syncs Mongo
5. ℹ️ on a fresh install with no tagged form, the migration completes without touching 0027 or 0028
