### PR TITLE
fix(project settings): remove deployment check for showing anonymous submission permission option DEV-2460

### DIFF
--- a/jsapp/js/components/permissions/publicShareSettings.component.tsx
+++ b/jsapp/js/components/permissions/publicShareSettings.component.tsx
@@ -18,7 +18,6 @@ const HELP_ARTICLE_ANON_SUBMISSIONS_URL = 'managing_permissions.html'
 interface PublicShareSettingsProps {
   publicPerms: PermissionResponse[]
   assetUid: string
-  deploymentActive: boolean
   userCanShare: boolean
 }
 
@@ -82,16 +81,14 @@ class PublicShareSettings extends React.Component<PublicShareSettingsProps> {
           />
         </bem.FormModal__item>
 
-        {this.props.deploymentActive && (
-          <bem.FormModal__item>
-            <Checkbox
-              checked={anonCanViewData}
-              disabled={!this.props.userCanShare}
-              onChange={this.togglePerms.bind(this, 'view_submissions')}
-              label={t('Anyone can view submissions made to this form')}
-            />
-          </bem.FormModal__item>
-        )}
+        <bem.FormModal__item>
+          <Checkbox
+            checked={anonCanViewData}
+            disabled={!this.props.userCanShare}
+            onChange={this.togglePerms.bind(this, 'view_submissions')}
+            label={t('Anyone can view submissions made to this form')}
+          />
+        </bem.FormModal__item>
 
         {anonCanView && <TextBox label={t('Shareable link')} type='text' readOnly value={url} />}
       </bem.FormModal__item>

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -279,7 +279,6 @@ export default class SharingForm extends React.Component<SharingFormProps, Shari
               <PublicShareSettings
                 publicPerms={this.state.publicPerms}
                 assetUid={this.props.assetUid}
-                deploymentActive={this.state.asset.deployment__active}
                 userCanShare={isManagingPossible}
               />
             </bem.FormModal__item>


### PR DESCRIPTION
### 📣 Summary
Removes a check for project deployment status that determined whether or not the checkbox for enabling anonymous users to view submission data was visible, so users can now view/toggle option for undeployed projects.

### 👀 Preview steps
1. Have a project with some submissions 
2. Archive the project
3. Go the the sharing view in project settings 
4. 🔴 [on main] notice that there is no checkbox for "Anyone can view submissions made to this form", regardless of whether or not that option was previously checked.
5. 🟢 [on PR] Verify that checkbox is always visible, regardless of deployment status
