### PR TITLE
fix(xlsForm): keep leading "=" in labels as text instead of a formula DEV-1235

### DIFF
--- a/kpi/mixins/xls_exportable.py
+++ b/kpi/mixins/xls_exportable.py
@@ -80,7 +80,11 @@ class XlsExportableMixin:
             # achieve this isolation.
             ss_dict = self.ordered_xlsform_content(**kwargs)
             output = BytesIO()
-            with xlsxwriter.Workbook(output) as workbook:
+            # Keep values like `=foo` as literal strings; XLSForm cells are
+            # never Excel formulas (DEV-1235).
+            with xlsxwriter.Workbook(
+                output, {'strings_to_formulas': False}
+            ) as workbook:
                 for sheet_name, contents in ss_dict.items():
                     cur_sheet = workbook.add_worksheet(sheet_name)
                     _add_contents_to_sheet(cur_sheet, contents)

--- a/kpi/tests/test_assets.py
+++ b/kpi/tests/test_assets.py
@@ -509,6 +509,32 @@ class AssetContentTests(AssetsTestCase):
         version_string = settings_sheet[version_col][1].value
         assert version_string == f'1 ({date_string})'
 
+    def test_to_xlsx_io_preserves_leading_equals_in_label(self):
+        # DEV-1235: a cell starting with `=` must stay a literal string, not
+        # become an Excel formula (else `Err:520` in XLSForm, `0` in Enketo).
+        asset = Asset.objects.create(
+            content={
+                'survey': [
+                    {'type': 'text', 'label': '=foo', 'name': 'q1'},
+                ]
+            },
+            owner=self.user,
+            asset_type='survey',
+        )
+        xlsx_io = asset.to_xlsx_io()
+        workbook = openpyxl.load_workbook(xlsx_io)
+        survey_sheet = workbook['survey']
+        header = [cell.value for cell in survey_sheet[1]]
+        label_col = next(
+            i
+            for i, col in enumerate(header, start=1)
+            if col and col.startswith('label')
+        )
+        label_cell = survey_sheet.cell(row=2, column=label_col)
+        # 's' == string; a formula cell would be 'f'
+        assert label_cell.data_type == 's'
+        assert label_cell.value == '=foo'
+
     def test_unique__version__field_on_import_with_version(self):
             xlsx_io = self.asset.to_xlsx_io(versioned=True)
             workbook = openpyxl.load_workbook(xlsx_io)


### PR DESCRIPTION
### 📣 Summary

Question and choice labels that start with an equals sign (e.g. `=foo`) now display and export correctly instead of turning into `0` or a spreadsheet error.

### 📖 Description

If a label began with `=`, it was mistaken for a spreadsheet formula. The deployed form showed `0` in place of the label in Enketo, and exporting the form to XLSForm produced an error (`Err:520`) where the label should be. Labels (and other cells) starting with `=` are now kept as plain text everywhere.

### 💭 Notes

- Root cause: `Asset.to_xlsx_io()` builds the workbook with `xlsxwriter`, whose generic `write()` routes any `=`-prefixed string to `write_formula()`. The deploy path feeds the same in-memory xlsx to pyxform, so one bug corrupted **both** the XLSForm export and the deployed XForm (pyxform reads the formula's cached `0`).
- Fix: pass `{'strings_to_formulas': False}` to the `xlsxwriter.Workbook`. XLSForm cells are never Excel formulas, so this is safe; it's workbook-scoped, so it also covers `+`/`-`/`@` prefixes and the survey, choices and settings sheets.
- Added regression test `test_to_xlsx_io_preserves_leading_equals_in_label`.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. add a text question with the label `=foo`, then deploy the form
3. 🔴 [on main] open the form in Enketo → the label shows `0`; export the form to XLSForm → the cell shows `Err:520`
4. 🟢 [on PR] open the form in Enketo → the label shows `=foo`; export the form to XLSForm → the cell shows `=foo`
