### PR TITLE
feat(bulkProcessing): accept both submission `uuid` and `root_uuid` in bulk endpoints DEV-2663

### DIFF
--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -43,14 +43,22 @@ def get_submission_root_uuid_map(asset, submission_uuids: list[str]) -> dict[str
         return {}
 
     requested = [remove_uuid_prefix(uuid) for uuid in submission_uuids]
-    root_uuid_by_identifier = {}
-    for uuid, root_uuid in Instance.objects.filter(
-        Q(root_uuid__in=requested) | Q(uuid__in=requested),
-        xform=asset.deployment.xform,
-    ).values_list('uuid', 'root_uuid'):
-        root_uuid = root_uuid or uuid
-        root_uuid_by_identifier.setdefault(uuid, root_uuid)
-        root_uuid_by_identifier[root_uuid] = root_uuid
+    rows = list(
+        Instance.objects.filter(
+            Q(root_uuid__in=requested) | Q(uuid__in=requested),
+            xform=asset.deployment.xform,
+        )
+        .order_by('pk')
+        .values_list('uuid', 'root_uuid')
+    )
+
+    # `uuid` has no uniqueness constraint, so order by `pk` to stay reproducible
+    root_uuid_by_identifier = {uuid: root_uuid or uuid for uuid, root_uuid in rows}
+
+    # `root_uuid` does, so it always identifies itself: apply it last
+    root_uuid_by_identifier.update(
+        {(root_uuid or uuid): (root_uuid or uuid) for uuid, root_uuid in rows}
+    )
 
     return root_uuid_by_identifier
 

--- a/kobo/apps/subsequences/serializers.py
+++ b/kobo/apps/subsequences/serializers.py
@@ -2,11 +2,13 @@ from copy import deepcopy
 
 import jsonschema.exceptions
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 from rest_framework import serializers
 
 from kobo.apps.openrosa.apps.logger.models import Instance
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import remove_uuid_prefix
 from kobo.apps.subsequences.actions import ACTION_IDS_TO_CLASSES
 from kobo.apps.subsequences.models import (
     BulkActionItemStatus,
@@ -23,6 +25,34 @@ from kobo.apps.subsequences.utils.time import utc_datetime_to_js_str
 # than at the call site: `makemessages` only extracts literal arguments, so
 # `t(CONSTANT)` would leave the string out of the catalogs entirely.
 INVALID_PARAMS_ERROR = t('Invalid parameters for this action')
+
+
+def get_submission_root_uuid_map(asset, submission_uuids: list[str]) -> dict[str, str]:
+    """
+    Map the submission identifiers a client may send to their root UUIDs
+
+    The frontend normally sends the root UUID, but some submissions do not have
+    one yet, and for those it sends the submission's `uuid` instead. Accept
+    either and return the root UUID to use for each, since that is what the
+    rest of the bulk code is keyed on
+
+    TODO: drop this helper, and filter on `root_uuid` directly again, once LRM
+    0027 and 0028 have completed everywhere and every client sends root UUIDs
+    """
+    if not asset.has_deployment:
+        return {}
+
+    requested = [remove_uuid_prefix(uuid) for uuid in submission_uuids]
+    root_uuid_by_identifier = {}
+    for uuid, root_uuid in Instance.objects.filter(
+        Q(root_uuid__in=requested) | Q(uuid__in=requested),
+        xform=asset.deployment.xform,
+    ).values_list('uuid', 'root_uuid'):
+        root_uuid = root_uuid or uuid
+        root_uuid_by_identifier.setdefault(uuid, root_uuid)
+        root_uuid_by_identifier[root_uuid] = root_uuid
+
+    return root_uuid_by_identifier
 
 
 class QuestionAdvancedFeatureUpdateSerializer(serializers.ModelSerializer):
@@ -176,7 +206,7 @@ class BulkActionCreateSerializer(serializers.Serializer):
                 {'params': {'language': ['This field is required.']}}
             )
 
-        self._validate_submissions_exist(asset, submission_uuids)
+        submission_uuids = self._resolve_submission_root_uuids(asset, submission_uuids)
 
         skipped = self._get_existing_result_uuids(
             asset, question_xpath, action_id, params, submission_uuids
@@ -200,18 +230,19 @@ class BulkActionCreateSerializer(serializers.Serializer):
         attrs['skipped_uuids'] = sorted(skipped)
         return attrs
 
-    def _validate_submissions_exist(self, asset, submission_uuids):
+    def _resolve_submission_root_uuids(self, asset, submission_uuids) -> list[str]:
+        """
+        Validate the requested submissions and return their root UUIDs
+        """
         if not asset.has_deployment:
             raise serializers.ValidationError(
                 'Bulk actions can only be created for deployed assets.'
             )
-        existing = set(
-            Instance.objects.filter(
-                xform=asset.deployment.xform,
-                root_uuid__in=submission_uuids,
-            ).values_list('root_uuid', flat=True)
-        )
-        missing = [uuid for uuid in submission_uuids if uuid not in existing]
+
+        requested = [remove_uuid_prefix(uuid) for uuid in submission_uuids]
+        root_uuid_by_identifier = get_submission_root_uuid_map(asset, requested)
+
+        missing = [uuid for uuid in requested if uuid not in root_uuid_by_identifier]
         if missing:
             raise serializers.ValidationError(
                 {
@@ -220,6 +251,8 @@ class BulkActionCreateSerializer(serializers.Serializer):
                     ]
                 }
             )
+
+        return [root_uuid_by_identifier[uuid] for uuid in requested]
 
     def _get_active_bulk_conflict_uuids(
         self,
@@ -452,12 +485,18 @@ class BulkAcceptSerializer(serializers.Serializer):
         language = self.validated_data.get('language')
         now_str = utc_datetime_to_js_str(timezone.now())
 
+        root_uuid_by_identifier = get_submission_root_uuid_map(asset, submission_uids)
+        submission_root_uuids = [
+            root_uuid_by_identifier.get(identifier, identifier)
+            for identifier in map(remove_uuid_prefix, submission_uids)
+        ]
+
         with transaction.atomic():
             supplements = list(
                 SubmissionSupplement.objects.select_for_update()
                 .filter(
                     asset=asset,
-                    submission_uuid__in=submission_uids,
+                    submission_uuid__in=submission_root_uuids,
                 )
             )
 

--- a/kobo/apps/subsequences/tasks.py
+++ b/kobo/apps/subsequences/tasks.py
@@ -545,12 +545,29 @@ def _get_bulk_action_request_data(action_data: dict) -> dict:
 def _get_submission_for_bulk_action_item(item):
     """
     Load the deployed submission targeted by a bulk action item
+
+    TODO: drop the `_uuid` branch from `query` once LRM 0028 is complete
     """
+    root_uuid = item.submission_root_uuid
     submissions = item.parent.asset.deployment.get_submissions(
         user=item.parent.asset.owner,
-        query={'meta/rootUuid': add_uuid_prefix(item.submission_root_uuid)},
+        query={
+            '$or': [
+                {SUBMISSION_UUID_FIELD: add_uuid_prefix(root_uuid)},
+                {'_uuid': root_uuid},
+            ]
+        },
     )
-    return next(iter(submissions), None)
+    submission = next(iter(submissions), None)
+    if submission is None:
+        return None
+
+    # Everything downstream reads `meta/rootUuid` straight off this dict, so
+    # fill it in for documents LRM 0028 has not reached yet
+    if not submission.get(SUBMISSION_UUID_FIELD):
+        submission[SUBMISSION_UUID_FIELD] = add_uuid_prefix(root_uuid)
+
+    return submission
 
 
 def _mark_bulk_item_failed(item, error: str | None = None) -> None:

--- a/kobo/apps/subsequences/tasks.py
+++ b/kobo/apps/subsequences/tasks.py
@@ -558,9 +558,20 @@ def _get_submission_for_bulk_action_item(item):
             ]
         },
     )
-    submission = next(iter(submissions), None)
-    if submission is None:
+    candidates = list(submissions)
+    if not candidates:
         return None
+
+    # `_uuid` is only a fallback, so a `meta/rootUuid` match always wins
+    submission = next(
+        (
+            candidate
+            for candidate in candidates
+            if remove_uuid_prefix(candidate.get(SUBMISSION_UUID_FIELD) or '')
+            == root_uuid
+        ),
+        candidates[0],
+    )
 
     # Everything downstream reads `meta/rootUuid` straight off this dict, so
     # fill it in for documents LRM 0028 has not reached yet

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
@@ -7,7 +7,6 @@ from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.subsequences.models import SubmissionSupplement
 from kobo.apps.subsequences.tests.api.v2.base import SubsequenceBaseTestCase
 
-
 TRANSCRIPTION_VERSION = {
     '_dateCreated': '2026-01-01T00:00:00.000000Z',
     '_uuid': '00000000-0000-0000-0000-000000000001',

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_accept.py
@@ -3,6 +3,7 @@ import uuid
 from django.urls import reverse
 from rest_framework import status
 
+from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.subsequences.models import SubmissionSupplement
 from kobo.apps.subsequences.tests.api.v2.base import SubsequenceBaseTestCase
 
@@ -404,3 +405,69 @@ class BulkAcceptAPITestCase(SubsequenceBaseTestCase):
             }
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class BulkAcceptSubmissionUuidResolutionTestCase(SubsequenceBaseTestCase):
+    """
+    Supplements are keyed on the root UUID, but a client may send `_uuid`
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.accept_url = reverse(
+            self._get_endpoint('data-supplements-bulk-list'),
+            args=[self.asset.uid],
+        )
+        self.instance = Instance.objects.get(
+            xform=self.asset.deployment.xform, root_uuid=self.submission_uuid
+        )
+        SubmissionSupplement.objects.create(
+            asset=self.asset,
+            submission_uuid=self.submission_uuid,
+            content=_transcription_supplement(self.submission_uuid),
+        )
+
+    def _post_accept(self, submission_uids):
+        return self.client.post(
+            self.accept_url,
+            data={
+                'submission_uids': submission_uids,
+                'question_xpath': 'q1',
+                'action_id': 'automatic_google_transcription',
+                'operation': 'accept',
+            },
+            format='json',
+        )
+
+    def _accepted_date(self):
+        supplement = SubmissionSupplement.objects.get(
+            asset=self.asset, submission_uuid=self.submission_uuid
+        )
+        versions = supplement.content['q1']['automatic_google_transcription'][
+            '_versions'
+        ]
+        return versions[0].get('_dateAccepted')
+
+    def test_accept_by_current_uuid_of_edited_submission(self):
+        edited_uuid = str(uuid.uuid4())
+        Instance.objects.filter(pk=self.instance.pk).update(uuid=edited_uuid)
+
+        response = self._post_accept([edited_uuid])
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['accepted_count'] == 1
+        assert self._accepted_date() is not None
+
+    def test_accept_by_root_uuid_still_works(self):
+        response = self._post_accept([self.submission_uuid])
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['accepted_count'] == 1
+        assert self._accepted_date() is not None
+
+    def test_unknown_uuid_accepts_nothing(self):
+        response = self._post_accept([str(uuid.uuid4())])
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['accepted_count'] == 0
+        assert self._accepted_date() is None

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.urls import reverse
 from rest_framework import status
 
+from kobo.apps.openrosa.apps.logger.models import Instance
 from kobo.apps.subsequences.models import (
     BulkActionItemStatus,
     BulkActionStatus,
@@ -715,3 +716,90 @@ class EnsureQuestionAdvancedFeatureTestCase(SubsequenceBaseTestCase):
         languages = [p['language'] for p in feature.params]
         assert 'de' in languages
         assert 'fr' in languages
+
+
+class BulkActionSubmissionUuidResolutionTestCase(SubsequenceBaseTestCase):
+    """
+    Clients may identify a submission by either of its two UUIDs
+
+    `_uuid` changes every time a submission is edited, while `meta/rootUuid`
+    never does, and the data table exposes both. The endpoint must accept
+    either and store the root UUID, as the single-submission endpoint does
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.list_url = reverse(
+            self._get_endpoint('advanced-features-bulk-actions-list'),
+            args=[self.asset.uid],
+        )
+        self.instance = Instance.objects.get(
+            xform=self.asset.deployment.xform, root_uuid=self.submission_uuid
+        )
+
+    def _edit_submission(self) -> str:
+        """
+        Simulate an edit: `uuid` moves on, `root_uuid` stays put
+        """
+        edited_uuid = str(uuid.uuid4())
+        Instance.objects.filter(pk=self.instance.pk).update(uuid=edited_uuid)
+        return edited_uuid
+
+    def _post(self, submission_uuids):
+        return self.client.post(
+            self.list_url,
+            data={
+                'action_id': 'automatic_google_transcription',
+                'question_xpath': 'q1',
+                'submission_uuids': submission_uuids,
+                'params': {'language': 'en', 'locale': 'en-US'},
+            },
+            format='json',
+        )
+
+    def test_edited_submission_accepted_by_current_uuid(self):
+        edited_uuid = self._edit_submission()
+
+        response = self._post([edited_uuid])
+
+        assert response.status_code == status.HTTP_201_CREATED
+        action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
+        # Stored and echoed back as the root UUID, not the edit UUID
+        assert list(
+            action.items.values_list('submission_root_uuid', flat=True)
+        ) == [self.submission_uuid]
+        assert response.data['submission_uuids'] == [self.submission_uuid]
+
+    def test_edited_submission_still_accepted_by_root_uuid(self):
+        self._edit_submission()
+
+        response = self._post([self.submission_uuid])
+
+        assert response.status_code == status.HTTP_201_CREATED
+        action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
+        assert list(
+            action.items.values_list('submission_root_uuid', flat=True)
+        ) == [self.submission_uuid]
+
+    def test_submission_without_root_uuid_accepted_by_uuid(self):
+        """
+        LRM 0027/0028 have not finished everywhere, so `root_uuid` can be null
+        """
+        Instance.objects.filter(pk=self.instance.pk).update(root_uuid=None)
+
+        response = self._post([self.submission_uuid])
+
+        assert response.status_code == status.HTTP_201_CREATED
+        action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
+        assert list(
+            action.items.values_list('submission_root_uuid', flat=True)
+        ) == [self.submission_uuid]
+
+    def test_unknown_uuid_still_rejected(self):
+        unknown_uuid = str(uuid.uuid4())
+
+        response = self._post([self.submission_uuid, unknown_uuid])
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert unknown_uuid in response.data['submission_uuids'][0]
+        assert self.submission_uuid not in response.data['submission_uuids'][0]

--- a/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
+++ b/kobo/apps/subsequences/tests/api/v2/test_bulk_actions.py
@@ -765,9 +765,9 @@ class BulkActionSubmissionUuidResolutionTestCase(SubsequenceBaseTestCase):
         assert response.status_code == status.HTTP_201_CREATED
         action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
         # Stored and echoed back as the root UUID, not the edit UUID
-        assert list(
-            action.items.values_list('submission_root_uuid', flat=True)
-        ) == [self.submission_uuid]
+        assert list(action.items.values_list('submission_root_uuid', flat=True)) == [
+            self.submission_uuid
+        ]
         assert response.data['submission_uuids'] == [self.submission_uuid]
 
     def test_edited_submission_still_accepted_by_root_uuid(self):
@@ -777,9 +777,9 @@ class BulkActionSubmissionUuidResolutionTestCase(SubsequenceBaseTestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
-        assert list(
-            action.items.values_list('submission_root_uuid', flat=True)
-        ) == [self.submission_uuid]
+        assert list(action.items.values_list('submission_root_uuid', flat=True)) == [
+            self.submission_uuid
+        ]
 
     def test_submission_without_root_uuid_accepted_by_uuid(self):
         """
@@ -791,9 +791,9 @@ class BulkActionSubmissionUuidResolutionTestCase(SubsequenceBaseTestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         action = SubsequenceBulkAction.objects.get(uid=response.data['uid'])
-        assert list(
-            action.items.values_list('submission_root_uuid', flat=True)
-        ) == [self.submission_uuid]
+        assert list(action.items.values_list('submission_root_uuid', flat=True)) == [
+            self.submission_uuid
+        ]
 
     def test_unknown_uuid_still_rejected(self):
         unknown_uuid = str(uuid.uuid4())


### PR DESCRIPTION
### 📣 Summary
The frontend now sends `root_uuid` when starting and accepting bulk transcription/translation jobs, but falls back to `uuid` for submissions that don't have a `root_uuid` available yet. 

The bulk endpoints only matched on `root_uuid`, so this makes them accept either identifier and resolve it to the `root_uuid` the rest of the pipeline is keyed on, consistent with the existing single-processing endpoint.

### 📖 Description
A submission has two identifiers: `root_uuid`, which remains stable throughout its lifetime, and `uuid`, which changes whenever the submission is edited.

The frontend normally sends root_uuid, but it may not be available yet because the long-running migration that syncs root_uuid to MongoDB is still in progress. In those cases, the frontend only has uuid.

The bulk pipeline remains keyed on root_uuid throughout. This change allows the bulk endpoints to accept either identifier and canonicalise it to root_uuid before processing.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have an account and a project with audio submissions.
2. trigger a bulk transcription of those audio files. (Use `?ff_bulkProcessingEnabled=true` to enable bulk actions in the UI.)
3. once the transcription is processed, edit one of the submissions and re-trigger bulk transcription.
4. 🔴 [on main] notice that this fails with an "Unknown submission" error.
5. 🟢 [on PR] notice that this now works correctly and the FE sends `root_uuid` in the payload.