### PR TITLE
ci(releases): improve checkout-with-github-app-token action DEV-2578

### DIFF
--- a/.github/actions/checkout-with-github-app-token/action.yml
+++ b/.github/actions/checkout-with-github-app-token/action.yml
@@ -51,3 +51,4 @@ runs:
       token: ${{ steps.app-token.outputs.token }}
       ref: ${{ inputs.ref }}
       fetch-depth: "0"
+      fetch-tags: true

--- a/.github/actions/checkout-with-github-app-token/action.yml
+++ b/.github/actions/checkout-with-github-app-token/action.yml
@@ -29,7 +29,7 @@ runs:
     id: app-token
     uses: actions/create-github-app-token@v3
     with:
-      app-id: ${{ inputs.client-id }}
+      client-id: ${{ inputs.client-id }}
       private-key: ${{ inputs.private-key }}
       owner: ${{ inputs.owner }}
       repositories: ${{ inputs.repositories }}

--- a/.github/actions/checkout-with-github-app-token/action.yml
+++ b/.github/actions/checkout-with-github-app-token/action.yml
@@ -2,10 +2,24 @@ name: 'Checkout with Github App token'
 description: 'Checkout repo with a Github App token and set bot config, so that push to the repo would trigger workflows.'
 
 inputs:
-  app-id:
+  client-id:
     required: true
   private-key:
     required: true
+  ref:
+    description: 'Git ref to checkout (default: current ref)'
+    required: false
+  owner:
+    description: 'GitHub organization for cross-repo token scope (optional)'
+    required: false
+  repositories:
+    description: 'Comma-separated list of repos for cross-repo token scope (optional)'
+    required: false
+
+outputs:
+  token:
+    description: 'The generated GitHub App token'
+    value: ${{ steps.app-token.outputs.token }}
 
 runs:
   using: "composite"
@@ -13,10 +27,12 @@ runs:
 
   - name: Generate a token to trigger a workflow from a workflow
     id: app-token
-    uses: actions/create-github-app-token@v2
+    uses: actions/create-github-app-token@v3
     with:
-      app-id: ${{ inputs.app-id }}
+      app-id: ${{ inputs.client-id }}
       private-key: ${{ inputs.private-key }}
+      owner: ${{ inputs.owner }}
+      repositories: ${{ inputs.repositories }}
 
   - name: Get GitHub App user id
     id: get-user-id
@@ -30,7 +46,8 @@ runs:
       git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
       git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
-  - uses: actions/checkout@v5
+  - uses: actions/checkout@v6
     with:
       token: ${{ steps.app-token.outputs.token }}
+      ref: ${{ inputs.ref || github.ref }}
       fetch-depth: "0"

--- a/.github/actions/checkout-with-github-app-token/action.yml
+++ b/.github/actions/checkout-with-github-app-token/action.yml
@@ -49,5 +49,5 @@ runs:
   - uses: actions/checkout@v6
     with:
       token: ${{ steps.app-token.outputs.token }}
-      ref: ${{ inputs.ref || github.ref }}
+      ref: ${{ inputs.ref }}
       fetch-depth: "0"

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+        client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
         private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
     - name: create next RC branch
       id: branch

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -48,6 +48,7 @@ jobs:
     if: ${{ needs.version.outputs.prev_released == 'true' }}
     runs-on: ubuntu-24.04
     steps:
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -48,7 +48,6 @@ jobs:
     if: ${{ needs.version.outputs.prev_released == 'true' }}
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -143,7 +143,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
@@ -187,7 +186,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -113,7 +113,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+        client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
         private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
 
     - name: draft a changelog
@@ -146,7 +146,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+        client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
         private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
 
     - name: deploy to beta
@@ -190,7 +190,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        app-id: ${{ secrets.KOBO_BOT_APP_ID }}
+        client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
         private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
 
     - name: Merge

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -143,6 +143,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
@@ -186,6 +187,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}


### PR DESCRIPTION
### 💭 Notes

Standardize `app-id` and `client-id` usage to `client-id` and bump GHA actions.

Future-proof `checkout-with-github-app-token` action with 3 optional
parameters: ref, owner and repository.