### PR TITLE
feat(usage): add support link DEV-2702

### DIFF
--- a/jsapp/js/account/usage/usage.component.tsx
+++ b/jsapp/js/account/usage/usage.component.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 
-import { Group, LoadingOverlay } from '@mantine/core'
+import { Anchor, Group, LoadingOverlay } from '@mantine/core'
 import { when } from 'mobx'
 import { useLocation } from 'react-router-dom'
 import { getAccountLimits } from '#/account/stripe.api'
@@ -21,6 +21,8 @@ import {
   type OrganizationsServiceUsageSummary,
   useOrganizationsServiceUsageSummary,
 } from './useOrganizationsServiceUsageSummary'
+
+const USAGE_LIMITS_SUPPORT_URL = 'account_usage_limits.html'
 
 interface LimitState {
   storageByteRemainingLimit: LimitAmount
@@ -162,6 +164,16 @@ export default function Usage() {
       <LimitNotifications accountPage />
       <header className={styles.header}>
         <h2 className={styles.headerText}>{t('Your usage')}</h2>
+        {envStore.data.support_url && (
+          <Anchor
+            href={envStore.data.support_url + USAGE_LIMITS_SUPPORT_URL}
+            target='_blank'
+            rel='noreferrer'
+            size='sm'
+          >
+            {t('Learn more about account usage')}
+          </Anchor>
+        )}
       </header>
       {limits.stripeEnabled && <YourPlan />}
       <Group align='stretch'>

--- a/jsapp/js/account/usage/usage.module.scss
+++ b/jsapp/js/account/usage/usage.module.scss
@@ -22,8 +22,9 @@
 .header {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  // No `space-between` here: the support article link sits next to the title.
   align-items: center;
+  gap: 16px;
 }
 
 .updated {


### PR DESCRIPTION
### 📣 Summary

Adds a link to support.

### 👀 Preview steps

1. ℹ️ have stripe set up
2. Go to Account → Usage
7. 🟢 notice a new link!
