### PR TITLE
fix(datatable): fallback values for missing choice names DEV-2573

### DIFF
--- a/jsapp/js/components/submissions/TableDropdownFilter.tsx
+++ b/jsapp/js/components/submissions/TableDropdownFilter.tsx
@@ -3,7 +3,7 @@ import type { Column, Filter, FilterRender } from 'react-table'
 import { getQuestionOrChoiceDisplayName } from '#/assetUtils'
 import Select from '#/components/common/Select'
 import type { TableColumn } from '#/components/submissions/table.types'
-import type { SurveyChoice } from '#/dataInterface'
+import type { LabelValuePair, SurveyChoice } from '#/dataInterface'
 
 const getChoiceFilterValue = (item: SurveyChoice): string | undefined =>
   item.name || item.$autoname || item.$autovalue || undefined
@@ -30,12 +30,8 @@ const TableDropdownFilter: FilterRender = (props: TableDropdownFilterProps) => {
   const selectFromListName = 'selectFromListName' in props.column ? props.column.selectFromListName : undefined
   const translationIndex = 'translationIndex' in props.column ? props.column.translationIndex || 0 : 0
 
-  interface ChoiceOption {
-    value: string
-    label: string
-  }
   const seenValues = new Set<string>()
-  const choiceOptions = choices.reduce<ChoiceOption[]>((acc, item) => {
+  const choiceOptions = choices.reduce<LabelValuePair[]>((acc, item) => {
     if (item.list_name !== selectFromListName) return acc
     const value = getChoiceFilterValue(item)
     if (!value || seenValues.has(value)) return acc

--- a/jsapp/js/components/submissions/TableDropdownFilter.tsx
+++ b/jsapp/js/components/submissions/TableDropdownFilter.tsx
@@ -30,7 +30,10 @@ const TableDropdownFilter: FilterRender = (props: TableDropdownFilterProps) => {
   const selectFromListName = 'selectFromListName' in props.column ? props.column.selectFromListName : undefined
   const translationIndex = 'translationIndex' in props.column ? props.column.translationIndex || 0 : 0
 
-  interface ChoiceOption { value: string; label: string }
+  interface ChoiceOption {
+    value: string
+    label: string
+  }
   const seenValues = new Set<string>()
   const choiceOptions = choices.reduce<ChoiceOption[]>((acc, item) => {
     if (item.list_name !== selectFromListName) return acc

--- a/jsapp/js/components/submissions/TableDropdownFilter.tsx
+++ b/jsapp/js/components/submissions/TableDropdownFilter.tsx
@@ -3,6 +3,10 @@ import type { Column, Filter, FilterRender } from 'react-table'
 import { getQuestionOrChoiceDisplayName } from '#/assetUtils'
 import Select from '#/components/common/Select'
 import type { TableColumn } from '#/components/submissions/table.types'
+import type { SurveyChoice } from '#/dataInterface'
+
+const getChoiceFilterValue = (item: SurveyChoice): string | undefined =>
+  item.name || item.$autoname || item.$autovalue || undefined
 
 interface TableDropdownFilterProps {
   column: TableColumn | Column<any>
@@ -26,24 +30,17 @@ const TableDropdownFilter: FilterRender = (props: TableDropdownFilterProps) => {
   const selectFromListName = 'selectFromListName' in props.column ? props.column.selectFromListName : undefined
   const translationIndex = 'translationIndex' in props.column ? props.column.translationIndex || 0 : 0
 
-  // Duplicate values can exist in the choices array, so we use a Set to filter them out
+  interface ChoiceOption { value: string; label: string }
   const seenValues = new Set<string>()
-  const data = [
-    { value: SHOW_ALL_VALUE, label: t('Show All') },
-    ...choices
-      .filter((choiceItem) => choiceItem.list_name === selectFromListName)
-      .filter((item) => {
-        if (seenValues.has(item.name)) return false
-        seenValues.add(item.name)
-        return true
-      })
-      .map((item) => {
-        return {
-          value: item.name,
-          label: getQuestionOrChoiceDisplayName(item, translationIndex),
-        }
-      }),
-  ]
+  const choiceOptions = choices.reduce<ChoiceOption[]>((acc, item) => {
+    if (item.list_name !== selectFromListName) return acc
+    const value = getChoiceFilterValue(item)
+    if (!value || seenValues.has(value)) return acc
+    seenValues.add(value)
+    acc.push({ value, label: getQuestionOrChoiceDisplayName(item, translationIndex) })
+    return acc
+  }, [])
+  const data = [{ value: SHOW_ALL_VALUE, label: t('Show All') }, ...choiceOptions]
 
   // Map internal filter value (empty string) to our sentinel value for display
   const displayValue = !props.filter || props.filter.value === '' ? SHOW_ALL_VALUE : props.filter.value


### PR DESCRIPTION
### 📣 Summary

Fixes the select one/many column filter dropdown on the data table to handle choices with a missing `name` by falling back to `$autoname` then `$autovalue` before dropping value from list.

### 👀 Preview steps

1. Upload the following xlsform as a new project:
[missing-name-select.xlsx](https://github.com/user-attachments/files/30703068/missing-name-select.xlsx)
2. Make a few submissions
3. Open project data table
4. 🔴 [on main] notice the mantine component throws an error that breaks entire view
5. 🟢 [on PR] Verify table renders and dropdown correctly shows choice labels with usable filter values
6. Select a choice from the dropdown
7. 🟢 notice the table filters correctly to rows matching that choice
