### PR TITLE
feat(massEmails): pace sends against the provider rate limit DEV-2681

### DIFF
--- a/kobo/apps/mass_emails/checks.py
+++ b/kobo/apps/mass_emails/checks.py
@@ -46,20 +46,6 @@ def check_mass_email_send_settings(app_configs, **kwargs):
             )
         )
 
-    if settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS <= 0:
-        errors.append(
-            Error(
-                f'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS is '
-                f'{settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS}, but must '
-                f'be greater than 0.',
-                hint=(
-                    'Set the MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS '
-                    'environment variable to a positive number.'
-                ),
-                id='mass_emails.E003',
-            )
-        )
-
     if settings.MAILER_CONNECTION_IDLE_TIMEOUT <= 0:
         errors.append(
             Error(
@@ -70,7 +56,7 @@ def check_mass_email_send_settings(app_configs, **kwargs):
                     'Set the MAILER_CONNECTION_IDLE_TIMEOUT environment '
                     'variable to a positive number.'
                 ),
-                id='mass_emails.E004',
+                id='mass_emails.E003',
             )
         )
 

--- a/kobo/apps/mass_emails/checks.py
+++ b/kobo/apps/mass_emails/checks.py
@@ -28,17 +28,19 @@ def check_mass_email_send_settings(app_configs, **kwargs):
             )
         )
 
-    if not (0 < settings.MASS_EMAIL_SEND_RATE_RATIO <= 0.5):
+    if not (0 < settings.MASS_EMAIL_SEND_RATE_RATIO <= 1.0):
         errors.append(
             Error(
                 f'MASS_EMAIL_SEND_RATE_RATIO is '
                 f'{settings.MASS_EMAIL_SEND_RATE_RATIO}, but must be greater '
-                f'than 0 and at most 0.5.',
+                f'than 0 and at most 1.',
                 hint=(
                     'Set the MASS_EMAIL_SEND_RATE_RATIO environment variable '
-                    'to a value between 0 (exclusive) and 0.5 (inclusive), '
-                    'so two full budget windows landing back to back still '
-                    "can't exceed the provider's real rate limit."
+                    'to a value between 0 (exclusive) and 1 (inclusive). '
+                    '0.5 or below is recommended so two full budget windows '
+                    "landing back to back still can't exceed the provider's "
+                    'real rate limit; above that is allowed but at the risk '
+                    'of bursting past it near a window boundary.'
                 ),
                 id='mass_emails.E002',
             )

--- a/kobo/apps/mass_emails/checks.py
+++ b/kobo/apps/mass_emails/checks.py
@@ -28,17 +28,47 @@ def check_mass_email_send_settings(app_configs, **kwargs):
             )
         )
 
-    if settings.MASS_EMAIL_SLEEP_SECONDS < 0:
+    if not (0 < settings.MASS_EMAIL_SEND_RATE_RATIO <= 0.5):
         errors.append(
             Error(
-                f'MASS_EMAIL_SLEEP_SECONDS is '
-                f'{settings.MASS_EMAIL_SLEEP_SECONDS}, but must not be '
-                f'negative.',
+                f'MASS_EMAIL_SEND_RATE_RATIO is '
+                f'{settings.MASS_EMAIL_SEND_RATE_RATIO}, but must be greater '
+                f'than 0 and at most 0.5.',
                 hint=(
-                    'Set the MASS_EMAIL_SLEEP_SECONDS environment variable '
-                    'to 0 or a positive integer.'
+                    'Set the MASS_EMAIL_SEND_RATE_RATIO environment variable '
+                    'to a value between 0 (exclusive) and 0.5 (inclusive), '
+                    'so two full budget windows landing back to back still '
+                    "can't exceed the provider's real rate limit."
                 ),
                 id='mass_emails.E002',
+            )
+        )
+
+    if settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS <= 0:
+        errors.append(
+            Error(
+                f'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS is '
+                f'{settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS}, but must '
+                f'be greater than 0.',
+                hint=(
+                    'Set the MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS '
+                    'environment variable to a positive number.'
+                ),
+                id='mass_emails.E003',
+            )
+        )
+
+    if settings.MAILER_CONNECTION_IDLE_TIMEOUT <= 0:
+        errors.append(
+            Error(
+                f'MAILER_CONNECTION_IDLE_TIMEOUT is '
+                f'{settings.MAILER_CONNECTION_IDLE_TIMEOUT}, but must be '
+                f'greater than 0.',
+                hint=(
+                    'Set the MAILER_CONNECTION_IDLE_TIMEOUT environment '
+                    'variable to a positive number.'
+                ),
+                id='mass_emails.E004',
             )
         )
 

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -306,9 +306,9 @@ class MassEmailSender:
                         sleep(remaining)
                     window_start = monotonic()
                     spent_in_window = 0
+                self.send_email(email_config, record)
                 self.cache_limit_value(email_config, self.limits[email_config.id] - 1)
                 self.cache_limit_value(None, self.total_limit - 1)
-                self.send_email(email_config, record)
                 spent_in_window += 1
 
     def send_email(self, email_config, record):

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -345,11 +345,10 @@ class MassEmailSender:
             # run there. The record stays `enqueued` for the next run.
             raise
         except MailerProviderRateThrottledError as e:
-            logging.warning(
-                f'Provider rate limit hit, cooling down for '
-                f'{settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS}s: {e}'
-            )
-            sleep(settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS)
+            logging.warning(f'Provider rate limit hit, stopping this run: {e}')
+            # TODO(DEV-2693): needs its own non-blocking cooldown instead of
+            # being treated exactly like a quota-exhausted stop.
+            raise
         except MailerError as e:
             logging.warning(f'Error sending record {record}: {e}')
             record.status = EmailStatus.FAILED
@@ -386,7 +385,7 @@ def send_emails():
     sender = MassEmailSender()
     try:
         sender.send_day_emails()
-    except MailerProviderQuotaExhaustedError:
+    except (MailerProviderQuotaExhaustedError, MailerProviderRateThrottledError):
         # Already logged in `send_email()`. Nothing left to do this run: the
         # remaining `enqueued` records are picked up by the next hourly run.
         pass

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, time, timedelta
 from enum import Enum
 from math import ceil
-from time import sleep
+from time import monotonic, sleep
 from typing import Optional
 
 from celery.exceptions import SoftTimeLimitExceeded
@@ -22,14 +22,13 @@ from kobo.apps.mass_emails.models import (
 )
 from kobo.apps.organizations.models import OrganizationUser
 from kobo.celery import celery_app
-from kpi.utils.log import logging
-from kpi.utils.mailer import (
-    EmailMessage,
-    Mailer,
-    is_connection_alive,
-    reset_connection,
-    with_smtp_connection,
+from kpi.exceptions import (
+    MailerError,
+    MailerProviderQuotaExhaustedError,
+    MailerProviderRateThrottledError,
 )
+from kpi.utils.log import logging
+from kpi.utils.mailer import EmailMessage, Mailer, with_smtp_connection
 
 if settings.STRIPE_ENABLED:
     from kobo.apps.stripe.utils.subscription_limits import get_plan_name
@@ -269,9 +268,18 @@ class MassEmailSender:
 
     @with_smtp_connection
     def send_day_emails(self):
-        emails_sent = 0
-
-        batch_size = settings.MASS_EMAIL_THROTTLE_PER_SECOND
+        # Claim only a share of the provider's real per-second limit: it
+        # also carries transactional email, which draws on the same budget
+        # without going through this throttle.
+        budget_per_second = max(
+            1,
+            int(
+                settings.MASS_EMAIL_THROTTLE_PER_SECOND
+                * settings.MASS_EMAIL_SEND_RATE_RATIO
+            ),
+        )
+        window_start = monotonic()
+        spent_in_window = 0
 
         for email_config in self.configs:
             limit = self.limits.get(email_config.id)
@@ -285,13 +293,23 @@ class MassEmailSender:
                 f'Processing {limit} records for MassEmailConfig({email_config})'
             )
             for record in records:
-                if emails_sent > 0 and emails_sent % batch_size == 0:
-                    logging.info(f'sleeping for {settings.MASS_EMAIL_SLEEP_SECONDS}')
-                    sleep(settings.MASS_EMAIL_SLEEP_SECONDS)
+                if spent_in_window >= budget_per_second:
+                    # The provider counts in 1-second windows, so ours must
+                    # too: sleep only what's left of the current one rather
+                    # than a fixed amount.
+                    remaining = 1 - (monotonic() - window_start)
+                    if remaining > 0:
+                        logging.info(
+                            f'sleeping for {remaining:.3f}s to stay within '
+                            f'the per-second budget'
+                        )
+                        sleep(remaining)
+                    window_start = monotonic()
+                    spent_in_window = 0
                 self.cache_limit_value(email_config, self.limits[email_config.id] - 1)
                 self.cache_limit_value(None, self.total_limit - 1)
                 self.send_email(email_config, record)
-                emails_sent += 1
+                spent_in_window += 1
 
     def send_email(self, email_config, record):
         logging.info(f'Processing MassEmailRecord({record})')
@@ -311,38 +329,38 @@ class MassEmailSender:
             html_content_or_template=content,
         )
         try:
-            sent = Mailer.send(message, connection=self.connection)
-            if not sent and self.connection is not None:
-                # `Mailer.send()` reports any SMTP error as a plain `False`, so
-                # probe the socket to tell a dropped connection apart from a
-                # message the server simply refused. Only the former is worth
-                # reconnecting for, and it would otherwise fail every remaining
-                # record of the run.
-                #
-                # Don't resend this particular message on the fresh
-                # connection: a dropped connection can happen right after the
-                # server already accepted the message but before we read its
-                # acknowledgement, so we can't tell a lost send apart from a
-                # lost confirmation. Resending would risk a duplicate. Just
-                # reconnect for the records still to come and report this one
-                # failed, same as before the connection was reused across the
-                # whole run.
-                if not is_connection_alive(self.connection):
-                    logging.warning('SMTP connection lost, reconnecting')
-                    reset_connection(self.connection)
+            Mailer.send(
+                message,
+                connection=self.connection,
+                idle_timeout=settings.MAILER_CONNECTION_IDLE_TIMEOUT,
+            )
         except SoftTimeLimitExceeded:
             # Let this propagate: it must not be recorded as a failure. The
             # record stays `enqueued` and is picked up by the next run.
             raise
+        except MailerProviderQuotaExhaustedError as e:
+            logging.warning(f'Daily quota exhausted, stopping this run: {e}')
+            # Let this propagate, same as `SoftTimeLimitExceeded`: it must
+            # not be recorded as a failure, and `send_emails()` stops the
+            # run there. The record stays `enqueued` for the next run.
+            raise
+        except MailerProviderRateThrottledError as e:
+            logging.warning(
+                f'Provider rate limit hit, cooling down for '
+                f'{settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS}s: {e}'
+            )
+            sleep(settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS)
+        except MailerError as e:
+            logging.warning(f'Error sending record {record}: {e}')
+            record.status = EmailStatus.FAILED
+            record.save()
         except Exception as e:
             logging.exception(f'Error when attempting to send record {record}: {e}')
-            sent = False
-        if sent:
-            record.status = EmailStatus.SENT
-        else:
             record.status = EmailStatus.FAILED
-
-        record.save()
+            record.save()
+        else:
+            record.status = EmailStatus.SENT
+            record.save()
 
 
 @celery_app.task(
@@ -368,6 +386,10 @@ def send_emails():
     sender = MassEmailSender()
     try:
         sender.send_day_emails()
+    except MailerProviderQuotaExhaustedError:
+        # Already logged in `send_email()`. Nothing left to do this run: the
+        # remaining `enqueued` records are picked up by the next hourly run.
+        pass
     except SoftTimeLimitExceeded:
         # Expected under load: the run is capped by design and the remaining
         # `enqueued` records are simply picked up by the next hourly run.

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -301,6 +301,17 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
             send_emails()
         assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
 
+    def test_send_emails_stops_gracefully_on_rate_throttled(self):
+        # TODO(DEV-2693): currently the same treatment as quota-exhausted.
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_day_emails',
+            side_effect=MailerProviderRateThrottledError('slow down'),
+        ):
+            send_emails()
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
+
     @override_settings(MAX_MASS_EMAILS_PER_DAY=100)
     def test_send_recurring_emails_when_initialized(self):
         self._setup_common_test_data()
@@ -605,28 +616,26 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
         assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
 
-    def test_rate_throttled_error_cools_down_and_the_run_continues(self):
+    def test_rate_throttled_error_stops_the_run_immediately(self):
+        # TODO(DEV-2693): this currently matches quota-exhausted exactly -
+        # no blocking sleep fits inside the task's soft time limit. See the
+        # docstring on MailerProviderRateThrottledError.
         connection = MagicMock()
         with (
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
                 'kobo.apps.mass_emails.tasks.Mailer.send',
-                side_effect=[
-                    MailerProviderRateThrottledError('slow down'),
-                    None,
-                    None,
-                ],
+                side_effect=[None, MailerProviderRateThrottledError('slow down')],
             ) as send_mock,
-            patch('kobo.apps.mass_emails.tasks.sleep') as sleep_mock,
+            pytest.raises(MailerProviderRateThrottledError),
         ):
             MassEmailSender().send_day_emails()
 
-        sleep_mock.assert_any_call(settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS)
-        assert send_mock.call_count == 3
-        # The throttled record is not written off: it stays enqueued for the
-        # next run instead of being marked failed
-        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 1
-        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+        assert send_mock.call_count == 2
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 1
+        # The throttled record, and the one never reached, stay enqueued
+        # rather than being written off as failed
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 2
 
     def test_quota_exhausted_error_stops_the_run_immediately(self):
         connection = MagicMock()

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -312,6 +312,48 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
             send_emails()
         assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
 
+    def test_soft_time_limit_does_not_decrement_the_interrupted_record_s_quota(self):
+        # The record that triggered the interrupt was never actually sent, so
+        # the daily budget it was about to claim must not be spent on it:
+        # otherwise a resumable interruption quietly wastes quota.
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_email',
+            side_effect=SoftTimeLimitExceeded,
+        ):
+            send_emails()
+
+        sender = MassEmailSender()
+        assert sum(sender.limits.values()) == 300
+        assert sender.total_limit == 300
+
+    def test_quota_exhausted_does_not_decrement_the_interrupted_record_s_quota(self):
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_email',
+            side_effect=MailerProviderQuotaExhaustedError('quota gone'),
+        ):
+            send_emails()
+
+        sender = MassEmailSender()
+        assert sum(sender.limits.values()) == 300
+        assert sender.total_limit == 300
+
+    def test_rate_throttled_does_not_decrement_the_interrupted_record_s_quota(self):
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_email',
+            side_effect=MailerProviderRateThrottledError('slow down'),
+        ):
+            send_emails()
+
+        sender = MassEmailSender()
+        assert sum(sender.limits.values()) == 300
+        assert sender.total_limit == 300
+
     @override_settings(MAX_MASS_EMAILS_PER_DAY=100)
     def test_send_recurring_emails_when_initialized(self):
         self._setup_common_test_data()

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -18,6 +18,11 @@ from model_bakery import baker
 from model_bakery.recipe import seq
 
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.exceptions import (
+    MailerError,
+    MailerProviderQuotaExhaustedError,
+    MailerProviderRateThrottledError,
+)
 from kpi.tests.base_test_case import BaseTestCase
 from ..models import EmailStatus, MassEmailConfig, MassEmailJob, MassEmailRecord
 from ..tasks import (
@@ -218,22 +223,28 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         plan_name = sender.get_plan_name(org_user)
         assert plan_name == 'Not available'
 
-    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=2)
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=4, MASS_EMAIL_SEND_RATE_RATIO=0.5)
     def test_send_is_throttled(self):
+        # budget_per_second = 4 * 0.5 = 2. `monotonic` is pinned so every
+        # window looks fully elapsed instantly, isolating the trigger
+        # pattern (every 2 sends, sleep once) from real elapsed time.
         self._setup_common_test_data()
         calls = []
-        with patch(
-            'kobo.apps.mass_emails.tasks.sleep',
-            side_effect=lambda *x: calls.append('sleep'),
-        ):
-            with patch.object(
+        with (
+            patch('kobo.apps.mass_emails.tasks.monotonic', return_value=0),
+            patch(
+                'kobo.apps.mass_emails.tasks.sleep',
+                side_effect=lambda *x: calls.append('sleep'),
+            ),
+            patch.object(
                 MassEmailSender,
                 'send_email',
                 side_effect=lambda *x: calls.append('send_email'),
-            ):
-                sender = MassEmailSender()
-                sender.limits = {self.configs[0].id: 3, self.configs[1].id: 2}
-                sender.send_day_emails()
+            ),
+        ):
+            sender = MassEmailSender()
+            sender.limits = {self.configs[0].id: 3, self.configs[1].id: 2}
+            sender.send_day_emails()
         assert calls == [
             'send_email',
             'send_email',
@@ -275,6 +286,18 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
             # The task must swallow the soft time limit itself rather than
             # surfacing as a task failure: it is an expected outcome of a
             # capped, resumable run.
+            send_emails()
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
+
+    def test_send_emails_stops_gracefully_on_quota_exhausted(self):
+        self._setup_common_test_data()
+        generate_mass_email_user_lists()
+        with patch(
+            'kobo.apps.mass_emails.tasks.MassEmailSender.send_day_emails',
+            side_effect=MailerProviderQuotaExhaustedError('quota gone'),
+        ):
+            # Same as the soft time limit above: an expected, resumable stop,
+            # not a task failure.
             send_emails()
         assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).exists()
 
@@ -525,7 +548,11 @@ class GenerateDailyEmailUserListTaskTestCase(BaseMassEmailsTestCase):
 
 class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
     """
-    Cover how a send run handles its SMTP connection.
+    Cover how a send run handles its SMTP connection, and how it reacts to
+    what `Mailer.send()` raises. The connection reset/retry mechanics
+    themselves live in `Mailer.send()` and are covered in
+    `kpi/tests/test_mailer.py` - these tests only cover what this layer is
+    responsible for: record status and run control flow.
     """
 
     fixtures = ['test_data']
@@ -548,7 +575,7 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         with (
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
-                'kobo.apps.mass_emails.tasks.Mailer.send', return_value=True
+                'kobo.apps.mass_emails.tasks.Mailer.send', return_value=None
             ) as send_mock,
         ):
             MassEmailSender().send_day_emails()
@@ -563,51 +590,61 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         for call in send_mock.call_args_list:
             assert call.kwargs['connection'] is connection
 
-    def test_dropped_connection_is_reset_but_the_record_is_not_retried(self):
+    def test_mailer_error_marks_the_record_failed_and_the_run_continues(self):
         connection = MagicMock()
         with (
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
                 'kobo.apps.mass_emails.tasks.Mailer.send',
-                side_effect=[False, True, True],
+                side_effect=[MailerError('mailbox unavailable'), None, None],
             ) as send_mock,
-            patch(
-                'kobo.apps.mass_emails.tasks.is_connection_alive', return_value=False
-            ),
-            patch('kobo.apps.mass_emails.tasks.reset_connection') as reset_mock,
         ):
             MassEmailSender().send_day_emails()
 
-        assert reset_mock.call_count == 1
-        # Three sends for three records: the first one is not retried on the
-        # fresh connection, since we can't tell a dropped connection apart
-        # from one that dropped right after the server accepted the message -
-        # resending it would risk a duplicate
         assert send_mock.call_count == 3
         assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
         assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
 
-    def test_refused_recipient_does_not_reset_the_connection(self):
+    def test_rate_throttled_error_cools_down_and_the_run_continues(self):
         connection = MagicMock()
         with (
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
                 'kobo.apps.mass_emails.tasks.Mailer.send',
-                side_effect=[False, True, True],
+                side_effect=[
+                    MailerProviderRateThrottledError('slow down'),
+                    None,
+                    None,
+                ],
             ) as send_mock,
-            patch(
-                'kobo.apps.mass_emails.tasks.is_connection_alive', return_value=True
-            ),
-            patch('kobo.apps.mass_emails.tasks.reset_connection') as reset_mock,
+            patch('kobo.apps.mass_emails.tasks.sleep') as sleep_mock,
         ):
             MassEmailSender().send_day_emails()
 
-        # The connection is still usable, so reconnecting would only cost a
-        # handshake and resend a message the server already refused
-        assert reset_mock.call_count == 0
+        sleep_mock.assert_any_call(settings.MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS)
         assert send_mock.call_count == 3
-        assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 1
+        # The throttled record is not written off: it stays enqueued for the
+        # next run instead of being marked failed
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 1
         assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+
+    def test_quota_exhausted_error_stops_the_run_immediately(self):
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send',
+                side_effect=[None, MailerProviderQuotaExhaustedError('quota gone')],
+            ) as send_mock,
+            pytest.raises(MailerProviderQuotaExhaustedError),
+        ):
+            MassEmailSender().send_day_emails()
+
+        assert send_mock.call_count == 2
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 1
+        # The record that hit the quota error, and the one never reached,
+        # stay enqueued rather than being written off as failed
+        assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 2
 
     def test_soft_time_limit_closes_the_connection_and_leaves_records_enqueued(self):
         connection = MagicMock()
@@ -615,7 +652,7 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
             patch('kpi.utils.mailer.get_connection', return_value=connection),
             patch(
                 'kobo.apps.mass_emails.tasks.Mailer.send',
-                side_effect=[True, SoftTimeLimitExceeded()],
+                side_effect=[None, SoftTimeLimitExceeded()],
             ) as send_mock,
             pytest.raises(SoftTimeLimitExceeded),
         ):

--- a/kobo/apps/mass_emails/tests/test_checks.py
+++ b/kobo/apps/mass_emails/tests/test_checks.py
@@ -8,7 +8,6 @@ class MassEmailSendSettingsCheckTestCase(TestCase):
         'mass_emails.E001',
         'mass_emails.E002',
         'mass_emails.E003',
-        'mass_emails.E004',
     )
 
     @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0)
@@ -33,15 +32,10 @@ class MassEmailSendSettingsCheckTestCase(TestCase):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E002' for e in errors)
 
-    @override_settings(MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS=0)
-    def test_zero_throttle_cooldown_fails(self):
-        errors = run_checks()
-        assert any(e.id == 'mass_emails.E003' for e in errors)
-
     @override_settings(MAILER_CONNECTION_IDLE_TIMEOUT=0)
     def test_zero_idle_timeout_fails(self):
         errors = run_checks()
-        assert any(e.id == 'mass_emails.E004' for e in errors)
+        assert any(e.id == 'mass_emails.E003' for e in errors)
 
     def test_default_settings_pass(self):
         errors = run_checks()

--- a/kobo/apps/mass_emails/tests/test_checks.py
+++ b/kobo/apps/mass_emails/tests/test_checks.py
@@ -4,18 +4,38 @@ from django.test import TestCase, override_settings
 
 class MassEmailSendSettingsCheckTestCase(TestCase):
 
+    ALL_CHECK_IDS = (
+        'mass_emails.E001',
+        'mass_emails.E002',
+        'mass_emails.E003',
+        'mass_emails.E004',
+    )
+
     @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0)
     def test_zero_throttle_fails(self):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E001' for e in errors)
 
-    @override_settings(MASS_EMAIL_SLEEP_SECONDS=-1)
-    def test_negative_sleep_fails(self):
+    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0)
+    def test_zero_send_rate_ratio_fails(self):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E002' for e in errors)
 
+    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0.51)
+    def test_send_rate_ratio_above_half_fails(self):
+        errors = run_checks()
+        assert any(e.id == 'mass_emails.E002' for e in errors)
+
+    @override_settings(MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS=0)
+    def test_zero_throttle_cooldown_fails(self):
+        errors = run_checks()
+        assert any(e.id == 'mass_emails.E003' for e in errors)
+
+    @override_settings(MAILER_CONNECTION_IDLE_TIMEOUT=0)
+    def test_zero_idle_timeout_fails(self):
+        errors = run_checks()
+        assert any(e.id == 'mass_emails.E004' for e in errors)
+
     def test_default_settings_pass(self):
         errors = run_checks()
-        assert not any(
-            e.id in ('mass_emails.E001', 'mass_emails.E002') for e in errors
-        )
+        assert not any(e.id in self.ALL_CHECK_IDS for e in errors)

--- a/kobo/apps/mass_emails/tests/test_checks.py
+++ b/kobo/apps/mass_emails/tests/test_checks.py
@@ -21,8 +21,15 @@ class MassEmailSendSettingsCheckTestCase(TestCase):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E002' for e in errors)
 
-    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0.51)
-    def test_send_rate_ratio_above_half_fails(self):
+    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0.75)
+    def test_send_rate_ratio_above_half_is_allowed(self):
+        # Above 0.5 risks bursting past the provider's rate limit near a
+        # window boundary, but it's the admin's call, not a hard block.
+        errors = run_checks()
+        assert not any(e.id == 'mass_emails.E002' for e in errors)
+
+    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=1.01)
+    def test_send_rate_ratio_above_one_fails(self):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E002' for e in errors)
 

--- a/kobo/apps/organizations/models.py
+++ b/kobo/apps/organizations/models.py
@@ -25,7 +25,9 @@ from organizations.abstract import (
 )
 from organizations.utils import create_organization as create_organization_base
 
+from kpi.exceptions import MailerError
 from kpi.fields import KpiUidField
+from kpi.utils.log import logging
 from kpi.utils.mailer import EmailMessage, Mailer
 from kpi.utils.placeholders import replace_placeholders
 from .constants import (
@@ -388,7 +390,10 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
             language=sender_language,
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(f'Failed to send organization invite acceptance email: {e}')
 
     def send_invite_email(self):
         is_registered_user = bool(self.invitee)
@@ -450,7 +455,10 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
             language=invitee_language,
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(f'Failed to send organization invite email: {e}')
 
     def send_refusal_email(self):
         """
@@ -480,7 +488,10 @@ class OrganizationInvitation(AbstractOrganizationInvitation):
             language=sender_language,
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(f'Failed to send organization invite refusal email: {e}')
 
 
 create_organization = partial(create_organization_base, model=Organization)

--- a/kobo/apps/organizations/tasks.py
+++ b/kobo/apps/organizations/tasks.py
@@ -12,6 +12,8 @@ from kobo.apps.organizations.models import OrganizationInviteStatusChoices
 from kobo.apps.project_ownership.models import Transfer
 from kobo.apps.project_ownership.utils import create_invite
 from kobo.celery import celery_app
+from kpi.exceptions import MailerError
+from kpi.utils.log import logging
 from kpi.utils.mailer import EmailMessage, Mailer
 
 
@@ -89,4 +91,7 @@ def mark_organization_invite_as_expired():
             )
         )
 
-    Mailer.send(email_messages)
+    try:
+        Mailer.send(email_messages)
+    except MailerError as e:
+        logging.warning(f'Failed to send expired organization invite emails: {e}')

--- a/kobo/apps/organizations/tests/test_organization_invitations.py
+++ b/kobo/apps/organizations/tests/test_organization_invitations.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from constance.test import override_config
 from ddt import data, ddt, unpack
@@ -27,6 +28,7 @@ from kobo.apps.organizations.tasks import mark_organization_invite_as_expired
 from kobo.apps.organizations.tests.test_organizations_api import (
     BaseOrganizationAssetApiTestCase,
 )
+from kpi.exceptions import MailerError
 from kpi.models import Asset
 from kpi.tests.utils.transaction import immediate_on_commit
 from kpi.urls.router_api_v2 import URL_NAMESPACE
@@ -99,6 +101,21 @@ class OrganizationInviteTestCase(BaseOrganizationInviteTestCase):
                     mail.outbox[index].to[0],
                     invite.email if invite else invitation['invitee'],
                 )
+
+    def test_invitation_is_still_created_when_the_email_fails_to_send(self):
+        """
+        A `MailerError` while sending the invite email must be caught and
+        logged, not left to propagate and fail the request: the invitation
+        itself should still be created.
+        """
+        with patch(
+            'kobo.apps.organizations.models.Mailer.send',
+            side_effect=MailerError('boom'),
+        ):
+            response = self._create_invite(self.owner_user)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(mail.outbox), 0)
 
     @data(
         ('owner', status.HTTP_200_OK),

--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -148,7 +148,9 @@ class Invite(AbstractTimeStampedModel):
         try:
             Mailer.send(email_message)
         except MailerError as e:
-            logging.warning(f'Failed to send project ownership transfer invite email: {e}')
+            logging.warning(
+                f'Failed to send project ownership transfer invite email: {e}'
+            )
 
     def send_refusal_email(self):
 

--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -6,8 +6,10 @@ from django.db import models
 from django.utils.translation import gettext as t
 
 from kobo.apps.organizations.utils import get_real_owner
+from kpi.exceptions import MailerError
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
+from kpi.utils.log import logging
 from kpi.utils.mailer import EmailMessage, Mailer
 
 from .choices import InviteStatusChoices
@@ -102,7 +104,12 @@ class Invite(AbstractTimeStampedModel):
             language=self.recipient.extra_details.data.get('last_ui_language'),
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(
+                f'Failed to send project ownership transfer acceptance email: {e}'
+            )
 
     def send_invite_email(self):
 
@@ -138,7 +145,10 @@ class Invite(AbstractTimeStampedModel):
             language=self.recipient.extra_details.data.get('last_ui_language'),
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(f'Failed to send project ownership transfer invite email: {e}')
 
     def send_refusal_email(self):
 
@@ -164,7 +174,12 @@ class Invite(AbstractTimeStampedModel):
             language=self.recipient.extra_details.data.get('last_ui_language'),
         )
 
-        Mailer.send(email_message)
+        try:
+            Mailer.send(email_message)
+        except MailerError as e:
+            logging.warning(
+                f'Failed to send project ownership transfer refusal email: {e}'
+            )
 
 
 class OrgMembershipAutoInviteManager(models.Manager):

--- a/kobo/apps/project_ownership/tasks.py
+++ b/kobo/apps/project_ownership/tasks.py
@@ -14,6 +14,8 @@ from django.utils.translation import gettext as t
 
 from kobo.apps.project_ownership.models.invite import InviteType
 from kobo.celery import celery_app
+from kpi.exceptions import MailerError
+from kpi.utils.log import logging
 from kpi.utils.mailer import EmailMessage, Mailer
 from .exceptions import AsyncTaskException, TransferStillPendingException
 from .models.choices import (
@@ -191,7 +193,10 @@ def mark_as_expired():
             )
         )
 
-    Mailer.send(email_messages)
+    try:
+        Mailer.send(email_messages)
+    except MailerError as e:
+        logging.warning(f'Failed to send expired invite emails: {e}')
 
 
 @celery_app.task
@@ -244,7 +249,10 @@ def send_email_to_admins(invite_uid: str):
         ),
     )
 
-    Mailer.send(email_message)
+    try:
+        Mailer.send(email_message)
+    except MailerError as e:
+        logging.warning(f'Failed to send admin failure report email: {e}')
 
 
 @celery_app.task

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1838,25 +1838,18 @@ if os.environ.get('EMAIL_PORT'):
 if os.environ.get('EMAIL_USE_TLS'):
     EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS')
 
-# To be set up based on the SMTP provider limits & quotas. On SES, keep
-# `MASS_EMAIL_THROTTLE_PER_SECOND` at or below the account `MaxSendRate`, and
-# `MAX_MASS_EMAILS_PER_DAY` below `Max24HourSend` minus the transactional
-# volume (both are returned by the SES `GetSendQuota` API).
-#
-# `MAX_MASS_EMAILS_PER_DAY` is a global ceiling shared by every live config and
-# split between them in proportion to their pending records, not a per-config
-# quota. Keep it above the number of records a single run enqueues across all
-# configs: a batch that cannot drain in one day keeps its config frozen, since
-# no recipient list is recomputed while records are still pending, so the
-# emails go out stale. Worse, anything still enqueued after
-# `MASS_EMAIL_ENQUEUED_RECORD_EXPIRY` days is marked as failed without ever
-# being sent.
-#
-# Raising it is not free: it also caps the blast radius of a user query that
-# selects far more people than intended.
+# Size these to the SMTP provider actually configured for this deployment
+# (one provider at a time).
+# See kpi.utils.mailer.Mailer and kobo.apps.mass_emails.tasks.MassEmailSender.
 MAX_MASS_EMAILS_PER_DAY = env.int('MAX_MASS_EMAILS_PER_DAY', 10000)
 MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
-MASS_EMAIL_SLEEP_SECONDS = env.int('MASS_EMAIL_SLEEP_SECONDS', 1)
+MASS_EMAIL_SEND_RATE_RATIO = env.float('MASS_EMAIL_SEND_RATE_RATIO', 0.35)
+# Cooldown after a provider rate-throttle response (see kpi.exceptions.MailerProviderRateThrottledError)  # noqa: E501
+MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS = env.int(
+    'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS', 60 * 5
+)
+# Margin under the provider's SMTP idle timeout.
+MAILER_CONNECTION_IDLE_TIMEOUT = env.int('MAILER_CONNECTION_IDLE_TIMEOUT', 10)
 # change the interval between "daily" email sends for testing. this will set both
 # the frequency of the task and the expiry time of the cached email limits. should
 # only be True on small testing instances

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1843,10 +1843,14 @@ if os.environ.get('EMAIL_USE_TLS'):
 # See kpi.utils.mailer.Mailer and kobo.apps.mass_emails.tasks.MassEmailSender.
 MAX_MASS_EMAILS_PER_DAY = env.int('MAX_MASS_EMAILS_PER_DAY', 10000)
 MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
+# Some servers can share the same provider account and quota diluting their share of it
+# further than transactional email alone would.
 MASS_EMAIL_SEND_RATE_RATIO = env.float('MASS_EMAIL_SEND_RATE_RATIO', 0.35)
-# Cooldown after a provider rate-throttle response (see kpi.exceptions.MailerProviderRateThrottledError)  # noqa: E501
+# Cooldown after a provider rate-throttle response (see kpi.exceptions.MailerProviderRateThrottledError).  # noqa: E501
+# SMTP gives no Retry-After, so there's no real signal for how long to wait.
+# Defaults long: this should already be rare given the per-second budget.
 MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS = env.int(
-    'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS', 60 * 5
+    'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS', 60 * 60
 )
 # Margin under the provider's SMTP idle timeout.
 MAILER_CONNECTION_IDLE_TIMEOUT = env.int('MAILER_CONNECTION_IDLE_TIMEOUT', 10)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1849,12 +1849,6 @@ MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
 # back still can't exceed the provider's rate limit; higher is allowed if
 # an admin accepts the risk of bursting past it near a window boundary.
 MASS_EMAIL_SEND_RATE_RATIO = env.float('MASS_EMAIL_SEND_RATE_RATIO', 0.35)
-# Cooldown after a provider rate-throttle response (see kpi.exceptions.MailerProviderRateThrottledError).  # noqa: E501
-# SMTP gives no Retry-After, so there's no real signal for how long to wait.
-# Defaults long: this should already be rare given the per-second budget.
-MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS = env.int(
-    'MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS', 60 * 60
-)
 # Margin under the provider's SMTP idle timeout.
 MAILER_CONNECTION_IDLE_TIMEOUT = env.int('MAILER_CONNECTION_IDLE_TIMEOUT', 10)
 # change the interval between "daily" email sends for testing. this will set both

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1845,6 +1845,9 @@ MAX_MASS_EMAILS_PER_DAY = env.int('MAX_MASS_EMAILS_PER_DAY', 10000)
 MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
 # Some servers can share the same provider account and quota diluting their share of it
 # further than transactional email alone would.
+# 0.5 or below is recommended so two full budget windows landing back to
+# back still can't exceed the provider's rate limit; higher is allowed if
+# an admin accepts the risk of bursting past it near a window boundary.
 MASS_EMAIL_SEND_RATE_RATIO = env.float('MASS_EMAIL_SEND_RATE_RATIO', 0.35)
 # Cooldown after a provider rate-throttle response (see kpi.exceptions.MailerProviderRateThrottledError).  # noqa: E501
 # SMTP gives no Retry-After, so there's no real signal for how long to wait.

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -148,6 +148,30 @@ class KobocatProfileException(Exception):
     pass
 
 
+class MailerError(Exception):
+    """
+    A message could not be sent
+    """
+
+
+class MailerProviderThrottledError(MailerError):
+    """
+    The provider's response matched a catalogued throttling/quota signature
+    """
+
+
+class MailerProviderQuotaExhaustedError(MailerProviderThrottledError):
+    """
+    The provider is refusing until a quota resets. Not worth retrying today.
+    """
+
+
+class MailerProviderRateThrottledError(MailerProviderThrottledError):
+    """
+    The provider is asking us to slow down. Safe to retry after a cooldown.
+    """
+
+
 class MissingXFormException(Exception):
     pass
 

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -168,13 +168,17 @@ class MailerProviderQuotaExhaustedError(MailerProviderThrottledError):
 
 class MailerProviderRateThrottledError(MailerProviderThrottledError):
     """
-    The provider is asking us to slow down. Safe to retry after a cooldown.
+    The provider is asking us to slow down, unlike a hard quota.
 
     Should be rare in practice: `MassEmailSender.send_day_emails()` already
     paces sends against a per-second budget kept under the provider's real
     limit, so the provider itself shouldn't need to say "slow down" except
     for unaccounted-for traffic sharing the same account (e.g. transactional
     email) or a misconfigured `MASS_EMAIL_SEND_RATE_RATIO`.
+
+    TODO(DEV-2693): currently handled exactly like
+    `MailerProviderQuotaExhaustedError`, which defeats the point of having
+    two separate exceptions. Needs a real, non-blocking cooldown.
     """
 
 

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -169,6 +169,12 @@ class MailerProviderQuotaExhaustedError(MailerProviderThrottledError):
 class MailerProviderRateThrottledError(MailerProviderThrottledError):
     """
     The provider is asking us to slow down. Safe to retry after a cooldown.
+
+    Should be rare in practice: `MassEmailSender.send_day_emails()` already
+    paces sends against a per-second budget kept under the provider's real
+    limit, so the provider itself shouldn't need to say "slow down" except
+    for unaccounted-for traffic sharing the same account (e.g. transactional
+    email) or a misconfigured `MASS_EMAIL_SEND_RATE_RATIO`.
     """
 
 

--- a/kpi/tests/test_mailer.py
+++ b/kpi/tests/test_mailer.py
@@ -1,15 +1,23 @@
-from smtplib import SMTPException, SMTPServerDisconnected
+from smtplib import (
+    SMTPException,
+    SMTPRecipientsRefused,
+    SMTPResponseException,
+    SMTPServerDisconnected,
+)
+from time import monotonic
 from unittest.mock import MagicMock, Mock, patch
 
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.test import TestCase, override_settings
 
-from kpi.utils.mailer import (
-    is_connection_alive,
-    reset_connection,
-    with_smtp_connection,
+from kpi.exceptions import (
+    MailerError,
+    MailerProviderQuotaExhaustedError,
+    MailerProviderRateThrottledError,
 )
+from kpi.utils.mailer import Mailer, with_smtp_connection
+from kpi.utils.mailer import EmailMessage as MailerEmailMessage
 
 
 def fake_send(email_message):
@@ -150,30 +158,30 @@ class TestConnectionHelpers(TestCase):
         connection = MagicMock()
         connection.connection.noop.return_value = (250, b'OK')
 
-        assert is_connection_alive(connection) is True
+        assert Mailer._is_connection_alive(connection) is True
 
     def test_dropped_connection_is_not_alive(self):
         connection = MagicMock()
         connection.connection.noop.side_effect = SMTPServerDisconnected()
 
-        assert is_connection_alive(connection) is False
+        assert Mailer._is_connection_alive(connection) is False
 
     def test_unopened_connection_is_not_alive(self):
         connection = MagicMock()
         connection.connection = None
 
-        assert is_connection_alive(connection) is False
+        assert Mailer._is_connection_alive(connection) is False
 
     def test_non_smtp_backend_is_always_alive(self):
         # File and console backends hold no socket that could have dropped
         connection = Mock(spec=[])
 
-        assert is_connection_alive(connection) is True
+        assert Mailer._is_connection_alive(connection) is True
 
     def test_reset_connection_reopens_in_place(self):
         connection = MagicMock()
 
-        reset_connection(connection)
+        Mailer._reset_connection(connection)
 
         assert connection.close.call_count == 1
         assert connection.open.call_count == 1
@@ -182,6 +190,355 @@ class TestConnectionHelpers(TestCase):
         connection = MagicMock()
         connection.close.side_effect = SMTPServerDisconnected()
 
-        reset_connection(connection)
+        Mailer._reset_connection(connection)
 
         assert connection.open.call_count == 1
+
+
+class TestClassifySmtpException(TestCase):
+    """
+    Cover how raw `smtplib` exceptions are turned into typed `MailerError`s.
+    """
+
+    def test_ses_rate_throttle_signature_matches(self):
+        exc = SMTPResponseException(
+            454, b'Throttling failure: Maximum sending rate exceeded.'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+        assert not isinstance(error, MailerProviderQuotaExhaustedError)
+
+    def test_ses_quota_throttle_signature_matches(self):
+        exc = SMTPResponseException(
+            454, b'Throttling failure: Daily message quota exceeded.'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderQuotaExhaustedError)
+        assert not isinstance(error, MailerProviderRateThrottledError)
+
+    def test_sendgrid_too_frequent_connects_signature_matches(self):
+        exc = SMTPResponseException(
+            450, b'too frequent connects from 1.2.3.4, please try again later.'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_sendgrid_hourly_throttle_signature_matches(self):
+        exc = SMTPResponseException(
+            452, b'Too many recipients received this hour (throttled)'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_sendgrid_temporarily_deferred_signature_matches(self):
+        exc = SMTPResponseException(
+            421, b'Message from (1.2.3.4) temporarily deferred'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_sendgrid_credits_exceeded_signature_matches(self):
+        exc = SMTPResponseException(
+            451, b'Authentication failed: Maximum credits exceeded'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderQuotaExhaustedError)
+
+    def test_office365_submission_quota_exceeded_signature_matches(self):
+        exc = SMTPResponseException(
+            550, b'5.2.2 Submission quota exceeded'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderQuotaExhaustedError)
+
+    def test_office365_daily_recipient_limit_signature_matches(self):
+        exc = SMTPResponseException(
+            550,
+            b"5.1.90 Your message can't be sent because you've reached your "
+            b"daily limit for message recipients",
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderQuotaExhaustedError)
+
+    def test_office365_recipient_hourly_limit_from_sender_signature_matches(self):
+        exc = SMTPResponseException(
+            550,
+            b"5.2.121 Recipient's per hour message receive limit from "
+            b"specific sender exceeded",
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_office365_recipient_hourly_limit_signature_matches(self):
+        exc = SMTPResponseException(
+            550, b"5.2.122 Recipient's per hour message receive limit exceeded"
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_office365_unrelated_access_denied_does_not_match(self):
+        # Office365 has several unrelated 550 messages (e.g. a
+        # compromised/blocked account); only the catalogued phrasings above
+        # are throttling/quota signals.
+        exc = SMTPResponseException(550, b'Access denied, bad outbound sender')
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert type(error) is MailerError
+
+    def test_unmatched_code_falls_back_to_plain_error(self):
+        exc = SMTPResponseException(550, b'Mailbox unavailable')
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert type(error) is MailerError
+
+    def test_unmatched_text_on_a_catalogued_code_falls_back_to_plain_error(self):
+        exc = SMTPResponseException(454, b'Some other transient failure')
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert type(error) is MailerError
+
+    def test_smtp_recipients_refused_uses_the_recipient_code(self):
+        exc = SMTPRecipientsRefused(
+            {'to@example.com': (454, b'Maximum sending rate exceeded.')}
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_connection_level_exception_returns_a_plain_error(self):
+        exc = SMTPServerDisconnected('Connection unexpectedly closed')
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert type(error) is MailerError
+
+    def test_text_is_decoded_whether_bytes_or_str(self):
+        exc = SMTPResponseException(454, 'Maximum sending rate exceeded.')
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderRateThrottledError)
+
+
+class TestMailerSendSingle(TestCase):
+    """
+    Cover `Mailer.send()` for a single `EmailMessage`.
+    """
+
+    def setUp(self):
+        self.message = MailerEmailMessage(
+            to='to@example.com',
+            subject='Subject',
+            plain_text_content_or_template='Body',
+        )
+
+    def test_send_succeeds_without_raising(self):
+        with patch('kpi.utils.mailer.send_mail') as send_mail_mock:
+            Mailer.send(self.message)
+
+        send_mail_mock.assert_called_once()
+
+    def test_no_connection_raises_immediately_without_retry(self):
+        with (
+            patch(
+                'kpi.utils.mailer.send_mail',
+                side_effect=SMTPResponseException(550, b'Mailbox unavailable'),
+            ) as send_mail_mock,
+            self.assertRaises(MailerError),
+        ):
+            Mailer.send(self.message)
+
+        # No connection was passed in, so there is nothing to reconnect
+        send_mail_mock.assert_called_once()
+
+    def test_refused_recipient_does_not_reset_the_connection(self):
+        connection = MagicMock()
+        with (
+            patch(
+                'kpi.utils.mailer.send_mail',
+                side_effect=SMTPResponseException(550, b'Mailbox unavailable'),
+            ) as send_mail_mock,
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=True),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            self.assertRaises(MailerError),
+        ):
+            Mailer.send(self.message, connection=connection)
+
+        assert reset_mock.call_count == 0
+        assert send_mail_mock.call_count == 1
+
+    def test_dead_connection_is_reset_but_the_message_is_not_retried(self):
+        # A dropped connection can happen right after the server already
+        # accepted the message but before we read its acknowledgement, so a
+        # resend risks a duplicate (see DEV-2675/PR #7435). The connection is
+        # still repaired for the records still to come.
+        connection = MagicMock()
+        with (
+            patch(
+                'kpi.utils.mailer.send_mail',
+                side_effect=SMTPServerDisconnected(),
+            ) as send_mail_mock,
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=False),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            self.assertRaises(MailerError),
+        ):
+            Mailer.send(self.message, connection=connection)
+
+        assert reset_mock.call_count == 1
+        assert send_mail_mock.call_count == 1
+
+    def test_throttled_signature_propagates_its_specific_type(self):
+        connection = MagicMock()
+        with (
+            patch(
+                'kpi.utils.mailer.send_mail',
+                side_effect=SMTPResponseException(
+                    454, b'Throttling failure: Maximum sending rate exceeded.'
+                ),
+            ),
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=True),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+        ):
+            with self.assertRaises(MailerProviderRateThrottledError):
+                Mailer.send(self.message, connection=connection)
+
+        # A throttled message is not a dropped connection, no reconnecting
+        assert reset_mock.call_count == 0
+
+    def test_send_updates_the_connection_last_used_timestamp(self):
+        connection = MagicMock(spec=[])
+
+        with patch('kpi.utils.mailer.send_mail'):
+            Mailer.send(self.message, connection=connection)
+
+        assert isinstance(connection._mailer_last_used, float)
+
+
+class TestMailerSendBatch(TestCase):
+    """
+    Cover `Mailer.send()` for a list of `EmailMessage`s.
+    """
+
+    def setUp(self):
+        self.messages = [
+            MailerEmailMessage(
+                to='to@example.com',
+                subject='Subject',
+                plain_text_content_or_template='Body',
+            )
+        ]
+
+    def test_batch_send_succeeds_without_raising(self):
+        connection = MagicMock()
+
+        Mailer.send(self.messages, connection=connection)
+
+        connection.send_messages.assert_called_once()
+
+    def test_batch_failure_is_not_retried(self):
+        connection = MagicMock()
+        connection.send_messages.side_effect = SMTPResponseException(
+            454, b'Throttling failure: Maximum sending rate exceeded.'
+        )
+
+        with (
+            patch('kpi.utils.mailer.Mailer._is_connection_alive') as alive_mock,
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            self.assertRaises(MailerProviderRateThrottledError),
+        ):
+            Mailer.send(self.messages, connection=connection)
+
+        # The batch branch never probes or resets: retrying risks
+        # re-sending messages that already went out earlier in the list
+        assert alive_mock.call_count == 0
+        assert reset_mock.call_count == 0
+        assert connection.send_messages.call_count == 1
+
+
+class TestMailerIdleTimeout(TestCase):
+    """
+    Cover the proactive idle-timeout check on a reused connection.
+    """
+
+    def test_reopen_if_idle_skips_when_never_used(self):
+        connection = MagicMock(spec=[])
+
+        with patch('kpi.utils.mailer.Mailer._is_connection_alive') as alive_mock:
+            Mailer._reopen_if_idle(connection, idle_timeout=10)
+
+        assert alive_mock.call_count == 0
+
+    def test_reopen_if_idle_skips_within_the_timeout(self):
+        connection = MagicMock(spec=[])
+        connection._mailer_last_used = monotonic()
+
+        with patch('kpi.utils.mailer.Mailer._is_connection_alive') as alive_mock:
+            Mailer._reopen_if_idle(connection, idle_timeout=10)
+
+        assert alive_mock.call_count == 0
+
+    def test_reopen_if_idle_resets_a_stale_dead_connection(self):
+        connection = MagicMock(spec=[])
+        connection._mailer_last_used = monotonic() - 20
+
+        with (
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=False),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+        ):
+            Mailer._reopen_if_idle(connection, idle_timeout=10)
+
+        assert reset_mock.call_count == 1
+
+    def test_reopen_if_idle_leaves_a_stale_but_alive_connection_untouched(self):
+        connection = MagicMock(spec=[])
+        connection._mailer_last_used = monotonic() - 20
+
+        with (
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=True),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+        ):
+            Mailer._reopen_if_idle(connection, idle_timeout=10)
+
+        assert reset_mock.call_count == 0
+
+    def test_send_proactively_reopens_a_stale_connection_before_sending(self):
+        connection = MagicMock(spec=[])
+        connection._mailer_last_used = monotonic() - 20
+        message = MailerEmailMessage(
+            to='to@example.com',
+            subject='Subject',
+            plain_text_content_or_template='Body',
+        )
+
+        with (
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=False),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            patch('kpi.utils.mailer.send_mail'),
+        ):
+            Mailer.send(message, connection=connection, idle_timeout=10)
+
+        assert reset_mock.call_count == 1

--- a/kpi/tests/test_mailer.py
+++ b/kpi/tests/test_mailer.py
@@ -269,7 +269,7 @@ class TestClassifySmtpException(TestCase):
         exc = SMTPResponseException(
             550,
             b"5.1.90 Your message can't be sent because you've reached your "
-            b"daily limit for message recipients",
+            b"daily limit for message recipients",  # noqa Q000
         )
 
         error = Mailer._classify_smtp_exception(exc)
@@ -280,7 +280,7 @@ class TestClassifySmtpException(TestCase):
         exc = SMTPResponseException(
             550,
             b"5.2.121 Recipient's per hour message receive limit from "
-            b"specific sender exceeded",
+            b"specific sender exceeded",  # noqa Q000
         )
 
         error = Mailer._classify_smtp_exception(exc)

--- a/kpi/tests/test_mailer.py
+++ b/kpi/tests/test_mailer.py
@@ -220,6 +220,15 @@ class TestClassifySmtpException(TestCase):
         assert isinstance(error, MailerProviderQuotaExhaustedError)
         assert not isinstance(error, MailerProviderRateThrottledError)
 
+    def test_signature_matches_regardless_of_response_text_casing(self):
+        exc = SMTPResponseException(
+            454, b'Throttling failure: DAILY MESSAGE QUOTA exceeded.'
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerProviderQuotaExhaustedError)
+
     def test_sendgrid_too_frequent_connects_signature_matches(self):
         exc = SMTPResponseException(
             450, b'too frequent connects from 1.2.3.4, please try again later.'
@@ -411,6 +420,24 @@ class TestMailerSendSingle(TestCase):
         assert reset_mock.call_count == 1
         assert send_mail_mock.call_count == 1
 
+    def test_dropped_socket_is_reset_and_classified_as_a_plain_error(self):
+        # A raw OSError (e.g. ConnectionResetError) carries no SMTP status
+        # code, but is still a dropped-connection signal like SMTPServerDisconnected.
+        connection = MagicMock()
+        with (
+            patch(
+                'kpi.utils.mailer.send_mail',
+                side_effect=ConnectionResetError(),
+            ) as send_mail_mock,
+            patch('kpi.utils.mailer.Mailer._is_connection_alive', return_value=False),
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            self.assertRaises(MailerError),
+        ):
+            Mailer.send(self.message, connection=connection)
+
+        assert reset_mock.call_count == 1
+        assert send_mail_mock.call_count == 1
+
     def test_throttled_signature_propagates_its_specific_type(self):
         connection = MagicMock()
         with (
@@ -474,6 +501,21 @@ class TestMailerSendBatch(TestCase):
 
         # The batch branch never probes or resets: retrying risks
         # re-sending messages that already went out earlier in the list
+        assert alive_mock.call_count == 0
+        assert reset_mock.call_count == 0
+        assert connection.send_messages.call_count == 1
+
+    def test_batch_dropped_socket_is_classified_as_a_plain_error(self):
+        connection = MagicMock()
+        connection.send_messages.side_effect = ConnectionResetError()
+
+        with (
+            patch('kpi.utils.mailer.Mailer._is_connection_alive') as alive_mock,
+            patch('kpi.utils.mailer.Mailer._reset_connection') as reset_mock,
+            self.assertRaises(MailerError),
+        ):
+            Mailer.send(self.messages, connection=connection)
+
         assert alive_mock.call_count == 0
         assert reset_mock.call_count == 0
         assert connection.send_messages.call_count == 1

--- a/kpi/utils/mailer.py
+++ b/kpi/utils/mailer.py
@@ -209,9 +209,11 @@ class Mailer:
             connection._mailer_last_used = monotonic()
 
     @classmethod
-    def _classify_smtp_exception(cls, exc: SMTPException) -> MailerError:
+    def _classify_smtp_exception(
+        cls, exc: Union[SMTPException, OSError]
+    ) -> MailerError:
         """
-        Turn a raw `smtplib` exception into a typed `MailerError`
+        Turn a raw `smtplib`/socket exception into a typed `MailerError`
 
         Only exceptions that carry an SMTP status code can be matched against
         `THROTTLE_SIGNATURES`. Everything else (e.g. a dropped connection)
@@ -228,8 +230,11 @@ class Mailer:
             return MailerError(str(exc))
 
         text = cls._decode_smtp_text(msg)
+        text_lower = text.lower()
         for signature_code, substring, exception_class in cls.THROTTLE_SIGNATURES:
-            if (signature_code is None or code == signature_code) and substring in text:
+            if (
+                signature_code is None or code == signature_code
+            ) and substring.lower() in text_lower:
                 return exception_class(f'{code} {text}')
 
         return MailerError(f'{code} {text}')
@@ -328,7 +333,7 @@ class Mailer:
             else:
                 with get_connection() as new_connection:
                     new_connection.send_messages(messages)
-        except SMTPException as e:
+        except (SMTPException, OSError) as e:
             # No retry here: Django's `send_messages()` gives no per-message
             # success/failure back, so retrying a partially-sent batch risks
             # re-sending messages that already went out.
@@ -340,7 +345,7 @@ class Mailer:
     ):
         try:
             cls._dispatch_single(email_message, connection)
-        except SMTPException as e:
+        except (SMTPException, OSError) as e:
             if connection is not None and not cls._is_connection_alive(connection):
                 # A dropped connection can happen right after the server
                 # already accepted the message but before we read its

--- a/kpi/utils/mailer.py
+++ b/kpi/utils/mailer.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from functools import wraps
-from smtplib import SMTPException
+from smtplib import (
+    SMTPException,
+    SMTPRecipientsRefused,
+    SMTPResponseException,
+)
+from time import monotonic
 from typing import Optional, Union
 
 from django.conf import settings
@@ -12,56 +17,12 @@ from django.template.loader import get_template
 from django.utils.translation import activate
 from django.utils.translation import gettext as t
 
+from kpi.exceptions import (
+    MailerError,
+    MailerProviderQuotaExhaustedError,
+    MailerProviderRateThrottledError,
+)
 from kpi.utils.log import logging
-
-SMTP_ALIVE_STATUS_CODE = 250
-
-
-def is_connection_alive(connection: BaseEmailBackend) -> bool:
-    """
-    Tell whether the connection can still carry another message
-
-    `Mailer.send()` reports every SMTP error as a plain `False`, so the caller
-    needs this to tell a dropped socket apart from a message the server merely
-    refused. Only the former is worth reconnecting for: a refused recipient
-    leaves the connection perfectly usable, and tearing it down would cost a
-    full handshake on every failure.
-    """
-
-    if not hasattr(connection, 'connection'):
-        # Not an SMTP backend. The file and console backends used outside
-        # production hold no socket that could have dropped.
-        return True
-
-    if connection.connection is None:
-        return False
-
-    try:
-        code, _ = connection.connection.noop()
-    except (OSError, SMTPException):
-        return False
-
-    return code == SMTP_ALIVE_STATUS_CODE
-
-
-def reset_connection(connection: BaseEmailBackend):
-    """
-    Close and reopen a connection in place
-
-    Django leaves a connection it did not open itself untouched, so a socket
-    dropped mid-run stays broken until it is explicitly replaced. Only the
-    underlying socket is renewed, so callers holding this backend keep a valid
-    reference.
-    """
-
-    try:
-        connection.close()
-    except Exception as e:
-        # Django re-raises when quitting a socket that has already dropped,
-        # which would mask the error that led us here in the first place.
-        logging.warning(f'Error while closing the email connection: {e}')
-
-    connection.open()
 
 
 def with_smtp_connection(func):
@@ -119,10 +80,10 @@ class EmailMessage:
         to: Union[str, list],
         subject: str,
         plain_text_content_or_template: str,
-        template_variables: dict = None,
-        html_content_or_template: str = None,
-        language: str = None,
-        from_: str = None,
+        template_variables: dict | None = None,
+        html_content_or_template: str | None = None,
+        language: str | None = None,
+        from_: str | None = None,
     ):
         default_language = settings.LANGUAGE_CODE
 
@@ -170,47 +131,223 @@ class EmailMessage:
 
 class Mailer:
 
+    SMTP_ALIVE_STATUS_CODE = 250
+
+    # (status code or None, substring to match in the response text,
+    # exception to raise). Checked in order, first match wins. `None` for
+    # the code means "match on text alone" - used where a provider's docs
+    # don't pin down a single reliable leading SMTP code. The code alone is
+    # never enough on its own either: SES returns the same 454 for both a
+    # transient rate limit and an exhausted daily quota, distinguished only
+    # by wording.
+    #
+    # Sources:
+    # - SES: https://docs.aws.amazon.com/ses/latest/dg/manage-sending-quotas-errors.html
+    # - SendGrid: https://twilio.com/docs/sendgrid/for-developers/sending-email/smtp-errors-and-troubleshooting  # noqa
+    # - Office365/Exchange: https://learn.microsoft.com/en-us/troubleshoot/exchange/email-delivery/ndr/non-delivery-reports-in-exchange-online.  # noqa
+    #   Enhanced codes there are listed without a paired basic SMTP code; 550
+    #   is Microsoft's documented convention for a 5.x.x enhanced code
+    #   returned live at submission time.
+    #
+    # An unmatched response keeps today's plain failure behavior
+    # (`MailerError`), no pause.
+    THROTTLE_SIGNATURES = (
+        # AWS
+        (454, 'Daily message quota', MailerProviderQuotaExhaustedError),
+        (454, 'Maximum sending rate', MailerProviderRateThrottledError),
+        # SendGrid
+        (451, 'Maximum credits exceeded', MailerProviderQuotaExhaustedError),
+        (450, 'too frequent connects', MailerProviderRateThrottledError),
+        (
+            452,
+            'Too many recipients received this hour',
+            MailerProviderRateThrottledError,
+        ),
+        (421, 'temporarily deferred', MailerProviderRateThrottledError),
+        # Office365
+        (None, 'Submission quota exceeded', MailerProviderQuotaExhaustedError),
+        (None, 'reached your daily limit', MailerProviderQuotaExhaustedError),
+        (None, 'per hour message receive limit', MailerProviderRateThrottledError),
+    )
+
     @classmethod
     def send(
         cls,
         email_messages: Union[EmailMessage, list[EmailMessage]],
         connection: Optional[BaseEmailBackend] = None,
-    ) -> bool:
+        idle_timeout: Optional[float] = None,
+    ) -> None:
         """
         Send one or several messages, optionally reusing an existing connection.
+
+        Raises a `MailerError` (or a more specific subclass, e.g.
+        `MailerProviderRateThrottledError`) on failure instead of returning a bool,
+        so callers can react to *why* a send failed rather than treating
+        every failure the same way. Returns normally on success.
 
         When `connection` is omitted, a new one is opened and closed for every
         call, which costs a full SMTP handshake per message. Callers sending in
         bulk should open a connection once and pass it in: Django only closes
         the connection it opened itself, so an already-open one stays up across
         calls and each message still reports its own success.
+
+        `idle_timeout`, only meaningful alongside a reused `connection`,
+        proactively checks and repairs a connection that has sat idle longer
+        than the given number of seconds before attempting the send, rather
+        than discovering it is dead after the fact.
         """
 
-        if isinstance(email_messages, EmailMessage):
-            try:
-                send_mail(
-                    email_messages.subject,
-                    email_messages.text_message,
-                    email_messages.from_,
-                    email_messages.to,
-                    html_message=email_messages.html_message,
-                    fail_silently=False,
-                    connection=connection,
-                )
-            except SMTPException as e:
-                logging.error(str(e), exc_info=True)
-                return False
-        else:
-            # Django `send_mass_mail()` does not support HTML
-            messages = [em.to_multi_alternative() for em in email_messages]
-            try:
-                if connection is not None:
-                    connection.send_messages(messages)
-                else:
-                    with get_connection() as new_connection:
-                        new_connection.send_messages(messages)
-            except SMTPException as e:
-                logging.error(str(e), exc_info=True)
-                return False
+        if connection is not None and idle_timeout is not None:
+            cls._reopen_if_idle(connection, idle_timeout)
 
-        return True
+        if isinstance(email_messages, EmailMessage):
+            cls._send_single(email_messages, connection)
+        else:
+            cls._send_batch(email_messages, connection)
+
+        if connection is not None:
+            connection._mailer_last_used = monotonic()
+
+    @classmethod
+    def _classify_smtp_exception(cls, exc: SMTPException) -> MailerError:
+        """
+        Turn a raw `smtplib` exception into a typed `MailerError`
+
+        Only exceptions that carry an SMTP status code can be matched against
+        `THROTTLE_SIGNATURES`. Everything else (e.g. a dropped connection)
+        becomes a plain `MailerError`.
+        """
+
+        if isinstance(exc, SMTPRecipientsRefused):
+            # One (code, message) pair per recipient. Every caller here sends to
+            # a single recipient, so the first refusal is the only one that matters.
+            code, msg = next(iter(exc.recipients.values()))
+        elif isinstance(exc, SMTPResponseException):
+            code, msg = exc.smtp_code, exc.smtp_error
+        else:
+            return MailerError(str(exc))
+
+        text = cls._decode_smtp_text(msg)
+        for signature_code, substring, exception_class in cls.THROTTLE_SIGNATURES:
+            if (signature_code is None or code == signature_code) and substring in text:
+                return exception_class(f'{code} {text}')
+
+        return MailerError(f'{code} {text}')
+
+    @staticmethod
+    def _decode_smtp_text(value: Union[bytes, str]) -> str:
+        if isinstance(value, bytes):
+            return value.decode('utf-8', errors='replace')
+        return str(value)
+
+    @staticmethod
+    def _dispatch_single(
+        email_message: EmailMessage, connection: Optional[BaseEmailBackend]
+    ):
+        send_mail(
+            email_message.subject,
+            email_message.text_message,
+            email_message.from_,
+            email_message.to,
+            html_message=email_message.html_message,
+            fail_silently=False,
+            connection=connection,
+        )
+
+    @classmethod
+    def _is_connection_alive(cls, connection: BaseEmailBackend) -> bool:
+        """
+        Tell whether the connection can still carry another message
+
+        `Mailer.send()` raises on every SMTP error, so callers wrapping it
+        with a reused connection need this to tell a dropped socket apart
+        from a message the server merely refused. Only the former is worth
+        reconnecting for: a refused recipient leaves the connection perfectly
+        usable, and tearing it down would cost a full handshake on every
+        failure.
+        """
+
+        if not hasattr(connection, 'connection'):
+            # Not an SMTP backend. The file and console backends used outside
+            # production hold no socket that could have dropped.
+            return True
+
+        if connection.connection is None:
+            return False
+
+        try:
+            code, _ = connection.connection.noop()
+        except (OSError, SMTPException):
+            return False
+
+        return code == cls.SMTP_ALIVE_STATUS_CODE
+
+    @classmethod
+    def _reopen_if_idle(cls, connection: BaseEmailBackend, idle_timeout: float):
+        last_used = getattr(connection, '_mailer_last_used', None)
+        if last_used is None or monotonic() - last_used <= idle_timeout:
+            return
+        if not cls._is_connection_alive(connection):
+            logging.warning(
+                'SMTP connection idle past timeout, reconnecting proactively'
+            )
+            cls._reset_connection(connection)
+
+    @staticmethod
+    def _reset_connection(connection: BaseEmailBackend):
+        """
+        Close and reopen a connection in place
+
+        Django leaves a connection it did not open itself untouched, so a
+        socket dropped mid-run stays broken until it is explicitly replaced.
+        Only the underlying socket is renewed, so callers holding this
+        backend keep a valid reference.
+        """
+
+        try:
+            connection.close()
+        except Exception as e:
+            # Django re-raises when quitting a socket that has already
+            # dropped, which would mask the error that led us here in the
+            # first place.
+            logging.warning(f'Error while closing the email connection: {e}')
+
+        connection.open()
+
+    @classmethod
+    def _send_batch(
+        cls,
+        email_messages: list[EmailMessage],
+        connection: Optional[BaseEmailBackend],
+    ):
+        # Django `send_mass_mail()` does not support HTML
+        messages = [em.to_multi_alternative() for em in email_messages]
+        try:
+            if connection is not None:
+                connection.send_messages(messages)
+            else:
+                with get_connection() as new_connection:
+                    new_connection.send_messages(messages)
+        except SMTPException as e:
+            # No retry here: Django's `send_messages()` gives no per-message
+            # success/failure back, so retrying a partially-sent batch risks
+            # re-sending messages that already went out.
+            raise cls._classify_smtp_exception(e) from e
+
+    @classmethod
+    def _send_single(
+        cls, email_message: EmailMessage, connection: Optional[BaseEmailBackend]
+    ):
+        try:
+            cls._dispatch_single(email_message, connection)
+        except SMTPException as e:
+            if connection is not None and not cls._is_connection_alive(connection):
+                # A dropped connection can happen right after the server
+                # already accepted the message but before we read its
+                # acknowledgement, so we can't tell a lost send apart from a
+                # lost confirmation. Resending would risk a duplicate: just
+                # reconnect for the records still to come and report this
+                # one failed.
+                logging.warning('SMTP connection lost, reconnecting')
+                cls._reset_connection(connection)
+            raise cls._classify_smtp_exception(e) from e


### PR DESCRIPTION
### 📣 Summary

Mass email campaigns now pace themselves to stay within the email provider's sending limits, instead of risking being throttled or blocked for sending too fast.

### 👷 Description for instance maintainers

Two new environment variables control mass-email pacing and replace the removed `MASS_EMAIL_SLEEP_SECONDS`:

- `MASS_EMAIL_SEND_RATE_RATIO` (default `0.35`): share of `MASS_EMAIL_THROTTLE_PER_SECOND` actually claimed per second, leaving headroom for transactional email and other instances sharing the same provider account. `0.5` or below is recommended so two full budget windows landing back to back still can't exceed the provider's rate limit; a Django system check only blocks values outside `(0, 1]`, an admin can go above `0.5` at the risk of bursting past the limit near a window boundary.
- `MAILER_CONNECTION_IDLE_TIMEOUT` (default `10`): seconds a reused SMTP connection can sit idle before it's proactively checked and reconnected ahead of the next send.

`MASS_EMAIL_THROTTLE_PER_SECOND` and `MAX_MASS_EMAILS_PER_DAY` keep their existing meaning, but should be reviewed per deployment: they must reflect the actual provider's real limits, which differ between a main SES account, a secondary SES account, SendGrid, or Office365. No migrations.

### 💭 Notes

`Mailer.send()` no longer returns a `bool`; it raises a typed exception on failure (new hierarchy in `kpi/exceptions.py`: `MailerError`, `MailerProviderThrottledError` → `MailerProviderRateThrottledError`/`MailerProviderQuotaExhaustedError`, matched against a per-provider SMTP signature catalog for SES/SendGrid/Office365 sourced from official docs, not live-probed against a real relay — an unmatched response falls back to today's plain-failure behavior). This is a breaking API change; every caller in the repo was updated, including four "solo" send sites (org invites, project-ownership invites) that previously ignored the return value and silently swallowed failures.

`send_day_emails()`'s fixed batch-sleep throttle is replaced by a real 1-second sliding-window budget. Connection reconnect-on-drop logic moved from `mass_emails/tasks.py` into `Mailer.send()` itself so every caller benefits, plus a new idle-timeout-aware proactive check. The existing "don't resend on an ambiguous connection drop" fix (DEV-2675, PR #7435) is preserved unchanged.

`MailerProviderRateThrottledError` currently stops the run exactly like `MailerProviderQuotaExhaustedError` (flagged by Greptile: an earlier version slept `MASS_EMAIL_THROTTLE_COOLDOWN_SECONDS` synchronously, which exceeded the task's own soft time limit). That makes the two exceptions synonyms for now - a real non-blocking cooldown is tracked in DEV-2693.

### 👀 Preview steps

No UI surface here (background Celery task + SMTP). Quick reference, no manual setup:

- `kpi/tests/test_mailer.py::TestClassifySmtpException` — a mocked SES/SendGrid/Office365 throttle response comes back as `MailerProviderRateThrottledError` or `MailerProviderQuotaExhaustedError`
- `kobo/apps/mass_emails/tests/test_celery_tasks.py::TestMassEmailSenderConnection` — a rate-throttled or quota-exhausted record stops the run outright and stays `enqueued` for the next scheduled run (see the Notes section on why these two aren't differentiated yet - DEV-2693)
- `kobo/apps/mass_emails/tests/test_celery_tasks.py::TestMassEmailSender::test_send_is_throttled` — the per-second budget actually paces sends instead of the old fixed-batch sleep

To watch it live end to end, from scratch, in `manage.py shell` (`docker exec -it kobofe-kpi-1 /opt/venv/bin/python manage.py shell`):

1. ℹ️ create ~20 throwaway users whose email points back to your own inbox (Gmail plus-addressing works: `you+test1@gmail.com` etc. all land in `you@gmail.com`)
   ```python
   from kobo.apps.kobo_auth.shortcuts import User

   test_emails = [f'you+test{i}@gmail.com' for i in range(1, 20)]
   for i, email in enumerate(test_emails):
       User.objects.get_or_create(username=f'mass_email_test_{i}', defaults={'email': email})
   ```
2. point the `test_users` query at them (it's the query mass email configs use for exactly this purpose - see `get_all_test_users()`)
   ```python
   from constance import config
   config.MASS_EMAIL_TEST_EMAILS = '\n'.join(test_emails)
   ```
3. create a config targeting them. Note the `date_created` backdate: `generate_mass_email_user_lists()` only picks up configs created before today
   ```python
   from datetime import timedelta
   from django.utils import timezone
   from kobo.apps.mass_emails.models import MassEmailConfig

   email_config = MassEmailConfig.objects.create(
       name='Manual test',
       subject='Test mass email',
       template='Hello ##username##, this is a test.',
       query='test_users',
       frequency=1,
       live=True,
       date_created=timezone.now() - timedelta(days=1),
   )
   ```
4. run the real pipeline synchronously (no worker needed, these are plain functions)
   ```python
   from kobo.apps.mass_emails.tasks import generate_mass_email_user_lists, send_emails

   generate_mass_email_user_lists()
   send_emails()
   ```
5. 🟢 watch the logs: with the default settings (`MASS_EMAIL_THROTTLE_PER_SECOND=40`, `MASS_EMAIL_SEND_RATE_RATIO=0.35`, budget = 14/s) with ~20 records you should see 14 `Processing MassEmailRecord(...)` lines, one `sleeping for ...s to stay within the per-second budget` line, then the rest - not the old fixed "N sent, sleep 1s" pattern
6. 🟢 to see it paced more slowly and watchably, drop the budget in the same shell session before re-running (`send_emails()` reads `django.conf.settings` live, no restart needed): `from django.conf import settings; settings.MASS_EMAIL_THROTTLE_PER_SECOND = 2; settings.MASS_EMAIL_SEND_RATE_RATIO = 1.0` gives a budget of 2/s
7. re-running the same day: `generate_mass_email_user_lists()` and the per-config daily quota are both cached for the day and won't re-trigger; reset with:
   ```python
   from django.core.cache import cache
   from kobo.apps.mass_emails.models import EmailStatus, MassEmailRecord
   from kobo.apps.mass_emails.tasks import PROCESSED_EMAILS_CACHE_KEY, MassEmailSender

   MassEmailRecord.objects.filter(email_job__email_config=email_config).update(status=EmailStatus.ENQUEUED)
   cache_key_date = MassEmailSender.get_cache_key_date(timezone.now())
   cache.delete(PROCESSED_EMAILS_CACHE_KEY.format(key_date=cache_key_date))
   cache.delete(f'mass_emails_{cache_key_date.isoformat()}_email_remaining_total')
   cache.delete(f'mass_emails_{cache_key_date.isoformat()}_email_remaining_{email_config.id}')
   ```
8. no real email lands anywhere unless `EMAIL_BACKEND` is pointed at real SMTP credentials - the dev default (`filebased`) just writes messages to `EMAIL_FILE_PATH` instead
9. cleanup: `email_config.live = False; email_config.save()` (or delete jobs/records then the config - `MassEmailJob`/`MassEmailRecord` use `on_delete=PROTECT`, so the config can't be deleted while they exist)