### PR TITLE
fix(library): more actions dropdown menu DEV-2714

### DIFF
--- a/jsapp/js/components/assetsTable/AssetMoreActions.tsx
+++ b/jsapp/js/components/assetsTable/AssetMoreActions.tsx
@@ -22,6 +22,7 @@ interface AssetMoreActionsProps {
   onEditLanguages: () => void
   onMoveToCollection: (collectionUrl: string | null) => void
   onDelete: () => void
+  withinRow?: boolean
 }
 
 /**
@@ -42,24 +43,17 @@ export default function AssetMoreActions(props: AssetMoreActionsProps) {
   const userCanEdit = userCan('change_asset', props.asset)
   const userCanDelete = userCan('delete_submissions', props.asset)
 
-  // Close menu when mouse leaves the row
+  // In the table row context, close the menu when the mouse leaves the row
   React.useEffect(() => {
-    if (!isMenuOpen) return
+    if (!isMenuOpen || !props.withinRow) return
 
-    const handleMouseMove = (e: MouseEvent) => {
-      // Find the closest row element
-      const target = e.target as HTMLElement
-      const row = target.closest('.assets-table-row--asset')
+    const row = menuRef.current?.closest('.assets-table-row--asset')
+    if (!row) return
 
-      // If we're not hovering over the row anymore, close the menu
-      if (menuRef.current && !row?.contains(menuRef.current)) {
-        setIsMenuOpen(false)
-      }
-    }
-
-    document.addEventListener('mousemove', handleMouseMove)
-    return () => document.removeEventListener('mousemove', handleMouseMove)
-  }, [isMenuOpen])
+    const handleMouseLeave = () => setIsMenuOpen(false)
+    row.addEventListener('mouseleave', handleMouseLeave)
+    return () => row.removeEventListener('mouseleave', handleMouseLeave)
+  }, [isMenuOpen, props.withinRow])
 
   // Only non-collection assets have downloads
   let downloads: AssetDownloads = []
@@ -88,7 +82,7 @@ export default function AssetMoreActions(props: AssetMoreActionsProps) {
         opened={isMenuOpen}
         onChange={setIsMenuOpen}
         withinPortal={false}
-        closeOnClickOutside={false}
+        closeOnClickOutside={!props.withinRow}
         zIndex={50}
       >
         <Menu.Target>

--- a/jsapp/js/components/assetsTable/assetActionButtons.tsx
+++ b/jsapp/js/components/assetsTable/assetActionButtons.tsx
@@ -38,6 +38,7 @@ interface AssetActionButtonsProps extends WithRouterProps {
   asset: AssetResponse
   has_deployment?: boolean
   deployment__active?: boolean
+  withinRow?: boolean
 }
 
 interface AssetActionButtonsState {
@@ -312,6 +313,7 @@ class AssetActionButtons extends React.Component<AssetActionButtonsProps, AssetA
           onEditLanguages={this.editLanguages}
           onMoveToCollection={this.moveToCollection}
           onDelete={this.delete}
+          withinRow={this.props.withinRow}
         />
       </menu>
     )

--- a/jsapp/js/components/assetsTable/assetsTableRow.tsx
+++ b/jsapp/js/components/assetsTable/assetsTableRow.tsx
@@ -30,7 +30,7 @@ class AssetsTableRow extends React.Component<AssetsTableRowProps> {
         <bem.AssetsTableRow__link href={`#/library/asset/${this.props.asset.uid}`} />
 
         <bem.AssetsTableRow__buttons>
-          <AssetActionButtons asset={this.props.asset} />
+          <AssetActionButtons asset={this.props.asset} withinRow />
         </bem.AssetsTableRow__buttons>
 
         <bem.AssetsTableRow__column m='icon-status'>


### PR DESCRIPTION
### 📣 Summary

Fixes a bug where the "More actions" dropdown menu in the detail view for collections would not stay open when moving the mouse from the trigger button to the menu.

### 👀 Preview steps

1. ℹ️ Have an account with at least one collection in the library
2. Navigate to collection's detail page
3. Click the "More actions" (⋯) button in the page header
4. 🔴 [on main] notice the dropdown disappears before you can reach the menu items
5. 🟢 [on PR] move the mouse to the menu items and notice the dropdown stays open
6. Click a menu item to confirm it works
7. 🟢 [on PR] Check collection item action dropdown behavior in list view and verify that it remains unchanged. It should still close when the mouse moves outside of the relevant row.