### PR TITLE
fix(massEmails): stop OOM when generating send lists at scale DEV-2684

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -9,7 +9,7 @@ from constance import config
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
-from django.db.models import Count, Q
+from django.db.models import Count, Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext
 
@@ -56,24 +56,32 @@ def enqueue_mass_email_records(email_config):
     Creates a email job and enqueues email records for users based on query
     """
     job = MassEmailJob.objects.create(email_config=email_config)
-    users = get_users_for_config(email_config)
+    user_ids = get_users_for_config(email_config)
     # edge case: if a one-off email has no recipients, store a warning and turn
     # it off
-    if len(users) == 0 and email_config.type == EmailType.ONE_TIME:
+    if len(user_ids) == 0 and email_config.type == EmailType.ONE_TIME:
         logging.warning(
             f'No recipients found for one-time email config'
             f' {email_config.uid}: {email_config.name}. Turning it off.'
         )
         email_config.live = False
         email_config.save()
-    records = [
-        MassEmailRecord(user=user, email_job=job, status=EmailStatus.ENQUEUED)
-        for user in users
-    ]
-    MassEmailRecord.objects.bulk_create(records)
+
+    # Instantiating millions of unsaved MassEmailRecord objects at once is ~1 GB,
+    # so build and insert them in batches instead.
+    batch_size = 10000
+    total_created = 0
+    for start_idx in range(0, len(user_ids), batch_size):
+        end_idx = start_idx + batch_size
+        records = [
+            MassEmailRecord(user_id=user_id, email_job=job, status=EmailStatus.ENQUEUED)
+            for user_id in user_ids[start_idx:end_idx]
+        ]
+        MassEmailRecord.objects.bulk_create(records, batch_size=batch_size)
+        total_created += len(records)
 
     logging.info(
-        f'Created {len(records)} MassEmailRecord(s) for {email_config.name} '
+        f'Created {total_created} MassEmailRecord(s) for {email_config.name} '
         f'with query {email_config.query}'
     )
 
@@ -392,7 +400,7 @@ def send_emails():
 
 def get_users_for_config(email_config):
     """
-    Get users based on query, excluding recent recipients
+    Get user ids based on query, excluding recent recipients
 
     frequency = -1: One time email
     frequency = 1: Daily emails
@@ -400,8 +408,16 @@ def get_users_for_config(email_config):
     """
     now = timezone.now()
     users = email_config.get_users_queryset()
+    # `get_users_queryset()` returns a QuerySet for real queries but a plain list
+    # (e.g. `[]`) from the default fallback; normalize to a list of ids without
+    # materializing full User instances.
+    if isinstance(users, QuerySet):
+        user_ids = list(users.values_list('id', flat=True))
+    else:
+        user_ids = [getattr(user, 'id', user) for user in users]
+
     if email_config.frequency == -1:
-        return users
+        return user_ids
     day_boundary = MassEmailSender.get_cache_key_date(now)
 
     cutoff_date = day_boundary - timedelta(days=email_config.frequency - 1)
@@ -416,7 +432,7 @@ def get_users_for_config(email_config):
             date_modified__gte=cutoff_date
         ).values_list('user_id', flat=True)
     )
-    return [user for user in users if user.id not in recent_recipients]
+    return [user_id for user_id in user_ids if user_id not in recent_recipients]
 
 
 @celery_app.task(time_limit=TASK_TIMEOUT, soft_time_limit=TASK_TIMEOUT)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -69,7 +69,7 @@ def enqueue_mass_email_records(email_config):
 
     # Instantiating millions of unsaved MassEmailRecord objects at once is ~1 GB,
     # so build and insert them in batches instead.
-    batch_size = 10000
+    batch_size = max(1, settings.USAGE_QUERY_USER_ID_BATCH_SIZE)
     total_created = 0
     for start_idx in range(0, len(user_ids), batch_size):
         end_idx = start_idx + batch_size

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -23,6 +23,7 @@ from ..models import EmailStatus, MassEmailConfig, MassEmailJob, MassEmailRecord
 from ..tasks import (
     PROCESSED_EMAILS_CACHE_KEY,
     MassEmailSender,
+    enqueue_mass_email_records,
     generate_mass_email_user_lists,
     render_template,
     send_emails,
@@ -421,6 +422,28 @@ class GenerateDailyEmailUserListTaskTestCase(BaseMassEmailsTestCase):
         )
         self.assertEqual(records.count(), enqueued_count)
         self.assertIn(email_config.id, cache.get(self.cache_key))
+
+    def test_enqueue_creates_records_via_id_path(self):
+        """
+        enqueue_mass_email_records builds records from user ids (not User
+        instances) and stores one enqueued row per recipient.
+        """
+        email_config = self._create_email_config('Test')
+
+        enqueue_mass_email_records(email_config)
+
+        job = MassEmailJob.objects.filter(email_config=email_config).latest(
+            'date_created'
+        )
+        records = MassEmailRecord.objects.filter(email_job=job)
+        self.assertEqual(records.count(), 2)
+        self.assertEqual(
+            set(records.values_list('user_id', flat=True)),
+            {self.user1.id, self.user2.id},
+        )
+        self.assertTrue(
+            all(record.status == EmailStatus.ENQUEUED for record in records)
+        )
 
     def test_new_email_records_are_created_when_no_enqueued_emails_exist(self):
         """

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -551,6 +551,67 @@ class OrganizationsUtilsTestCase(BaseTestCase):
                 == 2
             )
 
+    def test_get_paid_subscription_limits_none_returns_all_orgs(self):
+        """
+        Passing None fetches limits for every org without building a giant
+        subscriber_id IN clause.
+        """
+        first_metadata = {
+            f'{UsageType.MT_CHARACTERS}_limit': '100',
+            'product_type': 'plan',
+            'plan_type': 'enterprise',
+        }
+        second_metadata = {
+            f'{UsageType.MT_CHARACTERS}_limit': '200',
+            'product_type': 'plan',
+            'plan_type': 'enterprise',
+        }
+        generate_plan_subscription(self.organization, metadata=first_metadata)
+        generate_plan_subscription(self.second_organization, metadata=second_metadata)
+
+        limits_by_org = {
+            row['org_id']: row for row in get_paid_subscription_limits(None)
+        }
+
+        assert self.organization.id in limits_by_org
+        assert self.second_organization.id in limits_by_org
+        assert (
+            limits_by_org[self.organization.id][f'{UsageType.MT_CHARACTERS}_limit']
+            == '100'
+        )
+        assert (
+            limits_by_org[self.second_organization.id][
+                f'{UsageType.MT_CHARACTERS}_limit'
+            ]
+            == '200'
+        )
+
+    def test_effective_limits_addon_merge_does_not_mutate_shared_default(self):
+        """
+        Orgs without a subscription share one default-limits object; merging a
+        one-time addon for one org must not change any other org's limits.
+        """
+        generate_free_plan()
+        submission_addon = _create_one_time_addon_product(
+            {f'{UsageType.SUBMISSION}_limit': '10'}
+        )
+        customer = baker.make(Customer, subscriber=self.organization)
+        _create_payment(
+            product=submission_addon,
+            price=submission_addon.default_price,
+            customer=customer,
+        )
+
+        results = get_organizations_effective_limits(include_onetime_addons=True)
+
+        # org with the addon gets the free-plan default (5000) plus the addon (10)
+        assert results[self.organization.id][f'{UsageType.SUBMISSION}_limit'] == 5010
+        # every other org keeps the untouched shared default
+        assert (
+            results[self.second_organization.id][f'{UsageType.SUBMISSION}_limit']
+            == 5000
+        )
+
     @data(
         (True, False, 'My plan'),
         (True, True, 'My plan and My addon'),

--- a/kobo/apps/stripe/utils/billing_dates.py
+++ b/kobo/apps/stripe/utils/billing_dates.py
@@ -1,5 +1,6 @@
 import calendar
 from datetime import datetime
+from types import MappingProxyType
 from zoneinfo import ZoneInfo
 
 from dateutil.relativedelta import relativedelta
@@ -23,9 +24,11 @@ def get_current_billing_period_dates_by_org(
     first_of_next_month = first_of_this_month + relativedelta(months=1)
 
     if not settings.STRIPE_ENABLED:
-        # Callers only read these dates, so share one object across all orgs and
-        # stream ids to avoid loading millions of full Organization instances.
-        shared_dates = {'start': first_of_this_month, 'end': first_of_next_month}
+        # Share one read-only dates mapping across all orgs and stream ids to
+        # avoid loading millions of full Organization instances.
+        shared_dates = MappingProxyType(
+            {'start': first_of_this_month, 'end': first_of_next_month}
+        )
         results = {}
         if orgs is not None:
             for org in orgs:
@@ -81,9 +84,12 @@ def get_current_billing_period_dates_by_org(
             }
         return results
 
-    # Share one dates object across every default org and stream ids to avoid
-    # loading millions of full instances and shipping a giant NOT-IN clause.
-    shared_dates = {'start': first_of_this_month, 'end': first_of_next_month}
+    # Share one read-only dates mapping across every default org and stream ids
+    # to avoid loading millions of full instances and shipping a giant NOT-IN
+    # clause.
+    shared_dates = MappingProxyType(
+        {'start': first_of_this_month, 'end': first_of_next_month}
+    )
     for org_id in Organization.objects.values_list('id', flat=True).iterator():
         if org_id in already_seen:
             continue

--- a/kobo/apps/stripe/utils/billing_dates.py
+++ b/kobo/apps/stripe/utils/billing_dates.py
@@ -23,28 +23,28 @@ def get_current_billing_period_dates_by_org(
     first_of_next_month = first_of_this_month + relativedelta(months=1)
 
     if not settings.STRIPE_ENABLED:
+        # Callers only read these dates, so share one object across all orgs and
+        # stream ids to avoid loading millions of full Organization instances.
+        shared_dates = {'start': first_of_this_month, 'end': first_of_next_month}
         results = {}
         if orgs is not None:
             for org in orgs:
-                results[org.id] = {
-                    'start': first_of_this_month,
-                    'end': first_of_next_month,
-                }
+                results[org.id] = shared_dates
             return results
 
-        for org in Organization.objects.all():
-            results[org.id] = {'start': first_of_this_month, 'end': first_of_next_month}
+        for org_id in Organization.objects.values_list('id', flat=True).iterator():
+            results[org_id] = shared_dates
         return results
 
     # check 1: look for active subscriptions
     all_active_billing_dates = get_current_billing_period_dates_for_active_plans(orgs)
 
     results = {}
-    already_seen = []
+    already_seen = set()
     remaining_orgs = []
     for org_id, dates in all_active_billing_dates.items():
         results[org_id] = dates
-        already_seen.append(org_id)
+        already_seen.add(org_id)
 
     # check 2: look for canceled subscriptions
     if orgs is not None:
@@ -69,7 +69,7 @@ def get_current_billing_period_dates_by_org(
     for org_id, dates in all_canceled_billing_dates.items():
         # prioritize active subscriptions over canceled ones
         results[org_id] = results.get(org_id) or dates
-        already_seen.append(org_id)
+        already_seen.add(org_id)
 
     # default: beginning of this month and beginning of next month
     if orgs is not None:
@@ -81,11 +81,13 @@ def get_current_billing_period_dates_by_org(
             }
         return results
 
-    for org in Organization.objects.filter(~Q(id__in=already_seen)):
-        results[org.id] = {
-            'start': first_of_this_month,
-            'end': first_of_next_month,
-        }
+    # Share one dates object across every default org and stream ids to avoid
+    # loading millions of full instances and shipping a giant NOT-IN clause.
+    shared_dates = {'start': first_of_this_month, 'end': first_of_next_month}
+    for org_id in Organization.objects.values_list('id', flat=True).iterator():
+        if org_id in already_seen:
+            continue
+        results[org_id] = shared_dates
     return results
 
 

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -1,4 +1,6 @@
+from copy import deepcopy
 from math import inf
+from types import MappingProxyType
 from typing import Optional
 
 from django.apps import apps
@@ -161,20 +163,21 @@ def get_organizations_subscription_limits(
         else:
             default_plan_limits[limit_key] = default_limit
 
-    # The vast majority of orgs have no subscription row and therefore identical, pure
-    # default limits. Build that dict once and share the same object across all
-    # such orgs instead of allocating millions of identical dicts. Callers that mutate
-    # a returned dict (e.g. the addon merge in
-    # `get_organizations_effective_limits`) MUST copy it first.
-    default_limits = {}
-    for usage_type, _ in UsageType.choices:
-        default_limits[f'{usage_type}_limit'] = determine_limit(
-            usage_type,
-            None,
-            None,
-            default_plan_limits[f'{usage_type}_limit'],
-            include_storage_addons,
-        )
+    # The vast majority of orgs have no subscription row and therefore identical,
+    # pure default limits: build them once and share one read-only mapping across
+    # all such orgs instead of allocating millions of identical dicts.
+    default_limits = MappingProxyType(
+        {
+            f'{usage_type}_limit': determine_limit(
+                usage_type,
+                None,
+                None,
+                default_plan_limits[f'{usage_type}_limit'],
+                include_storage_addons,
+            )
+            for usage_type, _ in UsageType.choices
+        }
+    )
 
     results = {}
     for org_id in all_org_ids:
@@ -232,9 +235,8 @@ def get_organizations_effective_limits(
         else:
             # Avoid loading millions of full Organization instances just to read ids.
             org_ids = Organization.objects.values_list('id', flat=True).iterator()
-        # Share one default-limits object across all orgs; callers that mutate a
-        # returned dict must copy it first.
-        shared_default_limits = _get_default_usage_limits()
+        # Share one read-only default-limits mapping across all orgs.
+        shared_default_limits = MappingProxyType(_get_default_usage_limits())
         return {org_id: shared_default_limits for org_id in org_ids}
 
     effective_limits = get_organizations_subscription_limits(
@@ -248,9 +250,9 @@ def get_organizations_effective_limits(
             limits = effective_limits.get(org_id)
             if limits is None:
                 continue
-            # `limits` may be the shared default object reused across orgs; copy
-            # before mutating so we don't corrupt every other org's limits.
-            limits = dict(limits)
+            # `limits` may be the read-only default mapping shared across orgs;
+            # copy before mutating (`dict()` first: deepcopy rejects mappingproxy)
+            limits = deepcopy(dict(limits))
             for usage_type, _ in UsageType.choices:
                 addon = org_addons.get(f'total_{usage_type}_limit', 0)
                 limits[f'{usage_type}_limit'] += addon

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -107,13 +107,16 @@ def get_organizations_subscription_limits(
 
     # determine which orgs we care about and get their ids
     if organizations is not None:
-        orgs = organizations
+        all_org_ids = [org.id for org in organizations]
     else:
-        orgs = Organization.objects.all()
-    all_org_ids = [org.id for org in orgs]
+        # Avoid loading millions of full Organization instances just to read ids.
+        all_org_ids = list(Organization.objects.values_list('id', flat=True))
 
-    # get paid subscription limits
-    subscription_limits = get_paid_subscription_limits(all_org_ids)
+    # get paid subscription limits; pass None through when we want all orgs so
+    # `get_paid_subscription_limits` skips building a giant IN clause
+    subscription_limits = get_paid_subscription_limits(
+        all_org_ids if organizations is not None else None
+    )
     subscription_limits_by_org_id = {}
     for row in subscription_limits:
         row_limits = subscription_limits_by_org_id.get(row['org_id'], {})
@@ -158,16 +161,31 @@ def get_organizations_subscription_limits(
         else:
             default_plan_limits[limit_key] = default_limit
 
+    # The vast majority of orgs have no subscription row and therefore identical, pure
+    # default limits. Build that dict once and share the same object across all
+    # such orgs instead of allocating millions of identical dicts. Callers that mutate
+    # a returned dict (e.g. the addon merge in
+    # `get_organizations_effective_limits`) MUST copy it first.
+    default_limits = {}
+    for usage_type, _ in UsageType.choices:
+        default_limits[f'{usage_type}_limit'] = determine_limit(
+            usage_type,
+            None,
+            None,
+            default_plan_limits[f'{usage_type}_limit'],
+            include_storage_addons,
+        )
+
     results = {}
     for org_id in all_org_ids:
+        org_subscription = subscription_limits_by_org_id.get(org_id)
+        if org_subscription is None:
+            results[org_id] = default_limits
+            continue
         all_org_limits = {}
         for usage_type, _ in UsageType.choices:
-            plan_limit = subscription_limits_by_org_id.get(org_id, {}).get(
-                f'{usage_type}_limit'
-            )
-            addon_limit = subscription_limits_by_org_id.get(org_id, {}).get(
-                'addon_storage_limit'
-            )
+            plan_limit = org_subscription.get(f'{usage_type}_limit')
+            addon_limit = org_subscription.get('addon_storage_limit')
             default_limit = default_plan_limits[f'{usage_type}_limit']
             limit = determine_limit(
                 usage_type,
@@ -209,24 +227,41 @@ def get_organizations_effective_limits(
     """
 
     if not settings.STRIPE_ENABLED:
-        orgs = organizations or Organization.objects.all()
-        return {org.id: _get_default_usage_limits() for org in orgs}
+        if organizations is not None:
+            org_ids = [org.id for org in organizations]
+        else:
+            # Avoid loading millions of full Organization instances just to read ids.
+            org_ids = Organization.objects.values_list('id', flat=True).iterator()
+        # Share one default-limits object across all orgs; callers that mutate a
+        # returned dict must copy it first.
+        shared_default_limits = _get_default_usage_limits()
+        return {org_id: shared_default_limits for org_id in org_ids}
 
     effective_limits = get_organizations_subscription_limits(
         include_storage_addons=include_storage_addons, organizations=organizations
     )
     if include_onetime_addons:
         PlanAddOn = apps.get_model('stripe', 'PlanAddOn')  # noqa
+        # `addon_limits` is keyed only by the (small) set of orgs holding addons.
         addon_limits = PlanAddOn.get_organizations_totals(organizations=organizations)
-        for org_id, limits in effective_limits.items():
+        for org_id, org_addons in addon_limits.items():
+            limits = effective_limits.get(org_id)
+            if limits is None:
+                continue
+            # `limits` may be the shared default object reused across orgs; copy
+            # before mutating so we don't corrupt every other org's limits.
+            limits = dict(limits)
             for usage_type, _ in UsageType.choices:
-                addon = addon_limits.get(org_id, {}).get(f'total_{usage_type}_limit', 0)
+                addon = org_addons.get(f'total_{usage_type}_limit', 0)
                 limits[f'{usage_type}_limit'] += addon
+            effective_limits[org_id] = limits
     return effective_limits
 
 
 @requires_stripe
-def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> QuerySet:
+def get_paid_subscription_limits(
+    organization_ids: list[str] | None = None, **kwargs
+) -> QuerySet:
     """
     Return the most recent limits for all usage types for given organizations based on
     their most recent subscriptions. If they have both a regular plan and an addon,
@@ -256,14 +291,15 @@ def get_paid_subscription_limits(organization_ids: list[str], **kwargs) -> Query
         _get_subscription_metadata_fields_for_usage_type(UsageType.LOG_LOOKBACK_DAYS)
     )
 
-    # Get organizations we care about (either those in the 'organizations' param or all)
-    org_filter = Q(customer__subscriber_id__in=[org_id for org_id in organization_ids])
-
-    active_subscriptions = Subscription.objects.filter(
-        org_filter
-        & Q(status__in=ACTIVE_STRIPE_STATUSES)
-        & Q(items__price__product__metadata__product_type__in=['plan', 'addon'])
+    subscription_filter = Q(status__in=ACTIVE_STRIPE_STATUSES) & Q(
+        items__price__product__metadata__product_type__in=['plan', 'addon']
     )
+    # Restrict to the requested orgs only when a list is given: a multi-million-element
+    # `subscriber_id__in` IN clause is a multi-MB SQL string. `None` means all.
+    if organization_ids is not None:
+        subscription_filter &= Q(customer__subscriber_id__in=organization_ids)
+
+    active_subscriptions = Subscription.objects.filter(subscription_filter)
 
     most_recent_subs = (
         active_subscriptions.values(

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -2434,3 +2434,8 @@ ACCESS_LOG_LIFESPAN = env.int('ACCESS_LOG_LIFESPAN', 744)
 LAST_PROJECT_ACTIVITY_THROTTLE_SECONDS = env.int(
     'LAST_PROJECT_ACTIVITY_THROTTLE_SECONDS', 3600  # seconds
 )
+
+# Fleet-wide usage queries filter on `user_id__in=<all users>`; at full scale
+# that is a multi-million-element IN clause. Split it into chunks of this size
+# and run one query per chunk.
+USAGE_QUERY_USER_ID_CHUNK_SIZE = env.int('USAGE_QUERY_USER_ID_CHUNK_SIZE', 20000)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -2396,6 +2396,7 @@ LONG_RUNNING_MIGRATION_SMALL_BATCH_SIZE = 100
 VERSION_DELETION_BATCH_SIZE = 2000
 S3_DELETE_BATCH_SIZE = 1000
 AZURE_DELETE_BATCH_SIZE = 256
+USAGE_QUERY_USER_ID_BATCH_SIZE = 20000
 
 # Number of stuck tasks should be restarted at a time
 MAX_RESTARTED_TASKS = 100
@@ -2434,8 +2435,3 @@ ACCESS_LOG_LIFESPAN = env.int('ACCESS_LOG_LIFESPAN', 744)
 LAST_PROJECT_ACTIVITY_THROTTLE_SECONDS = env.int(
     'LAST_PROJECT_ACTIVITY_THROTTLE_SECONDS', 3600  # seconds
 )
-
-# Fleet-wide usage queries filter on `user_id__in=<all users>`; at full scale
-# that is a multi-million-element IN clause. Split it into chunks of this size
-# and run one query per chunk.
-USAGE_QUERY_USER_ID_CHUNK_SIZE = env.int('USAGE_QUERY_USER_ID_CHUNK_SIZE', 20000)

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -431,6 +431,44 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
     )
+    def test_submission_counters_chunked_queries_match_unchunked(self):
+        """
+        A billing window whose user list spans multiple chunks must return
+        the same totals as a single-query run.
+        """
+        six_months_ago = timezone.now() - relativedelta(months=6)
+        six_months_from_now = six_months_ago + relativedelta(years=1)
+        shared_window = {'start': six_months_ago, 'end': six_months_from_now}
+        mock_billing_periods = {
+            self.someuser.organization.id: shared_window,
+            self.anotheruser.organization.id: shared_window,
+        }
+        asset_2 = self._create_asset(self.someuser)
+        three_months_ago = timezone.now() - relativedelta(months=3)
+        self.add_submissions(
+            count=2, asset=asset_2, username='someuser', date_override=three_months_ago
+        )
+
+        with patch(
+            'kpi.utils.usage_calculator.get_current_billing_period_dates_by_org',
+            return_value=mock_billing_periods,
+        ):
+            unchunked = get_submissions_for_current_billing_period_by_user_id()
+            # both users now share one window, so a chunk size of 1 forces the
+            # multi-chunk merge path
+            with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=1):
+                chunked = get_submissions_for_current_billing_period_by_user_id()
+            # a misconfigured chunk size must clamp to 1, not crash or skip
+            with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=0):
+                clamped = get_submissions_for_current_billing_period_by_user_id()
+
+        assert chunked == unchunked
+        assert clamped == unchunked
+        assert chunked[self.someuser.id] == 2
+
+    @pytest.mark.skipif(
+        not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
+    )
     def test_nlp_counters_current_period_all_orgs(self):
         six_months_ago = timezone.now() - relativedelta(months=6)
         six_months_from_now = six_months_ago + relativedelta(years=1)

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -456,11 +456,11 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
             unchunked = get_submissions_for_current_billing_period_by_user_id()
             # both users now share one window, so a chunk size of 1 forces the
             # multi-chunk merge path
-            with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=1):
+            with override_settings(USAGE_QUERY_USER_ID_BATCH_SIZE=1):
                 chunked = get_submissions_for_current_billing_period_by_user_id()
             # a misconfigured chunk size must clamp to 1, not crash or
             # silently skip users
-            with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=0):
+            with override_settings(USAGE_QUERY_USER_ID_BATCH_SIZE=0):
                 clamped = get_submissions_for_current_billing_period_by_user_id()
 
         assert chunked == unchunked

--- a/kpi/tests/test_usage_calculator.py
+++ b/kpi/tests/test_usage_calculator.py
@@ -458,7 +458,8 @@ class ServiceUsageCalculatorTestCase(BaseServiceUsageTestCase):
             # multi-chunk merge path
             with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=1):
                 chunked = get_submissions_for_current_billing_period_by_user_id()
-            # a misconfigured chunk size must clamp to 1, not crash or skip
+            # a misconfigured chunk size must clamp to 1, not crash or
+            # silently skip users
             with override_settings(USAGE_QUERY_USER_ID_CHUNK_SIZE=0):
                 clamped = get_submissions_for_current_billing_period_by_user_id()
 

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -62,38 +62,44 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
 
     NLPUsageCounter = apps.get_model('trackers', 'NLPUsageCounter')  # noqa
 
+    chunk_size = settings.USAGE_QUERY_USER_ID_CHUNK_SIZE
     results = {}
     for (start, end), user_ids in windows.items():
-        nlp_tracking = (
-            NLPUsageCounter.objects.filter(
-                user_id__in=user_ids, date__range=[start, end]
+        for start_idx in range(0, len(user_ids), chunk_size):
+            end_idx = start_idx + chunk_size
+            chunk = user_ids[start_idx:end_idx]
+            nlp_tracking = (
+                NLPUsageCounter.objects.filter(
+                    user_id__in=chunk, date__range=[start, end]
+                )
+                .values('user_id')
+                .annotate(
+                    asr_seconds_current_period=Coalesce(
+                        Sum(f'total_{UsageType.ASR_SECONDS}'),
+                        0,
+                    ),
+                    mt_characters_current_period=Coalesce(
+                        Sum(f'total_{UsageType.MT_CHARACTERS}'),
+                        0,
+                    ),
+                    llm_requests_current_period=Coalesce(
+                        Sum(f'total_{UsageType.LLM_REQUESTS}'),
+                        0,
+                    ),
+                )
             )
-            .values('user_id')
-            .annotate(
-                asr_seconds_current_period=Coalesce(
-                    Sum(f'total_{UsageType.ASR_SECONDS}'),
-                    0,
-                ),
-                mt_characters_current_period=Coalesce(
-                    Sum(f'total_{UsageType.MT_CHARACTERS}'),
-                    0,
-                ),
-                llm_requests_current_period=Coalesce(
-                    Sum(f'total_{UsageType.LLM_REQUESTS}'),
-                    0,
-                ),
-            )
-        )
-        for row in nlp_tracking:
-            results[row['user_id']] = {
-                UsageType.ASR_SECONDS: row[f'{UsageType.ASR_SECONDS}_current_period'],
-                UsageType.MT_CHARACTERS: row[
-                    f'{UsageType.MT_CHARACTERS}_current_period'
-                ],
-                UsageType.LLM_REQUESTS: row[
-                    f'{UsageType.LLM_REQUESTS}_current_period'
-                ],
-            }
+            for row in nlp_tracking:
+                results[row['user_id']] = {
+                    UsageType.ASR_SECONDS: row[
+                        f'{UsageType.ASR_SECONDS}_current_period'
+                    ],
+                    UsageType.MT_CHARACTERS: row[
+                        f'{UsageType.MT_CHARACTERS}_current_period'
+                    ],
+                    UsageType.LLM_REQUESTS: row[
+                        f'{UsageType.LLM_REQUESTS}_current_period'
+                    ],
+                }
     return results
 
 
@@ -112,17 +118,21 @@ def get_submission_counts_in_date_range_by_user_id(
 ) -> dict[int, int]:
     windows = group_user_ids_by_date_range(date_ranges_by_user)
 
+    chunk_size = settings.USAGE_QUERY_USER_ID_CHUNK_SIZE
     results = {}
     for (start, end), user_ids in windows.items():
-        rows = (
-            DailyXFormSubmissionCounter.objects.filter(
-                user_id__in=user_ids, date__range=[start, end]
+        for start_idx in range(0, len(user_ids), chunk_size):
+            end_idx = start_idx + chunk_size
+            chunk = user_ids[start_idx:end_idx]
+            rows = (
+                DailyXFormSubmissionCounter.objects.filter(
+                    user_id__in=chunk, date__range=[start, end]
+                )
+                .values('user_id')
+                .annotate(total=Coalesce(Sum('counter'), 0))
             )
-            .values('user_id')
-            .annotate(total=Coalesce(Sum('counter'), 0))
-        )
-        for row in rows:
-            results[row['user_id']] = row['total']
+            for row in rows:
+                results[row['user_id']] = row['total']
     return results
 
 

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -62,7 +62,8 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
 
     NLPUsageCounter = apps.get_model('trackers', 'NLPUsageCounter')  # noqa
 
-    # clamp: 0 would make range() raise, a negative value would skip every chunk
+    # clamp: 0 would make range() raise, a negative value would skip
+    # every chunk
     chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():
@@ -119,7 +120,8 @@ def get_submission_counts_in_date_range_by_user_id(
 ) -> dict[int, int]:
     windows = group_user_ids_by_date_range(date_ranges_by_user)
 
-    # clamp: 0 would make range() raise, a negative value would skip every chunk
+    # clamp: 0 would make range() raise, a negative value would skip
+    # every chunk
     chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -64,7 +64,7 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
 
     # clamp: 0 would make range() raise, a negative value would skip
     # every chunk
-    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
+    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_BATCH_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():
         for start_idx in range(0, len(user_ids), chunk_size):
@@ -122,7 +122,7 @@ def get_submission_counts_in_date_range_by_user_id(
 
     # clamp: 0 would make range() raise, a negative value would skip
     # every chunk
-    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
+    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_BATCH_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():
         for start_idx in range(0, len(user_ids), chunk_size):

--- a/kpi/utils/usage_calculator.py
+++ b/kpi/utils/usage_calculator.py
@@ -62,7 +62,8 @@ def get_nlp_usage_in_date_range_by_user_id(date_ranges_by_user) -> dict[int, NLP
 
     NLPUsageCounter = apps.get_model('trackers', 'NLPUsageCounter')  # noqa
 
-    chunk_size = settings.USAGE_QUERY_USER_ID_CHUNK_SIZE
+    # clamp: 0 would make range() raise, a negative value would skip every chunk
+    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():
         for start_idx in range(0, len(user_ids), chunk_size):
@@ -118,7 +119,8 @@ def get_submission_counts_in_date_range_by_user_id(
 ) -> dict[int, int]:
     windows = group_user_ids_by_date_range(date_ranges_by_user)
 
-    chunk_size = settings.USAGE_QUERY_USER_ID_CHUNK_SIZE
+    # clamp: 0 would make range() raise, a negative value would skip every chunk
+    chunk_size = max(1, settings.USAGE_QUERY_USER_ID_CHUNK_SIZE)
     results = {}
     for (start, end), user_ids in windows.items():
         for start_idx in range(0, len(user_ids), chunk_size):


### PR DESCRIPTION
## 📣 Summary
Automated emails, like usage limit alerts, go out again on very large servers.

## 📖 Description
On servers with millions of accounts, the daily job that prepares email recipient lists ran out of memory and stopped, so no emails were sent. The job now uses a fraction of the memory and the emails are sent as expected.

## 💭 Notes
- The pipeline loaded full User/Organization objects and built a dict per org for the whole fleet: several GB of memory on large instances, worker OOM-killed, failure silent (transaction rolls back, "done for today" flag never set, send task skips).
- Fix: ids via `values_list`, one shared default limits/dates dict (the addon merge copies before mutating; a test pins that), no giant `IN` clauses (`None` now means "all orgs"; per-user usage queries run in batches via `USAGE_QUERY_USER_ID_BATCH_SIZE`, default 20000 and clamped to at least 1), records enqueued by `user_id` in batches.
- Repro at 50k users: peak went from 94.4 MB to 22.5 MB, same 50,010 records.

## 👀 Preview steps
Backend only. Seed 50k users and run `enqueue_mass_email_records` under `tracemalloc`:
1. 🔴 on the base branch: peak ~94 MB for 50k recipients, growing ~2 KB per user, so several GB at production scale
2. 🟢 on this PR: peak ~22 MB, identical records created
