### PR TITLE
fix(xlsImport): match project languages to XLSForm languages DEV-2657

### DIFF
--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -7,11 +7,12 @@ import tempfile
 from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 import constance
 import dateutil.parser
+import formpack
 import requests
 from django.conf import settings
 from django.contrib.postgres.indexes import BTreeIndex, HashIndex
@@ -21,13 +22,6 @@ from django.db.models.functions import Cast, Coalesce, Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from openpyxl.utils.exceptions import InvalidFileException
-from private_storage.fields import PrivateFileField
-from rest_framework import exceptions
-from rest_framework.reverse import reverse
-from werkzeug.http import parse_options_header
-
-import formpack
 from formpack.constants import KOBO_LOCK_SHEET
 from formpack.schema.fields import (
     IdCopyField,
@@ -38,6 +32,13 @@ from formpack.schema.fields import (
 )
 from formpack.utils.kobo_locking import get_kobo_locking_profiles
 from formpack.utils.string import ellipsize
+from openpyxl.utils.exceptions import InvalidFileException
+from private_storage.fields import PrivateFileField
+from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
+from rest_framework import exceptions
+from rest_framework.reverse import reverse
+from werkzeug.http import parse_options_header
+
 from kobo.apps.audit_log.utils import get_lookback_date
 from kobo.apps.openrosa.libs.utils.common_tags import META_ROOT_UUID
 from kobo.apps.reports.report_data import build_formpack
@@ -87,7 +88,6 @@ from kpi.utils.standardize_content import standardize_content_in_place
 from kpi.utils.storage import is_filesystem_storage
 from kpi.utils.strings import to_str
 from kpi.zip_importer import HttpContentParse
-from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
 
 
 def utcnow(*args, **kwargs):
@@ -379,7 +379,9 @@ class ImportTask(ImportExportTask):
                     # The below is copied from `_parse_b64_upload` pretty much as is
                     # TODO: review and test carefully
                     asset = destination
-                    self._make_translations_explicit(kontent)
+                    # Derive `translations` from the file so `Asset.save()`
+                    # does not restore languages removed from it (DEV-2657)
+                    standardize_content_in_place(kontent)
                     asset.content = kontent
                     asset.save()
                     messages['updated'].append({
@@ -418,18 +420,6 @@ class ImportTask(ImportExportTask):
             if name in names:
                 raise DuplicateNameException(f'Duplicate node name: {name}')
             names.add(name)
-
-    @staticmethod
-    def _make_translations_explicit(survey_dict: dict[str, Any]) -> None:
-        """
-        Expand the uploaded content so that its list of languages comes from
-        the uploaded file only.
-
-        `Asset.save()` restores the translations saved in the database when the
-        content it receives does not declare any of its own, which would keep
-        alive the languages that the new XLSForm no longer contains.
-        """
-        standardize_content_in_place(survey_dict)
 
     def _parse_b64_upload(self, base64_encoded_upload, messages, **kwargs):
         filename = kwargs.get('filename', False)
@@ -504,7 +494,9 @@ class ImportTask(ImportExportTask):
                     _append_kobo_locking_profiles(
                         base64_encoded_upload, survey_dict
                     )
-                self._make_translations_explicit(survey_dict)
+                # Derive `translations` from the file so `Asset.save()`
+                # does not restore languages removed from it (DEV-2657)
+                standardize_content_in_place(survey_dict)
                 asset.content = survey_dict
                 old_name = asset.name
                 # saving sometimes changes the name

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -7,7 +7,7 @@ import tempfile
 from collections import defaultdict
 from io import BytesIO
 from os.path import split, splitext
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 import constance
@@ -83,6 +83,7 @@ from kpi.utils.rename_xls_sheet import (
     rename_xlsx_sheet,
 )
 from kpi.utils.sluggify import is_valid_node_name
+from kpi.utils.standardize_content import standardize_content_in_place
 from kpi.utils.storage import is_filesystem_storage
 from kpi.utils.strings import to_str
 from kpi.zip_importer import HttpContentParse
@@ -378,6 +379,7 @@ class ImportTask(ImportExportTask):
                     # The below is copied from `_parse_b64_upload` pretty much as is
                     # TODO: review and test carefully
                     asset = destination
+                    self._make_translations_explicit(kontent)
                     asset.content = kontent
                     asset.save()
                     messages['updated'].append({
@@ -416,6 +418,18 @@ class ImportTask(ImportExportTask):
             if name in names:
                 raise DuplicateNameException(f'Duplicate node name: {name}')
             names.add(name)
+
+    @staticmethod
+    def _make_translations_explicit(survey_dict: dict[str, Any]) -> None:
+        """
+        Expand the uploaded content so that its list of languages comes from
+        the uploaded file only.
+
+        `Asset.save()` restores the translations saved in the database when the
+        content it receives does not declare any of its own, which would keep
+        alive the languages that the new XLSForm no longer contains.
+        """
+        standardize_content_in_place(survey_dict)
 
     def _parse_b64_upload(self, base64_encoded_upload, messages, **kwargs):
         filename = kwargs.get('filename', False)
@@ -490,6 +504,7 @@ class ImportTask(ImportExportTask):
                     _append_kobo_locking_profiles(
                         base64_encoded_upload, survey_dict
                     )
+                self._make_translations_explicit(survey_dict)
                 asset.content = survey_dict
                 old_name = asset.name
                 # saving sometimes changes the name

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -117,6 +117,35 @@ class AssetImportTaskTest(BaseTestCase):
             task_data
         )
 
+    def _import_sheets(self, sheets, name, asset=None):
+        """
+        Import `sheets` into `asset`, or into a brand-new survey when no asset
+        is given, and return the asset as stored in the database.
+        """
+        task_data = self._construct_xlsx_for_import(sheets, name=name)
+        if asset is None:
+            empty_asset = self.client.post(
+                reverse(self._get_endpoint('asset-list')),
+                data={'asset_type': 'survey'},
+                headers={'accept': 'application/json'},
+            )
+            task_data['destination'] = empty_asset.json()['url']
+        else:
+            task_data['destination'] = reverse(
+                self._get_endpoint('asset-detail'),
+                kwargs={'uid_asset': asset.uid},
+            )
+
+        response = self.client.post(
+            reverse(self._get_endpoint('importtask-list')), task_data
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'complete'
+        return Asset.objects.get(
+            uid=detail_response.data['messages']['updated'][0]['uid']
+        )
+
     @responses.activate
     def test_import_asset_from_xls_url(self):
         # Host the XLS on a mock HTTP server
@@ -992,6 +1021,136 @@ class AssetImportTaskTest(BaseTestCase):
                 'but only these translations are present in the form:'
             )
         )
+
+    def test_reimport_xls_drops_language_removed_from_the_file(self):
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        [
+                            'type',
+                            'name',
+                            'label::English (en)',
+                            'label::French (fr)',
+                            'label::Spanish (es)',
+                        ],
+                        ['integer', 'age', 'Age?', 'Âge ?', '¿Edad?'],
+                    ],
+                ),
+            ),
+            'Three languages',
+        )
+        assert asset.content['translations'] == [
+            'English (en)',
+            'French (fr)',
+            'Spanish (es)',
+        ]
+
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'label::French (fr)'],
+                        ['integer', 'age', 'Age?', 'Âge ?'],
+                    ],
+                ),
+            ),
+            'Two languages',
+            asset=asset,
+        )
+        assert asset.content['translations'] == ['English (en)', 'French (fr)']
+        assert asset.summary['languages'] == ['English (en)', 'French (fr)']
+        assert asset.content['survey'][0]['label'] == ['Age?', 'Âge ?']
+
+    def test_reimport_xls_without_languages_resets_to_no_language(self):
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'label::French (fr)'],
+                        ['integer', 'age', 'Age?', 'Âge ?'],
+                    ],
+                ),
+            ),
+            'Two languages',
+        )
+        assert asset.content['translations'] == ['English (en)', 'French (fr)']
+
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label'],
+                        ['integer', 'age', 'Age?'],
+                    ],
+                ),
+            ),
+            'No language',
+            asset=asset,
+        )
+        assert asset.content['translations'] == [None]
+        # `[None]` is normalized to `[]` in the summary, i.e. no language
+        assert asset.summary['languages'] == []
+        assert asset.content['survey'][0]['label'] == ['Age?']
+
+    def test_reimport_xls_keeps_language_left_in_a_hint_column_only(self):
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'label::French (fr)'],
+                        ['integer', 'age', 'Age?', 'Âge ?'],
+                    ],
+                ),
+            ),
+            'Two languages',
+        )
+
+        # `label::French (fr)` is gone, but the language is still used by
+        # another column, so it must survive
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'hint::French (fr)'],
+                        ['integer', 'age', 'Age?', 'En années'],
+                    ],
+                ),
+            ),
+            'Partially translated',
+            asset=asset,
+        )
+        assert asset.content['translations'] == ['English (en)', 'French (fr)']
+        assert asset.content['survey'][0]['label'] == ['Age?', None]
+        assert asset.content['survey'][0]['hint'] == [None, 'En années']
+
+    def test_reimport_xls_ignores_language_suffix_in_settings_sheet(self):
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)'],
+                        ['integer', 'age', 'Age?'],
+                    ],
+                ),
+                (
+                    'settings',
+                    [
+                        ['form_title::French (fr)'],
+                        ['Mon projet'],
+                    ],
+                ),
+            ),
+            'Language in the settings sheet',
+        )
+        assert asset.content['translations'] == ['English (en)']
 
     def test_import_strip_newline_from_form_title_setting(self):
         survey_sheet_content = [


### PR DESCRIPTION
### 📣 Summary

Re-uploading an XLSForm now sets the project languages to exactly the languages of the uploaded file, instead of keeping languages that were removed from it.

### 📖 Description

Uploading a form with three languages and re-uploading it with two used to leave the third language defined with empty strings, and removing all languages created an unnamed language. Project languages now always match the file: a language stays only if at least one `survey` or `choices` column still uses it, and a file with plain `label` columns brings the project back to "no languages defined".

### 💭 Notes

- Cause: `Asset.save()` restores the DB translations when the incoming content declares none (#7020, for the Form Builder). An imported spreadsheet dict has no `translations` key yet, so the stored list was injected before `formpack.expand_content()` ran — which only ever appends to that list.
- Fix: the import path expands the content (`standardize_content_in_place()`) before assigning it, so the language list comes from the file. Covers both import destinations (base64 and URL). Form Builder path untouched; a direct API `PATCH content` still hits the old fallback — separate ticket territory.
- Related: DEV-2656.

### 👀 Preview steps

1. ℹ️ have an account and a project
2. upload an XLSForm with three languages (`label::English (en)`, `label::French (fr)`, `label::Spanish (es)`)
3. remove every `::Spanish (es)` column and re-upload to the same project
4. 🔴 [on main] Spanish still listed as a project language, with empty strings
5. 🟢 [on PR] project lists English and French only
6. replace the remaining language columns with a plain `label` column and re-upload
7. 🔴 [on main] languages still there, plus an unnamed language
8. 🟢 [on PR] project back to "no languages defined"
