### PR TITLE
fix(tags): return each tag once from `/api/v2/tags/` DEV-1576

### DIFF
--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -44,7 +44,6 @@ class TagListTestCase(BaseTagTestCase):
         assert response.data['count'] == 1
         assert response.data['results'][0]['name'] == self.tag.name
 
-
     def test_user_cannot_see_others(self):
         self.client.login(username='anotheruser', password='anotheruser')
         response = self.client.get(self.url)

--- a/kpi/tests/api/v2/test_api_tags.py
+++ b/kpi/tests/api/v2/test_api_tags.py
@@ -32,6 +32,19 @@ class TagListTestCase(BaseTagTestCase):
         assert response.data['count'] == 1
         assert response.data['results'][0]['name'] == self.tag.name
 
+    def test_tag_shared_by_several_assets_is_returned_once(self):
+        other_asset = Asset.objects.create(
+            owner=User.objects.get(username='someuser')
+        )
+        other_asset.tags.add(self.tag)
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['name'] == self.tag.name
+
+
     def test_user_cannot_see_others(self):
         self.client.login(username='anotheruser', password='anotheruser')
         response = self.client.get(self.url)

--- a/kpi/views/v2/tag.py
+++ b/kpi/views/v2/tag.py
@@ -63,7 +63,7 @@ class TagViewSet(viewsets.ReadOnlyModelViewSet):
         return Tag.objects.filter(
             taggit_taggeditem_items__content_type=content_type,
             taggit_taggeditem_items__object_id__in=[accessible_asset_pks],
-        )
+        ).distinct()
 
     def get_serializer_class(self):
         if self.action == 'list':


### PR DESCRIPTION
### 📣 Summary
`TagViewSet.get_queryset()` filters across the `taggit_taggeditem` join table, so a tag attached to N accessible assets was emitted N times, `.distinct()` collapses it back to one row per tag. 

### 📖 Description
`TagViewSet.get_queryset()` filters `Tag` on `taggit_taggeditem_items__*` to restrict tags to assets the user may view. Because that filter spans a multi-valued relationship, the underlying SQL joins `taggit_tag` onto `taggit_taggeditem` and returns one row per tag/asset pairing so a tag applied to two accessible assets came back twice, with an identica `name` and `url`.                                                                                                                                                                            

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ Log in and create two library items.
2. Add the same tag (e.g. `foo`) to both via the "Edit tags" action.
3. Visit `/api/v2/tags/`
4. 🔴 [on main] `foo` is listed twice and `count` is `2`
5. 🟢 [on PR] `foo` is listed once and `count` is `1`
