### PR TITLE
feat(stripe): only run cleanup tasks on stripe-enabled instances DEV-1563

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1573,12 +1573,6 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/30'),
         'options': {'queue': 'kpi_low_priority_queue'}
     },
-    # Schedule every 30 minutes
-    'attachment-cleanup-for-users-exceeding-limits': {
-        'task': 'kobo.apps.trash_bin.tasks.attachment.schedule_auto_attachment_cleanup_for_users',  # noqa
-        'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_low_priority_queue'}
-    },
     # Schedule every 5 minutes
     'cleanup-anonymous-exports': {
         'task': 'kpi.tasks.cleanup_anonymous_exports',
@@ -1703,6 +1697,12 @@ if STRIPE_ENABLED:
         'task': 'kobo.apps.stripe.tasks.update_exceeded_limit_counters',
         'schedule': crontab(minute='*/' + str(minute_interval)),
         'options': {'queue': 'kpi_low_priority_queue'},
+    }
+
+    CELERY_BEAT_SCHEDULE['attachment-cleanup-for-users-exceeding-limits'] = {
+        'task': 'kobo.apps.trash_bin.tasks.attachment.schedule_auto_attachment_cleanup_for_users',  # noqa
+        'schedule': crontab(minute='*/30'),
+        'options': {'queue': 'kpi_low_priority_queue'}
     }
 
 CELERY_BROKER_TRANSPORT_OPTIONS = {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1702,7 +1702,7 @@ if STRIPE_ENABLED:
     CELERY_BEAT_SCHEDULE['attachment-cleanup-for-users-exceeding-limits'] = {
         'task': 'kobo.apps.trash_bin.tasks.attachment.schedule_auto_attachment_cleanup_for_users',  # noqa
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_low_priority_queue'},
     }
 
 CELERY_BROKER_TRANSPORT_OPTIONS = {


### PR DESCRIPTION


### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes
Prevents a recurring error in kpi workers on instances that do not have stripe enabled that were previously trying to run a stripe-only job.


### 👀 Preview steps

1. ℹ️ disable stripe locally (remember to restart containers)
2. In settings, update the `schedule_auto_attachment_cleanup_for_users` job to run every 2 minutes
3. Follow at the kpi worker logs 
4. 🔴 [on main] error
5. 🟢 [on PR] (remember to change the schedule to every 2m so you don't have to wait 30m) no error

