### PR TITLE
fix(dataTable): improve select_x data displaying DEV-2476

### DIFF
--- a/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
@@ -132,9 +132,6 @@ const videoSubmission = buildMediaSubmission(
   'attachment-video-1',
 )
 
-// Choices 'a' and 'b' were renamed to 'a1' and 'b1', so only
-// the new names exist in the choice list below while the submission still holds
-// the old ones.
 const renamedChoicesQuestion: SurveyRow = {
   type: QuestionTypeName.select_multiple,
   $kuid: 'renamedChoicesQuestion',
@@ -144,6 +141,9 @@ const renamedChoicesQuestion: SurveyRow = {
   select_from_list_name: 'animals_list',
 }
 
+// Choices 'a' and 'b' were renamed to 'a1' and 'b1', so only
+// the new names exist in the choice list below while the submission still holds
+// the old ones.
 const renamedChoices: SurveyChoice[] = [
   { name: 'a1', label: ['Whale'], list_name: 'animals_list', $autovalue: 'a1', $kuid: 'whaleChoice' },
   { name: 'b1', label: ['Frog'], list_name: 'animals_list', $autovalue: 'b1', $kuid: 'frogChoice' },

--- a/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
@@ -132,7 +132,7 @@ const videoSubmission = buildMediaSubmission(
   'attachment-video-1',
 )
 
-// Reproduces DEV-2476: choices 'a' and 'b' were renamed to 'A' and 'B', so only
+// Choices 'a' and 'b' were renamed to 'a1' and 'b1', so only
 // the new names exist in the choice list below while the submission still holds
 // the old ones.
 const renamedChoicesQuestion: SurveyRow = {
@@ -145,8 +145,8 @@ const renamedChoicesQuestion: SurveyRow = {
 }
 
 const renamedChoices: SurveyChoice[] = [
-  { name: 'A', label: ['Whale'], list_name: 'animals_list', $autovalue: 'A', $kuid: 'whaleChoice' },
-  { name: 'B', label: ['Frog'], list_name: 'animals_list', $autovalue: 'B', $kuid: 'frogChoice' },
+  { name: 'a1', label: ['Whale'], list_name: 'animals_list', $autovalue: 'a1', $kuid: 'whaleChoice' },
+  { name: 'b1', label: ['Frog'], list_name: 'animals_list', $autovalue: 'b1', $kuid: 'frogChoice' },
   { name: 'c', label: ['Crocodile'], list_name: 'animals_list', $autovalue: 'c', $kuid: 'crocodileChoice' },
 ]
 

--- a/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { CellInfo } from 'react-table'
 import { QuestionTypeName, SUPPLEMENTAL_DETAILS_PROP } from '#/constants'
-import type { SubmissionAttachment, SubmissionResponse } from '#/dataInterface'
+import type { SubmissionAttachment, SubmissionResponse, SurveyChoice, SurveyRow } from '#/dataInterface'
 import assetDataFactory from '#/endpoints/assetData.factory'
 import { KOBO_MODAL_SHARED_PROPS } from '#/theme/kobo/Modal'
 import {
@@ -132,6 +132,26 @@ const videoSubmission = buildMediaSubmission(
   'attachment-video-1',
 )
 
+// Reproduces DEV-2476: choices 'a' and 'b' were renamed to 'A' and 'B', so only
+// the new names exist in the choice list below while the submission still holds
+// the old ones.
+const renamedChoicesQuestion: SurveyRow = {
+  type: QuestionTypeName.select_multiple,
+  $kuid: 'renamedChoicesQuestion',
+  $autoname: 'Favourite_animals',
+  $xpath: 'Favourite_animals',
+  label: ['Favourite animals'],
+  select_from_list_name: 'animals_list',
+}
+
+const renamedChoices: SurveyChoice[] = [
+  { name: 'A', label: ['Whale'], list_name: 'animals_list', $autovalue: 'A', $kuid: 'whaleChoice' },
+  { name: 'B', label: ['Frog'], list_name: 'animals_list', $autovalue: 'B', $kuid: 'frogChoice' },
+  { name: 'c', label: ['Crocodile'], list_name: 'animals_list', $autovalue: 'c', $kuid: 'crocodileChoice' },
+]
+
+const renamedChoicesSubmission = assetDataFactory(1, { Favourite_animals: 'a b c' })
+
 const meta: Meta<typeof DataTableCell> = {
   title: 'Components/DataTableCell',
   component: DataTableCell,
@@ -182,6 +202,42 @@ export const PlainText: Story = {
     docs: {
       description: {
         story: 'Modal opens via Mantine modals; this story is wrapped in ModalsProvider so the expand button works.',
+      },
+    },
+  },
+}
+
+export const SelectMultipleWithRenamedChoices: Story = {
+  args: {
+    asset: simpleSurveyAsset,
+    reactTableRow: buildReactTableRow(renamedChoicesSubmission, renamedChoicesSubmission.Favourite_animals),
+    columnKey: 'Favourite_animals',
+    question: renamedChoicesQuestion,
+    choices: renamedChoices,
+    showGroupName: false,
+    translationIndex: 0,
+    submissionCount: 2,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Two of the selected choices were renamed in a newer form version, so they have no label left to show. The cell falls back to their raw values instead of dropping them, showing "a, b, Crocodile".',
+      },
+    },
+  },
+}
+
+export const SelectMultipleAsXmlValues: Story = {
+  args: {
+    ...SelectMultipleWithRenamedChoices.args,
+    translationIndex: -1,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same data with the "Display XML Values" table setting, which arrives here as a negative translation index. No labels are looked up, so the response shows exactly as stored: "a b c".',
       },
     },
   },

--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@mantine/core'
 import type { CellInfo } from 'react-table'
-import { getColumnLabel } from '#/components/submissions/tableUtils'
+import { getColumnLabel, getSelectResponseLabel } from '#/components/submissions/tableUtils'
 import {
   ADDITIONAL_SUBMISSION_PROPS,
   META_QUESTION_TYPES,
@@ -30,7 +30,9 @@ interface DataTableCellProps {
 }
 
 export default function DataTableCell(props: DataTableCellProps) {
-  const shouldShowSelectMultipleLabels = props.translationIndex === 0
+  // Table settings encode the "XML Values" display option as a negative
+  // translation index (see `TableSettings`).
+  const shouldShowSelectLabels = props.translationIndex > -1
   const submission = props.reactTableRow.original
   const submissionIndex = props.reactTableRow.index + 1
   const columnName = getColumnLabel(props.asset, props.columnKey, props.showGroupName, props.translationIndex)
@@ -123,36 +125,26 @@ export default function DataTableCell(props: DataTableCellProps) {
       }
     }
 
-    if (props.question.type === QUESTION_TYPES.select_one.id) {
-      const choice = props.choices.find(
-        (choiceItem) =>
-          choiceItem.list_name === props.question?.select_from_list_name &&
-          choiceItem.name === props.reactTableRow.value,
-      )
-      if (choice?.label && choice.label[props.translationIndex]) {
-        return <span className='trimmed-text'>{choice.label[props.translationIndex]}</span>
-      } else {
-        return <span className='trimmed-text'>{props.reactTableRow.value}</span>
-      }
-    }
+    // Keep both select types on one path. They had separate branches that
+    // drifted apart, and `select_multiple` ended up hiding values it couldn't
+    // map to a label (DEV-2476). With labels off, the raw value falls through to
+    // the default rendering below.
     if (
-      props.question.type === QUESTION_TYPES.select_multiple.id &&
-      props.reactTableRow.value &&
-      shouldShowSelectMultipleLabels
+      shouldShowSelectLabels &&
+      (props.question.type === QUESTION_TYPES.select_one.id ||
+        props.question.type === QUESTION_TYPES.select_multiple.id)
     ) {
-      const values = props.reactTableRow.value.split(' ')
-      const labels: Array<string | null> = []
-      values.forEach((valueItem: string) => {
-        const choice = props.choices.find(
-          (choiceItem) =>
-            choiceItem.list_name === props.question?.select_from_list_name && choiceItem.name === valueItem,
-        )
-        if (choice && choice.label && choice.label[props.translationIndex]) {
-          labels.push(choice.label[props.translationIndex])
-        }
-      })
-
-      return <span className='trimmed-text'>{labels.join(', ')}</span>
+      return (
+        <span className='trimmed-text'>
+          {getSelectResponseLabel({
+            value: props.reactTableRow.value,
+            questionType: props.question.type,
+            listName: props.question.select_from_list_name,
+            choices: props.choices,
+            translationIndex: props.translationIndex,
+          })}
+        </span>
+      )
     }
     if (props.question.type === META_QUESTION_TYPES.start || props.question.type === META_QUESTION_TYPES.end) {
       return <span className='trimmed-text'>{formatTimeDateShort(props.reactTableRow.value)}</span>

--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -125,10 +125,6 @@ export default function DataTableCell(props: DataTableCellProps) {
       }
     }
 
-    // Keep both select types on one path. They had separate branches that
-    // drifted apart, and `select_multiple` ended up hiding values it couldn't
-    // map to a label (DEV-2476). With labels off, the raw value falls through to
-    // the default rendering below.
     if (
       shouldShowSelectLabels &&
       (props.question.type === QUESTION_TYPES.select_one.id ||

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -154,19 +154,21 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
           <ul>
             {item.data.split(' ').map((answer, answerIndex) => {
               choice = this.findChoice(item.listName, answer)
-              if (choice) {
-                return (
-                  <li key={answerIndex}>
-                    <bem.SubmissionDataTable__value>
-                      {choice.label?.[this.props.translationIndex] || choice.name}
-                    </bem.SubmissionDataTable__value>
-                  </li>
-                )
-              } else {
+              if (!choice) {
+                // Not always a bug: the choice may have been renamed or removed
+                // after this submission came in.
                 console.error(`Choice not found for "${item.listName}" and "${answer}".`)
-                // fallback to raw data to display anything meaningful
-                return answer
               }
+              // Unmatched answers still get their own `<li>` with the raw value,
+              // so the list accounts for everything that was selected. A bare
+              // string here would be invalid markup inside the `<ul>`.
+              return (
+                <li key={answerIndex}>
+                  <bem.SubmissionDataTable__value>
+                    {choice?.label?.[this.props.translationIndex] || answer}
+                  </bem.SubmissionDataTable__value>
+                </li>
+              )
             })}
           </ul>
         )

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -152,24 +152,28 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       case QUESTION_TYPES.select_multiple.id:
         return (
           <ul>
-            {item.data.split(' ').map((answer, answerIndex) => {
-              choice = this.findChoice(item.listName, answer)
-              if (!choice) {
-                // Not always a bug: the choice may have been renamed or removed
-                // after this submission came in.
-                console.error(`Choice not found for "${item.listName}" and "${answer}".`)
-              }
-              // Unmatched answers still get their own `<li>` with the raw value,
-              // so the list accounts for everything that was selected. A bare
-              // string here would be invalid markup inside the `<ul>`.
-              return (
-                <li key={answerIndex}>
-                  <bem.SubmissionDataTable__value>
-                    {choice?.label?.[this.props.translationIndex] || answer}
-                  </bem.SubmissionDataTable__value>
-                </li>
-              )
-            })}
+            {/* Dropping empty pieces keeps stray spaces in the stored response from becoming blank bullets. */}
+            {item.data
+              .split(' ')
+              .filter((answer) => answer !== '')
+              .map((answer, answerIndex) => {
+                choice = this.findChoice(item.listName, answer)
+                if (!choice) {
+                  // Not always a bug: the choice may have been renamed or
+                  // removed after this submission came in.
+                  console.error(`Choice not found for "${item.listName}" and "${answer}".`)
+                }
+                // Unmatched answers still get their own `<li>` with the raw
+                // value, so the list accounts for everything that was selected.
+                // A bare string here would be invalid markup inside the `<ul>`.
+                return (
+                  <li key={answerIndex}>
+                    <bem.SubmissionDataTable__value>
+                      {choice?.label?.[this.props.translationIndex] || answer}
+                    </bem.SubmissionDataTable__value>
+                  </li>
+                )
+              })}
           </ul>
         )
       case QUESTION_TYPES.date.id:

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -76,12 +76,12 @@ describe('tableUtils', () => {
 
   describe('getSelectResponseLabel', () => {
     // The 'animals' list once had choices 'a', 'b' and 'c', then 'a' and 'b'
-    // were renamed to 'A' and 'B'. Only the current names are here, as that's
+    // were renamed to 'a1' and 'b1'. Only the current names are here, as that's
     // all the latest form version gives us, so submissions storing 'a' or 'b'
     // have nothing to match. 'other_list' guards against cross-list matches.
     const animalChoices = [
-      { name: 'A', label: ['Whale', 'Wieloryb'], list_name: 'animals', $autovalue: 'A', $kuid: 'k1' },
-      { name: 'B', label: ['Frog', 'Żaba'], list_name: 'animals', $autovalue: 'B', $kuid: 'k2' },
+      { name: 'a1', label: ['archaeopteryx', 'archaeopteryks'], list_name: 'animals', $autovalue: 'a1', $kuid: 'k1' },
+      { name: 'b1', label: ['badger', 'borsuk'], list_name: 'animals', $autovalue: 'b1', $kuid: 'k2' },
       { name: 'c', label: ['Crocodile', 'Krokodyl'], list_name: 'animals', $autovalue: 'c', $kuid: 'k3' },
       { name: 'a', label: ['Apple'], list_name: 'other_list', $autovalue: 'a', $kuid: 'k4' },
     ] as const satisfies SurveyChoice[]
@@ -97,11 +97,11 @@ describe('tableUtils', () => {
       })
 
     it('should return labels of all selected select_multiple choices', () => {
-      const test = getAnimalsLabel('A B c', QuestionTypeName.select_multiple)
-      chai.expect(test).to.equal('Whale, Frog, Crocodile')
+      const test = getAnimalsLabel('a1 b1 c', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('archaeopteryx, badger, Crocodile')
     })
 
-    // The DEV-2476 bug: unmatched values were omitted, so this returned only
+    // Bug fixed: unmatched values were omitted, so this returned only
     // 'Crocodile' with no hint that two more options were selected.
     it('should fall back to raw values for select_multiple choices missing from the form', () => {
       const test = getAnimalsLabel('a b c', QuestionTypeName.select_multiple)
@@ -111,8 +111,8 @@ describe('tableUtils', () => {
     it('should use labels of given translation for select_multiple', () => {
       // Mixes a matched and an unmatched value, as the fallback should not
       // depend on which translation was asked for.
-      const test = getAnimalsLabel('a B c', QuestionTypeName.select_multiple, 1)
-      chai.expect(test).to.equal('a, Żaba, Krokodyl')
+      const test = getAnimalsLabel('a b1 c', QuestionTypeName.select_multiple, 1)
+      chai.expect(test).to.equal('a, borsuk, Krokodyl')
     })
 
     it('should fall back to raw value when a translation has no label', () => {
@@ -123,8 +123,8 @@ describe('tableUtils', () => {
     })
 
     it('should not produce dangling separators for select_multiple stray whitespace', () => {
-      const test = getAnimalsLabel(' A  c ', QuestionTypeName.select_multiple)
-      chai.expect(test).to.equal('Whale, Crocodile')
+      const test = getAnimalsLabel(' a1  c ', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('archaeopteryx, Crocodile')
     })
 
     it('should only match choices of the question own list', () => {

--- a/jsapp/js/components/submissions/tableUtils.tests.ts
+++ b/jsapp/js/components/submissions/tableUtils.tests.ts
@@ -1,8 +1,10 @@
 import { QuestionTypeName, SUPPLEMENTAL_DETAILS_PROP } from '#/constants'
-import type { SubmissionResponse } from '#/dataInterface'
+import type { AnyRowTypeName } from '#/constants'
+import type { SubmissionResponse, SurveyChoice } from '#/dataInterface'
 import {
   getAllDataColumns,
   getColumnLabel,
+  getSelectResponseLabel,
   isTableColumnFilterableByTextInput,
   selectNestedRow,
   shouldDropLegacyAttachmentColumn,
@@ -70,6 +72,84 @@ describe('tableUtils', () => {
     // TODO: write more tests here… I haven't got enough time to go over all
     // possible cases, just added one that I was fixing a bug for and a couple
     // that came to my mind.
+  })
+
+  describe('getSelectResponseLabel', () => {
+    // The 'animals' list once had choices 'a', 'b' and 'c', then 'a' and 'b'
+    // were renamed to 'A' and 'B'. Only the current names are here, as that's
+    // all the latest form version gives us, so submissions storing 'a' or 'b'
+    // have nothing to match. 'other_list' guards against cross-list matches.
+    const animalChoices = [
+      { name: 'A', label: ['Whale', 'Wieloryb'], list_name: 'animals', $autovalue: 'A', $kuid: 'k1' },
+      { name: 'B', label: ['Frog', 'Żaba'], list_name: 'animals', $autovalue: 'B', $kuid: 'k2' },
+      { name: 'c', label: ['Crocodile', 'Krokodyl'], list_name: 'animals', $autovalue: 'c', $kuid: 'k3' },
+      { name: 'a', label: ['Apple'], list_name: 'other_list', $autovalue: 'a', $kuid: 'k4' },
+    ] as const satisfies SurveyChoice[]
+
+    /** Resolves a response against `animalChoices`, as every case here does. */
+    const getAnimalsLabel = (value: string, questionType: AnyRowTypeName, translationIndex = 0) =>
+      getSelectResponseLabel({
+        value,
+        questionType,
+        listName: 'animals',
+        choices: animalChoices,
+        translationIndex,
+      })
+
+    it('should return labels of all selected select_multiple choices', () => {
+      const test = getAnimalsLabel('A B c', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('Whale, Frog, Crocodile')
+    })
+
+    // The DEV-2476 bug: unmatched values were omitted, so this returned only
+    // 'Crocodile' with no hint that two more options were selected.
+    it('should fall back to raw values for select_multiple choices missing from the form', () => {
+      const test = getAnimalsLabel('a b c', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('a, b, Crocodile')
+    })
+
+    it('should use labels of given translation for select_multiple', () => {
+      // Mixes a matched and an unmatched value, as the fallback should not
+      // depend on which translation was asked for.
+      const test = getAnimalsLabel('a B c', QuestionTypeName.select_multiple, 1)
+      chai.expect(test).to.equal('a, Żaba, Krokodyl')
+    })
+
+    it('should fall back to raw value when a translation has no label', () => {
+      // 'c' does match a choice, but index 5 is past the end of its labels,
+      // like a choice left untranslated in one language.
+      const test = getAnimalsLabel('c', QuestionTypeName.select_multiple, 5)
+      chai.expect(test).to.equal('c')
+    })
+
+    it('should not produce dangling separators for select_multiple stray whitespace', () => {
+      const test = getAnimalsLabel(' A  c ', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('Whale, Crocodile')
+    })
+
+    it('should only match choices of the question own list', () => {
+      // 'a' is labelled 'Apple' in 'other_list' but absent from 'animals', so it
+      // must stay raw instead of borrowing that label.
+      const test = getAnimalsLabel('a', QuestionTypeName.select_multiple)
+      chai.expect(test).to.equal('a')
+    })
+
+    it('should return label of selected select_one choice', () => {
+      const test = getAnimalsLabel('c', QuestionTypeName.select_one)
+      chai.expect(test).to.equal('Crocodile')
+    })
+
+    it('should fall back to raw value for a select_one choice missing from the form', () => {
+      const test = getAnimalsLabel('a', QuestionTypeName.select_one)
+      chai.expect(test).to.equal('a')
+    })
+
+    it('should not split select_one values on spaces', () => {
+      // A single value may contain spaces. Treating them as separators would
+      // mangle this into 'a, b, Crocodile'.
+      const test = getAnimalsLabel('a b c', QuestionTypeName.select_one)
+      chai.expect(test).to.equal('a b c')
+    })
   })
 
   describe('isTableColumnFilterableByTextInput', () => {

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -590,8 +590,7 @@ export interface SelectResponseLabelOptions {
  *
  * Choices can be renamed in the Form Builder, while old submissions keep the
  * `name` that was current when they came in. Any value that no longer matches a
- * choice is shown raw, because dropping it would imply it was never selected
- * (DEV-2476).
+ * choice is shown raw, because dropping it would imply it was never selected.
  */
 export function getSelectResponseLabel(options: SelectResponseLabelOptions): string {
   const { value, questionType, listName, choices, translationIndex } = options

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -26,7 +26,7 @@ import {
   SUPPLEMENTAL_DETAILS_PROP,
 } from '#/constants'
 import type { AnyRowTypeName } from '#/constants'
-import type { AssetResponse, SubmissionResponse, SurveyRow } from '#/dataInterface'
+import type { AssetResponse, SubmissionResponse, SurveyChoice, SurveyRow } from '#/dataInterface'
 import { recordKeys, recordValues } from '#/utils'
 import type { TableColumn } from './table.types'
 
@@ -567,6 +567,52 @@ export function buildFilterQuery(
   }
 
   return output
+}
+
+export interface SelectResponseLabelOptions {
+  /** Raw response, as stored in submission data. */
+  value: string
+  questionType: AnyRowTypeName | undefined
+  /** The question's `select_from_list_name`. */
+  listName: string | undefined
+  /** All of the form's choices, not just the ones of this question's list. */
+  choices: SurveyChoice[]
+  /**
+   * Index into a choice `label` array. Only pass a non-negative one; negative
+   * means "display raw XML values", where there's nothing to resolve.
+   */
+  translationIndex: number
+}
+
+/**
+ * Builds the human-readable value of a `select_one` or `select_multiple`
+ * response, i.e. the label(s) of the selected choice(s).
+ *
+ * Choices can be renamed in the Form Builder, while old submissions keep the
+ * `name` that was current when they came in. Any value that no longer matches a
+ * choice is shown raw, because dropping it would imply it was never selected
+ * (DEV-2476).
+ */
+export function getSelectResponseLabel(options: SelectResponseLabelOptions): string {
+  const { value, questionType, listName, choices, translationIndex } = options
+
+  // `select_multiple` is the only type that packs several values into one
+  // string. Splitting any other type would mangle values that contain spaces.
+  let values = [value]
+  if (questionType === QUESTION_TYPES.select_multiple.id) {
+    // Filtering empties keeps stray spaces from becoming dangling separators.
+    values = value.split(' ').filter((valueItem) => valueItem !== '')
+  }
+
+  return values
+    .map((valueItem) => {
+      // Choice names are only unique within their own list, hence matching both.
+      const choice = choices.find((choiceItem) => choiceItem.list_name === listName && choiceItem.name === valueItem)
+      // A choice may exist but have no label in this translation, so this
+      // fallback covers more than just renamed choices.
+      return choice?.label?.[translationIndex] || valueItem
+    })
+    .join(', ')
 }
 
 /**

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -578,8 +578,10 @@ export interface SelectResponseLabelOptions {
   /** All of the form's choices, not just the ones of this question's list. */
   choices: SurveyChoice[]
   /**
-   * Index into a choice `label` array. Only pass a non-negative one; negative
-   * means "display raw XML values", where there's nothing to resolve.
+   * Index into a choice `label` array. A negative one (the "Display XML Values"
+   * setting) matches no label, so every value comes back raw — but
+   * `select_multiple` values still get re-joined with commas, so callers that
+   * need the response exactly as stored don't come here.
    */
   translationIndex: number
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Data Table now shows all selected options of a `select_many` question, falling back to the raw value for options that were renamed or removed in a later version of the form.

### 💭 Notes

When a form is edited, the `name` of a select option can change, while submissions collected earlier keep the old one. The DATA table had no label to show for such values, and for `select_many` questions it dropped them from the cell entirely — a response of three animals could show up as just one, with nothing hinting the other two were ever picked.

Those values now appear as-is, next to the labels of the options that still match. This is how `select_one` questions already behaved.

Same fix applies to the single submission modal, which listed unmatched values but in a way that broke the bullet list.

Changes here:
- `jsapp/js/components/submissions/tableUtils.ts`
  - adds `getSelectResponseLabel()` for resolving both `select_one` and `select_many` responses with a per-value fallback to the raw value
- `jsapp/js/components/submissions/DataTableCell/index.tsx`
  - both select types now go through the helper instead of two branches that had quietly drifted apart
  - label lookup is now gated on `translationIndex > -1` ("Display XML Values"). It used to be `=== 0` for `select_many`, so picking any language other than the first one showed raw values instead of labels. Free bug fix 🎁🐛🔨
- `jsapp/js/components/submissions/submissionDataTable.tsx`
  - unmatched values already fell back to the raw value here, but returned a bare string inside the `<ul>`, so it landed outside the `<li>` and without a key (Also 🎁🐛🔨)
- `jsapp/js/components/submissions/tableUtils.tests.ts` - 9 cases for the helper
- `jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx`
  - 2 stories for the renamed-options cell, with labels and with XML values

Not touched: the column filter dropdown still only offers options from the current form version, so these newly visible legacy values can't be filtered on - made an issue though: https://linear.app/kobotoolbox/issue/DEV-2576/data-table-column-filter-only-lists-option-values-from-the-latest-form.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. add a `select_many` question with three options, name them `a`, `b` and `c`, and label them `archaeopteryx`, `badger` and `crocodile`
3. deploy the form and submit one response with all three animals selected
4. edit the form and rename the option names `a` and `b` to `a1` and `b1` — leave the labels alone, and leave `c` as it is
5. redeploy the form
6. go to Project → Data → Table, open 'Table display options' and pick 'XML Values' — all three original values `a b c` show up, as they should
7. switch 'Table display options' to 'Labels'
8. 🔴 [on main] the cell shows only "crocodile" — the archaeopteryx and the badger swam off without a trace
9. 🟢 [on PR] the cell shows "a, b, crocodile"
10. 🟢 open the submission (click the row) and see the same three values listed there
11. if your form has a second language, switch 'Table display options' to 'Labels - <language>'
12. 🔴 [on main] the cell shows raw values `a b c`, no labels at all
13. 🟢 [on PR] the cell shows the labels of that language, with `a` and `b` still raw
