### PR TITLE
feat(auth): add auth redesign feature flag DEV-1867

### DIFF
--- a/jsapp/js/featureFlags.ts
+++ b/jsapp/js/featureFlags.ts
@@ -6,6 +6,7 @@ import { recordValues } from './utils'
  */
 export enum FeatureFlag {
   exampleFeatureEnabled = 'exampleFeatureEnabled', //Comment out when we have active FFs
+  authRedesignEnabled = 'authRedesignEnabled',
 }
 
 /**

--- a/jsapp/js/router/RequireFeatureFlag.tsx
+++ b/jsapp/js/router/RequireFeatureFlag.tsx
@@ -1,0 +1,14 @@
+import type React from 'react'
+import { Navigate } from 'react-router-dom'
+import { type FeatureFlag, useFeatureFlag } from '#/featureFlags'
+import { ROUTES } from './routerConstants'
+
+interface Props {
+  flag: FeatureFlag
+  children: React.ReactNode
+}
+
+export default function RequireFeatureFlag({ flag, children }: Props) {
+  const isFlagEnabled = useFeatureFlag(flag)
+  return isFlagEnabled ? <>{children}</> : <Navigate to={ROUTES.FORMS} replace />
+}


### PR DESCRIPTION
### 💭 Notes
Adds a feature flag to be used in the auth redesign project, as well as a new RequireFeatureFlag route guard that can be used to protect in-development auth routes.

### 👀 Preview steps
1. Add a temporary route to `router.tsx`:
   ```tsx
   <Route
     path='/auth'
     element={
       <RequireFeatureFlag flag={FeatureFlag.authRedesignEnabled}>
         <div>Auth redesign enabled</div>
       </RequireFeatureFlag>
     }
   />
2. Navigate to /#/auth
3. Verify you are redirected to /#/forms (and then to login if you aren't logged in)
4. Navigate to /#/auth?ff_authRedesignEnabled=true
5. Verify you reach test page
