### PR TITLE
feat(bulkProcessing): improve language blocking DEV-2661

### DIFF
--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -18,9 +18,10 @@ import {
 import ButtonNew from '#/components/common/ButtonNew'
 import LanguageSelector from '#/components/languages/LanguageSelector'
 import type { LanguageCode } from '#/components/languages/languagesStore'
-import { getBlockedTargetLanguages, getSuggestedLanguages } from '#/components/processing/common/utils'
+import { getSuggestedLanguages } from '#/components/processing/common/utils'
 import { getSupplementalPathParts } from '#/components/processing/processingUtils'
 import { BulkProcessingWarningModal } from '#/components/submissions/BulkProcessingModals/BulkProcessingWarningModal'
+import { getBlockedBulkTranslationLanguages } from '#/components/submissions/bulkProcessingUtils'
 import { getSupplementalDetailsContent } from '#/components/submissions/submissionUtils'
 import type { SubmissionResponse } from '#/dataInterface'
 import envStore from '#/envStore'
@@ -99,30 +100,13 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   const advancedFeatures = advancedFeaturesData?.status === 200 ? advancedFeaturesData.data : []
   const suggestedLanguages = getSuggestedLanguages(advancedFeatures)
 
-  // `fieldXpath` points at the transcript column being translated, so its language code is the column's language.
-  const { sourceRowPath, languageCode: columnLanguage } = getSupplementalPathParts(props.fieldXpath)
+  // `fieldXpath` points at the transcript column being translated, so the source question is one level up from it.
+  const { sourceRowPath } = getSupplementalPathParts(props.fieldXpath)
 
-  // Translating a transcript into its own language leaves behind an empty column that can't be deleted, so that
-  // language must not be pickable.
-  //
-  // Hiding the column's language alone isn't enough. A row only needs a transcript with some value to be eligible, no
-  // matter which language it is in, so a row transcribed in another language gets translated from that one instead.
-  // Hence the scan over selected rows. `regionCode` holds the transcript's locale, which the back end prefers over
-  // `languageCode` when deciding what to translate from.
-  const hiddenLanguages = useMemo(() => {
-    const languages = new Set<LanguageCode>(columnLanguage ? [columnLanguage] : [])
-
-    props.selectedSubmissions.forEach((submission) => {
-      const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
-      if (transcript?.languageCode) {
-        getBlockedTargetLanguages(transcript.languageCode, transcript.regionCode).forEach((language) =>
-          languages.add(language),
-        )
-      }
-    })
-
-    return [...languages]
-  }, [columnLanguage, props.selectedSubmissions, sourceRowPath])
+  const hiddenLanguages = useMemo(
+    () => getBlockedBulkTranslationLanguages(props.selectedSubmissions, props.fieldXpath),
+    [props.fieldXpath, props.selectedSubmissions],
+  )
 
   // Use bulk processing alerts hook
   // Near-limit should reflect only the submissions that still need translation.

--- a/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.tests.ts
+++ b/jsapp/js/components/submissions/BulkProcessingModals/alerts/alertEvaluators.tests.ts
@@ -1259,9 +1259,11 @@ describe('evaluateNoSource', () => {
   })
 
   describe('for translation', () => {
+    // Translation always runs off a transcript column, so the xpath is a supplemental path here, not a bare question
+    // name like in the transcription block above.
     const baseContext: AlertEvaluationContext = {
       submissions: [],
-      fieldXpath: 'audio_question',
+      fieldXpath: '_supplementalDetails/audio_question/transcript_en',
       actionType: 'translation',
       activeBulkActions: [],
       previouslyFilteredSubmissionUuids: new Set(),
@@ -1381,6 +1383,40 @@ describe('evaluateNoSource', () => {
 
       expect(result).to.not.equal(null)
       expect(result?.filteredSubmissionUuids).to.deep.equal(['uuid-1'])
+    })
+
+    it('should flag submissions transcribed in another language than the column', () => {
+      // The Spanish row is empty in the English column, so it has no source to translate and has to be filtered out
+      // rather than blocking the whole action.
+      const mockSubmissions = [
+        assetDataFactory(1, {
+          _uuid: 'uuid-1',
+          _supplementalDetails: {
+            audio_question: {
+              transcript: { languageCode: 'en', value: 'Hello world' },
+            },
+          },
+        }),
+        assetDataFactory(2, {
+          _uuid: 'uuid-2',
+          _supplementalDetails: {
+            audio_question: {
+              transcript: { languageCode: 'es', value: 'Hola mundo' },
+            },
+          },
+        }),
+      ]
+
+      const context: AlertEvaluationContext = {
+        ...baseContext,
+        submissions: mockSubmissions,
+      }
+
+      const result = evaluateNoSource(context)
+
+      expect(result).to.not.equal(null)
+      expect(result?.filteredSubmissionUuids).to.deep.equal(['uuid-2'])
+      expect(result?.computedValues.count).to.equal(1)
     })
 
     it('should skip submissions already filtered by previous evaluators', () => {

--- a/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.tests.ts
@@ -2,9 +2,10 @@ import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
 import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
-import type { SubmissionAttachment } from '#/dataInterface'
+import type { SubmissionAttachment, TransxObject } from '#/dataInterface'
 import assetDataFactory from '#/endpoints/assetData.factory'
 import {
+  getBlockedBulkTranslationLanguages,
   getBulkProcessingColumnKey,
   getVisibleBulkProcessingSubmissionUuidsToRefresh,
   hasAnyTranscribableAudio,
@@ -310,6 +311,23 @@ describe('bulkProcessingUtils', () => {
 
       chai.expect(test).to.be.false
     })
+
+    it('should return false for a transcript in another language than the column', () => {
+      // A question holds one transcript, and it belongs to the column of its own language. So this row is empty in the
+      // English column and has nothing for it to translate.
+      const test = hasTranslatableTranscript(
+        assetDataFactory(1, {
+          _supplementalDetails: {
+            Secret_password_as_an_audio_file: {
+              transcript: { languageCode: 'es', value: 'Hola mundo' },
+            },
+          },
+        }),
+        transcriptColumnKey,
+      )
+
+      chai.expect(test).to.be.false
+    })
   })
 
   describe('hasAnyTranslatableTranscript', () => {
@@ -333,12 +351,29 @@ describe('bulkProcessingUtils', () => {
 
     const noTranscriptSubmission = assetDataFactory(3)
 
+    const otherLanguageTranscriptSubmission = assetDataFactory(4, {
+      _supplementalDetails: {
+        Secret_password_as_an_audio_file: {
+          transcript: { languageCode: 'es', value: 'Hola mundo' },
+        },
+      },
+    })
+
     it('should return false for an empty selection', () => {
       chai.expect(hasAnyTranslatableTranscript([], transcriptColumnKey)).to.be.false
     })
 
     it('should return false when no selected submission has a transcript', () => {
       const test = hasAnyTranslatableTranscript([noTranscriptSubmission, noTranscriptSubmission], transcriptColumnKey)
+
+      chai.expect(test).to.be.false
+    })
+
+    it('should return false when all transcripts are in another language than the column', () => {
+      const test = hasAnyTranslatableTranscript(
+        [otherLanguageTranscriptSubmission, noTranscriptSubmission],
+        transcriptColumnKey,
+      )
 
       chai.expect(test).to.be.false
     })
@@ -359,6 +394,61 @@ describe('bulkProcessingUtils', () => {
       )
 
       chai.expect(test).to.be.true
+    })
+  })
+
+  describe('getBlockedBulkTranslationLanguages', () => {
+    const questionXpath = 'Secret_password_as_an_audio_file'
+    const englishColumnKey = `_supplementalDetails/${questionXpath}/transcript_en`
+
+    function buildTranscriptSubmission(id: number, transcript: TransxObject) {
+      return assetDataFactory(id, { _supplementalDetails: { [questionXpath]: { transcript } } })
+    }
+
+    it("should block the column's own language for an empty selection", () => {
+      chai.expect(getBlockedBulkTranslationLanguages([], englishColumnKey)).to.deep.equal(['en'])
+    })
+
+    it("should block the column's own language when rows are transcribed in it", () => {
+      const submissions = [buildTranscriptSubmission(1, { languageCode: 'en', value: 'Hello world' })]
+
+      chai.expect(getBlockedBulkTranslationLanguages(submissions, englishColumnKey)).to.deep.equal(['en'])
+    })
+
+    it('should not block the language of a row transcribed in another language', () => {
+      // A Spanish row got selected alongside the English ones. It is empty in this column and the `no-source` alert
+      // drops it, so Spanish has to stay pickable as a target.
+      const submissions = [
+        buildTranscriptSubmission(1, { languageCode: 'en', value: 'Hello world' }),
+        buildTranscriptSubmission(2, { languageCode: 'es', value: 'Hola mundo' }),
+      ]
+
+      chai.expect(getBlockedBulkTranslationLanguages(submissions, englishColumnKey)).to.deep.equal(['en'])
+    })
+
+    it('should block the locale of a translatable row on top of the column language', () => {
+      // Nothing stops `regionCode` from disagreeing with `languageCode`, and the back end would translate this from
+      // French. So French has to go too, or the undeletable empty column comes right back.
+      const submissions = [buildTranscriptSubmission(1, { languageCode: 'en', regionCode: 'fr-CA', value: 'Bonjour' })]
+
+      chai
+        .expect(getBlockedBulkTranslationLanguages(submissions, englishColumnKey))
+        .to.deep.equal(['en', 'fr-CA', 'fr'])
+    })
+
+    it('should ignore the locale of a row it cannot translate from', () => {
+      // Same mismatched pair as above, but this row lives in the Spanish column, so this column never reads it.
+      const submissions = [buildTranscriptSubmission(1, { languageCode: 'es', regionCode: 'fr-CA', value: 'Bonjour' })]
+
+      chai.expect(getBlockedBulkTranslationLanguages(submissions, englishColumnKey)).to.deep.equal(['en'])
+    })
+
+    it('should ignore rows whose transcript is still awaiting approval', () => {
+      const submissions = [
+        buildTranscriptSubmission(1, { languageCode: 'en', regionCode: 'fr-CA', pendingReview: true }),
+      ]
+
+      chai.expect(getBlockedBulkTranslationLanguages(submissions, englishColumnKey)).to.deep.equal(['en'])
     })
   })
 })

--- a/jsapp/js/components/submissions/bulkProcessingUtils.ts
+++ b/jsapp/js/components/submissions/bulkProcessingUtils.ts
@@ -1,6 +1,8 @@
 import { ActionIdEnum } from '#/api/models/actionIdEnum'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionSubmissionStatusResponseStatusEnum } from '#/api/models/bulkActionSubmissionStatusResponseStatusEnum'
+import type { LanguageCode } from '#/components/languages/languagesStore'
+import { getBlockedTargetLanguages } from '#/components/processing/common/utils'
 import { buildSupplementalPath, getSupplementalPathParts } from '#/components/processing/processingUtils'
 import { SUPPLEMENTAL_DETAILS_PROP } from '#/constants'
 import type { SubmissionResponse } from '#/dataInterface'
@@ -30,16 +32,22 @@ export function hasAnyTranscribableAudio(submissions: SubmissionResponse[], fiel
  * Checks if given submission has a transcript that can be used as a source for
  * translation in given transcript column.
  *
- * A transcript is a usable source only when it has an actual value. A transcript
- * that is still awaiting approval has no `value` (the backend omits it and sets
- * `pendingReview` instead), so it can't be translated yet.
+ * A transcript awaiting approval has no `value` (the backend sends `pendingReview`
+ * instead), so it can't be translated yet. One in another language belongs to a
+ * different column: a question holds a single transcript, and it only shows up in
+ * the column matching its language, so the cell is empty here.
  */
 export function hasTranslatableTranscript(submission: SubmissionResponse, fieldXpath: string): boolean {
   // `fieldXpath` of a transcript column is a supplemental details path, but
   // `_supplementalDetails` is keyed by question xpath, so we need to convert it.
-  const { sourceRowPath } = getSupplementalPathParts(fieldXpath)
-  // Note: we assume here that there can be only one transcript.
-  return Boolean(submission._supplementalDetails?.[sourceRowPath]?.transcript?.value)
+  const { sourceRowPath, languageCode } = getSupplementalPathParts(fieldXpath)
+  const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
+
+  if (!transcript?.value) {
+    return false
+  }
+
+  return transcript.languageCode === languageCode
 }
 
 /**
@@ -48,6 +56,36 @@ export function hasTranslatableTranscript(submission: SubmissionResponse, fieldX
  */
 export function hasAnyTranslatableTranscript(submissions: SubmissionResponse[], fieldXpath: string): boolean {
   return submissions.some((submission) => hasTranslatableTranscript(submission, fieldXpath))
+}
+
+/**
+ * Gets languages the user shouldn't be able to pick when bulk translating given transcript column.
+ * Translating a transcript into its own language leaves an empty column that can't be deleted, so the column's language
+ * is always blocked.
+ * Rows this column can't translate from are ignored, as they get dropped before the action runs anyway.
+ */
+export function getBlockedBulkTranslationLanguages(
+  submissions: SubmissionResponse[],
+  fieldXpath: string,
+): LanguageCode[] {
+  const { sourceRowPath, languageCode: columnLanguage } = getSupplementalPathParts(fieldXpath)
+  const languages = new Set<LanguageCode>(columnLanguage ? [columnLanguage] : [])
+
+  // Scanning the rows catches `regionCode`, the transcript's locale. The back end translates from the locale whenever
+  // there is one, without checking it against the language, so an `es` transcript with an `fr-CA` locale really would
+  // be translated from French.
+  submissions
+    .filter((submission) => hasTranslatableTranscript(submission, fieldXpath))
+    .forEach((submission) => {
+      const transcript = submission._supplementalDetails?.[sourceRowPath]?.transcript
+      if (transcript?.languageCode) {
+        getBlockedTargetLanguages(transcript.languageCode, transcript.regionCode).forEach((language) =>
+          languages.add(language),
+        )
+      }
+    })
+
+  return [...languages]
 }
 
 export function getBulkProcessingColumnKey(bulkAction: BulkActionResponse) {

--- a/jsapp/js/dataInterface.ts
+++ b/jsapp/js/dataInterface.ts
@@ -197,7 +197,7 @@ export interface SubmissionAttachment {
   is_deleted?: boolean
 }
 
-interface TransxObject {
+export interface TransxObject {
   languageCode: LanguageCode
   value?: string | null
   /** transcripts only */


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed bulk translation blocking languages it shouldn't: when a project has transcripts in more than one language for the same question, all of those languages became unavailable as translation targets.

### 📖 Description

If some submissions were transcribed in English and others in Spanish for the same question, both English and Spanish disappeared from the language list when starting a bulk translation, leaving no way to translate one into the other. Now only the transcript you're actually translating from counts.

### 💭 Notes

Changes here:

- **`bulkProcessingUtils.ts`**
  - `hasTranslatableTranscript` now also checks the transcript language against the column language.
  - `getBlockedBulkTranslationLanguages` — new, moved out of the modal so it can be unit tested. Always blocks the column's own language, and beyond that only considers rows it can genuinely translate from.
- **`BulkTranslationModal.tsx`** — the ~20-line `useMemo` is now a call to the helper above.
- **`dataInterface.ts`** — exported `TransxObject` so tests can type transcript fixtures.
- **tests** — the translation `evaluateNoSource` cases were passing a bare question name as `fieldXpath`; translation always runs off a transcript column, so those fixtures never matched reality. Fixed, plus coverage for the mixed-language case and for the locale/language mismatch.

### 👀 Preview steps

1. ℹ️ Have a project with an audio question
2. Submit at least 3 responses to it
3. Go to Project → Data → Table
4. Create manual transcriptions for submissions - two English, and the third one in Spanish
5. 🟢 Notice you now have two transcript columns: one English, one Spanish
6. Select all three rows, open the column header menu on the **English** transcript column header → "Translate selected transcriptions"
7. 🔴 [on main] neither English nor Spanish appears in the language list, so there's no way forward
8. 🟢 [on PR] Spanish is available, and the modal warns that 1 submission is missing transcription and will be ignored
9. 🟢 Notice English is still unavailable — translating the English transcript into English would leave an empty column behind
10. Pick Spanish and create the translations
11. 🟢 Notice only the two English-transcript rows got translated, and the Spanish row was left alone
12. now open the column header menu on the **Spanish** transcript column header with all three rows still selected
13. 🟢 notice English is available here and Spanish is not — mirror image of step 8
