### PR TITLE
feat(sso): expose managed sso fields in /me endpoint DEV-2408

### DIFF
--- a/jsapp/js/api/models/meListResponseSocialAccountsItem.ts
+++ b/jsapp/js/api/models/meListResponseSocialAccountsItem.ts
@@ -17,4 +17,6 @@ export type MeListResponseSocialAccountsItem = {
   date_joined?: string
   email?: string
   username?: string
+  managed?: boolean
+  managed_domains?: string[]
 }

--- a/jsapp/js/api/models/socialAccount.ts
+++ b/jsapp/js/api/models/socialAccount.ts
@@ -22,4 +22,6 @@ export interface SocialAccount {
   readonly date_joined: string
   readonly email: string
   readonly username: string
+  readonly managed: boolean
+  readonly managed_domains: readonly string[]
 }

--- a/jsapp/js/api/models/userReportsListResponseSocialAccountsItem.ts
+++ b/jsapp/js/api/models/userReportsListResponseSocialAccountsItem.ts
@@ -17,4 +17,6 @@ export type UserReportsListResponseSocialAccountsItem = {
   date_joined?: string
   email?: string
   username?: string
+  managed?: boolean
+  managed_domains?: string[]
 }

--- a/jsapp/js/api/react-query/server-logs-superusers/msw.ts
+++ b/jsapp/js/api/react-query/server-logs-superusers/msw.ts
@@ -516,6 +516,13 @@ export const getApiV2UserReportsListResponseMock = (
       date_joined: faker.helpers.arrayElement([`${faker.date.past().toISOString().split('.')[0]}Z`, undefined]),
       email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
       username: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+      managed: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+      managed_domains: faker.helpers.arrayElement([
+        Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+          faker.string.alpha({ length: { min: 10, max: 20 } }),
+        ),
+        undefined,
+      ]),
     })),
     organizations: {
       organization_name: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),

--- a/jsapp/js/api/react-query/user-team-organization-usage/msw.ts
+++ b/jsapp/js/api/react-query/user-team-organization-usage/msw.ts
@@ -1360,6 +1360,13 @@ export const getMeRetrieveResponseMock = (overrideResponse: Partial<MeListRespon
     date_joined: faker.helpers.arrayElement([`${faker.date.past().toISOString().split('.')[0]}Z`, undefined]),
     email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     username: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+    managed: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+    managed_domains: faker.helpers.arrayElement([
+      Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+      ),
+      undefined,
+    ]),
   })),
   validated_password: faker.datatype.boolean(),
   accepted_tos: faker.datatype.boolean(),
@@ -1430,6 +1437,13 @@ export const getMePartialUpdateResponseMock = (overrideResponse: Partial<MeListR
     date_joined: faker.helpers.arrayElement([`${faker.date.past().toISOString().split('.')[0]}Z`, undefined]),
     email: faker.helpers.arrayElement([faker.internet.email(), undefined]),
     username: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+    managed: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+    managed_domains: faker.helpers.arrayElement([
+      Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+      ),
+      undefined,
+    ]),
   })),
   validated_password: faker.datatype.boolean(),
   accepted_tos: faker.datatype.boolean(),
@@ -1476,6 +1490,10 @@ export const getMeSocialAccountsListResponseMock = (
     date_joined: `${faker.date.past().toISOString().split('.')[0]}Z`,
     email: faker.internet.email(),
     username: faker.string.alpha({ length: { min: 10, max: 20 } }),
+    managed: faker.datatype.boolean(),
+    managed_domains: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+      faker.string.alpha({ length: { min: 10, max: 20 } }),
+    ),
   })),
   ...overrideResponse,
 })
@@ -1489,6 +1507,10 @@ export const getMeSocialAccountsRetrieveResponseMock = (
   date_joined: `${faker.date.past().toISOString().split('.')[0]}Z`,
   email: faker.internet.email(),
   username: faker.string.alpha({ length: { min: 10, max: 20 } }),
+  managed: faker.datatype.boolean(),
+  managed_domains: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+    faker.string.alpha({ length: { min: 10, max: 20 } }),
+  ),
   ...overrideResponse,
 })
 

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -102,12 +102,19 @@ class SocialAccountSerializer(serializers.ModelSerializer):
             visible_apps = [
                 app for app in candidate_apps if not app.settings.get('hidden')
             ]
-            if len(visible_apps) > 1:
+            if len(visible_apps) == 0:
                 logging.warn(
                     f'Multiple social apps returned for provider {provider},'
-                    f' returning first visible candidate'
+                    f' returning first candidate'
                 )
-            app = visible_apps[0]
+                app = candidate_apps[0]
+            else:
+                if len(visible_apps) > 1:
+                    logging.warn(
+                        f'Multiple social apps returned for provider {provider},'
+                        f' returning first visible candidate'
+                    )
+                app = visible_apps[0]
         elif len(candidate_apps) == 0:
             logging.warn(f'No social app found for provider {provider}')
             return None

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -3,7 +3,7 @@ from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.models import SocialAccount
 from django.utils.translation import gettext as t
 from django_request_cache import cache_for_request
-from drf_spectacular.plumbing import build_array_type, build_basic_type
+from drf_spectacular.plumbing import build_array_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -1,9 +1,16 @@
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.models import SocialAccount
 from django.utils.translation import gettext as t
+from django_request_cache import cache_for_request
+from drf_spectacular.plumbing import build_array_type, build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+
+from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
+from kpi.schema_extensions.v2.generic.schema import GENERIC_STRING_SCHEMA
+from kpi.utils.log import logging
 
 
 class EmailAddressSerializer(serializers.ModelSerializer):
@@ -56,6 +63,8 @@ class SocialAccountSerializer(serializers.ModelSerializer):
 
     email = serializers.SerializerMethodField()
     username = serializers.SerializerMethodField()
+    managed = serializers.SerializerMethodField()
+    managed_domains = serializers.SerializerMethodField()
 
     class Meta:
         model = SocialAccount
@@ -66,6 +75,8 @@ class SocialAccountSerializer(serializers.ModelSerializer):
             'date_joined',
             'email',
             'username',
+            'managed',
+            'managed_domains',
         )
 
     @extend_schema_field(OpenApiTypes.EMAIL)
@@ -79,3 +90,46 @@ class SocialAccountSerializer(serializers.ModelSerializer):
     def get_username(self, obj):
         if obj.extra_data:
             return obj.extra_data.get('username')
+
+    @cache_for_request
+    def get_social_app_custom_data(self, obj):
+        provider = obj.provider
+        candidate_apps = get_adapter().list_apps(
+            self.context.get('request'), provider=provider
+        )
+        if len(candidate_apps) > 1:
+            # mirror logic in allauth get_app(), but warn instead of raising an error
+            visible_apps = [
+                app for app in candidate_apps if not app.settings.get('hidden')
+            ]
+            if len(visible_apps) > 1:
+                logging.warn(
+                    f'Multiple social apps returned for provider {provider},'
+                    f' returning first visible candidate'
+                )
+                app = visible_apps[0]
+        elif len(candidate_apps) == 0:
+            logging.warn(f'No social app found for provider {provider}')
+            return None
+        else:
+            app = candidate_apps[0]
+        try:
+            return SocialAppCustomData.objects.get(social_app=app)
+        except SocialAppCustomData.DoesNotExist:
+            return None
+
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_managed(self, obj):
+        social_app_custom_data = self.get_social_app_custom_data(obj)
+        return bool(social_app_custom_data) and social_app_custom_data.managed
+
+    @extend_schema_field(build_array_type(schema=GENERIC_STRING_SCHEMA))
+    def get_managed_domains(self, obj):
+        social_app_custom_data = self.get_social_app_custom_data(obj)
+        if not social_app_custom_data:
+            return []
+        return list(
+            SocialAppManagedDomain.objects.filter(
+                social_app=social_app_custom_data
+            ).values_list('domain', flat=True)
+        )

--- a/kobo/apps/accounts/serializers.py
+++ b/kobo/apps/accounts/serializers.py
@@ -107,7 +107,7 @@ class SocialAccountSerializer(serializers.ModelSerializer):
                     f'Multiple social apps returned for provider {provider},'
                     f' returning first visible candidate'
                 )
-                app = visible_apps[0]
+            app = visible_apps[0]
         elif len(candidate_apps) == 0:
             logging.warn(f'No social app found for provider {provider}')
             return None

--- a/kobo/apps/accounts/tests/test_current_user.py
+++ b/kobo/apps/accounts/tests/test_current_user.py
@@ -1,5 +1,6 @@
 import re
 from datetime import timedelta
+from unittest.mock import patch
 
 import dateutil
 from constance.test import override_config
@@ -12,12 +13,15 @@ from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
 from kpi.utils.fuzzy_int import FuzzyInt
 
 
 class CurrentUserAPITestCase(APITestCase):
     def setUp(self):
-        self.user = baker.make(settings.AUTH_USER_MODEL, username='spongebob', email='me@sponge.bob')
+        self.user = baker.make(
+            settings.AUTH_USER_MODEL, username='spongebob', email='me@sponge.bob'
+        )
         self.client.force_login(self.user)
         self.url = reverse('currentuser-detail')
 
@@ -28,7 +32,7 @@ class CurrentUserAPITestCase(APITestCase):
         other_social_account = baker.make('socialaccount.SocialAccount')
         # This modifies the user account
         self.client.get(self.url)
-        with self.assertNumQueries(FuzzyInt(3, 5)):
+        with self.assertNumQueries(FuzzyInt(4, 6)):
             res = self.client.get(self.url)
         for social_account in social_accounts:
             self.assertContains(res, social_account.uid)
@@ -38,17 +42,12 @@ class CurrentUserAPITestCase(APITestCase):
         extra_details = self.user.extra_details
         extra_details.data['name'] = 'SpongeBob'
         extra_details.save()
-        patch_data = {
-            'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}
-        }
+        patch_data = {'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}}
         response = self.client.patch(self.url, data=patch_data, format='json')
         assert response.status_code == status.HTTP_200_OK
         response_extra_details = response.json()['extra_details']
         # What we just set should obviously be there
-        assert (
-            response_extra_details['organization']
-            == 'Trap Remix 10 Hours, Inc.'
-        )
+        assert response_extra_details['organization'] == 'Trap Remix 10 Hours, Inc.'
         # …and what we didn't touch should still be there as well
         assert response_extra_details['name'] == 'SpongeBob'
 
@@ -62,16 +61,11 @@ class CurrentUserAPITestCase(APITestCase):
         assert response_extra_details['name'] == 'SpongeBob'
 
         # Make sure the validator accepts reasonable values
-        patch_data = {
-            'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}
-        }
+        patch_data = {'extra_details': {'organization': 'Trap Remix 10 Hours, Inc.'}}
         response = self.client.patch(self.url, data=patch_data, format='json')
         assert response.status_code == status.HTTP_200_OK
         response_extra_details = response.json()['extra_details']
-        assert (
-            response_extra_details['organization']
-            == 'Trap Remix 10 Hours, Inc.'
-        )
+        assert response_extra_details['organization'] == 'Trap Remix 10 Hours, Inc.'
 
         # Make sure the validator, you know, validates and rejects empty
         # strings for required fields
@@ -128,9 +122,7 @@ class CurrentUserAPITestCase(APITestCase):
         # Ensure accepted_tos is initially False
         response = self.client.get(self.url)
         assert response.data['accepted_tos'] is False
-        assert (
-            'last_tos_accept_time' not in self.user.extra_details.private_data
-        )
+        assert 'last_tos_accept_time' not in self.user.extra_details.private_data
 
         def now_without_microseconds():
             return timezone.now().replace(microsecond=0)
@@ -140,9 +132,7 @@ class CurrentUserAPITestCase(APITestCase):
         response = self.client.post(reverse('tos'))
         assert response.status_code == status.HTTP_204_NO_CONTENT
         self.user.refresh_from_db()
-        accept_time_str = (
-            self.user.extra_details.private_data['last_tos_accept_time']
-        )
+        accept_time_str = self.user.extra_details.private_data['last_tos_accept_time']
         accept_time = dateutil.parser.isoparse(accept_time_str)
         assert time_before_signup <= accept_time <= now_without_microseconds()
 
@@ -224,3 +214,44 @@ class CurrentUserAPITestCase(APITestCase):
         response_extra_details = response.json()['extra_details']
         assert response_extra_details['organization'] == 'sample'
         assert response_extra_details['organization_website'] == 'sample.org'
+
+    def test_sso_account_fields(self):
+        app = baker.make('socialaccount.SocialApp')
+        baker.make('socialaccount.SocialAccount', user=self.user, provider=app.provider)
+        custom_data = SocialAppCustomData.objects.create(social_app=app, managed=True)
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain='example.com'
+        )
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        social_accounts = response.data['social_accounts']
+        social_account = social_accounts[0]
+        assert social_account['managed'] is True
+        assert social_account['managed_domains'] == ['example.com']
+
+    def test_sso_accounts_missing_social_app(self):
+        baker.make('socialaccount.SocialAccount', user=self.user)
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        social_accounts = response.data['social_accounts']
+        social_account = social_accounts[0]
+        assert social_account['managed'] is False
+        assert social_account['managed_domains'] == []
+
+    @patch('kpi.utils.log.logging.warning')
+    def test_sso_accounts_multiple_social_apps(self, mock_logging):
+        # extremely unlikely that we have 2 sso apps with the same provider
+        # so there's no real defined expeected behavior, just make sure the request
+        # doesn't fail
+        app = baker.make('socialaccount.SocialApp', provider='provider')
+        app2 = baker.make('socialaccount.SocialApp', provider='provider')
+        baker.make('socialaccount.SocialApp', provider='provider')
+        SocialAppCustomData.objects.create(social_app=app)
+        SocialAppCustomData.objects.create(social_app=app2)
+        baker.make('socialaccount.SocialAccount', user=self.user, provider='provider')
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        mock_logging.assert_called_once_with(
+            'Multiple social apps returned for provider provider,'
+            ' returning first visible candidate'
+        )

--- a/kobo/apps/accounts/tests/test_current_user.py
+++ b/kobo/apps/accounts/tests/test_current_user.py
@@ -241,7 +241,7 @@ class CurrentUserAPITestCase(APITestCase):
     @patch('kpi.utils.log.logging.warning')
     def test_sso_accounts_multiple_social_apps(self, mock_logging):
         # extremely unlikely that we have 2 sso apps with the same provider
-        # so there's no real defined expeected behavior, just make sure the request
+        # so there's no real defined expected behavior, just make sure the request
         # doesn't fail
         app = baker.make('socialaccount.SocialApp', provider='provider')
         app2 = baker.make('socialaccount.SocialApp', provider='provider')

--- a/kpi/schema_extensions/v2/me/extensions.py
+++ b/kpi/schema_extensions/v2/me/extensions.py
@@ -127,6 +127,8 @@ class SocialAccountFieldExtension(OpenApiSerializerFieldExtension):
                     'date_joined': build_basic_type(OpenApiTypes.DATETIME),
                     'email': build_basic_type(OpenApiTypes.EMAIL),
                     'username': GENERIC_STRING_SCHEMA,
+                    'managed': build_basic_type(OpenApiTypes.BOOL),
+                    'managed_domains': build_array_type(schema=GENERIC_STRING_SCHEMA),
                 }
             )
         )

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -26940,6 +26940,15 @@
                                 },
                                 "username": {
                                     "type": "string"
+                                },
+                                "managed": {
+                                    "type": "boolean"
+                                },
+                                "managed_domains": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }
@@ -31904,12 +31913,25 @@
                     "username": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "managed": {
+                        "type": "boolean",
+                        "readOnly": true
+                    },
+                    "managed_domains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true
                     }
                 },
                 "required": [
                     "date_joined",
                     "email",
                     "last_login",
+                    "managed",
+                    "managed_domains",
                     "provider",
                     "uid",
                     "username"
@@ -33315,6 +33337,15 @@
                                 },
                                 "username": {
                                     "type": "string"
+                                },
+                                "managed": {
+                                    "type": "boolean"
+                                },
+                                "managed_domains": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -19247,6 +19247,12 @@ components:
                 format: email
               username:
                 type: string
+              managed:
+                type: boolean
+              managed_domains:
+                type: array
+                items:
+                  type: string
         validated_password:
           type: boolean
         accepted_tos:
@@ -22745,10 +22751,20 @@ components:
         username:
           type: string
           readOnly: true
+        managed:
+          type: boolean
+          readOnly: true
+        managed_domains:
+          type: array
+          items:
+            type: string
+          readOnly: true
       required:
       - date_joined
       - email
       - last_login
+      - managed
+      - managed_domains
       - provider
       - uid
       - username
@@ -23813,6 +23829,12 @@ components:
                 format: email
               username:
                 type: string
+              managed:
+                type: boolean
+              managed_domains:
+                type: array
+                items:
+                  type: string
         organizations:
           type: object
           properties:


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Include additional SSO properties `managed` and `managed_domains` for social accounts the `/me` endpoint


### 💭 Notes
There is no direct link between SocialAccounts and SocialApps. The only think we have to connect a SocialAccount to a SocialApp is the provider, which is not a ForeignKey and not actually unique. In practice, however, it is very unlikely for there to be an installation with >1 SSO with the same provider, so we just mirror the logic in allauth's `get_app`, but don't raise an exception for the rare case that there are >1 or 0 apps from the given provider. Instead we just assume that the SSO is not managed and has no associated domains.


### 👀 Preview steps
Make sure SSO is enabled.

1. ℹ️ have an admin user and a user with an SSO account.
2. In Django admin, create a SocialAppCustomData object for the SSO provider with managed=True and the sso user's email domain.
3. Login as the sso user.
4. Navigate to `/me`
5. 🟢 [on PR] notice the response contains `managed: True` and `managed_domains: ['<domain>']` in the `'social_accounts'` field.

