### PR TITLE
ci(darker): print the diff so formatting failures are self-explanatory DEV-1034

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -57,7 +57,13 @@ jobs:
           # revision, missing linter, …). Do not capture the output — darker
           # writes crash details to stderr, so capturing stdout and testing it
           # for emptiness makes every crash look like a pass.
-          darker --check --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH
+          #
+          # `--diff` makes darker PRINT the reformatting/isort patch it wants.
+          # Without it, `--check` signals findings through the exit code alone
+          # and prints nothing, so a formatting failure shows up as a blank red
+          # X with no explanation. `--diff` does not change the exit code; it
+          # just reveals what `format-python.sh origin/main` would fix.
+          darker --check --diff --isort -L "flake8 --max-line-length=88 --extend-ignore=F821" kpi kobo hub -r $LATEST_IN_BASE_BRANCH
         # `bash` (not a bare `/usr/bin/bash`) so the step keeps `-e -o pipefail`
         # and aborts on the first failing command.
         shell: bash


### PR DESCRIPTION
### 💭 Notes

Follow-up to #7316. That PR correctly made the `darker` job trust darker's exit code, but the command uses `darker --check`, which signals formatting/isort findings through the **exit code only** and prints nothing. The result: a real formatting failure shows up as a blank red ❌ with no output (see the silent failures on #7299 and #7339).

This adds `--diff` so darker prints the exact reformatting/isort patch it wants. `--diff` does not change the exit code, so #7316's crash-vs-clean behavior is preserved — the job just now explains itself.

Verified locally with the exact CI command against a real failing range:
- findings → `exit 1` **and** the patch is printed to stdout
- clean → `exit 0`, no output
- YAML parses

Devs hitting a red darker can then see what to run (`format-python.sh origin/main`) instead of guessing.

CI/internal only, no behavior change.