### PR TITLE
feat(assetVersion): add version_number to `/api/v2/assets/<uid>/versions/` DEV-1825

### DIFF
--- a/jsapp/js/api/models/versionListResponse.ts
+++ b/jsapp/js/api/models/versionListResponse.ts
@@ -17,4 +17,5 @@ export interface VersionListResponse {
   readonly content_hash: string
   readonly date_deployed: VersionListResponseDateDeployed
   readonly date_modified: string
+  readonly version_number: string
 }

--- a/jsapp/js/api/models/versionRetrieveResponse.ts
+++ b/jsapp/js/api/models/versionRetrieveResponse.ts
@@ -18,5 +18,6 @@ export interface VersionRetrieveResponse {
   readonly content_hash: string
   readonly date_deployed: VersionRetrieveResponseDateDeployed
   readonly date_modified: string
+  readonly version_number: string
   readonly content: VersionRetrieveResponseContent
 }

--- a/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
+++ b/jsapp/js/api/react-query/manage-projects-and-library-content/msw.ts
@@ -4013,6 +4013,7 @@ export const getApiV2AssetsVersionsListResponseMock = (
       faker.datatype.boolean(),
     ]),
     date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
+    version_number: faker.string.alpha({ length: { min: 10, max: 20 } }),
   })),
   ...overrideResponse,
 })
@@ -4028,6 +4029,7 @@ export const getApiV2AssetsVersionsRetrieveResponseMock = (
     faker.datatype.boolean(),
   ]),
   date_modified: `${faker.date.past().toISOString().split('.')[0]}Z`,
+  version_number: faker.string.alpha({ length: { min: 10, max: 20 } }),
   content: {
     schema: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
     survey: faker.helpers.arrayElement([

--- a/kpi/schema_extensions/v2/versions/extensions.py
+++ b/kpi/schema_extensions/v2/versions/extensions.py
@@ -88,3 +88,13 @@ class UrlFieldExtension(OpenApiSerializerFieldExtension):
             uid_asset='a3C9wWefqZVkChNLKqqXVZ',
             uid_version='vf7pK9SmkJPYZVzr4uypi4',
         )
+
+
+class VersionNumberFieldExtension(OpenApiSerializerFieldExtension):
+    target_class = 'kpi.schema_extensions.v2.versions.fields.VersionNumberField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        # Major number for deployed versions (e.g. "12"), or a minor number
+        # appended to the preceding deployment for undeployed versions
+        # (e.g. "11.4")
+        return GENERIC_STRING_SCHEMA

--- a/kpi/schema_extensions/v2/versions/fields.py
+++ b/kpi/schema_extensions/v2/versions/fields.py
@@ -23,3 +23,7 @@ class UidField(serializers.ReadOnlyField):
 
 class UrlField(serializers.SerializerMethodField):
     pass
+
+
+class VersionNumberField(serializers.SerializerMethodField):
+    pass

--- a/kpi/schema_extensions/v2/versions/serializers.py
+++ b/kpi/schema_extensions/v2/versions/serializers.py
@@ -6,6 +6,7 @@ from .fields import (
     DateModifiedField,
     UidField,
     UrlField,
+    VersionNumberField,
 )
 
 VersionListResponse = inline_serializer_class(
@@ -16,6 +17,7 @@ VersionListResponse = inline_serializer_class(
         'content_hash': ContentHashField(),
         'date_deployed': DateDeployedField(),
         'date_modified': DateModifiedField(),
+        'version_number': VersionNumberField(),
     },
 )
 

--- a/kpi/schema_extensions/v2/versions/serializers.py
+++ b/kpi/schema_extensions/v2/versions/serializers.py
@@ -30,6 +30,7 @@ VersionRetrieveResponse = inline_serializer_class(
         'content_hash': ContentHashField(),
         'date_deployed': DateDeployedField(),
         'date_modified': DateModifiedField(),
+        'version_number': VersionNumberField(),
         'content': ContentField(),
     },
 )

--- a/kpi/serializers/v2/asset_version.py
+++ b/kpi/serializers/v2/asset_version.py
@@ -26,10 +26,10 @@ class AssetVersionListSerializer(serializers.Serializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Memo of `{asset_id: {version_id: label}}`, built lazily per asset by
-        # `get_version_number`. The asset is taken from `obj`, not the view, so
-        # this works both for the versions endpoints and when this serializer is
-        # the nested `deployed_versions` field of an asset (whose view is
+        # Memo of `{asset_id: {version_id: label}}`, filled lazily per asset by
+        # `_build_version_labels`. The asset is taken from `obj`, not the view,
+        # so this works both for the versions endpoints and when this serializer
+        # is the nested `deployed_versions` field of an asset (whose view is
         # `AssetViewSet`, which has no `asset_uid`). Keyed by `asset_id` so one
         # instance stays correct even if reused across assets
         self._version_labels = {}
@@ -37,7 +37,7 @@ class AssetVersionListSerializer(serializers.Serializer):
     def get_date_deployed(self, obj):
         return obj.deployed and obj.date_modified
 
-    def get_version_number(self, obj):
+    def get_version_number(self, obj) -> str:
         """
         Human-readable version number (see `_build_version_labels`), consistent
         across pages, `?deployed=` filters, and the `retrieve` action
@@ -46,11 +46,10 @@ class AssetVersionListSerializer(serializers.Serializer):
         history) and memoized on this serializer instance, so serializing a
         whole page adds one query, not one per row. The lookup is keyed on `id`.
         """
-        labels = self._version_labels.get(obj.asset_id)
-        if labels is None:
-            labels = self._version_labels[obj.asset_id] = (
-                self._build_version_labels(obj.asset_id)
-            )
+        try:
+            labels = self._version_labels[obj.asset_id]
+        except KeyError:
+            labels = self._build_version_labels(obj.asset_id)
         return labels[obj.id]
 
     def get_url(self, obj):
@@ -60,11 +59,11 @@ class AssetVersionListSerializer(serializers.Serializer):
             request=self.context.get('request', None),
         )
 
-    @classmethod
-    def _build_version_labels(cls, asset_id):
+    def _build_version_labels(self, asset_id: int) -> dict[int, str]:
         """
-        Build `{version_id: "1.2"}` for every version of the asset, in a single
-        query and one ordered pass over its full history
+        Build, cache, and return `{version_id: "1.2"}` for every version of the
+        asset, from a single query and one ordered pass over its full history.
+        The result is stored in `self._version_labels[asset_id]`
 
         Deployed versions get a major number, e.g. "12": the 1st deployment
         (chronologically) is "1", the 12th is "12". Undeployed versions get a
@@ -91,6 +90,7 @@ class AssetVersionListSerializer(serializers.Serializer):
             else:
                 minor += 1
                 labels[version_id] = f'{major}.{minor}'
+        self._version_labels[asset_id] = labels
         return labels
 
 

--- a/kpi/serializers/v2/asset_version.py
+++ b/kpi/serializers/v2/asset_version.py
@@ -1,22 +1,4 @@
 # coding: utf-8
-import datetime
-
-from django.db.models import (
-    Case,
-    Count,
-    DateTimeField,
-    F,
-    IntegerField,
-    OuterRef,
-    Q,
-    RowRange,
-    Subquery,
-    Sum,
-    Value,
-    When,
-    Window,
-)
-from django.db.models.functions import Coalesce
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -31,12 +13,6 @@ from kpi.schema_extensions.v2.versions.fields import (
     VersionNumberField,
 )
 
-# A timestamp guaranteed to precede any real `AssetVersion.date_modified`
-# value, used as a floor for versions created before the asset's first
-# deployment (i.e. when the correlated subquery below finds no prior
-# deployment to compare against)
-_EPOCH = datetime.datetime(1, 1, 1, tzinfo=datetime.timezone.utc)
-
 
 class AssetVersionListSerializer(serializers.Serializer):
     # If you change these fields, please update the `only()` and
@@ -48,186 +24,63 @@ class AssetVersionListSerializer(serializers.Serializer):
     date_modified = DateModifiedField()
     version_number = VersionNumberField()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Per-request memo of each asset's full-history label map, filled lazily
+        # by `get_version_number`. Always a single asset in practice, but keyed
+        # by `asset_id` to stay correct regardless
+        self._version_labels = {}
+
     def get_date_deployed(self, obj):
         return obj.deployed and obj.date_modified
 
-    # Version numbering:
-    # Each version gets a label like "12" (a deployment) or "11.4" (the 4th
-    # undeployed form change made after the 11th deployment). The numbers span
-    # the asset's whole history, so the front end can't derive them while
-    # paginating - the API computes them. In plain terms:
-    #
-    #   - major = a correlated SUBQUERY. It reads the full history through
-    #     `OuterRef`, so it stays correct even when the outer query is trimmed -
-    #     by a `?deployed=` filter, or down to one row for `retrieve`.
-    #   - minor = a WINDOW. A running count has to see the sibling rows around
-    #     each version, so it's computed over the whole list page at once.
-    #   - retrieve = falls back to a count query for the minor number, because a
-    #     single serialized object has no sibling rows for a window to run over
-    #     (filtering is not the reason - the minor window is fine under
-    #     `?deployed=`; see `test_version_number_with_deployed_filter`).
-    #
-    # Versions are ordered chronologically, breaking ties on `id` so the order
-    # is total and deterministic. `_at_or_before(date_modified, id)` matches
-    # every version at or before that position
-    @staticmethod
-    def _at_or_before(date_modified, id_):
-        return Q(date_modified__lt=date_modified) | Q(
-            date_modified=date_modified, id__lte=id_
-        )
-
     @classmethod
-    def _major_subquery(cls):
+    def _labels_for_asset(cls, asset_id):
         """
-        Correlated subquery: the number of deployments at or before each row,
-        in `(date_modified, id)` order - i.e. the row's major number (for a
-        deployed row, it counts itself)
+        Build `{version_id: "1.2"}` for every version of the asset, in a single
+        query and one ordered pass over its full history
 
-        This references the asset's full version history through `OuterRef`,
-        so it is unaffected by an outer `?deployed=` filter or by narrowing the
-        queryset to a single object (the `retrieve` action). Using it in both
-        the list and retrieve paths guarantees they report the same number.
+        Deployed versions get a major number, e.g. "12": the 1st deployment
+        (chronologically) is "1", the 12th is "12". Undeployed versions get a
+        minor number appended to the major of the most recent deployment before
+        them, e.g. "11.4" is the 4th form change after the 11th deployment;
+        drafts made before any deployment use major "0" (e.g. "0.1").
+
+        Versions are ordered by `(date_modified, id)`, so the walk is total and
+        deterministic even when timestamps are tied - a draft ordered before a
+        same-timestamp deployment is numbered before the major increments.
         """
-        deployments = (
-            AssetVersion.objects.filter(
-                asset_id=OuterRef('asset_id'), deployed=True
-            )
-            .filter(cls._at_or_before(OuterRef('date_modified'), OuterRef('id')))
-            .order_by()
-            .values('asset_id')
-            .annotate(count=Count('id'))
-            .values('count')
+        rows = (
+            AssetVersion.objects.filter(asset_id=asset_id)
+            .order_by('date_modified', 'id')
+            .values_list('id', 'deployed')
         )
-        return Coalesce(Subquery(deployments), 0)
-
-    @classmethod
-    def annotate_major_number(cls, queryset):
-        """
-        Annotate `_version_major` (see `_major_subquery`). Safe for any action,
-        including `retrieve`, since it is a filter-independent subquery
-        """
-        return queryset.annotate(_version_major=cls._major_subquery())
-
-    @classmethod
-    def annotate_version_numbers(cls, queryset):
-        """
-        Annotate every row with `_version_major` and `_version_minor`, computed
-        across all the asset's versions in a single query, so the version
-        number stays consistent while the front end paginates: everything is
-        evaluated before pagination slices the page.
-
-        - `_version_major`: see `_major_subquery`.
-        - `_version_minor`: for undeployed versions, their position among the
-          undeployed versions that follow the most recent deployment (deployed
-          rows get `0`, which the serializer ignores). It is a running count
-          (window) partitioned by `_version_group` - the date of the most
-          recent deployment at or before each row (a correlated subquery,
-          floored to `_EPOCH` before the first deployment). We partition by that
-          date rather than by `_version_major` because a window function cannot
-          be nested inside another window's `PARTITION BY`.
-
-        `_version_minor` is a window, so it needs the sibling rows of a full
-        list page (a `?deployed=` filter is fine — it still sees every row it
-        needs to count). The `retrieve` action, which serializes a single
-        object with no siblings, must instead use `_minor_fallback`.
-        """
-        last_deployed_date = (
-            AssetVersion.objects.filter(
-                asset_id=OuterRef('asset_id'),
-                deployed=True,
-                date_modified__lte=OuterRef('date_modified'),
-            )
-            .order_by('-date_modified')
-            .values('date_modified')[:1]
-        )
-        return cls.annotate_major_number(queryset).annotate(
-            _version_group=Coalesce(
-                Subquery(last_deployed_date),
-                Value(_EPOCH, output_field=DateTimeField()),
-            ),
-        ).annotate(
-            _version_minor=Window(
-                expression=Sum(
-                    Case(
-                        When(deployed=False, then=1),
-                        default=0,
-                        output_field=IntegerField(),
-                    )
-                ),
-                partition_by=[F('_version_group')],
-                order_by=[F('date_modified').asc(), F('id').asc()],
-                frame=RowRange(start=None, end=0),
-            ),
-        )
-
-    @classmethod
-    def _minor_fallback(cls, obj):
-        """
-        Count how many undeployed versions have been made since the deployment
-        that precedes `obj` (or since the beginning, if there is none). Mirrors
-        the `_version_minor` window - same `(date_modified, id)` ordering - so a
-        version gets the same minor number whether it is served by `list` or
-        `retrieve`, even when timestamps are tied
-        """
-        last_deployed_date = (
-            AssetVersion.objects.filter(
-                asset_id=obj.asset_id,
-                deployed=True,
-                date_modified__lte=obj.date_modified,
-            )
-            .order_by('-date_modified')
-            .values_list('date_modified', flat=True)
-            .first()
-        )
-        undeployed = AssetVersion.objects.filter(
-            asset_id=obj.asset_id, deployed=False
-        ).filter(cls._at_or_before(obj.date_modified, obj.id))
-        if last_deployed_date is not None:
-            undeployed = undeployed.filter(
-                date_modified__gte=last_deployed_date
-            )
-        return undeployed.count()
+        labels = {}
+        major = minor = 0
+        for version_id, deployed in rows:
+            if deployed:
+                major += 1
+                minor = 0
+                labels[version_id] = str(major)
+            else:
+                minor += 1
+                labels[version_id] = f'{major}.{minor}'
+        return labels
 
     def get_version_number(self, obj):
         """
-        Human-readable version number, computed across all the asset's
-        versions (not just the current page), so it stays consistent while the
-        front end paginates through the list
+        Human-readable version number (see `_labels_for_asset`), consistent
+        across pages, `?deployed=` filters, and the `retrieve` action
 
-        Deployed versions get a major number, e.g. "12": the 1st deployed
-        version (chronologically) is "1", the 12th is "12".
-
-        Undeployed versions get a minor number appended to the major number of
-        the most recently deployed version that precedes them, e.g. "11.4" is
-        the 4th form change made after the 11th deployment. Undeployed versions
-        made before any deployment use a major number of "0".
-
-        The numbers are normally supplied by the annotations added in
-        `AssetVersionViewSet.get_queryset()`. The major number is always
-        annotated (`_version_major`); the minor number is annotated for the
-        `list` action and falls back to `_minor_fallback` otherwise (e.g. the
-        `retrieve` action, which serializes a single object).
+        The full-history label map is computed once per serializer instance and
+        memoized per asset (see `__init__`), so serializing a whole page costs
+        one extra query, not one per row. The lookup is keyed on `id`.
         """
-        major = getattr(obj, '_version_major', None)
-        if major is None:
-            # Defensive: the serializer is used without the annotation. Count
-            # deployments the same way `_major_subquery` does
-            major = (
-                AssetVersion.objects.filter(
-                    asset_id=obj.asset_id, deployed=True
-                )
-                .filter(self._at_or_before(obj.date_modified, obj.id))
-                .count()
+        if obj.asset_id not in self._version_labels:
+            self._version_labels[obj.asset_id] = self._labels_for_asset(
+                obj.asset_id
             )
-
-        if obj.deployed:
-            return str(major)
-
-        minor = getattr(obj, '_version_minor', None)
-        if minor is None:
-            minor = self._minor_fallback(obj)
-
-        return f'{major}.{minor}'
+        return self._version_labels[obj.asset_id][obj.id]
 
     def get_url(self, obj):
         return reverse(

--- a/kpi/serializers/v2/asset_version.py
+++ b/kpi/serializers/v2/asset_version.py
@@ -26,16 +26,42 @@ class AssetVersionListSerializer(serializers.Serializer):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Per-request memo of each asset's full-history label map, filled lazily
-        # by `get_version_number`. Always a single asset in practice, but keyed
-        # by `asset_id` to stay correct regardless
+        # Memo of `{asset_id: {version_id: label}}`, built lazily per asset by
+        # `get_version_number`. The asset is taken from `obj`, not the view, so
+        # this works both for the versions endpoints and when this serializer is
+        # the nested `deployed_versions` field of an asset (whose view is
+        # `AssetViewSet`, which has no `asset_uid`). Keyed by `asset_id` so one
+        # instance stays correct even if reused across assets
         self._version_labels = {}
 
     def get_date_deployed(self, obj):
         return obj.deployed and obj.date_modified
 
+    def get_version_number(self, obj):
+        """
+        Human-readable version number (see `_build_version_labels`), consistent
+        across pages, `?deployed=` filters, and the `retrieve` action
+
+        The label map is built once per asset (a single query over its full
+        history) and memoized on this serializer instance, so serializing a
+        whole page adds one query, not one per row. The lookup is keyed on `id`.
+        """
+        labels = self._version_labels.get(obj.asset_id)
+        if labels is None:
+            labels = self._version_labels[obj.asset_id] = (
+                self._build_version_labels(obj.asset_id)
+            )
+        return labels[obj.id]
+
+    def get_url(self, obj):
+        return reverse(
+            'asset-version-detail',
+            args=(obj.asset.uid, obj.uid),
+            request=self.context.get('request', None),
+        )
+
     @classmethod
-    def _labels_for_asset(cls, asset_id):
+    def _build_version_labels(cls, asset_id):
         """
         Build `{version_id: "1.2"}` for every version of the asset, in a single
         query and one ordered pass over its full history
@@ -66,28 +92,6 @@ class AssetVersionListSerializer(serializers.Serializer):
                 minor += 1
                 labels[version_id] = f'{major}.{minor}'
         return labels
-
-    def get_version_number(self, obj):
-        """
-        Human-readable version number (see `_labels_for_asset`), consistent
-        across pages, `?deployed=` filters, and the `retrieve` action
-
-        The full-history label map is computed once per serializer instance and
-        memoized per asset (see `__init__`), so serializing a whole page costs
-        one extra query, not one per row. The lookup is keyed on `id`.
-        """
-        if obj.asset_id not in self._version_labels:
-            self._version_labels[obj.asset_id] = self._labels_for_asset(
-                obj.asset_id
-            )
-        return self._version_labels[obj.asset_id][obj.id]
-
-    def get_url(self, obj):
-        return reverse(
-            'asset-version-detail',
-            args=(obj.asset.uid, obj.uid),
-            request=self.context.get('request', None),
-        )
 
 
 class AssetVersionSerializer(AssetVersionListSerializer):

--- a/kpi/serializers/v2/asset_version.py
+++ b/kpi/serializers/v2/asset_version.py
@@ -3,11 +3,12 @@ import datetime
 
 from django.db.models import (
     Case,
+    Count,
     DateTimeField,
     F,
     IntegerField,
-    Max,
     OuterRef,
+    Q,
     RowRange,
     Subquery,
     Sum,
@@ -50,25 +51,85 @@ class AssetVersionListSerializer(serializers.Serializer):
     def get_date_deployed(self, obj):
         return obj.deployed and obj.date_modified
 
+    # Version numbering:
+    # Each version gets a label like "12" (a deployment) or "11.4" (the 4th
+    # undeployed form change made after the 11th deployment). The numbers span
+    # the asset's whole history, so the front end can't derive them while
+    # paginating - the API computes them. In plain terms:
+    #
+    #   - major = a correlated SUBQUERY. It reads the full history through
+    #     `OuterRef`, so it stays correct even when the outer query is trimmed -
+    #     by a `?deployed=` filter, or down to one row for `retrieve`.
+    #   - minor = a WINDOW. A running count has to see the sibling rows around
+    #     each version, so it's computed over the whole list page at once.
+    #   - retrieve = falls back to a count query for the minor number, because a
+    #     single serialized object has no sibling rows for a window to run over
+    #     (filtering is not the reason - the minor window is fine under
+    #     `?deployed=`; see `test_version_number_with_deployed_filter`).
+    #
+    # Versions are ordered chronologically, breaking ties on `id` so the order
+    # is total and deterministic. `_at_or_before(date_modified, id)` matches
+    # every version at or before that position
     @staticmethod
-    def annotate_version_numbers(queryset):
+    def _at_or_before(date_modified, id_):
+        return Q(date_modified__lt=date_modified) | Q(
+            date_modified=date_modified, id__lte=id_
+        )
+
+    @classmethod
+    def _major_subquery(cls):
+        """
+        Correlated subquery: the number of deployments at or before each row,
+        in `(date_modified, id)` order - i.e. the row's major number (for a
+        deployed row, it counts itself)
+
+        This references the asset's full version history through `OuterRef`,
+        so it is unaffected by an outer `?deployed=` filter or by narrowing the
+        queryset to a single object (the `retrieve` action). Using it in both
+        the list and retrieve paths guarantees they report the same number.
+        """
+        deployments = (
+            AssetVersion.objects.filter(
+                asset_id=OuterRef('asset_id'), deployed=True
+            )
+            .filter(cls._at_or_before(OuterRef('date_modified'), OuterRef('id')))
+            .order_by()
+            .values('asset_id')
+            .annotate(count=Count('id'))
+            .values('count')
+        )
+        return Coalesce(Subquery(deployments), 0)
+
+    @classmethod
+    def annotate_major_number(cls, queryset):
+        """
+        Annotate `_version_major` (see `_major_subquery`). Safe for any action,
+        including `retrieve`, since it is a filter-independent subquery
+        """
+        return queryset.annotate(_version_major=cls._major_subquery())
+
+    @classmethod
+    def annotate_version_numbers(cls, queryset):
         """
         Annotate every row with `_version_major` and `_version_minor`, computed
-        across all the asset's versions in a single query (two window
-        functions), so the version number stays consistent while the front end
-        paginates: the windows are evaluated before pagination slices the page.
+        across all the asset's versions in a single query, so the version
+        number stays consistent while the front end paginates: everything is
+        evaluated before pagination slices the page.
 
-        - `_version_major`: running count of deployments - the major number for
-          deployed versions, and the major prefix for undeployed ones.
+        - `_version_major`: see `_major_subquery`.
         - `_version_minor`: for undeployed versions, their position among the
           undeployed versions that follow the most recent deployment (deployed
-          rows get `0`, which the serializer ignores).
+          rows get `0`, which the serializer ignores). It is a running count
+          (window) partitioned by `_version_group` - the date of the most
+          recent deployment at or before each row (a correlated subquery,
+          floored to `_EPOCH` before the first deployment). We partition by that
+          date rather than by `_version_major` because a window function cannot
+          be nested inside another window's `PARTITION BY`.
 
-        The minor window partitions by `_version_group` - the date of the most
-        recent deployment at or before each row (a correlated subquery, floored
-        to `_EPOCH` before the first deployment). We partition by that instead
-        of by `_version_major` because a window function cannot be nested inside
-        another window's `PARTITION BY`
+        `_version_minor` is a window, so it needs the sibling rows of a full
+        list page (a `?deployed=` filter is fine — it still sees every row it
+        needs to count). The `retrieve` action, which serializes a single
+        object with no siblings, must instead use `_minor_fallback`.
         """
         last_deployed_date = (
             AssetVersion.objects.filter(
@@ -79,25 +140,12 @@ class AssetVersionListSerializer(serializers.Serializer):
             .order_by('-date_modified')
             .values('date_modified')[:1]
         )
-        window_order = [F('date_modified').asc(), F('id').asc()]
-        running_frame = RowRange(start=None, end=0)
-        return queryset.annotate(
+        return cls.annotate_major_number(queryset).annotate(
             _version_group=Coalesce(
                 Subquery(last_deployed_date),
                 Value(_EPOCH, output_field=DateTimeField()),
             ),
         ).annotate(
-            _version_major=Window(
-                expression=Sum(
-                    Case(
-                        When(deployed=True, then=1),
-                        default=0,
-                        output_field=IntegerField(),
-                    )
-                ),
-                order_by=window_order,
-                frame=running_frame,
-            ),
             _version_minor=Window(
                 expression=Sum(
                     Case(
@@ -107,16 +155,44 @@ class AssetVersionListSerializer(serializers.Serializer):
                     )
                 ),
                 partition_by=[F('_version_group')],
-                order_by=window_order,
-                frame=running_frame,
+                order_by=[F('date_modified').asc(), F('id').asc()],
+                frame=RowRange(start=None, end=0),
             ),
         )
+
+    @classmethod
+    def _minor_fallback(cls, obj):
+        """
+        Count how many undeployed versions have been made since the deployment
+        that precedes `obj` (or since the beginning, if there is none). Mirrors
+        the `_version_minor` window - same `(date_modified, id)` ordering - so a
+        version gets the same minor number whether it is served by `list` or
+        `retrieve`, even when timestamps are tied
+        """
+        last_deployed_date = (
+            AssetVersion.objects.filter(
+                asset_id=obj.asset_id,
+                deployed=True,
+                date_modified__lte=obj.date_modified,
+            )
+            .order_by('-date_modified')
+            .values_list('date_modified', flat=True)
+            .first()
+        )
+        undeployed = AssetVersion.objects.filter(
+            asset_id=obj.asset_id, deployed=False
+        ).filter(cls._at_or_before(obj.date_modified, obj.id))
+        if last_deployed_date is not None:
+            undeployed = undeployed.filter(
+                date_modified__gte=last_deployed_date
+            )
+        return undeployed.count()
 
     def get_version_number(self, obj):
         """
         Human-readable version number, computed across all the asset's
         versions (not just the current page), so it stays consistent while the
-        front end paginates through the list.
+        front end paginates through the list
 
         Deployed versions get a major number, e.g. "12": the 1st deployed
         version (chronologically) is "1", the 12th is "12".
@@ -126,49 +202,30 @@ class AssetVersionListSerializer(serializers.Serializer):
         the 4th form change made after the 11th deployment. Undeployed versions
         made before any deployment use a major number of "0".
 
-        The numbers are normally supplied for free by `annotate_version_numbers`
-        (used by `AssetVersionViewSet.get_queryset()` for the `list` action);
-        we only fall back to count queries when the annotations are absent, e.g.
-        the `retrieve` action, which serializes a single object.
+        The numbers are normally supplied by the annotations added in
+        `AssetVersionViewSet.get_queryset()`. The major number is always
+        annotated (`_version_major`); the minor number is annotated for the
+        `list` action and falls back to `_minor_fallback` otherwise (e.g. the
+        `retrieve` action, which serializes a single object).
         """
         major = getattr(obj, '_version_major', None)
         if major is None:
-            # Number of deployments up to (and, for a deployed version,
-            # including) this version
-            major = AssetVersion.objects.filter(
-                asset_id=obj.asset_id,
-                deployed=True,
-                date_modified__lte=obj.date_modified,
-            ).count()
+            # Defensive: the serializer is used without the annotation. Count
+            # deployments the same way `_major_subquery` does
+            major = (
+                AssetVersion.objects.filter(
+                    asset_id=obj.asset_id, deployed=True
+                )
+                .filter(self._at_or_before(obj.date_modified, obj.id))
+                .count()
+            )
 
         if obj.deployed:
             return str(major)
 
         minor = getattr(obj, '_version_minor', None)
         if minor is None:
-            # Count how many undeployed versions have been made since the last
-            # deployment (or since the beginning, if there is no prior one):
-            # undeployed versions up to this one, excluding those made on or
-            # before the last deployment
-            last_deployed_date = (
-                AssetVersion.objects.filter(
-                    asset_id=obj.asset_id,
-                    deployed=True,
-                    date_modified__lte=obj.date_modified,
-                )
-                .values('asset_id')
-                .annotate(latest=Max('date_modified'))
-                .values('latest')
-            )
-            minor = AssetVersion.objects.filter(
-                asset_id=obj.asset_id,
-                deployed=False,
-                date_modified__lte=obj.date_modified,
-                date_modified__gt=Coalesce(
-                    Subquery(last_deployed_date),
-                    Value(_EPOCH, output_field=DateTimeField()),
-                ),
-            ).count()
+            minor = self._minor_fallback(obj)
 
         return f'{major}.{minor}'
 

--- a/kpi/serializers/v2/asset_version.py
+++ b/kpi/serializers/v2/asset_version.py
@@ -1,4 +1,21 @@
 # coding: utf-8
+import datetime
+
+from django.db.models import (
+    Case,
+    DateTimeField,
+    F,
+    IntegerField,
+    Max,
+    OuterRef,
+    RowRange,
+    Subquery,
+    Sum,
+    Value,
+    When,
+    Window,
+)
+from django.db.models.functions import Coalesce
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
@@ -10,7 +27,14 @@ from kpi.schema_extensions.v2.versions.fields import (
     DateModifiedField,
     UidField,
     UrlField,
+    VersionNumberField,
 )
+
+# A timestamp guaranteed to precede any real `AssetVersion.date_modified`
+# value, used as a floor for versions created before the asset's first
+# deployment (i.e. when the correlated subquery below finds no prior
+# deployment to compare against)
+_EPOCH = datetime.datetime(1, 1, 1, tzinfo=datetime.timezone.utc)
 
 
 class AssetVersionListSerializer(serializers.Serializer):
@@ -21,9 +45,132 @@ class AssetVersionListSerializer(serializers.Serializer):
     content_hash = ContentHashField()
     date_deployed = DateDeployedField(read_only=True)
     date_modified = DateModifiedField()
+    version_number = VersionNumberField()
 
     def get_date_deployed(self, obj):
         return obj.deployed and obj.date_modified
+
+    @staticmethod
+    def annotate_version_numbers(queryset):
+        """
+        Annotate every row with `_version_major` and `_version_minor`, computed
+        across all the asset's versions in a single query (two window
+        functions), so the version number stays consistent while the front end
+        paginates: the windows are evaluated before pagination slices the page.
+
+        - `_version_major`: running count of deployments - the major number for
+          deployed versions, and the major prefix for undeployed ones.
+        - `_version_minor`: for undeployed versions, their position among the
+          undeployed versions that follow the most recent deployment (deployed
+          rows get `0`, which the serializer ignores).
+
+        The minor window partitions by `_version_group` - the date of the most
+        recent deployment at or before each row (a correlated subquery, floored
+        to `_EPOCH` before the first deployment). We partition by that instead
+        of by `_version_major` because a window function cannot be nested inside
+        another window's `PARTITION BY`
+        """
+        last_deployed_date = (
+            AssetVersion.objects.filter(
+                asset_id=OuterRef('asset_id'),
+                deployed=True,
+                date_modified__lte=OuterRef('date_modified'),
+            )
+            .order_by('-date_modified')
+            .values('date_modified')[:1]
+        )
+        window_order = [F('date_modified').asc(), F('id').asc()]
+        running_frame = RowRange(start=None, end=0)
+        return queryset.annotate(
+            _version_group=Coalesce(
+                Subquery(last_deployed_date),
+                Value(_EPOCH, output_field=DateTimeField()),
+            ),
+        ).annotate(
+            _version_major=Window(
+                expression=Sum(
+                    Case(
+                        When(deployed=True, then=1),
+                        default=0,
+                        output_field=IntegerField(),
+                    )
+                ),
+                order_by=window_order,
+                frame=running_frame,
+            ),
+            _version_minor=Window(
+                expression=Sum(
+                    Case(
+                        When(deployed=False, then=1),
+                        default=0,
+                        output_field=IntegerField(),
+                    )
+                ),
+                partition_by=[F('_version_group')],
+                order_by=window_order,
+                frame=running_frame,
+            ),
+        )
+
+    def get_version_number(self, obj):
+        """
+        Human-readable version number, computed across all the asset's
+        versions (not just the current page), so it stays consistent while the
+        front end paginates through the list.
+
+        Deployed versions get a major number, e.g. "12": the 1st deployed
+        version (chronologically) is "1", the 12th is "12".
+
+        Undeployed versions get a minor number appended to the major number of
+        the most recently deployed version that precedes them, e.g. "11.4" is
+        the 4th form change made after the 11th deployment. Undeployed versions
+        made before any deployment use a major number of "0".
+
+        The numbers are normally supplied for free by `annotate_version_numbers`
+        (used by `AssetVersionViewSet.get_queryset()` for the `list` action);
+        we only fall back to count queries when the annotations are absent, e.g.
+        the `retrieve` action, which serializes a single object.
+        """
+        major = getattr(obj, '_version_major', None)
+        if major is None:
+            # Number of deployments up to (and, for a deployed version,
+            # including) this version
+            major = AssetVersion.objects.filter(
+                asset_id=obj.asset_id,
+                deployed=True,
+                date_modified__lte=obj.date_modified,
+            ).count()
+
+        if obj.deployed:
+            return str(major)
+
+        minor = getattr(obj, '_version_minor', None)
+        if minor is None:
+            # Count how many undeployed versions have been made since the last
+            # deployment (or since the beginning, if there is no prior one):
+            # undeployed versions up to this one, excluding those made on or
+            # before the last deployment
+            last_deployed_date = (
+                AssetVersion.objects.filter(
+                    asset_id=obj.asset_id,
+                    deployed=True,
+                    date_modified__lte=obj.date_modified,
+                )
+                .values('asset_id')
+                .annotate(latest=Max('date_modified'))
+                .values('latest')
+            )
+            minor = AssetVersion.objects.filter(
+                asset_id=obj.asset_id,
+                deployed=False,
+                date_modified__lte=obj.date_modified,
+                date_modified__gt=Coalesce(
+                    Subquery(last_deployed_date),
+                    Value(_EPOCH, output_field=DateTimeField()),
+                ),
+            ).count()
+
+        return f'{major}.{minor}'
 
     def get_url(self, obj):
         return reverse(

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -158,18 +158,19 @@ class AssetVersionTestCase(TestCase):
 
         This covers two separate concerns:
         1. Correctness of the numbering logic itself, via the fallback path (no
-        window annotations) - deployed versions get a running major number,
-        undeployed versions get a minor number that resets after each
-        deployment, and versions created before the first deployment are
-        correctly numbered under major "0".
+        annotations) - deployed versions get a running major number, undeployed
+        versions get a minor number that resets after each deployment, and
+        versions created before the first deployment are correctly numbered
+        under major "0".
 
         2. That the production `list` endpoint path (`get_queryset()` +
-        `annotate_version_numbers()`) computes identical numbers via window
-        function annotations, and that reading those annotations during
-        serialization fires zero additional queries - i.e. the version numbers
-        for a full page are resolved without any N+1 query per version, which
-        is the whole reason this was implemented as an annotated queryset
-        rather than per-object lookups.
+        `annotate_version_numbers()`) computes identical numbers via its
+        annotations (a subquery for the major number, a window for the minor),
+        and that reading those annotations during serialization fires zero
+        additional queries - i.e. the version numbers for a full page are
+        resolved without any N+1 query per version, which is the whole reason
+        this was implemented as an annotated queryset rather than per-object
+        lookups.
         """
         asset = Asset.objects.create(asset_type='survey')
         # Remove the version created alongside the asset so we fully control
@@ -228,6 +229,66 @@ class AssetVersionTestCase(TestCase):
                 for version in rows
             }
         self.assertEqual(annotated_by_uid, expected_by_uid)
+
+        # `retrieve` path: the major number is annotated (a filter-independent
+        # subquery) and the minor number falls back to a count query. It must
+        # match the numbers reported by `list` for every version
+        retrieve_view = AssetVersionViewSet()
+        retrieve_view.action = 'retrieve'
+        retrieve_view.request = Request(RequestFactory().get('/'))
+        retrieve_view._asset_uid = asset.uid
+        retrieve_by_uid = {
+            version.uid: serializer.get_version_number(version)
+            for version in retrieve_view.get_queryset()
+        }
+        self.assertEqual(retrieve_by_uid, expected_by_uid)
+
+    def test_version_number_with_deployed_filter(self):
+        """
+        The version number must stay correct when the list is filtered with
+        `?deployed=`, even though that removes rows before the numbers are
+        computed. The major number is a filter-independent subquery, so drafts
+        keep the major of the deployment that precedes them (e.g. "2.1", not
+        "0.1")
+        """
+        asset = Asset.objects.create(asset_type='survey')
+        asset.asset_versions.all().delete()
+        base_date = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))
+        # (deployed?, expected number when unfiltered)
+        sequence = [
+            (False, '0.1'),
+            (True, '1'),
+            (True, '2'),
+            (False, '2.1'),
+            (False, '2.2'),
+            (True, '3'),
+            (False, '3.1'),
+        ]
+        for index, (deployed, _expected) in enumerate(sequence):
+            version = AssetVersion.objects.create(
+                asset=asset, version_content={'survey': []}, deployed=deployed
+            )
+            AssetVersion.objects.filter(pk=version.pk).update(
+                date_modified=base_date + timedelta(minutes=index)
+            )
+
+        serializer = AssetVersionListSerializer()
+
+        def numbers_for(deployed):
+            # Mirror `get_queryset()` for a `?deployed=` request: the rows are
+            # filtered before the numbers are annotated
+            queryset = AssetVersionListSerializer.annotate_version_numbers(
+                AssetVersion.objects.filter(
+                    asset_id=asset.id, deployed=deployed
+                )
+            )
+            return [
+                serializer.get_version_number(version)
+                for version in queryset.order_by('date_modified', 'id')
+            ]
+
+        self.assertEqual(numbers_for(False), ['0.1', '2.1', '2.2', '3.1'])
+        self.assertEqual(numbers_for(True), ['1', '2', '3'])
 
     def test_version_date_modified(self):
         date_forced = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -3,16 +3,13 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from django.utils import timezone
-
-from rest_framework.request import Request
 
 from formpack.utils.expand_content import SCHEMA_VERSION
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.exceptions import BadAssetTypeException
 from kpi.serializers.v2.asset_version import AssetVersionListSerializer
-from kpi.views.v2.asset_version import AssetVersionViewSet
 from kpi.utils.hash import calculate_hash
 from ..models import Asset, AssetVersion
 
@@ -150,27 +147,38 @@ class AssetVersionTestCase(TestCase):
         version.refresh_from_db()
         assert version._content_hash is not None
 
+    def _make_versions(self, asset, sequence, base_date, tied=False):
+        """
+        Create versions from a list of (deployed?, expected_label) tuples and
+        return `{version_uid: expected_label}`. When `tied` is True every
+        version shares `base_date`; otherwise `date_modified` increases by a
+        minute per row (creation/`id` order still breaks ties)
+        """
+        expected_by_uid = {}
+        for index, (deployed, expected) in enumerate(sequence):
+            version = AssetVersion.objects.create(
+                asset=asset, version_content={'survey': []}, deployed=deployed
+            )
+            date_modified = base_date if tied else (
+                base_date + timedelta(minutes=index)
+            )
+            # `date_modified` is auto-set, so force our controlled value
+            AssetVersion.objects.filter(pk=version.pk).update(
+                date_modified=date_modified
+            )
+            expected_by_uid[version.uid] = expected
+        return expected_by_uid
+
     def test_version_number(self):
         """
-        Test that `AssetVersionListSerializer.get_version_number()` returns the
-        correct major/minor version label ("1", "2.1", "3", etc.) for a realistic
-        chronological sequence of deployed and undeployed versions
+        `get_version_number()` returns the correct major/minor label ("1",
+        "2.1", "3", ...) for a realistic sequence of deployed and undeployed
+        versions: deployments get a running major number, drafts get a minor
+        number that resets after each deployment, and drafts before the first
+        deployment fall under major "0"
 
-        This covers two separate concerns:
-        1. Correctness of the numbering logic itself, via the fallback path (no
-        annotations) - deployed versions get a running major number, undeployed
-        versions get a minor number that resets after each deployment, and
-        versions created before the first deployment are correctly numbered
-        under major "0".
-
-        2. That the production `list` endpoint path (`get_queryset()` +
-        `annotate_version_numbers()`) computes identical numbers via its
-        annotations (a subquery for the major number, a window for the minor),
-        and that reading those annotations during serialization fires zero
-        additional queries - i.e. the version numbers for a full page are
-        resolved without any N+1 query per version, which is the whole reason
-        this was implemented as an annotated queryset rather than per-object
-        lookups.
+        Also asserts that serializing a whole page costs exactly one query (the
+        memoized full-history label map), i.e. there is no N+1 per version.
         """
         asset = Asset.objects.create(asset_type='survey')
         # Remove the version created alongside the asset so we fully control
@@ -178,117 +186,97 @@ class AssetVersionTestCase(TestCase):
         asset.asset_versions.all().delete()
 
         base_date = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))
+        expected_by_uid = self._make_versions(
+            asset,
+            [
+                (False, '0.1'),  # undeployed change before any deployment
+                (True, '1'),     # first deployment
+                (True, '2'),     # second deployment
+                (False, '2.1'),  # form change after the 2nd deployment
+                (False, '2.2'),
+                (True, '3'),     # third deployment
+                (False, '3.1'),
+            ],
+            base_date,
+        )
 
-        # A chronological sequence of (deployed?, expected version_number)
-        sequence = [
-            (False, '0.1'),  # undeployed change before any deployment
-            (True, '1'),     # first deployment
-            (True, '2'),     # second deployment
-            (False, '2.1'),  # form change after the 2nd deployment
-            (False, '2.2'),
-            (True, '3'),     # third deployment
-            (False, '3.1'),
-        ]
-
-        expected_by_uid = {}
-        for index, (deployed, expected) in enumerate(sequence):
-            version = AssetVersion.objects.create(
-                asset=asset,
-                version_content={'survey': []},
-                deployed=deployed,
-            )
-            # `date_modified` is auto-set, so force a strictly increasing value
-            AssetVersion.objects.filter(pk=version.pk).update(
-                date_modified=base_date + timedelta(minutes=index)
-            )
-            expected_by_uid[version.uid] = expected
-
-        # The endpoint returns versions newest-first, and the version number
-        # must not depend on which page a version lands on
+        # A single serializer instance memoizes the label map per asset, so a
+        # whole page resolves in exactly one query - no per-row N+1
         serializer = AssetVersionListSerializer()
-
-        # Fallback path (e.g. the `retrieve` action): no `_version_major`
-        # annotation, so the major number is computed with a count query
-        computed_by_uid = {
-            version.uid: serializer.get_version_number(version)
-            for version in asset.asset_versions.all()
-        }
-        self.assertEqual(computed_by_uid, expected_by_uid)
-
-        # Production `list` path: both numbers arrive as window annotations, so
-        # serializing the whole page must not fire a single extra query (no
-        # N+1). One query fetches + computes the windows; serialization adds 0
-        view = AssetVersionViewSet()
-        view.action = 'list'
-        view.request = Request(RequestFactory().get('/'))
-        view._asset_uid = asset.uid
-        rows = list(view.get_queryset())
-        with self.assertNumQueries(0):
-            annotated_by_uid = {
+        rows = list(asset.asset_versions.all())
+        with self.assertNumQueries(1):
+            computed_by_uid = {
                 version.uid: serializer.get_version_number(version)
                 for version in rows
             }
-        self.assertEqual(annotated_by_uid, expected_by_uid)
-
-        # `retrieve` path: the major number is annotated (a filter-independent
-        # subquery) and the minor number falls back to a count query. It must
-        # match the numbers reported by `list` for every version
-        retrieve_view = AssetVersionViewSet()
-        retrieve_view.action = 'retrieve'
-        retrieve_view.request = Request(RequestFactory().get('/'))
-        retrieve_view._asset_uid = asset.uid
-        retrieve_by_uid = {
-            version.uid: serializer.get_version_number(version)
-            for version in retrieve_view.get_queryset()
-        }
-        self.assertEqual(retrieve_by_uid, expected_by_uid)
+        self.assertEqual(computed_by_uid, expected_by_uid)
 
     def test_version_number_with_deployed_filter(self):
         """
-        The version number must stay correct when the list is filtered with
-        `?deployed=`, even though that removes rows before the numbers are
-        computed. The major number is a filter-independent subquery, so drafts
-        keep the major of the deployment that precedes them (e.g. "2.1", not
-        "0.1")
+        The label is derived from the asset's full history, so it stays correct
+        even when the page is filtered with `?deployed=`: a draft keeps the
+        major of the deployment that precedes it (e.g. "2.1", not "0.1")
         """
         asset = Asset.objects.create(asset_type='survey')
         asset.asset_versions.all().delete()
         base_date = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))
-        # (deployed?, expected number when unfiltered)
-        sequence = [
-            (False, '0.1'),
-            (True, '1'),
-            (True, '2'),
-            (False, '2.1'),
-            (False, '2.2'),
-            (True, '3'),
-            (False, '3.1'),
-        ]
-        for index, (deployed, _expected) in enumerate(sequence):
-            version = AssetVersion.objects.create(
-                asset=asset, version_content={'survey': []}, deployed=deployed
-            )
-            AssetVersion.objects.filter(pk=version.pk).update(
-                date_modified=base_date + timedelta(minutes=index)
-            )
+        self._make_versions(
+            asset,
+            [
+                (False, '0.1'),
+                (True, '1'),
+                (True, '2'),
+                (False, '2.1'),
+                (False, '2.2'),
+                (True, '3'),
+                (False, '3.1'),
+            ],
+            base_date,
+        )
 
         serializer = AssetVersionListSerializer()
 
         def numbers_for(deployed):
-            # Mirror `get_queryset()` for a `?deployed=` request: the rows are
-            # filtered before the numbers are annotated
-            queryset = AssetVersionListSerializer.annotate_version_numbers(
-                AssetVersion.objects.filter(
-                    asset_id=asset.id, deployed=deployed
-                )
-            )
-            return [
-                serializer.get_version_number(version)
-                for version in queryset.order_by('date_modified', 'id')
-            ]
+            # Mirror `get_queryset()` for a `?deployed=` request: the page is
+            # filtered, but the label map still spans the full history
+            queryset = AssetVersion.objects.filter(
+                asset_id=asset.id, deployed=deployed
+            ).order_by('date_modified', 'id')
+            return [serializer.get_version_number(v) for v in queryset]
 
         self.assertEqual(numbers_for(False), ['0.1', '2.1', '2.2', '3.1'])
         self.assertEqual(numbers_for(True), ['1', '2', '3'])
+
+    def test_version_number_with_tied_timestamps(self):
+        """
+        Versions are ordered by `(date_modified, id)`, so even when several
+        share `date_modified` the numbering respects id (creation) order: a
+        draft ordered before a same-timestamp deployment stays under the
+        pre-deployment major and must not inflate the minor of the draft that
+        comes after the deployment
+        """
+        asset = Asset.objects.create(asset_type='survey')
+        asset.asset_versions.all().delete()
+        tied = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))
+        # All three share one timestamp; id order decides:
+        # draft-before, deployment, draft-after
+        expected_by_uid = self._make_versions(
+            asset,
+            [
+                (False, '0.1'),  # draft before the deployment
+                (True, '1'),     # deployment
+                (False, '1.1'),  # draft after the deployment (not "1.2")
+            ],
+            tied,
+            tied=True,
+        )
+
+        serializer = AssetVersionListSerializer()
+        numbers = {
+            version.uid: serializer.get_version_number(version)
+            for version in asset.asset_versions.all()
+        }
+        self.assertEqual(numbers, expected_by_uid)
 
     def test_version_date_modified(self):
         date_forced = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -1,14 +1,18 @@
 import json
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.utils import timezone
+
+from rest_framework.request import Request
 
 from formpack.utils.expand_content import SCHEMA_VERSION
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.exceptions import BadAssetTypeException
+from kpi.serializers.v2.asset_version import AssetVersionListSerializer
+from kpi.views.v2.asset_version import AssetVersionViewSet
 from kpi.utils.hash import calculate_hash
 from ..models import Asset, AssetVersion
 
@@ -145,6 +149,85 @@ class AssetVersionTestCase(TestCase):
 
         version.refresh_from_db()
         assert version._content_hash is not None
+
+    def test_version_number(self):
+        """
+        Test that `AssetVersionListSerializer.get_version_number()` returns the
+        correct major/minor version label ("1", "2.1", "3", etc.) for a realistic
+        chronological sequence of deployed and undeployed versions
+
+        This covers two separate concerns:
+        1. Correctness of the numbering logic itself, via the fallback path (no
+        window annotations) - deployed versions get a running major number,
+        undeployed versions get a minor number that resets after each
+        deployment, and versions created before the first deployment are
+        correctly numbered under major "0".
+
+        2. That the production `list` endpoint path (`get_queryset()` +
+        `annotate_version_numbers()`) computes identical numbers via window
+        function annotations, and that reading those annotations during
+        serialization fires zero additional queries - i.e. the version numbers
+        for a full page are resolved without any N+1 query per version, which
+        is the whole reason this was implemented as an annotated queryset
+        rather than per-object lookups.
+        """
+        asset = Asset.objects.create(asset_type='survey')
+        # Remove the version created alongside the asset so we fully control
+        # the sequence below
+        asset.asset_versions.all().delete()
+
+        base_date = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))
+
+        # A chronological sequence of (deployed?, expected version_number)
+        sequence = [
+            (False, '0.1'),  # undeployed change before any deployment
+            (True, '1'),     # first deployment
+            (True, '2'),     # second deployment
+            (False, '2.1'),  # form change after the 2nd deployment
+            (False, '2.2'),
+            (True, '3'),     # third deployment
+            (False, '3.1'),
+        ]
+
+        expected_by_uid = {}
+        for index, (deployed, expected) in enumerate(sequence):
+            version = AssetVersion.objects.create(
+                asset=asset,
+                version_content={'survey': []},
+                deployed=deployed,
+            )
+            # `date_modified` is auto-set, so force a strictly increasing value
+            AssetVersion.objects.filter(pk=version.pk).update(
+                date_modified=base_date + timedelta(minutes=index)
+            )
+            expected_by_uid[version.uid] = expected
+
+        # The endpoint returns versions newest-first, and the version number
+        # must not depend on which page a version lands on
+        serializer = AssetVersionListSerializer()
+
+        # Fallback path (e.g. the `retrieve` action): no `_version_major`
+        # annotation, so the major number is computed with a count query
+        computed_by_uid = {
+            version.uid: serializer.get_version_number(version)
+            for version in asset.asset_versions.all()
+        }
+        self.assertEqual(computed_by_uid, expected_by_uid)
+
+        # Production `list` path: both numbers arrive as window annotations, so
+        # serializing the whole page must not fire a single extra query (no
+        # N+1). One query fetches + computes the windows; serialization adds 0
+        view = AssetVersionViewSet()
+        view.action = 'list'
+        view.request = Request(RequestFactory().get('/'))
+        view._asset_uid = asset.uid
+        rows = list(view.get_queryset())
+        with self.assertNumQueries(0):
+            annotated_by_uid = {
+                version.uid: serializer.get_version_number(version)
+                for version in rows
+            }
+        self.assertEqual(annotated_by_uid, expected_by_uid)
 
     def test_version_date_modified(self):
         date_forced = datetime(2022, 1, 1, 0, 0, 0, tzinfo=ZoneInfo('UTC'))

--- a/kpi/views/v2/asset_version.py
+++ b/kpi/views/v2/asset_version.py
@@ -99,10 +99,20 @@ class AssetVersionViewSet(AssetNestedObjectViewsetMixin,
                 'uid', 'deployed', 'date_modified', 'asset_id', '_content_hash'
             )
             # Compute each version's major/minor number across every version of
-            # the asset in a single query (two window functions), evaluated
-            # before pagination slices the page so the numbers stay stable
-            # across pages and the serializer needs no per-row query
+            # the asset in a single query, evaluated before pagination slices
+            # the page so the numbers stay stable across pages and the
+            # serializer needs no per-row query. The major number is a
+            # filter-independent subquery, so it stays correct even under a
+            # `?deployed=` filter; the minor number is a window.
             _queryset = AssetVersionListSerializer.annotate_version_numbers(
+                _queryset
+            )
+        else:
+            # Other actions (e.g. `retrieve`) serialize a single object, where a
+            # window cannot see sibling rows; the major number, being a
+            # subquery, is still correct, and the minor number falls back to a
+            # count query in the serializer.
+            _queryset = AssetVersionListSerializer.annotate_major_number(
                 _queryset
             )
         # `AssetVersionListSerializer.get_url()` asks for the asset UID

--- a/kpi/views/v2/asset_version.py
+++ b/kpi/views/v2/asset_version.py
@@ -98,6 +98,13 @@ class AssetVersionViewSet(AssetNestedObjectViewsetMixin,
             _queryset = _queryset.only(
                 'uid', 'deployed', 'date_modified', 'asset_id', '_content_hash'
             )
+            # Compute each version's major/minor number across every version of
+            # the asset in a single query (two window functions), evaluated
+            # before pagination slices the page so the numbers stay stable
+            # across pages and the serializer needs no per-row query
+            _queryset = AssetVersionListSerializer.annotate_version_numbers(
+                _queryset
+            )
         # `AssetVersionListSerializer.get_url()` asks for the asset UID
         _queryset = _queryset.select_related('asset')
         return _queryset

--- a/kpi/views/v2/asset_version.py
+++ b/kpi/views/v2/asset_version.py
@@ -94,26 +94,11 @@ class AssetVersionViewSet(AssetNestedObjectViewsetMixin,
             _queryset = _queryset.filter(deployed=_deployed)
         if self.action == 'list':
             # Save time by only retrieving fields from the DB that the
-            # serializer will use
+            # serializer will use. The `version_number` is derived from the
+            # asset's full history by `AssetVersionListSerializer` (one memoized
+            # query per request), so no queryset annotation is needed here
             _queryset = _queryset.only(
                 'uid', 'deployed', 'date_modified', 'asset_id', '_content_hash'
-            )
-            # Compute each version's major/minor number across every version of
-            # the asset in a single query, evaluated before pagination slices
-            # the page so the numbers stay stable across pages and the
-            # serializer needs no per-row query. The major number is a
-            # filter-independent subquery, so it stays correct even under a
-            # `?deployed=` filter; the minor number is a window.
-            _queryset = AssetVersionListSerializer.annotate_version_numbers(
-                _queryset
-            )
-        else:
-            # Other actions (e.g. `retrieve`) serialize a single object, where a
-            # window cannot see sibling rows; the major number, being a
-            # subquery, is still correct, and the minor number falls back to a
-            # count query in the serializer.
-            _queryset = AssetVersionListSerializer.annotate_major_number(
-                _queryset
             )
         # `AssetVersionListSerializer.get_url()` asks for the asset UID
         _queryset = _queryset.select_related('asset')

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -33884,6 +33884,10 @@
                         "type": "string",
                         "format": "date-time",
                         "readOnly": true
+                    },
+                    "version_number": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -33891,7 +33895,8 @@
                     "date_deployed",
                     "date_modified",
                     "uid",
-                    "url"
+                    "url",
+                    "version_number"
                 ]
             },
             "VersionRetrieveResponse": {
@@ -33929,6 +33934,10 @@
                     "date_modified": {
                         "type": "string",
                         "format": "date-time",
+                        "readOnly": true
+                    },
+                    "version_number": {
+                        "type": "string",
                         "readOnly": true
                     },
                     "content": {
@@ -34002,7 +34011,8 @@
                     "date_deployed",
                     "date_modified",
                     "uid",
-                    "url"
+                    "url",
+                    "version_number"
                 ]
             },
             "historyExportResponse": {

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -24204,12 +24204,16 @@ components:
           type: string
           format: date-time
           readOnly: true
+        version_number:
+          type: string
+          readOnly: true
       required:
       - content_hash
       - date_deployed
       - date_modified
       - uid
       - url
+      - version_number
     VersionRetrieveResponse:
       type: object
       properties:
@@ -24235,6 +24239,9 @@ components:
         date_modified:
           type: string
           format: date-time
+          readOnly: true
+        version_number:
+          type: string
           readOnly: true
         content:
           type: object
@@ -24285,6 +24292,7 @@ components:
       - date_modified
       - uid
       - url
+      - version_number
     historyExportResponse:
       type: object
       properties:


### PR DESCRIPTION
### 📣 Summary
This PR adds a `version_number` field to the asset versions API, returning "12" for deployed versions and "11.4" for undeployed versions (numbered relative to the deployment that precedes them), computed server-side so the numbering stays correct regardless of pagination.

### 📖 Description
#### Why this needed to be done in the backend
The Form History UI (Project → Form tab) needs to label each version like v12, v11.4, etc. - deployed versions get a whole "major" number, and undeployed (draft) versions get a "minor" number counting up since the last deployment.

The frontend currently derives this from array index, which only works because the full list is loaded at once. We're moving this list to paginated infinite scroll, and a version's correct number depends on the entire history of the asset before it - not just the versions on the current page. The frontend has no way to know, from a single page of results, how many deployments happened earlier in history, so it can't reliably compute this itself once pagination is introduced. 

#### What changed
Added a `version_number` field to the versions serializer. For each request, we fetch the asset's full version history as a lightweight (id, deployed) list in a single ordered query, then walk it once in Python to build a map of version id → label: deployed versions increment the major number and reset the minor, undeployed versions increment the minor. The serializer looks up each row's label from that map, so both the paginated list endpoint and retrieve return identical, pagination-independent numbers with no per-row queries.

#### Why computed on the fly instead of stored on the model
I considered storing these numbers as columns on AssetVersion, populated at save time like the existing _content_hash field, but ruled it out because the table has millions of rows and would need a long, risky backfill migration for a display-only field. Version counts per asset are in the low hundreds in practice, so fetching two integer columns for one asset's history and looping over them is negligible work - it requires no migration and is automatically correct for all existing data. If per-asset version counts ever grow into the tens of thousands, the stored-column approach becomes worth revisiting; at current scale it isn't.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a form
2. deploy the form, edit it a few times (saving each time without deploying), then deploy it again, and make one more edit afterward without deploying
4. 🔴 [on main] notice that `/api/v2/assets/<uid>/versions/` doesn't return anything regarding version numbers
5. 🟢 [on PR] notice that `/api/v2/assets/<uid>/versions/` returns a version_number field on each version - a whole number (e.g. "2") for deployed versions, and a major.minor number (e.g. "2.1") for undeployed versions, numbered relative to the deployment that precedes them
6. Verify the retrieve endpoint as well.
