### PR TITLE
fix(userReports): reduce snapshot refresh cadence and mid-run MV refreshes DEV-2566

### DIFF
--- a/kobo/apps/user_reports/tasks.py
+++ b/kobo/apps/user_reports/tasks.py
@@ -1,3 +1,5 @@
+import time
+
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
@@ -17,7 +19,7 @@ from kobo.apps.user_reports.utils.snapshot_refresh_helpers import (
     cleanup_stale_snapshots_and_refresh_mv,
     get_or_create_run,
     iter_org_chunks_after,
-    process_chunk,
+    process_chunk, refresh_user_reports_materialized_view,
 )
 from kobo.celery import celery_app
 from kpi.utils.log import logging
@@ -83,6 +85,7 @@ def refresh_user_report_snapshots(**kwargs):
     )
 
     last_processed_org_id = run.last_processed_org_id or ''
+    last_time = time.time()
 
     try:
         while chunk_qs := iter_org_chunks_after(last_processed_org_id):
@@ -108,6 +111,13 @@ def refresh_user_report_snapshots(**kwargs):
                 last_processed_org_id=last_processed_org_id,
                 date_modified=timezone.now(),
             )
+
+            # Refresh the materialized view at most hourly during a run
+            # (was every 15 minutes) to cut its load on the database.
+            if time.time() - last_time >= 60 * 60:
+                logging.info('\tRefreshing the materialized view…')
+                last_time = time.time()
+                refresh_user_reports_materialized_view()
 
         # All orgs processed: cleanup stale, refresh MV and mark run as completed
         logging.info('Clean-up')

--- a/kobo/apps/user_reports/tasks.py
+++ b/kobo/apps/user_reports/tasks.py
@@ -1,5 +1,3 @@
-import time
-
 from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
@@ -19,7 +17,7 @@ from kobo.apps.user_reports.utils.snapshot_refresh_helpers import (
     cleanup_stale_snapshots_and_refresh_mv,
     get_or_create_run,
     iter_org_chunks_after,
-    process_chunk, refresh_user_reports_materialized_view,
+    process_chunk,
 )
 from kobo.celery import celery_app
 from kpi.utils.log import logging
@@ -85,7 +83,6 @@ def refresh_user_report_snapshots(**kwargs):
     )
 
     last_processed_org_id = run.last_processed_org_id or ''
-    last_time = time.time()
 
     try:
         while chunk_qs := iter_org_chunks_after(last_processed_org_id):
@@ -111,11 +108,6 @@ def refresh_user_report_snapshots(**kwargs):
                 last_processed_org_id=last_processed_org_id,
                 date_modified=timezone.now(),
             )
-
-            if time.time() - last_time >= 15 * 60:
-                logging.info('\tRefreshing the materialized view…')
-                last_time = time.time()
-                refresh_user_reports_materialized_view()
 
         # All orgs processed: cleanup stale, refresh MV and mark run as completed
         logging.info('Clean-up')

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1589,10 +1589,10 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/5'),
         'options': {'queue': 'kpi_low_priority_queue'},
     },
-    # Schedule every 15 minutes
+    # Schedule 3 times a day (every 8 hours)
     'refresh-user-report-snapshot': {
         'task': 'kobo.apps.user_reports.tasks.refresh_user_report_snapshots',
-        'schedule': crontab(minute='*/15'),
+        'schedule': crontab(minute=0, hour='*/8'),
         'options': {'queue': 'kpi_long_running_tasks_queue'},
     },
     # Schedule every day at midnight UTC


### PR DESCRIPTION
### 📣 Summary

Reduces the load from the User Reports background job on busy servers: it now runs 3 times a day instead of every 15 minutes, and rebuilds its data view at most once an hour during a pass instead of every 15 minutes.

### 📖 Description

Urgent mitigation while the fuller rework is in progress. The background job that keeps organizations' billing and usage figures up to date was running every 15 minutes and rebuilding its underlying data view every 15 minutes during each multi-hour pass, which contributed to database lock contention and memory pressure. This lowers its cadence to 3 times a day and rebuilds the view at most once an hour during a pass (plus once at the end).

### 💭 Notes

- Deliberately minimal stop-gap off `release/2.026.27` while DEV-2566 (#7348, the fuller reliability rework) is finalized and DEV-2567 (#7350, the query fix) lands. Two changes only.
- `base.py`: beat schedule `*/15` → `crontab(minute=0, hour='*/8')` (3×/day). The live schedule is a `PeriodicTask` DB row (`ThrottledDatabaseScheduler`); changing the settings entry's crontab syncs to the existing row via `update_or_create` on beat startup, so this reschedules the running task (and re-enables it if the row was manually disabled to stop the bleeding).
- `tasks.py`: raised the mid-run `refresh_user_reports_materialized_view()` interval from every 15 minutes to at most hourly (the end-of-pass `cleanup_stale_snapshots_and_refresh_mv` still rebuilds once at completion). One-line change.
- Orthogonal to the query fix (DEV-2567) and the lock/heartbeat rework (DEV-2566 / #7348) — this only touches cadence and MV-refresh frequency.

### 👀 Preview steps

1. ℹ️ have a worker on `kpi_long_running_tasks_queue` and `celery beat` running
2. trigger / observe `refresh_user_report_snapshots`
3. 🔴 [on release] beat fires it every 15 min, and the materialized view is rebuilt every 15 min during a run
4. 🟢 [on PR] beat fires it 3×/day, and the materialized view is rebuilt at most hourly during a run (plus once at the end)
