### PR TITLE
feat(formbuilder): add toggle for enabling choice deduplication DEV-2582

### DIFF
--- a/jsapp/js/components/metadataEditor.js
+++ b/jsapp/js/components/metadataEditor.js
@@ -236,6 +236,7 @@ export default class MetadataEditor extends React.Component {
                   : t('Enable audio recording in the background')
               }
               disabled={this.props.isDisabled}
+              className='form-builder-aside__switch'
             />
           </bem.FormModal__item>
         </bem.FormBuilderMeta__row>

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -518,6 +518,8 @@ export interface AssetContentSettings {
   /** The name of the locking profile applied to whole form. */
   'kobo--locking-profile'?: string
   default_language?: string | null
+  /** When 'yes', allows duplicate choice values in the same list. */
+  allow_choice_duplicates?: 'yes' | 'no'
 }
 
 /**

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { Text } from '@mantine/core'
+import { Switch, Text } from '@mantine/core'
 import alertify from 'alertifyjs'
 import cx from 'classnames'
 import clonedeep from 'lodash.clonedeep'
@@ -135,6 +135,7 @@ interface EditableFormState extends SurveyStateStoreData {
   name: string
   preventNavigatingOut: boolean
   settings__style?: FormStyleName
+  settings__allow_choice_duplicates: boolean
   showCascadePopup: boolean
   cascadeLastSelectedRowIndex?: number
   surveyAppRendered: boolean
@@ -161,6 +162,7 @@ export default function EditableForm(props: EditableFormProps) {
     isBackgroundAudioBannerDismissed: false,
     name: '',
     preventNavigatingOut: false,
+    settings__allow_choice_duplicates: false,
     showCascadePopup: false,
     surveyAppRendered: false,
     surveyLoadError: undefined,
@@ -221,9 +223,15 @@ export default function EditableForm(props: EditableFormProps) {
   useEffect(() => {
     if (state.asset) {
       let settingsStyle: FormStyleName | undefined
+      let settingsAllowChoiceDuplicates = false
       if (state.asset.content?.settings && !Array.isArray(state.asset.content?.settings)) {
         settingsStyle = state.asset.content.settings.style
+        settingsAllowChoiceDuplicates = state.asset.content.settings.allow_choice_duplicates === 'yes'
       }
+      setState((currentState) => ({
+        ...currentState,
+        settings__allow_choice_duplicates: settingsAllowChoiceDuplicates,
+      }))
       launchAppForSurveyContent(state.asset.content, {
         name: state.asset.name,
         settings__style: settingsStyle,
@@ -316,6 +324,16 @@ export default function EditableForm(props: EditableFormProps) {
     return AVAILABLE_FORM_STYLES.find((option) => option.value === optionVal)
   }
 
+  function onAllowChoiceDuplicatesChange(isChecked: boolean) {
+    // Immediately update the survey settings so deduplication logic sees the change
+    app?.survey.settings.set('allow_choice_duplicates', isChecked ? 'yes' : 'no')
+    setState((currentState) => ({
+      ...currentState,
+      settings__allow_choice_duplicates: isChecked,
+    }))
+    onSurveyChangeDebounced()
+  }
+
   function onSurveyChange() {
     if (!state.asset_updated !== update_states.UNSAVED_CHANGES) {
       preventClosingTab()
@@ -389,6 +407,8 @@ export default function EditableForm(props: EditableFormProps) {
       app?.survey.settings.set('style', state.settings__style)
     }
 
+    app?.survey.settings.set('allow_choice_duplicates', state.settings__allow_choice_duplicates ? 'yes' : 'no')
+
     if (state.name) {
       app?.survey.settings.set('title', state.name)
     }
@@ -440,6 +460,8 @@ export default function EditableForm(props: EditableFormProps) {
     if (state.settings__style !== undefined) {
       app.survey.settings.set('style', state.settings__style)
     }
+
+    app.survey.settings.set('allow_choice_duplicates', state.settings__allow_choice_duplicates ? 'yes' : 'no')
 
     let surveyJSON = surveyToValidJson(app.survey)
     const surveyJSONWithMatrix = koboMatrixParser({ source: surveyJSON }).source
@@ -1003,6 +1025,22 @@ export default function EditableForm(props: EditableFormProps) {
                 menuPlacement='bottom'
                 isDisabled={isChangingAppearanceRestricted()}
                 isSearchable={false}
+              />
+            </bem.FormBuilderAside__row>
+
+            <bem.FormBuilderAside__row>
+              <bem.FormBuilderAside__header>{t('Choice options')}</bem.FormBuilderAside__header>
+
+              <Switch
+                checked={state.settings__allow_choice_duplicates}
+                onChange={(event) => onAllowChoiceDuplicatesChange(event.currentTarget.checked)}
+                label={t('Allow duplicate choice values')}
+                description={t(
+                  'When enabled, multiple choices in the same list can have the same value. ' +
+                    'When disabled, duplicate values are automatically made unique.',
+                )}
+                disabled={isChangingAppearanceRestricted()}
+                className='form-builder-aside__switch'
               />
             </bem.FormBuilderAside__row>
 

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -326,7 +326,12 @@ export default function EditableForm(props: EditableFormProps) {
 
   function onAllowChoiceDuplicatesChange(isChecked: boolean) {
     // Immediately update the survey settings so deduplication logic sees the change
-    app?.survey.settings.set('allow_choice_duplicates', isChecked ? 'yes' : 'no')
+    // Only store 'yes' value; unset when false to keep settings clean
+    if (isChecked) {
+      app?.survey.settings.set('allow_choice_duplicates', 'yes')
+    } else {
+      app?.survey.settings.unset('allow_choice_duplicates')
+    }
     setState((currentState) => ({
       ...currentState,
       settings__allow_choice_duplicates: isChecked,
@@ -407,7 +412,11 @@ export default function EditableForm(props: EditableFormProps) {
       app?.survey.settings.set('style', state.settings__style)
     }
 
-    app?.survey.settings.set('allow_choice_duplicates', state.settings__allow_choice_duplicates ? 'yes' : 'no')
+    if (state.settings__allow_choice_duplicates) {
+      app?.survey.settings.set('allow_choice_duplicates', 'yes')
+    } else {
+      app?.survey.settings.unset('allow_choice_duplicates')
+    }
 
     if (state.name) {
       app?.survey.settings.set('title', state.name)
@@ -461,7 +470,11 @@ export default function EditableForm(props: EditableFormProps) {
       app.survey.settings.set('style', state.settings__style)
     }
 
-    app.survey.settings.set('allow_choice_duplicates', state.settings__allow_choice_duplicates ? 'yes' : 'no')
+    if (state.settings__allow_choice_duplicates) {
+      app.survey.settings.set('allow_choice_duplicates', 'yes')
+    } else {
+      app.survey.settings.unset('allow_choice_duplicates')
+    }
 
     let surveyJSON = surveyToValidJson(app.survey)
     const surveyJSONWithMatrix = koboMatrixParser({ source: surveyJSON }).source

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1048,9 +1048,7 @@ export default function EditableForm(props: EditableFormProps) {
                 checked={state.settings__allow_choice_duplicates}
                 onChange={(event) => onAllowChoiceDuplicatesChange(event.currentTarget.checked)}
                 label={t('Allow duplicate choice values')}
-                description={t(
-                  'When enabled, multiple choices in the same list can have the same value. When disabled, duplicate values are automatically made unique.',
-                )}
+                description={t('When enabled, multiple choices in the same list can have the same value.')}
                 disabled={isChangingAppearanceRestricted()}
                 className='form-builder-aside__switch'
               />

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -223,10 +223,10 @@ export default function EditableForm(props: EditableFormProps) {
   useEffect(() => {
     if (state.asset) {
       let settingsStyle: FormStyleName | undefined
-      let settingsAllowChoiceDuplicates = false
+      let settingsAllowChoiceDuplicates = true
       if (state.asset.content?.settings && !Array.isArray(state.asset.content?.settings)) {
         settingsStyle = state.asset.content.settings.style
-        settingsAllowChoiceDuplicates = state.asset.content.settings.allow_choice_duplicates === 'yes'
+        settingsAllowChoiceDuplicates = state.asset.content.settings.allow_choice_duplicates !== 'no'
       }
       setState((currentState) => ({
         ...currentState,

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -223,10 +223,10 @@ export default function EditableForm(props: EditableFormProps) {
   useEffect(() => {
     if (state.asset) {
       let settingsStyle: FormStyleName | undefined
-      let settingsAllowChoiceDuplicates = true
+      let settingsAllowChoiceDuplicates = false
       if (state.asset.content?.settings && !Array.isArray(state.asset.content?.settings)) {
         settingsStyle = state.asset.content.settings.style
-        settingsAllowChoiceDuplicates = state.asset.content.settings.allow_choice_duplicates !== 'no'
+        settingsAllowChoiceDuplicates = state.asset.content.settings.allow_choice_duplicates === 'yes'
       }
       setState((currentState) => ({
         ...currentState,

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1041,19 +1041,6 @@ export default function EditableForm(props: EditableFormProps) {
               />
             </bem.FormBuilderAside__row>
 
-            <bem.FormBuilderAside__row>
-              <bem.FormBuilderAside__header>{t('Choice options')}</bem.FormBuilderAside__header>
-
-              <Switch
-                checked={state.settings__allow_choice_duplicates}
-                onChange={(event) => onAllowChoiceDuplicatesChange(event.currentTarget.checked)}
-                label={t('Allow duplicate choice values')}
-                description={t('When enabled, multiple choices in the same list can have the same value.')}
-                disabled={isChangingAppearanceRestricted()}
-                className='form-builder-aside__switch'
-              />
-            </bem.FormBuilderAside__row>
-
             {hasMetadataAndDetails() && (
               <bem.FormBuilderAside__row>
                 <bem.FormBuilderAside__header>{t('Metadata')}</bem.FormBuilderAside__header>
@@ -1066,6 +1053,19 @@ export default function EditableForm(props: EditableFormProps) {
                 />
               </bem.FormBuilderAside__row>
             )}
+
+            <bem.FormBuilderAside__row>
+              <bem.FormBuilderAside__header>{t('Choice options')}</bem.FormBuilderAside__header>
+
+              <Switch
+                checked={state.settings__allow_choice_duplicates}
+                onChange={(event) => onAllowChoiceDuplicatesChange(event.currentTarget.checked)}
+                label={t('Allow duplicate choice names')}
+                description={t('When enabled, multiple choices in the same list can have the same name.')}
+                disabled={isChangingAppearanceRestricted()}
+                className='form-builder-aside__switch'
+              />
+            </bem.FormBuilderAside__row>
           </bem.FormBuilderAside__content>
         )}
 

--- a/jsapp/js/editorMixins/EditableForm.tsx
+++ b/jsapp/js/editorMixins/EditableForm.tsx
@@ -1036,8 +1036,7 @@ export default function EditableForm(props: EditableFormProps) {
                 onChange={(event) => onAllowChoiceDuplicatesChange(event.currentTarget.checked)}
                 label={t('Allow duplicate choice values')}
                 description={t(
-                  'When enabled, multiple choices in the same list can have the same value. ' +
-                    'When disabled, duplicate values are automatically made unique.',
+                  'When enabled, multiple choices in the same list can have the same value. When disabled, duplicate values are automatically made unique.',
                 )}
                 disabled={isChangingAppearanceRestricted()}
                 className='form-builder-aside__switch'

--- a/jsapp/js/theme/kobo/Switch.module.css
+++ b/jsapp/js/theme/kobo/Switch.module.css
@@ -41,7 +41,8 @@
 }
 
 /* Matches the Checkbox label colour and 8px gap so inline controls line up. */
-.label {
+.label,
+.description {
   color: var(--mantine-color-gray-1);
   padding-inline-start: 8px;
 }
@@ -59,10 +60,6 @@
 .label[data-disabled] {
   color: var(--kobo-choice-control-disabled-label);
   opacity: 1;
-}
-
-.description {
-  color: var(--mantine-color-gray-2);
 }
 
 .error {

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -259,6 +259,10 @@ $s-form-builder-content-width: 1024px;
   }
 }
 
+.form-builder-aside__switch .mantine-Switch-input:not(:checked) + .mantine-Switch-track {
+  background-color: var(--mantine-color-gray-4);
+}
+
 // CASCADE MODAL CONTENTS
 
 .cascade-popup {

--- a/jsapp/xlform/src/model.choices.coffee
+++ b/jsapp/xlform/src/model.choices.coffee
@@ -124,15 +124,30 @@ module.exports = do ->
       return _.uniq(option_keys)
 
     finalize: ->
-      # ensure that all options have names
+      # ensure that all options have names and deduplicate if needed
+      # check if allow_choice_duplicates is enabled in settings
+      survey = @getSurvey?()
+      allowDuplicates = survey?.settings?.get('allow_choice_duplicates') is 'yes'
       names = []
       for option in @options.models
         label = option.get("label")
         name = option.get("name")
         if not name
+          # no name set - generate from label
           name = $modelUtils.sluggify(label, {
-            preventDuplicates: names
+            preventDuplicates: if allowDuplicates then false else names
             lowerCase: true
+            lrstrip: true
+            characterLimit: 40
+            incrementorPadding: false
+            validXmlTag: false
+          })
+          option.set("name", name)
+        else if not allowDuplicates and name in names
+          # name exists but is a duplicate - make it unique
+          name = $modelUtils.sluggify(name, {
+            preventDuplicates: names
+            lowerCase: false
             lrstrip: true
             characterLimit: 40
             incrementorPadding: false

--- a/jsapp/xlform/src/model.choices.coffee
+++ b/jsapp/xlform/src/model.choices.coffee
@@ -124,7 +124,7 @@ module.exports = do ->
       return _.uniq(option_keys)
 
     finalize: ->
-      # ensure that all options have names and deduplicate if needed
+      # ensure that all options have names
       # check if allow_choice_duplicates is enabled in settings
       survey = @getSurvey?()
       allowDuplicates = survey?.settings?.get('allow_choice_duplicates') is 'yes'
@@ -137,17 +137,6 @@ module.exports = do ->
           name = $modelUtils.sluggify(label, {
             preventDuplicates: if allowDuplicates then false else names
             lowerCase: true
-            lrstrip: true
-            characterLimit: 40
-            incrementorPadding: false
-            validXmlTag: false
-          })
-          option.set("name", name)
-        else if not allowDuplicates and name in names
-          # name exists but is a duplicate - make it unique
-          name = $modelUtils.sluggify(name, {
-            preventDuplicates: names
-            lowerCase: false
             lrstrip: true
             characterLimit: 40
             incrementorPadding: false

--- a/jsapp/xlform/src/view.choices.coffee
+++ b/jsapp/xlform/src/view.choices.coffee
@@ -123,6 +123,8 @@ module.exports = do ->
       @n.change ((input)->
         val = input.currentTarget.value
         other_names = @options.cl.getNames()
+        survey = @options.cl.getSurvey?()
+        allowDuplicates = survey?.settings?.get('allow_choice_duplicates') is 'yes'
         if @model.get('name')? && val.toLowerCase() == @model.get('name').toLowerCase()
           other_names.splice _.indexOf(other_names, @model.get('name')), 1
         if val is ''
@@ -132,7 +134,7 @@ module.exports = do ->
           @$el.trigger("choice-list-update", @options.cl.cid)
         else
           val = $modelUtils.sluggify(val, {
-                    preventDuplicates: other_names
+                    preventDuplicates: if allowDuplicates then false else other_names
                     lowerCase: false
                     lrstrip: true
                     incrementorPadding: false
@@ -143,6 +145,8 @@ module.exports = do ->
           @model.set('name', val)
           @model.set('setManually', true)
           @$el.trigger("choice-list-update", @options.cl.cid)
+        # Update the input to show the (possibly deduplicated) value
+        @n.val(val)
         return newValue: val
       ).bind @
       @pw.html(@p)
@@ -204,15 +208,20 @@ module.exports = do ->
         nval = nval.replace /\t/g, ' '
         @model.set("label", nval, silent: true)
         other_names = @options.cl.getNames()
+        survey = @options.cl.getSurvey?()
+        allowDuplicates = survey?.settings?.get('allow_choice_duplicates') is 'yes'
         if !@model.get('setManually')
           sluggifyOpts =
-            preventDuplicates: other_names
+            preventDuplicates: if allowDuplicates then false else other_names
             lowerCase: false
             stripSpaces: true
             lrstrip: true
             incrementorPadding: 3
             validXmlTag: true
-          @model.set("name", $modelUtils.sluggify(nval, sluggifyOpts))
+          newName = $modelUtils.sluggify(nval, sluggifyOpts)
+          @model.set("name", newName)
+          # Update the name input in the UI to reflect the deduplicated value
+          @n.val(newName)
         @$el.trigger("choice-list-update", @options.cl.cid)
         @model.getSurvey()?.trigger('change')
         return


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Form Builder now has a setting to allow duplicate choice values.

### 💭 Notes

Changes here:
- **EditableForm.tsx**: Added "Allow duplicate choice values" toggle in Layout & Settings panel. The toggle immediately updates survey settings so deduplication logic responds right away (no save required).
- **view.choices.coffee**: 
  - Name input now updates immediately when deduplication occurs (both for auto-generated names from labels and manual name entry)
  - Checks `allow_choice_duplicates` setting before deduplicating
- **model.choices.coffee**: `finalize()` respects the setting when generating names for choices without names
- **dataInterface.ts**: Added `allow_choice_duplicates` to TypeScript types
- **Switch styling**: Minor CSS fixes for switch appearance in the aside panel

The setting is stored as `allow_choice_duplicates: 'yes' | 'no'` in the form's settings, matching the XLSForm spec.

### 👀 Preview steps

1. ℹ️ Have a project with a form
2. Open the form in Form Builder
3. Add a Select One question with two choices
4. Type "apple" as the name for both choices
5. 🔴 [on main] Second choice stays as "apple" in the input, but silently becomes "apple_1" - you only see this after reload
6. 🟢 [on PR] Second choice immediately shows "apple_1" in the input field
7. Go to Layout & Settings
8. 🟢 [on PR] See new "Choice options" section with "Allow duplicate choice values" toggle
9. Turn the toggle ON
10. Change both choice names to "apple" again
11. 🟢 [on PR] Both choices keep the name "apple" - no deduplication happens
12. Save the form and reload
13. 🟢 [on PR] Toggle is still ON, choices are still both "apple"
