### PR TITLE
fix(admin): correct CORS configuration guidance DEV-2471

### DIFF
--- a/kobo/apps/external_integrations/migrations/0002_do_nothing.py
+++ b/kobo/apps/external_integrations/migrations/0002_do_nothing.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='corsmodel',
             name='cors',
-            field=models.CharField(help_text='Must contain exactly the URI scheme, host, and port, e.g. https://example.com:1234. Standard ports (80 for http and 443 for https) may be omitted.', max_length=255, verbose_name='allowed origin'),
+            field=models.CharField(help_text='Must contain exactly the URI scheme and host, e.g. https://example.com. Include a port only if it is non-standard, e.g. https://example.com:1234. Do not include the default port for the scheme (80 for http, 443 for https): browsers never send it in the `Origin` header, so it would never match.', max_length=255, verbose_name='allowed origin'),
         ),
     ]

--- a/kobo/apps/external_integrations/migrations/0002_do_nothing.py
+++ b/kobo/apps/external_integrations/migrations/0002_do_nothing.py
@@ -13,6 +13,17 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='corsmodel',
             name='cors',
-            field=models.CharField(help_text='Must contain exactly the URI scheme and host, e.g. https://example.com. Include a port only if it is non-standard, e.g. https://example.com:1234. Do not include the default port for the scheme (80 for http, 443 for https): browsers never send it in the `Origin` header, so it would never match.', max_length=255, verbose_name='allowed origin'),
+            field=models.CharField(
+                help_text=(
+                    'Must contain exactly the URI scheme and host, e.g.'
+                    ' https://example.com. Include a port only if it is'
+                    ' non-standard, e.g. https://example.com:1234. Do not'
+                    ' include the default port for the scheme (80 for http, 443'
+                    ' for https): browsers never send it in the `Origin`'
+                    ' header, so it would never match.'
+                ),
+                max_length=255,
+                verbose_name='allowed origin',
+            ),
         ),
     ]

--- a/kobo/apps/external_integrations/models.py
+++ b/kobo/apps/external_integrations/models.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from django.core.exceptions import ValidationError
 from django.db import models
 
 
@@ -12,10 +13,24 @@ class CorsModel(models.Model):
         max_length=255,
         verbose_name='allowed origin',
         help_text=
-            'Must contain exactly the URI scheme, host, and port, e.g. '
-            'https://example.com:1234. Standard ports (80 for http and 443 '
-            'for https) may be omitted.'
+            'Must contain exactly the URI scheme and host, e.g. '
+            'https://example.com. Include a port only if it is non-standard, '
+            'e.g. https://example.com:1234. Do not include the default port '
+            'for the scheme (80 for http, 443 for https): browsers never send '
+            'it in the `Origin` header, so it would never match.'
     )
+
+    def clean(self):
+        super().clean()
+        for scheme, port in {'http:': '80', 'https:': '443'}:
+            if self.cors.startswith(scheme) and self.cors.endswith(f':{port}'):
+                raise ValidationError({
+                    'cors': (
+                        f'Do not include the default port ({port}) for '
+                        f'{scheme[:-1]}. Browsers never send it in the '
+                        f'`Origin` header, so this entry would never match.'
+                    )
+                })
 
     def __str__(self):
         return self.cors

--- a/kobo/apps/external_integrations/models.py
+++ b/kobo/apps/external_integrations/models.py
@@ -23,7 +23,7 @@ class CorsModel(models.Model):
 
     def clean(self):
         super().clean()
-        for scheme, port in {'http:': '80', 'https:': '443'}:
+        for scheme, port in ('http:', '80'), ('https:', '443'):
             if self.cors.startswith(scheme) and self.cors.endswith(f':{port}'):
                 raise ValidationError(
                     {

--- a/kobo/apps/external_integrations/models.py
+++ b/kobo/apps/external_integrations/models.py
@@ -12,25 +12,28 @@ class CorsModel(models.Model):
     cors = models.CharField(
         max_length=255,
         verbose_name='allowed origin',
-        help_text=
+        help_text=(
             'Must contain exactly the URI scheme and host, e.g. '
             'https://example.com. Include a port only if it is non-standard, '
             'e.g. https://example.com:1234. Do not include the default port '
             'for the scheme (80 for http, 443 for https): browsers never send '
             'it in the `Origin` header, so it would never match.'
+        ),
     )
 
     def clean(self):
         super().clean()
         for scheme, port in {'http:': '80', 'https:': '443'}:
             if self.cors.startswith(scheme) and self.cors.endswith(f':{port}'):
-                raise ValidationError({
-                    'cors': (
-                        f'Do not include the default port ({port}) for '
-                        f'{scheme[:-1]}. Browsers never send it in the '
-                        f'`Origin` header, so this entry would never match.'
-                    )
-                })
+                raise ValidationError(
+                    {
+                        'cors': (
+                            f'Do not include the default port ({port}) for '
+                            f'{scheme[:-1]}. Browsers never send it in the '
+                            '`Origin` header, so this entry would never match.'
+                        )
+                    }
+                )
 
     def __str__(self):
         return self.cors

--- a/kobo/apps/external_integrations/signals.py
+++ b/kobo/apps/external_integrations/signals.py
@@ -6,7 +6,9 @@ from .models import CorsModel
 
 def cors_allow_external_sites(sender, request, **kwargs):
     origin = request.headers.get('origin')
-    return CorsModel.objects.filter(cors=origin).exists()
+    if not origin:
+        return False
+    return CorsModel.objects.filter(cors__iexact=origin).exists()
 
 
 check_request_enabled.connect(cors_allow_external_sites)

--- a/kobo/apps/external_integrations/tests/test_cors.py
+++ b/kobo/apps/external_integrations/tests/test_cors.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from django.core.exceptions import ValidationError
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
@@ -38,3 +39,21 @@ class CorsTests(APITestCase, RequiresStripeAPIKeyMixin):
         self.assertTrue(response.has_header(self.cors_response_header_name))
         self.assertEqual(response[self.cors_response_header_name],
                          trusted_origin)
+
+    def test_origin_is_case_insensitive(self):
+        CorsModel.objects.create(cors='https://www.fsf.org')
+        response = self.client.get(
+            self.innocuous_url, headers={'origin': 'https://WWW.FSF.org'}
+        )
+        self.assertTrue(response.has_header(self.cors_response_header_name))
+
+    def test_default_http_port_rejected(self):
+        with self.assertRaises(ValidationError):
+            CorsModel(cors='http://example.com:80').full_clean()
+
+    def test_default_https_port_rejected(self):
+        with self.assertRaises(ValidationError):
+            CorsModel(cors='https://example.com:443').full_clean()
+
+    def test_non_standard_port_allowed(self):
+        CorsModel(cors='https://example.com:1234').full_clean()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [ ] ~~for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any~~
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [x] delete this checklist section from the final squash commit before merging
11. [x] fast-forward Linear issue to Done status after merging, as no QA team involvement is needed

### 👷 Description for instance maintainers
Fix CORS configuration guidance in the Django Admin interface so that it correctly says NOT to add default ports 80 or 443 for HTTP or HTTPS, respectively. Add a validator to prevent saving new origins if this guidance is not heeded.

### 👀 Preview steps
1. Go to `/admin/external_integrations/corsmodel/add/`
2. Check that the help text includes "Do not include the default port for the scheme (80 for http, 443 for https)"
3. Attempt to add `http://some-origin:80` and `https://some-origin:443`: both should fail
4. Attempt to add an oddball `http://some-origin:443`: it should succeed