### PR TITLE
fix(attachments): use root_uuid for media folder naming DEV-2515

### DIFF
--- a/kobo/apps/openrosa/apps/logger/models/attachment.py
+++ b/kobo/apps/openrosa/apps/logger/models/attachment.py
@@ -32,7 +32,7 @@ def generate_attachment_filename(instance, filename):
         'attachments',
         xform.uuid or xform.id_string or '__pk-{}'.format(xform.pk),
         instance.root_uuid,
-        os.path.split(filename)[1]
+        os.path.split(filename)[1],
     )
 
 

--- a/kobo/apps/openrosa/apps/logger/models/attachment.py
+++ b/kobo/apps/openrosa/apps/logger/models/attachment.py
@@ -26,12 +26,14 @@ from .instance import Instance
 
 def generate_attachment_filename(instance, filename):
     xform = instance.xform
+
     return os.path.join(
         xform.user.username,
         'attachments',
         xform.uuid or xform.id_string or '__pk-{}'.format(xform.pk),
-        instance.uuid or '__pk-{}'.format(instance.pk),
-        os.path.split(filename)[1])
+        instance.root_uuid,
+        os.path.split(filename)[1]
+    )
 
 
 def upload_to(attachment, filename):

--- a/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_clean_duplicated_submissions.py
@@ -3,7 +3,6 @@ import uuid as uuid_module
 
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.utils import timezone
 
@@ -55,16 +54,22 @@ class TestCleanDuplicatedSubmissions(TestBase):
 
     # ------------------------------------------------------------------ helpers
     def _add_attachment(self, instance):
-        fake_file = SimpleUploadedFile(
-            'test.txt', b'content', content_type='text/plain'
-        )
-        return Attachment.objects.create(
+        """
+        Insert an Attachment row directly via bulk_create, bypassing save()
+        (and its `generate_attachment_filename` call, which requires
+        `instance.root_uuid`) since these rows simulate attachments already
+        present in storage from before root_uuid existed.
+        """
+        attachment = Attachment(
             instance=instance,
             xform=self.xform,
-            media_file=fake_file,
+            user=self.user,
+            media_file=f'attachments/legacy-{uuid_module.uuid4()}.txt',
             mimetype='text/plain',
             media_file_size=7,
         )
+        Attachment.objects.bulk_create([attachment])
+        return attachment
 
     def _add_parsed_instance(self, instance):
         parsed, _ = ParsedInstance.objects.get_or_create(instance=instance)

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -917,8 +917,7 @@ class BaseDeploymentBackend(abc.ABC):
 
             # fall back until LRM 0027/0028 are not completed
             root_uuid = remove_uuid_prefix(
-                submission.get(META_ROOT_UUID)
-                or submission['_uuid']
+                submission.get(META_ROOT_UUID) or submission['_uuid']
             )
             attachment['filename'] = os.path.join(
                 self.asset.owner.username,

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -914,12 +914,18 @@ class BaseDeploymentBackend(abc.ABC):
                         continue
 
             filename = attachment['filename']
+
+            # fall back until LRM 0027/0028 are not completed
+            root_uuid = remove_uuid_prefix(
+                submission.get(META_ROOT_UUID)
+                or submission['_uuid']
+            )
             attachment['filename'] = os.path.join(
                 self.asset.owner.username,
                 'attachments',
                 # KoboCAT accepts submissions even when they lack `formhub/uuid`
                 self.form_uuid or submission['formhub/uuid'],
-                submission['_uuid'],
+                root_uuid,
                 os.path.basename(filename)
             )
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -3039,6 +3039,48 @@ class SubmissionDuplicateApiTests(
         assert deployment.SUBMISSION_DEPRECATED_UUID_XPATH not in response.data
         assert 'deprecatedID' not in duplicated_instance.xml
 
+    def test_duplicate_submission_attachment_uses_own_root_uuid(self):
+        """
+        The duplicate's attachment must be stored under a folder named
+        after the duplicate's own root_uuid, not the source submission's.
+        """
+        submission = {
+            '__version__': self.asset.latest_deployed_version.uid,
+            'q1': 'foo',
+            'meta/instanceID': f'uuid:{uuid.uuid4()}',
+            '_attachments': [{'filename': 'IMG_4266-11_38_22.jpg'}],
+        }
+        self.asset.deployment.mock_submissions([submission])
+
+        source_instance = Instance.objects.get(pk=submission['_id'])
+        source_attachment = source_instance.attachments.get()
+        assert (
+            source_attachment.media_file.name.split('/')[-2]
+            == source_instance.root_uuid
+        )
+
+        url = reverse(
+            self._get_endpoint('submission-duplicate'),
+            kwargs={
+                'uid_asset': self.asset.uid,
+                'pk': submission['_id'],
+            },
+        )
+        response = self.client.post(url, {'format': 'json'})
+        assert response.status_code == status.HTTP_201_CREATED
+
+        duplicated_instance = Instance.objects.get(pk=response.data['_id'])
+        duplicated_attachment = duplicated_instance.attachments.get()
+
+        assert duplicated_instance.root_uuid != source_instance.root_uuid
+        assert (
+            duplicated_attachment.media_file.name.split('/')[-2]
+            == duplicated_instance.root_uuid
+        )
+        assert (
+            duplicated_attachment.media_file.name != source_attachment.media_file.name
+        )
+
 
 class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
 


### PR DESCRIPTION
### 📣 Summary
Media files for edited submissions could end up in an export folder that no longer matches the submission, making them hard to find.

### 💭 Notes
- `generate_attachment_filename()` (`kobo/apps/openrosa/apps/logger/models/attachment.py`), used as the `upload_to` for `Attachment.media_file`, now names the folder after `instance.root_uuid` instead of `instance.uuid`/pk. `root_uuid` is static for the life of a submission, while `uuid` changes on every edit, so a submission whose first version had no attachments no longer gets a media folder disconnected from its identity once a later edit adds one.
- `BaseDeploymentBackend._rewrite_json_attachment_urls()` (`kpi/deployment_backends/base_backend.py`) applies the same `root_uuid` naming when rewriting attachment filenames/URLs in the submission JSON, falling back to `_uuid` when `meta/rootUuid` isn't present yet (submissions not backfilled by LRM 0027/0028).
- Backward compatible: attachments already stored under a uuid-named folder are untouched; only newly created attachments use the new naming.
- `test_clean_duplicated_submissions.py`'s `_add_attachment` helper now uses `bulk_create` instead of `.create()` to bypass `save()`/`generate_attachment_filename`, since its fixtures intentionally simulate legacy instances with `root_uuid=None` (attachment creation never actually happens against a row without a populated `root_uuid` in production).

### 👀 Preview steps

1. ℹ️ have an account and a project with a form containing an optional media question
2. submit an entry without media
3. edit that submission and add a photo
4. download a Media Attachments (ZIP) export
5. 🔴 [on main] the media folder for the submission is named after the edit's uuid, not its rootUuid
6. 🟢 [on PR] the media folder is named after the submission's rootUuid, consistent across edits
