### PR TITLE
fix(myLibrary): menu overflowing ugly in single collection route DEV-2387

### DIFF
--- a/jsapp/js/components/assetsTable/assetsTable.scss
+++ b/jsapp/js/components/assetsTable/assetsTable.scss
@@ -34,10 +34,9 @@ $assets-table-hover-bg: colors.$kobo-gray-100;
     height: 100%;
   }
 
-  &.assets-table--collection-content {
+  &.assets-table--no-scroll {
     // we disable horizontal scrolling to make the popover menu appear outside the table
     overflow-x: initial;
-    min-width: $assets-table-min-width;
   }
 }
 

--- a/jsapp/js/components/assetsTable/assetsTable.tsx
+++ b/jsapp/js/components/assetsTable/assetsTable.tsx
@@ -9,7 +9,7 @@ import type { AssetResponse, MetadataResponse } from '#/dataInterface'
 import type { OrderDirection } from '#/projects/projectViews/constants'
 import { getScrollbarWidth, hasVerticalScrollbar } from '#/utils'
 import { ASSETS_TABLE_COLUMNS, ASSETS_TABLE_CONTEXTS, ORDER_DIRECTIONS } from './assetsTableConstants'
-import type { AssetsTableColumn, AssetsTableContextName } from './assetsTableConstants'
+import { type AssetsTableColumn, AssetsTableContextName } from './assetsTableConstants'
 import AssetsTableRow from './assetsTableRow'
 
 bem.AssetsTable = makeBem(null, 'assets-table')
@@ -355,6 +355,9 @@ export default class AssetsTable extends React.Component<AssetsTableProps, Asset
     const modifiers: string[] = [this.props.context]
     if (this.state.isFullscreen) {
       modifiers.push('fullscreen')
+    }
+    if (this.props.context === AssetsTableContextName.COLLECTION_CONTENT) {
+      modifiers.push('no-scroll')
     }
 
     return (


### PR DESCRIPTION
### 📣 Summary

When viewing a single collection with a small amount of items, the "More actions" menu was being displayed in small scrollable container making it hard to use it. No more.

### 💭 Notes

This actually worked some time ago but we've renamed `ASSETS_TABLE_CONTEXTS` items and they were being used directly in css (bad code). This is still a deprecated part of code, so I added a small fix for this.

### 👀 Preview steps

1. ℹ️ Have a collection with one item
2. Go to My Library → Collection
3. Hover over the library item and click "…" (More actions)
4. 🔴 [on main] Notice that most of the menu is cut off by overflow (scrollbar appears)
5. 🟢 [on PR] Notice now whole menu is being visible
