### PR TITLE
feat(frontend): override Switch styles for Formbuilder DEV-2712

### DIFF
--- a/jsapp/js/components/metadataEditor.js
+++ b/jsapp/js/components/metadataEditor.js
@@ -236,6 +236,7 @@ export default class MetadataEditor extends React.Component {
                   : t('Enable audio recording in the background')
               }
               disabled={this.props.isDisabled}
+              className='form-builder-aside__switch'
             />
           </bem.FormModal__item>
         </bem.FormBuilderMeta__row>

--- a/jsapp/js/theme/kobo/Switch.module.css
+++ b/jsapp/js/theme/kobo/Switch.module.css
@@ -41,7 +41,8 @@
 }
 
 /* Matches the Checkbox label colour and 8px gap so inline controls line up. */
-.label {
+.label,
+.description {
   color: var(--mantine-color-gray-1);
   padding-inline-start: 8px;
 }
@@ -59,10 +60,6 @@
 .label[data-disabled] {
   color: var(--kobo-choice-control-disabled-label);
   opacity: 1;
-}
-
-.description {
-  color: var(--mantine-color-gray-2);
 }
 
 .error {

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -259,8 +259,20 @@ $s-form-builder-content-width: 1024px;
   }
 }
 
-.form-builder-aside__switch .mantine-Switch-input:not(:checked) + .mantine-Switch-track {
-  background-color: var(--mantine-color-gray-4);
+// The aside's light gray background washes out both unchecked track colours from
+// the Switch theme, so darken them here. Set `background-color` rather than
+// `--switch-bg` to stay ahead of the theme's var declarations, which means the
+// disabled state needs restating too — kept paler than the enabled one so it
+// still reads as unavailable, mirroring the checked pair (blue-6 / blue-7).
+.form-builder-aside__switch {
+  .mantine-Switch-input:not(:checked) + .mantine-Switch-track {
+    background-color: var(--mantine-color-gray-4);
+  }
+
+  .mantine-Switch-input:disabled:not(:checked) + .mantine-Switch-track,
+  .mantine-Switch-input[data-disabled]:not(:checked) + .mantine-Switch-track {
+    background-color: var(--mantine-color-gray-5);
+  }
 }
 
 // CASCADE MODAL CONTENTS

--- a/jsapp/scss/components/_kobo.form-builder.scss
+++ b/jsapp/scss/components/_kobo.form-builder.scss
@@ -259,6 +259,10 @@ $s-form-builder-content-width: 1024px;
   }
 }
 
+.form-builder-aside__switch .mantine-Switch-input:not(:checked) + .mantine-Switch-track {
+  background-color: var(--mantine-color-gray-4);
+}
+
 // CASCADE MODAL CONTENTS
 
 .cascade-popup {


### PR DESCRIPTION
### 💭 Notes

Formbuilder aside has gray background. Switch assumes white background. I overriden the switch color to make it look better.

### 👀 Preview steps

1. ℹ️ Have an account and a project
2. Edit project in Formbuilder
3. Open "Layout & Settings"
4. 🔴 [on main] Notice that (off) Switch has very low contrast in comparison to background
5. 🟢 [on PR] Notice it looks better
