### PR TITLE
fix(massEmails): reduce mass email send lag DEV-2675

### DIFF
--- a/kobo/apps/mass_emails/__init__.py
+++ b/kobo/apps/mass_emails/__init__.py
@@ -10,4 +10,7 @@ class MassEmailsConfig(AppConfig):
         # Makes sure all signal handlers are connected
         from kobo.apps.mass_emails import signals  # noqa
 
+        # Makes sure system checks are registered
+        from kobo.apps.mass_emails import checks  # noqa
+
         super().ready()

--- a/kobo/apps/mass_emails/checks.py
+++ b/kobo/apps/mass_emails/checks.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+def check_mass_email_send_settings(app_configs, **kwargs):
+    """
+    Validate the operational settings used by the mass email send loop
+
+    An invalid value here would abort a `send_emails` run mid-way (a
+    `ZeroDivisionError` from the throttle batching, or a `ValueError` from
+    `time.sleep()`), stranding the remaining enqueued records until the next
+    scheduled run.
+    """
+
+    errors = []
+
+    if settings.MASS_EMAIL_THROTTLE_PER_SECOND < 1:
+        errors.append(
+            Error(
+                f'MASS_EMAIL_THROTTLE_PER_SECOND is '
+                f'{settings.MASS_EMAIL_THROTTLE_PER_SECOND}, but must be at '
+                f'least 1.',
+                hint=(
+                    'Set the MASS_EMAIL_THROTTLE_PER_SECOND environment '
+                    'variable to a positive integer.'
+                ),
+                id='mass_emails.E001',
+            )
+        )
+
+    if settings.MASS_EMAIL_SLEEP_SECONDS < 0:
+        errors.append(
+            Error(
+                f'MASS_EMAIL_SLEEP_SECONDS is '
+                f'{settings.MASS_EMAIL_SLEEP_SECONDS}, but must not be '
+                f'negative.',
+                hint=(
+                    'Set the MASS_EMAIL_SLEEP_SECONDS environment variable '
+                    'to 0 or a positive integer.'
+                ),
+                id='mass_emails.E002',
+            )
+        )
+
+    return errors
+
+
+register(check_mass_email_send_settings)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -1,12 +1,15 @@
 from datetime import date, datetime, time, timedelta
 from enum import Enum
+from functools import wraps
 from math import ceil
+from smtplib import SMTPException
 from time import sleep
 from typing import Optional
 
 from constance import config
 from django.conf import settings
 from django.core.cache import cache
+from django.core.mail import get_connection
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Q
 from django.utils import timezone
@@ -33,6 +36,38 @@ templates_placeholders = {
     '##plan_name##': 'plan_name',
     '##date_created##': 'date_created',
 }
+
+
+def with_smtp_connection(func):
+    """
+    Open a single SMTP connection for the whole duration of the decorated method
+
+    The connection is exposed as `self.connection` and closed on the way out.
+    Without it, every message goes through `send_mail()`, which opens and tears
+    down a connection per email. That handshake caps the real throughput far
+    below `MASS_EMAIL_THROTTLE_PER_SECOND` and makes large sends run into the
+    task time limit.
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        # `get_connection()` instantiates `settings.EMAIL_BACKEND`, so it either
+        # returns a backend or raises before the assignment. Every backend
+        # inherits `open()` and `close()` from `BaseEmailBackend`, where they
+        # are no-ops for the ones holding no socket.
+        self.connection = get_connection()
+        self.connection.open()
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            try:
+                self.connection.close()
+            except Exception as e:
+                logging.warning(f'Error while closing the email connection: {e}')
+            self.connection = None
+
+    return wrapper
+
 
 PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{key_date}_emails'
 TASK_TIMEOUT = (
@@ -99,6 +134,7 @@ class MassEmailSender:
 
     def __init__(self):
         now = timezone.now()
+        self.connection = None
         self.today = now.date()
         cache_date = self.get_cache_key_date(send_date=now)
         self.cache_key_prefix = f'mass_emails_{cache_date.isoformat()}_email_remaining'
@@ -255,6 +291,7 @@ class MassEmailSender:
             plan_name = gettext('Not available')
         return plan_name
 
+    @with_smtp_connection
     def send_day_emails(self):
         emails_sent = 0
         for email_config in self.configs:
@@ -296,7 +333,17 @@ class MassEmailSender:
             html_content_or_template=content,
         )
         try:
-            sent = Mailer.send(message)
+            sent = Mailer.send(message, connection=self.connection)
+            if not sent and self.connection is not None:
+                # `Mailer.send()` reports any SMTP error as a plain `False`, so
+                # probe the socket to tell a dropped connection apart from a
+                # message the server simply refused. Only the former is worth
+                # reconnecting for, and it would otherwise fail every remaining
+                # record of the run.
+                if not self._connection_is_alive():
+                    logging.warning('SMTP connection lost, reconnecting')
+                    self._reset_connection()
+                    sent = Mailer.send(message, connection=self.connection)
         except Exception as e:
             logging.exception(f'Error when attempting to send record {record}: {e}')
             sent = False
@@ -306,6 +353,39 @@ class MassEmailSender:
             record.status = EmailStatus.FAILED
 
         record.save()
+
+    def _connection_is_alive(self) -> bool:
+        """
+        Tell whether the SMTP socket can still carry another message.
+
+        Only an actual drop justifies reconnecting. A refused recipient or a
+        rejected message leaves the connection perfectly usable, and tearing it
+        down for those would cost a full handshake on every failure.
+        """
+
+        if not hasattr(self.connection, 'connection'):
+            # Not an SMTP backend. The file and console backends used outside
+            # production hold no socket that could have dropped.
+            return True
+        if self.connection.connection is None:
+            return False
+        try:
+            code, _ = self.connection.connection.noop()
+        except (OSError, SMTPException):
+            return False
+
+        return code == 250
+
+    def _reset_connection(self):
+        """
+        Close and reopen the SMTP connection.
+
+        Django leaves a connection it did not open itself untouched, so a
+        socket dropped mid-run stays broken until it is explicitly replaced.
+        """
+
+        close_connection_quietly(self.connection)
+        self.connection.open()
 
 
 @celery_app.task(

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -4,6 +4,7 @@ from math import ceil
 from time import sleep
 from typing import Optional
 
+from celery.exceptions import SoftTimeLimitExceeded
 from constance import config
 from django.conf import settings
 from django.core.cache import cache
@@ -44,6 +45,10 @@ PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{key_date}_emails'
 TASK_TIMEOUT = (
     5 * 60 if getattr(settings, 'MASS_EMAILS_CONDENSE_SEND', False) else 60 * 60
 )  # 5 minutes if condense send, otherwise 1h
+# Reserve a few seconds between the soft and hard time limits of `send_emails`
+# so a run that hits the soft limit mid-send has time to close the SMTP
+# connection gracefully instead of being SIGKILLed with the socket still open.
+SEND_EMAILS_SOFT_LIMIT_BUFFER = 10
 
 
 def enqueue_mass_email_records(email_config):
@@ -317,6 +322,10 @@ class MassEmailSender:
                     logging.warning('SMTP connection lost, reconnecting')
                     reset_connection(self.connection)
                     sent = Mailer.send(message, connection=self.connection)
+        except SoftTimeLimitExceeded:
+            # Let this propagate: it must not be recorded as a failure. The
+            # record stays `enqueued` and is picked up by the next run.
+            raise
         except Exception as e:
             logging.exception(f'Error when attempting to send record {record}: {e}')
             sent = False
@@ -329,8 +338,10 @@ class MassEmailSender:
 
 
 @celery_app.task(
-    time_limit=TASK_TIMEOUT - 2, soft_time_limit=TASK_TIMEOUT - 2
-)  # subtract 2 so we don't run in to the generate_send task
+    time_limit=TASK_TIMEOUT - 2,
+    soft_time_limit=TASK_TIMEOUT - 2 - SEND_EMAILS_SOFT_LIMIT_BUFFER,
+)  # subtract 2 from time_limit so this run finishes before the next
+# `generate_mass_email_user_lists` run, scheduled 59 minutes later
 def send_emails():
     """
     Send the emails for the current day. It schedules the emails if they have not
@@ -347,7 +358,15 @@ def send_emails():
         return
 
     sender = MassEmailSender()
-    sender.send_day_emails()
+    try:
+        sender.send_day_emails()
+    except SoftTimeLimitExceeded:
+        # Expected under load: the run is capped by design and the remaining
+        # `enqueued` records are simply picked up by the next hourly run.
+        logging.warning(
+            'send_emails hit its soft time limit, stopping early; remaining '
+            'enqueued records will be sent on the next run'
+        )
     finished_one_offs = (
         MassEmailConfig.objects.filter(
             pk__in=sender.config_ids, frequency=-1, live=True

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -1,15 +1,12 @@
 from datetime import date, datetime, time, timedelta
 from enum import Enum
-from functools import wraps
 from math import ceil
-from smtplib import SMTPException
 from time import sleep
 from typing import Optional
 
 from constance import config
 from django.conf import settings
 from django.core.cache import cache
-from django.core.mail import get_connection
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Q
 from django.utils import timezone
@@ -25,7 +22,13 @@ from kobo.apps.mass_emails.models import (
 from kobo.apps.organizations.models import OrganizationUser
 from kobo.celery import celery_app
 from kpi.utils.log import logging
-from kpi.utils.mailer import EmailMessage, Mailer
+from kpi.utils.mailer import (
+    EmailMessage,
+    Mailer,
+    is_connection_alive,
+    reset_connection,
+    with_smtp_connection,
+)
 
 if settings.STRIPE_ENABLED:
     from kobo.apps.stripe.utils.subscription_limits import get_plan_name
@@ -36,38 +39,6 @@ templates_placeholders = {
     '##plan_name##': 'plan_name',
     '##date_created##': 'date_created',
 }
-
-
-def with_smtp_connection(func):
-    """
-    Open a single SMTP connection for the whole duration of the decorated method
-
-    The connection is exposed as `self.connection` and closed on the way out.
-    Without it, every message goes through `send_mail()`, which opens and tears
-    down a connection per email. That handshake caps the real throughput far
-    below `MASS_EMAIL_THROTTLE_PER_SECOND` and makes large sends run into the
-    task time limit.
-    """
-
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        # `get_connection()` instantiates `settings.EMAIL_BACKEND`, so it either
-        # returns a backend or raises before the assignment. Every backend
-        # inherits `open()` and `close()` from `BaseEmailBackend`, where they
-        # are no-ops for the ones holding no socket.
-        self.connection = get_connection()
-        self.connection.open()
-        try:
-            return func(self, *args, **kwargs)
-        finally:
-            try:
-                self.connection.close()
-            except Exception as e:
-                logging.warning(f'Error while closing the email connection: {e}')
-            self.connection = None
-
-    return wrapper
-
 
 PROCESSED_EMAILS_CACHE_KEY = 'mass_emails_{key_date}_emails'
 TASK_TIMEOUT = (
@@ -294,6 +265,9 @@ class MassEmailSender:
     @with_smtp_connection
     def send_day_emails(self):
         emails_sent = 0
+
+        batch_size = settings.MASS_EMAIL_THROTTLE_PER_SECOND
+
         for email_config in self.configs:
             limit = self.limits.get(email_config.id)
             if not limit:
@@ -305,7 +279,6 @@ class MassEmailSender:
             logging.info(
                 f'Processing {limit} records for MassEmailConfig({email_config})'
             )
-            batch_size = settings.MASS_EMAIL_THROTTLE_PER_SECOND
             for record in records:
                 if emails_sent > 0 and emails_sent % batch_size == 0:
                     logging.info(f'sleeping for {settings.MASS_EMAIL_SLEEP_SECONDS}')
@@ -340,9 +313,9 @@ class MassEmailSender:
                 # message the server simply refused. Only the former is worth
                 # reconnecting for, and it would otherwise fail every remaining
                 # record of the run.
-                if not self._connection_is_alive():
+                if not is_connection_alive(self.connection):
                     logging.warning('SMTP connection lost, reconnecting')
-                    self._reset_connection()
+                    reset_connection(self.connection)
                     sent = Mailer.send(message, connection=self.connection)
         except Exception as e:
             logging.exception(f'Error when attempting to send record {record}: {e}')
@@ -353,39 +326,6 @@ class MassEmailSender:
             record.status = EmailStatus.FAILED
 
         record.save()
-
-    def _connection_is_alive(self) -> bool:
-        """
-        Tell whether the SMTP socket can still carry another message.
-
-        Only an actual drop justifies reconnecting. A refused recipient or a
-        rejected message leaves the connection perfectly usable, and tearing it
-        down for those would cost a full handshake on every failure.
-        """
-
-        if not hasattr(self.connection, 'connection'):
-            # Not an SMTP backend. The file and console backends used outside
-            # production hold no socket that could have dropped.
-            return True
-        if self.connection.connection is None:
-            return False
-        try:
-            code, _ = self.connection.connection.noop()
-        except (OSError, SMTPException):
-            return False
-
-        return code == 250
-
-    def _reset_connection(self):
-        """
-        Close and reopen the SMTP connection.
-
-        Django leaves a connection it did not open itself untouched, so a
-        socket dropped mid-run stays broken until it is explicitly replaced.
-        """
-
-        close_connection_quietly(self.connection)
-        self.connection.open()
 
 
 @celery_app.task(

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -1,6 +1,6 @@
 import random
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -507,3 +507,87 @@ class GenerateDailyEmailUserListTaskTestCase(BaseMassEmailsTestCase):
         generate_mass_email_user_lists()
         email_config.refresh_from_db()
         assert not email_config.live
+
+
+class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
+    """
+    Cover how a send run handles its SMTP connection.
+    """
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        config = self._create_email_config(name='Config')
+        job = MassEmailJob.objects.create(email_config=config)
+        for user in (self.user1, self.user2, self.user3):
+            self._create_email_record(
+                user=user,
+                email_config=config,
+                job=job,
+                status=EmailStatus.ENQUEUED,
+            )
+
+    def test_a_single_connection_is_reused_across_records(self):
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send', return_value=True
+            ) as send_mock,
+        ):
+            MassEmailSender().send_day_emails()
+
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 3
+        # One handshake for the whole run rather than one per record
+        assert connection.open.call_count == 1
+        assert connection.close.call_count == 1
+        # Every message travels on that one connection. Without this, a message
+        # falls back to `send_mail()` opening its own connection.
+        assert send_mock.call_count == 3
+        for call in send_mock.call_args_list:
+            assert call.kwargs['connection'] is connection
+
+    def test_dropped_connection_is_reset_and_the_record_retried(self):
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send',
+                side_effect=[False, True, True, True],
+            ) as send_mock,
+            patch(
+                'kobo.apps.mass_emails.tasks.is_connection_alive', return_value=False
+            ),
+            patch('kobo.apps.mass_emails.tasks.reset_connection') as reset_mock,
+        ):
+            MassEmailSender().send_day_emails()
+
+        assert reset_mock.call_count == 1
+        # Four sends for three records: the first one is retried on the fresh
+        # connection instead of being written off
+        assert send_mock.call_count == 4
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 3
+
+    def test_refused_recipient_does_not_reset_the_connection(self):
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send',
+                side_effect=[False, True, True],
+            ) as send_mock,
+            patch(
+                'kobo.apps.mass_emails.tasks.is_connection_alive', return_value=True
+            ),
+            patch('kobo.apps.mass_emails.tasks.reset_connection') as reset_mock,
+        ):
+            MassEmailSender().send_day_emails()
+
+        # The connection is still usable, so reconnecting would only cost a
+        # handshake and resend a message the server already refused
+        assert reset_mock.call_count == 0
+        assert send_mock.call_count == 3
+        assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
+from celery.exceptions import SoftTimeLimitExceeded
 from constance.test import override_config
 from ddt import data, ddt, unpack
 from django.conf import settings
@@ -263,6 +264,19 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         self._setup_common_test_data()
         send_emails()
         assert len(mail.outbox) == 0
+
+    def test_send_emails_stops_gracefully_on_soft_time_limit(self):
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_day_emails',
+            side_effect=SoftTimeLimitExceeded,
+        ):
+            # The task must swallow the soft time limit itself rather than
+            # surfacing as a task failure: it is an expected outcome of a
+            # capped, resumable run.
+            send_emails()
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
 
     @override_settings(MAX_MASS_EMAILS_PER_DAY=100)
     def test_send_recurring_emails_when_initialized(self):
@@ -591,3 +605,24 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         assert send_mock.call_count == 3
         assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
         assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+
+    def test_soft_time_limit_closes_the_connection_and_leaves_records_enqueued(self):
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send',
+                side_effect=[True, SoftTimeLimitExceeded()],
+            ) as send_mock,
+            pytest.raises(SoftTimeLimitExceeded),
+        ):
+            MassEmailSender().send_day_emails()
+
+        # `with_smtp_connection`'s `finally` still runs: the connection is not
+        # left dangling even though the run was interrupted
+        assert connection.close.call_count == 1
+        assert send_mock.call_count == 2
+        # The interrupted record, and the one never reached, stay enqueued
+        # rather than being written off as failed
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 1
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 2

--- a/kobo/apps/mass_emails/tests/test_checks.py
+++ b/kobo/apps/mass_emails/tests/test_checks.py
@@ -1,0 +1,21 @@
+from django.core.checks import run_checks
+from django.test import TestCase, override_settings
+
+
+class MassEmailSendSettingsCheckTestCase(TestCase):
+
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0)
+    def test_zero_throttle_fails(self):
+        errors = run_checks()
+        assert any(e.id == 'mass_emails.E001' for e in errors)
+
+    @override_settings(MASS_EMAIL_SLEEP_SECONDS=-1)
+    def test_negative_sleep_fails(self):
+        errors = run_checks()
+        assert any(e.id == 'mass_emails.E002' for e in errors)
+
+    def test_default_settings_pass(self):
+        errors = run_checks()
+        assert not any(
+            e.id in ('mass_emails.E001', 'mass_emails.E002') for e in errors
+        )

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -149,8 +149,10 @@ def get_users_within_range_of_usage_limit(
     }
 
     owner_by_org = {
-        org.id: org.owner_user_object.pk
-        for org in Organization.objects.filter(owner__isnull=False)
+        org['id']: org['owner__organization_user__user__id']
+        for org in Organization.objects.filter(owner__isnull=False).values(
+            'id', 'owner__organization_user__user__id'
+        )
     }
     limits_by_owner = {
         owner_by_org[org_id]: limits for org_id, limits in limits_by_org.items()

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1838,9 +1838,25 @@ if os.environ.get('EMAIL_PORT'):
 if os.environ.get('EMAIL_USE_TLS'):
     EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
 
-MAX_MASS_EMAILS_PER_DAY = 1000
-MASS_EMAIL_THROTTLE_PER_SECOND = 40
-MASS_EMAIL_SLEEP_SECONDS = 1
+# To be set up based on the SMTP provider limits & quotas. On SES, keep
+# `MASS_EMAIL_THROTTLE_PER_SECOND` at or below the account `MaxSendRate`, and
+# `MAX_MASS_EMAILS_PER_DAY` below `Max24HourSend` minus the transactional
+# volume (both are returned by the SES `GetSendQuota` API).
+#
+# `MAX_MASS_EMAILS_PER_DAY` is a global ceiling shared by every live config and
+# split between them in proportion to their pending records, not a per-config
+# quota. Keep it above the number of records a single run enqueues across all
+# configs: a batch that cannot drain in one day keeps its config frozen, since
+# no recipient list is recomputed while records are still pending, so the
+# emails go out stale. Worse, anything still enqueued after
+# `MASS_EMAIL_ENQUEUED_RECORD_EXPIRY` days is marked as failed without ever
+# being sent.
+#
+# Raising it is not free: it also caps the blast radius of a user query that
+# selects far more people than intended.
+MAX_MASS_EMAILS_PER_DAY = env.int('MAX_MASS_EMAILS_PER_DAY', 10000)
+MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
+MASS_EMAIL_SLEEP_SECONDS = env.int('MASS_EMAIL_SLEEP_SECONDS', 1)
 # change the interval between "daily" email sends for testing. this will set both
 # the frequency of the task and the expiry time of the cached email limits. should
 # only be True on small testing instances

--- a/kpi/tests/test_mailer.py
+++ b/kpi/tests/test_mailer.py
@@ -1,8 +1,15 @@
+from smtplib import SMTPException, SMTPServerDisconnected
 from unittest.mock import MagicMock, Mock, patch
 
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.test import TestCase, override_settings
+
+from kpi.utils.mailer import (
+    is_connection_alive,
+    reset_connection,
+    with_smtp_connection,
+)
 
 
 def fake_send(email_message):
@@ -72,3 +79,109 @@ class TestEmailBackend(TestCase):
             )
 
             assert msg.send() == 1
+
+
+class TestConnectionHelpers(TestCase):
+    """
+    Cover the connection reuse helpers backing bulk sending.
+    """
+
+    def test_smtp_connection_is_opened_once_and_closed(self):
+        connection = MagicMock()
+
+        class Sender:
+            @with_smtp_connection
+            def run(self):
+                # The connection is available for the whole call
+                assert self.connection is connection
+                return 'done'
+
+        with patch('kpi.utils.mailer.get_connection', return_value=connection):
+            assert Sender().run() == 'done'
+
+        assert connection.open.call_count == 1
+        assert connection.close.call_count == 1
+
+    def test_smtp_connection_is_closed_when_the_method_raises(self):
+        connection = MagicMock()
+
+        class Sender:
+            @with_smtp_connection
+            def run(self):
+                raise ValueError('boom')
+
+        with patch('kpi.utils.mailer.get_connection', return_value=connection):
+            with self.assertRaises(ValueError):
+                Sender().run()
+
+        assert connection.close.call_count == 1
+
+    def test_closing_error_does_not_mask_the_original_one(self):
+        connection = MagicMock()
+        connection.close.side_effect = SMTPException('cannot quit')
+
+        class Sender:
+            @with_smtp_connection
+            def run(self):
+                raise ValueError('the real error')
+
+        with patch('kpi.utils.mailer.get_connection', return_value=connection):
+            with self.assertRaises(ValueError) as context:
+                Sender().run()
+
+        assert str(context.exception) == 'the real error'
+
+    def test_connection_is_released_after_the_call(self):
+        connection = MagicMock()
+
+        class Sender:
+            @with_smtp_connection
+            def run(self):
+                return None
+
+        sender = Sender()
+        with patch('kpi.utils.mailer.get_connection', return_value=connection):
+            sender.run()
+
+        # Leaving a closed connection behind would make later sends fail
+        assert sender.connection is None
+
+    def test_live_connection_is_alive(self):
+        connection = MagicMock()
+        connection.connection.noop.return_value = (250, b'OK')
+
+        assert is_connection_alive(connection) is True
+
+    def test_dropped_connection_is_not_alive(self):
+        connection = MagicMock()
+        connection.connection.noop.side_effect = SMTPServerDisconnected()
+
+        assert is_connection_alive(connection) is False
+
+    def test_unopened_connection_is_not_alive(self):
+        connection = MagicMock()
+        connection.connection = None
+
+        assert is_connection_alive(connection) is False
+
+    def test_non_smtp_backend_is_always_alive(self):
+        # File and console backends hold no socket that could have dropped
+        connection = Mock(spec=[])
+
+        assert is_connection_alive(connection) is True
+
+    def test_reset_connection_reopens_in_place(self):
+        connection = MagicMock()
+
+        reset_connection(connection)
+
+        assert connection.close.call_count == 1
+        assert connection.open.call_count == 1
+
+    def test_reset_connection_reopens_despite_a_closing_error(self):
+        connection = MagicMock()
+        connection.close.side_effect = SMTPServerDisconnected()
+
+        reset_connection(connection)
+
+        assert connection.open.call_count == 1

--- a/kpi/utils/mailer.py
+++ b/kpi/utils/mailer.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from smtplib import SMTPException
-from typing import Union
+from typing import Optional, Union
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection, send_mail
+from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.backends.smtp import EmailBackend as UpstreamEmailBackend
 from django.template.loader import get_template
 from django.utils.translation import activate
@@ -89,7 +90,21 @@ class EmailMessage:
 class Mailer:
 
     @classmethod
-    def send(cls, email_messages: Union[EmailMessage, list[EmailMessage]]) -> bool:
+    def send(
+        cls,
+        email_messages: Union[EmailMessage, list[EmailMessage]],
+        connection: Optional[BaseEmailBackend] = None,
+    ) -> bool:
+        """
+        Send one or several messages, optionally reusing an existing connection.
+
+        When `connection` is omitted, a new one is opened and closed for every
+        call, which costs a full SMTP handshake per message. Callers sending in
+        bulk should open a connection once and pass it in: Django only closes
+        the connection it opened itself, so an already-open one stays up across
+        calls and each message still reports its own success.
+        """
+
         if isinstance(email_messages, EmailMessage):
             try:
                 send_mail(
@@ -99,16 +114,20 @@ class Mailer:
                     email_messages.to,
                     html_message=email_messages.html_message,
                     fail_silently=False,
+                    connection=connection,
                 )
             except SMTPException as e:
                 logging.error(str(e), exc_info=True)
                 return False
         else:
             # Django `send_mass_mail()` does not support HTML
-            email_messages = [em.to_multi_alternative() for em in email_messages]
+            messages = [em.to_multi_alternative() for em in email_messages]
             try:
-                with get_connection() as connection:
-                    connection.send_messages(email_messages)
+                if connection is not None:
+                    connection.send_messages(messages)
+                else:
+                    with get_connection() as new_connection:
+                        new_connection.send_messages(messages)
             except SMTPException as e:
                 logging.error(str(e), exc_info=True)
                 return False

--- a/kpi/utils/mailer.py
+++ b/kpi/utils/mailer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import wraps
 from smtplib import SMTPException
 from typing import Optional, Union
 
@@ -12,6 +13,86 @@ from django.utils.translation import activate
 from django.utils.translation import gettext as t
 
 from kpi.utils.log import logging
+
+SMTP_ALIVE_STATUS_CODE = 250
+
+
+def is_connection_alive(connection: BaseEmailBackend) -> bool:
+    """
+    Tell whether the connection can still carry another message
+
+    `Mailer.send()` reports every SMTP error as a plain `False`, so the caller
+    needs this to tell a dropped socket apart from a message the server merely
+    refused. Only the former is worth reconnecting for: a refused recipient
+    leaves the connection perfectly usable, and tearing it down would cost a
+    full handshake on every failure.
+    """
+
+    if not hasattr(connection, 'connection'):
+        # Not an SMTP backend. The file and console backends used outside
+        # production hold no socket that could have dropped.
+        return True
+
+    if connection.connection is None:
+        return False
+
+    try:
+        code, _ = connection.connection.noop()
+    except (OSError, SMTPException):
+        return False
+
+    return code == SMTP_ALIVE_STATUS_CODE
+
+
+def reset_connection(connection: BaseEmailBackend):
+    """
+    Close and reopen a connection in place
+
+    Django leaves a connection it did not open itself untouched, so a socket
+    dropped mid-run stays broken until it is explicitly replaced. Only the
+    underlying socket is renewed, so callers holding this backend keep a valid
+    reference.
+    """
+
+    try:
+        connection.close()
+    except Exception as e:
+        # Django re-raises when quitting a socket that has already dropped,
+        # which would mask the error that led us here in the first place.
+        logging.warning(f'Error while closing the email connection: {e}')
+
+    connection.open()
+
+
+def with_smtp_connection(func):
+    """
+    Open a single connection for the whole duration of the decorated method
+
+    The connection is exposed as `self.connection` and closed on the way out.
+    Without it, every message goes through `send_mail()`, which opens and tears
+    down a connection per email. That handshake caps the real throughput far
+    below what the provider allows and makes large sends run into their task
+    time limit.
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        # `get_connection()` instantiates `settings.EMAIL_BACKEND`, so it either
+        # returns a backend or raises before the assignment. Every backend
+        # inherits `open()` and `close()` from `BaseEmailBackend`, where they
+        # are no-ops for the ones holding no socket.
+        self.connection = get_connection()
+        self.connection.open()
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            try:
+                self.connection.close()
+            except Exception as e:
+                logging.warning(f'Error while closing the email connection: {e}')
+            self.connection = None
+
+    return wrapper
 
 
 class EmailBackend(UpstreamEmailBackend):


### PR DESCRIPTION
### 📣 Summary

Some account emails, like storage limit warnings, were arriving days after they were triggered.

### 💭 Notes

Several fixes that together bring mass email delivery lag down:

- `kobo/apps/mass_emails/user_queries.py`: removed an N+1 query when resolving each organization's owner while building the recipient list. Already fixed on `main` by #7303 (DEV-2480), but that PR bundled it with the LLM usage queries feature, which isn't on `release/2.026.30` yet. This is a partial cherry-pick of #7303: only the `owner_by_org` query fix is kept.
- `kpi/utils/mailer.py`: added a `with_smtp_connection` decorator plus `is_connection_alive`/`reset_connection` helpers so `MassEmailSender.send_day_emails` reuses a single SMTP connection for the whole run instead of opening a new one per email (the handshake was the dominant cost per send). New coverage in `kpi/tests/test_mailer.py`.
- `kobo/settings/base.py`: `MAX_MASS_EMAILS_PER_DAY`, `MASS_EMAIL_THROTTLE_PER_SECOND`, and `MASS_EMAIL_SLEEP_SECONDS` are now environment variables instead of hardcoded, so the daily cap can be tuned without a code change.
- `kobo/apps/mass_emails/tasks.py`: `send_emails`'s `soft_time_limit` was equal to its `time_limit`, leaving no window to clean up before the hard kill. It's now `SEND_EMAILS_SOFT_LIMIT_BUFFER` (10s) lower. Separately, `MassEmailSender.send_email()`'s broad `except Exception` was catching `SoftTimeLimitExceeded` (it subclasses `Exception`) and marking the interrupted record `FAILED` - since record re-selection filters by `date_modified` regardless of status, that wrongly delayed the affected user's next email by a full `frequency` cycle. `send_email()` now re-raises it explicitly so it propagates through the SMTP connection's cleanup, and `send_emails()` catches it at the top level and returns normally instead of surfacing as a task failure, since the remaining `enqueued` records are picked up by the next scheduled run.

### 👀 Preview steps

This is a scheduled backend task with no UI surface, so the fix is best previewed through its regression tests rather than a manual walkthrough.

1. ℹ️ checkout this branch
2. 🔴 temporarily restore the pre-fix `send_emails`/`mailer` code and watch the SMTP connection-reuse tests fail:
   `git checkout 70818a538 -- kobo/apps/mass_emails/tasks.py kpi/utils/mailer.py`
   `docker exec kobofe-kpi-1 bash -c "cd /srv/src/kpi && pytest kobo/apps/mass_emails/tests/test_celery_tasks.py::TestMassEmailSenderConnection -v"`
   notice all 4 fail: without connection reuse, `connection.open`/`close` are called once per email instead of once per run, and the soft-limit test errors since the code it depends on doesn't exist yet
3. 🟢 restore the fix and rerun the same command: `git checkout 1baf269f7 -- kobo/apps/mass_emails/tasks.py kpi/utils/mailer.py`, all 4 pass
4. 🔴 now isolate the soft/hard time limit fix: `git checkout 1baf269f7~1 -- kobo/apps/mass_emails/tasks.py`
   `docker exec kobofe-kpi-1 bash -c "cd /srv/src/kpi && pytest kobo/apps/mass_emails/tests/test_celery_tasks.py -k soft_time_limit -v"`
   notice both fail: the interrupted record ends up `FAILED` instead of staying `enqueued`, and `SoftTimeLimitExceeded` propagates out of `send_emails()` instead of being caught
5. 🟢 restore the fix and rerun: `git checkout 1baf269f7 -- kobo/apps/mass_emails/tasks.py`, both pass
