### PR TITLE
fix(massEmails): add missing autoqa eligibility checks after .30→.33 merge

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -27,12 +27,15 @@ from kobo.apps.mass_emails.user_queries import (
     is_user_a_test_user,
     is_user_active,
     is_user_inactive,
+    is_user_over_80_percent_of_auto_qa_limits,
     is_user_over_80_percent_of_nlp_limits,
     is_user_over_80_percent_of_storage_limit,
     is_user_over_80_percent_of_submission_limit,
+    is_user_over_90_percent_of_auto_qa_limits,
     is_user_over_90_percent_of_nlp_limits,
     is_user_over_90_percent_of_storage_limit,
     is_user_over_90_percent_of_submission_limit,
+    is_user_over_100_percent_of_auto_qa_limits,
     is_user_over_100_percent_of_nlp_limits,
     is_user_over_100_percent_of_storage_limit,
     is_user_over_100_percent_of_submission_limit,
@@ -73,6 +76,9 @@ USER_ELIGIBILITY_CHECKS: dict[str, Callable] = {
     'users_above_80_percent_nlp_usage': is_user_over_80_percent_of_nlp_limits,
     'users_above_90_percent_nlp_usage': is_user_over_90_percent_of_nlp_limits,
     'users_above_100_percent_nlp_usage': is_user_over_100_percent_of_nlp_limits,
+    'users_above_80_percent_autoqa_usage': is_user_over_80_percent_of_auto_qa_limits,
+    'users_above_90_percent_autoqa_usage': is_user_over_90_percent_of_auto_qa_limits,
+    'users_above_100_percent_autoqa_usage': is_user_over_100_percent_of_auto_qa_limits,  # noqa
     'test_users': is_user_a_test_user,
 }
 EmailType = Enum('EmailType', ['RECURRING', 'ONE_TIME'])

--- a/kobo/apps/mass_emails/user_queries.py
+++ b/kobo/apps/mass_emails/user_queries.py
@@ -275,6 +275,24 @@ def is_user_inactive(user: User, days: int = 365) -> bool:
     return get_inactive_users(days=days).filter(pk=user.pk).exists()
 
 
+def is_user_over_80_percent_of_auto_qa_limits(user: User) -> bool:
+    return is_user_within_usage_range(
+        user, usage_types=[UsageType.LLM_REQUESTS], minimum=0.8, maximum=0.9
+    )
+
+
+def is_user_over_90_percent_of_auto_qa_limits(user: User) -> bool:
+    return is_user_within_usage_range(
+        user, usage_types=[UsageType.LLM_REQUESTS], minimum=0.9, maximum=1
+    )
+
+
+def is_user_over_100_percent_of_auto_qa_limits(user: User) -> bool:
+    return is_user_within_usage_range(
+        user, usage_types=[UsageType.LLM_REQUESTS], minimum=1
+    )
+
+
 def is_user_over_80_percent_of_nlp_limits(user: User) -> bool:
     return is_user_within_usage_range(
         user,

--- a/kobo/apps/project_ownership/models/invite.py
+++ b/kobo/apps/project_ownership/models/invite.py
@@ -11,7 +11,6 @@ from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.log import logging
 from kpi.utils.mailer import EmailMessage, Mailer
-
 from .choices import InviteStatusChoices
 
 


### PR DESCRIPTION
### 📣 Summary

Fixes a gap left over from the `release/2.026.30` → `release/2.026.33` merge: three mass-email queries had no matching eligibility check.

### 📖 Description

`release/2.026.33` already had AutoQA usage mass-email queries (`users_above_{80,90,100}_percent_autoqa_usage`) that predate `release/2.026.30`'s stale-record eligibility recheck (DEV-2682), so those three queries had no matching single-user eligibility check once the branches merged.

### 💭 Notes

Adds `is_user_over_{80,90,100}_percent_of_auto_qa_limits()` (`kobo/apps/mass_emails/user_queries.py`) and registers them in `USER_ELIGIBILITY_CHECKS` (`kobo/apps/mass_emails/models.py`), mirroring the existing storage/submission/nlp entries. Caught by the existing `test_every_user_query_has_an_eligibility_check` regression test, which is exactly what it's there for.
