### PR TITLE
fix(frontend): show project name in browser tab title for Data sections. Closes #7336

### DIFF
--- a/jsapp/js/components/formGallery/formGallery.component.tsx
+++ b/jsapp/js/components/formGallery/formGallery.component.tsx
@@ -2,6 +2,7 @@ import './formGallery.component.scss'
 
 import { Box, Center, Flex, Image } from '@mantine/core'
 import React, { useEffect, useMemo, useReducer } from 'react'
+import DocumentTitle from 'react-document-title'
 import ReactSelect from 'react-select'
 import { fetchGet, fetchGetUrl } from '#/api'
 import { getFlatQuestionsList } from '#/assetUtils'
@@ -143,118 +144,122 @@ export default function FormGallery(props: FormGalleryProps) {
     formViewClass += ' form-view--fullscreen'
   }
 
+  const docTitle = props.asset.name || t('Untitled')
+
   return (
-    <bem.Gallery className={formViewClass}>
-      <bem.Gallery__wrapper>
-        <bem.Gallery__header>
-          <h1>{t('Image Gallery')}</h1>
-          <bem.Gallery__headerIcons>
-            <Button
-              type='text'
-              size='m'
-              startIcon='expand'
-              onClick={() => dispatch({ type: 'toggleFullscreen' })}
-              tooltip={t('Toggle fullscreen')}
-            />
-          </bem.Gallery__headerIcons>
-        </bem.Gallery__header>
-        <bem.GalleryFilters>
-          {t('From')}
-          <bem.GalleryFiltersSelect>
-            <ReactSelect
-              options={questionFilterOptions}
-              defaultValue={defaultOption}
-              onChange={(newValue) => dispatch({ type: 'setFilterQuestion', question: newValue!.value })}
-            />
-          </bem.GalleryFiltersSelect>
-          <bem.GalleryFiltersDates>
-            <label>
-              {t('Between')}
-              <input type='date' onChange={(e) => dispatch({ type: 'setStartDate', value: e.target.value })} />
-            </label>
-            <label>
-              {t('and')}
-              <input type='date' onChange={(e) => dispatch({ type: 'setEndDate', value: e.target.value })} />
-            </label>
-          </bem.GalleryFiltersDates>
-        </bem.GalleryFilters>
-        <bem.GalleryGrid>
-          {attachments.map((attachment, index) =>
-            attachment.is_deleted ? (
-              <Center key={attachment.uid} title={attachment.filename} className='gallery-grid-deleted-attachment'>
-                <DeletedAttachment />
-              </Center>
-            ) : (
-              <Box key={attachment.uid} onClick={() => handleImageClick(index)} style={{ cursor: 'pointer' }}>
+    <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+      <bem.Gallery className={formViewClass}>
+        <bem.Gallery__wrapper>
+          <bem.Gallery__header>
+            <h1>{t('Image Gallery')}</h1>
+            <bem.Gallery__headerIcons>
+              <Button
+                type='text'
+                size='m'
+                startIcon='expand'
+                onClick={() => dispatch({ type: 'toggleFullscreen' })}
+                tooltip={t('Toggle fullscreen')}
+              />
+            </bem.Gallery__headerIcons>
+          </bem.Gallery__header>
+          <bem.GalleryFilters>
+            {t('From')}
+            <bem.GalleryFiltersSelect>
+              <ReactSelect
+                options={questionFilterOptions}
+                defaultValue={defaultOption}
+                onChange={(newValue) => dispatch({ type: 'setFilterQuestion', question: newValue!.value })}
+              />
+            </bem.GalleryFiltersSelect>
+            <bem.GalleryFiltersDates>
+              <label>
+                {t('Between')}
+                <input type='date' onChange={(e) => dispatch({ type: 'setStartDate', value: e.target.value })} />
+              </label>
+              <label>
+                {t('and')}
+                <input type='date' onChange={(e) => dispatch({ type: 'setEndDate', value: e.target.value })} />
+              </label>
+            </bem.GalleryFiltersDates>
+          </bem.GalleryFilters>
+          <bem.GalleryGrid>
+            {attachments.map((attachment, index) =>
+              attachment.is_deleted ? (
+                <Center key={attachment.uid} title={attachment.filename} className='gallery-grid-deleted-attachment'>
+                  <DeletedAttachment />
+                </Center>
+              ) : (
+                <Box key={attachment.uid} onClick={() => handleImageClick(index)} style={{ cursor: 'pointer' }}>
+                  <Image
+                    src={attachment.download_small_url}
+                    alt={attachment.filename}
+                    w={150}
+                    loading='lazy'
+                    fit='cover'
+                  />
+                </Box>
+              ),
+            )}
+            {attachments.length === 0 && !isLoading && t('No results')}
+          </bem.GalleryGrid>
+          {showLoadMore && (
+            <bem.GalleryFooter>
+              <Button
+                type='text'
+                size='m'
+                isPending={isLoading}
+                label={t('Load more')}
+                onClick={() => loadMoreSubmissions()}
+              />
+            </bem.GalleryFooter>
+          )}
+        </bem.Gallery__wrapper>
+        {currentAttachment && (
+          <ModalNew
+            opened={isModalOpen}
+            onClose={closeModal}
+            title={`Image ${currentModalImageIndex + 1} of ${totalSubmissions}`}
+            size='lg'
+            centered
+          >
+            <Flex align='center' gap='md' p='sm'>
+              {/* Previous button */}
+              <ActionIcon
+                variant='transparent'
+                color='gray'
+                size='md'
+                aria-label='Previous image'
+                onClick={() => navigateImage('prev')}
+                disabled={isLoading || currentModalImageIndex === 0}
+                iconName='angle-left'
+              />
+
+              {/* Current image */}
+              <Box style={{ flexGrow: 1, minWidth: 0 }}>
                 <Image
-                  src={attachment.download_small_url}
-                  alt={attachment.filename}
-                  w={150}
+                  src={currentAttachment.download_large_url || currentAttachment.download_url}
+                  alt={currentAttachment.filename}
+                  fit='contain'
+                  style={{ maxHeight: '70vh', width: '100%' }}
                   loading='lazy'
-                  fit='cover'
                 />
               </Box>
-            ),
-          )}
-          {attachments.length === 0 && !isLoading && t('No results')}
-        </bem.GalleryGrid>
-        {showLoadMore && (
-          <bem.GalleryFooter>
-            <Button
-              type='text'
-              size='m'
-              isPending={isLoading}
-              label={t('Load more')}
-              onClick={() => loadMoreSubmissions()}
-            />
-          </bem.GalleryFooter>
-        )}
-      </bem.Gallery__wrapper>
-      {currentAttachment && (
-        <ModalNew
-          opened={isModalOpen}
-          onClose={closeModal}
-          title={`Image ${currentModalImageIndex + 1} of ${totalSubmissions}`}
-          size='lg'
-          centered
-        >
-          <Flex align='center' gap='md' p='sm'>
-            {/* Previous button */}
-            <ActionIcon
-              variant='transparent'
-              color='gray'
-              size='md'
-              aria-label='Previous image'
-              onClick={() => navigateImage('prev')}
-              disabled={isLoading || currentModalImageIndex === 0}
-              iconName='angle-left'
-            />
 
-            {/* Current image */}
-            <Box style={{ flexGrow: 1, minWidth: 0 }}>
-              <Image
-                src={currentAttachment.download_large_url || currentAttachment.download_url}
-                alt={currentAttachment.filename}
-                fit='contain'
-                style={{ maxHeight: '70vh', width: '100%' }}
-                loading='lazy'
+              {/* Next button with loading state */}
+              <ActionIcon
+                variant='transparent'
+                color='gray'
+                size='md'
+                aria-label={isNextButtonLoading ? t('Loading next page') : t('Next image')}
+                onClick={() => navigateImage('next')}
+                disabled={!showLoadMore && isLastImage}
+                iconName='angle-right'
+                loading={isNextButtonLoading}
               />
-            </Box>
-
-            {/* Next button with loading state */}
-            <ActionIcon
-              variant='transparent'
-              color='gray'
-              size='md'
-              aria-label={isNextButtonLoading ? t('Loading next page') : t('Next image')}
-              onClick={() => navigateImage('next')}
-              disabled={!showLoadMore && isLastImage}
-              iconName='angle-right'
-              loading={isNextButtonLoading}
-            />
-          </Flex>
-        </ModalNew>
-      )}
-    </bem.Gallery>
+            </Flex>
+          </ModalNew>
+        )}
+      </bem.Gallery>
+    </DocumentTitle>
   )
 }

--- a/jsapp/js/components/map/formMapWrapper.tsx
+++ b/jsapp/js/components/map/formMapWrapper.tsx
@@ -1,5 +1,6 @@
 import { useQueries } from '@tanstack/react-query'
 import { useState } from 'react'
+import DocumentTitle from 'react-document-title'
 import { assetsDataList, getAssetsDataListQueryKey } from '#/api/react-query/survey-data'
 import type { AssetResponse } from '#/dataInterface'
 import type { WithRouterProps } from '#/router/legacy'
@@ -52,16 +53,20 @@ export default function FormMapWrapper(props: FormMapWrapperProps) {
   const totalCount =
     results[0]?.data?.status === 200 && !results[0]?.isFetching ? results[0].data.data.count : undefined
 
+  const docTitle = props.asset.name || t('Untitled')
+
   return (
-    <FormMap
-      asset={props.asset}
-      viewby={props.viewby ?? ''}
-      allData={allData}
-      isLoading={isLoading}
-      totalCount={totalCount}
-      pageCount={pageCount}
-      setPageCount={setPageCount}
-      setFields={setFields}
-    />
+    <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+      <FormMap
+        asset={props.asset}
+        viewby={props.viewby ?? ''}
+        allData={allData}
+        isLoading={isLoading}
+        totalCount={totalCount}
+        pageCount={pageCount}
+        setPageCount={setPageCount}
+        setFields={setFields}
+      />
+    </DocumentTitle>
   )
 }

--- a/jsapp/js/components/submissions/DataTableWrapper.tsx
+++ b/jsapp/js/components/submissions/DataTableWrapper.tsx
@@ -1,3 +1,4 @@
+import DocumentTitle from 'react-document-title'
 import type { AssetResponse } from '#/dataInterface'
 import { DataTable } from './table'
 import { useDataTableBulkActions } from './useDataTableBulkActions'
@@ -15,12 +16,16 @@ export default function DataTableWrapper(props: DataTableWrapperProps) {
     props.asset.uid,
   )
 
+  const docTitle = props.asset.name || t('Untitled')
+
   return (
-    <DataTable
-      asset={props.asset}
-      activeBulkActions={activeBulkActions}
-      hasActiveBulkActionsCreatedByCurrentUser={hasActiveBulkActionsCreatedByCurrentUser}
-      currentUsername={currentUsername}
-    />
+    <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+      <DataTable
+        asset={props.asset}
+        activeBulkActions={activeBulkActions}
+        hasActiveBulkActionsCreatedByCurrentUser={hasActiveBulkActionsCreatedByCurrentUser}
+        currentUsername={currentUsername}
+      />
+    </DocumentTitle>
   )
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
When you open a project's **Data** section, the browser tab title now shows the project's name instead of just "KoboToolbox", so you can tell multiple open projects apart.


### 📖 Description
Previously, only the **Summary**, **Form**, and **Settings** sections put the project's name in the browser tab title. The **Data** section — including the data table, the image Gallery, and the Map — showed only "KoboToolbox". This was confusing when you had several projects open in different tabs, all on their Data section, because every tab looked identical. This change makes all Data views include the project name in the tab title, matching the other sections.


### 👷 Description for instance maintainers
Front-end only change. No configuration, database, migration, or API changes. No action required on upgrade. The tab title is set client-side via the existing `react-document-title` mechanism already used by the other project sections; untitled assets fall back to "Untitled".


### 💭 Notes
- Follows the exact pattern already used by sibling views (`formSummary`, `formLanding`, `ProjectDownloads`, `Reports`, `RESTServices`): `<DocumentTitle title={`${asset.name || t('Untitled')} | KoboToolbox`}>`.
- Files changed: `submissions/DataTableWrapper.tsx` (main Data table), `formGallery/formGallery.component.tsx` (Gallery), `map/formMapWrapper.tsx` (Map). Gallery and Map had the same missing-title bug, so they're included.
- Verified locally: Biome, ESLint (0 errors), `tsc --noEmit` (0 errors), and the relevant Jest unit tests pass. The full app could **not** be run for a visual check. My machine can't run Docker (too resource-heavy for it), and this repo only documents a Docker-based dev environment. A quick manual confirm of the tab title on the Data / Gallery / Map sections would be appreciated.

### 👀 Preview steps

1. ℹ️ have an account and a project that has collected data
2. open the project and click the **Data** tab
3. 🔴 [on main] notice the browser tab title shows only "KoboToolbox"
4. 🟢 [on PR] notice the tab title now shows "<project name> | KoboToolbox"
5. also open **Data → Gallery** and **Data → Map**
6. 🟢 notice the tab title includes the project name there too
7. open two different projects in two tabs, both on their Data section
8. 🟢 notice each tab now shows its own project name, so they're distinguishable
