### PR TITLE
fix(api): return generic messages instead of raw exception text DEV-2489

### DIFF
--- a/kobo/apps/accounts/mfa/views.py
+++ b/kobo/apps/accounts/mfa/views.py
@@ -8,6 +8,7 @@ from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.shortcuts import resolve_url
 from django.urls import reverse
+from django.utils.translation import gettext as t
 from rest_framework.generics import ListAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -107,8 +108,11 @@ class MfaMethodActivationView(APIView):
                 mfa.save()
             except Exception as cause:
                 status = HTTP_400_BAD_REQUEST
+                # Log the cause, but never expose it to the client
                 logging.error(cause, exc_info=True)
-                response_data['error'] = str(cause)
+                response_data['error'] = t(
+                    'Could not activate this method. Please try again later.'
+                )
 
         if status == HTTP_200_OK:
             secret = adapter.decrypt(mfa.secret)

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -1,12 +1,13 @@
-import jsonschema.exceptions
 from copy import deepcopy
+
+import jsonschema.exceptions
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from rest_framework import serializers
 
-from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
 from kobo.apps.openrosa.apps.logger.models import Instance
+from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
 from kobo.apps.subsequences.models import (
     BulkActionItemStatus,
     BulkActionStatus,

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -17,6 +17,8 @@ from kobo.apps.subsequences.models import (
 )
 from kobo.apps.subsequences.utils.time import utc_datetime_to_js_str
 
+INVALID_PARAMS_ERROR = 'Invalid parameters for this action'
+
 
 class QuestionAdvancedFeatureUpdateSerializer(serializers.ModelSerializer):
     class Meta:
@@ -30,7 +32,9 @@ class QuestionAdvancedFeatureUpdateSerializer(serializers.ModelSerializer):
         try:
             action.__class__.validate_params(attrs.get('params'))
         except jsonschema.exceptions.ValidationError as ve:
-            raise serializers.ValidationError(ve)
+            # `str(ve)` is too verbose: it includes the whole schema and the
+            # submitted instance
+            raise serializers.ValidationError(INVALID_PARAMS_ERROR) from ve
         return data
 
     def update(self, instance, validated_data):
@@ -64,7 +68,9 @@ class QuestionAdvancedFeatureSerializer(serializers.ModelSerializer):
         try:
             Action.validate_params(attrs.get('params'))
         except jsonschema.exceptions.ValidationError as ve:
-            raise serializers.ValidationError(ve)
+            # `str(ve)` is too verbose: it includes the whole schema and the
+            # submitted instance
+            raise serializers.ValidationError(INVALID_PARAMS_ERROR) from ve
         return data
 
 

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -2,6 +2,7 @@ import jsonschema.exceptions
 from copy import deepcopy
 from django.db import IntegrityError, transaction
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as t
 from rest_framework import serializers
 
 from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
@@ -17,7 +18,10 @@ from kobo.apps.subsequences.models import (
 )
 from kobo.apps.subsequences.utils.time import utc_datetime_to_js_str
 
-INVALID_PARAMS_ERROR = 'Invalid parameters for this action'
+# This message reaches the UI, so it must be translatable. Wrap here rather
+# than at the call site: `makemessages` only extracts literal arguments, so
+# `t(CONSTANT)` would leave the string out of the catalogs entirely.
+INVALID_PARAMS_ERROR = t('Invalid parameters for this action')
 
 
 class QuestionAdvancedFeatureUpdateSerializer(serializers.ModelSerializer):

--- a/kpi/fields/writable_json.py
+++ b/kpi/fields/writable_json.py
@@ -28,10 +28,12 @@ class WritableJSONField(serializers.Field):
         else:
             try:
                 return json.loads(data)
-            except Exception as e:
-                raise serializers.ValidationError(
-                    t('Unable to parse JSON: {error}').format(error=e)
-                )
+            # `RecursionError` comes from deeply nested input, and is neither a
+            # `ValueError` nor a `TypeError`
+            except (TypeError, ValueError, RecursionError) as e:
+                # The decoder message can echo the submitted payload back to the
+                # client; keep it server-side only
+                raise serializers.ValidationError(t('Unable to parse JSON')) from e
 
     def to_representation(self, value):
         return value


### PR DESCRIPTION
### 📣 Summary

Error messages shown when something can't be saved are now short and readable instead of long technical text.

### 📖 Description

In a few places — setting up two-factor authentication, turning on automatic transcription or translation for a question, and saving a setting that contains JSON — KoboToolbox used to show a long, technical error message when something went wrong. Those messages now read as a short plain sentence, and they can be translated. The technical detail is still recorded on the server, so support can still investigate.

### 💭 Notes

Four CodeQL alerts from DEV-2422 ([#186](https://github.com/kobotoolbox/kpi/security/code-scanning/186), [#153](https://github.com/kobotoolbox/kpi/security/code-scanning/153), [#185](https://github.com/kobotoolbox/kpi/security/code-scanning/185), [#77](https://github.com/kobotoolbox/kpi/security/code-scanning/77)) — all four returned exception text straight to the client.

- `mfa/views.py`: `str(cause)` → fixed string. The UI never read that key (`mfaActions.ts` falls back to `non_field_errors`), so nothing visible changes.
- `subsequences/serializers.py` ×2: a raw `jsonschema` error stringifies to the **entire schema plus the submitted instance**. Now a generic message, wrapped in `gettext_lazy` at the constant so `makemessages` extracts it.
- `writable_json.py`: narrowed the bare `except Exception`. `RecursionError` is deliberately kept in the tuple — deeply nested JSON raises it (confirmed at ~100k levels) and it is neither `ValueError` nor `TypeError`, so dropping it would turn a 400 into a 500.
- **Sentry:** the MFA case already reports — `logging.error(…, exc_info=True)` is above the `event_level=WARNING` of our `LoggingIntegration`. The three DRF `ValidationError`s deliberately do not: they are user-input rejections, not bugs, and one event per malformed payload would drown the real errors.
- **Tradeoff:** params errors no longer say *which* param is wrong. `ve.message` alone would keep that (precedent: `kpi/fields/jsonschema_form_field.py:35`) but is still exception-derived text and would likely leave the alerts open. Easy to switch — one constant, one place.
- Contrary to the ticket's warning, no subsequences test asserted on the verbose output; no test changes were needed.

Both CI axes green on the touched apps, `darker --check --isort -L flake8` clean.

### 👀 Preview steps

1. ℹ️ have an account and a deployed project with an audio question `q1`
2. `PATCH /api/v2/assets/<uid>/` with `{"data_sharing": true}` (a bool, not JSON)
3. 🔴 [on main] the 400 body echoes the JSON decoder's message back
4. 🟢 [on PR] the 400 body is just `Unable to parse JSON`
5. `POST /api/v2/assets/<uid>/advanced-features/` with `{"action": "manual_translation", "params": [{"bad": "stuff"}], "question_xpath": "q1"}`
6. 🔴 [on main] the 400 body contains the whole JSON schema plus the payload you just sent
7. 🟢 [on PR] the 400 body is `Invalid parameters for this action`
