### PR TITLE
fix(frontend): notification with multiple error lines layout DEV-2482

### DIFF
--- a/jsapp/js/project/ProjectSettings/ProjectSettings.tsx
+++ b/jsapp/js/project/ProjectSettings/ProjectSettings.tsx
@@ -600,8 +600,10 @@ class ProjectSettings extends React.Component<ProjectSettingsProps, ProjectSetti
           {errorType}: {escapeHtml(importError)}
         </code>,
       )
-      // join returns an array of React nodes (strings and JSX elements with <br /> separators)
-      const message = <>{join(errLines, <br />)}</>
+      // join returns an array of React nodes (strings and JSX elements with <br /> separators).
+      // The wrapping <div> is required: the toast container lays out its direct children with
+      // `display: flex`, so without a block-level wrapper the lines render side-by-side as columns.
+      const message = <div>{join(errLines, <br />)}</div>
       notify.error(message)
     } else {
       // Fallback for responses without structured error messages


### PR DESCRIPTION
### 📣 Summary

Improve layout of import error notification when multiple lines of text
needs to be displayed.

### 💭 Notes

This is something reportert by Becca, and I wasn't able to reproduce it.
But by looking at the code it's clear what was the problem.

Notification element is a flex container (probably to center the
content), so when it receives multiple children, it displays them in a
row. Before passing multiple children, we wrap them in a div.

### 👀 Preview steps

1. ℹ️ Be Becca
2. Cause the error to happen
3. 🟢 Notice that error now renders properly