### PR TITLE
chore(frontend): remove leftover $ characters after #6987

### DIFF
--- a/jsapp/js/dropzone.utils.tsx
+++ b/jsapp/js/dropzone.utils.tsx
@@ -244,7 +244,7 @@ function onImportSingleXLSFormFile(name: string, base64Encoded: string | ArrayBu
               if (reason.messages?.error) {
                 errLines.push(
                   <code>
-                    ${reason.messages.error_type}: ${escapeHtml(reason.messages.error)}
+                    {reason.messages.error_type}: {escapeHtml(reason.messages.error)}
                   </code>,
                 )
               }


### PR DESCRIPTION
### 💭 Notes

While refactoring dropzone (#6987) we migrated a string to JSX and forgot to remove two `$` resulting in the characters appearing in error toast notification.