### PR TITLE
fix(dataTable): handle out-of-bounds translation index DEV-2666

### DIFF
--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -243,9 +243,9 @@ export function getQuestionOrChoiceDisplayName(
   }
 
   if (questionOrChoice.label && Array.isArray(questionOrChoice.label)) {
-    // If the user hasn't made translations yet for a form language show
-    // the xml names instead of blank.
-    if (questionOrChoice.label[translationIndex] === null) {
+    // Fall back to XML name if the label is missing (null) or the index is
+    // out of bounds (undefined).
+    if (questionOrChoice.label[translationIndex] == null) {
       return getRowName(questionOrChoice)
     }
     return questionOrChoice.label[translationIndex]


### PR DESCRIPTION
### 📣 Summary

Fixed a crash that prevented the data table from loading for projects where the saved display-language setting referred to a language that no longer exists in the form.

### 💭 Notes

The asset's `data-table.translation-index` setting is an integer index into `content.translations`. If translations are removed after the index was saved, the saved index can become out of bounds. `getQuestionOrChoiceDisplayName` guarded against `null` but not `undefined`, so it returned `undefined` as a choice label. Mantine's `Select` then called `.toLowerCase()` on this undefined result and crashed.

### 👀 Preview steps

1. ℹ️ Have a project with a `select_one` question and three languages
2. Open the data table, set display labels to the third language
3. Go back to the form builder and delete the second two languages
4. 🔴 [on main] Open the data table — "Unexpected Application Error" crash
5. 🟢 [on PR] Open the data table — loads normally, choice labels fall back to XML names
