### PR TITLE
fix(usage): batch usage queries by billing window DEV-2567

### DIFF
--- a/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
+++ b/kobo/apps/user_reports/utils/billing_and_usage_calculator.py
@@ -1,12 +1,12 @@
-from collections import defaultdict
-from datetime import datetime
-
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from kobo.apps.openrosa.apps.logger.models import DailyXFormSubmissionCounter
 from kobo.apps.organizations.models import Organization
-from kpi.utils.usage_calculator import get_storage_usage_by_user_id
+from kpi.utils.usage_calculator import (
+    get_storage_usage_by_user_id,
+    group_user_ids_by_date_range,
+)
 from ..typing_aliases import OrganizationIterator
 
 
@@ -55,12 +55,6 @@ class BillingAndUsageCalculator:
         except AttributeError:
             return None
 
-    @staticmethod
-    def _as_date(value):
-        # Billing bounds are tz-aware datetimes; `date` is a DateField, so
-        # normalize to a date for the Python-side window comparison below.
-        return value.date() if isinstance(value, datetime) else value
-
     def _get_submission_usage_batch(self, user_ids, date_ranges_by_user):
         if not user_ids:
             return {}
@@ -77,21 +71,7 @@ class BillingAndUsageCalculator:
         )
         all_time = {r['user_id']: r['total'] for r in rows}
 
-        # Get current-period submission counts. Each user has its own billing
-        # window. OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause
-        # per user forced the planner into a bitmap-or of one index scan per
-        # clause, each holding its own work_mem-sized state (the DB-server OOM
-        # seen on EU, DEV-2567). Group users by their distinct window instead and
-        # run one narrow query per window: ~90% of orgs share the default monthly
-        # window and windows key on day-of-month, so a chunk has only a few dozen
-        # distinct windows. Each query stays date-range-narrow (one annual plan
-        # can't widen the scan for the whole chunk) and aggregates in SQL,
-        # returning one row per user.
-        windows = defaultdict(list)
-        for uid, dr in date_ranges_by_user.items():
-            if dr.get('start') and dr.get('end'):
-                key = (self._as_date(dr['start']), self._as_date(dr['end']))
-                windows[key].append(uid)
+        windows = group_user_ids_by_date_range(date_ranges_by_user)
 
         current = {}
         for (start, end), uids in windows.items():

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -395,6 +395,42 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
     )
+    def test_submission_counters_current_period_sums_across_multiple_dates(self):
+        """
+        Regression test: submissions on different in-range dates for the
+        same user must be summed together, not just one of them counted.
+        """
+        six_months_ago = timezone.now() - relativedelta(months=6)
+        six_months_from_now = six_months_ago + relativedelta(years=1)
+        mock_billing_periods = {
+            self.someuser.organization.id: {
+                'start': six_months_ago,
+                'end': six_months_from_now,
+            },
+        }
+        asset_2 = self._create_asset(self.someuser)
+
+        three_months_ago = timezone.now() - relativedelta(months=3)
+        four_months_ago = timezone.now() - relativedelta(months=4)
+        self.add_submissions(
+            count=2, asset=asset_2, username='someuser', date_override=three_months_ago
+        )
+        self.add_submissions(
+            count=3, asset=asset_2, username='someuser', date_override=four_months_ago
+        )
+
+        with patch(
+            'kpi.utils.usage_calculator.get_current_billing_period_dates_by_org',
+            return_value=mock_billing_periods,
+        ):
+            submissions_by_user = (
+                get_submissions_for_current_billing_period_by_user_id()
+            )
+        assert submissions_by_user[self.someuser.id] == 5
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
     def test_nlp_counters_current_period_all_orgs(self):
         six_months_ago = timezone.now() - relativedelta(months=6)
         six_months_from_now = six_months_ago + relativedelta(years=1)

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from datetime import datetime
 from json import dumps, loads
 from math import inf
 
@@ -32,20 +34,37 @@ def get_storage_usage_by_user_id(user_ids: list[int] = None) -> dict[int, int]:
     return {res['user_id']: res['attachment_storage_bytes'] for res in query.iterator()}
 
 
+def _as_date(value):
+    # Billing bounds are tz-aware datetimes; `date` is a DateField, so
+    # normalize to a date for grouping users into shared query windows below.
+    return value.date() if isinstance(value, datetime) else value
+
+
 def get_submission_counts_in_date_range_by_user_id(
     date_ranges_by_user,
 ) -> dict[int, int]:
-    filters = Q()
+    # OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause per user
+    # forces the planner into a bitmap-or of one index scan per clause (DB-server
+    # OOM seen on EU, DEV-2567). Group users by their distinct window instead and
+    # run one narrow query per window: most orgs share the default monthly
+    # window, so there are only a handful of distinct windows even at full scale.
+    windows = defaultdict(list)
     for user_id, date_range in date_ranges_by_user.items():
-        filters |= Q(
-            user_id=user_id, date__range=[date_range['start'], date_range['end']]
+        key = (_as_date(date_range['start']), _as_date(date_range['end']))
+        windows[key].append(user_id)
+
+    results = {}
+    for (start, end), user_ids in windows.items():
+        rows = (
+            DailyXFormSubmissionCounter.objects.filter(
+                user_id__in=user_ids, date__range=[start, end]
+            )
+            .values('user_id')
+            .annotate(total=Coalesce(Sum('counter'), 0))
         )
-    all_sub_counters = (
-        DailyXFormSubmissionCounter.objects.values('counter', 'user_id', 'date')
-        .filter(filters)
-        .annotate(total=Sum('counter'))
-    )
-    return {row['user_id']: row['total'] for row in all_sub_counters}
+        for row in rows:
+            results[row['user_id']] = row['total']
+    return results
 
 
 def calculate_usage_balance(limit: float, usage: int) -> UsageBalance | None:
@@ -82,38 +101,48 @@ def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int,
 
 
 def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLPUsage]:
-    filters = Q()
+    # Same fix as get_submission_counts_in_date_range_by_user_id: group users by
+    # their distinct window and run one narrow query per window instead of one
+    # giant OR-chain across every user (DEV-2567).
+    windows = defaultdict(list)
     for user_id, date_range in date_ranges_by_user.items():
-        filters |= Q(
-            user_id=user_id, date__range=[date_range['start'], date_range['end']]
-        )
+        key = (_as_date(date_range['start']), _as_date(date_range['end']))
+        windows[key].append(user_id)
+
     NLPUsageCounter = apps.get_model('trackers', 'NLPUsageCounter')  # noqa
 
-    nlp_tracking = (
-        NLPUsageCounter.objects.values('user_id')
-        .filter(filters)
-        .annotate(
-            asr_seconds_current_period=Coalesce(
-                Sum(f'total_{UsageType.ASR_SECONDS}'),
-                0,
-            ),
-            mt_characters_current_period=Coalesce(
-                Sum(f'total_{UsageType.MT_CHARACTERS}'),
-                0,
-            ),
-            llm_requests_current_period=Coalesce(
-                Sum(f'total_{UsageType.LLM_REQUESTS}'),
-                0,
-            ),
-        )
-    )
     results = {}
-    for row in nlp_tracking:
-        results[row['user_id']] = {
-            UsageType.ASR_SECONDS: row[f'{UsageType.ASR_SECONDS}_current_period'],
-            UsageType.MT_CHARACTERS: row[f'{UsageType.MT_CHARACTERS}_current_period'],
-            UsageType.LLM_REQUESTS: row[f'{UsageType.LLM_REQUESTS}_current_period'],
-        }
+    for (start, end), user_ids in windows.items():
+        nlp_tracking = (
+            NLPUsageCounter.objects.filter(
+                user_id__in=user_ids, date__range=[start, end]
+            )
+            .values('user_id')
+            .annotate(
+                asr_seconds_current_period=Coalesce(
+                    Sum(f'total_{UsageType.ASR_SECONDS}'),
+                    0,
+                ),
+                mt_characters_current_period=Coalesce(
+                    Sum(f'total_{UsageType.MT_CHARACTERS}'),
+                    0,
+                ),
+                llm_requests_current_period=Coalesce(
+                    Sum(f'total_{UsageType.LLM_REQUESTS}'),
+                    0,
+                ),
+            )
+        )
+        for row in nlp_tracking:
+            results[row['user_id']] = {
+                UsageType.ASR_SECONDS: row[f'{UsageType.ASR_SECONDS}_current_period'],
+                UsageType.MT_CHARACTERS: row[
+                    f'{UsageType.MT_CHARACTERS}_current_period'
+                ],
+                UsageType.LLM_REQUESTS: row[
+                    f'{UsageType.LLM_REQUESTS}_current_period'
+                ],
+            }
     return results
 
 

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -24,49 +24,6 @@ from kobo.apps.stripe.utils.subscription_limits import (
 from kpi.utils.cache import CachedClass, cached_class_property
 
 
-def get_storage_usage_by_user_id(user_ids: list[int] = None) -> dict[int, int]:
-    query = UserProfile.objects.values('user_id', 'attachment_storage_bytes')
-    if user_ids is not None:
-        query = query.filter(user_id__in=user_ids)
-    else:
-        query = query.exclude(user_id=settings.ANONYMOUS_USER_ID)
-
-    return {res['user_id']: res['attachment_storage_bytes'] for res in query.iterator()}
-
-
-def _as_date(value):
-    # Billing bounds are tz-aware datetimes; `date` is a DateField, so
-    # normalize to a date for grouping users into shared query windows below.
-    return value.date() if isinstance(value, datetime) else value
-
-
-def get_submission_counts_in_date_range_by_user_id(
-    date_ranges_by_user,
-) -> dict[int, int]:
-    # OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause per user
-    # forces the planner into a bitmap-or of one index scan per clause (DB-server
-    # OOM seen on EU, DEV-2567). Group users by their distinct window instead and
-    # run one narrow query per window: most orgs share the default monthly
-    # window, so there are only a handful of distinct windows even at full scale.
-    windows = defaultdict(list)
-    for user_id, date_range in date_ranges_by_user.items():
-        key = (_as_date(date_range['start']), _as_date(date_range['end']))
-        windows[key].append(user_id)
-
-    results = {}
-    for (start, end), user_ids in windows.items():
-        rows = (
-            DailyXFormSubmissionCounter.objects.filter(
-                user_id__in=user_ids, date__range=[start, end]
-            )
-            .values('user_id')
-            .annotate(total=Coalesce(Sum('counter'), 0))
-        )
-        for row in rows:
-            results[row['user_id']] = row['total']
-    return results
-
-
 def calculate_usage_balance(limit: float, usage: int) -> UsageBalance | None:
     if limit == inf:
         return None
@@ -82,7 +39,9 @@ def calculate_usage_balance(limit: float, usage: int) -> UsageBalance | None:
 
 
 @requires_stripe
-def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int, int]:
+def get_nlp_usage_for_current_billing_period_by_user_id(
+    **kwargs,
+) -> dict[int, NLPUsage]:
     current_billing_dates_by_org = get_current_billing_period_dates_by_org()
     owner_by_org = {
         org_vals['id']: org_vals['owner__organization_user__user__id']
@@ -95,19 +54,11 @@ def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int,
         for org_id, dates in current_billing_dates_by_org.items()
         if org_id in owner_by_org
     }
-    return get_submission_counts_in_date_range_by_user_id(
-        current_billing_dates_by_owner
-    )
+    return get_nlp_usage_in_date_range_by_user_id(current_billing_dates_by_owner)
 
 
 def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLPUsage]:
-    # Same fix as get_submission_counts_in_date_range_by_user_id: group users by
-    # their distinct window and run one narrow query per window instead of one
-    # giant OR-chain across every user (DEV-2567).
-    windows = defaultdict(list)
-    for user_id, date_range in date_ranges_by_user.items():
-        key = (_as_date(date_range['start']), _as_date(date_range['end']))
-        windows[key].append(user_id)
+    windows = group_user_ids_by_date_range(date_ranges_by_user)
 
     NLPUsageCounter = apps.get_model('trackers', 'NLPUsageCounter')  # noqa
 
@@ -146,10 +97,37 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
     return results
 
 
+def get_storage_usage_by_user_id(user_ids: list[int] = None) -> dict[int, int]:
+    query = UserProfile.objects.values('user_id', 'attachment_storage_bytes')
+    if user_ids is not None:
+        query = query.filter(user_id__in=user_ids)
+    else:
+        query = query.exclude(user_id=settings.ANONYMOUS_USER_ID)
+
+    return {res['user_id']: res['attachment_storage_bytes'] for res in query.iterator()}
+
+
+def get_submission_counts_in_date_range_by_user_id(
+    date_ranges_by_user,
+) -> dict[int, int]:
+    windows = group_user_ids_by_date_range(date_ranges_by_user)
+
+    results = {}
+    for (start, end), user_ids in windows.items():
+        rows = (
+            DailyXFormSubmissionCounter.objects.filter(
+                user_id__in=user_ids, date__range=[start, end]
+            )
+            .values('user_id')
+            .annotate(total=Coalesce(Sum('counter'), 0))
+        )
+        for row in rows:
+            results[row['user_id']] = row['total']
+    return results
+
+
 @requires_stripe
-def get_nlp_usage_for_current_billing_period_by_user_id(
-    **kwargs,
-) -> dict[int, NLPUsage]:
+def get_submissions_for_current_billing_period_by_user_id(**kwargs) -> dict[int, int]:
     current_billing_dates_by_org = get_current_billing_period_dates_by_org()
     owner_by_org = {
         org_vals['id']: org_vals['owner__organization_user__user__id']
@@ -162,7 +140,35 @@ def get_nlp_usage_for_current_billing_period_by_user_id(
         for org_id, dates in current_billing_dates_by_org.items()
         if org_id in owner_by_org
     }
-    return get_nlp_usage_in_date_range_by_user_id(current_billing_dates_by_owner)
+    return get_submission_counts_in_date_range_by_user_id(
+        current_billing_dates_by_owner
+    )
+
+
+def group_user_ids_by_date_range(date_ranges_by_user) -> dict[tuple, list[int]]:
+    """
+    Group user ids sharing the same (start, end) billing window.
+
+    OR-ing one `(user_id=X AND date BETWEEN start AND end)` clause per user
+    forces the planner into a bitmap-or of one index scan per clause, each
+    holding its own work_mem-sized state (the DB-server OOM seen on EU,
+    DEV-2567). Grouping users by their distinct window lets callers run one
+    narrow `user_id__in=...` query per window instead: most orgs share the
+    default monthly window, so there are only a handful of distinct windows
+    even at full scale.
+    """
+    windows = defaultdict(list)
+    for user_id, date_range in date_ranges_by_user.items():
+        if date_range.get('start') and date_range.get('end'):
+            key = (_as_date(date_range['start']), _as_date(date_range['end']))
+            windows[key].append(user_id)
+    return windows
+
+
+def _as_date(value):
+    # Billing bounds are tz-aware datetimes; `date` is a DateField, so
+    # normalize to a date for grouping users into shared query windows below.
+    return value.date() if isinstance(value, datetime) else value
 
 
 class ServiceUsageCalculator(CachedClass):


### PR DESCRIPTION
### 📣 Summary

Fixes a background job that could overload the database and disrupt service when checking which accounts are approaching their usage limits.

### 💭 Notes

- Same root cause and fix pattern as the earlier `BillingAndUsageCalculator` fix in #7350 (bitmap-or OOM), applied to the two remaining call sites with the same shape: `get_submission_counts_in_date_range_by_user_id` and `get_nlp_usage_in_date_range_by_user_id` in `kpi/utils/usage_calculator.py`.
- Both functions built one giant `Q()` OR-chain (`user_id=X AND date BETWEEN start AND end` per user) and ran it as a single query. These are reached via `get_submissions_for_current_billing_period_by_user_id` / `get_nlp_usage_for_current_billing_period_by_user_id`, called without an `orgs` filter from `kobo.apps.mass_emails.user_queries.get_users_within_range_of_usage_limit` (the periodic `generate_mass_email_user_lists` task), so the OR-chain spanned every organization in the instance, not a bounded batch.
- Both now group users by their distinct `(start, end)` billing window and issue one `user_id__in=...` query per window instead, matching the existing calculator fix.
- Also fixed along the way: `get_submission_counts_in_date_range_by_user_id` was grouping by `.values('counter', 'user_id', 'date')` instead of `.values('user_id')`, so the `Sum('counter')` annotation wasn't actually aggregating per user, the returned dict kept only one arbitrary row per user rather than the true sum. Now grouped by `user_id` only, consistent with the NLP usage function and the calculator.
- No behavior change for callers, same return shape (`dict[int, int]` / `dict[int, NLPUsage]`), just fixed aggregation and no more single-query OR-chain.
- Follow-up cleanup bundled in this PR: the "group users by window" pattern above ended up duplicated three times (`BillingAndUsageCalculator._get_submission_usage_batch`, `get_submission_counts_in_date_range_by_user_id`, `get_nlp_usage_in_date_range_by_user_id`), each with its own copy of the same `_as_date` helper. Extracted the shared logic into `group_user_ids_by_date_range()` in `kpi/utils/usage_calculator.py`, which `billing_and_usage_calculator.py` already imports from. Pure refactor, no behavior change.

### 👀 Preview steps

Not user-facing; covered by existing unit tests in `kpi/tests/test_usage_calculator.py`, `kobo/apps/mass_emails/tests/test_usage_limit_user_queries.py`, and `kobo/apps/user_reports/tests/test_user_reports.py` 