### PR TITLE
fix(attachments): match media filenames across unicode normalization forms DEV-2686

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+import unicodedata
 import uuid
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
 from kobo.apps.openrosa.libs.permissions import assign_perm
 from kobo.apps.openrosa.libs.utils.common_tags import GEOLOCATION
+from kobo.apps.openrosa.libs.utils.logger_tools import get_soft_deleted_attachments
 from kpi.constants import PERM_ADD_SUBMISSIONS, PERM_CHANGE_SUBMISSIONS
 
 
@@ -458,6 +460,68 @@ class TestFormSubmission(TestBase):
         edited_attachment = edited_attachments[0]
         assert edited_attachment.hash == attachment_hash
         assert edited_attachment.media_file_basename == attachment_basename
+
+    def test_attachment_with_mismatched_unicode_normalization(self):
+        """
+        The client references a media file in NFC while the uploaded file
+        arrives in NFD (e.g. from macOS). The attachment must be created,
+        stored in NFC and NOT immediately soft-deleted (DEV-2686).
+        """
+        nfc_name = unicodedata.normalize('NFC', 'Guérisseur.jpg')
+        nfd_name = unicodedata.normalize('NFD', 'Guérisseur.jpg')
+        # Sanity check: the two forms differ byte-wise
+        self.assertNotEqual(nfc_name, nfd_name)
+
+        xml = (
+            "<?xml version='1.0' ?>"
+            '<tutorial id="tutorial">'
+            '<name>Larry</name>'
+            '<age>23</age>'
+            f'<picture>{nfc_name}</picture>'
+            '<has_children>0</has_children>'
+            '<web_browsers>firefox</web_browsers>'
+            f'<meta><instanceID>uuid:{uuid.uuid4().hex}</instanceID></meta>'
+            f'<formhub><uuid>{self.xform.uuid}</uuid></formhub>'
+            '</tutorial>'
+        )
+
+        source_media = os.path.join(
+            os.path.dirname(__file__),
+            '../fixtures/tutorial/instances/tutorial_with_attachment',
+            '1335783522563.jpg',
+        )
+        with open(source_media, 'rb') as f:
+            media_bytes = f.read()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xml_path = os.path.join(tmp_dir, 'submission.xml')
+            with open(xml_path, 'w') as xml_file:
+                xml_file.write(xml)
+
+            # Write the uploaded file under an NFD filename
+            media_path = os.path.join(tmp_dir, nfd_name)
+            with open(media_path, 'wb') as media_file:
+                media_file.write(media_bytes)
+
+            with open(media_path, 'rb') as media_file:
+                self._make_submission(xml_path, media_file=media_file)
+
+        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
+
+        instance = Instance.objects.order_by('-pk')[0]
+        # Visible manager excludes soft-deleted attachments
+        attachments = Attachment.objects.filter(instance=instance)
+        self.assertEqual(attachments.count(), 1)
+        self.assertEqual(attachments[0].media_file_basename, nfc_name)
+
+        # The stored file name keeps the accent (NFC), not stripped by
+        # `get_valid_name`'s `\w` regex on NFD input
+        stored_basename = os.path.basename(attachments[0].media_file.name)
+        self.assertEqual(unicodedata.normalize('NFC', stored_basename), stored_basename)
+        self.assertIn(unicodedata.normalize('NFC', 'é'), stored_basename)
+
+        # A re-check finds nothing to soft delete
+        self.assertEqual(get_soft_deleted_attachments(instance), [])
 
     def test_owner_can_edit_submissions(self):
         xml_submission_file_path = os.path.join(

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_submission.py
@@ -523,6 +523,91 @@ class TestFormSubmission(TestBase):
         # A re-check finds nothing to soft delete
         self.assertEqual(get_soft_deleted_attachments(instance), [])
 
+    def test_edit_conflicts_with_legacy_nfd_attachment_basename(self):
+        """
+        A row saved before NFC normalization keeps an NFD basename. Editing it
+        with the same name in NFC but different content must still be rejected
+        instead of silently replacing the attachment (DEV-2686).
+        """
+        nfc_name = unicodedata.normalize('NFC', 'Guérisseur.jpg')
+        nfd_name = unicodedata.normalize('NFD', 'Guérisseur.jpg')
+        fixture_dir = os.path.join(
+            os.path.dirname(__file__),
+            '../fixtures/tutorial/instances/tutorial_with_attachment',
+        )
+        instance_id = f'uuid:{uuid.uuid4().hex}'
+
+        def build_xml(instance_uuid: str, deprecated_uuid: str = None) -> str:
+            deprecated = (
+                f'<deprecatedID>{deprecated_uuid}</deprecatedID>'
+                if deprecated_uuid
+                else ''
+            )
+            return (
+                "<?xml version='1.0' ?>"
+                '<tutorial id="tutorial">'
+                '<name>Larry</name>'
+                '<age>23</age>'
+                f'<picture>{nfc_name}</picture>'
+                '<has_children>0</has_children>'
+                '<web_browsers>firefox</web_browsers>'
+                f'<meta><instanceID>{instance_uuid}</instanceID>{deprecated}</meta>'
+                f'<formhub><uuid>{self.xform.uuid}</uuid></formhub>'
+                '</tutorial>'
+            )
+
+        def write_media(tmp_dir: str, source_path: str) -> str:
+            """
+            Copy a fixture next to the submission, named as the XML expects.
+            """
+            media_path = os.path.join(tmp_dir, nfc_name)
+            with open(source_path, 'rb') as source:
+                with open(media_path, 'wb') as target:
+                    target.write(source.read())
+            return media_path
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xml_path = os.path.join(tmp_dir, 'submission.xml')
+            with open(xml_path, 'w') as xml_file:
+                xml_file.write(build_xml(instance_id))
+            media_path = write_media(
+                tmp_dir, os.path.join(fixture_dir, '1335783522563.jpg')
+            )
+            with open(media_path, 'rb') as media:
+                self._make_submission(xml_path, media_file=media)
+
+        self.assertEqual(self.response.status_code, status.HTTP_201_CREATED)
+        instance = Instance.objects.order_by('-pk')[0]
+
+        # Simulate a row saved before basenames were normalized
+        Attachment.objects.filter(instance=instance).update(
+            media_file_basename=nfd_name
+        )
+        attachment_hash = Attachment.objects.get(instance=instance).hash
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xml_path = os.path.join(tmp_dir, 'edit.xml')
+            with open(xml_path, 'w') as xml_file:
+                xml_file.write(build_xml(f'uuid:{uuid.uuid4().hex}', instance_id))
+            media_path = write_media(
+                tmp_dir,
+                os.path.join(
+                    fixture_dir,
+                    'attachment_with_different_content',
+                    '1335783522563.jpg',
+                ),
+            )
+            with open(media_path, 'rb') as media:
+                self._make_submission(xml_path, media_file=media, assert_success=False)
+
+        self.assertEqual(self.response.status_code, status.HTTP_409_CONFLICT)
+
+        # The legacy attachment is untouched and no duplicate was created
+        attachments = Attachment.all_objects.filter(instance=instance)
+        self.assertEqual(attachments.count(), 1)
+        self.assertEqual(attachments[0].hash, attachment_hash)
+        self.assertEqual(attachments[0].media_file_basename, nfd_name)
+
     def test_owner_can_edit_submissions(self):
         xml_submission_file_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import traceback
+import unicodedata
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
@@ -910,9 +911,13 @@ def save_attachments(
         f.name = normalize_nfc(f.name)
 
         # The basename of a (non-deleted) attachment must be unique per instance.
+        # Legacy rows may be stored in NFD, so match both forms.
         existing_attachment = Attachment.objects.filter(
             instance=instance,
-            media_file_basename=media_file_basename,
+            media_file_basename__in={
+                media_file_basename,
+                unicodedata.normalize('NFD', media_file_basename),
+            },
         ).first()
 
         uploaded_file_hash = calculate_hash(f, 'sha1')

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -95,6 +95,7 @@ from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
 from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
+from kpi.utils.files import normalize_nfc
 from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
@@ -903,7 +904,10 @@ def save_attachments(
         # `MultiPartParserWithRawFilenames` to preserve the original filename
         # before Django’s sanitizing process.
         original_name = getattr(f, '_raw_filename', None) or f.name
-        media_file_basename = os.path.basename(original_name)
+        media_file_basename = normalize_nfc(os.path.basename(original_name))
+        # NFC-normalize the stored name too: `get_valid_name`'s `\w` regex drops
+        # NFD combining marks, stripping the accent from `media_file.name`.
+        f.name = normalize_nfc(f.name)
 
         # The basename of a (non-deleted) attachment must be unique per instance.
         existing_attachment = Attachment.objects.filter(
@@ -987,7 +991,7 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
 
             # Only keep non-empty fields
             if basename:
-                basenames.append(basename)
+                basenames.append(normalize_nfc(basename))
 
     # Update Attachment objects to hide them if they are not used anymore.
     # We do not want to delete them until the instance itself is deleted.
@@ -1015,9 +1019,11 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     latest_attachments, remaining_attachments_ids = [], []
     basename_set = set(basenames)
     for attachment in queryset:
-        if attachment.media_file_basename in basename_set:
+        # Legacy rows may be stored in NFD; normalize both sides before comparing
+        normalized_basename = normalize_nfc(attachment.media_file_basename)
+        if normalized_basename in basename_set:
             latest_attachments.append(attachment)
-            basename_set.remove(attachment.media_file_basename)
+            basename_set.remove(normalized_basename)
         else:
             remaining_attachments_ids.append(attachment.id)
     remaining_attachments = queryset.filter(id__in=remaining_attachments_ids)

--- a/kpi/deployment_backends/base_backend.py
+++ b/kpi/deployment_backends/base_backend.py
@@ -39,6 +39,7 @@ from kpi.exceptions import BulkUpdateSubmissionsClientException
 from kpi.models.asset_file import AssetFile
 from kpi.models.paired_data import PairedData
 from kpi.utils.django_orm_helper import UpdateJSONFieldAttributes
+from kpi.utils.files import normalize_nfc
 from kpi.utils.log import logging
 from kpi.utils.submission import get_attachment_filenames_and_xpaths
 from kpi.utils.urls import versioned_reverse
@@ -929,7 +930,8 @@ class BaseDeploymentBackend(abc.ABC):
             )
 
             # Retrieve XPath and add it to attachment dictionary
-            basename = os.path.basename(attachment['filename'])
+            # Keys in `filenames_and_xpaths` are NFC; normalize the lookup too
+            basename = normalize_nfc(os.path.basename(attachment['filename']))
             attachment['question_xpath'] = filenames_and_xpaths.get(
                 basename,
                 filenames_and_xpaths.get(self._without_suffix(basename), ''),

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unicodedata
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
@@ -567,8 +568,14 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
             if element is None:
                 raise XPathNotFoundException
             attachment_filename = element.text
+            # Legacy DB rows may store the basename in either normalization
+            # form, so match against both NFC and NFD variants
+            basenames = {attachment_filename}
+            if attachment_filename:
+                basenames.add(unicodedata.normalize('NFC', attachment_filename))
+                basenames.add(unicodedata.normalize('NFD', attachment_filename))
             filters = {
-                'media_file_basename': attachment_filename,
+                'media_file_basename__in': basenames,
             }
         else:
             filters = {}

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 from django.test import RequestFactory, TestCase, override_settings
 
 from kpi.constants import API_NAMESPACES
+from kpi.deployment_backends.kc_access.storage import default_kobocat_storage
 from kpi.exceptions import (
     QueryParserNotSupportedFieldLookup,
     SearchQueryTooShortException,
@@ -835,3 +836,21 @@ class AttachmentFilenamesAndXpathsTestCase(TestCase):
 
         self.assertEqual(result.get(nfc_name), 'picture')
         self.assertNotIn(nfd_name, result)
+
+    def test_nfd_filename_also_maps_to_legacy_stripped_basename(self):
+        """
+        On file system storage, `get_valid_name()` drops combining marks, so
+        attachments saved before normalization live under an accent-less name.
+        That name must resolve to the XPath too (DEV-2686).
+        """
+        nfd_name = unicodedata.normalize('NFD', 'Guérisseur.jpg')
+        legacy_name = default_kobocat_storage.get_valid_name(nfd_name)
+        nfc_name = default_kobocat_storage.get_valid_name(
+            unicodedata.normalize('NFC', 'Guérisseur.jpg')
+        )
+        self.assertNotEqual(legacy_name, nfc_name)
+
+        result = get_attachment_filenames_and_xpaths({'picture': nfd_name}, ['picture'])
+
+        self.assertEqual(result.get(nfc_name), 'picture')
+        self.assertEqual(result.get(legacy_name), 'picture')

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import unicodedata
 from copy import deepcopy
 
 import pytest
@@ -23,6 +24,7 @@ from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
 from kpi.utils.strings import split_lines_to_list, strtobool
+from kpi.utils.submission import get_attachment_filenames_and_xpaths
 from kpi.utils.urls import versioned_reverse
 from kpi.utils.xml import (
     edit_submission_xml,
@@ -816,3 +818,20 @@ class XmlUtilsTestCase(TestCase):
         re_source = re.sub(pattern, r'\1', source)
         re_target = re.sub(pattern, r'\1', target)
         self.assertEqual(re_source, re_target)
+
+
+class AttachmentFilenamesAndXpathsTestCase(TestCase):
+
+    def test_nfd_filename_maps_to_xpath_via_nfc_basename(self):
+        """
+        A submission value stored in NFD must be keyed under its NFC form so
+        an NFC basename lookup resolves the XPath (DEV-2686).
+        """
+        nfc_name = unicodedata.normalize('NFC', 'Guérisseur.jpg')
+        nfd_name = unicodedata.normalize('NFD', 'Guérisseur.jpg')
+        self.assertNotEqual(nfc_name, nfd_name)
+
+        result = get_attachment_filenames_and_xpaths({'picture': nfd_name}, ['picture'])
+
+        self.assertEqual(result.get(nfc_name), 'picture')
+        self.assertNotIn(nfd_name, result)

--- a/kpi/utils/files.py
+++ b/kpi/utils/files.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+import unicodedata
 
 # from mimetypes import guess_type
 from django.core.files.base import ContentFile
@@ -17,3 +18,16 @@ class ExtendedContentFile(ContentFile):
         if not (mimetype := self._mimetype):
             mimetype, _ = mimetypes.guess_type(os.path.basename(self.name))
         return mimetype
+
+
+def normalize_nfc(value: str | None) -> str | None:
+    """
+    Return the NFC-normalized form of a string.
+
+    Filenames can reach the server in different unicode normalization forms
+    (e.g. macOS produces NFD combining marks), which breaks byte-exact
+    matching. Pass through None/empty values unchanged.
+    """
+    if not value:
+        return value
+    return unicodedata.normalize('NFC', value)

--- a/kpi/utils/submission.py
+++ b/kpi/utils/submission.py
@@ -41,7 +41,13 @@ def get_attachment_filenames_and_xpaths(
         else:
             if key in attachment_xpaths:
                 try:
-                    value = default_kobocat_storage.get_valid_name(normalize_nfc(value))
+                    # Attachments saved before basenames were normalized are
+                    # stored under the raw name, which `get_valid_name()` strips
+                    # of its combining marks. Key both forms so they resolve.
+                    raw_valid_name = default_kobocat_storage.get_valid_name(value)
+                    nfc_valid_name = default_kobocat_storage.get_valid_name(
+                        normalize_nfc(value)
+                    )
                 except SuspiciousFileOperation:
                     logging.error(f'Could not get valid name from {value}')
                     continue
@@ -56,6 +62,8 @@ def get_attachment_filenames_and_xpaths(
                         group = group_name.split('/')[-1]
                         key = key.replace(group, f'{group}[{group_index}]')
 
-                return_dict[value] = key
+                return_dict[nfc_valid_name] = key
+                if raw_valid_name != nfc_valid_name:
+                    return_dict[raw_valid_name] = key
 
     return return_dict

--- a/kpi/utils/submission.py
+++ b/kpi/utils/submission.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.core.exceptions import SuspiciousFileOperation
 
 from kpi.deployment_backends.kc_access.storage import default_kobocat_storage
+from kpi.utils.files import normalize_nfc
 from kpi.utils.log import logging
 
 
@@ -40,7 +41,7 @@ def get_attachment_filenames_and_xpaths(
         else:
             if key in attachment_xpaths:
                 try:
-                    value = default_kobocat_storage.get_valid_name(value)
+                    value = default_kobocat_storage.get_valid_name(normalize_nfc(value))
                 except SuspiciousFileOperation:
                     logging.error(f'Could not get valid name from {value}')
                     continue


### PR DESCRIPTION
### 📣 Summary

Media files with accented characters in their name now upload and play back instead of vanishing from the data table.

### 📖 Description

A recording called something like `Guérisseur.ogg` would upload without any error, then land in the data table as plain text with no way to play or download it. Same thing on edits, and re-uploading never helped. Those files stay attached to their question now.

### 💭 Notes

- The filename reaches us twice: as text in the submission XML, and as the name of the uploaded file. Depending on where the file came from (macOS especially), one side is NFD and the other NFC. Every match on that name was byte-exact, so they never lined up.
- Two things broke as a result. `get_soft_deleted_attachments()` didn't find the new upload in the XML basename set and soft-deleted it right after saving, and `question_xpath` came back `''`, so the UI had no question to hang the file on.
- Fix normalizes to NFC when the attachment comes in (basename plus the stored file name) and on both sides of every lookup. `get_attachment()` also accepts NFD so rows already in the DB still resolve.
- One trap: `get_valid_filename()`'s `\w` doesn't match combining marks, so an NFD name quietly loses its accent on the storage path. That's why `f.name` gets normalized too and not just the basename.
- No migration, no backfill. Already-broken submissions stay broken until someone edits or re-submits them, which now saves correctly.

### 👀 Preview steps

1. ℹ️ have a project with an audio (or any file) question, deployed
2. make a file with an NFD-encoded name. On macOS: `python3 -c "import unicodedata,shutil;shutil.copy('sound.m4a','/tmp/'+unicodedata.normalize('NFD','Guérisseur.m4a'))"`
3. open the Enketo form, attach that file, submit
4. open the project's data table
5. 🔴 [on main] the cell shows the filename as text, no player and no download. The attachment got soft-deleted on save
6. 🟢 [on PR] the player shows up and the file plays
7. edit the submission and save again
8. 🟢 file is still there
