### PR TITLE
feat(sso): do not allow blocked domains in managed sso DEV-2352

### DIFF
--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -1,5 +1,6 @@
 import re
 
+import constance
 from allauth.account.admin import EmailAddressAdmin as BaseEmailAddressAdmin
 from allauth.account.signals import email_confirmed
 from django.core.exceptions import ValidationError
@@ -105,6 +106,20 @@ class SocialAppCustomData(models.Model):
 def validate_domain(value):
     if EMAIL_DOMAIN_REGEX.fullmatch(value) is None:
         raise ValidationError(f'Invalid email domain: {value}')
+    blacklist_domains = constance.config.REGISTRATION_BLACKLIST_EMAIL_DOMAINS
+    blacklist_domain_set = {
+        d.strip().lower() for d in blacklist_domains.splitlines() if d.strip()
+    }
+
+    if value.strip().lower() in blacklist_domain_set:
+        raise ValidationError(f'Cannot manage forbidden email domain: {value}')
+
+    allowed_domains = constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
+    allowed_domain_list = [
+        domain.lower() for domain in allowed_domains.split('\n') if bool(domain)
+    ]
+    if allowed_domain_list and value not in allowed_domain_list:
+        raise ValidationError(f'Email domain not in allowed domain list {value}')
 
 
 class SocialAppManagedDomain(models.Model):

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -104,6 +104,7 @@ class SocialAppCustomData(models.Model):
 
 
 def validate_domain(value):
+    normalized_value = value.strip().lower()
     if EMAIL_DOMAIN_REGEX.fullmatch(value) is None:
         raise ValidationError(f'Invalid email domain: {value}')
     blacklist_domains = constance.config.REGISTRATION_BLACKLIST_EMAIL_DOMAINS
@@ -111,14 +112,14 @@ def validate_domain(value):
         d.strip().lower() for d in blacklist_domains.splitlines() if d.strip()
     }
 
-    if value.strip().lower() in blacklist_domain_set:
+    if normalized_value in blacklist_domain_set:
         raise ValidationError(f'Cannot manage forbidden email domain: {value}')
 
     allowed_domains = constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
     allowed_domain_list = [
         domain.lower() for domain in allowed_domains.split('\n') if bool(domain)
     ]
-    if allowed_domain_list and value not in allowed_domain_list:
+    if allowed_domain_list and normalized_value not in allowed_domain_list:
         raise ValidationError(f'Email domain not in allowed domain list {value}')
 
 

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -117,7 +117,7 @@ def validate_domain(value):
 
     allowed_domains = constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
     allowed_domain_list = [
-        domain.lower() for domain in allowed_domains.split('\n') if bool(domain)
+        domain.strip().lower() for domain in allowed_domains.split('\n') if bool(domain)
     ]
     if allowed_domain_list and normalized_value not in allowed_domain_list:
         raise ValidationError(f'Email domain not in allowed domain list {value}')

--- a/kobo/apps/accounts/tests/test_managed_domains.py
+++ b/kobo/apps/accounts/tests/test_managed_domains.py
@@ -16,8 +16,10 @@ class SocialAppManagedDomainTestCase(BaseTestCase):
         (None, None, 'good.com', True),
         (None, None, 'bad', False),
         (None, 'bad.com\nworse.com', 'bad.com', False),
+        (None, 'bad.com\nworse.com', 'bAD.cOm', False),
         (None, 'bad.com\nworse.com', 'good.com', True),
         ('good.com\nbetter.com', None, 'good.com', True),
+        ('good.com\nbetter.com', None, 'gOOd.com', True),
         ('good.com\nbetter.com', None, 'bad.com', False),
     )
     @unpack

--- a/kobo/apps/accounts/tests/test_managed_domains.py
+++ b/kobo/apps/accounts/tests/test_managed_domains.py
@@ -1,0 +1,37 @@
+from constance.test import override_config
+from ddt import data, ddt, unpack
+from django.core.exceptions import ValidationError
+
+from kobo.apps.accounts.models import (
+    validate_domain,
+)
+from kpi.tests.base_test_case import BaseTestCase
+
+
+@ddt
+class SocialAppManagedDomainTestCase(BaseTestCase):
+
+    @data(
+        # allow list, block list, domain, expect success
+        (None, None, 'good.com', True),
+        (None, None, 'bad', False),
+        (None, 'bad.com\nworse.com', 'bad.com', False),
+        (None, 'bad.com\nworse.com', 'good.com', True),
+        ('good.com\nbetter.com', None, 'good.com', True),
+        ('good.com\nbetter.com', None, 'bad.com', False),
+    )
+    @unpack
+    def test_validate_domain(self, allow_list, block_list, domain, expect_success):
+        with override_config(
+            REGISTRATION_ALLOWED_EMAIL_DOMAINS=allow_list,
+            REGISTRATION_BLACKLIST_EMAIL_DOMAINS=block_list,
+        ):
+            if not expect_success:
+                with self.assertRaises(ValidationError):
+                    validate_domain(domain)
+            else:
+                validate_domain(domain)
+
+        validate_domain('good.com')
+        with self.assertRaises(ValidationError):
+            validate_domain('bad!')

--- a/kpi/tests/test_registration.py
+++ b/kpi/tests/test_registration.py
@@ -50,9 +50,7 @@ class RegistrationTestCase(TestCase):
         REGISTRATION_ALLOWED_EMAIL_DOMAINS='foo.bar\nexample.com'
     )
     def test_allowed_domain_can_register(self):
-        response = self.client.post(
-            reverse('account_signup'), data=self.valid_data
-        )
+        response = self.client.post(reverse('account_signup'), data=self.valid_data)
         self.assertRedirects(response, '/accounts/confirm-email/')
 
     # use `override_config` decorator to deactivate all password validators


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Do not allow users to create managed SSO domains using domains that are on the blocklist or, if one is present, not in the allowlist.

### 💭 Notes
This isn't a catch-all, users could still add email domains to the blocklist after creating a SocialAppManagedDomain object, but it at least prevents trying to manage SSO domains that are already blocked.


### 👀 Preview steps

1. ℹ️ have an admin account and a social app
2. In Django admin > Constance, update `REGISTRATION_BLACKLIST_EMAIL_DOMAINS` with `bad.com`
3. Still in Django admin, create a Social app custom data object with associated domain `bad.com`
4. 🔴 [on main] You are allowed to create the domain
5. 🟢 [on PR] Error
6. In Django admin > Constance, update `REGISTRATION_ALLOWED_EMAIL_DOMAINS` with `good.com`
7. Update the Social app custom data object with domain `other.com`
8. 🔴 [on main] You are allowed to create the domain
9. 🟢 [on PR] Error
