### PR TITLE
fix(formbuilder): preserve manual skip logic and validation inputs DEV-2539

### DIFF
--- a/jsapp/xlform/src/mv.skipLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.skipLogicHelpers.coffee
@@ -403,12 +403,21 @@ module.exports = do ->
 
   class skipLogicHelpers.SkipLogicHandCodeHelper
     render: ($destination) ->
+      # Sync @textarea.text from @criteria so TextArea.render() restores the
+      # current value rather than the original one from construction time.
+      @textarea.text = @criteria
       $destination.append @$parent
       @textarea.render().attach_to @$parent
       @button.render().attach_to @$parent
       @button.bind_event 'click', () => @context.use_mode_selector_helper()
+      # Use 'input' (fires on every keystroke) rather than 'change' (fires on
+      # blur) so @criteria is always current. .off() prevents accumulating
+      # duplicate handlers across re-renders.
+      @textarea.$el.off('input').on 'input', () =>
+        @criteria = @textarea.$el.val()
+        @context.view_factory.survey.trigger('change')
     serialize: () ->
-      @textarea.$el.val() || @criteria
+      @criteria
     constructor: (@criteria, @builder, @view_factory, @context) ->
       @$parent = $('<div>')
       @textarea = @view_factory.create_textarea @criteria, 'skiplogic__handcode-edit'
@@ -426,7 +435,6 @@ module.exports = do ->
         @context.use_criterion_builder_helper()
       )
       @handcode_button.bind_event('click', () =>
-        @context.view_factory.survey.trigger('change')
         @context.use_hand_code_helper()
       )
 

--- a/jsapp/xlform/src/mv.skipLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.skipLogicHelpers.coffee
@@ -403,16 +403,13 @@ module.exports = do ->
 
   class skipLogicHelpers.SkipLogicHandCodeHelper
     render: ($destination) ->
-      # Sync @textarea.text from @criteria so TextArea.render() restores the
-      # current value rather than the original one from construction time.
       @textarea.text = @criteria
       $destination.append @$parent
       @textarea.render().attach_to @$parent
       @button.render().attach_to @$parent
       @button.bind_event 'click', () => @context.use_mode_selector_helper()
-      # Use 'input' (fires on every keystroke) rather than 'change' (fires on
-      # blur) so @criteria is always current. .off() prevents accumulating
-      # duplicate handlers across re-renders.
+      # Use 'input'  rather than 'change' so @criteria is always current.
+      # .off() prevents accumulating duplicate handlers across re-renders.
       @textarea.$el.off('input').on 'input', () =>
         @criteria = @textarea.$el.val()
         @context.view_factory.survey.trigger('change')

--- a/jsapp/xlform/src/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.validationLogicHelpers.coffee
@@ -80,11 +80,11 @@ module.exports = do ->
       @button.bind_event 'click', () =>
         @$handCode.replaceWith($destination)
         @context.use_mode_selector_helper()
-      @$handCode.on('change', () =>
+      @textarea.off('input').on 'input', () =>
+        @criteria = @textarea.val()
         @context.view_factory.survey.trigger('change')
-      )
     serialize: () ->
-      @textarea.val()
+      @criteria
     constructor: (criteria, builder, view_factory, context) ->
       super(criteria, builder, view_factory, context)
       @$handCode = $("""

--- a/jsapp/xlform/src/mv.validationLogicHelpers.coffee
+++ b/jsapp/xlform/src/mv.validationLogicHelpers.coffee
@@ -74,12 +74,14 @@ module.exports = do ->
       @handcode_button = view_factory.create_button '<i>${}</i> ' + t("Manually enter your validation logic in XLSForm code"), 'kobo-button kobo-button--blue'
 
   class validationLogicHelpers.ValidationLogicHandCodeHelper extends $skipLogicHelpers.SkipLogicHandCodeHelper
+    _onDeleteClick: () ->
+      @$handCode.replaceWith(@$destination)
+      @context.use_mode_selector_helper()
     render: ($destination) ->
-      $destination.replaceWith(@$handCode)
+      @$destination = $destination
+      @$destination.replaceWith(@$handCode)
       @button.render().attach_to @$handCode
-      @button.bind_event 'click', () =>
-        @$handCode.replaceWith($destination)
-        @context.use_mode_selector_helper()
+      @button.$el.off('click').on 'click', () => @_onDeleteClick()
       @textarea.off('input').on 'input', () =>
         @criteria = @textarea.val()
         @context.view_factory.survey.trigger('change')


### PR DESCRIPTION
### 📣 Summary

Fixed an issue where skip logic and validation criteria entered manually could be lost after closing and reopening the question settings panel.

### 💭 Notes

In the form builder's hand-code mode for skip logic and validation criteria, closing the settings panel (clicking ✕) and reopening it would reset the text field to the value it had when the panel was first opened. This meant any edits made since opening the panel were silently discarded — including deleting existing logic. Saving the form at that point would preserve the stale value rather than the intended one.

The root cause was that `TextArea.render()` always resets the DOM value to its original construction-time text. On each re-open, `render()` was called again, clobbering whatever the user had typed. Separately, `serialize()` read its value directly from the DOM element — which returns empty string when the element is detached — and fell back to the last-known non-empty value, making it impossible to clear existing logic.

Also removed a spurious `survey.trigger('change')` that was firing when switching to hand-code mode before the user had typed anything, which caused the save button to show unsaved changes immediately on mode switch.

### 👀 Preview steps

1. ℹ️ Have a project with at least two questions
2. Open the form builder and click the settings (gear) icon on a question
3. Go to **Skip Logic**, click "Manually enter your skip logic in XLSForm code", and type `${q1} != ''`
4. Click ✕ to close the settings panel, then reopen it
5. 🔴 [on main] the textarea is empty or reset to its original value
6. 🟢 [on PR] the textarea shows `${q1} != ''`
7. Clear the textarea completely, close the panel, and save the form
8. 🔴 [on main] the old skip logic value is still saved
9. 🟢 [on PR] the skip logic is cleared
10. Repeat steps 3–9 using **Validation Criteria** instead of Skip Logic
11. 🟢 [on PR] same correct behaviour for validation criteria
12. Click **Manually enter your skip logic in XLSForm code** without typing anything
13. 🔴 [on main] the save button shows unsaved changes immediately
14. 🟢 [on PR] the save button does not change until you actually type something
