### PR TITLE
feat(bulkProcessing): disable bulk option if no data DEV-2496 DEV-2499

### DIFF
--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
@@ -1,6 +1,7 @@
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import { getSupplementalPathParts } from '#/components/processing/processingUtils'
+import { hasTranscribableAudio, hasTranslatableTranscript } from '#/components/submissions/bulkProcessingUtils'
 import type { AlertEvaluationContext, AlertEvaluationResult } from './types'
 
 /**
@@ -175,23 +176,12 @@ export function evaluateNoSource(context: AlertEvaluationContext): AlertEvaluati
       return
     }
 
-    let hasSource = false
-
-    if (actionType === 'transcript') {
-      // For transcription: check if there's an audio attachment for this field
-      hasSource =
-        submission._attachments?.some(
-          (attachment) => attachment.question_xpath === fieldXpath && !attachment.is_deleted,
-        ) ?? false
-    } else {
-      // For translation: check if there's a transcript
-      // Note 1: we assume here that there can be only one transcript
-      // Note 2: `fieldXpath` can be question xpath for transcript case, but for translation case it would be path to
-      // supplementalDetails, but we need to compare it to question xpath, so we use utility function
-      const { sourceRowPath } = getSupplementalPathParts(fieldXpath)
-      const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
-      hasSource = Boolean(transcript?.value)
-    }
+    // Both checks are shared with the ones gating the matching table header menu
+    // items, so the menu and this alert can't disagree on what has a source.
+    const hasSource =
+      actionType === 'transcript'
+        ? hasTranscribableAudio(submission, fieldXpath)
+        : hasTranslatableTranscript(submission, fieldXpath)
 
     if (!hasSource) {
       missingSource.push(submission._uuid)

--- a/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
@@ -2,10 +2,14 @@ import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
-import type { SubmissionResponse } from '#/dataInterface'
+import type { SubmissionAttachment, SubmissionResponse } from '#/dataInterface'
 import {
   getBulkProcessingColumnKey,
   getVisibleBulkProcessingSubmissionUuidsToRefresh,
+  hasAnyTranscribableAudio,
+  hasAnyTranslatableTranscript,
+  hasTranscribableAudio,
+  hasTranslatableTranscript,
   isBulkProcessingCellInProgress,
 } from './bulkProcessingUtils'
 
@@ -161,5 +165,209 @@ describe('bulkProcessingUtils', () => {
     const test = getVisibleBulkProcessingSubmissionUuidsToRefresh(prev, [], [notVisibleSubmission])
 
     chai.expect(test).to.deep.equal([])
+  })
+
+  describe('hasTranscribableAudio', () => {
+    const audioQuestionXpath = 'Secret_password_as_an_audio_file'
+
+    function buildSubmission(attachments?: Array<Partial<SubmissionAttachment>>) {
+      return {
+        ...submission,
+        _attachments: attachments,
+      } as SubmissionResponse
+    }
+
+    it('should return true for an attachment of given question', () => {
+      const test = hasTranscribableAudio(
+        buildSubmission([{ question_xpath: audioQuestionXpath, uid: 'att1' }]),
+        audioQuestionXpath,
+      )
+
+      chai.expect(test).to.be.true
+    })
+
+    it('should return false for a deleted attachment', () => {
+      const test = hasTranscribableAudio(
+        buildSubmission([{ question_xpath: audioQuestionXpath, uid: 'att1', is_deleted: true }]),
+        audioQuestionXpath,
+      )
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false for an attachment of another question', () => {
+      const test = hasTranscribableAudio(
+        buildSubmission([{ question_xpath: 'Some_other_question', uid: 'att1' }]),
+        audioQuestionXpath,
+      )
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false when there are no attachments at all', () => {
+      chai.expect(hasTranscribableAudio(buildSubmission([]), audioQuestionXpath)).to.be.false
+      chai.expect(hasTranscribableAudio(buildSubmission(), audioQuestionXpath)).to.be.false
+    })
+  })
+
+  describe('hasAnyTranscribableAudio', () => {
+    const audioQuestionXpath = 'Secret_password_as_an_audio_file'
+
+    const audioSubmission = {
+      ...submission,
+      _attachments: [{ question_xpath: audioQuestionXpath, uid: 'att1' }],
+    } as SubmissionResponse
+
+    const deletedAudioSubmission = {
+      ...submission,
+      _uuid: 'deleted-audio-uuid',
+      _attachments: [{ question_xpath: audioQuestionXpath, uid: 'att2', is_deleted: true }],
+    } as SubmissionResponse
+
+    const noAudioSubmission = {
+      ...submission,
+      _uuid: 'no-audio-uuid',
+      _attachments: [],
+    } as SubmissionResponse
+
+    it('should return false for an empty selection', () => {
+      chai.expect(hasAnyTranscribableAudio([], audioQuestionXpath)).to.be.false
+    })
+
+    it('should return false when no selected submission has audio', () => {
+      const test = hasAnyTranscribableAudio([noAudioSubmission, deletedAudioSubmission], audioQuestionXpath)
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return true when at least one submission has audio', () => {
+      const test = hasAnyTranscribableAudio(
+        [noAudioSubmission, deletedAudioSubmission, audioSubmission],
+        audioQuestionXpath,
+      )
+
+      chai.expect(test).to.be.true
+    })
+  })
+
+  describe('hasTranslatableTranscript', () => {
+    const transcriptColumnKey = '_supplementalDetails/Secret_password_as_an_audio_file/transcript_en'
+
+    function buildSubmission(supplementalDetails?: SubmissionResponse['_supplementalDetails']) {
+      return {
+        ...submission,
+        _supplementalDetails: supplementalDetails,
+      } as SubmissionResponse
+    }
+
+    it('should return true for an approved transcript', () => {
+      const test = hasTranslatableTranscript(
+        buildSubmission({
+          Secret_password_as_an_audio_file: {
+            transcript: { languageCode: 'en', value: 'Hello world' },
+          },
+        }),
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.true
+    })
+
+    it('should return false for a transcript still awaiting approval', () => {
+      const test = hasTranslatableTranscript(
+        buildSubmission({
+          Secret_password_as_an_audio_file: {
+            transcript: { languageCode: 'en', pendingReview: true },
+          },
+        }),
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false when there is no transcript at all', () => {
+      const test = hasTranslatableTranscript(
+        buildSubmission({ Secret_password_as_an_audio_file: {} }),
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false when there are no supplemental details', () => {
+      const test = hasTranslatableTranscript(buildSubmission(), transcriptColumnKey)
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false for a transcript of another question', () => {
+      const test = hasTranslatableTranscript(
+        buildSubmission({
+          Some_other_question: {
+            transcript: { languageCode: 'en', value: 'Hello world' },
+          },
+        }),
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.false
+    })
+  })
+
+  describe('hasAnyTranslatableTranscript', () => {
+    const transcriptColumnKey = '_supplementalDetails/Secret_password_as_an_audio_file/transcript_en'
+
+    const approvedTranscriptSubmission = {
+      ...submission,
+      _supplementalDetails: {
+        Secret_password_as_an_audio_file: {
+          transcript: { languageCode: 'en', value: 'Hello world' },
+        },
+      },
+    } as SubmissionResponse
+
+    const pendingTranscriptSubmission = {
+      ...submission,
+      _uuid: 'pending-uuid',
+      _supplementalDetails: {
+        Secret_password_as_an_audio_file: {
+          transcript: { languageCode: 'en', pendingReview: true },
+        },
+      },
+    } as SubmissionResponse
+
+    const noTranscriptSubmission = {
+      ...submission,
+      _uuid: 'no-transcript-uuid',
+    } as SubmissionResponse
+
+    it('should return false for an empty selection', () => {
+      chai.expect(hasAnyTranslatableTranscript([], transcriptColumnKey)).to.be.false
+    })
+
+    it('should return false when no selected submission has a transcript', () => {
+      const test = hasAnyTranslatableTranscript([noTranscriptSubmission, noTranscriptSubmission], transcriptColumnKey)
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false when all transcripts are still awaiting approval', () => {
+      const test = hasAnyTranslatableTranscript(
+        [pendingTranscriptSubmission, noTranscriptSubmission],
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return true when at least one transcript is approved', () => {
+      const test = hasAnyTranslatableTranscript(
+        [noTranscriptSubmission, pendingTranscriptSubmission, approvedTranscriptSubmission],
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.true
+    })
   })
 })

--- a/jsapp/js/components/submissions/bulkProcessingUtils.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.ts
@@ -1,10 +1,54 @@
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
-import { buildSupplementalPath } from '#/components/processing/processingUtils'
+import { buildSupplementalPath, getSupplementalPathParts } from '#/components/processing/processingUtils'
 import { SUPPLEMENTAL_DETAILS_PROP } from '#/constants'
 import type { SubmissionResponse } from '#/dataInterface'
 import { removeDefaultUuidPrefix } from '#/utils'
+
+/**
+ * Checks if given submission has an audio file that can be transcribed in given
+ * audio question column.
+ *
+ * A deleted attachment is not a usable source, as all of its `*_url`s return 404.
+ */
+export function hasTranscribableAudio(submission: SubmissionResponse, fieldXpath: string): boolean {
+  return Boolean(
+    submission._attachments?.some((attachment) => attachment.question_xpath === fieldXpath && !attachment.is_deleted),
+  )
+}
+
+/**
+ * Checks if any of given submissions can be transcribed, i.e. if a bulk
+ * transcription action would have anything to work with.
+ */
+export function hasAnyTranscribableAudio(submissions: SubmissionResponse[], fieldXpath: string): boolean {
+  return submissions.some((submission) => hasTranscribableAudio(submission, fieldXpath))
+}
+
+/**
+ * Checks if given submission has a transcript that can be used as a source for
+ * translation in given transcript column.
+ *
+ * A transcript is a usable source only when it has an actual value. A transcript
+ * that is still awaiting approval has no `value` (the backend omits it and sets
+ * `pendingReview` instead), so it can't be translated yet.
+ */
+export function hasTranslatableTranscript(submission: SubmissionResponse, fieldXpath: string): boolean {
+  // `fieldXpath` of a transcript column is a supplemental details path, but
+  // `_supplementalDetails` is keyed by question xpath, so we need to convert it.
+  const { sourceRowPath } = getSupplementalPathParts(fieldXpath)
+  // Note: we assume here that there can be only one transcript.
+  return Boolean(submission._supplementalDetails?.[sourceRowPath]?.transcript?.value)
+}
+
+/**
+ * Checks if any of given submissions can be translated, i.e. if a bulk
+ * translation action would have anything to work with.
+ */
+export function hasAnyTranslatableTranscript(submissions: SubmissionResponse[], fieldXpath: string): boolean {
+  return submissions.some((submission) => hasTranslatableTranscript(submission, fieldXpath))
+}
 
 export function getBulkProcessingColumnKey(bulkAction: BulkActionResponse) {
   if (bulkAction.action_id === ActionIdEnum.automatic_google_transcription) {

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -984,15 +984,13 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
                 onTranscribeSelectedAudioFiles={this.onTranscribeSelectedAudioFiles.bind(this)}
                 onTranslateSelectedTranscriptions={this.onTranslateSelectedTranscriptions.bind(this)}
                 onApproveSelectedSubmissions={this.onApproveSelectedSubmissions.bind(this)}
-                isBulkProcessingDisabled={
-                  !(
-                    userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) ||
-                    userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)
-                  ) ||
-                  (!this.state.selectAll && recordKeys(this.state.selectedRows).length === 0)
+                userCanChangeSubmissions={
+                  userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) ||
+                  userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)
                 }
-                isBulkTranscriptionDisabled={!hasAnyTranscribableAudio(this.getSelectedSubmissions(), key)}
-                isBulkTranslationDisabled={!hasAnyTranslatableTranscript(this.getSelectedSubmissions(), key)}
+                hasRowsSelected={this.state.selectAll || recordKeys(this.state.selectedRows).length === 0}
+                hasAnyTranscribableAudio={hasAnyTranscribableAudio(this.getSelectedSubmissions(), key)}
+                hasAnyTranslatableTranscript={hasAnyTranslatableTranscript(this.getSelectedSubmissions(), key)}
                 additionalTriggerContent={
                   <span className='column-header-title' title={columnName}>
                     {columnIcon}

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -988,7 +988,7 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
                   userCan(PERMISSIONS_CODENAMES.change_submissions, this.props.asset) ||
                   userCanPartially(PERMISSIONS_CODENAMES.change_submissions, this.props.asset)
                 }
-                hasRowsSelected={this.state.selectAll || recordKeys(this.state.selectedRows).length === 0}
+                hasRowsSelected={this.state.selectAll || recordKeys(this.state.selectedRows).length !== 0}
                 hasAnyTranscribableAudio={hasAnyTranscribableAudio(this.getSelectedSubmissions(), key)}
                 hasAnyTranslatableTranscript={hasAnyTranslatableTranscript(this.getSelectedSubmissions(), key)}
                 additionalTriggerContent={

--- a/jsapp/js/components/submissions/table.tsx
+++ b/jsapp/js/components/submissions/table.tsx
@@ -25,6 +25,8 @@ import TableDropdownFilter from '#/components/submissions/TableDropdownFilter'
 import TableTextFilter from '#/components/submissions/TableTextFilter'
 import {
   getVisibleBulkProcessingSubmissionUuidsToRefresh,
+  hasAnyTranscribableAudio,
+  hasAnyTranslatableTranscript,
   isBulkProcessingCellInProgress,
 } from '#/components/submissions/bulkProcessingUtils'
 import ColumnsHideDropdown from '#/components/submissions/columnsHideDropdown'
@@ -508,20 +510,22 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
   }
 
   /**
-   * Opens a bulk processing modal for selected submissions.
+   * Returns full submission objects for the currently selected rows.
    * Note: Only submissions from the currently loaded page are included, even if
    * rows from other pages are selected. This is intentional - the warning modal
    * alerts users when they've selected rows across multiple pages.
    */
+  private getSelectedSubmissions(): SubmissionResponse[] {
+    const selectedSubmissionIds = recordKeys(this.state.selectedRows)
+    return this.state.submissions.filter((submission) => selectedSubmissionIds.includes(String(submission._id)))
+  }
+
+  /**
+   * Opens a bulk processing modal for selected submissions.
+   */
   private openBulkProcessingModal(fieldId: string, modalType: 'transcribe' | 'translate' | 'approve') {
     const selectedSubmissionIds = recordKeys(this.state.selectedRows)
-
-    // Filter to get full submission objects for the selected IDs.
-    // This only finds submissions on the current page - selections from other
-    // pages are intentionally excluded (user is warned about this).
-    const selectedSubmissions = this.state.submissions.filter((submission) =>
-      selectedSubmissionIds.includes(String(submission._id)),
-    )
+    const selectedSubmissions = this.getSelectedSubmissions()
 
     // Show warning if "Select All" would process more rows than are visible on current page
     const showWarningModal = this.state.selectAll && this.state.resultsTotal > selectedSubmissionIds.length
@@ -987,6 +991,8 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
                   ) ||
                   (!this.state.selectAll && recordKeys(this.state.selectedRows).length === 0)
                 }
+                isBulkTranscriptionDisabled={!hasAnyTranscribableAudio(this.getSelectedSubmissions(), key)}
+                isBulkTranslationDisabled={!hasAnyTranslatableTranscript(this.getSelectedSubmissions(), key)}
                 additionalTriggerContent={
                   <span className='column-header-title' title={columnName}>
                     {columnIcon}

--- a/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
+++ b/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
@@ -30,6 +30,16 @@ interface TableColumnSortDropdownProps {
   onApproveSelectedSubmissions?: (fieldId: string) => void
   isBulkProcessingDisabled?: boolean
   /**
+   * `true` when none of the selected submissions has an audio file in this
+   * column, so there is nothing to transcribe.
+   */
+  isBulkTranscriptionDisabled?: boolean
+  /**
+   * `true` when none of the selected submissions has an approved transcript in
+   * this column, so there is nothing to translate.
+   */
+  isBulkTranslationDisabled?: boolean
+  /**
    * To be put inside trigger, before the predefined content. Please note that
    * the trigger as a whole is clickable, so this additional content would need
    * stopPropagation to be clickable.
@@ -153,7 +163,7 @@ export default function TableColumnSortDropdown(props: TableColumnSortDropdownPr
               {canTranscribeSelectedAudioFiles && (
                 <Menu.Item
                   className='sort-dropdown-menu-button'
-                  disabled={props.isBulkProcessingDisabled}
+                  disabled={props.isBulkProcessingDisabled || props.isBulkTranscriptionDisabled}
                   onClick={transcribeSelectedAudioFiles}
                   leftSection={<Icon name='qt-audio' size='inherit' />}
                 >
@@ -164,7 +174,7 @@ export default function TableColumnSortDropdown(props: TableColumnSortDropdownPr
               {canTranslateSelectedTranscriptions && (
                 <Menu.Item
                   className='sort-dropdown-menu-button'
-                  disabled={props.isBulkProcessingDisabled}
+                  disabled={props.isBulkProcessingDisabled || props.isBulkTranslationDisabled}
                   onClick={translateSelectedTranscriptions}
                   leftSection={<Icon name='transcripts' size='inherit' />}
                 >

--- a/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
+++ b/jsapp/js/components/submissions/tableColumnSortDropdown.tsx
@@ -1,9 +1,6 @@
 import './tableColumnSortDropdown.scss'
-
-import React from 'react'
-import { useState } from 'react'
-
 import { Group } from '@mantine/core'
+import React, { useState } from 'react'
 import Menu from '#/components/common/Menu'
 import Icon from '#/components/common/icon'
 import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
@@ -28,17 +25,11 @@ interface TableColumnSortDropdownProps {
   onTranscribeSelectedAudioFiles?: (fieldId: string) => void
   onTranslateSelectedTranscriptions?: (fieldId: string) => void
   onApproveSelectedSubmissions?: (fieldId: string) => void
-  isBulkProcessingDisabled?: boolean
-  /**
-   * `true` when none of the selected submissions has an audio file in this
-   * column, so there is nothing to transcribe.
-   */
-  isBulkTranscriptionDisabled?: boolean
-  /**
-   * `true` when none of the selected submissions has an approved transcript in
-   * this column, so there is nothing to translate.
-   */
-  isBulkTranslationDisabled?: boolean
+  // Props below are being used by bulk processing code
+  userCanChangeSubmissions?: boolean
+  hasRowsSelected?: boolean
+  hasAnyTranscribableAudio?: boolean
+  hasAnyTranslatableTranscript?: boolean
   /**
    * To be put inside trigger, before the predefined content. Please note that
    * the trigger as a whole is clickable, so this additional content would need
@@ -163,7 +154,9 @@ export default function TableColumnSortDropdown(props: TableColumnSortDropdownPr
               {canTranscribeSelectedAudioFiles && (
                 <Menu.Item
                   className='sort-dropdown-menu-button'
-                  disabled={props.isBulkProcessingDisabled || props.isBulkTranscriptionDisabled}
+                  disabled={
+                    !props.userCanChangeSubmissions || !props.hasRowsSelected || !props.hasAnyTranscribableAudio
+                  }
                   onClick={transcribeSelectedAudioFiles}
                   leftSection={<Icon name='qt-audio' size='inherit' />}
                 >
@@ -174,7 +167,9 @@ export default function TableColumnSortDropdown(props: TableColumnSortDropdownPr
               {canTranslateSelectedTranscriptions && (
                 <Menu.Item
                   className='sort-dropdown-menu-button'
-                  disabled={props.isBulkProcessingDisabled || props.isBulkTranslationDisabled}
+                  disabled={
+                    !props.userCanChangeSubmissions || !props.hasRowsSelected || props.hasAnyTranslatableTranscript
+                  }
                   onClick={translateSelectedTranscriptions}
                   leftSection={<Icon name='transcripts' size='inherit' />}
                 >
@@ -185,7 +180,7 @@ export default function TableColumnSortDropdown(props: TableColumnSortDropdownPr
               {canApproveSelectedSubmissions && (
                 <Menu.Item
                   className='sort-dropdown-menu-button'
-                  disabled={props.isBulkProcessingDisabled}
+                  disabled={!props.userCanChangeSubmissions || !props.hasRowsSelected}
                   onClick={approveSelectedSubmissions}
                   leftSection={<Icon name='check' size='inherit' />}
                 >


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

The `Transcribe selected audio files` and `Translate selected transcriptions` options in the data table column menu are now greyed out when none of the selected submissions has anything to work with.

### 💭 Notes

Changes here:

- `bulkProcessingUtils.ts`
  - new `hasTranscribableAudio()` / `hasAnyTranscribableAudio()` — a non-deleted attachment for the given question xpath
  - new `hasTranslatableTranscript()` / `hasAnyTranslatableTranscript()` — a transcript with an actual `value`.
- `alerts/alertEvaluators.ts`
  - `evaluateNoSource()` now calls those shared helpers instead of doing its own inline checks.
- `tableColumnSortDropdown.tsx`
  - new `isBulkTranscriptionDisabled` and `isBulkTranslationDisabled` props, added into each item's existing `disabled` condition.
- `table.tsx`
  - extracted `getSelectedSubmissions()` (the column header needs the selected rows now, not just the modal opener) and passes both new props per column.
- `bulkProcessingUtils.tests.ts`
  - unit tests for all four helpers, including the deleted-attachment and pending-review cases.

### 👀 Preview steps

1. ℹ️ have an account and a project with an audio question, transcription/translation enabled in admin
2. add `?ff_bulkProcessingEnabled=true` to the URL to turn on the bulk processing feature flag
3. submit three responses: **A** and **B** with an audio recording, and **C** with the audio question skipped
4. go to Project → Data → Table
5. tick the checkbox for **C** only, then open the column menu (the caret in the header) of the audio question
6. 🔴 [on main] `Transcribe selected audio files` is clickable — click through the modal and get told there are no eligible submissions at the end
7. 🟢 [on PR] `Transcribe selected audio files` is greyed out
8. now tick **A** only and use `Transcribe selected audio files`, run the job, and wait for the transcript column to appear — leave the new transcript unapproved (it shows a `Review` button)
9. with **A** still the only selected row, open the column menu of the transcript column
10. 🔴 [on main] `Translate selected transcriptions` is clickable, and the modal only reveals at the end that nothing can be translated
11. 🟢 [on PR] `Translate selected transcriptions` is greyed out
12. tick **B** only (it has audio but no transcript at all) and open the transcript column menu
13. 🔴 [on main] `Translate selected transcriptions` is clickable
14. 🟢 [on PR] `Translate selected transcriptions` is greyed out
15. open **A**'s transcript and approve it, then go back to the table and select **A** again
16. 🟢 `Translate selected transcriptions` is now enabled and works as before — the option waits its turn instead of promising things it can't deliver
