### PR TITLE
fix(qualitativeAnalysis): allow duplicate casing in QA tags questions DEV-2483

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TagsResponseForm.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabAnalysis/AnalysisContent/AnalysisQuestionsList/AnalysisQuestionListItem/TagsResponseForm.tsx
@@ -31,6 +31,8 @@ export default function SelectMultipleResponseForm({ qaAnswer, onSave, disabled,
   return (
     <Radio.Group>
       <TagsInput
+        // Allow tags of different casing in the same TagsInput, but not trailing spaces
+        isDuplicate={(tagValue, currentTags) => currentTags.some((val) => val === tagValue)}
         data={suggestedTags}
         value={selectedValues}
         onChange={onSave}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Updated tag duplication logic to allow different casings of the same tag to be added (and suggested) as separate tags.


1. ℹ️ have an account and a project with multiple audio submissions
2. add a tags QA question
3. add tags "Poverty" and "poverty"
4. 🔴 [on main] notice that "poverty" doesn't get added
5. go to a new submission
6. add tag "poverty" here
7. 🟢 [on main] notice that "poverty" gets added
8. go to a new submissions
9. try adding both "Poverty" and "poverty" from the tags suggestions
10. 🔴 [on main] notice that both tags don't get added
11. 🟢 [on PR] notice that both tags can be added
