### PR TITLE
fix(digestAuth): use a fixed content type on auth failure DEV-2488

### DIFF
--- a/kobo/apps/openrosa/apps/viewer/tests/test_attachment_url.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_attachment_url.py
@@ -38,6 +38,20 @@ class TestBriefcaseAttachmentUrl(TestBase):
         response = digest_client.get(self._url())
         assert response.status_code == 200
 
+    def test_digest_auth_failure_returns_401_with_fixed_content_type(self):
+        """
+        A GET carrying a Digest header with invalid credentials must return
+        the AuthenticationFailed status (401) with a fixed `text/plain`
+        content type. It must not 500 on a missing request Content-Type
+        header, nor echo a caller-controlled Content-Type (DEV-2488).
+        """
+        self.client.logout()
+        digest_client = DigestClient()
+        digest_client.set_authorization(self.login_username, 'wrong-password')
+        response = digest_client.get(self._url())
+        assert response.status_code == 401
+        assert response['Content-Type'] == 'text/plain'
+
     def test_attachment_not_found(self):
         url = reverse(
             'briefcase-attachment',

--- a/kobo/apps/openrosa/libs/authentication.py
+++ b/kobo/apps/openrosa/libs/authentication.py
@@ -15,10 +15,11 @@ def digest_authentication(request):
     try:
         authentication = authenticator.authenticate(request)
     except AuthenticationFailed as e:
+        # The body is a fixed plain-text error message. Use a fixed content
+        # type rather than echoing the caller-controlled request Content-Type,
+        # which also 500s (KeyError) when the header is absent (DEV-2488).
         return HttpResponse(
-            str(e),
-            content_type=request.headers['content-type'],
-            status=AuthenticationFailed.status_code
+            str(e), content_type='text/plain', status=AuthenticationFailed.status_code
         )
     else:
         if not authentication:


### PR DESCRIPTION
### 📣 Summary

Fixed a server error (HTTP 500) that could occur when authentication failed while downloading a submission attachment.

### 📖 Description

When a client tried to download a submission attachment (for example over ODK Briefcase) with invalid credentials, the server could respond with an unexpected error instead of a proper "authentication required" response. It now consistently returns a 401.

### 💭 Notes

- `digest_authentication()` built the failure response with `content_type=request.headers['content-type']`. That header is caller-controlled and absent on the attachment `GET` path, so it raised `KeyError` → 500 on an unauthenticated route. Now pinned to `text/plain` (the body is a fixed plain-text error message).
- Also clears the CodeQL reflected-XSS alert (from DEV-2422): a request header no longer flows into the response `Content-Type`. Not practically exploitable (the path needs a CORS preflight the endpoint doesn't answer) — the 500 was the real bug.
- Added a regression test that drives the digest-failure branch (valid `Digest` header, wrong password) and asserts `401` + `text/plain`.
- Backend-only; no API schema change.

### 👀 Preview steps

1. ℹ️ Have a project with a submission that has an attachment.
2. As an anonymous client, request the Briefcase attachment URL with a `Digest` authorization header using wrong credentials and no `Content-Type` header.
3. 🔴 [on main] the server returns **HTTP 500** (KeyError on the missing `Content-Type`).
4. 🟢 [on PR] the server returns **HTTP 401** with `Content-Type: text/plain`.
