### PR TITLE
refactor(massEmails): fold the send-rate ratio into a single throttle setting DEV-2681

### DIFF
--- a/kobo/apps/mass_emails/checks.py
+++ b/kobo/apps/mass_emails/checks.py
@@ -14,35 +14,17 @@ def check_mass_email_send_settings(app_configs, **kwargs):
 
     errors = []
 
-    if settings.MASS_EMAIL_THROTTLE_PER_SECOND < 1:
+    if settings.MASS_EMAIL_THROTTLE_PER_SECOND < 0.1:
         errors.append(
             Error(
                 f'MASS_EMAIL_THROTTLE_PER_SECOND is '
                 f'{settings.MASS_EMAIL_THROTTLE_PER_SECOND}, but must be at '
-                f'least 1.',
+                f'least 0.1.',
                 hint=(
                     'Set the MASS_EMAIL_THROTTLE_PER_SECOND environment '
-                    'variable to a positive integer.'
+                    'variable to a positive number.'
                 ),
                 id='mass_emails.E001',
-            )
-        )
-
-    if not (0 < settings.MASS_EMAIL_SEND_RATE_RATIO <= 1.0):
-        errors.append(
-            Error(
-                f'MASS_EMAIL_SEND_RATE_RATIO is '
-                f'{settings.MASS_EMAIL_SEND_RATE_RATIO}, but must be greater '
-                f'than 0 and at most 1.',
-                hint=(
-                    'Set the MASS_EMAIL_SEND_RATE_RATIO environment variable '
-                    'to a value between 0 (exclusive) and 1 (inclusive). '
-                    '0.5 or below is recommended so two full budget windows '
-                    "landing back to back still can't exceed the provider's "
-                    'real rate limit; above that is allowed but at the risk '
-                    'of bursting past it near a window boundary.'
-                ),
-                id='mass_emails.E002',
             )
         )
 
@@ -56,7 +38,7 @@ def check_mass_email_send_settings(app_configs, **kwargs):
                     'Set the MAILER_CONNECTION_IDLE_TIMEOUT environment '
                     'variable to a positive number.'
                 ),
-                id='mass_emails.E003',
+                id='mass_emails.E002',
             )
         )
 

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -288,16 +288,7 @@ class MassEmailSender:
 
     @with_smtp_connection
     def send_day_emails(self):
-        # Claim only a share of the provider's real per-second limit: it
-        # also carries transactional email, which draws on the same budget
-        # without going through this throttle.
-        budget_per_second = max(
-            1,
-            int(
-                settings.MASS_EMAIL_THROTTLE_PER_SECOND
-                * settings.MASS_EMAIL_SEND_RATE_RATIO
-            ),
-        )
+        budget_per_second = settings.MASS_EMAIL_THROTTLE_PER_SECOND
         window_start = monotonic()
         spent_in_window = 0
         stale_threshold = timezone.now() - timedelta(

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -288,7 +288,16 @@ class MassEmailSender:
 
     @with_smtp_connection
     def send_day_emails(self):
+        # A fractional budget can't be enforced within a single second (an
+        # integer count of sends can only round it up, never hit it
+        # exactly), so widen the window to whatever it takes to hold a
+        # whole number of sends at the configured rate. `sends_per_window`
+        # is the floor of the budget rather than a round(), so a partial
+        # window is never claimed: the achieved rate stays at or under
+        # what was configured, never over it.
         budget_per_second = settings.MASS_EMAIL_THROTTLE_PER_SECOND
+        sends_per_window = max(1, int(budget_per_second))
+        window_length = max(1.0, sends_per_window / budget_per_second)
         window_start = monotonic()
         spent_in_window = 0
         stale_threshold = timezone.now() - timedelta(
@@ -330,11 +339,10 @@ class MassEmailSender:
                         f'is no longer eligible for {email_config.query}'
                     )
                     continue
-                if spent_in_window >= budget_per_second:
-                    # The provider counts in 1-second windows, so ours must
-                    # too: sleep only what's left of the current one rather
+                if spent_in_window >= sends_per_window:
+                    # Sleep only what's left of the current window rather
                     # than a fixed amount.
-                    remaining = 1 - (monotonic() - window_start)
+                    remaining = window_length - (monotonic() - window_start)
                     if remaining > 0:
                         logging.info(
                             f'sleeping for {remaining:.3f}s to stay within '

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -226,11 +226,11 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
         plan_name = sender.get_plan_name(self.user1.organization)
         assert plan_name == 'Not available'
 
-    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=4, MASS_EMAIL_SEND_RATE_RATIO=0.5)
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=2)
     def test_send_is_throttled(self):
-        # budget_per_second = 4 * 0.5 = 2. `monotonic` is pinned so every
-        # window looks fully elapsed instantly, isolating the trigger
-        # pattern (every 2 sends, sleep once) from real elapsed time.
+        # `monotonic` is pinned so every window looks fully elapsed
+        # instantly, isolating the trigger pattern (every 2 sends, sleep
+        # once) from real elapsed time.
         self._setup_common_test_data()
         calls = []
         with (

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -258,6 +258,72 @@ class TestMassEmailSender(BaseMassEmailsTestCase):
             'send_email',
         ]
 
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=2.5)
+    def test_send_is_throttled_below_one_per_second(self):
+        # sends_per_window = floor(2.5) = 2, window_length stays clamped
+        # to 1.0 (2 / 2.5 = 0.8, under the floor): 2 sends per window, not
+        # the 4-per-window a shorter-than-1s window would allow.
+        self._setup_common_test_data()
+        calls = []
+        with (
+            patch('kobo.apps.mass_emails.tasks.monotonic', return_value=0),
+            patch(
+                'kobo.apps.mass_emails.tasks.sleep',
+                side_effect=lambda *x: calls.append('sleep'),
+            ),
+            patch.object(
+                MassEmailSender,
+                'send_email',
+                side_effect=lambda *x: calls.append('send_email'),
+            ),
+        ):
+            sender = MassEmailSender()
+            sender.limits = {self.configs[0].id: 3, self.configs[1].id: 2}
+            sender.send_day_emails()
+        assert calls == [
+            'send_email',
+            'send_email',
+            'sleep',
+            'send_email',
+            'send_email',
+            'sleep',
+            'send_email',
+        ]
+
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0.5)
+    def test_send_is_throttled_above_one_second_per_send(self):
+        # A budget under 1/s can't be enforced within a single second, so
+        # the window widens instead of rounding the achieved rate up to
+        # 1/s: one send per 2-second window here.
+        self._setup_common_test_data()
+        calls = []
+        with (
+            patch('kobo.apps.mass_emails.tasks.monotonic', return_value=0),
+            patch(
+                'kobo.apps.mass_emails.tasks.sleep',
+                side_effect=lambda *x: calls.append('sleep'),
+            ),
+            patch.object(
+                MassEmailSender,
+                'send_email',
+                side_effect=lambda *x: calls.append('send_email'),
+            ),
+        ):
+            sender = MassEmailSender()
+            sender.limits = {self.configs[0].id: 3, self.configs[1].id: 2}
+            sender.send_day_emails()
+        assert calls == [
+            'send_email',
+            'sleep',
+            'send_email',
+            'sleep',
+            'send_email',
+            'sleep',
+            'send_email',
+            'sleep',
+            'send_email',
+        ]
+
     @override_settings(MASS_EMAILS_CONDENSE_SEND=True)
     @data((5, 0), (20, 15), (40, 30), (46, 45))
     @unpack

--- a/kobo/apps/mass_emails/tests/test_checks.py
+++ b/kobo/apps/mass_emails/tests/test_checks.py
@@ -7,7 +7,6 @@ class MassEmailSendSettingsCheckTestCase(TestCase):
     ALL_CHECK_IDS = (
         'mass_emails.E001',
         'mass_emails.E002',
-        'mass_emails.E003',
     )
 
     @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0)
@@ -15,27 +14,15 @@ class MassEmailSendSettingsCheckTestCase(TestCase):
         errors = run_checks()
         assert any(e.id == 'mass_emails.E001' for e in errors)
 
-    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0)
-    def test_zero_send_rate_ratio_fails(self):
+    @override_settings(MASS_EMAIL_THROTTLE_PER_SECOND=0.1)
+    def test_throttle_at_minimum_is_allowed(self):
         errors = run_checks()
-        assert any(e.id == 'mass_emails.E002' for e in errors)
-
-    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=0.75)
-    def test_send_rate_ratio_above_half_is_allowed(self):
-        # Above 0.5 risks bursting past the provider's rate limit near a
-        # window boundary, but it's the admin's call, not a hard block.
-        errors = run_checks()
-        assert not any(e.id == 'mass_emails.E002' for e in errors)
-
-    @override_settings(MASS_EMAIL_SEND_RATE_RATIO=1.01)
-    def test_send_rate_ratio_above_one_fails(self):
-        errors = run_checks()
-        assert any(e.id == 'mass_emails.E002' for e in errors)
+        assert not any(e.id == 'mass_emails.E001' for e in errors)
 
     @override_settings(MAILER_CONNECTION_IDLE_TIMEOUT=0)
     def test_zero_idle_timeout_fails(self):
         errors = run_checks()
-        assert any(e.id == 'mass_emails.E003' for e in errors)
+        assert any(e.id == 'mass_emails.E002' for e in errors)
 
     def test_default_settings_pass(self):
         errors = run_checks()

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1851,13 +1851,11 @@ if os.environ.get('EMAIL_USE_TLS'):
 # (one provider at a time).
 # See kpi.utils.mailer.Mailer and kobo.apps.mass_emails.tasks.MassEmailSender.
 MAX_MASS_EMAILS_PER_DAY = env.int('MAX_MASS_EMAILS_PER_DAY', 10000)
-MASS_EMAIL_THROTTLE_PER_SECOND = env.int('MASS_EMAIL_THROTTLE_PER_SECOND', 40)
-# Some servers can share the same provider account and quota diluting their share of it
-# further than transactional email alone would.
-# 0.5 or below is recommended so two full budget windows landing back to
-# back still can't exceed the provider's rate limit; higher is allowed if
-# an admin accepts the risk of bursting past it near a window boundary.
-MASS_EMAIL_SEND_RATE_RATIO = env.float('MASS_EMAIL_SEND_RATE_RATIO', 0.35)
+# This throttle applies only to mass email, not to transactional email
+# (e.g. forgot password). Set it well under the provider's real per-second
+# limit so there's still headroom left for transactional email, which
+# shares the same provider account but doesn't go through this throttle.
+MASS_EMAIL_THROTTLE_PER_SECOND = env.float('MASS_EMAIL_THROTTLE_PER_SECOND', 10)
 # Margin under the provider's SMTP idle timeout.
 MAILER_CONNECTION_IDLE_TIMEOUT = env.int('MAILER_CONNECTION_IDLE_TIMEOUT', 10)
 # change the interval between "daily" email sends for testing. this will set both

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -174,7 +174,7 @@ class MailerProviderRateThrottledError(MailerProviderThrottledError):
     paces sends against a per-second budget kept under the provider's real
     limit, so the provider itself shouldn't need to say "slow down" except
     for unaccounted-for traffic sharing the same account (e.g. transactional
-    email) or a misconfigured `MASS_EMAIL_SEND_RATE_RATIO`.
+    email) or a misconfigured `MASS_EMAIL_THROTTLE_PER_SECOND`.
 
     TODO(DEV-2693): currently handled exactly like
     `MailerProviderQuotaExhaustedError`, which defeats the point of having


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

`MASS_EMAIL_SEND_RATE_RATIO` was only ever multiplied against `MASS_EMAIL_THROTTLE_PER_SECOND` in one place (`MassEmailSender.send_day_emails`), so the two-setting split (added in DEV-2681, PR #7440) bought nothing beyond documenting the split between "provider's real limit" and "our share of it". This folds both into `MASS_EMAIL_THROTTLE_PER_SECOND` alone, now expressing mass email's own per-second budget directly.

`MASS_EMAIL_THROTTLE_PER_SECOND` switches from `env.int` to `env.float` and now accepts fractional values down to `0.1`, so a budget of less than one send per second is expressible (previously the ratio was the only way to get below the throttle's integer floor, and even then `send_day_emails()` clamped the product back up to a minimum of 1). The default drops from the equivalent of 14/s (40 × 0.35) to 10/s, leaving more headroom for transactional email (password resets, etc.) sharing the same provider account.
