### PR TITLE
fix(logger): resolve `root_uuid` conflicts in dedup command DEV-2450

### DIFF
--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -158,8 +158,12 @@ class Command(BaseCommand):
         ref_instance = parsed_instance.instance
         if not ref_instance.root_uuid:
             try:
-                # Savepoint so a unique-constraint violation rolls back only
-                # this statement instead of aborting the surrounding transaction.
+                # Isolate the write in its own atomic block so a caught
+                # IntegrityError cannot poison an enclosing transaction: a
+                # savepoint when the command runs inside one (e.g. under
+                # TestCase), or its own transaction when run standalone.
+                # Otherwise the conflict resolution below would run on an
+                # aborted transaction.
                 with kc_transaction_atomic():
                     Instance.objects.filter(pk=ref_instance.pk).update(
                         root_uuid=ref_instance.uuid

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -281,9 +281,10 @@ class Command(BaseCommand):
                 instances_to_update, ['uuid', 'xml', 'root_uuid', 'xml_hash']
             )
             # Only the identity fields changed, so sync just those to Mongo with
-            # a single bulk `$set` (after Postgres is committed) instead of a
-            # full `update_mongo()` per instance. The submission data and
-            # `_submitted_by` are untouched.
+            # a single bulk `$set` instead of a full `update_mongo()` per
+            # instance; the submission data and `_submitted_by` are untouched.
+            # If a Mongo write is missed, LRM 0028 syncs `meta/rootUuid` from the
+            # DB afterwards.
             mongo_updates = [
                 UpdateOne(
                     {'_id': instance.pk},

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError
 from django.db.models import F, QuerySet
 from django.db.models.aggregates import Count
 from more_itertools import chunked
+from pymongo import UpdateOne
 
 from kobo.apps.openrosa.apps.logger.models import (
     DailyXFormSubmissionCounter,
@@ -23,6 +24,11 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     set_meta,
 )
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
+from kobo.apps.openrosa.libs.utils.common_tags import (
+    META_INSTANCE_ID,
+    META_ROOT_UUID,
+    UUID,
+)
 from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 
 
@@ -227,7 +233,6 @@ class Command(BaseCommand):
             duplicated_instances, settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
         ):
             instances_to_update = []
-            parsed_instances_to_sync = []
             for duplicated_instance in duplicated_instance_batch:
                 try:
                     instance = Instance.objects.get(pk=duplicated_instance['id'])
@@ -268,17 +273,6 @@ class Command(BaseCommand):
                 instance.root_uuid = instance.uuid
                 instance.xml_hash = instance.get_hash(instance.xml)
                 instances_to_update.append(instance)
-
-                # Collect the parsed instances; Mongo is synced only after the
-                # bulk Postgres update below, so a failed bulk_update never
-                # leaves Mongo ahead of the database.
-                try:
-                    parsed_instances_to_sync.append(instance.parsed_instance)
-                except Instance.parsed_instance.RelatedObjectDoesNotExist:
-                    self.stderr.write(
-                        f'Instance {instance.pk} does not have ParsedInstance'
-                    )
-
                 idx += 1
 
             if self._verbosity >= 3:
@@ -286,7 +280,22 @@ class Command(BaseCommand):
             Instance.objects.bulk_update(
                 instances_to_update, ['uuid', 'xml', 'root_uuid', 'xml_hash']
             )
-            for parsed_instance in parsed_instances_to_sync:
-                parsed_instance.update_mongo(
-                    asynchronous=False, use_cached_parser=True
+            # Only the identity fields changed, so sync just those to Mongo with
+            # a single bulk `$set` (after Postgres is committed) instead of a
+            # full `update_mongo()` per instance. The submission data and
+            # `_submitted_by` are untouched.
+            mongo_updates = [
+                UpdateOne(
+                    {'_id': instance.pk},
+                    {
+                        '$set': {
+                            UUID: instance.uuid,
+                            META_INSTANCE_ID: add_uuid_prefix(instance.uuid),
+                            META_ROOT_UUID: add_uuid_prefix(instance.root_uuid),
+                        }
+                    },
                 )
+                for instance in instances_to_update
+            ]
+            if mongo_updates:
+                settings.MONGO_DB.instances.bulk_write(mongo_updates, ordered=False)

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import IntegrityError
 from django.db.models import F, QuerySet
 from django.db.models.aggregates import Count
 from more_itertools import chunked
@@ -13,8 +14,14 @@ from kobo.apps.openrosa.apps.logger.models import (
 )
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
-from kobo.apps.openrosa.apps.logger.utils import delete_instances
-from kobo.apps.openrosa.apps.logger.xform_instance_parser import set_meta
+from kobo.apps.openrosa.apps.logger.utils import (
+    delete_instances,
+    resolve_root_uuid_conflict,
+)
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
+    add_uuid_prefix,
+    set_meta,
+)
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
 
@@ -150,9 +157,17 @@ class Command(BaseCommand):
         # held the same value.
         ref_instance = parsed_instance.instance
         if not ref_instance.root_uuid:
-            Instance.objects.filter(pk=ref_instance.pk).update(
-                root_uuid=ref_instance.uuid
-            )
+            try:
+                # Savepoint so a unique-constraint violation rolls back only
+                # this statement instead of aborting the surrounding transaction.
+                with kc_transaction_atomic():
+                    Instance.objects.filter(pk=ref_instance.pk).update(
+                        root_uuid=ref_instance.uuid
+                    )
+            except IntegrityError:
+                # Another submission in this xform already holds this root_uuid;
+                # give the reference a unique one instead.
+                resolve_root_uuid_conflict(ref_instance, xform.id_string)
 
         if self._verbosity > 1:
             self.stdout.write(
@@ -208,6 +223,7 @@ class Command(BaseCommand):
             duplicated_instances, settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
         ):
             instances_to_update = []
+            parsed_instances_to_sync = []
             for duplicated_instance in duplicated_instance_batch:
                 try:
                     instance = Instance.objects.get(pk=duplicated_instance['id'])
@@ -236,28 +252,29 @@ class Command(BaseCommand):
                     instance.xml = set_meta(
                         instance.xml, 'instanceID', instance.uuid
                     )
+                    instance.xml = set_meta(
+                        instance.xml, 'rootUuid', add_uuid_prefix(instance.uuid)
+                    )
                 except ValueError:
-                    # Legacy submission without an instanceID node in its XML.
-                    # The DB `uuid` update above already resolves the collision.
+                    # Legacy submission without an instanceID/rootUuid node in
+                    # its XML; the DB fields below are what enforce uniqueness.
                     pass
+                # The new uuid makes this a distinct submission, so its
+                # root_uuid must follow it to stay unique per xform.
+                instance.root_uuid = instance.uuid
                 instance.xml_hash = instance.get_hash(instance.xml)
-                try:
-                    instance._populate_root_uuid()  # noqa
-                except AssertionError:
-                    # No derivable root_uuid on this legacy submission; fall
-                    # back to its uuid, as LRM 0027 does.
-                    instance.root_uuid = instance.uuid
                 instances_to_update.append(instance)
 
-                # Save the parsed instance to sync MongoDB
+                # Collect the parsed instances; Mongo is synced only after the
+                # bulk Postgres update below, so a failed bulk_update never
+                # leaves Mongo ahead of the database.
                 try:
-                    parsed_instance = instance.parsed_instance
+                    parsed_instances_to_sync.append(instance.parsed_instance)
                 except Instance.parsed_instance.RelatedObjectDoesNotExist:
-                    pass
-                else:
-                    parsed_instance.update_mongo(
-                        asynchronous=False, use_cached_parser=True
+                    self.stderr.write(
+                        f'Instance {instance.pk} does not have ParsedInstance'
                     )
+
                 idx += 1
 
             if self._verbosity >= 3:
@@ -265,3 +282,7 @@ class Command(BaseCommand):
             Instance.objects.bulk_update(
                 instances_to_update, ['uuid', 'xml', 'root_uuid', 'xml_hash']
             )
+            for parsed_instance in parsed_instances_to_sync:
+                parsed_instance.update_mongo(
+                    asynchronous=False, use_cached_parser=True
+                )

--- a/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/clean_duplicated_submissions_root_uuid.py
@@ -1,5 +1,3 @@
-import time
-
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
 from django.core.management import call_command
@@ -8,10 +6,8 @@ from django.db.utils import IntegrityError
 from pymongo import UpdateOne
 
 from kobo.apps.openrosa.apps.logger.models.instance import Instance
-from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
-    add_uuid_prefix,
-    set_meta,
-)
+from kobo.apps.openrosa.apps.logger.utils import resolve_root_uuid_conflict
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
 
@@ -112,34 +108,12 @@ class Command(BaseCommand):
 
             # Load XML only now, when we actually need it for conflict resolution
             instance = Instance.objects.only('pk', 'uuid', 'xml', 'xml_hash').get(pk=pk)
-
             old_uuid = instance.uuid
-            now = int(time.time() * 1000)
-            new_root_uuid = f'CONFLICT-{now}-{xform_id_string}-{old_uuid}'
-            try:
-                instance.xml = set_meta(
-                    instance.xml,
-                    'rootUuid',
-                    add_uuid_prefix(new_root_uuid),
-                )
-            except ValueError:
-                # instance has never been edited
-                pass
-
-            instance.xml_hash = instance.get_hash(instance.xml)
+            new_root_uuid = resolve_root_uuid_conflict(instance, xform_id_string)
             if self._verbosity >= 2:
                 self.stdout.write(
                     f'\tOld root_uuid: {old_uuid}, ' f'New root_uuid: {new_root_uuid}'
                 )
-            Instance.objects.filter(pk=pk).update(
-                xml=instance.xml,
-                xml_hash=instance.xml_hash,
-                root_uuid=new_root_uuid,
-            )
-            doc = settings.MONGO_DB.instances.find_one({'_id': pk})
-            if doc is not None:
-                doc['meta/rootUuid'] = add_uuid_prefix(new_root_uuid)
-                settings.MONGO_DB.instances.replace_one({'_id': pk}, doc)
 
     @staticmethod
     def _update_mongo_batch(update_data: list):

--- a/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
@@ -436,20 +436,29 @@ class TestCleanDuplicatedSubmissions(TestBase):
         # Hash fallback: "CONFLICT-" + a 64-char sha256 hexdigest.
         self.assertEqual(len(inst.root_uuid), len('CONFLICT-') + 64)
 
-    def test_replace_duplicates_syncs_mongo_root_uuid(self):
+    def test_replace_duplicates_syncs_mongo_identity_fields(self):
         """
-        Even without a rootUuid node in the XML (a non-edited submission), the
-        Mongo `meta/rootUuid` must be backfilled from the new root_uuid, since
-        it is built from the DB field, not the XML.
+        The renamed identity fields (`_uuid`, `meta/instanceID`,
+        `meta/rootUuid`) must be updated on the existing Mongo documents.
         """
 
         self._make_group_b()
+        # Submissions already exist in Mongo before the repair runs.
+        for pk in (self.b1.pk, self.b2.pk, self.b3.pk):
+            Instance.objects.get(pk=pk).parsed_instance.update_mongo(
+                asynchronous=False
+            )
+
         call_command('clean_duplicated_submissions', xform=self.xform.id_string)
 
         for pk in (self.b1.pk, self.b2.pk, self.b3.pk):
             instance = Instance.objects.get(pk=pk)
             doc = settings.MONGO_DB.instances.find_one({'_id': pk})
             self.assertIsNotNone(doc)
+            self.assertEqual(doc['_uuid'], instance.uuid)
+            self.assertEqual(
+                doc['meta/instanceID'], add_uuid_prefix(instance.uuid)
+            )
             self.assertEqual(
                 doc['meta/rootUuid'], add_uuid_prefix(instance.root_uuid)
             )

--- a/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
@@ -1,6 +1,7 @@
 import os
 import uuid as uuid_module
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
@@ -13,6 +14,8 @@ from kobo.apps.openrosa.apps.logger.models import (
     SurveyType,
 )
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
+from kobo.apps.openrosa.apps.logger.utils import resolve_root_uuid_conflict
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.utils.logger_tools import publish_xls_form
@@ -51,18 +54,21 @@ class TestCleanDuplicatedSubmissions(TestBase):
         )
 
     # ------------------------------------------------------------------ helpers
-
-    def _make_xml(self, instance_uuid, name='Test'):
-        """
-        Minimal valid XML submission for the tutorial form.
-        """
-        return (
-            f'<?xml version="1.0" ?>'
-            f'<{self.xform.id_string} id="{self.xform.id_string}">'
-            f'<meta><instanceID>uuid:{instance_uuid}</instanceID></meta>'
-            f'<name>{name}</name>'
-            f'</{self.xform.id_string}>'
+    def _add_attachment(self, instance):
+        fake_file = SimpleUploadedFile(
+            'test.txt', b'content', content_type='text/plain'
         )
+        return Attachment.objects.create(
+            instance=instance,
+            xform=self.xform,
+            media_file=fake_file,
+            mimetype='text/plain',
+            media_file_size=7,
+        )
+
+    def _add_parsed_instance(self, instance):
+        parsed, _ = ParsedInstance.objects.get_or_create(instance=instance)
+        return parsed
 
     def _create_instance(self, xml, instance_uuid):
         """
@@ -84,39 +90,32 @@ class TestCleanDuplicatedSubmissions(TestBase):
         results = Instance.objects.bulk_create([instance])
         return results[0]
 
-    def _add_attachment(self, instance):
-        fake_file = SimpleUploadedFile(
-            'test.txt', b'content', content_type='text/plain'
-        )
-        return Attachment.objects.create(
-            instance=instance,
-            xform=self.xform,
-            media_file=fake_file,
-            mimetype='text/plain',
-            media_file_size=7,
+    def _make_xml(self, instance_uuid, name='Test'):
+        """
+        Minimal valid XML submission for the tutorial form.
+        """
+        return (
+            f'<?xml version="1.0" ?>'
+            f'<{self.xform.id_string} id="{self.xform.id_string}">'
+            f'<meta><instanceID>uuid:{instance_uuid}</instanceID></meta>'
+            f'<name>{name}</name>'
+            f'</{self.xform.id_string}>'
         )
 
-    def _add_parsed_instance(self, instance):
-        parsed, _ = ParsedInstance.objects.get_or_create(instance=instance)
-        return parsed
+    def _make_xml_with_root_uuid(self, instance_uuid, root_uuid, name='Test'):
+        """
+        Submission XML that also carries a `meta/rootUuid` node.
+        """
 
-    def _setup_counters(self, count):
-        """
-        Pre-populate Monthly/Daily counters for today.
-        """
-        today = timezone.now().date()
-        MonthlyXFormSubmissionCounter.objects.update_or_create(
-            year=today.year,
-            month=today.month,
-            user_id=self.user.pk,
-            xform_id=self.xform.pk,
-            defaults={'counter': count},
-        )
-        DailyXFormSubmissionCounter.objects.update_or_create(
-            date=today,
-            user_id=self.user.pk,
-            xform_id=self.xform.pk,
-            defaults={'counter': count},
+        return (
+            f'<?xml version="1.0" ?>'
+            f'<{self.xform.id_string} id="{self.xform.id_string}">'
+            f'<meta>'
+            f'<instanceID>uuid:{instance_uuid}</instanceID>'
+            f'<rootUuid>uuid:{root_uuid}</rootUuid>'
+            f'</meta>'
+            f'<name>{name}</name>'
+            f'</{self.xform.id_string}>'
         )
 
     def _make_group_a(self):
@@ -144,6 +143,24 @@ class TestCleanDuplicatedSubmissions(TestBase):
             self._add_attachment(inst)
             self._add_parsed_instance(inst)
 
+    def _setup_counters(self, count):
+        """
+        Pre-populate Monthly/Daily counters for today.
+        """
+        today = timezone.now().date()
+        MonthlyXFormSubmissionCounter.objects.update_or_create(
+            year=today.year,
+            month=today.month,
+            user_id=self.user.pk,
+            xform_id=self.xform.pk,
+            defaults={'counter': count},
+        )
+        DailyXFormSubmissionCounter.objects.update_or_create(
+            date=today,
+            user_id=self.user.pk,
+            xform_id=self.xform.pk,
+            defaults={'counter': count},
+        )
     # -------------------------------------------------------- _delete_duplicates
 
     def test_delete_duplicates_removes_extras_and_keeps_reference(self):
@@ -324,3 +341,115 @@ class TestCleanDuplicatedSubmissions(TestBase):
         self.assertEqual(updated.count(), 2)
         for instance in updated:
             self.assertTrue(instance.uuid.startswith('DUPLICATE-'))
+
+    # ------------------------------------------ root_uuid conflict resolution
+
+    def test_replace_duplicates_gives_each_a_unique_root_uuid(self):
+        """
+        Divergent duplicates whose XML rootUuid points to the same value used to
+        collide on `unique_root_uuid_per_xform`. Each must now get a root_uuid
+        matching its own new DUPLICATE- uuid, and the XML rootUuid must follow.
+        """
+
+        uid = str(uuid_module.uuid4())
+        shared_root = str(uuid_module.uuid4())
+        b1 = self._create_instance(
+            self._make_xml_with_root_uuid(uid, shared_root, 'V1'), uid
+        )
+        b2 = self._create_instance(
+            self._make_xml_with_root_uuid(uid, shared_root, 'V2'), uid
+        )
+        for inst in (b1, b2):
+            self._add_parsed_instance(inst)
+
+        # Must not raise a unique constraint violation.
+        call_command('clean_duplicated_submissions', xform=self.xform.id_string)
+
+        b1.refresh_from_db()
+        b2.refresh_from_db()
+        self.assertEqual(b1.root_uuid, b1.uuid)
+        self.assertEqual(b2.root_uuid, b2.uuid)
+        self.assertNotEqual(b1.root_uuid, b2.root_uuid)
+        # The XML rootUuid now carries the new uuid, not the shared one.
+        self.assertIn(b1.uuid, b1.xml)
+        self.assertNotIn(shared_root, b1.xml)
+
+    def test_delete_duplicates_resolves_root_uuid_conflict(self):
+        """
+        If another submission in the xform already holds the reference's uuid as
+        its root_uuid, the reference must get a unique CONFLICT- root_uuid
+        instead of raising `unique_root_uuid_per_xform`.
+        """
+
+        self._make_group_a()
+        conflicting = self.a1.uuid
+        other = self._create_instance(
+            self._make_xml(str(uuid_module.uuid4()), 'Other'),
+            str(uuid_module.uuid4()),
+        )
+        Instance.objects.filter(pk=other.pk).update(root_uuid=conflicting)
+
+        call_command('clean_duplicated_submissions', xform=self.xform.id_string)
+
+        ref = Instance.objects.get(pk=self.a1.pk)
+        self.assertTrue(ref.root_uuid.startswith('CONFLICT-'))
+        self.assertNotEqual(ref.root_uuid, conflicting)
+        # The other submission keeps its root_uuid untouched.
+        other.refresh_from_db()
+        self.assertEqual(other.root_uuid, conflicting)
+
+    def test_resolve_root_uuid_conflict_syncs_xml_and_db(self):
+        """
+        The helper assigns a CONFLICT- root_uuid and writes it to the XML
+        rootUuid node when present.
+        """
+
+        uid = str(uuid_module.uuid4())
+        inst = self._create_instance(
+            self._make_xml_with_root_uuid(uid, str(uuid_module.uuid4()), 'V'), uid
+        )
+        self._add_parsed_instance(inst)
+
+        new_root = resolve_root_uuid_conflict(inst, self.xform.id_string)
+
+        inst.refresh_from_db()
+        self.assertEqual(inst.root_uuid, new_root)
+        self.assertTrue(new_root.startswith('CONFLICT-'))
+        self.assertIn(new_root, inst.xml)
+
+    def test_resolve_root_uuid_conflict_hashes_when_too_long(self):
+        """
+        When the descriptive form would exceed the `root_uuid` column length, a
+        hash form is used so it stays unique and within max_length.
+        """
+
+        long_uuid = 'x' * 249
+        inst = self._create_instance(self._make_xml('short', 'V'), long_uuid)
+        self._add_parsed_instance(inst)
+
+        resolve_root_uuid_conflict(inst, self.xform.id_string)
+
+        inst.refresh_from_db()
+        max_length = Instance._meta.get_field('root_uuid').max_length
+        self.assertTrue(inst.root_uuid.startswith('CONFLICT-'))
+        self.assertLessEqual(len(inst.root_uuid), max_length)
+        # Hash fallback: "CONFLICT-" + a 64-char sha256 hexdigest.
+        self.assertEqual(len(inst.root_uuid), len('CONFLICT-') + 64)
+
+    def test_replace_duplicates_syncs_mongo_root_uuid(self):
+        """
+        Even without a rootUuid node in the XML (a non-edited submission), the
+        Mongo `meta/rootUuid` must be backfilled from the new root_uuid, since
+        it is built from the DB field, not the XML.
+        """
+
+        self._make_group_b()
+        call_command('clean_duplicated_submissions', xform=self.xform.id_string)
+
+        for pk in (self.b1.pk, self.b2.pk, self.b3.pk):
+            instance = Instance.objects.get(pk=pk)
+            doc = settings.MONGO_DB.instances.find_one({'_id': pk})
+            self.assertIsNotNone(doc)
+            self.assertEqual(
+                doc['meta/rootUuid'], add_uuid_prefix(instance.root_uuid)
+            )

--- a/kobo/apps/openrosa/apps/logger/utils/__init__.py
+++ b/kobo/apps/openrosa/apps/logger/utils/__init__.py
@@ -1,4 +1,8 @@
 # flake8: noqa: F401
 from .counters import delete_null_user_daily_counters
 from .database_query import build_db_queries
-from .instance import delete_instances, set_instance_validation_statuses
+from .instance import (
+    delete_instances,
+    resolve_root_uuid_conflict,
+    set_instance_validation_statuses,
+)

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -264,10 +264,13 @@ def resolve_root_uuid_conflict(instance: Instance, xform_id_string: str) -> str:
 
     Instance.objects.filter(pk=instance.pk).update(**fields)
 
-    doc = settings.MONGO_DB.instances.find_one({'_id': instance.pk})
-    if doc is not None:
-        doc['meta/rootUuid'] = add_uuid_prefix(conflict_root_uuid)
-        settings.MONGO_DB.instances.replace_one({'_id': instance.pk}, doc)
+    # Targeted `$set` (not read-modify-write with replace_one) so a concurrent
+    # update to another field of the document is not clobbered. If this Mongo
+    # write is missed, LRM 0028 syncs `meta/rootUuid` from the DB afterwards.
+    settings.MONGO_DB.instances.update_one(
+        {'_id': instance.pk},
+        {'$set': {'meta/rootUuid': add_uuid_prefix(conflict_root_uuid)}},
+    )
 
     return conflict_root_uuid
 

--- a/kobo/apps/openrosa/apps/logger/utils/instance.py
+++ b/kobo/apps/openrosa/apps/logger/utils/instance.py
@@ -1,5 +1,7 @@
+import hashlib
 import logging
 import time
+from uuid import uuid4
 
 from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS, transaction
@@ -30,6 +32,7 @@ from ..exceptions import (
 )
 from ..models.instance import Instance
 from ..models.xform import XForm
+from ..xform_instance_parser import add_uuid_prefix, set_meta
 from .database_query import build_db_queries
 
 
@@ -226,6 +229,47 @@ def remove_validation_status_from_instance(instance: Instance) -> bool:
     instance.validation_status = {}
     instance.save(update_fields=['validation_status', 'date_modified'])
     return instance.parsed_instance.update_mongo(asynchronous=False)
+
+
+def resolve_root_uuid_conflict(instance: Instance, xform_id_string: str) -> str:
+    """
+    Give `instance` a unique `CONFLICT-` `root_uuid` when its intended one is
+    already used by another submission in the same xform, keeping Postgres, the
+    XML and Mongo in sync. Returns the new `root_uuid`.
+    """
+
+    # A uuid4 guarantees uniqueness per xform. Keep the value within the
+    # `root_uuid` CharField max_length: when the descriptive form is too long,
+    # fall back to a hash of it (not the sequential pk) so it still fits.
+    max_length = Instance._meta.get_field('root_uuid').max_length
+    conflict_root_uuid = (
+        f'CONFLICT-{uuid4().hex}-{xform_id_string}-{instance.uuid}'
+    )
+    if len(conflict_root_uuid) > max_length:
+        conflict_root_uuid = (
+            f'CONFLICT-{hashlib.sha256(conflict_root_uuid.encode()).hexdigest()}'
+        )
+    fields = {'root_uuid': conflict_root_uuid}
+    try:
+        instance.xml = set_meta(
+            instance.xml, 'rootUuid', add_uuid_prefix(conflict_root_uuid)
+        )
+    except ValueError:
+        # Legacy submission without a rootUuid node; the DB field alone enforces
+        # uniqueness.
+        pass
+    else:
+        fields['xml'] = instance.xml
+        fields['xml_hash'] = instance.get_hash(instance.xml)
+
+    Instance.objects.filter(pk=instance.pk).update(**fields)
+
+    doc = settings.MONGO_DB.instances.find_one({'_id': instance.pk})
+    if doc is not None:
+        doc['meta/rootUuid'] = add_uuid_prefix(conflict_root_uuid)
+        settings.MONGO_DB.instances.replace_one({'_id': instance.pk}, doc)
+
+    return conflict_root_uuid
 
 
 def set_instance_validation_statuses(


### PR DESCRIPTION
### 📣 Summary

A background data-repair task could fail on forms that contain certain duplicate submissions, leaving those forms unrepaired. It now resolves the conflict and continues.

### 💭 Notes

The `clean_duplicated_submissions` management command (run by long-running migration 0027) could raise `unique_root_uuid_per_xform` while assigning `root_uuid`, which aborted the whole form and left it flagged as failed.

Two root causes are fixed:
- `_replace_duplicates` gave a divergent duplicate a new unique `uuid` but left its `root_uuid` pointing at the shared value, because `_populate_root_uuid()` is a no-op once `root_uuid` is already set. It now sets `root_uuid` to the new uuid and updates the XML `rootUuid` node when that node exists.
- `_delete_duplicates` backfilled the reference `root_uuid` without handling a collision with another submission in the same form.

Both now fall back to a shared helper, `resolve_root_uuid_conflict()` in `logger.utils.instance`, which assigns a unique `CONFLICT-<uuid4>-...` `root_uuid` (hashed when it would exceed the column length, and never using the sequential pk) and keeps Postgres, the XML `rootUuid` node (when present) and the Mongo `meta/rootUuid` in sync. `_resolve_conflict_by_pk` in `clean_duplicated_submissions_root_uuid` now uses the same helper instead of duplicating the logic.

The conflicting `.update()` runs in its own `kc_transaction_atomic` block so a caught `IntegrityError` cannot poison an enclosing transaction: it is a savepoint when the command runs inside a transaction (for example under `TestCase`, which is what surfaced this), or its own transaction when run standalone in autocommit. Without it, the conflict resolution below would run on an aborted transaction. In `_replace_duplicates`, only the identity fields change, so after the Postgres bulk update Mongo is synced with a single bulk `$set` on `_uuid`, `meta/instanceID` and `meta/rootUuid` (on the existing docs) instead of a full `update_mongo()` per instance. Syncing after Postgres also means a failed write never leaves Mongo ahead of the database.

Mongo `meta/rootUuid` is built from the DB `root_uuid` field, not from the XML, so the backfill stays correct for submissions that have no `rootUuid` node in their XML (submissions that were never edited).

### 👀 Preview steps

It's easier to refer to unit tests.
