### PR TITLE
fix(longRunningMigrations): persist LRM 0027/0028 cursor DEV-2427

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -2,6 +2,7 @@
 
 from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
+from django.core.cache import cache
 from django.core.management import call_command
 from django.db import IntegrityError
 from django.db.models import Q
@@ -19,6 +20,7 @@ from kpi.utils.log import logging
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
 FAILED_TAG = 'kobo-root-uuid-failed-0027'
+LAST_XFORM_ID_CACHE_KEY = 'lrm_0027_last_xform_id'
 
 
 def run():
@@ -37,11 +39,18 @@ def run():
 
     _check_lrm_0005_is_completed()
 
-    last_xform_id = 0
+    # Persisted across Celery restarts: instances belonging to XForms this job
+    # permanently skips (pending_delete, or tagged failed) never get a
+    # `root_uuid`, so they always match the query in `get_xforms_queryset`.
+    # Without a persisted cursor, every restart would re-scan past them from
+    # XForm pk 0, potentially never reaching a fully empty batch within a
+    # single run.
+    last_xform_id = cache.get(LAST_XFORM_ID_CACHE_KEY, 0)
     with use_db(settings.OPENROSA_DB_ALIAS):
         while True:
-            xforms, last_xform_id = get_xforms_queryset(last_xform_id)
-            if last_xform_id == -1:
+            xforms, next_xform_id = get_xforms_queryset(last_xform_id)
+            if next_xform_id == -1:
+                cache.delete(LAST_XFORM_ID_CACHE_KEY)
                 break
             for xform in xforms:
                 logging.info(
@@ -57,6 +66,13 @@ def run():
                     logging.info(
                         f'[LRM 0027] - XForm #{xform.pk} ({xform.id_string}) - Done'
                     )
+
+            # Only advance the persisted cursor once every XForm in this batch
+            # has reached a terminal outcome (done or tagged failed), so a
+            # crash mid-batch re-processes the same small batch on restart
+            # instead of permanently skipping whatever wasn't finished yet.
+            last_xform_id = next_xform_id
+            cache.set(LAST_XFORM_ID_CACHE_KEY, last_xform_id, timeout=None)
 
 
 def get_instances_queryset(xform_id: int) -> QuerySet:

--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models import Q
 from pymongo import UpdateOne
 
@@ -12,6 +13,7 @@ from kpi.utils.log import logging
 
 
 CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE
+LAST_ID_CACHE_KEY = 'lrm_0028_last_id'
 
 
 def run():
@@ -21,7 +23,12 @@ def run():
     """
     _check_lrm_0027_is_completed()
 
-    last_id = 0
+    # Persisted across Celery restarts: instances belonging to XForms that LRM
+    # 0027 permanently skips (pending_delete, or tagged failed) never get
+    # `meta/rootUuid` set, so they always match the query below. Without a
+    # persisted cursor, every restart would re-scan past them from `_id` 0,
+    # potentially never reaching a fully empty batch within a single run.
+    last_id = cache.get(LAST_ID_CACHE_KEY, 0)
     while True:
         query = {
             '_id': {'$gt': last_id},
@@ -42,6 +49,7 @@ def run():
         docs = list(cursor)
 
         if not docs:
+            cache.delete(LAST_ID_CACHE_KEY)
             break
 
         logging.info(
@@ -49,6 +57,7 @@ def run():
         )
         _process_batch(docs)
         last_id = docs[-1]['_id']
+        cache.set(LAST_ID_CACHE_KEY, last_id, timeout=None)
 
 
 def _check_lrm_0027_is_completed():

--- a/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0028_sync_mongo_root_uuid.py
@@ -77,10 +77,13 @@ def _check_lrm_0027_is_completed():
 def _process_batch(docs: list):
     doc_ids = [doc['_id'] for doc in docs]
 
-    # Only fetch Postgres records that actually have a root_uuid populated
+    # Only fetch Postgres records that actually have a root_uuid populated,
+    # excluding trashed XForms: LRM 0027 never backfills them, but a race with
+    # some other write path could leave `root_uuid` set without us wanting to
+    # push it to Mongo for a project that's being deleted.
     instances_map = dict(
         Instance.objects.filter(
-            pk__in=doc_ids, root_uuid__isnull=False
+            pk__in=doc_ids, root_uuid__isnull=False, xform__pending_delete=False
         ).values_list('pk', 'root_uuid')
     )
 

--- a/kobo/apps/long_running_migrations/tests/test_backfill_root_uuid.py
+++ b/kobo/apps/long_running_migrations/tests/test_backfill_root_uuid.py
@@ -6,21 +6,33 @@ from django.core.management.base import CommandError
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 
-job = importlib.import_module(
+job_0027 = importlib.import_module(
     'kobo.apps.long_running_migrations.jobs.0027_backfill_remaining_root_uuid'
+)
+job_0028 = importlib.import_module(
+    'kobo.apps.long_running_migrations.jobs.0028_sync_mongo_root_uuid'
 )
 
 
 class BackfillRemainRootUuidTestCase(SimpleTestCase):
+    """
+    Also covers the Redis-persisted pagination cursor: instances belonging to
+    XForms this job permanently skips (pending_delete, or tagged failed)
+    never get a `root_uuid`, so a plain in-memory cursor would re-scan past
+    them from XForm pk 0 on every Celery restart, potentially never reaching
+    a fully empty batch within a single run.
+    """
 
     def test_direct_timeout_propagates_without_tagging(self):
         xform = self._mock_xform()
-        with patch.object(job, 'call_command', side_effect=SoftTimeLimitExceeded()):
+        with patch.object(
+            job_0027, 'call_command', side_effect=SoftTimeLimitExceeded()
+        ):
             with patch.object(
-                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+                job_0027.Instance.objects, 'bulk_update', side_effect=IntegrityError()
             ):
                 with self.assertRaises(SoftTimeLimitExceeded):
-                    job._process_instances_batch(xform, self._mock_queryset())
+                    job_0027._process_instances_batch(xform, self._mock_queryset())
         xform.tags.add.assert_not_called()
 
     def test_finds_timeout_nested_deep(self):
@@ -29,13 +41,13 @@ class BackfillRemainRootUuidTestCase(SimpleTestCase):
         inner.__context__ = timeout
         outer = CommandError('outer')
         outer.__context__ = inner
-        assert job._find_timeout_in_chain(outer) is timeout
+        assert job_0027._find_timeout_in_chain(outer) is timeout
 
     def test_finds_timeout_wrapped_in_cause(self):
         timeout = TimeLimitExceeded()
         exc = CommandError('wrapped')
         exc.__cause__ = timeout
-        assert job._find_timeout_in_chain(exc) is timeout
+        assert job_0027._find_timeout_in_chain(exc) is timeout
 
     def test_finds_timeout_wrapped_in_context(self):
         timeout = SoftTimeLimitExceeded()
@@ -45,38 +57,88 @@ class BackfillRemainRootUuidTestCase(SimpleTestCase):
             except SoftTimeLimitExceeded:
                 raise CommandError('wrapped')
         except CommandError as exc:
-            assert job._find_timeout_in_chain(exc) is timeout
+            assert job_0027._find_timeout_in_chain(exc) is timeout
 
     def test_returns_direct_soft_time_limit(self):
         exc = SoftTimeLimitExceeded()
-        assert job._find_timeout_in_chain(exc) is exc
+        assert job_0027._find_timeout_in_chain(exc) is exc
 
     def test_returns_direct_time_limit(self):
         exc = TimeLimitExceeded()
-        assert job._find_timeout_in_chain(exc) is exc
+        assert job_0027._find_timeout_in_chain(exc) is exc
 
     def test_returns_none_when_no_timeout(self):
         exc = CommandError('just a data error')
-        assert job._find_timeout_in_chain(exc) is None
+        assert job_0027._find_timeout_in_chain(exc) is None
+
+    def test_run_deletes_cursor_on_completion(self):
+        with patch.object(job_0027, '_check_lrm_0005_is_completed'), \
+                patch.object(job_0027, 'use_db'), \
+                patch.object(job_0027, 'cache') as mock_cache, \
+                patch.object(
+                    job_0027, 'get_xforms_queryset', return_value=([], -1)
+                ):
+            mock_cache.get.return_value = 0
+            job_0027.run()
+
+        mock_cache.delete.assert_called_once_with(job_0027.LAST_XFORM_ID_CACHE_KEY)
+        mock_cache.set.assert_not_called()
+
+    def test_run_persists_cursor_only_after_batch_fully_processed(self):
+        xform_a = self._mock_xform()
+        xform_b = self._mock_xform()
+        with patch.object(job_0027, '_check_lrm_0005_is_completed'), \
+                patch.object(job_0027, 'use_db'), \
+                patch.object(job_0027, 'cache') as mock_cache, \
+                patch.object(
+                    job_0027,
+                    'get_xforms_queryset',
+                    side_effect=[([xform_a, xform_b], 99), ([], -1)],
+                ), \
+                patch.object(job_0027, 'get_instances_queryset', return_value=None):
+            mock_cache.get.return_value = 0
+            job_0027.run()
+
+        # `cache.set` must not fire until both XForms in the batch are done,
+        # not once per XForm.
+        mock_cache.set.assert_called_once_with(
+            job_0027.LAST_XFORM_ID_CACHE_KEY, 99, timeout=None
+        )
+        mock_cache.delete.assert_called_once_with(job_0027.LAST_XFORM_ID_CACHE_KEY)
+
+    def test_run_resumes_from_persisted_cursor(self):
+        with patch.object(job_0027, '_check_lrm_0005_is_completed'), \
+                patch.object(job_0027, 'use_db'), \
+                patch.object(job_0027, 'cache') as mock_cache, \
+                patch.object(
+                    job_0027, 'get_xforms_queryset', return_value=([], -1)
+                ) as mock_get_xforms:
+            mock_cache.get.return_value = 42
+            job_0027.run()
+
+        mock_cache.get.assert_called_once_with(job_0027.LAST_XFORM_ID_CACHE_KEY, 0)
+        mock_get_xforms.assert_called_once_with(42)
 
     def test_stops_on_context_cycle(self):
         first = ValueError('first')
         second = ValueError('second')
         first.__context__ = second
         second.__context__ = first
-        assert job._find_timeout_in_chain(first) is None
+        assert job_0027._find_timeout_in_chain(first) is None
 
     def test_unrecoverable_error_tags_failed(self):
         xform = self._mock_xform()
         with patch.object(
-            job, 'call_command', side_effect=CommandError('genuine data error')
+            job_0027, 'call_command', side_effect=CommandError('genuine data error')
         ):
             with patch.object(
-                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+                job_0027.Instance.objects, 'bulk_update', side_effect=IntegrityError()
             ):
-                result = job._process_instances_batch(xform, self._mock_queryset())
+                result = job_0027._process_instances_batch(
+                    xform, self._mock_queryset()
+                )
         assert result is False
-        xform.tags.add.assert_called_once_with(job.FAILED_TAG)
+        xform.tags.add.assert_called_once_with(job_0027.FAILED_TAG)
 
     def test_wrapped_timeout_propagates_without_tagging(self):
         xform = self._mock_xform()
@@ -85,12 +147,12 @@ class BackfillRemainRootUuidTestCase(SimpleTestCase):
             'command has completed with errors: SoftTimeLimitExceeded()'
         )
         wrapped.__cause__ = timeout
-        with patch.object(job, 'call_command', side_effect=wrapped):
+        with patch.object(job_0027, 'call_command', side_effect=wrapped):
             with patch.object(
-                job.Instance.objects, 'bulk_update', side_effect=IntegrityError()
+                job_0027.Instance.objects, 'bulk_update', side_effect=IntegrityError()
             ):
                 with self.assertRaises(SoftTimeLimitExceeded):
-                    job._process_instances_batch(xform, self._mock_queryset())
+                    job_0027._process_instances_batch(xform, self._mock_queryset())
         xform.tags.add.assert_not_called()
 
     @staticmethod
@@ -105,3 +167,61 @@ class BackfillRemainRootUuidTestCase(SimpleTestCase):
         xform.pk = 1
         xform.id_string = 'a_form'
         return xform
+
+
+class SyncMongoRootUuidCursorTestCase(SimpleTestCase):
+    """
+    Covers the Redis-persisted pagination cursor: instances belonging to
+    XForms LRM 0027 permanently skips (pending_delete, or tagged failed)
+    never get `meta/rootUuid` set, so a plain in-memory cursor would re-scan
+    past them from `_id` 0 on every Celery restart, potentially never
+    reaching a fully empty batch within a single run.
+
+    `settings.MONGO_DB` is already `mongomock` in the test environment (see
+    `kobo/settings/testing.py`), so these hit it directly instead of mocking
+    the pymongo call chain.
+    """
+
+    def setUp(self):
+        super().setUp()
+        job_0028.settings.MONGO_DB.instances.delete_many({})
+
+    def test_run_deletes_cursor_on_completion(self):
+        with patch.object(job_0028, '_check_lrm_0027_is_completed'), \
+                patch.object(job_0028, 'cache') as mock_cache:
+            mock_cache.get.return_value = 0
+            job_0028.run()
+
+        mock_cache.delete.assert_called_once_with(job_0028.LAST_ID_CACHE_KEY)
+        mock_cache.set.assert_not_called()
+
+    def test_run_persists_cursor_after_batch(self):
+        job_0028.settings.MONGO_DB.instances.insert_many(
+            [{'_id': 10}, {'_id': 20}]
+        )
+        with patch.object(job_0028, '_check_lrm_0027_is_completed'), \
+                patch.object(job_0028, 'cache') as mock_cache, \
+                patch.object(job_0028, '_process_batch') as mock_process_batch:
+            mock_cache.get.return_value = 0
+            job_0028.run()
+
+        processed_ids = [doc['_id'] for doc in mock_process_batch.call_args[0][0]]
+        assert processed_ids == [10, 20]
+        mock_cache.set.assert_called_once_with(
+            job_0028.LAST_ID_CACHE_KEY, 20, timeout=None
+        )
+        mock_cache.delete.assert_called_once_with(job_0028.LAST_ID_CACHE_KEY)
+
+    def test_run_resumes_from_persisted_cursor(self):
+        job_0028.settings.MONGO_DB.instances.insert_many(
+            [{'_id': 42}, {'_id': 50}]
+        )
+        with patch.object(job_0028, '_check_lrm_0027_is_completed'), \
+                patch.object(job_0028, 'cache') as mock_cache, \
+                patch.object(job_0028, '_process_batch') as mock_process_batch:
+            mock_cache.get.return_value = 42
+            job_0028.run()
+
+        # `_id` 42 was already seen before the restart; only 50 should surface.
+        processed_ids = [doc['_id'] for doc in mock_process_batch.call_args[0][0]]
+        assert processed_ids == [50]


### PR DESCRIPTION
### 📣 Summary

Fixed a background data-repair job that could stall without making progress after a restart.

### 📖 Description

Two background migration jobs (LRM 0027 and 0028) backfill a stable identifier (`root_uuid`) for old submissions. They kept track of how far they'd gotten with an in-memory position that reset to the very beginning every time the job restarted, so a restart could waste a lot of time re-checking records it had already confirmed didn't need any work, instead of making forward progress. This position is now saved outside the job, so a restart picks up where it left off.

### 💭 Notes

Root cause: `last_xform_id` (0027) and `last_id` (0028) were plain local variables. Submissions belonging to XForms these jobs permanently skip (`pending_delete`, or tagged `kobo-root-uuid-failed-0027`) never get a `root_uuid`/`meta/rootUuid`, so they always match the "still needs backfill" query — every restart re-scanned past the same permanently-skipped records before reaching new work, which could prevent either job from ever completing a full pass in practice.

Both cursors are now persisted in Redis (`cache`, no TTL, cleared on natural completion). For 0027, the cursor only advances once every XForm in the current batch has reached a terminal outcome, so a crash mid-batch re-processes that small batch on restart instead of permanently skipping whatever wasn't finished. For 0028, the cursor advances right after each batch is processed, same as before.

Also excludes trashed XForms from LRM 0028's Postgres lookup (`xform__pending_delete=False`), for symmetry with LRM 0027's own exclusion.

### 👀 Preview steps

Project A: a few submissions. Project B: ~5000 via mockobo.

```python
import importlib
from django.conf import settings
from kobo.apps.openrosa.apps.logger.models import Instance, XForm

Instance.objects.all().update(root_uuid=None)

job_0027 = importlib.import_module(
    'kobo.apps.long_running_migrations.jobs.0027_backfill_remaining_root_uuid'
)
```

Add `print(last_xform_id)` right after the `last_xform_id = ` line in `0027_backfill_remaining_root_uuid.py`.

```python
job_0027.run()  # Ctrl+C after a few XForms log "Done"
job_0027.run()  # again
```

🔴 `release/2.026.30`: prints `0` both times.
🟢 this PR: 2nd call prints the xform pk it left off at.

Let 0027 finish, then:

```python
settings.MONGO_DB.instances.update_many(
    {'_userform_id': '<username>_<B_id_string>'},
    {'$unset': {'meta/rootUuid': ''}},
)

job_0028 = importlib.import_module(
    'kobo.apps.long_running_migrations.jobs.0028_sync_mongo_root_uuid'
)
```

Add `print(last_id)` right after the first `last_id = ...` line in `0028_sync_mongo_root_uuid.py`.

```python
job_0028.run()  # Ctrl+C mid-scan
job_0028.run()  # again
```

🔴 `release/2.026.30`: prints `0` both times.
🟢 this PR: 2nd call prints the `_id` it left off at.

Let both finish:

```python
from django.core.cache import cache
cache.get('lrm_0027_last_xform_id')  # None
cache.get('lrm_0028_last_id')  # None
```