### PR TITLE
perf(massEmails): fewer per-record queries when sending DEV-2691

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -140,8 +140,10 @@ class MassEmailConfig(AbstractTimeStampedModel):
         # deleted, deactivated or trashed user.
         if not _is_user_active_and_not_trashed(user):
             return False
+
         if not reevaluate_query:
             return True
+
         check = USER_ELIGIBILITY_CHECKS.get(self.query)
         if check is None:
             # Only reachable if an admin edits a live config's `query` while

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -306,10 +306,14 @@ class MassEmailSender:
             limit = self.limits.get(email_config.id)
             if not limit:
                 continue
+            # `user__is_active` stays deferred so it's re-fetched fresh right
+            # when a record is processed, not batched with the rest of user
+            # at query time: a run can span close to an hour, long enough
+            # for a recipient to be deactivated in between.
             records = MassEmailRecord.objects.filter(
                 status=EmailStatus.ENQUEUED,
                 email_job__email_config=email_config,
-            )
+            ).select_related('user', 'user__extra_details').defer('user__is_active')
             logging.info(
                 f'Processing up to {limit} records for MassEmailConfig({email_config})'
             )

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -324,11 +324,9 @@ class MassEmailSender:
             for record in records.iterator():
                 if budget_used >= limit:
                     break
-                # A user deactivated, deleted or trashed after enqueue must
-                # never be emailed, no matter how fresh the record is;
-                # `record.user` is loaded here, so this reads their current
-                # state. A record older than the stale threshold is also
-                # re-checked against its config's criteria.
+                # `is_active` stays deferred (see the queryset above), so
+                # it's still read fresh here even though the rest of
+                # `record.user` came from the join.
                 if not email_config.is_user_still_eligible(
                     record.user,
                     reevaluate_query=record.date_created < stale_threshold,

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -20,7 +20,7 @@ from kobo.apps.mass_emails.models import (
     MassEmailJob,
     MassEmailRecord,
 )
-from kobo.apps.organizations.models import OrganizationUser
+from kobo.apps.organizations.models import Organization
 from kobo.celery import celery_app
 from kpi.exceptions import (
     MailerError,
@@ -276,10 +276,11 @@ class MassEmailSender:
                         day_limit += config_limit
                 self.cache_limit_value(None, MAX_EMAILS)
 
-    def get_plan_name(self, org_user: OrganizationUser) -> str:
+    def get_plan_name(self, organization: Organization) -> str:
         plan_name = None
-        if settings.STRIPE_ENABLED:
-            plan_name = get_plan_name(org_user)
+        if settings.STRIPE_ENABLED and organization is not None:
+            plan_name = get_plan_name(organization)
+
         if plan_name is None:
             plan_name = gettext('Not available')
         return plan_name
@@ -360,8 +361,7 @@ class MassEmailSender:
 
     def send_email(self, email_config, record):
         logging.info(f'Processing MassEmailRecord({record})')
-        org_user = record.user.organization.organization_users.get(user=record.user)
-        plan_name = self.get_plan_name(org_user)
+        plan_name = self.get_plan_name(record.user.organization)
         data = {
             'username': record.user.username,
             'full_name': record.user.extra_details.data.get('name', None),

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -221,9 +221,8 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
 
     @pytest.mark.skipif(settings.STRIPE_ENABLED, reason='Test non-stripe functionality')
     def test_get_plan_name_stripe_disabled(self):
-        org_user = self.user1.organization.organization_users.get(user=self.user1)
         sender = MassEmailSender()
-        plan_name = sender.get_plan_name(org_user)
+        plan_name = sender.get_plan_name(self.user1.organization)
         assert plan_name == 'Not available'
 
     @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=4, MASS_EMAIL_SEND_RATE_RATIO=0.5)

--- a/kobo/apps/mass_emails/tests/test_eligibility_checks.py
+++ b/kobo/apps/mass_emails/tests/test_eligibility_checks.py
@@ -12,6 +12,7 @@ from kobo.apps.mass_emails.models import (
     MassEmailQueryParam,
 )
 from kobo.apps.mass_emails.user_queries import (
+    _is_user_active_and_not_trashed,
     is_user_active,
     is_user_inactive,
     is_user_within_usage_range,
@@ -105,18 +106,30 @@ class TestUsageEligibilityChecks(TestCase):
             )
         assert result is False
 
-    @override_settings(STRIPE_ENABLED=True)
-    def test_false_for_inactive_user_without_hitting_the_usage_calculator(self):
-        self.user.is_active = False
-        self.user.save()
-        with patch(
-            'kobo.apps.mass_emails.user_queries.ServiceUsageCalculator'
-        ) as mock_calc:
-            result = is_user_within_usage_range(
-                self.user, usage_types=[UsageType.STORAGE_BYTES], minimum=1
-            )
-        assert result is False
-        mock_calc.assert_not_called()
+
+class TestActiveAndNotTrashedGuard(TestCase):
+
+    def test_none_is_never_eligible(self):
+        assert _is_user_active_and_not_trashed(None) is False
+
+    def test_active_untrashed_user_is_eligible(self):
+        user = User.objects.create(username='fine')
+        assert _is_user_active_and_not_trashed(user) is True
+
+    def test_inactive_user_is_not_eligible(self):
+        user = User.objects.create(username='deactivated', is_active=False)
+        assert _is_user_active_and_not_trashed(user) is False
+
+    def test_deleted_between_the_main_query_and_the_check_is_not_eligible(self):
+        # Simulates select_related('user').defer('user__is_active'): the
+        # `user` object was already fetched (non-null) by an earlier query,
+        # but the row is gone by the time the deferred `is_active` is
+        # actually read, which raises DoesNotExist instead of returning
+        # None like a plain FK access would.
+        user = User.objects.create(username='deleted_mid_run')
+        stale_user = User.objects.defer('is_active').get(pk=user.pk)
+        user.delete()
+        assert _is_user_active_and_not_trashed(stale_user) is False
 
 
 class TestMassEmailConfigEligibility(TestCase):
@@ -148,8 +161,14 @@ class TestMassEmailConfigEligibility(TestCase):
         )
 
     def test_never_eligible_when_user_is_none_or_deactivated(self):
-        # The guard beats both the registered check and the fail-open path
-        for query in ('users_active_within_365_days', 'does_not_exist'):
+        # The guard beats both the registered check and the fail-open path.
+        # Includes a usage-range query: is_user_within_usage_range() no
+        # longer guards on its own, so this is the only thing protecting it.
+        for query in (
+            'users_active_within_365_days',
+            'users_above_100_percent_storage',
+            'does_not_exist',
+        ):
             email_config = MassEmailConfig.objects.create(
                 name=f'guard {query}', query=query
             )

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -326,7 +326,7 @@ def is_user_within_usage_range(
     isn't worth the extra cost.
     """
 
-    if not settings.STRIPE_ENABLED or not _is_user_active_and_not_trashed(user):
+    if not settings.STRIPE_ENABLED:
         return False
 
     minimum = minimum or 0
@@ -345,7 +345,14 @@ def is_user_within_usage_range(
 
 
 def _is_user_active_and_not_trashed(user: User | None) -> bool:
-    # `None` means the user was deleted (records keep a nullable FK)
-    if user is None or not user.is_active:
+    # `None` means the user was deleted before the main query ran (records
+    # keep a nullable FK). A user deleted *after* the query ran raises
+    # DoesNotExist when the deferred `is_active` is re-fetched.
+    if user is None:
+        return False
+    try:
+        if not user.is_active:
+            return False
+    except User.DoesNotExist:
         return False
     return not hasattr(user, 'trash')

--- a/kobo/apps/stripe/tests/test_stripe_utils.py
+++ b/kobo/apps/stripe/tests/test_stripe_utils.py
@@ -639,8 +639,7 @@ class OrganizationsUtilsTestCase(BaseTestCase):
             product = subscription.plan.product
             product.name = 'My addon'
             product.save()
-        org_user = self.organization.organization_users.first()
-        assert get_plan_name(org_user) == expected_name
+        assert get_plan_name(self.organization) == expected_name
 
     def test_get_default_plan_name(self):
         assert get_default_plan_name() is None

--- a/kobo/apps/stripe/utils/subscription_limits.py
+++ b/kobo/apps/stripe/utils/subscription_limits.py
@@ -9,7 +9,7 @@ from django.db.models import F, Max, Q, QuerySet, Window
 from django.db.models.functions import Coalesce
 
 from kobo.apps.organizations.constants import USAGE_TYPES_WITH_COUNTERS, UsageType
-from kobo.apps.organizations.models import Organization, OrganizationUser
+from kobo.apps.organizations.models import Organization
 from kobo.apps.organizations.types import UsageLimits
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 from kobo.apps.stripe.utils.import_management import requires_stripe
@@ -356,10 +356,10 @@ def get_paid_subscription_limits(
 
 
 @requires_stripe
-def get_plan_name(org_user: OrganizationUser, **kwargs) -> str | None:
+def get_plan_name(organization: Organization, **kwargs) -> str | None:
     Subscription = kwargs['subscription_model']
     subscriptions = Subscription.objects.filter(
-        customer__subscriber_id=org_user.organization.id,
+        customer__subscriber_id=organization.id,
         status__in=ACTIVE_STRIPE_STATUSES,
     )
 


### PR DESCRIPTION
### 📣 Summary

Sending mass emails now does fewer database queries per recipient, and no longer risks crashing if a recipient's account is deleted mid-send.

### 📖 Description

Sending a batch of mass emails looks up each recipient's profile details and their organization's plan name separately for every single email, most of which doesn't need to be a fresh, individual lookup. This change batches those lookups together where it's safe to do so, while still reading a recipient's active status fresh right before sending each email — a large batch can take close to an hour to fully send, so an account status still needs to be checked close to send time, not just once at the start. It also makes sure a recipient whose account was deleted partway through a send doesn't cause the sending process to fail.

### 💭 Notes

- `select_related('user', 'user__extra_details').defer('user__is_active')` on the enqueued-records query in `send_day_emails()` (`kobo/apps/mass_emails/tasks.py`). `is_active` stays deferred so it's still read fresh at per-record processing time, matching the freshness guarantee added for DEV-2691 (a run can span most of an hour under the DEV-2681 pacer, long enough for a recipient to be deactivated mid-run).
- Measured against mass-email configs before merging: consistent ~2 queries/record → ~1 query/record and ~2x wall-clock reduction on this slice of the send loop.
- `get_plan_name()` (`kobo/apps/stripe/utils/subscription_limits.py`) now takes an `Organization` directly instead of an `OrganizationUser`, since it only ever read `.organization.id` off the latter. Removes a redundant per-record `OrganizationUser` query in `send_email()`.
- `_is_user_active_and_not_trashed()` (`kobo/apps/mass_emails/user_queries.py`) now catches `User.DoesNotExist`: with `is_active` deferred, a recipient deleted between the main query running and that specific record being processed would otherwise raise instead of being treated as ineligible. Covered by a new unit test that simulates the deferred-field-on-a-deleted-row scenario directly.
