### PR TITLE
fix(bulkProcessing): hide transcript language from bulk translation modal DEV-2622

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/index.tsx
@@ -28,7 +28,8 @@ interface Props {
   submission: DataResponse
   supplement: DataSupplementResponse
   activeBulkActions: BulkActionResponse[]
-  languagesExisting: LanguageCode[]
+  /** Languages that can't be picked: already translated into, or the transcript's own language. */
+  languagesUnavailable: LanguageCode[]
   initialStep?: CreateSteps.Begin | CreateSteps.Language
   translationVersions: Array<SupplementalDataVersionItemManual | SupplementalDataVersionItemAutomatic>
   onCreate: (languageCode: LanguageCode, context: 'automated' | 'manual') => void
@@ -43,7 +44,7 @@ export default function TranslationAdd({
   submission,
   supplement,
   activeBulkActions,
-  languagesExisting,
+  languagesUnavailable,
   initialStep,
   translationVersions,
   onCreate,
@@ -100,7 +101,7 @@ export default function TranslationAdd({
           onNext={(nextStep: CreateSteps.Manual | CreateSteps.Automatic) => setStep(nextStep)}
           onLimitExceeded={() => setIsLimitBlockModalOpen(true)}
           usageType={UsageLimitTypes.TRANSLATION}
-          hiddenLanguages={languagesExisting}
+          hiddenLanguages={languagesUnavailable}
           suggestedLanguages={getSuggestedLanguages(advancedFeatures)}
           languageCode={languageCode}
           setLanguageCode={setLanguageCode}

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
@@ -13,6 +13,7 @@ import { CreateSteps } from '../../common/types'
 import {
   getAllTranslationsFromSupplementData,
   getLatestAutomaticTranslationVersionItem,
+  getLatestTranscriptVersionItem,
   isSupplementVersionAutomatic,
 } from '../../common/utils'
 import TranslationAdd from './TranslationAdd'
@@ -43,6 +44,14 @@ export default function TranslationTab({
     () => getAllTranslationsFromSupplementData(supplement, questionXpath, false),
     [supplement, questionXpath],
   )
+
+  // Languages that can't be picked for a new translation: the ones already translated into, plus the transcript's own
+  // language. Translating a transcript into its own language produces an empty, undeletable translation (DEV-2622).
+  const unavailableLanguages = useMemo(() => {
+    const transcriptLanguage = getLatestTranscriptVersionItem(supplement, questionXpath)?._data.language
+    const existingLanguages = translationVersions.map(({ _data }) => _data.language)
+    return transcriptLanguage ? [...existingLanguages, transcriptLanguage] : existingLanguages
+  }, [supplement, questionXpath, translationVersions])
 
   // Read languageCode from URL params if available (for direct navigation to specific translation)
   const params = useParams<{ languageCode?: string }>()
@@ -143,7 +152,7 @@ export default function TranslationTab({
           questionXpath={questionXpath}
           submission={submission}
           supplement={supplement}
-          languagesExisting={translationVersions.map(({ _data }) => _data.language)}
+          languagesUnavailable={unavailableLanguages}
           initialStep={translationVersion ? CreateSteps.Language : CreateSteps.Begin}
           translationVersions={translationVersions}
           activeBulkActions={activeBulkActions}

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
@@ -13,7 +13,7 @@ import { CreateSteps } from '../../common/types'
 import {
   getAllTranslationsFromSupplementData,
   getLatestAutomaticTranslationVersionItem,
-  getLatestTranscriptVersionItem,
+  getTranslationSourceLanguage,
   isSupplementVersionAutomatic,
 } from '../../common/utils'
 import TranslationAdd from './TranslationAdd'
@@ -45,12 +45,13 @@ export default function TranslationTab({
     [supplement, questionXpath],
   )
 
-  // Languages that can't be picked for a new translation: the ones already translated into, plus the transcript's own
-  // language. Translating a transcript into its own language produces an empty, undeletable translation.
+  // Languages that can't be picked for a new translation: the ones already translated into, plus the language of the
+  // transcript the translation would be sourced from. Translating a transcript into its own language produces an empty,
+  // undeletable translation.
   const unavailableLanguages = useMemo(() => {
-    const transcriptLanguage = getLatestTranscriptVersionItem(supplement, questionXpath)?._data.language
+    const sourceLanguage = getTranslationSourceLanguage(supplement, questionXpath)
     const existingLanguages = translationVersions.map(({ _data }) => _data.language)
-    return transcriptLanguage ? [...existingLanguages, transcriptLanguage] : existingLanguages
+    return sourceLanguage ? [...existingLanguages, sourceLanguage] : existingLanguages
   }, [supplement, questionXpath, translationVersions])
 
   // Read languageCode from URL params if available (for direct navigation to specific translation)

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
@@ -13,7 +13,7 @@ import { CreateSteps } from '../../common/types'
 import {
   getAllTranslationsFromSupplementData,
   getLatestAutomaticTranslationVersionItem,
-  getTranslationSourceLanguage,
+  getTranslationSourceLanguages,
   isSupplementVersionAutomatic,
 } from '../../common/utils'
 import TranslationAdd from './TranslationAdd'
@@ -45,14 +45,17 @@ export default function TranslationTab({
     [supplement, questionXpath],
   )
 
-  // Languages that can't be picked for a new translation: the ones already translated into, plus the language of the
-  // transcript the translation would be sourced from. Translating a transcript into its own language produces an empty,
-  // undeletable translation.
-  const unavailableLanguages = useMemo(() => {
-    const sourceLanguage = getTranslationSourceLanguage(supplement, questionXpath)
-    const existingLanguages = translationVersions.map(({ _data }) => _data.language)
-    return sourceLanguage ? [...existingLanguages, sourceLanguage] : existingLanguages
-  }, [supplement, questionXpath, translationVersions])
+  // Languages already translated into, plus the source transcript's own language. Translating a transcript into its own
+  // language leaves behind an empty column that can't be deleted, so that language has to go too.
+  const unavailableLanguages = useMemo(
+    () => [
+      ...new Set([
+        ...translationVersions.map(({ _data }) => _data.language),
+        ...getTranslationSourceLanguages(supplement, questionXpath),
+      ]),
+    ],
+    [supplement, questionXpath, translationVersions],
+  )
 
   // Read languageCode from URL params if available (for direct navigation to specific translation)
   const params = useParams<{ languageCode?: string }>()

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/index.tsx
@@ -46,7 +46,7 @@ export default function TranslationTab({
   )
 
   // Languages that can't be picked for a new translation: the ones already translated into, plus the transcript's own
-  // language. Translating a transcript into its own language produces an empty, undeletable translation (DEV-2622).
+  // language. Translating a transcript into its own language produces an empty, undeletable translation.
   const unavailableLanguages = useMemo(() => {
     const transcriptLanguage = getLatestTranscriptVersionItem(supplement, questionXpath)?._data.language
     const existingLanguages = translationVersions.map(({ _data }) => _data.language)

--- a/jsapp/js/components/processing/common/utils.tests.ts
+++ b/jsapp/js/components/processing/common/utils.tests.ts
@@ -1,5 +1,7 @@
 import type { AdvancedFeatureResponse } from '#/api/models/advancedFeatureResponse'
 import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
+import type { SupplementalDataManualTranscription } from '#/api/models/supplementalDataManualTranscription'
+import type { SupplementalDataVersionItemManual } from '#/api/models/supplementalDataVersionItemManual'
 import { getSuggestedLanguages, getTranslationSourceLanguage } from './utils'
 
 // Mock AdvancedFeatureResponse objects for tests
@@ -76,7 +78,7 @@ function buildTranscriptVersion(options: {
   dateCreated: string
   dateAccepted: string
   value?: string | null
-}) {
+}): SupplementalDataVersionItemManual {
   return {
     _uuid: options.uuid,
     _dateCreated: options.dateCreated,
@@ -88,24 +90,33 @@ function buildTranscriptVersion(options: {
   }
 }
 
-/** Wraps transcript versions in the `manual_transcription` shape of a supplement response. */
-function buildSupplement(versions: ReturnType<typeof buildTranscriptVersion>[]): DataSupplementResponse {
-  return {
-    _version: '1',
-    [XPATH]: {
-      manual_transcription: {
-        _dateCreated: '2026-01-01T00:00:00Z',
-        _dateModified: '2026-01-01T00:00:00Z',
-        _versions: versions,
-      },
-    },
-  } as unknown as DataSupplementResponse
+/**
+ * Wraps transcript versions in the `manual_transcription` shape of a supplement response. Pass no versions to get a
+ * supplement with no transcription action at all (`_versions` is never legitimately empty - the API requires at least
+ * one entry).
+ */
+function buildSupplement(versions: SupplementalDataVersionItemManual[]): DataSupplementResponse {
+  const actions: Record<string, { manual_transcription: SupplementalDataManualTranscription }> = versions.length
+    ? {
+        [XPATH]: {
+          manual_transcription: {
+            _dateCreated: '2026-01-01T00:00:00Z',
+            _dateModified: '2026-01-01T00:00:00Z',
+            _versions: versions,
+          },
+        },
+      }
+    : {}
+
+  // `DataSupplementResponse` is `{_version: string} & Record<string, SupplementalDataResponseAction>`, so `_version`
+  // would have to be a string *and* an action object at once. No literal can satisfy that, hence the assertion. The
+  // parts we actually assert on are fully typed above, so a wrong version or transcription shape still fails to compile.
+  return { _version: '1', ...actions } as DataSupplementResponse
 }
 
 describe('getTranslationSourceLanguage', () => {
   it('returns undefined when there are no transcripts at all', () => {
-    const supplement = { _version: '1' } as DataSupplementResponse
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal(undefined)
+    chai.expect(getTranslationSourceLanguage(buildSupplement([]), XPATH)).to.equal(undefined)
   })
 
   it('returns the language of the only accepted transcript', () => {

--- a/jsapp/js/components/processing/common/utils.tests.ts
+++ b/jsapp/js/components/processing/common/utils.tests.ts
@@ -1,5 +1,6 @@
 import type { AdvancedFeatureResponse } from '#/api/models/advancedFeatureResponse'
-import { getSuggestedLanguages } from './utils'
+import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
+import { getSuggestedLanguages, getTranslationSourceLanguage } from './utils'
 
 // Mock AdvancedFeatureResponse objects for tests
 const BASE: AdvancedFeatureResponse = {
@@ -63,5 +64,119 @@ describe('getSuggestedLanguages', () => {
 
   it('handles no params in AdvancedFeatureResponse', () => {
     chai.expect(getSuggestedLanguages([EMPTY_PARAMS_RESPONSE])).to.deep.equal([])
+  })
+})
+
+const XPATH = 'audio_question'
+
+/** Builds a transcript version. Pass `dateAccepted: ''` for a version still awaiting review. */
+function buildTranscriptVersion(options: {
+  uuid: string
+  language: string
+  dateCreated: string
+  dateAccepted: string
+  value?: string | null
+}) {
+  return {
+    _uuid: options.uuid,
+    _dateCreated: options.dateCreated,
+    _dateAccepted: options.dateAccepted,
+    _data: {
+      language: options.language,
+      value: options.value === undefined ? 'Some transcribed text' : options.value,
+    },
+  }
+}
+
+/** Wraps transcript versions in the `manual_transcription` shape of a supplement response. */
+function buildSupplement(versions: ReturnType<typeof buildTranscriptVersion>[]): DataSupplementResponse {
+  return {
+    _version: '1',
+    [XPATH]: {
+      manual_transcription: {
+        _dateCreated: '2026-01-01T00:00:00Z',
+        _dateModified: '2026-01-01T00:00:00Z',
+        _versions: versions,
+      },
+    },
+  } as unknown as DataSupplementResponse
+}
+
+describe('getTranslationSourceLanguage', () => {
+  it('returns undefined when there are no transcripts at all', () => {
+    const supplement = { _version: '1' } as DataSupplementResponse
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal(undefined)
+  })
+
+  it('returns the language of the only accepted transcript', () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'en',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-01T11:00:00Z',
+      }),
+    ])
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+  })
+
+  it('ignores transcripts that were never accepted', () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'en',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-01T11:00:00Z',
+      }),
+      // Newer, but still awaiting review, so the back end would not translate from it.
+      buildTranscriptVersion({ uuid: 'v2', language: 'fr', dateCreated: '2026-01-02T10:00:00Z', dateAccepted: '' }),
+    ])
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+  })
+
+  it('returns undefined when no transcript has been accepted', () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({ uuid: 'v1', language: 'en', dateCreated: '2026-01-01T10:00:00Z', dateAccepted: '' }),
+    ])
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal(undefined)
+  })
+
+  it('picks the most recently accepted transcript, not the most recently created one', () => {
+    const supplement = buildSupplement([
+      // Created first but accepted last, which is what the back end translates from.
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'en',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-03T10:00:00Z',
+      }),
+      buildTranscriptVersion({
+        uuid: 'v2',
+        language: 'fr',
+        dateCreated: '2026-01-02T10:00:00Z',
+        dateAccepted: '2026-01-02T11:00:00Z',
+      }),
+    ])
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+  })
+
+  it('ignores accepted transcripts that have no value left', () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'en',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-01T11:00:00Z',
+      }),
+      // Deleted transcripts keep their acceptance date but lose the text.
+      buildTranscriptVersion({
+        uuid: 'v2',
+        language: 'fr',
+        dateCreated: '2026-01-02T10:00:00Z',
+        dateAccepted: '2026-01-02T11:00:00Z',
+        value: null,
+      }),
+    ])
+    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
   })
 })

--- a/jsapp/js/components/processing/common/utils.tests.ts
+++ b/jsapp/js/components/processing/common/utils.tests.ts
@@ -2,7 +2,7 @@ import type { AdvancedFeatureResponse } from '#/api/models/advancedFeatureRespon
 import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
 import type { SupplementalDataManualTranscription } from '#/api/models/supplementalDataManualTranscription'
 import type { SupplementalDataVersionItemManual } from '#/api/models/supplementalDataVersionItemManual'
-import { getSuggestedLanguages, getTranslationSourceLanguage } from './utils'
+import { getBlockedTargetLanguages, getSuggestedLanguages, getTranslationSourceLanguages } from './utils'
 
 // Mock AdvancedFeatureResponse objects for tests
 const BASE: AdvancedFeatureResponse = {
@@ -77,6 +77,7 @@ function buildTranscriptVersion(options: {
   language: string
   dateCreated: string
   dateAccepted: string
+  locale?: string
   value?: string | null
 }): SupplementalDataVersionItemManual {
   return {
@@ -85,6 +86,7 @@ function buildTranscriptVersion(options: {
     _dateAccepted: options.dateAccepted,
     _data: {
       language: options.language,
+      locale: options.locale,
       value: options.value === undefined ? 'Some transcribed text' : options.value,
     },
   }
@@ -92,8 +94,8 @@ function buildTranscriptVersion(options: {
 
 /**
  * Wraps transcript versions in the `manual_transcription` shape of a supplement response. Pass no versions to get a
- * supplement with no transcription action at all (`_versions` is never legitimately empty - the API requires at least
- * one entry).
+ * supplement with no transcription action at all, rather than one holding an empty `_versions` - the API requires at
+ * least one entry there, so an empty list is a state that never occurs.
  */
 function buildSupplement(versions: SupplementalDataVersionItemManual[]): DataSupplementResponse {
   const actions: Record<string, { manual_transcription: SupplementalDataManualTranscription }> = versions.length
@@ -108,15 +110,36 @@ function buildSupplement(versions: SupplementalDataVersionItemManual[]): DataSup
       }
     : {}
 
-  // `DataSupplementResponse` is `{_version: string} & Record<string, SupplementalDataResponseAction>`, so `_version`
-  // would have to be a string *and* an action object at once. No literal can satisfy that, hence the assertion. The
-  // parts we actually assert on are fully typed above, so a wrong version or transcription shape still fails to compile.
+  // `DataSupplementResponse` is `{_version: string} & Record<string, SupplementalDataResponseAction>`, which asks
+  // `_version` to be a string *and* an action object at the same time. No literal can satisfy that, hence the
+  // assertion. Everything the tests read is typed above it, so a wrong transcription shape still fails to compile.
   return { _version: '1', ...actions } as DataSupplementResponse
 }
 
-describe('getTranslationSourceLanguage', () => {
-  it('returns undefined when there are no transcripts at all', () => {
-    chai.expect(getTranslationSourceLanguage(buildSupplement([]), XPATH)).to.equal(undefined)
+describe('getBlockedTargetLanguages', () => {
+  it('blocks just the language when there is no locale', () => {
+    chai.expect(getBlockedTargetLanguages('en')).to.deep.equal(['en'])
+  })
+
+  it('blocks both a locale and its base language', () => {
+    chai.expect(getBlockedTargetLanguages('en', 'en-CA')).to.deep.equal(['en-CA', 'en'])
+  })
+
+  it('blocks the locale over the language, since the back end translates from the locale', () => {
+    // Nothing checks `locale` against `language`, so this mismatched pair can be stored and would be translated from
+    // French. Blocking only `es` would leave `fr` pickable and bring the empty column back.
+    chai.expect(getBlockedTargetLanguages('es', 'fr-CA')).to.deep.equal(['fr-CA', 'fr'])
+  })
+
+  it('treats an empty locale as absent', () => {
+    chai.expect(getBlockedTargetLanguages('en', '')).to.deep.equal(['en'])
+    chai.expect(getBlockedTargetLanguages('en', null)).to.deep.equal(['en'])
+  })
+})
+
+describe('getTranslationSourceLanguages', () => {
+  it('returns nothing when there are no transcripts at all', () => {
+    chai.expect(getTranslationSourceLanguages(buildSupplement([]), XPATH)).to.deep.equal([])
   })
 
   it('returns the language of the only accepted transcript', () => {
@@ -128,7 +151,7 @@ describe('getTranslationSourceLanguage', () => {
         dateAccepted: '2026-01-01T11:00:00Z',
       }),
     ])
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['en'])
   })
 
   it('ignores transcripts that were never accepted', () => {
@@ -139,22 +162,22 @@ describe('getTranslationSourceLanguage', () => {
         dateCreated: '2026-01-01T10:00:00Z',
         dateAccepted: '2026-01-01T11:00:00Z',
       }),
-      // Newer, but still awaiting review, so the back end would not translate from it.
+      // Newer, but still awaiting review, so the back end would not translate from it yet.
       buildTranscriptVersion({ uuid: 'v2', language: 'fr', dateCreated: '2026-01-02T10:00:00Z', dateAccepted: '' }),
     ])
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['en'])
   })
 
-  it('returns undefined when no transcript has been accepted', () => {
+  it('returns nothing when no transcript has been accepted', () => {
     const supplement = buildSupplement([
       buildTranscriptVersion({ uuid: 'v1', language: 'en', dateCreated: '2026-01-01T10:00:00Z', dateAccepted: '' }),
     ])
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal(undefined)
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal([])
   })
 
   it('picks the most recently accepted transcript, not the most recently created one', () => {
     const supplement = buildSupplement([
-      // Created first but accepted last, which is what the back end translates from.
+      // Created first but accepted last, so this is the one the back end translates from.
       buildTranscriptVersion({
         uuid: 'v1',
         language: 'en',
@@ -168,7 +191,7 @@ describe('getTranslationSourceLanguage', () => {
         dateAccepted: '2026-01-02T11:00:00Z',
       }),
     ])
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['en'])
   })
 
   it('ignores accepted transcripts that have no value left', () => {
@@ -188,6 +211,32 @@ describe('getTranslationSourceLanguage', () => {
         value: null,
       }),
     ])
-    chai.expect(getTranslationSourceLanguage(supplement, XPATH)).to.equal('en')
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['en'])
+  })
+
+  it("blocks the source transcript's locale and its base language", () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'en',
+        locale: 'en-CA',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-01T11:00:00Z',
+      }),
+    ])
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['en-CA', 'en'])
+  })
+
+  it('blocks the locale even when it disagrees with the language', () => {
+    const supplement = buildSupplement([
+      buildTranscriptVersion({
+        uuid: 'v1',
+        language: 'es',
+        locale: 'fr-CA',
+        dateCreated: '2026-01-01T10:00:00Z',
+        dateAccepted: '2026-01-01T11:00:00Z',
+      }),
+    ])
+    chai.expect(getTranslationSourceLanguages(supplement, XPATH)).to.deep.equal(['fr-CA', 'fr'])
   })
 })

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -189,6 +189,31 @@ export const getLatestTranscriptVersionItem = (
     .sort(TransxVersionSortFunction)[0] as TranscriptVersionItem | undefined
 }
 
+/**
+ * Returns the language a new translation would actually be sourced from, or `undefined` if nothing can be translated
+ * yet.
+ *
+ * This mirrors the back end's dependency resolution (`RequiresTranscriptionMixin.attach_action_dependency`), which
+ * picks the transcript version with the most recent *acceptance* date and ignores versions that were never accepted.
+ * That differs from `getLatestTranscriptVersionItem`, which sorts by creation date - the two disagree whenever
+ * versions were accepted in a different order than they were created, so don't substitute one for the other.
+ */
+export const getTranslationSourceLanguage = (
+  supplementData: DataSupplementResponse,
+  xpath: string,
+): LanguageCode | undefined => {
+  const usableVersions = getAllTranscriptsFromSupplementData(supplementData, xpath)
+    .flatMap<TranscriptVersionItem>((transcript) => transcript._versions)
+    // An unaccepted version is not a source yet, and one without a text value was deleted or never finished.
+    // `_dateAccepted` is typed as a required string on manual versions but can be empty, hence the truthiness check.
+    .filter((version) => Boolean(version._dateAccepted) && isSupplementVersionWithValue(version))
+
+  // Newest acceptance first. `_dateAccepted` is an ISO-8601 string, so lexicographic order is chronological order.
+  const latestAccepted = usableVersions.sort((a, b) => (a._dateAccepted! < b._dateAccepted! ? 1 : -1))[0]
+
+  return latestAccepted?._data.language
+}
+
 // Qual
 
 /**

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -8,7 +8,7 @@ import type { SupplementalDataManualTranslation } from '#/api/models/supplementa
 import type { SupplementalDataVersionItemAutomatic } from '#/api/models/supplementalDataVersionItemAutomatic'
 import type { SupplementalDataVersionItemManual } from '#/api/models/supplementalDataVersionItemManual'
 
-import type { LanguageCode } from '#/components/languages/languagesStore'
+import type { LanguageCode, LocaleCode } from '#/components/languages/languagesStore'
 import { ProcessingTab } from '#/components/processing/routes.utils'
 import type {
   DisplaysList,
@@ -190,28 +190,45 @@ export const getLatestTranscriptVersionItem = (
 }
 
 /**
- * Returns the language a new translation would actually be sourced from, or `undefined` if nothing can be translated
- * yet.
+ * Language codes that must not be offered as translation targets, given the `language`/`locale` pair of the transcript
+ * a translation would come from.
  *
- * This mirrors the back end's dependency resolution (`RequiresTranscriptionMixin.attach_action_dependency`), which
- * picks the transcript version with the most recent *acceptance* date and ignores versions that were never accepted.
- * That differs from `getLatestTranscriptVersionItem`, which sorts by creation date - the two disagree whenever
- * versions were accepted in a different order than they were created, so don't substitute one for the other.
+ * Not just `[language]`, for two reasons. The back end translates from `locale` when it is set and never validates it
+ * against `language`, so `{language: 'es', locale: 'fr-CA'}` is storable and would be translated from French. And
+ * columns are keyed by base language (the back end does `language.split('-')[0]`), so `fr-CA` and `fr` end up sharing
+ * one column. Both codes come back, which also covers a regional target if one ever reaches the dropdown.
  */
-export const getTranslationSourceLanguage = (
+export const getBlockedTargetLanguages = (language: LanguageCode, locale?: LocaleCode | null): LanguageCode[] => {
+  const source = locale || language
+  return [...new Set([source, source.split('-')[0]])]
+}
+
+/**
+ * Language codes a new translation must not target, based on the transcript it would be sourced from. Empty when there
+ * is nothing to translate yet.
+ *
+ * Picks the source the way the back end does (`RequiresTranscriptionMixin.attach_action_dependency`): most recent
+ * *acceptance* date, skipping versions that were never accepted. `getLatestTranscriptVersionItem` sorts by creation
+ * date instead, and the two disagree when versions were accepted out of order, so don't swap one for the other.
+ */
+export const getTranslationSourceLanguages = (
   supplementData: DataSupplementResponse,
   xpath: string,
-): LanguageCode | undefined => {
+): LanguageCode[] => {
   const usableVersions = getAllTranscriptsFromSupplementData(supplementData, xpath)
     .flatMap<TranscriptVersionItem>((transcript) => transcript._versions)
-    // An unaccepted version is not a source yet, and one without a text value was deleted or never finished.
-    // `_dateAccepted` is typed as a required string on manual versions but can be empty, hence the truthiness check.
+    // An unaccepted version is not a source yet, and one with no text was deleted or never finished. `_dateAccepted` is
+    // typed as a required string on manual versions but comes back empty, so check the value rather than the key.
     .filter((version) => Boolean(version._dateAccepted) && isSupplementVersionWithValue(version))
 
-  // Newest acceptance first. `_dateAccepted` is an ISO-8601 string, so lexicographic order is chronological order.
+  // Newest acceptance first. These are ISO-8601 strings, so comparing them as strings gives chronological order.
   const latestAccepted = usableVersions.sort((a, b) => (a._dateAccepted! < b._dateAccepted! ? 1 : -1))[0]
 
-  return latestAccepted?._data.language
+  if (!latestAccepted) {
+    return []
+  }
+
+  return getBlockedTargetLanguages(latestAccepted._data.language, latestAccepted._data.locale)
 }
 
 // Qual

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -18,7 +18,7 @@ import {
 import ButtonNew from '#/components/common/ButtonNew'
 import LanguageSelector from '#/components/languages/LanguageSelector'
 import type { LanguageCode } from '#/components/languages/languagesStore'
-import { getSuggestedLanguages } from '#/components/processing/common/utils'
+import { getBlockedTargetLanguages, getSuggestedLanguages } from '#/components/processing/common/utils'
 import { getSupplementalPathParts } from '#/components/processing/processingUtils'
 import { BulkProcessingWarningModal } from '#/components/submissions/BulkProcessingModals/BulkProcessingWarningModal'
 import { getSupplementalDetailsContent } from '#/components/submissions/submissionUtils'
@@ -102,19 +102,22 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   // `fieldXpath` points at the transcript column being translated, so its language code is the column's language.
   const { sourceRowPath, languageCode: columnLanguage } = getSupplementalPathParts(props.fieldXpath)
 
-  // Translating a transcript into its own language produces an empty column that can't be removed, so we don't let
-  // users pick it.
+  // Translating a transcript into its own language leaves behind an empty column that can't be deleted, so that
+  // language must not be pickable.
   //
-  // The column's own language is not enough: eligibility only requires a transcript with a value, regardless of its
-  // language, so a selected row transcribed in another language would be translated from that other language instead.
-  // We therefore hide every language actually present across the selected rows too.
+  // Hiding the column's language alone isn't enough. A row only needs a transcript with some value to be eligible, no
+  // matter which language it is in, so a row transcribed in another language gets translated from that one instead.
+  // Hence the scan over selected rows. `regionCode` holds the transcript's locale, which the back end prefers over
+  // `languageCode` when deciding what to translate from.
   const hiddenLanguages = useMemo(() => {
     const languages = new Set<LanguageCode>(columnLanguage ? [columnLanguage] : [])
 
     props.selectedSubmissions.forEach((submission) => {
       const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
       if (transcript?.languageCode) {
-        languages.add(transcript.languageCode)
+        getBlockedTargetLanguages(transcript.languageCode, transcript.regionCode).forEach((language) =>
+          languages.add(language),
+        )
       }
     })
 

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -99,7 +99,12 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const advancedFeatures = advancedFeaturesData?.status === 200 ? advancedFeaturesData.data : []
   const suggestedLanguages = getSuggestedLanguages(advancedFeatures)
 
-  const { sourceRowPath } = getSupplementalPathParts(props.fieldXpath)
+  // `fieldXpath` points at the transcript column being translated, so its language code is the source language.
+  const { sourceRowPath, languageCode: transcriptLanguage } = getSupplementalPathParts(props.fieldXpath)
+
+  // Translating a transcript into its own language produces an empty column that can't be removed, so we don't let
+  // users pick it. See DEV-2622.
+  const hiddenLanguages = useMemo(() => (transcriptLanguage ? [transcriptLanguage] : []), [transcriptLanguage])
 
   // Use bulk processing alerts hook
   // Near-limit should reflect only the submissions that still need translation.
@@ -191,6 +196,7 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
               value={selectedLanguage}
               required
               suggestedLanguages={suggestedLanguages}
+              hiddenLanguages={hiddenLanguages}
               // Smaller message to fit in the modal
               nothingFoundMessage={t('I cannot find my language')}
             />

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -99,12 +99,27 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const advancedFeatures = advancedFeaturesData?.status === 200 ? advancedFeaturesData.data : []
   const suggestedLanguages = getSuggestedLanguages(advancedFeatures)
 
-  // `fieldXpath` points at the transcript column being translated, so its language code is the source language.
-  const { sourceRowPath, languageCode: transcriptLanguage } = getSupplementalPathParts(props.fieldXpath)
+  // `fieldXpath` points at the transcript column being translated, so its language code is the column's language.
+  const { sourceRowPath, languageCode: columnLanguage } = getSupplementalPathParts(props.fieldXpath)
 
   // Translating a transcript into its own language produces an empty column that can't be removed, so we don't let
-  // users pick it. See DEV-2622.
-  const hiddenLanguages = useMemo(() => (transcriptLanguage ? [transcriptLanguage] : []), [transcriptLanguage])
+  // users pick it.
+  //
+  // The column's own language is not enough: eligibility only requires a transcript with a value, regardless of its
+  // language, so a selected row transcribed in another language would be translated from that other language instead.
+  // We therefore hide every language actually present across the selected rows too.
+  const hiddenLanguages = useMemo(() => {
+    const languages = new Set<LanguageCode>(columnLanguage ? [columnLanguage] : [])
+
+    props.selectedSubmissions.forEach((submission) => {
+      const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
+      if (transcript?.languageCode) {
+        languages.add(transcript.languageCode)
+      }
+    })
+
+    return [...languages]
+  }, [columnLanguage, props.selectedSubmissions, sourceRowPath])
 
   // Use bulk processing alerts hook
   // Near-limit should reflect only the submissions that still need translation.


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

The language a transcript is already in is no longer offered when creating a translation, so you can't accidentally translate English into English and end up with a blank column you can't get rid of.

### 💭 Notes

Translating a transcript into its own language created an empty column in the data table that couldn't be removed, and nothing appeared under Translations. Fix is to keep that language out of the dropdown in the first place.

Changes here:

- `jsapp/js/components/processing/common/utils.ts`
  - `getTranslationSourceLanguages()` — new. Returns the language codes a new translation must not target for a given question. Picks the source transcript the way the back end does in `RequiresTranscriptionMixin.attach_action_dependency`: newest `_dateAccepted`, skipping versions never accepted and ones whose text is gone. Note this is deliberately *not* `getLatestTranscriptVersionItem()`, which sorts by creation date — when versions are accepted out of order the two pick different versions, and following the wrong one would hide the wrong language and let the bug straight back in. Both helpers stay, doc comments warn against swapping them.
  - `getBlockedTargetLanguages()` — new, and the reason this is a list rather than one code. The back end translates from `locale` when it's set and never checks it against `language`, so `{language: 'es', locale: 'fr-CA'}` is a storable transcript that gets translated from French. Columns are also keyed by base language (back end does `language.split('-')[0]`), so `fr-CA` and `fr` collide in one column. Both codes get blocked.
- `jsapp/js/components/processing/common/utils.tests.ts` — 10 tests over the two new helpers: acceptance-vs-creation order, unaccepted versions, deleted text, locale/language disagreement. Mutation-checked by breaking each rule in turn and confirming the matching test went red.
- `jsapp/js/components/submissions/.../BulkTranslationModal.tsx` — passes `hiddenLanguages` to `<LanguageSelector>`, which it never did. Blocks the column's own language plus every transcript language across the selected rows: eligibility only asks for a transcript with *some* text, so a row transcribed in another language would be translated from that one instead. Reads `regionCode` too, since that's where the flattened transcript keeps its locale.
- `jsapp/js/components/processing/.../TabTranslations/index.tsx` — same gap in single-submission processing. It was hiding existing translation languages but not the transcript's, so English → English was one click away here as well.
- `jsapp/js/components/processing/.../TranslationAdd/index.tsx` — `languagesExisting` → `languagesUnavailable`, since it now carries more than the existing translations. Single caller, so the rename stays put.

The dropdown itself only ever lists base language codes — regions live in a separate model and surface through `RegionSelector`, which translations don't use. Blocking the full locale is cheap insurance in case regional targets ever show up there.

### 👀 Preview steps

1. ℹ️ have an account and a project with an audio question and at least one submission
2. go to Project → Data → Table and transcribe that audio question in English (Data → open submission → Transcript, or select rows and use the bulk transcribe action)
3. accept the transcript
4. in the table, select the row(s), open the transcript column menu and choose the translate action
5. 🔴 [on main] English is in the language dropdown; pick it, start the translation, and a blank English translation column shows up in the table with no way to delete it and nothing under Translations
6. 🟢 [on PR] English isn't in the dropdown at all — the transcript language quietly excused itself
7. now open a single submission → Translations → add a translation
8. 🔴 [on main] English is offered here too
9. 🟢 [on PR] English is missing here as well, alongside any language already translated into
10. 🟢 pick any other language and confirm translating still works normally
