### PR TITLE
feat(organizations): add sorting to Members Table DEV-2457

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -62,10 +62,15 @@ export default function MembersRoute() {
     queryParams.ordering = `${orderPrefix}${order.fieldName}`
   }
 
-  /** Sorting affects which rows land on which page, so we go back to the first page whenever it changes. */
+  /**
+   * Sorting affects which rows land on which page, so we go back to the first page whenever it changes. Updating from
+   * the latest state, so we don't reset `limit` to a stale page size.
+   */
   function updateOrder(newOrder: SortableColumnOrder<MembersTableOrderableField>) {
     setOrder(newOrder)
-    setPagination({ ...pagination, start: 0 })
+    setPagination((currentPagination) => {
+      return { ...currentPagination, start: 0 }
+    })
   }
 
   const membersQuery = useOrganizationsMembersList(organization.id, queryParams, {

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -11,6 +11,7 @@ import type { ErrorDetail } from '#/api/models/errorDetail'
 import { InviteStatusChoicesEnum } from '#/api/models/inviteStatusChoicesEnum'
 import type { MemberListResponse } from '#/api/models/memberListResponse'
 import { MemberRoleEnum } from '#/api/models/memberRoleEnum'
+import type { OrganizationsMembersListParams } from '#/api/models/organizationsMembersListParams'
 import {
   getOrganizationsMembersListQueryKey,
   useOrganizationsMembersList,
@@ -21,11 +22,25 @@ import ButtonNew from '#/components/common/ButtonNew'
 import Avatar from '#/components/common/avatar'
 import Badge from '#/components/common/badge'
 import envStore from '#/envStore'
+import SortableProjectColumnHeader, {
+  type SortableColumnOrder,
+} from '#/projects/projectsTable/sortableProjectColumnHeader'
 import { formatDate } from '#/utils'
 import InviteeActionsDropdown from './InviteeActionsDropdown'
 import MemberActionsDropdown from './MemberActionsDropdown'
 import MemberRoleSelector from './MemberRoleSelector'
 import styles from './membersRoute.module.scss'
+
+/**
+ * API ordering names, not table column keys — the `Name` column orders by username (the endpoint cannot order by
+ * full name) and the `Status` column by `status`.
+ *
+ * These must stay a subset of `OrganizationsMembersListOrdering`; building `ordering` below from them means an
+ * invalid name here fails to typecheck. The 2FA column is absent because the endpoint cannot order by it.
+ */
+type MembersTableOrderableField = 'user__username' | 'status' | 'date_joined' | 'role'
+
+const ORDERABLE_FIELDS: MembersTableOrderableField[] = ['user__username', 'status', 'date_joined', 'role']
 
 export default function MembersRoute() {
   const [organization] = useOrganizationAssumed()
@@ -39,10 +54,23 @@ export default function MembersRoute() {
     limit: DEFAULT_PAGE_SIZE,
     start: 0,
   })
+  const [order, setOrder] = useState<SortableColumnOrder<MembersTableOrderableField>>({})
 
-  const membersQuery = useOrganizationsMembersList(organization.id, pagination, {
+  const queryParams: OrganizationsMembersListParams = { ...pagination }
+  if (order.fieldName && order.direction) {
+    const orderPrefix = order.direction === 'descending' ? '-' : ''
+    queryParams.ordering = `${orderPrefix}${order.fieldName}`
+  }
+
+  /** Sorting affects which rows land on which page, so we go back to the first page whenever it changes. */
+  function updateOrder(newOrder: SortableColumnOrder<MembersTableOrderableField>) {
+    setOrder(newOrder)
+    setPagination({ ...pagination, start: 0 })
+  }
+
+  const membersQuery = useOrganizationsMembersList(organization.id, queryParams, {
     query: {
-      queryKey: getOrganizationsMembersListQueryKey(organization.id, pagination),
+      queryKey: getOrganizationsMembersListQueryKey(organization.id, queryParams),
       placeholderData: keepPreviousData,
       // We might want to improve this in future, for now let's not retry
       retry: false,
@@ -65,10 +93,24 @@ export default function MembersRoute() {
     return { invite, member }
   }
 
+  /** Renders a column label that opens the sorting menu on click. */
+  function renderSortableHeader(fieldName: MembersTableOrderableField, label: string) {
+    return (
+      <SortableProjectColumnHeader
+        styling={false}
+        field={{ name: fieldName, label }}
+        orderableFields={ORDERABLE_FIELDS}
+        order={order}
+        onChangeOrderRequested={updateOrder}
+        fixedWidth
+      />
+    )
+  }
+
   const columns: Array<UniversalTableColumn<MemberListResponse>> = [
     {
       key: 'user__extra_details__name',
-      label: t('Name'),
+      label: renderSortableHeader('user__username', t('Name')),
       cellFormatter: (obj: MemberListResponse) => {
         const { invite, member } = getMemberOrInviteDetails(obj)
         return (
@@ -87,7 +129,7 @@ export default function MembersRoute() {
     },
     {
       key: 'invite',
-      label: t('Status'),
+      label: renderSortableHeader('status', t('Status')),
       size: 120,
       cellFormatter: (obj: MemberListResponse) => {
         const { invite } = getMemberOrInviteDetails(obj)
@@ -100,7 +142,7 @@ export default function MembersRoute() {
     },
     {
       key: 'date_joined',
-      label: t('Date added'),
+      label: renderSortableHeader('date_joined', t('Date added')),
       size: 140,
       cellFormatter: (obj: MemberListResponse) => {
         const { invite, member } = getMemberOrInviteDetails(obj)
@@ -109,7 +151,7 @@ export default function MembersRoute() {
     },
     {
       key: 'role',
-      label: t('Role'),
+      label: renderSortableHeader('role', t('Role')),
       size: 140,
       cellFormatter: (obj: MemberListResponse) => {
         const { invite, member } = getMemberOrInviteDetails(obj)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

The Members table columns can now be sorted by name, status, date added, and role.

### 💭 Notes

Frontend for the sorting API added in #7329. Reuses `SortableProjectColumnHeader`, same as the Usage → Projects breakdown table, so the menus look and behave identically.

Changes here (all in `MembersRoute.tsx`):

- `MembersTableOrderableField` — the four fields the endpoint accepts
- `renderSortableHeader()` — swaps the four plain string labels for sortable ones
- `queryParams` — ordering state mapped to the API's `-` prefix convention, merged with pagination. Also passed to `getOrganizationsMembersListQueryKey()`, so each sort order caches separately and `keepPreviousData` keeps the table from flashing empty between sorts.
- `updateOrder()` — resets to page 1

Two columns stay unsorted, both because the API has no ordering field for them:
- **2FA**
- **Name sorts by username, not full name.** No ordering field exists for full name. Since the cell shows full name above username, sorting looks slightly out of order for members whose two differ — expected, not a bug.

### 👀 Preview steps

1. ℹ️ have an account in a team/organization with several members, ideally with mixed roles, a pending invite or two, and enough people to fill more than one page
2. go to Account Settings → (your team name) → Members
3. 🔴 [on main] notice the column headers are just labels — nothing to click, no way to reorder
4. 🟢 [on PR] notice **Name**, **Status**, **Date added** and **Role** now have a caret next to the label
5. click **Name** → choose "Sort A→Z", then "Sort Z→A" → 🟢 rows reorder by username, and a teal arrow marks the sorted column
6. choose "Default sort" → 🟢 the original order returns
7. repeat on **Status**, **Date added** and **Role** → 🟢 each sorts both ways
8. sort by something, then page forward and back with the arrows at the bottom → 🟢 the sort sticks across pages
9. go to page 2, then change the sort → 🟢 you land back on page 1 instead of somewhere in the middle of the newly sorted list
10. 🟢 notice the **2FA** column has no caret — the API can't sort by it yet
