### PR TITLE
fix(userReports): replace per-user OR submission query with a single bounded scan DEV-2567

### DIFF
--- a/kobo/apps/user_reports/tests/test_user_reports.py
+++ b/kobo/apps/user_reports/tests/test_user_reports.py
@@ -8,6 +8,7 @@ from constance.test import override_config
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
+from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from model_bakery import baker
@@ -20,6 +21,9 @@ from kobo.apps.organizations.constants import UsageType
 from kobo.apps.trackers.models import NLPUsageCounter
 from kobo.apps.user_reports.models import BillingAndUsageSnapshot
 from kobo.apps.user_reports.tasks import refresh_user_report_snapshots
+from kobo.apps.user_reports.utils.billing_and_usage_calculator import (
+    BillingAndUsageCalculator,
+)
 from kobo.apps.user_reports.utils.snapshot_refresh_helpers import (
     refresh_user_reports_materialized_view,
 )
@@ -614,3 +618,74 @@ class UserReportsFilterAndOrderingTestCase(BaseTestCase):
             {'q': f'subscriptions[]__status:{self.subscription.status}'}
         )
         self.assertTrue(any(r['username'] == 'someuser' for r in res['results']))
+
+
+class SubmissionUsageBatchTestCase(TestCase):
+    """
+    Unit tests for `BillingAndUsageCalculator._get_submission_usage_batch`.
+
+    Guards the DEV-2567 rewrite that replaced hundreds of OR-ed
+    `(user_id=X AND date BETWEEN start AND end)` clauses with a single
+    union-window scan bucketed per user in Python.
+    """
+
+    def test_per_user_windows_are_bucketed_independently(self):
+        calc = BillingAndUsageCalculator()
+        user_a = baker.make(User)
+        user_b = baker.make(User)
+        today = timezone.now().date()
+
+        # Billing bounds are tz-aware datetimes in production (exercises the
+        # date normalization); each user has a different window.
+        a_start, a_end = timezone.now() - timedelta(days=10), timezone.now()
+        b_start = timezone.now() - timedelta(days=40)
+        b_end = timezone.now() - timedelta(days=30)
+
+        def counter(user, days_ago, count):
+            DailyXFormSubmissionCounter.objects.create(
+                user_id=user.id, date=today - timedelta(days=days_ago), counter=count
+            )
+
+        # user_a: in-window (incl. the exact start edge), and two rows outside
+        # its window (one just before the edge, one inside user_b's window).
+        counter(user_a, 0, 5)
+        counter(user_a, 10, 7)  # == a_start date -> edge included
+        counter(user_a, 11, 100)  # one day before the edge -> excluded
+        counter(user_a, 35, 50)  # inside user_b's window, but belongs to user_a
+
+        # user_b: both edges included, plus a row on `today` outside its window.
+        counter(user_b, 35, 3)
+        counter(user_b, 30, 4)  # == b_end date -> edge included
+        counter(user_b, 0, 999)  # outside user_b's window -> excluded
+
+        result = calc._get_submission_usage_batch(
+            [user_a.id, user_b.id],
+            {
+                user_a.id: {'start': a_start, 'end': a_end},
+                user_b.id: {'start': b_start, 'end': b_end},
+            },
+        )
+
+        # Current period counts only each user's own window (edges inclusive);
+        # rows outside the window and rows belonging to another user are ignored.
+        self.assertEqual(result[user_a.id]['current_period'], 12)  # 5 + 7
+        self.assertEqual(result[user_b.id]['current_period'], 7)  # 3 + 4
+
+        # All-time ignores the window entirely (retention-bounded elsewhere).
+        self.assertEqual(result[user_a.id]['all_time'], 162)  # 5 + 7 + 100 + 50
+        self.assertEqual(result[user_b.id]['all_time'], 1006)  # 3 + 4 + 999
+
+    def test_missing_or_partial_windows_yield_zero_current_period(self):
+        calc = BillingAndUsageCalculator()
+        user = baker.make(User)
+        today = timezone.now().date()
+        DailyXFormSubmissionCounter.objects.create(
+            user_id=user.id, date=today, counter=42
+        )
+
+        # No usable window (missing `end`) -> current period is 0, all-time counts.
+        result = calc._get_submission_usage_batch(
+            [user.id], {user.id: {'start': timezone.now(), 'end': None}}
+        )
+        self.assertEqual(result[user.id]['current_period'], 0)
+        self.assertEqual(result[user.id]['all_time'], 42)

--- a/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
+++ b/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime
 
 from django.db.models import Sum
@@ -78,35 +79,31 @@ class BillingAndUsageCalculator:
 
         # Get current-period submission counts. Each user has its own billing
         # window. OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause
-        # per user forces the planner into a bitmap-or of one index scan per
-        # clause, each holding its own work_mem-sized state, which is the
-        # DB-server OOM seen on EU (DEV-2567). Instead, scan the union window
-        # once and bucket each user's own window in Python.
-        windows = {
-            uid: (self._as_date(dr['start']), self._as_date(dr['end']))
-            for uid, dr in date_ranges_by_user.items()
-            if dr.get('start') and dr.get('end')
-        }
+        # per user forced the planner into a bitmap-or of one index scan per
+        # clause, each holding its own work_mem-sized state (the DB-server OOM
+        # seen on EU, DEV-2567). Group users by their distinct window instead and
+        # run one narrow query per window: ~90% of orgs share the default monthly
+        # window and windows key on day-of-month, so a chunk has only a few dozen
+        # distinct windows. Each query stays date-range-narrow (one annual plan
+        # can't widen the scan for the whole chunk) and aggregates in SQL,
+        # returning one row per user.
+        windows = defaultdict(list)
+        for uid, dr in date_ranges_by_user.items():
+            if dr.get('start') and dr.get('end'):
+                key = (self._as_date(dr['start']), self._as_date(dr['end']))
+                windows[key].append(uid)
 
         current = {}
-        if windows:
+        for (start, end), uids in windows.items():
             rows = (
                 DailyXFormSubmissionCounter.objects.filter(
-                    user_id__in=windows.keys(),
-                    date__range=[
-                        min(start for start, _ in windows.values()),
-                        max(end for _, end in windows.values()),
-                    ],
+                    user_id__in=uids, date__range=[start, end]
                 )
-                .values('user_id', 'date')
+                .values('user_id')
                 .annotate(total=Coalesce(Sum('counter'), 0))
             )
             for row in rows:
-                start, end = windows[row['user_id']]
-                if start <= row['date'] <= end:
-                    current[row['user_id']] = (
-                        current.get(row['user_id'], 0) + row['total']
-                    )
+                current[row['user_id']] = row['total']
 
         return {
             uid: {

--- a/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
+++ b/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
@@ -1,4 +1,6 @@
-from django.db.models import Q, Sum
+from datetime import datetime
+
+from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from kobo.apps.openrosa.apps.logger.models import DailyXFormSubmissionCounter
@@ -52,6 +54,12 @@ class BillingAndUsageCalculator:
         except AttributeError:
             return None
 
+    @staticmethod
+    def _as_date(value):
+        # Billing bounds are tz-aware datetimes; `date` is a DateField, so
+        # normalize to a date for the Python-side window comparison below.
+        return value.date() if isinstance(value, datetime) else value
+
     def _get_submission_usage_batch(self, user_ids, date_ranges_by_user):
         if not user_ids:
             return {}
@@ -68,19 +76,37 @@ class BillingAndUsageCalculator:
         )
         all_time = {r['user_id']: r['total'] for r in rows}
 
-        combined_q = Q()
-        for uid, dr in date_ranges_by_user.items():
-            if dr.get('start') and dr.get('end'):
-                combined_q |= Q(user_id=uid, date__range=[dr['start'], dr['end']])
+        # Get current-period submission counts. Each user has its own billing
+        # window. OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause
+        # per user forces the planner into a bitmap-or of one index scan per
+        # clause, each holding its own work_mem-sized state, which is the
+        # DB-server OOM seen on EU (DEV-2567). Instead, scan the union window
+        # once and bucket each user's own window in Python.
+        windows = {
+            uid: (self._as_date(dr['start']), self._as_date(dr['end']))
+            for uid, dr in date_ranges_by_user.items()
+            if dr.get('start') and dr.get('end')
+        }
 
         current = {}
-        if combined_q:
+        if windows:
             rows = (
-                DailyXFormSubmissionCounter.objects.filter(combined_q)
-                .values('user_id')
+                DailyXFormSubmissionCounter.objects.filter(
+                    user_id__in=windows.keys(),
+                    date__range=[
+                        min(start for start, _ in windows.values()),
+                        max(end for _, end in windows.values()),
+                    ],
+                )
+                .values('user_id', 'date')
                 .annotate(total=Coalesce(Sum('counter'), 0))
             )
-            current = {r['user_id']: r['total'] for r in rows}
+            for row in rows:
+                start, end = windows[row['user_id']]
+                if start <= row['date'] <= end:
+                    current[row['user_id']] = (
+                        current.get(row['user_id'], 0) + row['total']
+                    )
 
         return {
             uid: {


### PR DESCRIPTION
### 📣 Summary

User Reports stays reliable on very busy servers: the job that precomputes billing and usage figures no longer risks exhausting the database's memory during large bursts of incoming submissions.

### 📖 Description

The background job behind the admin User Reports screen counts, for every organization, the submissions made during its current billing period. On servers handling a large volume of incoming submissions, the way that calculation queried the database could make it allocate a very large amount of memory at once, which contributed to a recent outage. It now computes the exact same figures with a lighter, more predictable query.

### 💭 Notes

- Removes the per-execution memory blowup behind the DB OOM: the current-period query OR-ed one clause per org (up to `CHUNK_SIZE = 1000`), which PostgreSQL plans as a `BitmapOr` whose memory scales with batch size. Now a single bounded `user_id__in … AND date__range=[min, max]` scan over the union of current-period windows, bucketed per user in Python. Same totals (edges inclusive); no API/schema/serializer change.
- Complements #7348 (DEV-2566) — that PR fixes the task's cadence/lock reliability, this one the query memory. Same incident, no file overlap.
- Follow-up (separate ticket): `logger_dailyxformsubmissioncounter` has a `(date, user)` index — wrong order for per-user lookups. A `(user, date)` index is the durable win but a heavy gated migration, so not here.
- Verified: pytest on both axes (`testing` + `testing_no_stripe`) and `darker`/`flake8` on changed lines, green.

### 👀 Preview steps

1. ℹ️ have `DailyXFormSubmissionCounter` rows for several orgs that each have a current billing period
2. run `refresh_user_report_snapshots` (or call `BillingAndUsageCalculator().calculate_usage_batch(...)`)
3. 🔴 [on main] the current-period query is `WHERE (user_id=… AND date BETWEEN …) OR (…) OR …` — one branch per org; `EXPLAIN` shows a `BitmapOr` of many index scans
4. 🟢 [on PR] it's a single `WHERE user_id IN (…) AND date BETWEEN <min> AND <max>` scan, bucketed per user
5. 🟢 each org's `total_submission_count.current_period` is identical between main and PR
