### PR TITLE
fix(massEmails): exclude deactivated users from mass emails DEV-2691

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -8,6 +8,7 @@ from import_export import fields, resources
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.mass_emails.user_queries import (
+    _is_user_active_and_not_trashed,
     get_active_users,
     get_all_test_users,
     get_inactive_users,
@@ -123,13 +124,24 @@ class MassEmailConfig(AbstractTimeStampedModel):
         parameters = self._resolve_parameters(queryset_getter)
         return queryset_getter(**parameters)
 
-    def is_user_still_eligible(self, user: User) -> bool:
+    def is_user_still_eligible(
+        self, user: User | None, reevaluate_query: bool = True
+    ) -> bool:
         """
-        Cheap single-user recheck of `self.query`'s criteria, used before
-        sending a stale enqueued record to catch a recipient who stopped
-        matching while the record was sitting in the queue.
+        Whether a queued record's recipient may still be emailed.
+
+        A deleted, deactivated or trashed user is never eligible. With
+        `reevaluate_query`, the user is also re-checked against
+        `self.query`'s criteria - used for records that sat in the queue
+        long enough to go stale.
         """
 
+        # This also keeps the fail-open path below from applying to a
+        # deleted, deactivated or trashed user.
+        if not _is_user_active_and_not_trashed(user):
+            return False
+        if not reevaluate_query:
+            return True
         check = USER_ELIGIBILITY_CHECKS.get(self.query)
         if check is None:
             # Only reachable if an admin edits a live config's `query` while

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -122,6 +122,16 @@ class MassEmailSender:
         cache_date = self.get_cache_key_date(send_date=now)
         self.cache_key_prefix = f'mass_emails_{cache_date.isoformat()}_email_remaining'
 
+        # Users deactivated, deleted or trashed after enqueue must not be
+        # emailed. Mark their records stale up front so counts stay accurate
+        # and one-time configs can still finish and be turned off.
+        MassEmailRecord.objects.filter(
+            Q(user__isnull=True)
+            | Q(user__is_active=False)
+            | Q(user__trash__isnull=False),
+            status=EmailStatus.ENQUEUED,
+        ).update(status=EmailStatus.STALE)
+
         self.total_records = MassEmailRecord.objects.filter(
             status=EmailStatus.ENQUEUED
         ).count()
@@ -309,16 +319,20 @@ class MassEmailSender:
             for record in records.iterator():
                 if budget_used >= limit:
                     break
-                # Skip a stale record that no longer matches its config's criteria
-                if (
-                    record.date_created < stale_threshold
-                    and not email_config.is_user_still_eligible(record.user)
+                # A user deactivated, deleted or trashed after enqueue must
+                # never be emailed, no matter how fresh the record is;
+                # `record.user` is loaded here, so this reads their current
+                # state. A record older than the stale threshold is also
+                # re-checked against its config's criteria.
+                if not email_config.is_user_still_eligible(
+                    record.user,
+                    reevaluate_query=record.date_created < stale_threshold,
                 ):
                     record.status = EmailStatus.STALE
                     record.save(update_fields=['status', 'date_modified'])
                     logging.info(
                         f'Skipping stale MassEmailRecord({record}): recipient '
-                        f'no longer matches {email_config.query}'
+                        f'is no longer eligible for {email_config.query}'
                     )
                     continue
                 if spent_in_window >= budget_per_second:

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -517,18 +517,20 @@ class TestStaleRecordRevalidation(BaseMassEmailsTestCase):
         record = MassEmailRecord.objects.get(user=self.user1)
         assert record.status == EmailStatus.SENT
 
-    def test_fresh_record_is_sent_without_a_recheck(self):
+    def test_fresh_record_is_sent_without_reevaluating_the_query(self):
         self._create_email_record(
             user=self.user1,
             email_config=self.email_config,
             status=EmailStatus.ENQUEUED,
             days_ago=0,
         )
-        with patch.object(MassEmailConfig, 'is_user_still_eligible') as mock_check:
+        with patch.object(
+            MassEmailConfig, 'is_user_still_eligible', return_value=True
+        ) as mock_check:
             sender = MassEmailSender()
             sender.send_day_emails()
 
-        mock_check.assert_not_called()
+        mock_check.assert_called_once_with(self.user1, reevaluate_query=False)
         assert len(mail.outbox) == 1
         record = MassEmailRecord.objects.get(user=self.user1)
         assert record.status == EmailStatus.SENT
@@ -569,7 +571,9 @@ class TestStaleRecordRevalidation(BaseMassEmailsTestCase):
             days_ago=0,
         )
         with patch.object(
-            MassEmailConfig, 'is_user_still_eligible', return_value=False
+            MassEmailConfig,
+            'is_user_still_eligible',
+            side_effect=lambda user, reevaluate_query=True: not reevaluate_query,
         ):
             sender = MassEmailSender()
             original_limit = sender.limits[self.email_config.id]
@@ -617,7 +621,9 @@ class TestStaleRecordRevalidation(BaseMassEmailsTestCase):
         )
 
         with patch.object(
-            MassEmailConfig, 'is_user_still_eligible', return_value=False
+            MassEmailConfig,
+            'is_user_still_eligible',
+            side_effect=lambda user, reevaluate_query=True: not reevaluate_query,
         ):
             sender = MassEmailSender()
             assert sender.limits[self.email_config.id] == 2
@@ -844,6 +850,65 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         assert send_mock.call_count == 3
         for call in send_mock.call_args_list:
             assert call.kwargs['connection'] is connection
+
+    def test_deactivated_user_record_is_marked_stale_and_not_sent(self):
+        # A user deactivated after enqueue must not receive the email; their
+        # record is marked stale up front by MassEmailSender.__init__
+        self.user1.is_active = False
+        self.user1.save()
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send', return_value=None
+            ) as send_mock,
+        ):
+            MassEmailSender().send_day_emails()
+
+        user1_record = MassEmailRecord.objects.get(user=self.user1)
+        assert user1_record.status == EmailStatus.STALE
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+        sent_recipients = [call.args[0].to for call in send_mock.call_args_list]
+        assert self.user1.email not in sent_recipients
+
+    def test_orphaned_record_is_marked_stale_and_not_sent(self):
+        # Records whose user was deleted can never be sent; mark them stale
+        # so one-time configs still terminate
+        record = MassEmailRecord.objects.get(user=self.user1)
+        record.user = None
+        record.save()
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch('kobo.apps.mass_emails.tasks.Mailer.send', return_value=None),
+        ):
+            MassEmailSender().send_day_emails()
+
+        record.refresh_from_db()
+        assert record.status == EmailStatus.STALE
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+
+    def test_user_deactivated_mid_run_is_marked_stale_and_not_sent(self):
+        # The sender reads its batch (and runs its eager cleanup) while the
+        # user is still active, then the user is deactivated before their
+        # record is reached. The per-record guard catches it even though the
+        # record is far too young for the stale-threshold recheck.
+        sender = MassEmailSender()
+        self.user1.is_active = False
+        self.user1.save()
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send', return_value=None
+            ) as send_mock,
+        ):
+            sender.send_day_emails()
+
+        user1_record = MassEmailRecord.objects.get(user=self.user1)
+        assert user1_record.status == EmailStatus.STALE
+        sent_recipients = [call.args[0].to for call in send_mock.call_args_list]
+        assert self.user1.email not in sent_recipients
 
     def test_mailer_error_marks_the_record_failed_and_the_run_continues(self):
         connection = MagicMock()

--- a/kobo/apps/mass_emails/tests/test_eligibility_checks.py
+++ b/kobo/apps/mass_emails/tests/test_eligibility_checks.py
@@ -131,6 +131,36 @@ class TestMassEmailConfigEligibility(TestCase):
         user = User.objects.create(username='u')
         assert email_config.is_user_still_eligible(user) is True
 
+    def test_reevaluate_query_false_skips_the_registered_check(self):
+        # The cheap active/trash guard still applies, but the query criteria
+        # are not re-evaluated
+        email_config = MassEmailConfig.objects.create(
+            name='no reevaluation', query='users_active_within_365_days'
+        )
+        stale_user = User.objects.create(
+            username='stale_no_reeval',
+            last_login=timezone.now() - timedelta(days=400),
+        )
+        assert email_config.is_user_still_eligible(stale_user) is False
+        assert (
+            email_config.is_user_still_eligible(stale_user, reevaluate_query=False)
+            is True
+        )
+
+    def test_never_eligible_when_user_is_none_or_deactivated(self):
+        # The guard beats both the registered check and the fail-open path
+        for query in ('users_active_within_365_days', 'does_not_exist'):
+            email_config = MassEmailConfig.objects.create(
+                name=f'guard {query}', query=query
+            )
+            deactivated = User.objects.create(
+                username=f'deactivated_{query}',
+                last_login=timezone.now() - timedelta(days=1),
+                is_active=False,
+            )
+            assert email_config.is_user_still_eligible(None) is False
+            assert email_config.is_user_still_eligible(deactivated) is False
+
     def test_delegates_to_registered_check(self):
         email_config = MassEmailConfig.objects.create(
             name='active check', query='users_active_within_365_days'

--- a/kobo/apps/mass_emails/tests/test_user_activity_queries.py
+++ b/kobo/apps/mass_emails/tests/test_user_activity_queries.py
@@ -351,3 +351,21 @@ class UserActivityQueryTests(BaseTestCase):
         )
         inactive_users = get_inactive_users()
         self.assertFalse(user in inactive_users)
+
+    def test_deactivated_user_excluded_from_active_user_query(self):
+        """
+        Test that a user meeting the activity criteria is excluded from both
+        queries once their Django account is deactivated (is_active=False)
+        """
+        user = self._create_user('deactivated', self.recent_date)
+        active_users = get_active_users()
+        inactive_users = get_inactive_users()
+        self.assertTrue(user in active_users)
+        self.assertFalse(user in inactive_users)
+
+        user.is_active = False
+        user.save()
+        active_users = get_active_users()
+        inactive_users = get_inactive_users()
+        self.assertFalse(user in active_users)
+        self.assertFalse(user in inactive_users)

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -25,6 +25,7 @@ def get_active_users(days: int = 365) -> QuerySet:
     Retrieve users who have been active within specified number of days.
 
     A user is considered active if:
+    - They are not deactivated (``is_active=True``) and not in the trash
     - They have logged in within the given period, or were recently created and never
       logged in
     - They have modified or created an asset within the given period
@@ -47,7 +48,7 @@ def get_active_users(days: int = 365) -> QuerySet:
         extra_details__last_project_activity__gt=inactivity_threshold
     )
     return User.objects.filter(recent_login_filter | recently_active).exclude(
-        pk=settings.ANONYMOUS_USER_ID
+        Q(pk=settings.ANONYMOUS_USER_ID) | Q(is_active=False) | Q(trash__isnull=False)
     )
 
 
@@ -325,7 +326,7 @@ def is_user_within_usage_range(
     isn't worth the extra cost.
     """
 
-    if not settings.STRIPE_ENABLED or not is_user_active_and_not_trashed(user):
+    if not settings.STRIPE_ENABLED or not _is_user_active_and_not_trashed(user):
         return False
 
     minimum = minimum or 0
@@ -343,7 +344,8 @@ def is_user_within_usage_range(
     return False
 
 
-def is_user_active_and_not_trashed(user: User) -> bool:
-    if not user.is_active:
+def _is_user_active_and_not_trashed(user: User | None) -> bool:
+    # `None` means the user was deleted (records keep a nullable FK)
+    if user is None or not user.is_active:
         return False
     return not hasattr(user, 'trash')


### PR DESCRIPTION
### 📣 Summary

Deactivated accounts no longer receive mass emails.

### 📖 Description

Deactivated accounts could still show up as recipients of mass emails. That includes accounts moved to a private server, which stay around for months before their data is deleted. They're now left out of the recipient lists, and an account deactivated after a list was built won't get the email either.

### 💭 Notes

- `get_active_users()` was the only recipient query missing the `is_active` / trash exclusion the others already had.
- Builds on the eligibility recheck from #7448: records whose user is deactivated, deleted or trashed are marked `stale`. `MassEmailSender.__init__` sweeps them up front (keeps counts accurate, lets one-time configs terminate), and a per-record guard in the send loop catches changes that happen mid-run, regardless of the `MASS_EMAIL_STALE_RECORD_RECHECK_HOURS` threshold.
- `is_user_still_eligible()` now returns `False` for a deleted/deactivated/trashed user before consulting the check registry, so the fail-open path can't apply to them.

### 👀 Preview steps

1. ℹ️ have a superuser and a user who logged in within the last year
2. deactivate that user in `/admin/` (uncheck `Active`)
3. in a Django shell: `from kobo.apps.mass_emails.user_queries import get_active_users`
4. run `get_active_users().filter(username='<user>').exists()`
5. 🔴 [on 2.026.30] returns `True`, the deactivated user is still a mass email recipient
6. 🟢 [on PR] returns `False`
