### PR TITLE
ci(releases): disambiguate linear keys DEV-2625

### DIFF
--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -78,12 +78,12 @@ jobs:
         fetch-tags: true
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_minor }}
         base_ref: origin/${{ needs.version.outputs.prev_branch }}
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         command: update
         release_version: ${{ needs.version.outputs.current_minor }}
         stage: "Pending QA"

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -165,7 +165,7 @@ jobs:
         fetch-tags: true
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_patch }}
         base_ref: ${{ needs.version.outputs.current_released == 'true' && needs.version.outputs.prev_patch || format('origin/{0}', needs.version.outputs.prev_branch) }}
 
@@ -173,7 +173,7 @@ jobs:
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       if: ${{ needs.version.outputs.current_released == 'true' }}
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         command: update
         release_version: ${{ needs.version.outputs.current_patch }}
         stage: "Pending Image"

--- a/.github/workflows/release-3-delete.yml
+++ b/.github/workflows/release-3-delete.yml
@@ -103,13 +103,13 @@ jobs:
     - name: Find Linear release
       id: find
       env:
-        LINEAR_API_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+        LINEAR_PIPELINE_KEY_KPI: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         RELEASE_NAME: ${{ needs.version.outputs.current_minor }}
       run: |
         set -xe
 
         RELEASE_ID=$(curl -s -X POST https://api.linear.app/graphql \
-          -H "Authorization: $LINEAR_API_KEY" \
+          -H "Authorization: $LINEAR_PIPELINE_KEY_KPI" \
           -H "Content-Type: application/json" \
           -d "{\"query\": \"query { releases(filter: { name: { eq: \\\"$RELEASE_NAME\\\" } }) { nodes { id name } } }\"}" \
           | jq -r '.data.releases.nodes[0].id // empty')
@@ -124,14 +124,14 @@ jobs:
     - name: Delete Linear release
       if: steps.find.outputs.release_id != ''
       env:
-        LINEAR_API_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
+        LINEAR_PIPELINE_KEY_KPI: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         RELEASE_NAME: ${{ needs.version.outputs.current_minor }}
         RELEASE_ID: ${{ steps.find.outputs.release_id }}
       run: |
         set -xe
 
         RESULT=$(curl -s -X POST https://api.linear.app/graphql \
-          -H "Authorization: $LINEAR_API_KEY" \
+          -H "Authorization: $LINEAR_PIPELINE_KEY_KPI" \
           -H "Content-Type: application/json" \
           -d "{\"query\": \"mutation { releaseDelete(id: \\\"$RELEASE_ID\\\") { success } }\"}")
 

--- a/.github/workflows/release-3-tag.yml
+++ b/.github/workflows/release-3-tag.yml
@@ -414,13 +414,13 @@ jobs:
     # which excludes these).
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_patch }}
         base_ref: ${{ needs.version.outputs.prev_patch }}
 
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         command: update
         release_version: ${{ needs.version.outputs.current_patch }}
         stage: "Pending Release (preview on kf.master)"

--- a/.github/workflows/release-4-publish.yml
+++ b/.github/workflows/release-4-publish.yml
@@ -189,7 +189,7 @@ jobs:
         fetch-tags: true
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:
-        access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+        access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         command: complete
         release_version: ${{ inputs.tag }}
 


### PR DESCRIPTION
### 💭 Notes

Linear have different API keys for accessing pipelines and the rest of Linear (e.g. issues).