### PR TITLE
fix(organizations): sort role by level of privilege instead of alphabetically DEV-2454

### DIFF
--- a/jsapp/js/api/models/organizationsMembersListParams.ts
+++ b/jsapp/js/api/models/organizationsMembersListParams.ts
@@ -21,7 +21,7 @@ export type OrganizationsMembersListParams = {
    */
   offset?: number
   /**
-   * Which field to use when ordering the results.
+   * Which field to use when ordering the results. Note: `role` sorts by privilege rank (`member` → `admin` → `owner`).
    */
   ordering?: OrganizationsMembersListOrdering
   /**

--- a/jsapp/js/api/react-query/user-team-organization-usage/index.ts
+++ b/jsapp/js/api/react-query/user-team-organization-usage/index.ts
@@ -1501,7 +1501,7 @@ Allowed ordering fields:
 - `user__username`
 - `status`
 - `date_joined` (or `date_added`, `created`)
-- `role`
+- `role` (sorted by privilege rank: `member` → `admin` → `owner`)
 - `user__has_sso_enabled`
 
 Prefix field names with `-` for descending sort.

--- a/kobo/apps/organizations/docs/api/v2/members/list.md
+++ b/kobo/apps/organizations/docs/api/v2/members/list.md
@@ -15,7 +15,7 @@ Allowed ordering fields:
 - `user__username`
 - `status`
 - `date_joined` (or `date_added`, `created`)
-- `role`
+- `role` (sorted by privilege rank: `member` → `admin` → `owner`)
 - `user__has_sso_enabled`
 
 Prefix field names with `-` for descending sort.

--- a/kobo/apps/organizations/tests/test_organization_members_api.py
+++ b/kobo/apps/organizations/tests/test_organization_members_api.py
@@ -442,23 +442,25 @@ class OrganizationMemberAPITestCase(BaseOrganizationAssetApiTestCase):
         self._create_invite(self.someuser)
         self.client.force_login(self.someuser)
 
-        # Ascending sort by role: admin, member, owner
+        ROLE_LEVELS = {'member': 1, 'admin': 2, 'owner': 3}
+
+        # Ascending sort by role privilege: member, admin, owner
         response = self.client.get(f'{self.list_url}?ordering=role')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        roles_asc = [
-            (r['role'] or r['invite']['invitee_role']).lower()
+        role_levels_asc = [
+            ROLE_LEVELS[(r['role'] or r['invite']['invitee_role']).lower()]
             for r in response.data['results']
         ]
-        self.assertEqual(roles_asc, sorted(roles_asc))
+        self.assertEqual(role_levels_asc, sorted(role_levels_asc))
 
-        # Descending sort by role
+        # Descending sort by role privilege: owner, admin, member
         response = self.client.get(f'{self.list_url}?ordering=-role')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        roles_desc = [
-            (r['role'] or r['invite']['invitee_role']).lower()
+        role_levels_desc = [
+            ROLE_LEVELS[(r['role'] or r['invite']['invitee_role']).lower()]
             for r in response.data['results']
         ]
-        self.assertEqual(roles_desc, sorted(roles_asc, reverse=True))
+        self.assertEqual(role_levels_desc, sorted(role_levels_asc, reverse=True))
 
     def test_sort_members_by_sso_enabled(self):
         # Create SSO account for alice

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -471,7 +471,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
                     'user__has_sso_enabled',
                     '-user__has_sso_enabled',
                 ],
-                description='Which field to use when ordering the results. Note: `role` sorts by privilege rank (`member` → `admin` → `owner`).',
+                description=(
+                    'Which field to use when ordering the results. '
+                    'Note: `role` sorts by privilege rank '
+                    '(`member` → `admin` → `owner`).'
+                ),
             ),
         ],
     ),

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -2,17 +2,7 @@ from operator import attrgetter
 
 from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
-from django.db.models import (
-    Case,
-    CharField,
-    F,
-    IntegerField,
-    OuterRef,
-    Q,
-    QuerySet,
-    Value,
-    When,
-)
+from django.db.models import Case, CharField, F, OuterRef, Q, QuerySet, Value, When
 from django.db.models.expressions import Exists
 from django.db.models.functions import Coalesce, Lower
 from django.utils.http import http_date
@@ -90,6 +80,8 @@ from .serializers import (
     OrgMembershipInviteSerializer,
 )
 from .utils import revoke_org_asset_perms
+
+ROLE_RANKS = {'member': 1, 'admin': 2, 'owner': 3}
 
 
 class OrganizationAssetViewSet(AssetViewSet):
@@ -586,13 +578,6 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
             output_field=CharField(),
         )
 
-        role_sort_annotation = Case(
-            When(Exists(owner_subquery), then=Value(3)),
-            When(is_admin=True, then=Value(2)),
-            default=Value(1),
-            output_field=IntegerField(),
-        )
-
         # Annotate with the role based on organization ownership and admin status
         queryset = (
             OrganizationUser.objects.filter(
@@ -601,7 +586,6 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
             .select_related('user__extra_details')
             .annotate(
                 role=role_annotation,
-                role_sort=role_sort_annotation,
                 has_mfa_enabled=Exists(mfa_subquery),
                 has_sso_enabled=Exists(sso_subquery),
                 invite=Value(None, output_field=CharField()),
@@ -628,12 +612,6 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
                 Q(invitee_id__isnull=True) | ~Q(invitee_id__in=members_user_ids)
             ).annotate(
                 role=Lower(F('invitee_role')),
-                role_sort=Case(
-                    When(invitee_role='owner', then=Value(3)),
-                    When(invitee_role='admin', then=Value(2)),
-                    default=Value(1),
-                    output_field=IntegerField(),
-                ),
                 has_sso_enabled=Value(False),
                 ordering_date=F('created'),
                 model_type=Value('1_organization_invitation', output_field=CharField()),
@@ -643,6 +621,9 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
                 status_sort=Value('invited'),
             )
             queryset = list(queryset) + list(invitees)
+
+            for row in queryset:
+                row.role_sort = ROLE_RANKS.get(row.role, 0)
 
             SORT_FIELDS = {
                 'user__username': 'username_sort',

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -471,7 +471,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
                     'user__has_sso_enabled',
                     '-user__has_sso_enabled',
                 ],
-                description='Which field to use when ordering the results.',
+                description='Which field to use when ordering the results. Note: `role` sorts by privilege rank (`member` → `admin` → `owner`).',
             ),
         ],
     ),

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -6,6 +6,7 @@ from django.db.models import (
     Case,
     CharField,
     F,
+    IntegerField,
     OuterRef,
     Q,
     QuerySet,
@@ -581,6 +582,13 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
             output_field=CharField(),
         )
 
+        role_sort_annotation = Case(
+            When(Exists(owner_subquery), then=Value(3)),
+            When(is_admin=True, then=Value(2)),
+            default=Value(1),
+            output_field=IntegerField(),
+        )
+
         # Annotate with the role based on organization ownership and admin status
         queryset = (
             OrganizationUser.objects.filter(
@@ -589,6 +597,7 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
             .select_related('user__extra_details')
             .annotate(
                 role=role_annotation,
+                role_sort=role_sort_annotation,
                 has_mfa_enabled=Exists(mfa_subquery),
                 has_sso_enabled=Exists(sso_subquery),
                 invite=Value(None, output_field=CharField()),
@@ -615,6 +624,12 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
                 Q(invitee_id__isnull=True) | ~Q(invitee_id__in=members_user_ids)
             ).annotate(
                 role=Lower(F('invitee_role')),
+                role_sort=Case(
+                    When(invitee_role='owner', then=Value(3)),
+                    When(invitee_role='admin', then=Value(2)),
+                    default=Value(1),
+                    output_field=IntegerField(),
+                ),
                 has_sso_enabled=Value(False),
                 ordering_date=F('created'),
                 model_type=Value('1_organization_invitation', output_field=CharField()),
@@ -631,7 +646,7 @@ class OrganizationMemberViewSet(viewsets.ModelViewSet):
                 'date_joined': 'ordering_date',
                 'date_added': 'ordering_date',
                 'created': 'ordering_date',
-                'role': 'role',
+                'role': 'role_sort',
                 'user__has_sso_enabled': 'has_sso_enabled',
             }
 

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -12759,7 +12759,7 @@
         "/api/v2/organizations/{uid_organization}/members/": {
             "get": {
                 "operationId": "api_v2_organizations_members_list",
-                "description": "## List Members\n\nRetrieves all members and pending invitations in the specified organization.\n\n### Sorting\n\nResults can be sorted with the `ordering` parameter, e.g.:\n\n```shell\ncurl -X GET https://kf.kobotoolbox.org/api/v2/organizations/{uid_organization}/members/?ordering=-user__username\n```\n\nAllowed ordering fields:\n\n- `user__username`\n- `status`\n- `date_joined` (or `date_added`, `created`)\n- `role`\n- `user__has_sso_enabled`\n\nPrefix field names with `-` for descending sort.\n",
+                "description": "## List Members\n\nRetrieves all members and pending invitations in the specified organization.\n\n### Sorting\n\nResults can be sorted with the `ordering` parameter, e.g.:\n\n```shell\ncurl -X GET https://kf.kobotoolbox.org/api/v2/organizations/{uid_organization}/members/?ordering=-user__username\n```\n\nAllowed ordering fields:\n\n- `user__username`\n- `status`\n- `date_joined` (or `date_added`, `created`)\n- `role` (sorted by privilege rank: `member` → `admin` → `owner`)\n- `user__has_sso_enabled`\n\nPrefix field names with `-` for descending sort.\n",
                 "parameters": [
                     {
                         "name": "limit",
@@ -12801,7 +12801,7 @@
                                 "user__username"
                             ]
                         },
-                        "description": "Which field to use when ordering the results."
+                        "description": "Which field to use when ordering the results. Note: `role` sorts by privilege rank (`member` → `admin` → `owner`)."
                     },
                     {
                         "name": "start",

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -9316,7 +9316,7 @@ paths:
         - `user__username`
         - `status`
         - `date_joined` (or `date_added`, `created`)
-        - `role`
+        - `role` (sorted by privilege rank: `member` → `admin` → `owner`)
         - `user__has_sso_enabled`
 
         Prefix field names with `-` for descending sort.
@@ -9352,7 +9352,8 @@ paths:
           - status
           - user__has_sso_enabled
           - user__username
-        description: Which field to use when ordering the results.
+        description: 'Which field to use when ordering the results. Note: `role` sorts
+          by privilege rank (`member` → `admin` → `owner`).'
       - name: start
         required: false
         in: query


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [x] delete this checklist section from the final squash commit before merging

### 📣 Summary
Organizations members are now sorted by level of privilege in the members API when using `ordering=role` (previously they were sorted alphabetically)

### 👀 Preview steps
1. ℹ️ have an organization with multiple members with admin and member roles
2. 🟢 [on PR] notice that the members are sorted by level of privilege
    * Ascending Privilege (member → admin → owner): /api/v2/organizations/<UID>/members/?ordering=role
    * Descending Privilege (owner → admin → member): /api/v2/organizations/<UID>/members/?ordering=-role
