### PR TITLE
fix(analytics): update gtag function declaration DEV-2501

### DIFF
--- a/jsapp/js/main.js
+++ b/jsapp/js/main.js
@@ -75,7 +75,8 @@ moment.locale(currentLang())
 const gaTokenEl = document.head.querySelector('meta[name=google-analytics-token]')
 if (gaTokenEl !== null && gaTokenEl.content) {
   window.dataLayer = window.dataLayer || []
-  window.gtag = () => {
+  // biome-ignore lint/complexity/useArrowFunction: arrow functions lack `arguments`
+  window.gtag = function () {
     window.dataLayer.push(arguments)
   }
   window.gtag('js', new Date())


### PR DESCRIPTION
### 💭 Notes
`window.gtag` was defined as an arrow function, but arrow functions don't have their own arguments object. This resulted in using the (non-existent) arguments from the enclosing scope rather than the gtag call's own parameters. The result was that all GA4 tracking calls were broken, so no analytics data was being sent. Changed to a regular function () declaration, which has its own arguments object as the gtag pattern requires. 

### 👀 Preview steps
1. Launch kobo install with `GOOGLE_ANALYTICS_TOKEN=G-FAKETOKEN123` in kpi service env
2. Log in to app
3. 🔴 [on main] Check network tab and see no requests sent to analytics
4. 🟢 [on PR] Verify request sent to analytics
