### PR TITLE
fix(projectDownloads): kml exporting bug DEV-2695

### DIFF
--- a/jsapp/js/components/projectDownloads/ProjectExportsCreator.tsx
+++ b/jsapp/js/components/projectDownloads/ProjectExportsCreator.tsx
@@ -31,12 +31,13 @@ import {
   type ExportFormatOption,
   getContextualDefaultExportFormat,
   getExportFormatOptions,
+  preserveApiOnlySettings,
 } from '#/components/projectDownloads/exportsUtils'
 import { openDeleteExportSettingModal } from '#/components/projectDownloads/openDeleteExportSettingModal'
 import { getColumnLabel } from '#/components/submissions/tableUtils'
 import { ADDITIONAL_SUBMISSION_PROPS, SUPPLEMENTAL_DETAILS_PROP } from '#/constants'
 import type { AssetResponse, ExportSetting, ExportSettingRequest, MongoQuery } from '#/dataInterface'
-import { createDateQuery, formatTimeDate, notify, recordEntries, recordKeys, recordValues } from '#/utils'
+import { createDateQuery, formatTimeDate, notify, recordKeys, recordValues } from '#/utils'
 
 const NAMELESS_EXPORT_NAME = t('Latest unsaved settings')
 
@@ -223,9 +224,11 @@ export default function ProjectExportsCreator(props: ProjectExportsCreatorProps)
       isSaveCustomExportEnabled: typeof data.name === 'string' && data.name.length >= 1,
       customExportName: data.name,
       isCustomSelectionEnabled: customSelectionEnabled,
-      isFlattenGeoJsonEnabled: data.export_settings.flatten,
-      isXlsTypesAsTextEnabled: data.export_settings.xls_types_as_text,
-      isIncludeMediaUrlEnabled: data.export_settings.include_media_url,
+      // Only some export types store these, so a setting saved for another type
+      // leaves them undefined - use the defaults instead.
+      isFlattenGeoJsonEnabled: data.export_settings.flatten ?? DEFAULT_EXPORT_SETTINGS.FLATTEN_GEO_JSON,
+      isXlsTypesAsTextEnabled: data.export_settings.xls_types_as_text ?? DEFAULT_EXPORT_SETTINGS.XLS_TYPES_AS_TEXT,
+      isIncludeMediaUrlEnabled: data.export_settings.include_media_url ?? DEFAULT_EXPORT_SETTINGS.INCLUDE_MEDIA_URL,
       selectedRows: newSelectedRows,
     }
 
@@ -372,14 +375,13 @@ export default function ProjectExportsCreator(props: ProjectExportsCreatorProps)
       (definedExport) => definedExport.data?.name === payload.name,
     )
 
+    // We are about to overwrite that saved setting with this payload, so first
+    // take over the options it holds that this form has no field for.
     if (foundDefinedExport?.data) {
-      // Keep backend-only fields from existing settings payloads so updating one
-      // option does not accidentally drop older settings fields.
-      recordEntries(foundDefinedExport.data.export_settings).forEach(([key, value]) => {
-        if (!Object.prototype.hasOwnProperty.call(payload.export_settings, key)) {
-          payload.export_settings[key] = value as never
-        }
-      })
+      payload.export_settings = preserveApiOnlySettings(
+        payload.export_settings,
+        foundDefinedExport.data.export_settings,
+      )
     }
 
     mergeState({ isPending: true })

--- a/jsapp/js/components/projectDownloads/exportsUtils.tests.ts
+++ b/jsapp/js/components/projectDownloads/exportsUtils.tests.ts
@@ -1,0 +1,68 @@
+import type { ExportSettingSettings } from '#/dataInterface'
+import { ExportTypeName } from './exportsConstants'
+import { preserveApiOnlySettings } from './exportsUtils'
+
+function buildSettings(overrides: Partial<ExportSettingSettings> = {}): ExportSettingSettings {
+  return {
+    lang: '_default',
+    type: ExportTypeName.geojson,
+    fields: [],
+    group_sep: '/',
+    multiple_select: 'both',
+    hierarchy_in_labels: false,
+    fields_from_all_versions: true,
+    query: {},
+    ...overrides,
+  }
+}
+
+describe('preserveApiOnlySettings', () => {
+  it('keeps settings the form knows nothing about', () => {
+    const merged = preserveApiOnlySettings(
+      buildSettings(),
+      buildSettings({ submission_ids: [1, 2, 3], some_future_setting: 'foo' }),
+    )
+
+    chai.expect(merged.submission_ids).to.deep.equal([1, 2, 3])
+    chai.expect(merged.some_future_setting).to.equal('foo')
+  })
+
+  it('does not bring back `flatten` when a GeoJSON export is followed by a KML one', () => {
+    const merged = preserveApiOnlySettings(
+      buildSettings({ type: ExportTypeName.kml }),
+      buildSettings({ type: ExportTypeName.geojson, flatten: true }),
+    )
+
+    chai.expect(merged).to.not.have.property('flatten')
+  })
+
+  it('does not bring back other export type specific settings', () => {
+    const merged = preserveApiOnlySettings(
+      buildSettings({ type: ExportTypeName.kml }),
+      buildSettings({ type: ExportTypeName.xls, xls_types_as_text: true, include_media_url: true }),
+    )
+
+    chai.expect(merged).to.not.have.property('xls_types_as_text')
+    chai.expect(merged).to.not.have.property('include_media_url')
+  })
+
+  it('does not overwrite settings coming from the form', () => {
+    const merged = preserveApiOnlySettings(
+      buildSettings({ type: ExportTypeName.csv, group_sep: ':', include_media_url: false }),
+      buildSettings({ type: ExportTypeName.geojson, group_sep: '/', include_media_url: true }),
+    )
+
+    chai.expect(merged.type).to.equal(ExportTypeName.csv)
+    chai.expect(merged.group_sep).to.equal(':')
+    chai.expect(merged.include_media_url).to.equal(false)
+  })
+
+  it('does not mutate the given settings', () => {
+    const formSettings = buildSettings()
+    const savedSettings = buildSettings({ submission_ids: [1] })
+
+    preserveApiOnlySettings(formSettings, savedSettings)
+
+    chai.expect(formSettings).to.not.have.property('submission_ids')
+  })
+})

--- a/jsapp/js/components/projectDownloads/exportsUtils.ts
+++ b/jsapp/js/components/projectDownloads/exportsUtils.ts
@@ -1,11 +1,63 @@
 import { EXPORT_FORMATS } from '#/components/projectDownloads/exportsConstants'
-import type { AssetResponse, ExportDataLang } from '#/dataInterface'
+import type { AssetResponse, ExportDataLang, ExportSettingSettings } from '#/dataInterface'
+import { recordEntries } from '#/utils'
 
 export interface ExportFormatOption {
   value: ExportDataLang
   label: string
   /** Present only for languages (not for `EXPORT_FORMATS`). */
   langIndex?: number
+}
+
+/**
+ * Every export setting that the exports creator form builds on its own (see
+ * `onSubmit` in `ProjectExportsCreator`). The form sends some of them only for
+ * some export types - `flatten` for GeoJSON, `xls_types_as_text` for XLS - so
+ * when one of these keys is missing from a payload, it means "the selected
+ * export type doesn't take it".
+ */
+const FORM_MANAGED_EXPORT_SETTINGS: ReadonlyArray<keyof ExportSettingSettings> = [
+  'fields',
+  'fields_from_all_versions',
+  'flatten',
+  'group_sep',
+  'hierarchy_in_labels',
+  'include_media_url',
+  'lang',
+  'multiple_select',
+  'query',
+  'type',
+  'xls_types_as_text',
+]
+
+/**
+ * Returns the settings the form built, plus any setting from an existing saved
+ * export setting that the form has no field for (`submission_ids`, for example).
+ *
+ * Needed because saving overwrites the whole `export_settings` object: without
+ * copying those over, exporting from this form would delete options that were
+ * set up through the API.
+ *
+ * Settings from `FORM_MANAGED_EXPORT_SETTINGS` are never copied - the form is
+ * the only source of truth for them. Example: you export GeoJSON, so
+ * `flatten: true` lands in the payload and gets saved. Then you switch to KML
+ * and export again; this payload has no `flatten`, because KML doesn't support
+ * it. Copying the saved `flatten` back in would make the API reject the export.
+ */
+export function preserveApiOnlySettings(
+  formSettings: ExportSettingSettings,
+  savedSettings: ExportSettingSettings,
+): ExportSettingSettings {
+  const mergedSettings = { ...formSettings }
+
+  recordEntries(savedSettings).forEach(([key, value]) => {
+    if (FORM_MANAGED_EXPORT_SETTINGS.includes(key) || Object.prototype.hasOwnProperty.call(mergedSettings, key)) {
+      return
+    }
+    mergedSettings[key] = value
+  })
+
+  return mergedSettings
 }
 
 /**


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixed an error that blocked KML exports in projects where a GeoJSON export was created earlier.

### 📖 Description

Options that apply to a single export format no longer follow you when you switch format. Before this fix, exporting GeoJSON and then KML sent the GeoJSON-only "Flatten GeoJSON" option along with the KML request, and the server refused it. Projects already in that state recover on their next export, nothing to clean up.

### 💭 Notes

Changes here:

- **`exportsUtils.ts`**
  - `preserveApiOnlySettings()` replaces the inline merge loop that lived in `onSubmit`. When the form overwrites a saved export setting, keep the options the API supports but our form has no field for (`submission_ids` and friends) — except it now skips every key listed in `FORM_MANAGED_EXPORT_SETTINGS`.
  - That list is the actual fix. Each export saves its payload as an export setting (a nameless "Latest unsaved settings" record when you don't save a named preset), and the old loop copied back anything the fresh payload didn't have. Some of those keys are absent on purpose: `flatten` only ships for GeoJSON, `xls_types_as_text` for XLS. So a GeoJSON export left `flatten` in storage for the next KML export to inherit, and Backend rejects `flatten` for KML.
- **`ProjectExportsCreator.tsx`**
  - calls the new util, and `applyExportSettingToState()` now falls back to `DEFAULT_EXPORT_SETTINGS` for the three format-specific options
- **`exportsUtils.tests.ts`** -
  - new file: the GeoJSON → KML regression, plus the settings we still want carried over.

### 👀 Preview steps

1. ℹ️ have an account and a deployed project with a geopoint question and at least one submission
2. go to Project → Data → Downloads
3. set Export type to GeoJSON, click Export, wait for the file to appear in the list below
4. set Export type to KML, click Export
5. 🔴 [on main] error message, no KML file
6. 🟢 [on PR] the KML export is created and can be downloaded
7. switch back to GeoJSON, open Advanced options, untick "Flatten GeoJSON", export it, then export KML once more — 🟢 both still work
8. reload the page so the form restores your last used (KML) settings, then set Export type to GeoJSON and open Advanced options — 🟢 "Flatten GeoJSON" comes back checked, which is its default, instead of blank
