### PR TITLE
feat(frontend): Make MultiSelect searchable by default DEV-2569

### DIFF
--- a/jsapp/js/theme/kobo/MultiSelect.ts
+++ b/jsapp/js/theme/kobo/MultiSelect.ts
@@ -15,6 +15,7 @@ export const MultiSelectThemeKobo = MultiSelect.extend({
     // Keep default height aligned with Select when no explicit size is provided.
     size: 'md',
     withCheckIcon: false,
+    searchable: true,
     comboboxProps: {
       offset: 0,
       dropdownPadding: 0,


### PR DESCRIPTION
### 📣 Summary

Every place that uses MultiSelect in UI will now allow searching for options.

### 💭 Notes

Forgot this one line in previous PR #7353.
