### PR TITLE
feat(sso): expose managed sso fields in /environment endpoint DEV-2412

### DIFF
--- a/jsapp/js/api/models/socialApp.ts
+++ b/jsapp/js/api/models/socialApp.ts
@@ -16,4 +16,6 @@ export interface SocialApp {
   name: string
   client_id: string
   provider_id: SocialAppProviderId
+  managed: boolean
+  domains: string[]
 }

--- a/jsapp/js/api/react-query/configuration/msw.ts
+++ b/jsapp/js/api/react-query/configuration/msw.ts
@@ -87,6 +87,10 @@ export const getApiV2EnvironmentRetrieveResponseMock = (
     name: faker.string.alpha({ length: { min: 10, max: 20 } }),
     client_id: faker.string.alpha({ length: { min: 10, max: 20 } }),
     provider_id: faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), null]),
+    managed: faker.datatype.boolean(),
+    domains: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() =>
+      faker.string.alpha({ length: { min: 10, max: 20 } }),
+    ),
   })),
   asr_mt_features_enabled: faker.datatype.boolean(),
   submission_placeholder: faker.string.alpha({ length: { min: 10, max: 20 } }),

--- a/kpi/schema_extensions/v2/environment/serializers.py
+++ b/kpi/schema_extensions/v2/environment/serializers.py
@@ -6,6 +6,8 @@ class SocialAppSerializer(serializers.Serializer):
     name = serializers.CharField()
     client_id = serializers.CharField()
     provider_id = serializers.CharField(allow_blank=True, allow_null=True)
+    managed = serializers.BooleanField()
+    domains = serializers.ListField(child=serializers.CharField())
 
 
 class MetadataFieldOptionSerializer(serializers.Serializer):

--- a/kpi/tests/api/v2/test_api_environment.py
+++ b/kpi/tests/api/v2/test_api_environment.py
@@ -13,7 +13,7 @@ from rest_framework import status
 
 from hub.models.sitewide_message import SitewideMessage
 from hub.utils.i18n import I18nUtils
-from kobo.apps.accounts.models import SocialAppCustomData
+from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
 from kobo.apps.hook.constants import SUBMISSION_PLACEHOLDER
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.tests.base_test_case import BaseTestCase
@@ -167,13 +167,28 @@ class EnvironmentTests(BaseTestCase, RequiresStripeAPIKeyMixin):
         with self.assertNumQueries(queries):
             response = self.client.get(self.url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        app = baker.make('socialaccount.SocialApp')
-        custom_data = SocialAppCustomData.objects.create(social_app=app, is_public=True)
+        managed_app = baker.make('socialaccount.SocialApp')
+        unmanaged_app = baker.make('socialaccount.SocialApp')
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=managed_app, is_public=True, managed=True
+        )
         custom_data.save()
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain='example.com'
+        )
         with override_settings(SOCIALACCOUNT_PROVIDERS={'microsoft': {}}):
             with self.assertNumQueries(queries):
                 response = self.client.get(self.url, format='json')
-        self.assertContains(response, app.name)
+        assert len(response.data['social_apps']) == 2
+        socialapps_response = sorted(
+            response.data['social_apps'], key=lambda k: k['managed']
+        )
+        assert socialapps_response[0]['managed'] == False
+        assert socialapps_response[0]['domains'] == []
+        assert socialapps_response[0]['name'] == unmanaged_app.name
+        assert socialapps_response[1]['managed'] == True
+        assert socialapps_response[1]['domains'] == ['example.com']
+        assert socialapps_response[1]['name'] == managed_app.name
 
     @override_settings(SOCIALACCOUNT_PROVIDERS={})
     def test_social_apps_no_custom_data(self):

--- a/kpi/tests/api/v2/test_api_environment.py
+++ b/kpi/tests/api/v2/test_api_environment.py
@@ -183,10 +183,10 @@ class EnvironmentTests(BaseTestCase, RequiresStripeAPIKeyMixin):
         socialapps_response = sorted(
             response.data['social_apps'], key=lambda k: k['managed']
         )
-        assert socialapps_response[0]['managed'] == False
+        assert socialapps_response[0]['managed'] is False
         assert socialapps_response[0]['domains'] == []
         assert socialapps_response[0]['name'] == unmanaged_app.name
-        assert socialapps_response[1]['managed'] == True
+        assert socialapps_response[1]['managed'] is True
         assert socialapps_response[1]['domains'] == ['example.com']
         assert socialapps_response[1]['name'] == managed_app.name
 

--- a/kpi/views/v2/environment.py
+++ b/kpi/views/v2/environment.py
@@ -1,8 +1,9 @@
 import constance
 from allauth.socialaccount.models import SocialApp
 from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.exceptions import MultipleObjectsReturned
-from django.db.models import Q
+from django.db.models import Case, F, Q, Value, When
 from django.utils.translation import gettext_lazy as t
 from drf_spectacular.utils import extend_schema
 from markdown import markdown
@@ -167,15 +168,34 @@ class EnvironmentView(APIView):
     @staticmethod
     def process_other_configs(request):
         data = {}
-
-        data['social_apps'] = list(
-            (
-                SocialApp.objects.filter(
-                    Q(custom_data__is_public=True) | Q(custom_data__isnull=True)
+        social_apps = (
+            SocialApp.objects.select_related('custom_data')
+            .prefetch_related('custom_data__domains')
+            .filter(Q(custom_data__is_public=True) | Q(custom_data__isnull=True))
+            # managed iff there exists a related SocialAppCustomData object with
+            # managed=True
+            .annotate(
+                managed=Case(
+                    When(
+                        custom_data__managed__isnull=False,
+                        then=F('custom_data__managed'),
+                    ),
+                    default=Value(False),
                 )
-            ).values('provider', 'name', 'client_id', 'provider_id')
+            )
+            .values('provider', 'name', 'client_id', 'provider_id', 'managed')
+            # list all managed domains associated with the SocialAppCustomData object.
+            # filter + default so we get an empty array if there are none rather than
+            # [None]
+            .annotate(
+                domains=ArrayAgg(
+                    'custom_data__domains__domain',
+                    filter=Q(custom_data__domains__domain__isnull=False),
+                    default=Value([]),
+                )
+            )
         )
-
+        data['social_apps'] = list(social_apps)
         data['asr_mt_features_enabled'] = check_asr_mt_access_for_user(request.user)
         data['submission_placeholder'] = SUBMISSION_PLACEHOLDER
 

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -31932,10 +31932,21 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "managed": {
+                        "type": "boolean"
+                    },
+                    "domains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 },
                 "required": [
                     "client_id",
+                    "domains",
+                    "managed",
                     "name",
                     "provider",
                     "provider_id"

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -22765,8 +22765,16 @@ components:
           type:
           - string
           - 'null'
+        managed:
+          type: boolean
+        domains:
+          type: array
+          items:
+            type: string
       required:
       - client_id
+      - domains
+      - managed
       - name
       - provider
       - provider_id


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Include information about managed SSO domains in the `/environment` endpoint.

### 💭 Notes
Using prefetch and select related ensures there are no additional queries (tested by running the query in django shell with `--print-sql`). 


### 👀 Preview steps
Enable SSO

1. ℹ️ have an account and a project
2. Add a SocialAppCustomData object to the social app. Set it to `managed` and add a domain.
3. Navigate to `/api/v2/environment`
4. 🟢 [on PR] notice the response contains new `managed` and `domain` fields in the `social_apps` field on the response

