### PR TITLE
feat(projectViews): show organization IDs in the admin organization selector DEV-2500

### DIFF
--- a/kobo/apps/audit_log/tests/test_signals.py
+++ b/kobo/apps/audit_log/tests/test_signals.py
@@ -354,7 +354,8 @@ class TestAdminAuditLogIntegration(BaseTestCase):
         self.assertEqual(latest_log.user, self.admin)
         self.assertEqual(latest_log.model_name, 'organization')
         self.assertIn(
-            "adminuser updated organization 'Updated Test Org Name' (pk: org999)",
+            'adminuser updated organization '
+            "'Updated Test Org Name (org999)' (pk: org999)",
             latest_log.metadata['message']
         )
         self.assertIn(
@@ -396,7 +397,8 @@ class TestAdminAuditLogIntegration(BaseTestCase):
         self.assertEqual(latest_log.user, self.admin)
         self.assertEqual(latest_log.model_name, 'organization')
         self.assertIn(
-            "adminuser deleted organization 'Test Org for Audit' (pk: org999)",
+            'adminuser deleted organization '
+            "'Test Org for Audit (org999)' (pk: org999)",
             latest_log.metadata['message']
         )
 

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -93,6 +93,10 @@ class Organization(AbstractOrganization):
         choices=OrganizationType,
     )
 
+    def __str__(self) -> str:
+        # Names are not unique: include the ID so the admin can tell homonyms apart
+        return f'{self.name} ({self.id})'
+
     def add_user(self, user, is_admin=False):
         if not self.is_mmo and self.users.all().count():
             raise NotMultiMemberOrganizationException

--- a/kobo/apps/organizations/tests/admin/test_organization_admin.py
+++ b/kobo/apps/organizations/tests/admin/test_organization_admin.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.organizations.models import Organization
+from kobo.apps.project_views.models.project_view import ProjectView
 from kpi.constants import PERM_MANAGE_ASSET
 from kpi.models.asset import Asset
 from kpi.tests.utils.transaction import immediate_on_commit
@@ -147,6 +148,42 @@ class TestOrganizationAdminTestCase(TestCase):
         )
 
         assert 'already has an active Stripe subscription' in response.content.decode()
+
+    def test_autocomplete_results_include_organization_id(self):
+        """
+        Organization names are not unique, so the suggestions of the project view
+        organization selector must expose the ID to tell homonyms apart
+        """
+        homonym = Organization.objects.create(id='org5678', name='Test Organization')
+
+        response = self.client.get(
+            reverse('admin:autocomplete'),
+            data={
+                'term': 'Test Organization',
+                'app_label': 'project_views',
+                'model_name': 'projectview',
+                'field_name': 'organizations',
+            },
+        )
+
+        assert response.status_code == 200
+        assert {result['text'] for result in response.json()['results']} == {
+            f'Test Organization ({self.organization.id})',
+            f'Test Organization ({homonym.id})',
+        }
+
+    def test_project_view_form_shows_organization_id_of_selected_orgs(self):
+        project_view = ProjectView.objects.create(name='Test view', countries='*')
+        project_view.organizations.add(self.organization)
+
+        response = self.client.get(
+            reverse('admin:project_views_projectview_change', args=[project_view.pk])
+        )
+
+        assert response.status_code == 200
+        assert (
+            f'Test Organization ({self.organization.id})' in response.content.decode()
+        )
 
     def _manage_user_in_org(self, remove: bool = False):
         response = self._post_change_form({}, remove=remove)


### PR DESCRIPTION
### 📣 Summary

Organizations are now shown with their ID in the Django admin, so organizations that share the same name can be told apart.

### 📖 Description

Many organizations share a name while being completely separate teams. Until now the Organizations selector of a Project View listed only names, so there was no way to know which entry was the intended one. Organizations are now displayed as `Name (org_id)` everywhere the Django admin shows one: in the Organizations suggestions, in the entries already selected, and in the other organization pickers.

### 💭 Notes

- `Organization.__str__` now returns `f'{self.name} ({self.id})'`.
- Doing it on the model covers both label paths of the admin autocomplete in one place: `AutocompleteJsonView.serialize_result()` for the AJAX suggestions, and `ModelChoiceField.label_from_instance()` for the values already selected. Fixing it at the widget level meant overriding both, in four different admins, and keeping them in sync.
- Side effect: the admin audit log embeds `str(obj)` in `object_repr`, so its messages now read `updated organization 'Foo (org_x)' (pk: org_x)`. Two assertions were updated for it.
- No leak outside the admin: the organization invite emails pass `organization.name`, and the organization user import/export binds `ForeignKeyWidget(Organization, field='name')`.

### 👀 Preview steps

1. ℹ️ be a superuser, and have two organizations sharing the exact same name
2. go to `/admin/project_views/projectview/add/`
3. type that shared name into the **Organizations** field
4. 🔴 [on main] both suggestions read just the name — no way to tell which is which
5. 🟢 [on PR] each suggestion reads `Name (org_…)`
6. pick one, fill in the rest of the form and save, then reopen the project view
7. 🟢 the selected organization still reads `Name (org_…)`
