### PR TITLE
perf(longRunningMigrations): avoid full index scan in LRM 0027 xform paging DEV-2427

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
+++ b/kobo/apps/long_running_migrations/jobs/0027_backfill_remaining_root_uuid.py
@@ -4,7 +4,7 @@ from celery.exceptions import SoftTimeLimitExceeded, TimeLimitExceeded
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management import call_command
-from django.db import IntegrityError
+from django.db import IntegrityError, connections
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from pymongo import UpdateOne
@@ -97,13 +97,7 @@ def get_xforms_queryset(xform_id: int) -> tuple[QuerySet, int]:
     connection, avoiding cross-DB routing issues.
     """
 
-    xform_ids = list(
-        Instance.objects.filter(root_uuid__isnull=True)
-        .values_list('xform_id', flat=True)
-        .filter(xform_id__gt=xform_id)
-        .distinct()
-        .order_by('xform_id')[:CHUNK_SIZE]
-    )
+    xform_ids = _get_next_distinct_xform_ids(xform_id)
 
     if not xform_ids:
         return XForm.objects.none(), -1
@@ -151,6 +145,52 @@ def _find_timeout_in_chain(exc: BaseException) -> BaseException | None:
         current = current.__cause__ or current.__context__
 
     return None
+
+
+def _get_next_distinct_xform_ids(xform_id: int) -> list[int]:
+    """
+    Returns up to `CHUNK_SIZE` distinct `xform_id`s greater than `xform_id`
+    that still have at least one `Instance` with a null `root_uuid`.
+
+    PostgreSQL has no native loose ("skip") index scan, so a plain
+    `SELECT DISTINCT xform_id ... ORDER BY xform_id LIMIT` walks every
+    matching index entry in order, including duplicates, before it can move
+    on to the next distinct value. When a single XForm has millions of
+    null-`root_uuid` instances, that forces the scan to read all of them just
+    to advance past it, which can exceed `statement_timeout`. This recursive
+    CTE instead seeks directly to the next distinct `xform_id` at each step.
+    """
+
+    with connections[settings.OPENROSA_DB_ALIAS].cursor() as cursor:
+        cursor.execute(
+            """
+            WITH RECURSIVE cursor_walk AS (
+                (
+                    SELECT xform_id
+                    FROM logger_instance
+                    WHERE root_uuid IS NULL AND xform_id > %(xform_id)s
+                    ORDER BY xform_id
+                    LIMIT 1
+                )
+                UNION ALL
+                SELECT (
+                    SELECT xform_id
+                    FROM logger_instance
+                    WHERE root_uuid IS NULL AND xform_id > cursor_walk.xform_id
+                    ORDER BY xform_id
+                    LIMIT 1
+                )
+                FROM cursor_walk
+                WHERE cursor_walk.xform_id IS NOT NULL
+            )
+            SELECT xform_id
+            FROM cursor_walk
+            WHERE xform_id IS NOT NULL
+            LIMIT %(chunk_size)s
+            """,
+            {'xform_id': xform_id, 'chunk_size': CHUNK_SIZE},
+        )
+        return [row[0] for row in cursor.fetchall()]
 
 
 def _process_instances_batch(


### PR DESCRIPTION
### 📣 Summary

Speeds up an internal data migration that backfills missing submission `root_uuid`s, so it no longer times out on projects with a very large number of submissions.

### 👷 Description for instance maintainers

Long-running migration 0027 (`root_uuid` backfill) pages through XForms by repeatedly finding the next batch of distinct `xform_id`s that still have `Instance` rows with a null `root_uuid`. That pagination query used a plain `SELECT DISTINCT xform_id ... ORDER BY xform_id LIMIT`, relying on PostgreSQL to deduplicate as it scans.

PostgreSQL has no native loose ("skip") index scan: it has to walk every matching index entry in order, including duplicates, before it can move on to the next distinct value. When a single XForm has millions of `Instance` rows with a null `root_uuid`, the scan has to read all of them just to advance past that one XForm, even though the query only asks for 100 distinct ids.

In production this was confirmed with `EXPLAIN`, the planner estimated million of rows to walk to produce the next 100 distinct ids. In practice, the query got killed by PostgreSQL's `statement_timeout` (4200s in Celery workers) with `canceling statement due to statement timeout`, stalling the migration on that page of XForms.

Rewrote the pagination query as a recursive CTE that seeks directly to the next distinct `xform_id` at each step (`xform_id > current ORDER BY xform_id LIMIT 1`), instead of scanning through every duplicate row. Verified against production data: the same lookup that used to time out at 4200s now returns in under 1s.

### 💭 Notes

- No behavior change from the migration's point of view: same XForms are found, same order, same batch size (`CHUNK_SIZE`). Only the SQL used to find them changed.
- Timeout is barely impossible to reproduce locally without a huge amount of submissions.

### 👀 Preview steps

1. Locally, you can test the old queryset and see that `_get_next_distinct_xform_ids` returns the same xform ids.
