### PR TITLE
fix(darker): fail the linter job when darker crashes DEV-1034

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -41,14 +41,23 @@ jobs:
           MERGE_PARENTS=($(git rev-list --parents -1 ${{ github.sha }}))
           LATEST_IN_BASE_BRANCH=${MERGE_PARENTS[1]}
 
+          if [[ -z "$LATEST_IN_BASE_BRANCH" ]]; then
+            echo "::error::Could not resolve the base-branch SHA from ${{ github.sha }}."
+            exit 1
+          fi
+
           # Run darker. (https://github.com/akaihola/darker)
           # -L runs the linter
           #  `--ignore=F821` avoids raising false positive error in typing
           #   annotations with string, e.g. def my_method(my_model: 'ModelName')
           # -r REV specifies a commit to compare with the worktree
-          output=$(darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH)
-
-          # darker still exits with code 1 even with no errors on changes
-          # So, make this fail CI only if there is output from darker.
-          [[ -n "$output" ]] && echo "$output" && exit 1 || exit 0
-        shell: /usr/bin/bash {0}
+          #
+          # Let darker's exit code decide: it is 0 when there is nothing to
+          # report, and non-zero both for findings and for crashes (bad
+          # revision, missing linter, …). Do not capture the output — darker
+          # writes crash details to stderr, so capturing stdout and testing it
+          # for emptiness makes every crash look like a pass.
+          darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH
+        # `bash` (not a bare `/usr/bin/bash`) so the step keeps `-e -o pipefail`
+        # and aborts on the first failing command.
+        shell: bash


### PR DESCRIPTION
### 📣 Summary

No user-facing change — this fixes an internal code-quality check that was reporting success even when it had not actually run.

### 📖 Description

The automated Python style check that runs on every code change could fail to start and still report a green result, so problems it was meant to catch could slip through unnoticed. It now reports a clear failure whenever it cannot complete.

### 💭 Notes

The step captured darker's stdout and failed only when that string was non-empty. Darker writes crash details to **stderr**, so every crash produced empty stdout and took the `|| exit 0` branch. `shell: /usr/bin/bash {0}` also dropped GitHub's default `-e -o pipefail`, so nothing else could abort the step either.

- Trust darker's exit code instead of sniffing stdout — measured on the pinned `darker[isort]==2.1.1`: clean run exits **0**, findings and crashes exit non-zero.
- The comment justifying the workaround ("darker still exits with code 1 even with no errors") is stale and no longer true; removed so it doesn't invite a re-fix.
- `shell: bash` (keyword form) restores `-e -o pipefail`.
- Added an explicit guard for an unresolvable base SHA: `git rev-list` *succeeds* on a parentless commit, so `set -e` alone wouldn't catch it.

Verified locally against a scratch repo under `bash --noprofile --norc -eo pipefail`:

| Scenario | rc | before | after |
|---|---|---|---|
| clean tree | 0 | ✅ pass | ✅ pass |
| bad formatting / flake8 finding | 1 | ❌ fail | ❌ fail |
| unknown revision | 128 | ✅ **silent pass** | ❌ fail |
| flake8 binary missing | 1 | ✅ **silent pass** | ❌ fail |
| darker binary missing | 127 | ✅ **silent pass** | ❌ fail |
| bad darker flag | 2 | ✅ **silent pass** | ❌ fail |
| base SHA unresolvable | — | ✅ **silent pass** | ❌ fail + `::error::` |

Follow-up to #6263, which pinned darker but left the silent-pass wrapper in place. `darker.yml` was the only workflow with this pattern; `pytest.yml`'s `continue-on-error` steps are re-failed explicitly downstream.

### 👀 Preview steps

1. ℹ️ open a PR touching any `.py` file under `kpi/`, `kobo/` or `hub/`
2. temporarily break the step in `.github/workflows/darker.yml` — e.g. change the linter to `flake8-does-not-exist`
3. 🔴 [on main] the **Python linter (Darker)** job is green; the traceback is only visible by opening the step logs
4. 🟢 [on PR] the job fails and blocks the PR, with the traceback in the log
5. revert the temporary break
6. 🟢 introduce a real style error (e.g. `z=3`) and notice the job still fails as before
7. 🟢 with clean code, notice the job passes as before
