### PR TITLE
fix(tags): fix tags API to list only users assets DEV-2464

### DIFF
--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -4,8 +4,10 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 from taggit.models import Tag
 
+from kpi.constants import PERM_VIEW_ASSET
 from kpi.models import Asset, TagUid
 from kpi.schema_extensions.v2.tags.fields import ParentUrlField, TagUrlField
+from kpi.utils.object_permission import get_database_user, get_objects_for_user
 
 
 class TagSerializer(serializers.ModelSerializer):
@@ -25,9 +27,15 @@ class TagSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_assets(self, obj):
         request = self.context.get('request', None)
+        if not request or not request.user.is_authenticated:
+            return []
+
+        user = get_database_user(request.user)
+        accessible_assets = get_objects_for_user(user, PERM_VIEW_ASSET, Asset)
+
         return [
             reverse('asset-detail', args=(asset_uid,), request=request)
-            for asset_uid in Asset.objects.values_list('uid', flat=True)
+            for asset_uid in accessible_assets.filter(tags=obj).values_list('uid', flat=True)
         ]
 
     @extend_schema_field(TagUrlField)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -6,6 +6,7 @@ from taggit.models import Tag
 
 from kpi.constants import PERM_VIEW_ASSET
 from kpi.models import Asset, TagUid
+from kpi.permissions import IsAuthenticated
 from kpi.schema_extensions.v2.tags.fields import ParentUrlField, TagUrlField
 from kpi.utils.object_permission import get_database_user, get_objects_for_user
 
@@ -15,6 +16,7 @@ class TagSerializer(serializers.ModelSerializer):
     assets = serializers.SerializerMethodField()
     parent = serializers.SerializerMethodField()
     uid = serializers.ReadOnlyField(source='taguid.uid')
+    permission_classes = (IsAuthenticated,)
 
     class Meta:
         model = Tag
@@ -27,11 +29,7 @@ class TagSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_assets(self, obj):
         request = self.context.get('request', None)
-        if not request or not request.user.is_authenticated:
-            return []
-
-        user = get_database_user(request.user)
-        accessible_assets = get_objects_for_user(user, PERM_VIEW_ASSET, Asset)
+        accessible_assets = get_objects_for_user(request.user, PERM_VIEW_ASSET, Asset)
         assets_uids = accessible_assets.filter(tags=obj).values_list('uid', flat=True)
         return [
             reverse('asset-detail', args=(asset_uid,), request=request)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -32,10 +32,10 @@ class TagSerializer(serializers.ModelSerializer):
 
         user = get_database_user(request.user)
         accessible_assets = get_objects_for_user(user, PERM_VIEW_ASSET, Asset)
-
+        assets_uids = accessible_assets.filter(tags=obj).values_list('uid', flat=True)
         return [
             reverse('asset-detail', args=(asset_uid,), request=request)
-            for asset_uid in accessible_assets.filter(tags=obj).values_list('uid', flat=True)
+            for asset_uid in assets_uids
         ]
 
     @extend_schema_field(TagUrlField)

--- a/kpi/serializers/v2/tag.py
+++ b/kpi/serializers/v2/tag.py
@@ -8,7 +8,7 @@ from kpi.constants import PERM_VIEW_ASSET
 from kpi.models import Asset, TagUid
 from kpi.permissions import IsAuthenticated
 from kpi.schema_extensions.v2.tags.fields import ParentUrlField, TagUrlField
-from kpi.utils.object_permission import get_database_user, get_objects_for_user
+from kpi.utils.object_permission import get_objects_for_user
 
 
 class TagSerializer(serializers.ModelSerializer):

--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -117,4 +117,6 @@ class TagDetailTestCase(BaseTagTestCase):
 
         # Only the original `self.asset` should be returned,
         # since it belongs to 'someuser' and has `self.tag`
-        assert len(response.data.get('assets', [])) == 1
+        assets = response.data.get('assets', [])
+        assert len(assets) == 1
+        assert self.asset.uid in assets[0]

--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -100,3 +100,21 @@ class TagDetailTestCase(BaseTagTestCase):
         response = self.client.get(self.url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_only_asset_objects_for_user_are_listed(self):
+        # Create an asset that is NOT tagged with `self.tag`, but belongs to the owner
+        Asset.objects.create(owner=User.objects.get(username='someuser'))
+
+        # Create an asset that belongs to another user and IS tagged with `self.tag`
+        another_user = User.objects.get(username='anotheruser')
+        another_user_asset = Asset.objects.create(owner=another_user)
+        another_user_asset.tags.add(self.tag)
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['name'] == self.tag.name
+
+        # Only the original `self.asset` should be returned,
+        # since it belongs to 'someuser' and has `self.tag`
+        assert len(response.data.get('assets', [])) == 1


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
The detail view (/api/v2/tags/{uid}/) incorrectly iterates through the UIDs of all assets in the entire database and generates detail URLs for them. It should only enumerate the specific assets that are associated with the requested tag AND that the requesting user has permission to view.

### 📖 Description
* Modified the `get_assets` method so that it scopes the search space solely to assets the user is authorized to view (`get_objects_for_user(user, PERM_VIEW_ASSET, Asset)`).
* Filter that safe queryset to only return the UIDs for the assets tagged with the specific tag currently being serialized 
* Added an early exit if the user is unauthenticated or there is no request object (returning an empty list).
* Add a unit test to check this behavior

### 👀 Preview steps
1. Have multiple users, assets and tags
2. Go to the detail API view for a tag ` /api/v2/tags/<tag_uid>/` and verify that only the user assets are listed