### PR TITLE
fix(messages): global variable replacement DEV-2510

### DIFF
--- a/jsapp/js/components/support/helpBubble.tsx
+++ b/jsapp/js/components/support/helpBubble.tsx
@@ -116,9 +116,9 @@ class HelpBubble extends React.Component<HelpBubbleProps, HelpBubbleState> {
 
   interpolateMessageUserInfo(htmlString: string) {
     return htmlString
-      .replace('##username##', this.props.username)
-      .replace('##user_uid##', this.props.userUid)
-      .replace('##user_full_name##', this.props.userFullName || t('KoboToolbox user'))
+      .replace(/##username##/g, this.props.username)
+      .replace(/##user_uid##/g, this.props.userUid)
+      .replace(/##user_full_name##/g, this.props.userFullName || t('KoboToolbox user'))
   }
 
   renderSnippetRow(msg: InAppMessage, clickCallback: (messageUid: string) => void) {

--- a/jsapp/js/components/support/helpBubble.tsx
+++ b/jsapp/js/components/support/helpBubble.tsx
@@ -116,9 +116,9 @@ class HelpBubble extends React.Component<HelpBubbleProps, HelpBubbleState> {
 
   interpolateMessageUserInfo(htmlString: string) {
     return htmlString
-      .replace(/##username##/g, this.props.username)
-      .replace(/##user_uid##/g, this.props.userUid)
-      .replace(/##user_full_name##/g, this.props.userFullName || t('KoboToolbox user'))
+      .replace(/##username##/g, () => this.props.username)
+      .replace(/##user_uid##/g, () => this.props.userUid)
+      .replace(/##user_full_name##/g, () => this.props.userFullName || t('KoboToolbox user'))
   }
 
   renderSnippetRow(msg: InAppMessage, clickCallback: (messageUid: string) => void) {

--- a/jsapp/js/components/support/helpBubble.tsx
+++ b/jsapp/js/components/support/helpBubble.tsx
@@ -116,9 +116,9 @@ class HelpBubble extends React.Component<HelpBubbleProps, HelpBubbleState> {
 
   interpolateMessageUserInfo(htmlString: string) {
     return htmlString
-      .replace(/##username##/g, () => this.props.username)
-      .replace(/##user_uid##/g, () => this.props.userUid)
-      .replace(/##user_full_name##/g, () => this.props.userFullName || t('KoboToolbox user'))
+      .replaceAll('##username##', () => this.props.username)
+      .replaceAll('##user_uid##', () => this.props.userUid)
+      .replaceAll('##user_full_name##', () => this.props.userFullName || t('KoboToolbox user'))
   }
 
   renderSnippetRow(msg: InAppMessage, clickCallback: (messageUid: string) => void) {


### PR DESCRIPTION
### 📣 Summary
Fixes a bug that resulted in only the first instance of a template variable (i.e. ##username##) being replaced in in-app messages.

### 👀 Preview steps
1. Make an in-app message in the django admin like with the following snippet and message:
```
username 1 ##username##
username 2 ##username##
```
2. 🔴 [on target branch] notice that only first instance of username variable is replaced
3. 🟢 [on PR] notice that both instances are replaced
