### PR TITLE
feat(bulkProcessing): improve UI blocking code based on bulk job status(es) DEV-2538

### DIFF
--- a/jsapp/js/components/processing/common/conflictingOngoingJob.tests.ts
+++ b/jsapp/js/components/processing/common/conflictingOngoingJob.tests.ts
@@ -2,6 +2,7 @@ import chai from 'chai'
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
+import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
 import { getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock } from '#/api/react-query/survey-data/msw'
 import { isConflictingOngoingJobForSubmission } from './conflictingOngoingJob'
 
@@ -10,12 +11,18 @@ function buildBulkAction(
   language: string,
   overrides: Partial<BulkActionResponse> = {},
 ): BulkActionResponse {
+  const status = overrides.status ?? BulkActionResponseStatusEnum.in_progress
+  // These jobs hold one submission, so its status matches the job's. Every job
+  // status has a submission status of the same name, so we can just look it up.
+  const submissionStatus = BulkActionSubmissionStatusResponseStatusEnum[status]
+
   return getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock({
     uid: `bulk-${submissionUuid}-${language}`,
-    status: BulkActionResponseStatusEnum.in_progress,
+    status,
     action_id: ActionIdEnum.automatic_google_transcription,
     question_xpath: 'audio_question',
     submission_uuids: [submissionUuid],
+    submission_statuses: [{ uuid: submissionUuid, status: submissionStatus, error: null }],
     params: { language },
     progress: 0,
     created_by: { username: 'tester' },
@@ -147,5 +154,108 @@ describe('isConflictingOngoingJobForSubmission', () => {
     })
 
     chai.expect(result).to.equal(true)
+  })
+
+  // Reviewing one submission while the rest of its batch is still running.
+  describe('with a partially finished job', () => {
+    const siblingUuid = 'submission-2'
+
+    function buildPartiallyFinishedAction(overrides: Partial<BulkActionResponse> = {}) {
+      return buildBulkAction(submissionUuid, 'en', {
+        action_id: ActionIdEnum.automatic_google_transcription,
+        question_xpath: fieldXpath,
+        status: BulkActionResponseStatusEnum.in_progress,
+        submission_uuids: [submissionUuid, siblingUuid],
+        submission_statuses: [
+          { uuid: submissionUuid, status: BulkActionSubmissionStatusResponseStatusEnum.complete, error: null },
+          { uuid: siblingUuid, status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+        ],
+        ...overrides,
+      })
+    }
+
+    it('returns false for the submission that the job already finished', () => {
+      const result = isConflictingOngoingJobForSubmission({
+        activeBulkActions: [buildPartiallyFinishedAction()],
+        actionType: 'transcript',
+        fieldXpath,
+        submissionUuid,
+        selectedLanguage: 'en',
+      })
+
+      chai.expect(result).to.equal(false)
+    })
+
+    it('returns true for the sibling submission that the job is still processing', () => {
+      const result = isConflictingOngoingJobForSubmission({
+        activeBulkActions: [buildPartiallyFinishedAction()],
+        actionType: 'transcript',
+        fieldXpath,
+        submissionUuid: siblingUuid,
+        selectedLanguage: 'en',
+      })
+
+      chai.expect(result).to.equal(true)
+    })
+
+    it('returns false for a submission whose own processing failed', () => {
+      const result = isConflictingOngoingJobForSubmission({
+        activeBulkActions: [
+          buildPartiallyFinishedAction({
+            submission_statuses: [
+              { uuid: submissionUuid, status: BulkActionSubmissionStatusResponseStatusEnum.failed, error: 'nope' },
+              { uuid: siblingUuid, status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+            ],
+          }),
+        ],
+        actionType: 'transcript',
+        fieldXpath,
+        submissionUuid,
+        selectedLanguage: 'en',
+      })
+
+      chai.expect(result).to.equal(false)
+    })
+
+    it('returns true for a submission still queued behind an in-progress sibling', () => {
+      const result = isConflictingOngoingJobForSubmission({
+        activeBulkActions: [
+          buildPartiallyFinishedAction({
+            submission_statuses: [
+              { uuid: submissionUuid, status: BulkActionSubmissionStatusResponseStatusEnum.pending, error: null },
+              { uuid: siblingUuid, status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+            ],
+          }),
+        ],
+        actionType: 'transcript',
+        fieldXpath,
+        submissionUuid,
+        selectedLanguage: 'en',
+      })
+
+      chai.expect(result).to.equal(true)
+    })
+
+    it('matches submission uuids regardless of the default uuid prefix', () => {
+      const result = isConflictingOngoingJobForSubmission({
+        activeBulkActions: [
+          buildPartiallyFinishedAction({
+            submission_statuses: [
+              {
+                uuid: `uuid:${submissionUuid}`,
+                status: BulkActionSubmissionStatusResponseStatusEnum.in_progress,
+                error: null,
+              },
+            ],
+          }),
+        ],
+        actionType: 'transcript',
+        fieldXpath,
+        submissionUuid,
+        selectedLanguage: 'en',
+      })
+
+      chai.expect(result).to.equal(true)
+    })
   })
 })

--- a/jsapp/js/components/processing/common/conflictingOngoingJob.ts
+++ b/jsapp/js/components/processing/common/conflictingOngoingJob.ts
@@ -1,8 +1,8 @@
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
-import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { LanguageCode } from '#/components/languages/languagesStore'
+import { isSubmissionOngoingInBulkAction } from '#/components/submissions/bulkProcessingUtils'
 import { removeDefaultUuidPrefix } from '#/utils'
 
 interface IsConflictingOngoingJobArgs {
@@ -22,27 +22,37 @@ export function getSubmissionRootUuid(submission: DataResponse) {
   return removeDefaultUuidPrefix(submission['meta/rootUuid'])
 }
 
-// Pending and in-progress jobs can still write/update records, so only those
-// states can block editing in Single Processing.
-function isOngoingBulkAction(action: BulkActionResponse) {
-  return (
-    action.status === BulkActionResponseStatusEnum.pending || action.status === BulkActionResponseStatusEnum.in_progress
-  )
+/**
+ * Checks whether given job writes to the text we're about to edit.
+ *
+ * Assumes the job was already matched to our question xpath by the caller.
+ */
+function isConflictingAction(
+  action: BulkActionResponse,
+  actionType: IsConflictingOngoingJobArgs['actionType'],
+  selectedLanguage?: LanguageCode,
+) {
+  // A transcription job rewrites the transcript, which is both the text we edit
+  // on the transcript tab and the source a translation gets made from.
+  if (action.action_id === ActionIdEnum.automatic_google_transcription) {
+    return true
+  }
+
+  if (action.action_id === ActionIdEnum.automatic_google_translation) {
+    // A translation job reads the transcript, so it clashes with editing it.
+    // For translations it only clashes with the language it writes to.
+    return actionType === 'transcript' || action.params.language === selectedLanguage
+  }
+
+  return false
 }
 
 /**
  * Checks whether one submission should be considered locked by an active bulk job.
  *
- * Transcript rule:
- * - Ongoing bulk transcription on the same question conflicts.
- * - Ongoing bulk translation on the same question also conflicts, because the
- *   transcript is the source text the translation job is reading from.
- *
- * Translation rules:
- * - Ongoing bulk transcription on the same question conflicts because transcript
- *   is the translation source and may still change.
- * - Ongoing bulk translation on the same question conflicts only when target
- *   language matches; different languages write to different destinations.
+ * A job locks a submission when it targets the same question, writes to the text
+ * we want to edit (see `isConflictingAction`), and hasn't finished that
+ * submission yet (see `isSubmissionOngoingInBulkAction`).
  */
 export function isConflictingOngoingJobForSubmission(args: IsConflictingOngoingJobArgs) {
   const { activeBulkActions, actionType, fieldXpath, submissionUuid, selectedLanguage } = args
@@ -55,30 +65,16 @@ export function isConflictingOngoingJobForSubmission(args: IsConflictingOngoingJ
     return false
   }
 
-  return activeBulkActions.filter(isOngoingBulkAction).some((action) => {
+  return activeBulkActions.some((action) => {
     // Different question xpath means a different write target.
     if (action.question_xpath !== fieldXpath) {
       return false
     }
 
-    if (actionType === 'transcript') {
-      return (
-        (action.action_id === ActionIdEnum.automatic_google_transcription ||
-          action.action_id === ActionIdEnum.automatic_google_translation) &&
-        action.submission_uuids.includes(submissionUuid)
-      )
+    if (!isConflictingAction(action, actionType, selectedLanguage)) {
+      return false
     }
 
-    if (action.action_id === ActionIdEnum.automatic_google_transcription) {
-      // Translation depends on transcript content, so we treat active
-      // transcript generation as a conflict here too.
-      return action.submission_uuids.includes(submissionUuid)
-    }
-
-    if (action.action_id === ActionIdEnum.automatic_google_translation) {
-      return action.params.language === selectedLanguage && action.submission_uuids.includes(submissionUuid)
-    }
-
-    return false
+    return isSubmissionOngoingInBulkAction(action, [submissionUuid])
   })
 }

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.tests.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.tests.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
+import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
 import { getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock } from '#/api/react-query/survey-data/msw'
 import assetDataFactory from '#/endpoints/assetData.factory'
 import { asrExceeded, asrNearLimit, mtExceeded, mtNearLimit, withinLimits } from '#/endpoints/serviceUsage.factory'
@@ -21,11 +22,26 @@ function bulkActionFactory(
   language: string,
   overrides: Partial<BulkActionResponse> = {},
 ): BulkActionResponse {
-  return getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock({
+  const mock = getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock({
     uid,
     params: { language },
     ...overrides,
   })
+
+  // The generated mock randomizes `submission_statuses`, which would make tests
+  // pass or fail at random. Default them to the job status instead, and let a
+  // test override them when it cares about a specific submission.
+  if (!overrides.submission_statuses) {
+    // Every job status has a submission status of the same name, so we can just
+    // look it up.
+    const submissionStatus = BulkActionSubmissionStatusResponseStatusEnum[mock.status]
+
+    mock.submission_statuses = mock.submission_uuids.map((submissionUuid) => {
+      return { uuid: submissionUuid, status: submissionStatus, error: null }
+    })
+  }
+
+  return mock
 }
 
 describe('evaluateNoEligibleSubmissions', () => {
@@ -335,6 +351,79 @@ describe('evaluateConflictingJob', () => {
     const result = evaluateConflictingJob(context)
 
     expect(result).to.equal(null)
+  })
+
+  it('should only ignore submissions that the ongoing job has not finished yet', () => {
+    const context: AlertEvaluationContext = {
+      ...baseContext,
+      activeBulkActions: [
+        bulkActionFactory('uuid-1', 'en', {
+          // The job itself stays in progress until its last submission is done.
+          status: BulkActionResponseStatusEnum.in_progress,
+          question_xpath: 'audio_question',
+          action_id: ActionIdEnum.automatic_google_transcription,
+          submission_uuids: ['mock-uuid-1', 'mock-uuid-2', 'mock-uuid-3'],
+          submission_statuses: [
+            { uuid: 'mock-uuid-1', status: BulkActionSubmissionStatusResponseStatusEnum.complete, error: null },
+            { uuid: 'mock-uuid-2', status: BulkActionSubmissionStatusResponseStatusEnum.failed, error: 'nope' },
+            { uuid: 'mock-uuid-3', status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+          ],
+        }),
+      ],
+      submissions: [assetDataFactory(1), assetDataFactory(2), assetDataFactory(3)],
+    }
+
+    const result = evaluateConflictingJob(context)
+
+    expect(result).to.not.equal(null)
+    expect(result?.filteredSubmissionUuids).to.deep.equal(['mock-uuid-3'])
+    expect(result?.computedValues.count).to.equal(1)
+  })
+
+  it('should not show alert when the ongoing job already finished every selected submission', () => {
+    const context: AlertEvaluationContext = {
+      ...baseContext,
+      activeBulkActions: [
+        bulkActionFactory('uuid-1', 'en', {
+          status: BulkActionResponseStatusEnum.in_progress,
+          question_xpath: 'audio_question',
+          action_id: ActionIdEnum.automatic_google_transcription,
+          submission_uuids: ['mock-uuid-1', 'other-uuid'],
+          submission_statuses: [
+            { uuid: 'mock-uuid-1', status: BulkActionSubmissionStatusResponseStatusEnum.complete, error: null },
+            { uuid: 'other-uuid', status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+          ],
+        }),
+      ],
+      submissions: [assetDataFactory(1)],
+    }
+
+    const result = evaluateConflictingJob(context)
+
+    expect(result).to.equal(null)
+  })
+
+  it('should match submissions by root uuid even when it carries the default prefix', () => {
+    const context: AlertEvaluationContext = {
+      ...baseContext,
+      activeBulkActions: [
+        bulkActionFactory('uuid-1', 'en', {
+          status: BulkActionResponseStatusEnum.in_progress,
+          question_xpath: 'audio_question',
+          action_id: ActionIdEnum.automatic_google_transcription,
+          submission_uuids: ['uuid:mock-uuid-1'],
+          submission_statuses: [
+            { uuid: 'uuid:mock-uuid-1', status: BulkActionSubmissionStatusResponseStatusEnum.in_progress, error: null },
+          ],
+        }),
+      ],
+      submissions: [assetDataFactory(1)],
+    }
+
+    const result = evaluateConflictingJob(context)
+
+    expect(result).to.not.equal(null)
+    expect(result?.filteredSubmissionUuids).to.deep.equal(['mock-uuid-1'])
   })
 })
 

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts
@@ -1,7 +1,12 @@
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import { getSupplementalPathParts } from '#/components/processing/processingUtils'
-import { hasTranscribableAudio, hasTranslatableTranscript } from '#/components/submissions/bulkProcessingUtils'
+import {
+  getOngoingBulkActionSubmissionUuids,
+  hasTranscribableAudio,
+  hasTranslatableTranscript,
+} from '#/components/submissions/bulkProcessingUtils'
+import { removeDefaultUuidPrefix } from '#/utils'
 import type { AlertEvaluationContext, AlertEvaluationResult } from './types'
 
 /**
@@ -136,15 +141,20 @@ export function evaluateConflictingJob(context: AlertEvaluationContext): AlertEv
     return null
   }
 
-  // Collect all submission UUIDs from conflicting jobs
+  // Submissions a conflicting job already finished stay eligible for a new job,
+  // so collect only the ones it is still working on.
   const conflictingUuids = new Set<string>()
   conflictingJobs.forEach((job) => {
-    job.submission_uuids.forEach((uuid) => conflictingUuids.add(uuid))
+    getOngoingBulkActionSubmissionUuids(job).forEach((uuid) => conflictingUuids.add(uuid))
   })
 
-  // Filter out submissions that are in conflicting jobs
+  // Bulk actions are keyed by root uuid, so check both uuids of each submission.
   const filteredSubmissionUuids = submissions
-    .filter((submission) => conflictingUuids.has(submission._uuid))
+    .filter((submission) =>
+      [submission._uuid, submission['meta/rootUuid']].some(
+        (uuid) => uuid && conflictingUuids.has(removeDefaultUuidPrefix(uuid)),
+      ),
+    )
     .map((submission) => submission._uuid)
 
   if (filteredSubmissionUuids.length === 0) {

--- a/jsapp/js/components/submissions/bulkProcessingUtils.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.ts
@@ -69,6 +69,39 @@ export function getBulkProcessingColumnKey(bulkAction: BulkActionResponse) {
   return null
 }
 
+// A queued submission is not done yet, so it counts as ongoing too.
+const ONGOING_SUBMISSION_STATUSES: BulkActionSubmissionStatusResponseStatusEnum[] = [
+  BulkActionSubmissionStatusResponseStatusEnum.pending,
+  BulkActionSubmissionStatusResponseStatusEnum.in_progress,
+]
+
+/**
+ * Returns uuids of the submissions given bulk action hasn't finished yet.
+ *
+ * A bulk action has two kinds of status: its own, and one per submission. The
+ * job stays `in_progress` until the slowest submission finishes, so only the
+ * per-submission status tells you if a given submission is still being worked on.
+ */
+export function getOngoingBulkActionSubmissionUuids(bulkAction: BulkActionResponse): string[] {
+  return bulkAction.submission_statuses
+    .filter((submissionStatus) => ONGOING_SUBMISSION_STATUSES.includes(submissionStatus.status))
+    .map((submissionStatus) => removeDefaultUuidPrefix(submissionStatus.uuid))
+}
+
+/**
+ * Checks if this bulk action is still processing given submission.
+ *
+ * Pass every uuid that identifies the submission (usually `_uuid` and
+ * `meta/rootUuid`), because different code paths know it by different ones.
+ */
+export function isSubmissionOngoingInBulkAction(
+  bulkAction: BulkActionResponse,
+  submissionUuids: Array<string | undefined>,
+): boolean {
+  const ongoingUuids = new Set(getOngoingBulkActionSubmissionUuids(bulkAction))
+  return submissionUuids.some((uuid) => uuid && ongoingUuids.has(removeDefaultUuidPrefix(uuid)))
+}
+
 export function isBulkProcessingCellInProgress(
   bulkActions: BulkActionResponse[],
   submission: SubmissionResponse,
@@ -78,23 +111,12 @@ export function isBulkProcessingCellInProgress(
     return false
   }
 
-  const submissionUuids = new Set(
-    [removeDefaultUuidPrefix(submission._uuid), removeDefaultUuidPrefix(submission['meta/rootUuid'])].filter(Boolean),
-  )
-
   return bulkActions.some((bulkAction) => {
     if (getBulkProcessingColumnKey(bulkAction) !== columnKey) {
       return false
     }
 
-    // Treat both 'in_progress' and 'pending' as "Processing" to ensure the cell displays
-    // "Processing" for jobs that are queued but not yet started, as well as those already in progress.
-    return bulkAction.submission_statuses.some(
-      (submissionStatus) =>
-        (submissionStatus.status === BulkActionSubmissionStatusResponseStatusEnum.in_progress ||
-          submissionStatus.status === BulkActionSubmissionStatusResponseStatusEnum.pending) &&
-        submissionUuids.has(removeDefaultUuidPrefix(submissionStatus.uuid)),
-    )
+    return isSubmissionOngoingInBulkAction(bulkAction, [submission._uuid, submission['meta/rootUuid']])
   })
 }
 


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed transcripts and translations being locked for review/save while other rows from the same bulk job were still being processed.

### 💭 Notes

Root cause: we checked `submission_uuids` (every row in the job) against the *job's* status. A job stays `in_progress` until its slowest row finishes, so one straggler held the whole batch hostage. The per-row statuses in `submission_statuses` were the right source all along — the table view was already using them and got this right, which is why cells correctly flipped to "Review".

Changes here:

- **`jsapp/js/components/submissions/bulkProcessingUtils.ts`** - adding two new utils for per-row status, reusing code
- **`jsapp/js/components/processing/common/conflictingOngoingJob.ts`** - using the helper, fixing all possible consumers; dropped the job-level status filter that's now redundant
- **`jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.ts`** - `evaluateConflictingJob()` had the same bug and would ignore rows a running job had already finished
- **Tests** (`conflictingOngoingJob.tests.ts`, `alertEvaluators.tests.ts`) - coverage for the partially-finished job etc, no longer randomizng `submission_statuses`

### 👀 Preview steps

1. ℹ️ have a project with an audio question and at least 4-5 submissions — mix in one clearly longer recording so it finishes last
2. go to Project → Data → Table
3. select all the rows
4. in the audio column header dropdown pick "Transcribe selected audio files" and confirm in the modal
5. notice "Processing" appears for every row in the new transcription column
6. wait until at least one row flips to a "Review" button while at least one other row still says "Processing" ⚠️ this is the window we care about
7. click "Review" on one of the finished rows
8. 🔴 [on main] notice the "This submission is already being processed by another job." warning and a disabled "Save" button
9. 🟢 [on PR] notice no warning, and "Save" works — edit the transcript, save it, and the change sticks
10. go back to Project → Data → Table and click "Open" on a row that still says "Processing"
11. follow through with creating a transcript
12. 🟢 notice the warning and disabled buttons are still there for that one
