### PR TITLE
style(imports): fix formpack/pyxform import classification

### DIFF
--- a/kobo/apps/mass_emails/models.py
+++ b/kobo/apps/mass_emails/models.py
@@ -164,7 +164,7 @@ class MassEmailConfig(AbstractTimeStampedModel):
             if (
                 param.name not in func.__annotations__
                 or func.__annotations__[param.name] not in (int, float, str)
-            ):
+            ):  # fmt: skip
                 continue
             try:
                 value = func.__annotations__[param.name](param.value)

--- a/kobo/apps/openrosa/apps/logger/factory.py
+++ b/kobo/apps/openrosa/apps/logger/factory.py
@@ -3,10 +3,10 @@
 # django-factories but it mimics their functionality...
 from datetime import timedelta
 
-from pyxform import custom_values, Survey
+from pyxform import Survey, custom_values
 from pyxform.builder import create_survey_element_from_dict
 
-from kobo.apps.openrosa.apps.logger.models import XForm, Instance
+from kobo.apps.openrosa.apps.logger.models import Instance, XForm
 
 XFORM_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000"
 ONE_HOUR = timedelta(0, 3600)

--- a/kobo/apps/openrosa/apps/viewer/tests/test_export_builder.py
+++ b/kobo/apps/openrosa/apps/viewer/tests/test_export_builder.py
@@ -10,8 +10,8 @@ from pyxform.builder import create_survey_from_xls
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.viewer.tests.export_helpers import viewer_fixture_path
 from kobo.apps.openrosa.libs.utils.export_tools import (
-    dict_to_joined_export,
     ExportBuilder,
+    dict_to_joined_export,
 )
 from kpi.utils.mongo_helper import MongoHelper
 

--- a/kobo/apps/openrosa/apps/viewer/xls_writer.py
+++ b/kobo/apps/openrosa/apps/viewer/xls_writer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from collections import defaultdict
 
-from pyxform import Section, Question
+from pyxform import Question, Section
 from xlwt import Workbook
 
 from kobo.apps.openrosa.libs.utils.export_tools import question_types_to_exclude

--- a/kobo/apps/openrosa/koboform/pyxform_utils.py
+++ b/kobo/apps/openrosa/koboform/pyxform_utils.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import io
 import re
-import xlwt
 
+import xlwt
 from pyxform import xls2json_backends
 
 

--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -3,9 +3,9 @@ from collections import OrderedDict
 from copy import deepcopy
 
 from django.utils.translation import gettext as t
+from formpack import FormPack
 from rest_framework import serializers
 
-from formpack import FormPack
 from kpi.utils.bugfix import repair_file_column_content_and_save
 from kpi.utils.log import logging
 from .constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY

--- a/kpi/management/commands/import_survey_drafts_from_directory.py
+++ b/kpi/management/commands/import_survey_drafts_from_directory.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import dateutil.parser
 import glob
 import json
 import os
@@ -7,14 +6,15 @@ import random
 import re
 from io import StringIO
 
+import dateutil.parser
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from pyxform.xls2json_backends import csv_to_dict
 
 from kobo.apps.kobo_auth.shortcuts import User
-from kpi.models import Asset
 from kpi.constants import ASSET_TYPE_COLLECTION
+from kpi.models import Asset
 from kpi.utils.models import _set_auto_field_update
 
 

--- a/kpi/mixins/formpack_xlsform_utils.py
+++ b/kpi/mixins/formpack_xlsform_utils.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 
 from formpack.utils.flatten_content import flatten_content
 from formpack.utils.spreadsheet_content import flatten_to_spreadsheet_content
+
 from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kpi.utils.absolute_paths import insert_full_paths_in_place
 from kpi.utils.asset_translation_utils import (  # TRANSLATIONS_EQUAL,

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -12,12 +12,12 @@ from django.core.cache import cache
 from django.db import models, transaction
 from django.db.models import F, Prefetch, Q
 from django.utils.translation import gettext_lazy as t
-from taggit.managers import TaggableManager, _TaggableManager
-from taggit.utils import require_instance_manager
-
 from formpack.utils.flatten_content import flatten_content
 from formpack.utils.json_hash import json_hash
 from formpack.utils.kobo_locking import strip_kobo_locking_profile
+from taggit.managers import TaggableManager, _TaggableManager
+from taggit.utils import require_instance_manager
+
 from kobo.apps.data_collectors.models import DataCollectorGroup
 from kobo.apps.reports.constants import DEFAULT_REPORTS_KEY, SPECIFIC_REPORTS_KEY
 from kobo.apps.subsequences.utils.supplement_data import get_analysis_form_json

--- a/kpi/models/asset_version.py
+++ b/kpi/models/asset_version.py
@@ -2,8 +2,8 @@
 import datetime
 
 from django.db import models
-
 from formpack.utils.expand_content import expand_content
+
 from kpi.fields import KpiUidField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.hash import calculate_content_hash

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 
 import constance
 import dateutil.parser
+import formpack
 import requests
 from django.conf import settings
 from django.contrib.postgres.indexes import BTreeIndex, HashIndex
@@ -21,13 +22,6 @@ from django.db.models.functions import Cast, Coalesce, Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from openpyxl.utils.exceptions import InvalidFileException
-from private_storage.fields import PrivateFileField
-from rest_framework import exceptions
-from rest_framework.reverse import reverse
-from werkzeug.http import parse_options_header
-
-import formpack
 from formpack.constants import KOBO_LOCK_SHEET
 from formpack.schema.fields import (
     IdCopyField,
@@ -38,6 +32,13 @@ from formpack.schema.fields import (
 )
 from formpack.utils.kobo_locking import get_kobo_locking_profiles
 from formpack.utils.string import ellipsize
+from openpyxl.utils.exceptions import InvalidFileException
+from private_storage.fields import PrivateFileField
+from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
+from rest_framework import exceptions
+from rest_framework.reverse import reverse
+from werkzeug.http import parse_options_header
+
 from kobo.apps.audit_log.utils import get_lookback_date
 from kobo.apps.openrosa.libs.utils.common_tags import META_ROOT_UUID
 from kobo.apps.reports.report_data import build_formpack
@@ -86,7 +87,6 @@ from kpi.utils.sluggify import is_valid_node_name
 from kpi.utils.storage import is_filesystem_storage
 from kpi.utils.strings import to_str
 from kpi.zip_importer import HttpContentParse
-from pyxform.xls2json_backends import xls_to_dict, xlsx_to_dict
 
 
 def utcnow(*args, **kwargs):

--- a/kpi/renderers.py
+++ b/kpi/renderers.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Generator, Iterator
 from io import StringIO
 from typing import Any
 
+import formpack
 from dict2xml import dict2xml
 from django.core.serializers.json import DjangoJSONEncoder
 from django.template.loader import get_template
@@ -14,7 +15,6 @@ from rest_framework.exceptions import ErrorDetail, ParseError
 from rest_framework.request import Request
 from rest_framework_xml.renderers import XMLRenderer as DRFXMLRenderer
 
-import formpack
 from kobo.apps.reports.report_data import build_formpack
 from kpi.constants import GEO_QUESTION_TYPES
 from kpi.paginators import DefaultPagination

--- a/kpi/serializers/v2/asset_export_settings.py
+++ b/kpi/serializers/v2/asset_export_settings.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 from django.utils.translation import gettext as t
-from rest_framework import serializers
-from rest_framework.reverse import reverse
 from formpack.constants import (
     EXPORT_SETTING_FIELDS,
     EXPORT_SETTING_FIELDS_FROM_ALL_VERSIONS,
@@ -20,6 +18,8 @@ from formpack.constants import (
     VALID_EXPORT_TYPES,
     VALID_MULTIPLE_SELECTS,
 )
+from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from kpi.fields import WritableJSONField
 from kpi.models import Asset, AssetExportSettings

--- a/kpi/tests/test_asset_versions.py
+++ b/kpi/tests/test_asset_versions.py
@@ -5,8 +5,8 @@ from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 from django.utils import timezone
-
 from formpack.utils.expand_content import SCHEMA_VERSION
+
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.exceptions import BadAssetTypeException
 from kpi.utils.hash import calculate_hash

--- a/kpi/tests/test_mock_data.py
+++ b/kpi/tests/test_mock_data.py
@@ -2,8 +2,8 @@ from collections import OrderedDict
 from copy import deepcopy
 from unittest.mock import patch
 
-from formpack import FormPack
 from django.test import TestCase, override_settings
+from formpack import FormPack
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.reports import report_data

--- a/kpi/utils/asset_content_analyzer.py
+++ b/kpi/utils/asset_content_analyzer.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 import re
-
 from collections import OrderedDict
 
 from formpack.constants import KOBO_LOCK_ALL, KOBO_LOCK_COLUMN
-from formpack.utils.replace_aliases import META_TYPES, GEO_TYPES
+from formpack.utils.replace_aliases import GEO_TYPES, META_TYPES
 
 
 class AssetContentAnalyzer:

--- a/kpi/utils/autoname.py
+++ b/kpi/utils/autoname.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from enum import Enum
 
 from formpack.utils.json_hash import json_hash
+
 from kpi.exceptions import DuplicateNameException
 from kpi.utils.sluggify import is_valid_node_name, sluggify, sluggify_label
 

--- a/kpi/utils/pyxform_compatibility.py
+++ b/kpi/utils/pyxform_compatibility.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+
 from pyxform.constants import ALLOW_CHOICE_DUPLICATES
 
 

--- a/kpi/utils/standardize_content.py
+++ b/kpi/utils/standardize_content.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 from copy import deepcopy
 
+from formpack.utils.expand_content import SCHEMA_VERSION, expand_content
 from formpack.utils.replace_aliases import replace_aliases
-from formpack.utils.expand_content import expand_content, SCHEMA_VERSION
 
 ALLOWED_TYPES = {
     'score__row': True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ isort = true
 profile = "black"
 line_length = 88 # same as black
 known_first_party = "kobo"
+known_third_party = ["formpack", "pyxform"]
 no_lines_before = ["LOCALFOLDER"]
 
 [tool.ruff]
@@ -44,6 +45,7 @@ multiline-quotes = "double"
 docstring-quotes = "double"
 [tool.ruff.lint.isort]
 known-first-party = ["kobo"]
+known-third-party = ["formpack", "pyxform"]
 
 [tool.flake8]
 inline-quotes = "single"


### PR DESCRIPTION
### 💭 Notes

`formpack` is vendored locally at `src/formpack`. Both ruff's isort and the standalone `isort` package (used by `darker --isort`) auto-detect `src/` as a source root and then classify any import whose name matches a directory found there as first-party/local, instead of third-party. This caused `import formpack` to be grouped with `kobo`/`kpi` imports across the codebase instead of with third-party packages.

Same for `pyxform`