### PR TITLE
fix(frontend): AccountMenu language selector DEV-2705

### DIFF
--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -146,7 +146,7 @@ export default function AccountMenu() {
                     {langs.map((lang) => (
                       <ButtonNew
                         variant={lang.value === currentLanguage ? 'light' : 'transparent'}
-                        aria-disabled={lang.value === currentLanguage}
+                        disabled={lang.value === currentLanguage}
                         size='sm'
                         key={lang.value}
                         onClick={() => onLanguageChange(lang.value)}

--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -1,5 +1,4 @@
-import { Group, Paper, Stack, Text } from '@mantine/core'
-import { useMediaQuery } from '@mantine/hooks'
+import { Paper, Stack } from '@mantine/core'
 import { IconLogout, IconWorldFilled } from '@tabler/icons-react'
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -14,7 +13,6 @@ import { isAnyRouteBlockerActive } from '#/router/routerUtils'
 import sessionStore from '#/stores/session'
 import { currentLang } from '#/utils'
 import ButtonNew from '../common/ButtonNew'
-import KoboIcon from '../common/KoboIcon'
 import OrganizationBadge from './organizationBadge.component'
 
 /**
@@ -25,16 +23,13 @@ import OrganizationBadge from './organizationBadge.component'
  * Note: this displays a simplified content for user with invalidated password.
  */
 export default function AccountMenu() {
-  const [isLanguageSelectorToggled, setIsLanguageSelectorToggled] = useState<boolean>(false)
+  // Collapsed by default on every device: an expanded list pushes the logout button below the menu's scroll area, and
+  // quick access to logout matters more than quick access to languages.
+  const [isLanguageSelectorVisible, setIsLanguageSelectorVisible] = useState<boolean>(false)
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
 
-  // A collapsible list inside an already tapped-open menu is awkward on touch, so we keep the language list expanded
-  // there and drop the toggle in favour of a plain section label.
-  const isTouchDevice = useMediaQuery('(pointer: coarse)', false, { getInitialValueInEffect: false })
-  const isLanguageSelectorVisible = isTouchDevice || isLanguageSelectorToggled
-
   const toggleLanguageSelector = () => {
-    setIsLanguageSelectorToggled(!isLanguageSelectorToggled)
+    setIsLanguageSelectorVisible(!isLanguageSelectorVisible)
   }
 
   const shouldDisplayUrls =
@@ -121,24 +116,15 @@ export default function AccountMenu() {
             )}
 
             <bem.AccountBox__menuLI m={'lang'} key='3'>
-              {isTouchDevice && (
-                <Group gap={6}>
-                  <KoboIcon icon={IconWorldFilled} />
-                  <Text fw='600'>{t('Language')}</Text>
-                </Group>
-              )}
-              {!isTouchDevice && (
-                <ButtonNew
-                  leftIcon={IconWorldFilled}
-                  rightIcon={isLanguageSelectorVisible ? 'angle-up' : 'angle-down'}
-                  variant='transparent'
-                  onClick={toggleLanguageSelector}
-                  tabIndex={0}
-                  disabled={isTouchDevice}
-                >
-                  {t('Language')}
-                </ButtonNew>
-              )}
+              <ButtonNew
+                leftIcon={IconWorldFilled}
+                rightIcon={isLanguageSelectorVisible ? 'angle-up' : 'angle-down'}
+                variant='transparent'
+                onClick={toggleLanguageSelector}
+                tabIndex={0}
+              >
+                {t('Language')}
+              </ButtonNew>
 
               {isLanguageSelectorVisible && (
                 <Paper mt='xs'>

--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -130,7 +130,7 @@ export default function AccountMenu() {
               {!isTouchDevice && (
                 <ButtonNew
                   leftIcon={IconWorldFilled}
-                  rightIcon={isLanguageSelectorVisible ? 'angle-down' : 'angle-up'}
+                  rightIcon={isLanguageSelectorVisible ? 'angle-up' : 'angle-down'}
                   variant='transparent'
                   onClick={toggleLanguageSelector}
                   tabIndex={0}

--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -1,3 +1,5 @@
+import { Group, Paper, Stack, Text } from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
 import { IconLogout, IconWorldFilled } from '@tabler/icons-react'
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -12,6 +14,7 @@ import { isAnyRouteBlockerActive } from '#/router/routerUtils'
 import sessionStore from '#/stores/session'
 import { currentLang } from '#/utils'
 import ButtonNew from '../common/ButtonNew'
+import KoboIcon from '../common/KoboIcon'
 import OrganizationBadge from './organizationBadge.component'
 
 /**
@@ -22,11 +25,16 @@ import OrganizationBadge from './organizationBadge.component'
  * Note: this displays a simplified content for user with invalidated password.
  */
 export default function AccountMenu() {
-  const [isLanguageSelectorVisible, setIsLanguageSelectorVisible] = useState<boolean>(false)
+  const [isLanguageSelectorToggled, setIsLanguageSelectorToggled] = useState<boolean>(false)
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
 
+  // A collapsible list inside an already tapped-open menu is awkward on touch, so we keep the language list expanded
+  // there and drop the toggle in favour of a plain section label.
+  const isTouchDevice = useMediaQuery('(pointer: coarse)', false, { getInitialValueInEffect: false })
+  const isLanguageSelectorVisible = isTouchDevice || isLanguageSelectorToggled
+
   const toggleLanguageSelector = () => {
-    setIsLanguageSelectorVisible(!isLanguageSelectorVisible)
+    setIsLanguageSelectorToggled(!isLanguageSelectorToggled)
   }
 
   const shouldDisplayUrls =
@@ -51,24 +59,14 @@ export default function AccountMenu() {
     }
   }
 
-  const renderLangItem = (lang: LabelValuePair) => {
-    const currentLanguage = currentLang()
-    return (
-      <bem.AccountBox__menuLI key={lang.value}>
-        <bem.AccountBox__menuLink onClick={() => onLanguageChange(lang.value)}>
-          {lang.value === currentLanguage && <strong>{lang.label}</strong>}
-          {lang.value !== currentLanguage && lang.label}
-        </bem.AccountBox__menuLink>
-      </bem.AccountBox__menuLI>
-    )
-  }
-
   if (!sessionStore.isLoggedIn) {
     return null
   }
 
   const accountName = sessionStore.currentAccount.username
   const accountEmail = 'email' in sessionStore.currentAccount ? sessionStore.currentAccount.email : ''
+
+  const currentLanguage = currentLang()
 
   return (
     <bem.AccountBox>
@@ -123,11 +121,43 @@ export default function AccountMenu() {
             )}
 
             <bem.AccountBox__menuLI m={'lang'} key='3'>
-              <ButtonNew leftIcon={IconWorldFilled} variant='transparent' onClick={toggleLanguageSelector} tabIndex={0}>
-                {t('Language')}
-              </ButtonNew>
+              {isTouchDevice && (
+                <Group gap={6}>
+                  <KoboIcon icon={IconWorldFilled} />
+                  <Text fw='600'>{t('Language')}</Text>
+                </Group>
+              )}
+              {!isTouchDevice && (
+                <ButtonNew
+                  leftIcon={IconWorldFilled}
+                  rightIcon={isLanguageSelectorVisible ? 'angle-down' : 'angle-up'}
+                  variant='transparent'
+                  onClick={toggleLanguageSelector}
+                  tabIndex={0}
+                  disabled={isTouchDevice}
+                >
+                  {t('Language')}
+                </ButtonNew>
+              )}
 
-              {isLanguageSelectorVisible && <ul>{langs.map(renderLangItem)}</ul>}
+              {isLanguageSelectorVisible && (
+                <Paper mt='xs'>
+                  <Stack gap='xs' p='xs'>
+                    {langs.map((lang) => (
+                      <ButtonNew
+                        variant={lang.value === currentLanguage ? 'light' : 'transparent'}
+                        aria-disabled={lang.value === currentLanguage}
+                        size='sm'
+                        key={lang.value}
+                        onClick={() => onLanguageChange(lang.value)}
+                        justify='flex-start'
+                      >
+                        {lang.label}
+                      </ButtonNew>
+                    ))}
+                  </Stack>
+                </Paper>
+              )}
             </bem.AccountBox__menuLI>
 
             <bem.AccountBox__menuLI m={'logout'} key='4'>

--- a/jsapp/scss/components/_kobo.navigation.scss
+++ b/jsapp/scss/components/_kobo.navigation.scss
@@ -179,34 +179,6 @@
     }
   }
 
-  .account-box__menu-li--lang {
-    position: relative;
-    border-top: 1px solid colors.$kobo-gray-300;
-    padding-bottom: 5px;
-
-    ul {
-      margin-top: 5px;
-      background-color: colors.$kobo-white;
-      color: colors.$kobo-gray-700;
-      min-width: 140px;
-      padding: 0;
-      border: 1px solid colors.$kobo-gray-300;
-
-      li {
-        text-transform: capitalize;
-        padding: 0;
-
-        &:not(:last-child) {
-          border-bottom: 1px solid colors.$kobo-gray-300;
-        }
-
-        a {
-          padding: 10px 15px;
-        }
-      }
-    }
-  }
-
   .account-box__menu-li--logout {
     padding-top: 5px;
   }
@@ -315,25 +287,6 @@
       padding: 6px 12px;
       display: block;
       font-size: 12px;
-    }
-  }
-}
-
-// temporary fix for language menu on touch devices
-@media screen and (pointer: coarse) {
-  .account-box__menu .account-box__menu-li--lang {
-    ul {
-      opacity: 1;
-      position: static;
-      border: 1px solid colors.$kobo-gray-300;
-      margin-left: 12px;
-      padding: 0;
-      max-height: 1000px;
-      box-shadow: none;
-
-      li {
-        padding: 6px 18px;
-      }
     }
   }
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Fixes the UI of language selector.

### 💭 Notes

Migrate to Mantine, keeping the touch device functionality.

### 👀 Preview steps

1. ℹ️ have an account
2. Open top right account menu, click "Language"
3. 🔴 [on main] Notice that the list of languages looks bad, clickable areas are small and next to each other
4. 🟢 [on PR] Notice the list looks better, and is much harder to accidently click wrong langauge
5. In Dev Tools enable touch device simulation
6. 🟢 Notice that the list of languages is visible by default (no need to toggle it with "Language" button), and notice that "Language" is simple text, not clickable button
