### PR TITLE
fix(openapi): type validation error responses as ErrorValidation DEV-1220

### DIFF
--- a/jsapp/js/UniversalTable/index.tsx
+++ b/jsapp/js/UniversalTable/index.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react'
 
 import type { UseQueryResult } from '@tanstack/react-query'
-import type { ErrorObject } from 'schema-utils/declarations/validate'
 import type { ErrorDetail } from '#/api/models/errorDetail'
 import UniversalTableCore from './UniversalTableCore'
 import type { UniversalTableColumn } from './UniversalTableCore'
@@ -47,7 +46,7 @@ export namespace PaginatedListResponse {
   }
 }
 
-interface UniversalTableProps<Datum, TError = Error | ErrorDetail | ErrorObject> {
+interface UniversalTableProps<Datum, TError = Error | ErrorDetail> {
   // Below are props from `UniversalTable` that should come from the parent
   // component (these are kind of "configuration" props). The other
   // `UniversalTable` props are being handled here internally.

--- a/jsapp/js/account/organization/InviteeActionsDropdown.tsx
+++ b/jsapp/js/account/organization/InviteeActionsDropdown.tsx
@@ -4,7 +4,7 @@ import { Group, LoadingOverlay, Menu, Modal, Stack, Text } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { ServerError } from '#/api/ServerError'
 import type { ErrorDetail } from '#/api/models/errorDetail'
-import type { ErrorObject } from '#/api/models/errorObject'
+import type { ErrorValidation } from '#/api/models/errorValidation'
 import type { InviteResponse } from '#/api/models/inviteResponse'
 import { InviteStatusChoicesEnum } from '#/api/models/inviteStatusChoicesEnum'
 import {
@@ -32,7 +32,7 @@ export default function InviteeActionsDropdown({
   const orgInvitesPatch = useOrganizationsInvitesPartialUpdate({
     mutation: {
       onSuccess: () => notify(t('The invitation was resent'), 'success'),
-      onError: (error: ErrorObject | ErrorDetail | ServerError) => {
+      onError: (error: ErrorValidation | ErrorDetail | ServerError) => {
         const retryAfter =
           error instanceof ServerError && error.response.status === 429
             ? error.response.headers?.get('Retry-After')

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -7,7 +7,7 @@ import UniversalTable, { DEFAULT_PAGE_SIZE, type UniversalTableColumn } from '#/
 import InviteModal from '#/account/organization/InviteModal'
 import { getSimpleMMOLabel } from '#/account/organization/organization.utils'
 import subscriptionStore from '#/account/subscriptionStore'
-import type { ErrorObject } from '#/api/models/errorObject'
+import type { ErrorDetail } from '#/api/models/errorDetail'
 import { InviteStatusChoicesEnum } from '#/api/models/inviteStatusChoicesEnum'
 import type { MemberListResponse } from '#/api/models/memberListResponse'
 import { MemberRoleEnum } from '#/api/models/memberRoleEnum'
@@ -233,7 +233,7 @@ export default function MembersRoute() {
         </Box>
       )}
 
-      <UniversalTable<MemberListResponse, ErrorObject>
+      <UniversalTable<MemberListResponse, ErrorDetail>
         columns={columns}
         queryResult={membersQuery}
         pagination={pagination}

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -5,7 +5,7 @@ import prettyBytes from 'pretty-bytes'
 import { Link } from 'react-router-dom'
 import UniversalTable, { DEFAULT_PAGE_SIZE, type UniversalTableColumn } from '#/UniversalTable'
 import type { CustomAssetUsage } from '#/api/models/customAssetUsage'
-import type { ErrorObject } from '#/api/models/errorObject'
+import type { ErrorDetail } from '#/api/models/errorDetail'
 import type { OrganizationsAssetUsageListParams } from '#/api/models/organizationsAssetUsageListParams'
 import {
   getOrganizationsAssetUsageListQueryKey,
@@ -169,7 +169,7 @@ const ProjectBreakdown = () => {
           <Button size='s' type='text' startIcon='close' onClick={dismissIntervalBanner} />
         </div>
       )}
-      <UniversalTable<CustomAssetUsage, ErrorObject>
+      <UniversalTable<CustomAssetUsage, ErrorDetail>
         pagination={pagination}
         setPagination={setPagination}
         queryResult={queryResult}

--- a/jsapp/js/api/ServerError.ts
+++ b/jsapp/js/api/ServerError.ts
@@ -1,7 +1,6 @@
 import type { ErrorDetail } from './models/errorDetail'
-import type { ErrorObject } from './models/errorObject'
 
-export class ServerError extends Error implements ErrorObject, ErrorDetail {
+export class ServerError extends Error implements ErrorDetail {
   static async new(response: Response) {
     let parsedResponse: any
     let detail: any

--- a/jsapp/js/api/models/errorValidation.ts
+++ b/jsapp/js/api/models/errorValidation.ts
@@ -10,6 +10,6 @@ The endpoints are grouped by area of intended use. Each category contains relate
  * OpenAPI spec version: 2.0.0 (api_v2)
  */
 
-export interface ErrorObject {
-  detail: unknown
+export interface ErrorValidation {
+  [key: string]: string[]
 }

--- a/jsapp/js/api/orval.types.d.ts
+++ b/jsapp/js/api/orval.types.d.ts
@@ -1,10 +1,6 @@
 import './models/errorDetail'
-import './models/errorObject'
 
 // Extend error types with Error object like the custom fetch will return.
 declare module './models/errorDetail' {
   interface ErrorDetail extends Error {}
-}
-declare module './models/errorObject' {
-  interface ErrorObject extends Error {}
 }

--- a/jsapp/js/api/react-query/form-content/index.ts
+++ b/jsapp/js/api/react-query/form-content/index.ts
@@ -33,7 +33,7 @@ import type { ContentResponse } from '../../models/contentResponse'
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { OpenRosaXFormResponse } from '../../models/openRosaXFormResponse'
 
@@ -151,7 +151,7 @@ export type assetSnapshotsCreateResponse201 = {
 }
 
 export type assetSnapshotsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -186,7 +186,7 @@ export const assetSnapshotsCreate = async (
 }
 
 export const getAssetSnapshotsCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -223,9 +223,9 @@ export const getAssetSnapshotsCreateMutationOptions = <
 
 export type AssetSnapshotsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetSnapshotsCreate>>>
 export type AssetSnapshotsCreateMutationBody = AssetSnapshotCreateRequest
-export type AssetSnapshotsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetSnapshotsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetSnapshotsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetSnapshotsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetSnapshotsCreate>>,
     TError,

--- a/jsapp/js/api/react-query/library-collections/index.ts
+++ b/jsapp/js/api/react-query/library-collections/index.ts
@@ -27,7 +27,7 @@ import type { AssetSubscriptionsListParams } from '../../models/assetSubscriptio
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { PaginatedAssetSubscriptionResponseList } from '../../models/paginatedAssetSubscriptionResponseList'
 
@@ -135,7 +135,7 @@ export type assetSubscriptionsCreateResponse201 = {
 }
 
 export type assetSubscriptionsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -163,7 +163,7 @@ export const assetSubscriptionsCreate = async (
   })
 }
 
-export const getAssetSubscriptionsCreateMutationOptions = <TError = ErrorObject, TContext = unknown>(options?: {
+export const getAssetSubscriptionsCreateMutationOptions = <TError = ErrorValidation, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetSubscriptionsCreate>>,
     TError,
@@ -198,9 +198,9 @@ export const getAssetSubscriptionsCreateMutationOptions = <TError = ErrorObject,
 
 export type AssetSubscriptionsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetSubscriptionsCreate>>>
 export type AssetSubscriptionsCreateMutationBody = AssetSubscriptionRequest
-export type AssetSubscriptionsCreateMutationError = ErrorObject
+export type AssetSubscriptionsCreateMutationError = ErrorValidation
 
-export const useAssetSubscriptionsCreate = <TError = ErrorObject, TContext = unknown>(options?: {
+export const useAssetSubscriptionsCreate = <TError = ErrorValidation, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetSubscriptionsCreate>>,
     TError,

--- a/jsapp/js/api/react-query/manage-permissions/index.ts
+++ b/jsapp/js/api/react-query/manage-permissions/index.ts
@@ -21,7 +21,7 @@ import type {
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { PatchedPermissionAssignmentCloneRequest } from '../../models/patchedPermissionAssignmentCloneRequest'
 
@@ -138,7 +138,7 @@ export type assetsPermissionAssignmentsCreateResponse200 = {
 }
 
 export type assetsPermissionAssignmentsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -174,7 +174,7 @@ export const assetsPermissionAssignmentsCreate = async (
 }
 
 export const getAssetsPermissionAssignmentsCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -213,9 +213,12 @@ export type AssetsPermissionAssignmentsCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsPermissionAssignmentsCreate>>
 >
 export type AssetsPermissionAssignmentsCreateMutationBody = PermissionAssignmentCreateRequest
-export type AssetsPermissionAssignmentsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsPermissionAssignmentsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsPermissionAssignmentsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsPermissionAssignmentsCreate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsPermissionAssignmentsCreate>>,
     TError,
@@ -430,7 +433,7 @@ export type assetsPermissionAssignmentsBulkCreateResponse200 = {
 }
 
 export type assetsPermissionAssignmentsBulkCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -469,7 +472,7 @@ export const assetsPermissionAssignmentsBulkCreate = async (
 }
 
 export const getAssetsPermissionAssignmentsBulkCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -508,10 +511,10 @@ export type AssetsPermissionAssignmentsBulkCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsPermissionAssignmentsBulkCreate>>
 >
 export type AssetsPermissionAssignmentsBulkCreateMutationBody = PermissionAssignmentBulkRequest[]
-export type AssetsPermissionAssignmentsBulkCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsPermissionAssignmentsBulkCreateMutationError = ErrorValidation | ErrorDetail
 
 export const useAssetsPermissionAssignmentsBulkCreate = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -549,7 +552,7 @@ export type assetsPermissionAssignmentsBulkDestroyResponse204 = {
 }
 
 export type assetsPermissionAssignmentsBulkDestroyResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -585,7 +588,7 @@ export const assetsPermissionAssignmentsBulkDestroy = async (
 }
 
 export const getAssetsPermissionAssignmentsBulkDestroyMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -624,10 +627,10 @@ export type AssetsPermissionAssignmentsBulkDestroyMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsPermissionAssignmentsBulkDestroy>>
 >
 
-export type AssetsPermissionAssignmentsBulkDestroyMutationError = ErrorObject | ErrorDetail
+export type AssetsPermissionAssignmentsBulkDestroyMutationError = ErrorValidation | ErrorDetail
 
 export const useAssetsPermissionAssignmentsBulkDestroy = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -654,7 +657,7 @@ export type assetsPermissionAssignmentsClonePartialUpdateResponse200 = {
 }
 
 export type assetsPermissionAssignmentsClonePartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -694,7 +697,7 @@ export const assetsPermissionAssignmentsClonePartialUpdate = async (
 }
 
 export const getAssetsPermissionAssignmentsClonePartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -733,10 +736,10 @@ export type AssetsPermissionAssignmentsClonePartialUpdateMutationResult = NonNul
   Awaited<ReturnType<typeof assetsPermissionAssignmentsClonePartialUpdate>>
 >
 export type AssetsPermissionAssignmentsClonePartialUpdateMutationBody = PatchedPermissionAssignmentCloneRequest
-export type AssetsPermissionAssignmentsClonePartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsPermissionAssignmentsClonePartialUpdateMutationError = ErrorValidation | ErrorDetail
 
 export const useAssetsPermissionAssignmentsClonePartialUpdate = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<

--- a/jsapp/js/api/react-query/manage-projects-and-library-content/index.ts
+++ b/jsapp/js/api/react-query/manage-projects-and-library-content/index.ts
@@ -47,7 +47,7 @@ import type { DeploymentResponse } from '../../models/deploymentResponse'
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { HashResponse } from '../../models/hashResponse'
 
@@ -242,7 +242,7 @@ export type assetsCreateResponse201 = {
 }
 
 export type assetsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -273,7 +273,7 @@ export const assetsCreate = async (
   })
 }
 
-export const getAssetsCreateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getAssetsCreateMutationOptions = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsCreate>>,
     TError,
@@ -302,9 +302,9 @@ export const getAssetsCreateMutationOptions = <TError = ErrorObject | ErrorDetai
 
 export type AssetsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsCreate>>>
 export type AssetsCreateMutationBody = AssetCreateRequest
-export type AssetsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsCreate>>,
     TError,
@@ -429,7 +429,7 @@ export type assetsPartialUpdateResponse200 = {
 }
 
 export type assetsPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -465,7 +465,7 @@ export const assetsPartialUpdate = async (
 }
 
 export const getAssetsPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -502,9 +502,9 @@ export const getAssetsPartialUpdateMutationOptions = <
 
 export type AssetsPartialUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsPartialUpdate>>>
 export type AssetsPartialUpdateMutationBody = PatchedAssetPatchRequest
-export type AssetsPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsPartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsPartialUpdate>>,
     TError,
@@ -785,7 +785,7 @@ export type assetsDeploymentCreateResponse200 = {
 }
 
 export type assetsDeploymentCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -821,7 +821,7 @@ export const assetsDeploymentCreate = async (
 }
 
 export const getAssetsDeploymentCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -858,9 +858,9 @@ export const getAssetsDeploymentCreateMutationOptions = <
 
 export type AssetsDeploymentCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsDeploymentCreate>>>
 export type AssetsDeploymentCreateMutationBody = DeploymentCreateRequest
-export type AssetsDeploymentCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsDeploymentCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsDeploymentCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsDeploymentCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsDeploymentCreate>>,
     TError,
@@ -887,7 +887,7 @@ export type assetsDeploymentPartialUpdateResponse200 = {
 }
 
 export type assetsDeploymentPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -923,7 +923,7 @@ export const assetsDeploymentPartialUpdate = async (
 }
 
 export const getAssetsDeploymentPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -962,9 +962,9 @@ export type AssetsDeploymentPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsDeploymentPartialUpdate>>
 >
 export type AssetsDeploymentPartialUpdateMutationBody = PatchedDeploymentPatchRequest
-export type AssetsDeploymentPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsDeploymentPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsDeploymentPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsDeploymentPartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsDeploymentPartialUpdate>>,
     TError,
@@ -1745,7 +1745,7 @@ export type importsCreateResponse201 = {
 }
 
 export type importsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1786,7 +1786,7 @@ export const importsCreate = async (
   })
 }
 
-export const getImportsCreateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getImportsCreateMutationOptions = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof importsCreate>>,
     TError,
@@ -1815,9 +1815,9 @@ export const getImportsCreateMutationOptions = <TError = ErrorObject | ErrorDeta
 
 export type ImportsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof importsCreate>>>
 export type ImportsCreateMutationBody = ImportCreateRequest
-export type ImportsCreateMutationError = ErrorObject | ErrorDetail
+export type ImportsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useImportsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useImportsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof importsCreate>>,
     TError,
@@ -2031,7 +2031,7 @@ export type projectOwnershipInvitesCreateResponse201 = {
 }
 
 export type projectOwnershipInvitesCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2066,7 +2066,7 @@ export const projectOwnershipInvitesCreate = async (
 }
 
 export const getProjectOwnershipInvitesCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -2105,9 +2105,9 @@ export type ProjectOwnershipInvitesCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof projectOwnershipInvitesCreate>>
 >
 export type ProjectOwnershipInvitesCreateMutationBody = ProjectInviteCreatePayload
-export type ProjectOwnershipInvitesCreateMutationError = ErrorObject | ErrorDetail
+export type ProjectOwnershipInvitesCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useProjectOwnershipInvitesCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useProjectOwnershipInvitesCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof projectOwnershipInvitesCreate>>,
     TError,
@@ -2232,7 +2232,7 @@ export type projectOwnershipInvitesPartialUpdateResponse200 = {
 }
 
 export type projectOwnershipInvitesPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2271,7 +2271,7 @@ export const projectOwnershipInvitesPartialUpdate = async (
 }
 
 export const getProjectOwnershipInvitesPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -2310,10 +2310,10 @@ export type ProjectOwnershipInvitesPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof projectOwnershipInvitesPartialUpdate>>
 >
 export type ProjectOwnershipInvitesPartialUpdateMutationBody = PatchedInviteUpdatePayload
-export type ProjectOwnershipInvitesPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type ProjectOwnershipInvitesPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
 export const useProjectOwnershipInvitesPartialUpdate = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<

--- a/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
+++ b/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
@@ -4008,7 +4008,10 @@ export const getApiV2AssetsVersionsListResponseMock = (
     uid: faker.string.alpha({ length: { min: 10, max: 20 } }),
     url: faker.internet.url(),
     content_hash: faker.string.alpha({ length: { min: 10, max: 20 } }),
-    date_deployed: `${faker.date.past().toISOString().split('.')[0]}Z`,
+    date_deployed: faker.helpers.arrayElement([
+      `${faker.date.past().toISOString().split('.')[0]}Z`,
+      faker.datatype.boolean(),
+    ]),
     date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
   })),
   ...overrideResponse,
@@ -4020,7 +4023,10 @@ export const getApiV2AssetsVersionsRetrieveResponseMock = (
   uid: faker.string.alpha({ length: { min: 10, max: 20 } }),
   url: faker.internet.url(),
   content_hash: faker.string.alpha({ length: { min: 10, max: 20 } }),
-  date_deployed: `${faker.date.past().toISOString().split('.')[0]}Z`,
+  date_deployed: faker.helpers.arrayElement([
+    `${faker.date.past().toISOString().split('.')[0]}Z`,
+    faker.datatype.boolean(),
+  ]),
   date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
   content: {
     schema: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),

--- a/jsapp/js/api/react-query/other/index.ts
+++ b/jsapp/js/api/react-query/other/index.ts
@@ -29,7 +29,7 @@ import type { CustomerPortalPostResponse } from '../../models/customerPortalPost
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { Language } from '../../models/language'
 
@@ -760,7 +760,7 @@ export type stripeCustomerPortalCreateResponse200 = {
 }
 
 export type stripeCustomerPortalCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -795,7 +795,7 @@ export const stripeCustomerPortalCreate = async (
 }
 
 export const getStripeCustomerPortalCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -834,9 +834,9 @@ export type StripeCustomerPortalCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof stripeCustomerPortalCreate>>
 >
 export type StripeCustomerPortalCreateMutationBody = CustomerPortal
-export type StripeCustomerPortalCreateMutationError = ErrorObject | ErrorDetail
+export type StripeCustomerPortalCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useStripeCustomerPortalCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useStripeCustomerPortalCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof stripeCustomerPortalCreate>>,
     TError,
@@ -1526,7 +1526,7 @@ export type translationServicesListResponse200 = {
 }
 
 export type translationServicesListResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1576,7 +1576,7 @@ export const getTranslationServicesListQueryKey = (params?: TranslationServicesL
 
 export const getTranslationServicesListQueryOptions = <
   TData = Awaited<ReturnType<typeof translationServicesList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   params?: TranslationServicesListParams,
   options?: {
@@ -1599,11 +1599,11 @@ export const getTranslationServicesListQueryOptions = <
 }
 
 export type TranslationServicesListQueryResult = NonNullable<Awaited<ReturnType<typeof translationServicesList>>>
-export type TranslationServicesListQueryError = ErrorObject | ErrorDetail
+export type TranslationServicesListQueryError = ErrorValidation | ErrorDetail
 
 export function useTranslationServicesList<
   TData = Awaited<ReturnType<typeof translationServicesList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   params?: TranslationServicesListParams,
   options?: {

--- a/jsapp/js/api/react-query/server-logs-superusers/index.ts
+++ b/jsapp/js/api/react-query/server-logs-superusers/index.ts
@@ -25,7 +25,7 @@ import type { AuditLogsListParams } from '../../models/auditLogsListParams'
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { ExportCreateResponse } from '../../models/exportCreateResponse'
 
@@ -986,7 +986,7 @@ export type userReportsListResponse200 = {
 }
 
 export type userReportsListResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1034,7 +1034,7 @@ export const getUserReportsListQueryKey = (params?: UserReportsListParams) => {
 
 export const getUserReportsListQueryOptions = <
   TData = Awaited<ReturnType<typeof userReportsList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   params?: UserReportsListParams,
   options?: {
@@ -1057,11 +1057,11 @@ export const getUserReportsListQueryOptions = <
 }
 
 export type UserReportsListQueryResult = NonNullable<Awaited<ReturnType<typeof userReportsList>>>
-export type UserReportsListQueryError = ErrorObject | ErrorDetail
+export type UserReportsListQueryError = ErrorValidation | ErrorDetail
 
 export function useUserReportsList<
   TData = Awaited<ReturnType<typeof userReportsList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   params?: UserReportsListParams,
   options?: {

--- a/jsapp/js/api/react-query/survey-data-rest-services/index.ts
+++ b/jsapp/js/api/react-query/survey-data-rest-services/index.ts
@@ -25,7 +25,7 @@ import type { AssetsHooksLogsListParams } from '../../models/assetsHooksLogsList
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { Hook } from '../../models/hook'
 
@@ -202,7 +202,7 @@ export type assetsHooksCreateResponse201 = {
 }
 
 export type assetsHooksCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -237,7 +237,10 @@ export const assetsHooksCreate = async (
   })
 }
 
-export const getAssetsHooksCreateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getAssetsHooksCreateMutationOptions = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsHooksCreate>>,
     TError,
@@ -272,9 +275,9 @@ export const getAssetsHooksCreateMutationOptions = <TError = ErrorObject | Error
 
 export type AssetsHooksCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsHooksCreate>>>
 export type AssetsHooksCreateMutationBody = NonReadonly<Hook>
-export type AssetsHooksCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsHooksCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsHooksCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsHooksCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsHooksCreate>>,
     TError,
@@ -381,7 +384,7 @@ export type assetsHooksPartialUpdateResponse200 = {
 }
 
 export type assetsHooksPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -418,7 +421,7 @@ export const assetsHooksPartialUpdate = async (
 }
 
 export const getAssetsHooksPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -455,9 +458,9 @@ export const getAssetsHooksPartialUpdateMutationOptions = <
 
 export type AssetsHooksPartialUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsHooksPartialUpdate>>>
 export type AssetsHooksPartialUpdateMutationBody = NonReadonly<PatchedHook>
-export type AssetsHooksPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsHooksPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsHooksPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsHooksPartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsHooksPartialUpdate>>,
     TError,

--- a/jsapp/js/api/react-query/survey-data/index.ts
+++ b/jsapp/js/api/react-query/survey-data/index.ts
@@ -81,7 +81,7 @@ import type { EnketoViewResponse } from '../../models/enketoViewResponse'
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { ExportCreatePayload } from '../../models/exportCreatePayload'
 
@@ -260,7 +260,7 @@ export type assetsAdvancedFeaturesCreateResponse201 = {
 }
 
 export type assetsAdvancedFeaturesCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -296,7 +296,7 @@ export const assetsAdvancedFeaturesCreate = async (
 }
 
 export const getAssetsAdvancedFeaturesCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -335,9 +335,9 @@ export type AssetsAdvancedFeaturesCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsAdvancedFeaturesCreate>>
 >
 export type AssetsAdvancedFeaturesCreateMutationBody = AdvancedFeaturePostRequest
-export type AssetsAdvancedFeaturesCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsAdvancedFeaturesCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsAdvancedFeaturesCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsAdvancedFeaturesCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsAdvancedFeaturesCreate>>,
     TError,
@@ -470,7 +470,7 @@ export type assetsAdvancedFeaturesPartialUpdateResponse200 = {
 }
 
 export type assetsAdvancedFeaturesPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -510,7 +510,7 @@ export const assetsAdvancedFeaturesPartialUpdate = async (
 }
 
 export const getAssetsAdvancedFeaturesPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -549,10 +549,10 @@ export type AssetsAdvancedFeaturesPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsAdvancedFeaturesPartialUpdate>>
 >
 export type AssetsAdvancedFeaturesPartialUpdateMutationBody = PatchedAdvancedFeaturePatchRequest
-export type AssetsAdvancedFeaturesPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsAdvancedFeaturesPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
 export const useAssetsAdvancedFeaturesPartialUpdate = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -739,7 +739,7 @@ export type assetsAdvancedFeaturesBulkActionsCreateResponse201 = {
 }
 
 export type assetsAdvancedFeaturesBulkActionsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -779,7 +779,7 @@ export const assetsAdvancedFeaturesBulkActionsCreate = async (
 }
 
 export const getAssetsAdvancedFeaturesBulkActionsCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -818,10 +818,10 @@ export type AssetsAdvancedFeaturesBulkActionsCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsAdvancedFeaturesBulkActionsCreate>>
 >
 export type AssetsAdvancedFeaturesBulkActionsCreateMutationBody = BulkActionCreateRequest
-export type AssetsAdvancedFeaturesBulkActionsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsAdvancedFeaturesBulkActionsCreateMutationError = ErrorValidation | ErrorDetail
 
 export const useAssetsAdvancedFeaturesBulkActionsCreate = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1067,7 +1067,7 @@ export type assetsAttachmentsDestroyResponse204 = {
 }
 
 export type assetsAttachmentsDestroyResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1101,7 +1101,7 @@ export const assetsAttachmentsDestroy = async (
 }
 
 export const getAssetsAttachmentsDestroyMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1138,9 +1138,9 @@ export const getAssetsAttachmentsDestroyMutationOptions = <
 
 export type AssetsAttachmentsDestroyMutationResult = NonNullable<Awaited<ReturnType<typeof assetsAttachmentsDestroy>>>
 
-export type AssetsAttachmentsDestroyMutationError = ErrorObject | ErrorDetail
+export type AssetsAttachmentsDestroyMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsAttachmentsDestroy = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsAttachmentsDestroy = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsAttachmentsDestroy>>,
     TError,
@@ -1320,7 +1320,7 @@ export type assetsAttachmentsBulkDestroyResponse202 = {
 }
 
 export type assetsAttachmentsBulkDestroyResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1353,7 +1353,7 @@ export const assetsAttachmentsBulkDestroy = async (
 }
 
 export const getAssetsAttachmentsBulkDestroyMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1391,9 +1391,9 @@ export type AssetsAttachmentsBulkDestroyMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsAttachmentsBulkDestroy>>
 >
 
-export type AssetsAttachmentsBulkDestroyMutationError = ErrorObject | ErrorDetail
+export type AssetsAttachmentsBulkDestroyMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsAttachmentsBulkDestroy = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsAttachmentsBulkDestroy = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsAttachmentsBulkDestroy>>,
     TError,
@@ -2739,7 +2739,7 @@ export type assetsDataSupplementRetrieveResponse200 = {
 }
 
 export type assetsDataSupplementRetrieveResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2778,7 +2778,7 @@ export const getAssetsDataSupplementRetrieveQueryKey = (uidAsset: string, rootUu
 
 export const getAssetsDataSupplementRetrieveQueryOptions = <
   TData = Awaited<ReturnType<typeof assetsDataSupplementRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   rootUuid: string,
@@ -2804,11 +2804,11 @@ export const getAssetsDataSupplementRetrieveQueryOptions = <
 export type AssetsDataSupplementRetrieveQueryResult = NonNullable<
   Awaited<ReturnType<typeof assetsDataSupplementRetrieve>>
 >
-export type AssetsDataSupplementRetrieveQueryError = ErrorObject | ErrorDetail
+export type AssetsDataSupplementRetrieveQueryError = ErrorValidation | ErrorDetail
 
 export function useAssetsDataSupplementRetrieve<
   TData = Awaited<ReturnType<typeof assetsDataSupplementRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   rootUuid: string,
@@ -2853,7 +2853,7 @@ export type assetsDataSupplementPartialUpdateResponse200 = {
 }
 
 export type assetsDataSupplementPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2893,7 +2893,7 @@ export const assetsDataSupplementPartialUpdate = async (
 }
 
 export const getAssetsDataSupplementPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -2932,9 +2932,12 @@ export type AssetsDataSupplementPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsDataSupplementPartialUpdate>>
 >
 export type AssetsDataSupplementPartialUpdateMutationBody = PatchedDataSupplementPayload
-export type AssetsDataSupplementPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsDataSupplementPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsDataSupplementPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsDataSupplementPartialUpdate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsDataSupplementPartialUpdate>>,
     TError,
@@ -2974,7 +2977,7 @@ export type assetsDataAttachmentsListResponse200 = {
 }
 
 export type assetsDataAttachmentsListResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3034,7 +3037,7 @@ export const getAssetsDataAttachmentsListQueryKey = (
 
 export const getAssetsDataAttachmentsListQueryOptions = <
   TData = Awaited<ReturnType<typeof assetsDataAttachmentsList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidData: string,
@@ -3059,11 +3062,11 @@ export const getAssetsDataAttachmentsListQueryOptions = <
 }
 
 export type AssetsDataAttachmentsListQueryResult = NonNullable<Awaited<ReturnType<typeof assetsDataAttachmentsList>>>
-export type AssetsDataAttachmentsListQueryError = ErrorObject | ErrorDetail
+export type AssetsDataAttachmentsListQueryError = ErrorValidation | ErrorDetail
 
 export function useAssetsDataAttachmentsList<
   TData = Awaited<ReturnType<typeof assetsDataAttachmentsList>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidData: string,
@@ -3114,7 +3117,7 @@ export type attachmentRetrieveResponse200 = {
 }
 
 export type attachmentRetrieveResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3177,7 +3180,7 @@ export const getAttachmentRetrieveQueryKey = (
 
 export const getAttachmentRetrieveQueryOptions = <
   TData = Awaited<ReturnType<typeof attachmentRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidData: string,
@@ -3203,11 +3206,11 @@ export const getAttachmentRetrieveQueryOptions = <
 }
 
 export type AttachmentRetrieveQueryResult = NonNullable<Awaited<ReturnType<typeof attachmentRetrieve>>>
-export type AttachmentRetrieveQueryError = ErrorObject | ErrorDetail
+export type AttachmentRetrieveQueryError = ErrorValidation | ErrorDetail
 
 export function useAttachmentRetrieve<
   TData = Awaited<ReturnType<typeof attachmentRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidData: string,
@@ -3599,7 +3602,7 @@ export type assetsDataSupplementsBulkCreateResponse200 = {
 }
 
 export type assetsDataSupplementsBulkCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3635,7 +3638,7 @@ export const assetsDataSupplementsBulkCreate = async (
 }
 
 export const getAssetsDataSupplementsBulkCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -3674,9 +3677,12 @@ export type AssetsDataSupplementsBulkCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsDataSupplementsBulkCreate>>
 >
 export type AssetsDataSupplementsBulkCreateMutationBody = BulkAcceptRequest
-export type AssetsDataSupplementsBulkCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsDataSupplementsBulkCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsDataSupplementsBulkCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsDataSupplementsBulkCreate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsDataSupplementsBulkCreate>>,
     TError,
@@ -4080,7 +4086,7 @@ export type assetsExportSettingsCreateResponse201 = {
 }
 
 export type assetsExportSettingsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -4116,7 +4122,7 @@ export const assetsExportSettingsCreate = async (
 }
 
 export const getAssetsExportSettingsCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -4155,9 +4161,9 @@ export type AssetsExportSettingsCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsExportSettingsCreate>>
 >
 export type AssetsExportSettingsCreateMutationBody = ExportSettingCreatePayload
-export type AssetsExportSettingsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsExportSettingsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsExportSettingsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsExportSettingsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsExportSettingsCreate>>,
     TError,
@@ -4278,7 +4284,7 @@ export type assetsExportSettingsPartialUpdateResponse200 = {
 }
 
 export type assetsExportSettingsPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -4318,7 +4324,7 @@ export const assetsExportSettingsPartialUpdate = async (
 }
 
 export const getAssetsExportSettingsPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -4357,9 +4363,12 @@ export type AssetsExportSettingsPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsExportSettingsPartialUpdate>>
 >
 export type AssetsExportSettingsPartialUpdateMutationBody = PatchedExportSettingUpdatePayload
-export type AssetsExportSettingsPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsExportSettingsPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsExportSettingsPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsExportSettingsPartialUpdate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsExportSettingsPartialUpdate>>,
     TError,
@@ -4483,7 +4492,7 @@ export type assetsExportSettingsDataRetrieveResponse200 = {
 }
 
 export type assetsExportSettingsDataRetrieveResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -4555,7 +4564,7 @@ export const getAssetsExportSettingsDataRetrieveQueryKey = (
 
 export const getAssetsExportSettingsDataRetrieveQueryOptions = <
   TData = Awaited<ReturnType<typeof assetsExportSettingsDataRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidExportSetting: string,
@@ -4583,11 +4592,11 @@ export const getAssetsExportSettingsDataRetrieveQueryOptions = <
 export type AssetsExportSettingsDataRetrieveQueryResult = NonNullable<
   Awaited<ReturnType<typeof assetsExportSettingsDataRetrieve>>
 >
-export type AssetsExportSettingsDataRetrieveQueryError = ErrorObject | ErrorDetail
+export type AssetsExportSettingsDataRetrieveQueryError = ErrorValidation | ErrorDetail
 
 export function useAssetsExportSettingsDataRetrieve<
   TData = Awaited<ReturnType<typeof assetsExportSettingsDataRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidAsset: string,
   uidExportSetting: string,
@@ -4755,7 +4764,7 @@ export type assetsExportsCreateResponse201 = {
 }
 
 export type assetsExportsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -4791,7 +4800,7 @@ export const assetsExportsCreate = async (
 }
 
 export const getAssetsExportsCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -4828,9 +4837,9 @@ export const getAssetsExportsCreateMutationOptions = <
 
 export type AssetsExportsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsExportsCreate>>>
 export type AssetsExportsCreateMutationBody = ExportCreatePayload
-export type AssetsExportsCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsExportsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsExportsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsExportsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsExportsCreate>>,
     TError,
@@ -5150,7 +5159,7 @@ export type assetsFilesCreateResponse201 = {
 }
 
 export type assetsFilesCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -5185,7 +5194,10 @@ export const assetsFilesCreate = async (
   })
 }
 
-export const getAssetsFilesCreateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getAssetsFilesCreateMutationOptions = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsFilesCreate>>,
     TError,
@@ -5220,9 +5232,9 @@ export const getAssetsFilesCreateMutationOptions = <TError = ErrorObject | Error
 
 export type AssetsFilesCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsFilesCreate>>>
 export type AssetsFilesCreateMutationBody = CreateFilePayload
-export type AssetsFilesCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsFilesCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsFilesCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsFilesCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsFilesCreate>>,
     TError,
@@ -5609,7 +5621,7 @@ export type assetsPairedDataCreateResponse201 = {
 }
 
 export type assetsPairedDataCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -5645,7 +5657,7 @@ export const assetsPairedDataCreate = async (
 }
 
 export const getAssetsPairedDataCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -5682,9 +5694,9 @@ export const getAssetsPairedDataCreateMutationOptions = <
 
 export type AssetsPairedDataCreateMutationResult = NonNullable<Awaited<ReturnType<typeof assetsPairedDataCreate>>>
 export type AssetsPairedDataCreateMutationBody = NonReadonly<PairedData>
-export type AssetsPairedDataCreateMutationError = ErrorObject | ErrorDetail
+export type AssetsPairedDataCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsPairedDataCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsPairedDataCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsPairedDataCreate>>,
     TError,
@@ -5798,7 +5810,7 @@ export type assetsPairedDataPartialUpdateResponse200 = {
 }
 
 export type assetsPairedDataPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -5838,7 +5850,7 @@ export const assetsPairedDataPartialUpdate = async (
 }
 
 export const getAssetsPairedDataPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -5877,9 +5889,9 @@ export type AssetsPairedDataPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof assetsPairedDataPartialUpdate>>
 >
 export type AssetsPairedDataPartialUpdateMutationBody = PatchedPairedDataPatchPayload
-export type AssetsPairedDataPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type AssetsPairedDataPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useAssetsPairedDataPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useAssetsPairedDataPartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof assetsPairedDataPartialUpdate>>,
     TError,

--- a/jsapp/js/api/react-query/user-team-organization-usage/index.ts
+++ b/jsapp/js/api/react-query/user-team-organization-usage/index.ts
@@ -29,7 +29,7 @@ import type { EmailRequestPayload } from '../../models/emailRequestPayload'
 
 import type { ErrorDetail } from '../../models/errorDetail'
 
-import type { ErrorObject } from '../../models/errorObject'
+import type { ErrorValidation } from '../../models/errorValidation'
 
 import type { InviteCreatePayload } from '../../models/inviteCreatePayload'
 
@@ -409,7 +409,7 @@ export type organizationsPartialUpdateResponse200 = {
 }
 
 export type organizationsPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -445,7 +445,7 @@ export const organizationsPartialUpdate = async (
 }
 
 export const getOrganizationsPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -484,9 +484,9 @@ export type OrganizationsPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof organizationsPartialUpdate>>
 >
 export type OrganizationsPartialUpdateMutationBody = PatchedOrganizationPatchPayload
-export type OrganizationsPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type OrganizationsPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useOrganizationsPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useOrganizationsPartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof organizationsPartialUpdate>>,
     TError,
@@ -1037,7 +1037,7 @@ export type organizationsInvitesCreateResponse201 = {
 }
 
 export type organizationsInvitesCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1073,7 +1073,7 @@ export const organizationsInvitesCreate = async (
 }
 
 export const getOrganizationsInvitesCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1112,9 +1112,9 @@ export type OrganizationsInvitesCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof organizationsInvitesCreate>>
 >
 export type OrganizationsInvitesCreateMutationBody = InviteCreatePayload
-export type OrganizationsInvitesCreateMutationError = ErrorObject | ErrorDetail
+export type OrganizationsInvitesCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useOrganizationsInvitesCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useOrganizationsInvitesCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof organizationsInvitesCreate>>,
     TError,
@@ -1235,7 +1235,7 @@ export type organizationsInvitesPartialUpdateResponse200 = {
 }
 
 export type organizationsInvitesPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1275,7 +1275,7 @@ export const organizationsInvitesPartialUpdate = async (
 }
 
 export const getOrganizationsInvitesPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1314,9 +1314,12 @@ export type OrganizationsInvitesPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof organizationsInvitesPartialUpdate>>
 >
 export type OrganizationsInvitesPartialUpdateMutationBody = PatchedInvitePatchPayload
-export type OrganizationsInvitesPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type OrganizationsInvitesPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useOrganizationsInvitesPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useOrganizationsInvitesPartialUpdate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof organizationsInvitesPartialUpdate>>,
     TError,
@@ -1638,7 +1641,7 @@ export type organizationsMembersPartialUpdateResponse200 = {
 }
 
 export type organizationsMembersPartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -1678,7 +1681,7 @@ export const organizationsMembersPartialUpdate = async (
 }
 
 export const getOrganizationsMembersPartialUpdateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -1717,9 +1720,12 @@ export type OrganizationsMembersPartialUpdateMutationResult = NonNullable<
   Awaited<ReturnType<typeof organizationsMembersPartialUpdate>>
 >
 export type OrganizationsMembersPartialUpdateMutationBody = PatchedMemberPatchRequest
-export type OrganizationsMembersPartialUpdateMutationError = ErrorObject | ErrorDetail
+export type OrganizationsMembersPartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useOrganizationsMembersPartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useOrganizationsMembersPartialUpdate = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof organizationsMembersPartialUpdate>>,
     TError,
@@ -2110,7 +2116,7 @@ export type projectViewsExportRetrieveResponse200 = {
 }
 
 export type projectViewsExportRetrieveResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2149,7 +2155,7 @@ export const getProjectViewsExportRetrieveQueryKey = (uidProjectView: string, ob
 
 export const getProjectViewsExportRetrieveQueryOptions = <
   TData = Awaited<ReturnType<typeof projectViewsExportRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidProjectView: string,
   objType: string,
@@ -2173,11 +2179,11 @@ export const getProjectViewsExportRetrieveQueryOptions = <
 }
 
 export type ProjectViewsExportRetrieveQueryResult = NonNullable<Awaited<ReturnType<typeof projectViewsExportRetrieve>>>
-export type ProjectViewsExportRetrieveQueryError = ErrorObject | ErrorDetail
+export type ProjectViewsExportRetrieveQueryError = ErrorValidation | ErrorDetail
 
 export function useProjectViewsExportRetrieve<
   TData = Awaited<ReturnType<typeof projectViewsExportRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidProjectView: string,
   objType: string,
@@ -2207,7 +2213,7 @@ export type projectViewsExportCreateResponse200 = {
 }
 
 export type projectViewsExportCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2241,7 +2247,7 @@ export const projectViewsExportCreate = async (
 }
 
 export const getProjectViewsExportCreateMutationOptions = <
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
   TContext = unknown,
 >(options?: {
   mutation?: UseMutationOptions<
@@ -2278,9 +2284,9 @@ export const getProjectViewsExportCreateMutationOptions = <
 
 export type ProjectViewsExportCreateMutationResult = NonNullable<Awaited<ReturnType<typeof projectViewsExportCreate>>>
 
-export type ProjectViewsExportCreateMutationError = ErrorObject | ErrorDetail
+export type ProjectViewsExportCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useProjectViewsExportCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useProjectViewsExportCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof projectViewsExportCreate>>,
     TError,
@@ -2303,7 +2309,7 @@ export type projectViewsAssetsRetrieveResponse200 = {
 }
 
 export type projectViewsAssetsRetrieveResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -2357,7 +2363,7 @@ export const getProjectViewsAssetsRetrieveQueryKey = (
 
 export const getProjectViewsAssetsRetrieveQueryOptions = <
   TData = Awaited<ReturnType<typeof projectViewsAssetsRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidProjectView: string,
   params?: ProjectViewsAssetsRetrieveParams,
@@ -2381,11 +2387,11 @@ export const getProjectViewsAssetsRetrieveQueryOptions = <
 }
 
 export type ProjectViewsAssetsRetrieveQueryResult = NonNullable<Awaited<ReturnType<typeof projectViewsAssetsRetrieve>>>
-export type ProjectViewsAssetsRetrieveQueryError = ErrorObject | ErrorDetail
+export type ProjectViewsAssetsRetrieveQueryError = ErrorValidation | ErrorDetail
 
 export function useProjectViewsAssetsRetrieve<
   TData = Awaited<ReturnType<typeof projectViewsAssetsRetrieve>>,
-  TError = ErrorObject | ErrorDetail,
+  TError = ErrorValidation | ErrorDetail,
 >(
   uidProjectView: string,
   params?: ProjectViewsAssetsRetrieveParams,
@@ -3055,7 +3061,7 @@ export type mePartialUpdateResponse200 = {
 }
 
 export type mePartialUpdateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3089,7 +3095,10 @@ export const mePartialUpdate = async (
   })
 }
 
-export const getMePartialUpdateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getMePartialUpdateMutationOptions = <
+  TError = ErrorValidation | ErrorDetail,
+  TContext = unknown,
+>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof mePartialUpdate>>,
     TError,
@@ -3124,9 +3133,9 @@ export const getMePartialUpdateMutationOptions = <TError = ErrorObject | ErrorDe
 
 export type MePartialUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof mePartialUpdate>>>
 export type MePartialUpdateMutationBody = NonReadonly<PatchedCurrentUser>
-export type MePartialUpdateMutationError = ErrorObject | ErrorDetail
+export type MePartialUpdateMutationError = ErrorValidation | ErrorDetail
 
-export const useMePartialUpdate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useMePartialUpdate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof mePartialUpdate>>,
     TError,
@@ -3158,7 +3167,7 @@ export type meDestroyResponse204 = {
 }
 
 export type meDestroyResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3184,7 +3193,7 @@ export const meDestroy = async (options?: RequestInit): Promise<meDestroyRespons
   })
 }
 
-export const getMeDestroyMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getMeDestroyMutationOptions = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<Awaited<ReturnType<typeof meDestroy>>, TError, void, TContext>
   request?: SecondParameter<typeof fetchWithAuth>
 }): UseMutationOptions<Awaited<ReturnType<typeof meDestroy>>, TError, void, TContext> => {
@@ -3204,9 +3213,9 @@ export const getMeDestroyMutationOptions = <TError = ErrorObject | ErrorDetail, 
 
 export type MeDestroyMutationResult = NonNullable<Awaited<ReturnType<typeof meDestroy>>>
 
-export type MeDestroyMutationError = ErrorObject | ErrorDetail
+export type MeDestroyMutationError = ErrorValidation | ErrorDetail
 
-export const useMeDestroy = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useMeDestroy = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<Awaited<ReturnType<typeof meDestroy>>, TError, void, TContext>
   request?: SecondParameter<typeof fetchWithAuth>
 }) => {
@@ -3315,7 +3324,7 @@ export type meEmailsCreateResponse201 = {
 }
 
 export type meEmailsCreateResponse400 = {
-  data: ErrorObject
+  data: ErrorValidation
   status: 400
 }
 
@@ -3349,7 +3358,7 @@ export const meEmailsCreate = async (
   })
 }
 
-export const getMeEmailsCreateMutationOptions = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const getMeEmailsCreateMutationOptions = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof meEmailsCreate>>,
     TError,
@@ -3378,9 +3387,9 @@ export const getMeEmailsCreateMutationOptions = <TError = ErrorObject | ErrorDet
 
 export type MeEmailsCreateMutationResult = NonNullable<Awaited<ReturnType<typeof meEmailsCreate>>>
 export type MeEmailsCreateMutationBody = EmailRequestPayload
-export type MeEmailsCreateMutationError = ErrorObject | ErrorDetail
+export type MeEmailsCreateMutationError = ErrorValidation | ErrorDetail
 
-export const useMeEmailsCreate = <TError = ErrorObject | ErrorDetail, TContext = unknown>(options?: {
+export const useMeEmailsCreate = <TError = ErrorValidation | ErrorDetail, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof meEmailsCreate>>,
     TError,

--- a/kpi/schema_extensions/imports.py
+++ b/kpi/schema_extensions/imports.py
@@ -9,6 +9,7 @@ import kpi.schema_extensions.v2.data.extensions
 import kpi.schema_extensions.v2.export_settings.extensions
 import kpi.schema_extensions.v2.export_tasks.extensions
 import kpi.schema_extensions.v2.files.extensions
+import kpi.schema_extensions.v2.generic.extensions
 import kpi.schema_extensions.v2.imports.extensions
 import kpi.schema_extensions.v2.invites.extensions
 import kpi.schema_extensions.v2.me.extensions

--- a/kpi/schema_extensions/v2/generic/extensions.py
+++ b/kpi/schema_extensions/v2/generic/extensions.py
@@ -1,0 +1,20 @@
+from drf_spectacular.extensions import OpenApiSerializerExtension
+from drf_spectacular.plumbing import (
+    build_array_type,
+    build_basic_type,
+    build_object_type,
+)
+from drf_spectacular.types import OpenApiTypes
+
+
+class ErrorValidationSerializerExtension(OpenApiSerializerExtension):
+    target_class = 'kpi.utils.schema_extensions.response.ErrorValidationSerializer'
+
+    def map_serializer(self, auto_schema, direction):
+        # Free-form mapping of field name -> list of error messages, matching
+        # DRF's unwrapped serializer `ValidationError` payloads.
+        return build_object_type(
+            additionalProperties=build_array_type(
+                schema=build_basic_type(OpenApiTypes.STR)
+            )
+        )

--- a/kpi/utils/schema_extensions/response.py
+++ b/kpi/utils/schema_extensions/response.py
@@ -12,8 +12,17 @@ class ErrorDetailSerializer(serializers.Serializer):
     detail = serializers.CharField()
 
 
-class ErrorObjectSerializer(serializers.Serializer):
-    detail = serializers.JSONField()
+class ErrorValidationSerializer(serializers.Serializer):
+    """
+    Represents a DRF validation error response: a mapping of field names to
+    lists of error messages, e.g. ``{'field_name': ['Error message']}``.
+
+    DRF's default exception handler returns serializer ``ValidationError``
+    payloads unwrapped (there is no ``detail`` envelope), so the schema is a
+    free-form ``Record<string, string[]>``. The concrete schema is defined by
+    ``ErrorValidationSerializerExtension``; this serializer has no fields and
+    only exists so drf-spectacular registers the ``ErrorValidation`` component.
+    """
 
 
 class ErrorSerializer(serializers.Serializer):
@@ -223,11 +232,11 @@ def open_api_error_responses(
             'validations_errors', {'field_name': ['Error message']}
         )
         response[(status.HTTP_400_BAD_REQUEST, error_media_type)] = OpenApiResponse(
-            response=ErrorObjectSerializer(),
+            response=ErrorValidationSerializer(),
             examples=[
                 OpenApiExample(
                     name='Bad request',
-                    value={'detail': validation_errors},
+                    value=validation_errors,
                     response_only=True,
                     media_type=error_media_type,
                 )

--- a/static/openapi/schema_openrosa.json
+++ b/static/openapi/schema_openrosa.json
@@ -184,16 +184,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -201,16 +199,14 @@
                             },
                             "text/xml": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -665,16 +661,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -682,16 +676,14 @@
                             },
                             "text/xml": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -1044,16 +1036,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -1061,16 +1051,14 @@
                             },
                             "text/xml": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -4366,14 +4354,14 @@
                     "detail"
                 ]
             },
-            "ErrorObject": {
+            "ErrorValidation": {
                 "type": "object",
-                "properties": {
-                    "detail": {}
-                },
-                "required": [
-                    "detail"
-                ]
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             },
             "JSONSubmissionPayload": {
                 "type": "object",

--- a/static/openapi/schema_openrosa.yaml
+++ b/static/openapi/schema_openrosa.yaml
@@ -178,23 +178,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
             text/xml:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
         '202':
@@ -547,23 +545,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
             text/xml:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
         '202':
@@ -846,23 +842,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
             text/xml:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
         '202':
@@ -3153,12 +3147,12 @@ components:
           type: string
       required:
       - detail
-    ErrorObject:
+    ErrorValidation:
       type: object
-      properties:
-        detail: {}
-      required:
-      - detail
+      additionalProperties:
+        type: array
+        items:
+          type: string
     JSONSubmissionPayload:
       type: object
       properties:

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -560,16 +560,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -990,16 +988,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -1354,16 +1350,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -1558,16 +1552,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -2157,16 +2149,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -2819,16 +2809,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -3282,16 +3270,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -3689,16 +3675,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -3812,16 +3796,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -5466,16 +5448,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -6172,16 +6152,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -6272,16 +6250,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -6373,16 +6349,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -6710,16 +6684,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7006,16 +6978,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7110,16 +7080,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7283,16 +7251,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7446,16 +7412,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7598,16 +7562,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -7816,16 +7778,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -8189,16 +8149,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -8816,16 +8774,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -8989,16 +8945,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -9644,16 +9598,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -9807,16 +9759,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -10146,16 +10096,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -10421,16 +10369,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -10510,16 +10456,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -10620,16 +10564,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -11621,16 +11563,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -12077,16 +12017,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -12530,16 +12468,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -12725,16 +12661,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -13067,16 +13001,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -13689,16 +13621,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -13868,16 +13798,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -14311,16 +14239,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -14433,16 +14359,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -14546,16 +14470,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -16223,16 +16145,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -16936,16 +16856,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -17118,16 +17036,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -17385,16 +17301,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -17463,16 +17377,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -17616,16 +17528,14 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ErrorObject"
+                                    "$ref": "#/components/schemas/ErrorValidation"
                                 },
                                 "examples": {
                                     "BadRequest": {
                                         "value": {
-                                            "detail": {
-                                                "field_name": [
-                                                    "Error message"
-                                                ]
-                                            }
+                                            "field_name": [
+                                                "Error message"
+                                            ]
                                         },
                                         "summary": "Bad request"
                                     }
@@ -25412,14 +25322,14 @@
                     "detail"
                 ]
             },
-            "ErrorObject": {
+            "ErrorValidation": {
                 "type": "object",
-                "properties": {
-                    "detail": {}
-                },
-                "required": [
-                    "detail"
-                ]
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             },
             "ExportCreatePayload": {
                 "type": "object",

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -407,13 +407,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/asset_snapshots/{uid_asset_snapshot}/:
@@ -684,13 +683,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/asset_subscriptions/{uid_asset_subscription}/:
@@ -969,13 +967,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/:
@@ -1102,13 +1099,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -1490,13 +1486,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/advanced-features/{uid_advanced_feature}/:
@@ -1934,13 +1929,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/advanced-features/bulk-actions/:
@@ -2301,13 +2295,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/advanced-features/bulk-actions/{action_uid}/:
@@ -2595,13 +2588,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/attachments/audio-duration/:
@@ -2739,13 +2731,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/content/:
@@ -4001,13 +3992,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     patch:
@@ -4494,13 +4484,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/data/{uid_data}/attachments/:
@@ -4573,13 +4562,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/data/{uid_data}/attachments/{id}/:
@@ -4658,13 +4646,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/data/{uid_data}/attachments/{id}/{suffix}/:
@@ -4972,13 +4959,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/data/validation_statuses/:
@@ -5200,13 +5186,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     patch:
@@ -5266,13 +5251,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/export-settings/:
@@ -5414,13 +5398,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/export-settings/{uid_export_setting}/:
@@ -5517,13 +5500,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -5621,13 +5603,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/exports/:
@@ -5799,13 +5780,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/exports/{uid_export}/:
@@ -6061,13 +6041,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/files/{uid_file}/:
@@ -6624,13 +6603,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/hooks/{uid_hook}/:
@@ -6729,13 +6707,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -7173,13 +7150,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/paired-data/{uid_paired_data}/:
@@ -7274,13 +7250,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -7488,13 +7463,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/permission-assignments/{uid_permission_assignment}/:
@@ -7658,13 +7632,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -7725,13 +7698,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/permission-assignments/clone/:
@@ -7793,13 +7765,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/assets/{uid_asset}/qual-questions/{uid_qa_question}/tags/:
@@ -8552,13 +8523,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/imports/{uid_import}/:
@@ -8849,13 +8819,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/organizations/{uid_organization}/asset_usage/:
@@ -9147,13 +9116,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/organizations/{uid_organization}/invites/{guid}/:
@@ -9270,13 +9238,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -9493,13 +9460,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -10095,13 +10061,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/project-ownership/invites/{uid_invite}/:
@@ -10216,13 +10181,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -10489,13 +10453,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     post:
@@ -10565,13 +10528,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/project-views/{uid_project_view}/assets/:
@@ -10633,13 +10595,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/project-views/{uid_project_view}/assets/counts/:
@@ -11685,13 +11646,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/stripe/products/:
@@ -12186,13 +12146,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/translation-services/{code}/:
@@ -12396,13 +12355,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /api/v2/users/:
@@ -12574,13 +12532,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
     delete:
@@ -12630,13 +12587,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /me/emails/:
@@ -12727,13 +12683,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorObject'
+                $ref: '#/components/schemas/ErrorValidation'
               examples:
                 BadRequest:
                   value:
-                    detail:
-                      field_name:
-                      - Error message
+                    field_name:
+                    - Error message
                   summary: Bad request
           description: ''
   /me/social-accounts/:
@@ -18140,12 +18095,12 @@ components:
           type: string
       required:
       - detail
-    ErrorObject:
+    ErrorValidation:
       type: object
-      properties:
-        detail: {}
-      required:
-      - detail
+      additionalProperties:
+        type: array
+        items:
+          type: string
     ExportCreatePayload:
       type: object
       properties:


### PR DESCRIPTION
### 📣 Summary

The API reference now documents validation errors with their real shape — a map of field name to error messages — instead of an untyped placeholder.

### 📖 Description

When a request fails validation, the KoboToolbox API returns each field's errors as a list of messages. Until now the API reference described this `400` response as an untyped `detail` object, which didn't match what the API actually sends. It is now documented accurately, so anyone building against the API — or relying on the types generated from its schema — gets the correct shape for validation errors.

### 💭 Notes

- Renamed the OpenAPI type `ErrorObject` (`{ detail: unknown }`) → `ErrorValidation` (`Record<string, string[]>`), matching DRF's unwrapped serializer `ValidationError` payloads (there is no `detail` envelope — the custom exception handler delegates to stock DRF). A new `ErrorValidationSerializer` plus a drf-spectacular `OpenApiSerializerExtension` emit `additionalProperties: string[]`; the `400` example was flattened to match.
- Regenerated `static/openapi/*` and the orval client. `ServerError` no longer `implements` the renamed type and the `orval.types.d.ts` `Error` augmentation for it was dropped — a validation map isn't an `Error`.
- The two list views (`MembersRoute`, `usageProjectBreakdown`) now type their table error as `ErrorDetail` (their GET hooks never return a validation map); also fixed a stray `schema-utils` `ErrorObject` import in `UniversalTable`.
- No runtime behavior change. Gates green: tsc, biome, ruff, darker, schema generation (no drf-spectacular warnings).

### 👀 Preview steps

1. ℹ️ open the API docs at `/api/v2/docs/` on an endpoint that can return `400` (e.g. create asset)
2. look at the documented `400 Bad Request` response body and its example
3. 🔴 [on main] the schema is `ErrorObject` = `{ detail: <unknown> }` and the example wraps the errors under `detail`
4. 🟢 [on PR] the schema is `ErrorValidation` = `{ "<field>": ["<message>"] }` — a flat field→messages map matching the actual API response
