### PR TITLE
feat(openRosa): block superuser form submissions by default DEV-32

### DIFF
--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -65,7 +65,10 @@ from kpi.utils.xml import (
 
 
 @ddt
-@override_settings(DEFAULT_DEPLOYMENT_BACKEND='mock')
+# These tests create submissions as the superuser `adminuser`, which is blocked
+# by default (DEV-32). Opt into it here since the restriction is not what they
+# exercise.
+@override_settings(DEFAULT_DEPLOYMENT_BACKEND='mock', ALLOW_SUPERUSER_SUBMISSIONS=True)
 class TestProjectHistoryLogs(BaseAuditLogTestCase):
     """
     Integration tests for flows that create ProjectHistoryLogs

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -20,6 +20,7 @@ from django.urls import reverse
 from django_digest.test import DigestAuth
 from rest_framework import status
 from rest_framework.authtoken.models import Token
+from rest_framework.test import force_authenticate
 
 from kobo.apps.data_collectors.models import DataCollector, DataCollectorGroup
 from kobo.apps.kobo_auth.shortcuts import User
@@ -1197,3 +1198,27 @@ class TestSuperuserSubmissionRestriction(TestAbstractViewSet):
         self.xform.require_auth = False
         self.xform.save(update_fields=['require_auth'])
         check_submission_permissions(self._request_for(AnonymousUser()), self.xform)
+
+    def test_superuser_gets_403_through_submission_endpoint(self):
+        # End-to-end guard: a superuser submitting through the real endpoint
+        # must get a 403 OpenRosa response, proving the exception is mapped to
+        # the right protocol response and not only raised in isolation.
+        path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '..',
+            'fixtures',
+            'transport_submission.json',
+        )
+        with open(path, 'rb') as f:
+            data = json.loads(f.read())
+
+        request = self.factory.post('/submission', data, format='json')
+        force_authenticate(request, user=self.superuser)
+        view = XFormSubmissionApi.as_view({'post': 'create'})
+        response = view(request, username=self.user.username)
+
+        # The OpenRosa error handler flattens every PermissionDenied to a
+        # generic "Access denied" body, so assert on the mapped response rather
+        # than the guard's internal message.
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('Access denied', response.data['error'])

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -1196,6 +1196,4 @@ class TestSuperuserSubmissionRestriction(TestAbstractViewSet):
         # Anonymous submissions to public forms keep working.
         self.xform.require_auth = False
         self.xform.save(update_fields=['require_auth'])
-        check_submission_permissions(
-            self._request_for(AnonymousUser()), self.xform
-        )
+        check_submission_permissions(self._request_for(AnonymousUser()), self.xform)

--- a/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
+++ b/kobo/apps/openrosa/apps/api/tests/viewsets/test_xform_submission_api.py
@@ -10,6 +10,7 @@ import simplejson as json
 from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import PermissionDenied
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.test.client import Client
@@ -35,6 +36,7 @@ from kobo.apps.openrosa.libs.utils import logger_tools
 from kobo.apps.openrosa.libs.utils.logger_tools import (
     OpenRosaResponseNotAllowed,
     OpenRosaTemporarilyUnavailable,
+    check_submission_permissions,
 )
 from kobo.apps.organizations.constants import UsageType
 from kpi.constants import PERM_ADD_SUBMISSIONS
@@ -1142,3 +1144,58 @@ def submit_data(identifier, survey_, username_, live_server_url, token_):
                 headers=headers
             )
             return response.status_code
+
+
+class TestSuperuserSubmissionRestriction(TestAbstractViewSet):
+    """
+    Superusers are blocked from submitting data by default (DEV-32). The guard
+    lives in `check_submission_permissions`, the single chokepoint every
+    submission path goes through, so it is exercised directly here.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.publish_xls_form()
+        self.superuser = User.objects.create_superuser(
+            'superadmin', 'superadmin@example.com', 'superadmin'
+        )
+
+    def _request_for(self, user):
+        request = self.factory.post('/submission')
+        request.user = user
+        return request
+
+    def test_superuser_blocked_by_default(self):
+        # `require_auth` form: the superuser guard must fire before the usual
+        # owner/permission checks.
+        with self.assertRaises(PermissionDenied):
+            check_submission_permissions(self._request_for(self.superuser), self.xform)
+
+    def test_superuser_blocked_on_anonymous_form(self):
+        # Even forms that accept anonymous submissions must reject superusers,
+        # which is why the guard sits before the `require_auth` early-return.
+        self.xform.require_auth = False
+        self.xform.save(update_fields=['require_auth'])
+        with self.assertRaises(PermissionDenied):
+            check_submission_permissions(self._request_for(self.superuser), self.xform)
+
+    @override_settings(ALLOW_SUPERUSER_SUBMISSIONS=True)
+    def test_superuser_allowed_when_opted_in(self):
+        # With the opt-in flag on, the superuser guard no longer raises. Use an
+        # anonymous-submission form so no later owner/permission check trips.
+        self.xform.require_auth = False
+        self.xform.save(update_fields=['require_auth'])
+        # Should not raise.
+        check_submission_permissions(self._request_for(self.superuser), self.xform)
+
+    def test_regular_user_not_blocked(self):
+        # A non-superuser owner submitting to their own form is unaffected.
+        check_submission_permissions(self._request_for(self.user), self.xform)
+
+    def test_anonymous_submission_still_allowed(self):
+        # Anonymous submissions to public forms keep working.
+        self.xform.require_auth = False
+        self.xform.save(update_fields=['require_auth'])
+        check_submission_permissions(
+            self._request_for(AnonymousUser()), self.xform
+        )

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -127,6 +127,22 @@ def check_submission_permissions(
     :raises: PermissionDenied based on the above criteria.
     """
 
+    # Block superusers from submitting data unless a self-hoster has explicitly
+    # opted into the risk (see DEV-32). Checked before `require_auth` so it also
+    # applies to forms that accept anonymous submissions. Internal callers pass
+    # `request=None` and are never affected.
+    if (
+        request
+        and request.user.is_superuser
+        and not settings.ALLOW_SUPERUSER_SUBMISSIONS
+    ):
+        raise PermissionDenied(
+            t(
+                'Superusers are not allowed to submit data. '
+                'Please use a regular account.'
+            )
+        )
+
     if not xform.require_auth:
         # Anonymous submissions are allowed!
         return

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1261,6 +1261,12 @@ TEMPLATES = [
 ]
 
 DEFAULT_SUBMISSIONS_COUNT_NUMBER_OF_DAYS = 31
+
+# Superusers submitting real survey data through the OpenRosa API tends to break
+# things (see DEV-32), so it is blocked by default. Self-hosters who really need
+# a superuser to submit can opt back into the risk by setting this to `True`;
+# consider yourself warned that bad things can happen.
+ALLOW_SUPERUSER_SUBMISSIONS = env.bool('ALLOW_SUPERUSER_SUBMISSIONS', False)
 GOOGLE_ANALYTICS_TOKEN = os.environ.get('GOOGLE_ANALYTICS_TOKEN')
 SENTRY_JS_DSN = None
 if SENTRY_JS_DSN_URL := env.url('SENTRY_JS_DSN', default=None):


### PR DESCRIPTION
### 📣 Summary

Superuser accounts can no longer submit data to forms, preventing accidental damage to projects from test submissions.

### 📖 Description

Submitting data while signed in as a superuser can corrupt a project's data. Superuser accounts are now blocked from submitting to any form — whether through KoboCollect, Enketo web forms, or the API. Regular accounts are unaffected; use one to submit or test data.

### 👷 Description for instance maintainers

This restriction is **on by default**. Self-hosters who deliberately rely on superuser submissions can re-enable them by setting the environment variable `ALLOW_SUPERUSER_SUBMISSIONS=True`. Doing so re-arms a known footgun — superuser submissions can break projects.

### 💭 Notes

- Guard added at the top of `check_submission_permissions` (`logger_tools.py`), the single chokepoint every submission path flows through (Collect, Enketo web, authenticated, data-collector token, and edits).
- Placed **before** the `require_auth` early-return, so superusers are blocked even on forms that accept anonymous submissions.
- Gated by a Django setting, not Constance — a superuser can't lift their own restriction from `/admin/`.
- Internal callers pass `request=None` and are never affected (imports, restores, etc.).
- The OpenRosa error handler flattens every `PermissionDenied` to a generic `Access denied` 403, so that's what the submitter (Collect/Enketo) sees; the more explicit "use a regular account" wording stays in the code/logs.

### 👀 Preview steps

1. ℹ️ have a superuser account and a deployed project
2. authenticate as the superuser and submit to the form (Enketo web form or the OpenRosa submission API)
3. 🔴 [on main] the submission is accepted
4. 🟢 [on PR] the submission is rejected with a `403` ("Access denied")
5. 🟢 [on PR, with `ALLOW_SUPERUSER_SUBMISSIONS=True`] the submission is accepted again
