### PR TITLE
ci(releases): cleanup branch workflow DEV-2424

### DIFF
--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -63,21 +63,9 @@ jobs:
         git push origin $NEW_BRANCH
 
 
-  changelog:
-    needs:
-      - version
-      - create-current-branch
-    runs-on: ubuntu-24.04
-    steps:
-    - name: create Linear ticket to track a draft of changelog
-      run: |
-        echo 'TODO, for now do it manually'
-
-
   notify-current:
     needs:
       - version
-      - changelog
     uses: './.github/workflows/zulip.yml'
     secrets: inherit
     with:
@@ -108,7 +96,6 @@ jobs:
       - current-branch
       - version
       - create-current-branch
-      - changelog
       - notify-prev
       - notify-current
     if: ${{ failure() }}

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -66,6 +66,7 @@ jobs:
   notify-current:
     needs:
       - version
+      - create-current-branch
     uses: './.github/workflows/zulip.yml'
     secrets: inherit
     with:
@@ -80,6 +81,7 @@ jobs:
   notify-prev:
     needs:
       - version
+      - create-current-branch
     uses: './.github/workflows/zulip.yml'
     secrets: inherit
     with:


### PR DESCRIPTION
### 💭 Notes

Cleanup branch workflow:
- rename concurrency group `branch-` → `release-branch-` for clarity
- remove unused `id: branch` from the create step
- simplified the Zulip notification
- fix failure notification condition (`failure()` → `!cancelled() && failure()`)
