### PR TITLE
feat(constance): let admins restrict anonymous user permissions DEV-2470

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -185,6 +185,15 @@ if os.environ.get('DEFAULT_FROM_EMAIL'):
     DEFAULT_FROM_EMAIL = env.str('DEFAULT_FROM_EMAIL')
     SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
+# Absolute ceiling for anonymous users' permissions; the Constance setting of
+# the same name below can only narrow it further, never widen it.
+ALLOWED_ANONYMOUS_PERMISSIONS = (
+    'kpi.view_asset',
+    'kpi.discover_asset',
+    'kpi.add_submissions',
+    'kpi.view_submissions',
+)
+
 # Configuration options that superusers can modify in the Django admin
 # interface. Please note that it's not as simple as moving a setting into the
 # `CONSTANCE_CONFIG` dictionary: each place where the setting's value is needed
@@ -295,6 +304,11 @@ CONSTANCE_CONFIG = {
     'SSRF_DENIED_IP_ADDRESS': (
         '',
         'Blacklisted IP addresses to bypass SSRF protection\nOne per line',
+    ),
+    'ALLOWED_ANONYMOUS_PERMISSIONS': (
+        '\n'.join(ALLOWED_ANONYMOUS_PERMISSIONS),
+        'Permissions grantable to anonymous (public) users\nOne per line. '
+        'Can only narrow the server maximum; entries outside it are ignored.',
     ),
     'EXPOSE_GIT_REV': (
         False,
@@ -790,6 +804,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     'Security': (
         'SSRF_ALLOWED_IP_ADDRESS',
         'SSRF_DENIED_IP_ADDRESS',
+        'ALLOWED_ANONYMOUS_PERMISSIONS',
         'MFA_ISSUER_NAME',
         'MFA_ENABLED',
         'MFA_LOCALIZED_HELP_TEXT',
@@ -869,13 +884,6 @@ WSGI_APPLICATION = 'kobo.wsgi.application'
 
 # What User object should be mapped to AnonymousUser?
 ANONYMOUS_USER_ID = -1
-# Permissions assigned to AnonymousUser are restricted to the following
-ALLOWED_ANONYMOUS_PERMISSIONS = (
-    'kpi.view_asset',
-    'kpi.discover_asset',
-    'kpi.add_submissions',
-    'kpi.view_submissions',
-)
 
 # run heavy migration scripts by default
 # NOTE: this should be set to False for major deployments. This can take a long time

--- a/kpi/backends.py
+++ b/kpi/backends.py
@@ -1,11 +1,13 @@
 # coding: utf-8
-from django.conf import settings
 from django.contrib.auth.backends import ModelBackend as DjangoModelBackend
 from django.contrib.auth.management import DEFAULT_DB_ALIAS
 
 from .utils.database import get_thread_local
 from .utils.object_permission import get_database_user
-from .utils.permissions import is_user_anonymous
+from .utils.permissions import (
+    get_allowed_anonymous_permissions,
+    is_user_anonymous,
+)
 
 
 class ObjectPermissionBackend(DjangoModelBackend):
@@ -15,7 +17,7 @@ class ObjectPermissionBackend(DjangoModelBackend):
         permissions = super().get_group_permissions(user_obj, obj)
         if is_anonymous:
             # Obey limits on anonymous users' permissions
-            allowed_set = set(settings.ALLOWED_ANONYMOUS_PERMISSIONS)
+            allowed_set = get_allowed_anonymous_permissions()
             return permissions.intersection(allowed_set)
         else:
             return permissions
@@ -26,7 +28,7 @@ class ObjectPermissionBackend(DjangoModelBackend):
         permissions = super().get_all_permissions(user_obj, obj)
         if is_anonymous:
             # Obey limits on anonymous users' permissions
-            allowed_set = set(settings.ALLOWED_ANONYMOUS_PERMISSIONS)
+            allowed_set = get_allowed_anonymous_permissions()
             return permissions.intersection(allowed_set)
         else:
             return permissions
@@ -37,7 +39,7 @@ class ObjectPermissionBackend(DjangoModelBackend):
         if obj is None or not hasattr(obj, 'has_perm'):
             if is_anonymous:
                 # Obey limits on anonymous users' permissions
-                if perm not in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+                if perm not in get_allowed_anonymous_permissions():
                     return False
 
             return super().has_perm(user_obj, perm, obj)

--- a/kpi/mixins/object_permission.py
+++ b/kpi/mixins/object_permission.py
@@ -32,7 +32,10 @@ from kpi.utils.object_permission import (
     post_assign_perm,
     post_remove_perm,
 )
-from kpi.utils.permissions import is_user_anonymous
+from kpi.utils.permissions import (
+    get_allowed_anonymous_permissions,
+    is_user_anonymous,
+)
 from kpi.utils.project_views import (
     get_project_view_user_permissions_for_asset,
     user_has_project_view_asset_perm,
@@ -141,12 +144,12 @@ class ObjectPermissionMixin:
         """
         Restrict a set of tuples in the format (user_id, permission_id) to
         only those permissions that apply to the content_type of this object
-        and are listed in settings.ALLOWED_ANONYMOUS_PERMISSIONS.
+        and are allowed for anonymous users.
         """
         content_type = ContentType.objects.get_for_model(self)
-        # Translate settings.ALLOWED_ANONYMOUS_PERMISSIONS to primary keys
+        # Translate the allowed anonymous permissions to primary keys
         codenames = set()
-        for perm in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+        for perm in get_allowed_anonymous_permissions():
             app_label, codename = perm_parse(perm)
             if app_label == content_type.app_label:
                 codenames.add(codename)
@@ -455,13 +458,15 @@ class ObjectPermissionMixin:
         if is_anonymous:
             # Is an anonymous user allowed to have this permission?
             fq_permission = f'{app_label}.{codename}'
-            if (
-                not deny
-                and fq_permission not in settings.ALLOWED_ANONYMOUS_PERMISSIONS
-            ):
-                raise serializers.ValidationError({
-                    'permission': f'Anonymous users cannot be granted the permission {codename}.'
-                })
+            if not deny and fq_permission not in get_allowed_anonymous_permissions():
+                raise serializers.ValidationError(
+                    {
+                        'permission': (
+                            f'Anonymous users cannot be granted the '
+                            f'permission {codename}.'
+                        )
+                    }
+                )
         perm_model = self._get_permission_model(app_label, codename)
         existing_perms = self.permissions.filter(user=user_obj)
         identical_existing_perm = existing_perms.filter(
@@ -649,7 +654,7 @@ class ObjectPermissionMixin:
         if result and is_anonymous:
             # Is an anonymous user allowed to have this permission?
             fq_permission = '{}.{}'.format(app_label, codename)
-            if fq_permission not in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+            if fq_permission not in get_allowed_anonymous_permissions():
                 return False
         return result
 

--- a/kpi/serializers/v2/asset_permission_assignment.py
+++ b/kpi/serializers/v2/asset_permission_assignment.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional
 
-from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.db import transaction
 from django.urls import Resolver404
@@ -31,7 +30,10 @@ from kpi.utils.object_permission import (
     post_remove_partial_perms,
     post_remove_perm,
 )
-from kpi.utils.permissions import is_user_anonymous
+from kpi.utils.permissions import (
+    get_allowed_anonymous_permissions,
+    is_user_anonymous,
+)
 from kpi.utils.urls import absolute_resolve
 
 ASSIGN_OWNER_ERROR_MESSAGE = "Owner's permissions cannot be assigned explicitly"
@@ -701,7 +703,7 @@ class AssetBulkInsertPermissionSerializer(serializers.Serializer):
             user_obj = user_pk_to_obj_cache[addition.user_pk]
             if is_user_anonymous(user_obj):
                 fq_permission = f'kpi.{addition.permission_codename}'
-                if fq_permission not in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+                if fq_permission not in get_allowed_anonymous_permissions():
                     raise serializers.ValidationError(
                         {
                             'permission': (

--- a/kpi/tests/test_permissions.py
+++ b/kpi/tests/test_permissions.py
@@ -1,5 +1,8 @@
+from constance.test import override_config
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import DjangoObjectPermissions
 
 from kobo.apps.kobo_auth.shortcuts import User
@@ -21,7 +24,7 @@ from kpi.constants import (
 from kpi.exceptions import BadPermissionsException
 from kpi.permissions import AssetSnapshotPermission
 from kpi.utils.object_permission import get_all_objects_for_user
-
+from kpi.utils.permissions import get_allowed_anonymous_permissions
 from ..models import ObjectPermission
 from ..models.asset import Asset
 
@@ -885,6 +888,23 @@ class PermissionsTestCase(BasePermissionsTestCase):
         self.assertTrue(grantee.has_perm(PERM_VIEW_SUBMISSIONS, asset))
         self.assertTrue(asset.get_perms(grantee), asset.get_perms(anonymous_user))
 
+    @override_config(
+        ALLOWED_ANONYMOUS_PERMISSIONS='kpi.view_asset\nkpi.discover_asset\n'
+        'kpi.add_submissions'
+    )
+    def test_constance_can_restrict_anonymous_permissions(self):
+        """Removing a permission from the Constance list blocks its grant."""
+        asset = self.admin_asset
+        anonymous_user = AnonymousUser()
+
+        # view_submissions is no longer in the list
+        with self.assertRaises(ValidationError):
+            asset.assign_perm(anonymous_user, PERM_VIEW_SUBMISSIONS)
+
+        # a permission still in the list works
+        asset.assign_perm(anonymous_user, PERM_VIEW_ASSET)
+        self.assertTrue(anonymous_user.has_perm(PERM_VIEW_ASSET, asset))
+
     def test_org_admin_inherited_and_implied_permissions(self):
         """
         Test the inherited (and implied) permissions for an admin within
@@ -937,3 +957,27 @@ class PermissionsTestCase(BasePermissionsTestCase):
         assert django_perm_class.perms_map['PATCH'] == [
             '%(app_label)s.change_%(model_name)s'
         ]
+
+
+class AllowedAnonymousPermissionsHelperTestCase(TestCase):
+    """Ceiling intersected with the Constance list."""
+
+    def test_default_returns_full_ceiling(self):
+        self.assertEqual(
+            get_allowed_anonymous_permissions(),
+            set(settings.ALLOWED_ANONYMOUS_PERMISSIONS),
+        )
+
+    @override_config(ALLOWED_ANONYMOUS_PERMISSIONS='kpi.view_asset')
+    def test_constance_restricts_to_subset(self):
+        self.assertEqual(get_allowed_anonymous_permissions(), {'kpi.view_asset'})
+
+    @override_config(
+        ALLOWED_ANONYMOUS_PERMISSIONS='kpi.view_asset\nkpi.not_a_real_perm'
+    )
+    def test_permission_outside_ceiling_is_ignored(self):
+        self.assertEqual(get_allowed_anonymous_permissions(), {'kpi.view_asset'})
+
+    @override_config(ALLOWED_ANONYMOUS_PERMISSIONS='')
+    def test_empty_config_yields_no_permissions(self):
+        self.assertEqual(get_allowed_anonymous_permissions(), set())

--- a/kpi/utils/permissions.py
+++ b/kpi/utils/permissions.py
@@ -69,12 +69,23 @@ def grant_all_model_level_perms(
         # The user is anonymous, so pare down the permissions to only those
         # that the configuration allows for anonymous users
         q_query = Q()
-        for allowed_permission in settings.ALLOWED_ANONYMOUS_PERMISSIONS:
+        for allowed_permission in get_allowed_anonymous_permissions():
             app_label, codename = perm_parse(allowed_permission)
             q_query |= Q(content_type__app_label=app_label, codename=codename)
         permissions_to_assign = permissions_to_assign.filter(q_query)
 
     user.user_permissions.add(*permissions_to_assign)
+
+
+def get_allowed_anonymous_permissions() -> set:
+    """Settings ceiling narrowed by the Constance list of the same name."""
+    from constance import config
+
+    from kpi.utils.strings import split_lines_to_list
+
+    ceiling = set(settings.ALLOWED_ANONYMOUS_PERMISSIONS)
+    configured = set(split_lines_to_list(config.ALLOWED_ANONYMOUS_PERMISSIONS))
+    return ceiling & configured
 
 
 def is_user_anonymous(user):


### PR DESCRIPTION
### 📣 Summary

Server administrators can now limit which permissions may be granted to anonymous (public) users — for example, letting a form be viewed publicly while preventing its submitted data from being shared publicly.

### 📖 Description

Previously the set of permissions that could be handed to anonymous users was fixed for the whole server. A superuser can now narrow that set from the server configuration (Constance settings), for instance by removing "view submissions" so that public data sharing is no longer possible on that server. The server's built-in maximum still applies, so this can only make public access more restrictive, never broader.

### 💭 Notes

- New Constance setting `ALLOWED_ANONYMOUS_PERMISSIONS` (one-per-line, in the **Security** fieldset). Default equals the existing `settings.ALLOWED_ANONYMOUS_PERMISSIONS`, so behaviour is unchanged out of the box.
- Effective set = `settings.ALLOWED_ANONYMOUS_PERMISSIONS` (hard ceiling) `∩` the configured list, computed by a new `get_allowed_anonymous_permissions()` helper. It can only subtract from the ceiling; a permission listed outside the ceiling is ignored.
- All 8 read sites (auth backend, object-permission mixin, permission-assignment serializer, grant utility) now go through the helper instead of reading `settings` directly.
- UI is intentionally unchanged (per ticket scope): attempting to grant a now-blocked permission surfaces the existing "Failed to update permissions" toast.
- No migration and no OpenAPI/orval regeneration — the setting is Django-admin-only and the serializer change is method-body logic, not a schema field.

### 👀 Preview steps

1. ℹ️ have a superuser account and a project
2. 🔴 [on main] there is no server setting to stop anonymous users from being granted "view submissions" — public data sharing can always be enabled
3. 🟢 [on PR] go to `/admin/constance/config/`, find **ALLOWED_ANONYMOUS_PERMISSIONS** under Security, delete the `kpi.view_submissions` line, and save
4. 🟢 in the project's Sharing settings, try to make submissions viewable publicly (assign `view_submissions` to the anonymous user) → it is rejected (standard "Failed to update permissions" toast)
5. 🟢 "Anyone can view this form" (still listed) keeps working, confirming only the removed permission is blocked
