### PR TITLE
ci(releases): extract changelog generation into reusable workflow DEV-660

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,6 +28,7 @@ jobs:
   changelog:
     runs-on: ubuntu-24.04
     steps:
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets['client-id'] }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,11 +28,6 @@ jobs:
   changelog:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.ref }}
-        fetch-depth: 0
-        fetch-tags: true
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets['client-id'] }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,8 +35,8 @@ jobs:
         fetch-tags: true
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        client-id: ${{ secrets.client-id }}
-        private-key: ${{ secrets.private-key }}
+        client-id: ${{ secrets['client-id'] }}
+        private-key: ${{ secrets['private-key'] }}
         ref: ${{ inputs.ref }}
 
     - name: Generate changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,61 @@
+name: Generate changelog
+
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout (branch or tag)'
+        required: true
+        type: string
+      version:
+        description: 'Version tag for git-cliff (e.g. 2.026.28)'
+        required: true
+        type: string
+      draft:
+        description: 'If true, prepend a draft notice header (stabilize-time preview)'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      client-id:
+        required: true
+      private-key:
+        required: true
+
+
+jobs:
+  changelog:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+        fetch-tags: true
+    - uses: ./.github/actions/checkout-with-github-app-token
+      with:
+        app-id: ${{ secrets.client-id }}
+        private-key: ${{ secrets.private-key }}
+        ref: ${{ inputs.ref }}
+
+    - name: Generate changelog
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        npx git-cliff@2.10.0 -u --tag "$VERSION"
+
+    - name: Prepend draft notice (if draft)
+      if: ${{ inputs.draft }}
+      run: |
+        NOTICE='> ⚠️ **DRAFT** — this changelog is auto-generated on every push and may be inaccurate (e.g. include commits from untagged patches). It will be regenerated authoritatively at tag time. Please wait until after tagging before making manual edits.\n\n'
+        sed -i "1i\\${NOTICE}" CHANGELOG.md
+
+    - name: Commit to dedicated branch
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        git checkout -B changelog/$VERSION
+        git add -f CHANGELOG.md
+        git commit -m "chore(releases): generate CHANGELOG.md for $VERSION"
+        git push -f --set-upstream origin changelog/$VERSION

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-tags: true
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
-        app-id: ${{ secrets.client-id }}
+        client-id: ${{ secrets.client-id }}
         private-key: ${{ secrets.private-key }}
         ref: ${{ inputs.ref }}
 

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -48,6 +48,7 @@ jobs:
     if: ${{ needs.version.outputs.prev_released == 'true' }}
     runs-on: ubuntu-24.04
     steps:
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -48,7 +48,6 @@ jobs:
     if: ${{ needs.version.outputs.prev_released == 'true' }}
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -143,7 +143,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
@@ -187,7 +186,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -128,6 +128,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
@@ -171,6 +172,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/checkout-with-github-app-token
       with:
         client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -103,29 +103,14 @@ jobs:
       - npm-test
       - locale
     if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
-    runs-on: ubuntu-24.04
-    env:
-      PREV_BRANCH: ${{ needs.version.outputs.prev_branch }}
-      CURRENT_BRANCH: ${{ needs.version.outputs.current_branch }}
-      CURRENT_PATCH: ${{ needs.version.outputs.current_patch }}
-    steps:
-
-    - uses: actions/checkout@v6
-    - uses: ./.github/actions/checkout-with-github-app-token
-      with:
-        client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
-        private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
-
-    - name: draft a changelog
-      run: |
-        npx git-cliff@2.10.0 -u --tag $CURRENT_PATCH
-
-    - name: commit the changelog to a dedicated branch
-      run: |
-        git checkout -B changelog/$CURRENT_PATCH
-        git add -f CHANGELOG.md
-        git commit -m "chore(releases): generate CHANGELOG.md for $CURRENT_PATCH"
-        git push -f --set-upstream origin changelog/$CURRENT_PATCH
+    uses: './.github/workflows/changelog.yml'
+    secrets:
+      client-id: ${{ secrets.KOBO_BOT_CLIENT_ID }}
+      private-key: ${{ secrets.KOBO_BOT_PRIVATE_KEY }}
+    with:
+      ref: ${{ needs.version.outputs.current_branch }}
+      version: ${{ needs.version.outputs.current_patch }}
+      draft: true
 
 
   # Note: deploy only the latest release branch instead of all cascading release branches.


### PR DESCRIPTION
### 💭 Notes

Extract inline changelog generation from release-2-stabilize into a dedicated reusable workflow (changelog.yml). Supports both draft mode (stabilize-time preview) and authoritative mode (at tag time).

Update release-2-stabilize.yml to use the new reusable workflow.