### PR TITLE
fix(mailer): classify SES per-session message limit DEV-2675

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -23,6 +23,7 @@ from kobo.apps.mass_emails.models import (
 from kobo.apps.organizations.models import Organization
 from kobo.celery import celery_app
 from kpi.exceptions import (
+    MailerConnectionSessionLimitError,
     MailerError,
     MailerProviderQuotaExhaustedError,
     MailerProviderRateThrottledError,
@@ -351,7 +352,18 @@ class MassEmailSender:
                         sleep(remaining)
                     window_start = monotonic()
                     spent_in_window = 0
-                self.send_email(email_config, record)
+                try:
+                    self.send_email(email_config, record)
+                except MailerConnectionSessionLimitError as e:
+                    # The connection already reconnected inside
+                    # send_email(); skip this record without spending
+                    # budget on it and move straight to the next one
+                    # instead of stopping the whole run.
+                    logging.warning(
+                        f'Connection session limit hit on {record}, will '
+                        f'retry on a later run: {e}'
+                    )
+                    continue
                 self.cache_limit_value(email_config, self.limits[email_config.id] - 1)
                 self.cache_limit_value(None, self.total_limit - 1)
                 spent_in_window += 1
@@ -393,6 +405,12 @@ class MassEmailSender:
             logging.warning(f'Provider rate limit hit, stopping this run: {e}')
             # TODO(DEV-2693): needs its own non-blocking cooldown instead of
             # being treated exactly like a quota-exhausted stop.
+            raise
+        except MailerConnectionSessionLimitError:
+            # Let this propagate: the connection is already reconnected
+            # (see Mailer._send_single()), so the caller should skip this
+            # one record and move on rather than stop the whole run or
+            # record it as a failure. The record stays `enqueued`.
             raise
         except MailerError as e:
             logging.warning(f'Error sending record {record}: {e}')

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -19,6 +19,7 @@ from model_bakery.recipe import seq
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.exceptions import (
+    MailerConnectionSessionLimitError,
     MailerError,
     MailerProviderQuotaExhaustedError,
     MailerProviderRateThrottledError,
@@ -962,6 +963,38 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         # The record that hit the quota error, and the one never reached,
         # stay enqueued rather than being written off as failed
         assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 2
+
+    def test_connection_session_limit_error_skips_the_record_and_continues(self):
+        # Unlike rate-throttled/quota-exhausted, this must not stop the run:
+        # the connection is already reconnected by the time Mailer.send()
+        # raises it, so the next record should be attempted right away.
+        connection = MagicMock()
+        with (
+            patch('kpi.utils.mailer.get_connection', return_value=connection),
+            patch(
+                'kobo.apps.mass_emails.tasks.Mailer.send',
+                side_effect=[
+                    None,
+                    MailerConnectionSessionLimitError('session limit reached'),
+                    None,
+                ],
+            ) as send_mock,
+        ):
+            sender = MassEmailSender()
+            email_config = MassEmailConfig.objects.get(name='Config')
+            original_limit = sender.limits[email_config.id]
+            sender.send_day_emails()
+
+        assert send_mock.call_count == 3
+        assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 2
+        assert MassEmailRecord.objects.filter(status=EmailStatus.FAILED).count() == 0
+        # stays enqueued for a later run, not written off as failed
+        assert (
+            MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 1
+        )
+        # only the 2 real sends spend budget, not the skipped one
+        remaining = cache.get(f'{sender.cache_key_prefix}_{email_config.id}')
+        assert remaining == original_limit - 2
 
     def test_soft_time_limit_closes_the_connection_and_leaves_records_enqueued(self):
         connection = MagicMock()

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -182,6 +182,18 @@ class MailerProviderRateThrottledError(MailerProviderThrottledError):
     """
 
 
+class MailerConnectionSessionLimitError(MailerError):
+    """
+    The provider closed the connection after hitting its per-session
+    message cap.
+
+    Not account-wide like a rate/quota throttle: the connection is already
+    reconnected by the time this is raised (see `Mailer._send_single()`),
+    so the caller should skip this one record and keep going, not stop the
+    whole run.
+    """
+
+
 class MissingXFormException(Exception):
     pass
 

--- a/kpi/tests/test_mailer.py
+++ b/kpi/tests/test_mailer.py
@@ -12,12 +12,13 @@ from django.core.mail import EmailMessage
 from django.test import TestCase, override_settings
 
 from kpi.exceptions import (
+    MailerConnectionSessionLimitError,
     MailerError,
     MailerProviderQuotaExhaustedError,
     MailerProviderRateThrottledError,
 )
-from kpi.utils.mailer import Mailer, with_smtp_connection
 from kpi.utils.mailer import EmailMessage as MailerEmailMessage
+from kpi.utils.mailer import Mailer, with_smtp_connection
 
 
 def fake_send(email_message):
@@ -255,6 +256,18 @@ class TestClassifySmtpException(TestCase):
         error = Mailer._classify_smtp_exception(exc)
 
         assert isinstance(error, MailerProviderRateThrottledError)
+
+    def test_ses_max_message_count_per_session_signature_matches(self):
+        exc = SMTPResponseException(
+            421,
+            b'Connection closed by server. Maximum message count per '
+            b'session reached.',
+        )
+
+        error = Mailer._classify_smtp_exception(exc)
+
+        assert isinstance(error, MailerConnectionSessionLimitError)
+        assert not isinstance(error, MailerProviderRateThrottledError)
 
     def test_sendgrid_credits_exceeded_signature_matches(self):
         exc = SMTPResponseException(

--- a/kpi/utils/mailer.py
+++ b/kpi/utils/mailer.py
@@ -18,6 +18,7 @@ from django.utils.translation import activate
 from django.utils.translation import gettext as t
 
 from kpi.exceptions import (
+    MailerConnectionSessionLimitError,
     MailerError,
     MailerProviderQuotaExhaustedError,
     MailerProviderRateThrottledError,
@@ -164,6 +165,11 @@ class Mailer:
             MailerProviderRateThrottledError,
         ),
         (421, 'temporarily deferred', MailerProviderRateThrottledError),
+        (
+            421,
+            'Maximum message count per session reached',
+            MailerConnectionSessionLimitError,
+        ),
         # Office365
         (None, 'Submission quota exceeded', MailerProviderQuotaExhaustedError),
         (None, 'reached your daily limit', MailerProviderQuotaExhaustedError),


### PR DESCRIPTION
### 📣 Summary

A mass email recipient whose send happened to hit SES's per-session message limit was never getting emailed, silently, with no retry.

### 📖 Description

SES closes the SMTP connection after it's carried a certain number of messages in one session — a normal connection-lifecycle event, not a problem with the recipient or the message. The code already reconnects correctly when this happens, but it didn't recognize this specific SES response, so it fell back to treating it like any other send failure: the recipient's record was marked permanently failed and never retried, even though nothing was actually wrong with their address.

### 💭 Notes

- New `MailerConnectionSessionLimitError` (`kpi/exceptions.py`), deliberately not a subclass of `MailerProviderThrottledError`: that hierarchy exists for account-wide throttling (rate limit, daily quota), where stopping the whole send run makes sense. This is per-connection only, and the connection is already reconnected by the time it's raised, so the run should just skip this one record and keep going.
- New signature in `Mailer.THROTTLE_SIGNATURES` (`kpi/utils/mailer.py`): `421` + `"Maximum message count per session reached"` → `MailerConnectionSessionLimitError`.
- `send_day_emails()` (`kobo/apps/mass_emails/tasks.py`) now catches this specifically around the send call: logs a warning, leaves the record `ENQUEUED` for a later run, and moves on to the next record without spending any of the day's send budget on it — same treatment as a stale-skipped record.
- Found while testing the DEV-2681/DEV-2682 mass email pacing work against the real AWS SES mailbox simulator.

### 👀 Preview steps

1. ℹ️ have a mass email record in `ENQUEUED` status
2. mock `Mailer.send()` to raise `MailerConnectionSessionLimitError` for that record, followed by a normal send for the next one
3. run `MassEmailSender().send_day_emails()`
4. 🔴 [on main] the record is marked `FAILED` and never retried
5. 🟢 [on PR] the record stays `ENQUEUED`, and the run continues to the next record instead of stopping
