### PR TITLE
fix(subsequences): keep value key when pendingReview DEV-2508

### DIFF
--- a/kobo/apps/subsequences/actions/mixins.py
+++ b/kobo/apps/subsequences/actions/mixins.py
@@ -151,7 +151,12 @@ class TranscriptionActionMixin:
         }
 
         if pending_review:
+            # `value` is intentionally blanked out here: the FE only needs
+            # `pendingReview` to render its "Review" button, but formpack
+            # exports read `value` unconditionally and must not crash or
+            # leak an unreviewed result
             entry['pendingReview'] = True
+            entry['value'] = ''
         else:
             entry['value'] = version_data.get('value')
 
@@ -343,7 +348,12 @@ class TranslationActionMixin(RequiresTranscriptionMixin):
             }
 
             if pending_review:
+                # `value` is intentionally blanked out here: the FE only needs
+                # `pendingReview` to render its "Review" button, but formpack
+                # exports read `value` unconditionally and must not crash or
+                # leak an unreviewed result
                 entry['pendingReview'] = True
+                entry['value'] = ''
             else:
                 entry['value'] = version_data.get('value')
 

--- a/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_transcription.py
@@ -499,6 +499,7 @@ def test_transform_data_for_output():
             'regionCode': None,
             '_sortByDate': retrieved_data['_versions'][0]['_dateCreated'],
             'pendingReview': True,
+            'value': '',
         },
     }
 

--- a/kobo/apps/subsequences/tests/test_automatic_google_translation.py
+++ b/kobo/apps/subsequences/tests/test_automatic_google_translation.py
@@ -612,11 +612,13 @@ def test_transform_data_for_output():
     assert result == {
         ('translation', 'es'): {
             'pendingReview': True,
+            'value': '',
             'languageCode': 'es',
             '_sortByDate': retrieved_data['es']['_versions'][0]['_dateCreated'],
         },
         ('translation', 'fr'): {
             'pendingReview': True,
+            'value': '',
             'languageCode': 'fr',
             '_sortByDate': retrieved_data['fr']['_versions'][0]['_dateCreated'],
         },
@@ -652,6 +654,7 @@ def test_transform_data_for_output_with_delete():
     assert result == {
         ('translation', 'fr'): {
             'pendingReview': True,
+            'value': '',
             'languageCode': 'fr',
             '_sortByDate': retrieved_data['fr']['_versions'][0]['_dateCreated'],
         },

--- a/kobo/apps/subsequences/tests/test_models.py
+++ b/kobo/apps/subsequences/tests/test_models.py
@@ -245,7 +245,9 @@ class SubmissionSupplementTestCase(TestCase):
         When a transcription or translation version has a value but no
         `_dateAccepted`, `retrieve_data(for_output=True)` must include it
         with `pendingReview: True` so the FE can render the "Review" button.
-        `value` is intentionally absent from the pending payload.
+        `value` is intentionally blanked out (empty string) from the pending
+        payload so the unreviewed result isn't leaked, while still letting
+        formpack exports read `value` unconditionally without crashing.
         """
         self._add_manual_nlp_action('transcription', 'en', 'Hello')
         self._add_manual_nlp_action('translation', 'es', 'Hola')
@@ -267,16 +269,16 @@ class SubmissionSupplementTestCase(TestCase):
         transcription_data = output[self.xpath].get('transcript')
         translation_data = output[self.xpath].get('translation')
 
-        # Pending transcription: pendingReview present, value absent
+        # Pending transcription: pendingReview present, value blanked out
         assert transcription_data is not None
         assert transcription_data.get('pendingReview') is True
-        assert 'value' not in transcription_data
+        assert transcription_data['value'] == ''
         assert transcription_data['languageCode'] == 'en'
 
-        # Pending translation: pendingReview present, value absent
+        # Pending translation: pendingReview present, value blanked out
         assert translation_data is not None
         assert translation_data['es'].get('pendingReview') is True
-        assert 'value' not in translation_data['es']
+        assert translation_data['es']['value'] == ''
         assert translation_data['es']['languageCode'] == 'es'
 
     def test_retrieve_data_for_output_selects_most_recent_transcript(self):
@@ -374,7 +376,7 @@ class SubmissionSupplementTestCase(TestCase):
 
         assert transcript is not None
         assert transcript.get('pendingReview') is True
-        assert 'value' not in transcript
+        assert transcript['value'] == ''
         assert transcript['languageCode'] == 'en'
 
     def test_retrieve_data_for_output_accepted_transcript_has_no_pending_review(self):

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -1571,7 +1571,7 @@ class SubmissionApiTests(SubmissionDeleteTestCaseMixin, BaseSubmissionTestCase):
             response.data['results'][0]['_supplementalDetails']['q1']['transcript']
         )
         assert transcript.get('pendingReview') is True
-        assert 'value' not in transcript
+        assert transcript['value'] == ''
 
         transcription_data['q1']['automatic_google_transcription']['_versions'][0][
             '_dateAccepted'


### PR DESCRIPTION
### 📣 Summary

Exporting submission data (XLSX, CSV, etc.) could fail when a transcription or translation was still awaiting review.

### 💭 Notes

`transform_data_for_output` (`kobo/apps/subsequences/actions/mixins.py`) previously omitted the `value` key entirely from the `_supplementalDetails` payload whenever `pendingReview` was `True`, keeping only the `pendingReview` flag.

The `/api/v2/assets/{uid}/data` endpoint (its only intended consumer per DEV-2333 / #7182) only needs the `pendingReview` flag to render the frontend's "Review" button, so this was fine there. 
However `SubmissionSupplement.retrieve_data(for_output=True)` is also reused by the export pipeline (`ExportTask.get_export_object` → `get_submissions(for_output=True)`), and formpack's `QualTranscriptField.get_value_from_entry` reads `response['value']` unconditionally, with no `except KeyError` guard (unlike its translation counterpart, which happens to be guarded). A submission whose latest transcription for a given language was pending review would therefore raise an uncaught `KeyError` while building that export row.

Fix: both methods now always include `value` in the output entry. When `pending_review` is `True`, `value` is set to an empty string instead of being omitted, so the unreviewed content isn't leaked to the frontend, but formpack (and any other consumer) can read the key unconditionally without crashing.

### 👀 Preview steps

1. ℹ️ have an account and a project with an automatic transcription action enabled
2. submit a response and let the automatic transcription complete without accepting it (so it stays pending review)
3. export the submission data (XLSX or CSV)
4. 🔴 [on release/2.026.27] export fails with an uncaught `KeyError`
5. 🟢 [on this PR] export succeeds; the transcript column is blank for that row until the transcription is accepted