### PR TITLE
fix(bulkProcessing): keep activity log progress in sync with bulk items DEV-2498

### DIFF
--- a/kobo/apps/subsequences/audit.py
+++ b/kobo/apps/subsequences/audit.py
@@ -44,7 +44,17 @@ def sync_bulk_action_history_log(bulk_action) -> None:
     """
     Refresh the bulk-specific metadata on the existing history log row
     """
-    transaction.on_commit(lambda: _sync_bulk_action_history_log(bulk_action.pk))
+    sync_bulk_action_history_log_by_uid(bulk_action.pk)
+
+
+def sync_bulk_action_history_log_by_uid(bulk_action_uid: str) -> None:
+    """
+    Refresh the history log for a bulk action known only by its uid
+
+    Callers that update a child item with `queryset.update()` never load the
+    parent, so this avoids an extra query just to satisfy the signature
+    """
+    transaction.on_commit(lambda: _sync_bulk_action_history_log(bulk_action_uid))
 
 
 def _sync_bulk_action_history_log(bulk_action_uid: str) -> None:
@@ -55,22 +65,30 @@ def _sync_bulk_action_history_log(bulk_action_uid: str) -> None:
             SubsequenceBulkAction.objects.select_related('asset', 'asset__owner')
             .get(pk=bulk_action_uid)
         )
-        history_log = (
-            ProjectHistoryLog.objects.filter(
-                action=AuditAction.BULK_PROCESSING,
-                metadata__asset_uid=bulk_action.asset.uid,
-                metadata__bulk_action__uid=bulk_action.uid,
+        # Child items finish in parallel, so several workers can reach this at
+        # once. Refreshing the log is a read-modify-write of a single JSON blob,
+        # which loses updates under concurrency: two workers both read `3`,
+        # then write `4` and `5` in either order, and the counter can visibly go
+        # backwards. Taking the row lock first, and only then reading the item
+        # counts, keeps the stored progress monotonic
+        with transaction.atomic():
+            history_log = (
+                ProjectHistoryLog.objects.select_for_update()
+                .filter(
+                    action=AuditAction.BULK_PROCESSING,
+                    metadata__asset_uid=bulk_action.asset.uid,
+                    metadata__bulk_action__uid=bulk_action.uid,
+                )
+                .order_by('-date_created')
+                .first()
             )
-            .order_by('-date_created')
-            .first()
-        )
-        if history_log is None:
-            return
+            if history_log is None:
+                return
 
-        metadata = history_log.metadata.copy()
-        metadata['bulk_action'] = bulk_action.get_history_log_metadata()
-        history_log.metadata = metadata
-        history_log.save(update_fields=['metadata'])
+            metadata = history_log.metadata.copy()
+            metadata['bulk_action'] = bulk_action.get_history_log_metadata()
+            history_log.metadata = metadata
+            history_log.save(update_fields=['metadata'])
     except Exception:
         logging.exception(
             'Failed to sync bulk processing history log for '

--- a/kobo/apps/subsequences/audit.py
+++ b/kobo/apps/subsequences/audit.py
@@ -69,8 +69,8 @@ def _sync_bulk_action_history_log(bulk_action_uid: str) -> None:
         # once. Refreshing the log is a read-modify-write of a single JSON blob,
         # which loses updates under concurrency: two workers both read `3`,
         # then write `4` and `5` in either order, and the counter can visibly go
-        # backwards. Taking the row lock first, and only then reading the item
-        # counts, keeps the stored progress monotonic
+        # backwards. Taking the row lock first keeps the stored snapshot
+        # monotonic
         with transaction.atomic():
             history_log = (
                 ProjectHistoryLog.objects.select_for_update()
@@ -85,6 +85,7 @@ def _sync_bulk_action_history_log(bulk_action_uid: str) -> None:
             if history_log is None:
                 return
 
+            bulk_action.refresh_from_db()
             metadata = history_log.metadata.copy()
             metadata['bulk_action'] = bulk_action.get_history_log_metadata()
             history_log.metadata = metadata

--- a/kobo/apps/subsequences/models.py
+++ b/kobo/apps/subsequences/models.py
@@ -374,6 +374,18 @@ class BulkActionItemStatus(models.TextChoices):
     CANCELLED = 'cancelled'
 
 
+# An item reaches one of these exactly once, which makes them the natural
+# trigger for refreshing the bulk processing history log: the progress numbers
+# only ever change when an item lands here
+TERMINAL_BULK_ACTION_ITEM_STATUSES = frozenset(
+    [
+        BulkActionItemStatus.COMPLETE,
+        BulkActionItemStatus.FAILED,
+        BulkActionItemStatus.CANCELLED,
+    ]
+)
+
+
 PENDING_OPERATION_MARKER = 'pending'
 
 BULK_ACTION_TYPE_TRANSCRIPTION = 'transcription'

--- a/kobo/apps/subsequences/tasks.py
+++ b/kobo/apps/subsequences/tasks.py
@@ -225,10 +225,12 @@ def start_bulk_item_job(self, bulk_action_item_id: str):
     impatient watchdog tasks from spawning duplicate requests while we wait for
     Google to reply.
     """
+    from .audit import sync_bulk_action_history_log_by_uid
     from .models import (
+        PENDING_OPERATION_MARKER,
+        TERMINAL_BULK_ACTION_ITEM_STATUSES,
         BulkActionItemStatus,
         BulkActionStatus,
-        PENDING_OPERATION_MARKER,
     )
 
     SubsequenceBulkActionItem = apps.get_model(  # noqa: N806
@@ -398,6 +400,12 @@ def start_bulk_item_job(self, bulk_action_item_id: str):
                 update_fields.append('service_id')
         item.save(update_fields=update_fields)
 
+        # Google occasionally finishes inside the initial synchronous wait, so
+        # an item can reach a terminal state without ever going through
+        # `poll_run_external_process()`. Keep the activity log current here too
+        if extracted_status in TERMINAL_BULK_ACTION_ITEM_STATUSES:
+            sync_bulk_action_history_log_by_uid(item.parent_id)
+
         if extracted_status == BulkActionItemStatus.IN_PROGRESS:
             poll_run_external_process.apply_async(
                 kwargs={
@@ -428,6 +436,10 @@ def update_batch_status(subsequence_bulk_action_id: str):
 
     The parent stays in_progress while any item is active. Once all items are in
     terminal states, the parent is marked complete and progress reaches 100.
+
+    This task is the only thing that advances `progress` and moves the parent to
+    a terminal status, so it must keep re-queueing itself for as long as the
+    batch is running, including on the paths where it does no work
     """
     from .audit import sync_bulk_action_history_log
     from .models import BulkActionItemStatus, BulkActionStatus
@@ -549,6 +561,7 @@ def _mark_bulk_item_failed(item, error: str | None = None) -> None:
     """
     Move a child item to failed so the parent batch can reach a terminal state
     """
+    from .audit import sync_bulk_action_history_log_by_uid
     from .models import PENDING_OPERATION_MARKER
 
     item.status = 'failed'
@@ -566,6 +579,9 @@ def _mark_bulk_item_failed(item, error: str | None = None) -> None:
         )
     else:
         item.save(update_fields=['status', 'service_id', 'date_modified'])
+
+    # 'failed' is terminal, so the batch progress just moved
+    sync_bulk_action_history_log_by_uid(item.parent_id)
 
 
 def _clear_pending_operation_marker(item) -> None:
@@ -721,7 +737,11 @@ def _update_bulk_action_item_status(
     """
     Mirror an async supplement status back to the matching bulk child item
     """
-    from .models import BulkActionItemStatus
+    from .audit import sync_bulk_action_history_log_by_uid
+    from .models import (
+        TERMINAL_BULK_ACTION_ITEM_STATUSES,
+        BulkActionItemStatus,
+    )
 
     bulk_action_uid = action_data.get('bulk_action_uid')
     if not bulk_action_uid:
@@ -741,8 +761,19 @@ def _update_bulk_action_item_status(
     elif status != BulkActionItemStatus.FAILED:
         updates['failure_error'] = None
 
-    SubsequenceBulkActionItem.objects.filter(
+    updated = SubsequenceBulkActionItem.objects.filter(
         parent__uid=bulk_action_uid,
         submission_root_uuid=submission_uuid,
         status__in=[BulkActionItemStatus.PENDING, BulkActionItemStatus.IN_PROGRESS],
     ).update(**updates)
+
+    # Refresh the activity log as soon as the item lands in a terminal state, so
+    # the progress there matches what the data table already shows. Waiting for
+    # the next `update_batch_status()` tick instead left the activity page up to
+    # `BULK_ACTION_STATUS_POLL_INTERVAL` behind
+    #
+    # The filter above only matches items that are still active, so `updated` is
+    # 1 only on a real transition. Repeated polls that re-assert 'in_progress'
+    # match nothing and cost no extra writes
+    if updated and status in TERMINAL_BULK_ACTION_ITEM_STATUSES:
+        sync_bulk_action_history_log_by_uid(bulk_action_uid)

--- a/kobo/apps/subsequences/tasks.py
+++ b/kobo/apps/subsequences/tasks.py
@@ -436,10 +436,6 @@ def update_batch_status(subsequence_bulk_action_id: str):
 
     The parent stays in_progress while any item is active. Once all items are in
     terminal states, the parent is marked complete and progress reaches 100.
-
-    This task is the only thing that advances `progress` and moves the parent to
-    a terminal status, so it must keep re-queueing itself for as long as the
-    batch is running, including on the paths where it does no work
     """
     from .audit import sync_bulk_action_history_log
     from .models import BulkActionItemStatus, BulkActionStatus


### PR DESCRIPTION
### 📣 Summary
This PR fixes bulk transcription and translation jobs reporting stale progress on the project activity page.

### 📖 Description
#### Problem
The data table and the project activity page report bulk processing progress from two different sources. The data table reads the bulk action item rows directly, so it is always current. The activity page reads a snapshot stored on the project history log, which is written when the job starts and refreshed only as a side effect of a periodic Celery task. That made the activity page only as fresh as the periodic task.

#### Solution 
The history log is now refreshed as each submission reaches a terminal state, rather than waiting for the next poll, so the activity page and the data table move together. Because several submissions can finish at once and refreshing the log is a read-modify-write of a single JSON field, the refresh takes a row lock so concurrent updates cannot be lost.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️  Have an account and a project with at least 10 audio submissions
2. Enable bulk processing via the feature flag (`?ff_bulkProcessingEnabled=true`)
3. Bulk select the submissions and, from the data table's submission question column, hit **Transcribe selected audio files**
4. Open **Project Settings → Activity** in a second tab and watch the counter (e.g. `0/10`) under *Recent project activity* while keeping an eye on the data table
5. 🔴 [on main] notice that the data table shows the **Review** button for several processed submissions while the activity counter lags well behind (e.g. `1/10` when the data table already shows 5 **Review** buttons)
6. 🟢 [on PR] notice that the two stay in sync - the activity counter advances as each submission finishes
7. Repeat a few times to confirm it holds
