### PR TITLE
test(storybook): fix DeleteAccountBanner tests DEV-2462

### DIFF
--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -92,8 +92,9 @@ export const UserOwnsMMO: Story = {
 export const UserHasOnlyNonProjectAssets: Story = {
   parameters: {
     msw: {
-      handlers: {
-        assets: http.get(endpoints.ASSETS_URL, (info) => {
+      handlers: [
+        organizationMock(),
+        http.get(endpoints.ASSETS_URL, (info) => {
           const query = new URL(info.request.url).searchParams.get('q')
 
           if (query?.includes('asset_type:survey')) {
@@ -112,7 +113,7 @@ export const UserHasOnlyNonProjectAssets: Story = {
             results: [],
           })
         }),
-      },
+      ],
     },
   },
   play: async ({ canvasElement }) => {

--- a/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
+++ b/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
@@ -4008,7 +4008,10 @@ export const getApiV2AssetsVersionsListResponseMock = (
     uid: faker.string.alpha({ length: { min: 10, max: 20 } }),
     url: faker.internet.url(),
     content_hash: faker.string.alpha({ length: { min: 10, max: 20 } }),
-    date_deployed: `${faker.date.past().toISOString().split('.')[0]}Z`,
+    date_deployed: faker.helpers.arrayElement([
+      `${faker.date.past().toISOString().split('.')[0]}Z`,
+      faker.datatype.boolean(),
+    ]),
     date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
   })),
   ...overrideResponse,
@@ -4020,7 +4023,10 @@ export const getApiV2AssetsVersionsRetrieveResponseMock = (
   uid: faker.string.alpha({ length: { min: 10, max: 20 } }),
   url: faker.internet.url(),
   content_hash: faker.string.alpha({ length: { min: 10, max: 20 } }),
-  date_deployed: `${faker.date.past().toISOString().split('.')[0]}Z`,
+  date_deployed: faker.helpers.arrayElement([
+    `${faker.date.past().toISOString().split('.')[0]}Z`,
+    faker.datatype.boolean(),
+  ]),
   date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
   content: {
     schema: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),


### PR DESCRIPTION
### 💭 Notes

This was caused by two seemingly unrelated things - on release branch I fixed delete account button and added storybook tests (that use msw) to cover that fix. On main I updated msw recently and it requires a different mocks definition (an array instead of object) - all stories were correct except the release branch ones I've added and that got auto merged into main.

Also includes missed orval rebuilding.

### 👀 Preview steps

Notice storybook tests don't fail.