### PR TITLE
feat(projectDownloads): show media checkbox for GeoJSON DEV-2477

### DIFF
--- a/jsapp/js/components/projectDownloads/ProjectExportsCreator.tsx
+++ b/jsapp/js/components/projectDownloads/ProjectExportsCreator.tsx
@@ -360,7 +360,8 @@ export default function ProjectExportsCreator(props: ProjectExportsCreatorProps)
 
     if (
       currentState.selectedExportType.value === EXPORT_TYPES.xls.value ||
-      currentState.selectedExportType.value === EXPORT_TYPES.csv.value
+      currentState.selectedExportType.value === EXPORT_TYPES.csv.value ||
+      currentState.selectedExportType.value === EXPORT_TYPES.geojson.value
     ) {
       payload.export_settings.include_media_url = currentState.isIncludeMediaUrlEnabled
     }
@@ -598,7 +599,8 @@ export default function ProjectExportsCreator(props: ProjectExportsCreatorProps)
           )}
 
           {(state.selectedExportType.value === EXPORT_TYPES.xls.value ||
-            state.selectedExportType.value === EXPORT_TYPES.csv.value) && (
+            state.selectedExportType.value === EXPORT_TYPES.csv.value ||
+            state.selectedExportType.value === EXPORT_TYPES.geojson.value) && (
             <bem.ProjectDownloads__columnRow>
               <Checkbox
                 checked={state.isIncludeMediaUrlEnabled}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

GeoJSON exports now include media URLs by default and have a matching "Include media URLs" checkbox under Advanced options, just like XLS and CSV exports.

### 💭 Notes

This turned out to be a frontend-only fix. The backend (`_build_export_options` in `kpi/models/import_export_task.py`) already reads `include_media_url` and passes it to formpack for every export type, GeoJSON included — the UI just never sent it.

### 👀 Preview steps

1. ℹ️ have a project with both a geopoint question and a photo/media question, deployed, with submissions
2. go to Project → Data → Downloads
3. set "Select export type" to GeoJSON and expand "Advanced options"
4. 🔴 [on main] notice there's no "Include media URLs" checkbox for GeoJSON
5. 🟢 [on PR] notice the "Include media URLs" checkbox is now there and enabled by default