### PR TITLE
fix(submissions): use correct Mongo indexes on `root_uuid`/`_uuid` fields INFRA-551

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.db.models import Q
 from pymongo import UpdateOne
 
 from kobo.apps.long_running_migrations.exceptions import (
@@ -9,7 +8,6 @@ from kobo.apps.long_running_migrations.models import LongRunningMigration
 from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import add_uuid_prefix
 from kpi.utils.log import logging
-
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
 

--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -25,11 +25,7 @@ def run():
     while True:
         query = {
             '_id': {'$gt': last_id},
-            '$or': [
-                {'meta/rootUuid': {'$exists': False}},
-                {'meta/rootUuid': None},
-                {'meta/rootUuid': ''},
-            ],
+            'meta/rootUuid': {'$exists': False},
         }
 
         # Paginate forward by _id to guarantee no infinite loops
@@ -54,10 +50,10 @@ def run():
 def _check_lrm_0027_is_completed():
     """
     Raises `LongRunningMigrationDependencyError` if LRM 0027 has not yet
-    reached a terminal state (completed or failed).
+    reached a terminal state (i.e.: completed).
     """
     if not LongRunningMigration.objects.filter(
-        Q(status='completed') | Q(status='failed'),
+        status='completed',
         name__startswith='0027',
     ).exists():
         raise LongRunningMigrationDependencyError(

--- a/kpi/views/v2/data.py
+++ b/kpi/views/v2/data.py
@@ -1121,12 +1121,12 @@ class DataViewSet(
                     {'query': t('Value must be valid JSON.')}
                 )
             # Older data may have `meta/rootUuid` set to NULL.
-            # The long-running migration `0005` is responsible for backfilling
-            # `meta/rootUuid` for all existing submissions.
+            # The long-running migrations `0005`, `0027`, `0028`) are responsible for
+            # backfilling `meta/rootUuid` for all existing submissions.
             #
             # Until this migration is fully applied everywhere, we must fall back
-            # to `meta/instanceID`. This fallback is temporary and potentially
-            # unsafe because `instanceID` is NOT guaranteed to be unique per project.
+            # to `_uuid`. This fallback is temporary and potentially
+            # unsafe because `_uuid` is NOT guaranteed to be unique per project.
             #
             # Once all submissions have a populated `meta/rootUuid`, this `$or`
             # condition can be removed and lookups should rely exclusively on
@@ -1135,7 +1135,7 @@ class DataViewSet(
             uuid_query = {
                 '$or': [
                     {'meta/rootUuid': submission_id_or_root_uuid},
-                    {'meta/instanceID': submission_id_or_root_uuid},
+                    {'_uuid': remove_uuid_prefix(submission_id_or_root_uuid)},
                 ]
             }
 


### PR DESCRIPTION
### 👷 Description for instance maintainers

This is the application-side counterpart to kobotoolbox/kobo-docker#381, which reworks the MongoDB indexes on the `instances` collection (drops indexes that only backed dead code, adds indexes matching how the app actually queries `meta/rootUuid`/`_uuid`). Both PRs should land together on an instance.

Two changes here:

- `kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py`: simplifies the "still missing root_uuid" query to a plain `meta/rootUuid: {$exists: False}` (was also matching `None`/`''`, which the backfill never produces), matching the shape of the new `id_rootUuid_idx` index from kobo-docker#381. Also tightens `_check_lrm_0027_is_completed` to require LRM 0027's status to be strictly `completed` before 0028 runs, instead of accepting `completed` or `failed`.
- `kpi/views/v2/data.py` (`_get_submission_by_id_or_root_uuid`): the legacy UUID-lookup fallback now queries `_uuid` instead of `meta/instanceID`, matching the `{_userform_id, _uuid}` index added in kobotoolbox/kobo-docker#381 rather than relying on an index we're retiring.

### 💭 Notes

Related to kobotoolbox/kobo-docker#381. 