### PR TITLE
style(KMLExport): sort import and add blank line for darker DEV-1635

### DIFF
--- a/kobo/apps/openrosa/apps/viewer/tasks.py
+++ b/kobo/apps/openrosa/apps/viewer/tasks.py
@@ -12,8 +12,8 @@ from django.core.mail import mail_admins
 from kobo.apps.openrosa.apps.viewer.models.export import Export
 from kobo.apps.openrosa.libs.exceptions import NoRecordsFoundError
 from kobo.apps.openrosa.libs.utils.export_tools import (
+    generate_attachments_zip_export,
     generate_export,
-    generate_attachments_zip_export
 )
 from kobo.apps.openrosa.libs.utils.logger_tools import (
     mongo_sync_status,

--- a/kobo/apps/openrosa/libs/renderers/renderers.py
+++ b/kobo/apps/openrosa/libs/renderers/renderers.py
@@ -32,6 +32,7 @@ class CSVRenderer(BaseRenderer):
     format = 'csv'
     charset = 'utf-8'
 
+
 # TODO add ZIP(attachments) support
 
 


### PR DESCRIPTION
### 💭 Notes

Formatting-only follow-up. When #7316 changed the `darker` job to trust darker's exit code (instead of the old "fail only if stdout is non-empty" workaround), two pre-existing findings on lines touched by #7299 (`feat(KMLExport): cleanup legacy KoboCAT KML logic`) started failing the job on `main` — with no output, because `darker --check` reports via exit code and prints nothing.

The old check had been silently swallowing all `black`/`isort` reformatting findings, so these slipped through when #7299 merged.

Two changes, both exactly what `darker --isort` produces:
- `kobo/apps/openrosa/apps/viewer/tasks.py` — sort the `export_tools` import block + trailing comma
- `kobo/apps/openrosa/libs/renderers/renderers.py` — add the blank line black wants before the module-level comment

Verified locally with the exact CI command (`darker --check --isort -L "flake8 ..." kpi kobo hub -r <main>`): exit 1 → exit 0 after this change.

No behavior change; internal only.