### PR TITLE
style(organizations): reformat sso_subquery for darker

### DIFF
--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -528,9 +528,9 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
         ).values('pk')
 
         # Subquery to check if the user has an associated SSO account
-        sso_subquery = SocialAccount.objects.filter(
-            user=OuterRef('user_id')
-        ).values('pk')
+        sso_subquery = SocialAccount.objects.filter(user=OuterRef('user_id')).values(
+            'pk'
+        )
 
         # Subquery to check if the user is the owner
         owner_subquery = OrganizationOwner.objects.filter(


### PR DESCRIPTION
Internal-only formatting fix — no user-facing or maintainer-facing change, so the changelog sections are omitted.

### 💭 Notes

Verified with the exact CI command (exit 0):

```
darker --check --diff --isort -L 'flake8 --max-line-length=88 --extend-ignore=F821' kobo/apps/organizations/views.py -r origin/main
```

### 👀 Preview steps

1. 🔴 [on main] `darker --check … -r origin/main` reports a reformat diff for `sso_subquery`.
2. 🟢 [on PR] the same command is clean.
