### PR TITLE
build(frontend): bump insecure js-yaml versions DEV-2678

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3894,9 +3894,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19880,9 +19880,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -23387,19 +23387,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/orval/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/orval/node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -210,7 +210,10 @@
     },
     "storybook": "$storybook",
     "coffee-script": "$coffeescript",
-    "minimist": "^1.2.6"
+    "minimist": "^1.2.6",
+    "orval": {
+      "js-yaml": "^4.3.1"
+    }
   },
   "scripts": {
     "preinstall": "npm run hint",


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Updated the `js-yaml` dependency to patch a set of denial-of-service advisories.

### 💭 Notes

Neither `jest` nor `@storybook/test-runner` pins `js-yaml` — their ranges already allowed safe versions. `orval@7.21.0` was the actual blocker: it pins `js-yaml` at exactly `4.1.1`, so `npm update` couldn't reach it. npm's suggested fix was `orval@8` but it felt too hardcore for now.

### 👀 Preview steps

1. Run `npm install`
3. Run `npm ls js-yaml --all`
4. 🔴 [on main] notice `js-yaml@3.15.0`, `4.3.0` and `4.1.1` in the tree
5. 🟢 [on PR] notice everything is `3.15.1` or `4.3.1`, with no separate copy nested under `orval/`
6. run `npm audit`
7. 🔴 [on main] notice `js-yaml` listed as high severity
8. 🟢 [on PR] notice `js-yaml` is gone from the report
9. run `npx jest --listTests` and `npm run build:orval`
10. 🟢 notice both still work, and that `build:orval` leaves no unexpected changes in `jsapp/js/api/`
