### PR TITLE
fix(massEmails): don't resend after an ambiguous SMTP drop DEV-2675

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -318,10 +318,18 @@ class MassEmailSender:
                 # message the server simply refused. Only the former is worth
                 # reconnecting for, and it would otherwise fail every remaining
                 # record of the run.
+                #
+                # Don't resend this particular message on the fresh
+                # connection: a dropped connection can happen right after the
+                # server already accepted the message but before we read its
+                # acknowledgement, so we can't tell a lost send apart from a
+                # lost confirmation. Resending would risk a duplicate. Just
+                # reconnect for the records still to come and report this one
+                # failed, same as before the connection was reused across the
+                # whole run.
                 if not is_connection_alive(self.connection):
                     logging.warning('SMTP connection lost, reconnecting')
                     reset_connection(self.connection)
-                    sent = Mailer.send(message, connection=self.connection)
         except SoftTimeLimitExceeded:
             # Let this propagate: it must not be recorded as a failure. The
             # record stays `enqueued` and is picked up by the next run.

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -563,13 +563,13 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         for call in send_mock.call_args_list:
             assert call.kwargs['connection'] is connection
 
-    def test_dropped_connection_is_reset_and_the_record_retried(self):
+    def test_dropped_connection_is_reset_but_the_record_is_not_retried(self):
         connection = MagicMock()
         with (
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
                 'kobo.apps.mass_emails.tasks.Mailer.send',
-                side_effect=[False, True, True, True],
+                side_effect=[False, True, True],
             ) as send_mock,
             patch(
                 'kobo.apps.mass_emails.tasks.is_connection_alive', return_value=False
@@ -579,10 +579,13 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
             MassEmailSender().send_day_emails()
 
         assert reset_mock.call_count == 1
-        # Four sends for three records: the first one is retried on the fresh
-        # connection instead of being written off
-        assert send_mock.call_count == 4
-        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 3
+        # Three sends for three records: the first one is not retried on the
+        # fresh connection, since we can't tell a dropped connection apart
+        # from one that dropped right after the server accepted the message -
+        # resending it would risk a duplicate
+        assert send_mock.call_count == 3
+        assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
 
     def test_refused_recipient_does_not_reset_the_connection(self):
         connection = MagicMock()


### PR DESCRIPTION
### 📣 Summary

Under a rare connection hiccup, a mass account email could occasionally be sent twice to the same recipient.

### 💭 Notes

Greptile flagged this on [kpi#7433](https://github.com/kobotoolbox/kpi/pull/7433) (`chore(release): merge forward release/2.026.33 → main`, comment on `kobo/apps/mass_emails/tasks.py:324`):

> **Ambiguous SMTP failures get resent.** When the SMTP server accepts a message but the connection drops before the client receives the final acknowledgement, `Mailer.send()` reduces the exception to `False` and this branch resends the same message, causing the recipient to receive a duplicate while the record is stored as sent only once.

The flagged code isn't new to #7433 - it was introduced by [kpi#7431](https://github.com/kobotoolbox/kpi/pull/7431) (`perf(massEmails): reuse a single SMTP connection per send run`), which is where this comment should have landed, but the PR had already merged into `release/2.026.30` by the time #7433 (the automated merge-forward carrying that commit toward `main`) presented the diff for review there.

**Why this is a real regression, not a pre-existing issue.** Before #7431, every email opened and closed its own SMTP connection, and `send_email()` never retried a failed send - an ambiguous drop just meant the record was (possibly incorrectly) marked `FAILED`, with no risk of a duplicate. #7431 introduced connection reuse across a whole run for performance, and added a reconnect-and-resend step so one dead connection wouldn't fail every remaining record in the batch. That resend is what created the duplicate risk: `smtplib` raises the same `SMTPServerDisconnected` whether the connection died before anything was sent or right after the message was fully transmitted but before the final `250` was read, so the code can't tell a safe-to-retry drop apart from one that already reached the server.

**Fix scope**, deliberately narrow: `smtplib` doesn't expose enough to reliably distinguish those two cases without instrumenting the SMTP transaction ourselves, which is a bigger design question (tracked separately, not fixed here). So this reverts to the pre-#7431 outcome for this one case: on a dropped connection, `MassEmailSender.send_email()` still repairs the shared connection so the rest of the batch keeps going, but no longer resends the message that just failed - it's marked `FAILED`, same as it always was before the connection was shared across a run.

### 👀 Preview steps

Backend-only scheduled task, no UI surface. Verify with the updated regression test:

1. ℹ️ checkout this branch
2. 🔴 revert just the fix, keep the updated test: `git checkout e930a58d7~1 -- kobo/apps/mass_emails/tasks.py`
   `docker exec kobofe-kpi-1 bash -c "cd /srv/src/kpi && pytest kobo/apps/mass_emails/tests/test_celery_tasks.py -k dropped_connection -p no:xdist -v"`
   notice it fails: the old code resends (4 `Mailer.send()` calls for 3 records) and the first record ends up `SENT` instead of `FAILED`
3. 🟢 restore the fix and rerun: `git checkout e930a58d7 -- kobo/apps/mass_emails/tasks.py`, it passes
