### PR TITLE
fix(xlsImport): block translated XLSForm missing language-specific columns DEV-2656

### DIFF
--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -251,7 +251,7 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb
+formpack @ git+https://github.com/kobotoolbox/formpack.git@f8cd2a19e2c39d85639004b5fcf85b8f69a48da4
     # via -r dependencies/pip/requirements.in
 freezegun==1.5.5
     # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/dev_requirements.txt
+++ b/dependencies/pip/dev_requirements.txt
@@ -251,7 +251,7 @@ flake8-quotes==3.4.0
     # via -r dependencies/pip/dev_requirements.in
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@3bf65b74fe876a514cff839fb10c24470dd63de2
+formpack @ git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb
     # via -r dependencies/pip/requirements.in
 freezegun==1.5.5
     # via -r dependencies/pip/dev_requirements.in

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
-git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb#egg=formpack
+git+https://github.com/kobotoolbox/formpack.git@f8cd2a19e2c39d85639004b5fcf85b8f69a48da4#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
-git+https://github.com/kobotoolbox/formpack.git@c00683281c5df4cdac86144d8e52c13e283f3e5e#egg=formpack
+git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -197,7 +197,7 @@ fido2==2.2.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@c00683281c5df4cdac86144d8e52c13e283f3e5e
+formpack @ git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb
     # via -r dependencies/pip/requirements.in
 funcsigs==1.0.2
     # via begins

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -197,7 +197,7 @@ fido2==2.2.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb
+formpack @ git+https://github.com/kobotoolbox/formpack.git@f8cd2a19e2c39d85639004b5fcf85b8f69a48da4
     # via -r dependencies/pip/requirements.in
 funcsigs==1.0.2
     # via begins

--- a/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.tsx
+++ b/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.tsx
@@ -173,18 +173,18 @@ export default function LibraryUploadModal(props: LibraryUploadModalProps) {
 
     if (importData.status === 'error') {
       terminalImportStatusRef.current = terminalStatus
-      const errLines: React.ReactNode[] = [t('Import Failed!')]
+      const errLines: React.ReactNode[] = [<strong key='title'>{t('Import Failed!')}</strong>]
       if (uploadFilename) {
-        errLines.push(<code key='filename'>Name: {uploadFilename}</code>)
+        errLines.push(<small key='filename'>Name: {uploadFilename}</small>)
       }
       if (importData.messages?.error) {
         errLines.push(
-          <code key='error'>
+          <small key='error'>
             {importData.messages.error_type}: {escapeHtml(importData.messages.error)}
-          </code>,
+          </small>,
         )
       }
-      notify.error(<div>{join(errLines, <br />)}</div>)
+      notify.error(<div style={{ textAlign: 'left' }}>{join(errLines, <br />)}</div>)
       onRequestClose()
     }
   }, [currentImportUid, importDetailsQuery.data, onRequestClose, uploadFilename])

--- a/jsapp/js/dropzone.utils.tsx
+++ b/jsapp/js/dropzone.utils.tsx
@@ -237,18 +237,18 @@ function onImportSingleXLSFormFile(name: string, base64Encoded: string | ArrayBu
           (reason: ImportResponse) => {
             if (reason?.status === 'error') {
               const errLines = []
-              errLines.push(t('Import Failed!'))
+              errLines.push(<strong>{t('Import Failed!')}</strong>)
               if (name) {
-                errLines.push(<code>Name: {name}</code>)
+                errLines.push(<small>Name: {name}</small>)
               }
               if (reason.messages?.error) {
                 errLines.push(
-                  <code>
+                  <small>
                     {reason.messages.error_type}: {escapeHtml(reason.messages.error)}
-                  </code>,
+                  </small>,
                 )
               }
-              reject(<div>{join(errLines, <br />)}</div>)
+              reject(<div style={{ textAlign: 'left' }}>{join(errLines, <br />)}</div>)
             } else {
               reject(IMPORT_FAILED_GENERIC_MESSAGE)
             }

--- a/kobo/apps/reports/constants.py
+++ b/kobo/apps/reports/constants.py
@@ -7,7 +7,3 @@ CHARTABLE_TYPES = [
 
 SPECIFIC_REPORTS_KEY = 'specified'
 DEFAULT_REPORTS_KEY = 'default'
-
-FUZZY_VERSION_ID_KEY = '_version_'
-FUZZY_VERSION_PATTERN = r'^__?version__?(\d{3})?$'
-INFERRED_VERSION_ID_KEY = '__inferred_version__'

--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -4,11 +4,11 @@ from copy import deepcopy
 
 from django.utils.translation import gettext as t
 from formpack import FormPack
+from formpack.constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY
 from rest_framework import serializers
 
 from kpi.utils.bugfix import repair_file_column_content_and_save
 from kpi.utils.log import logging
-from .constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY
 
 
 def build_formpack(asset, submission_stream=None, use_all_form_versions=True):

--- a/kpi/mixins/formpack_xlsform_utils.py
+++ b/kpi/mixins/formpack_xlsform_utils.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import copy
-import re
 from collections import OrderedDict
 
+from formpack.constants import FUZZY_VERSION_RE
 from formpack.utils.flatten_content import flatten_content
 from formpack.utils.spreadsheet_content import flatten_to_spreadsheet_content
 
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kpi.utils.absolute_paths import insert_full_paths_in_place
 from kpi.utils.asset_translation_utils import (  # TRANSLATIONS_EQUAL,
     TRANSLATION_ADDED,
@@ -178,7 +177,7 @@ class FormpackXLSFormUtilsMixin:
         for idx in range(len(content[self.WORKING_SHEET]) - 1, 0, -1):
             field = content[self.WORKING_SHEET][idx]
             try:
-                if re.match(FUZZY_VERSION_PATTERN, field['name']):
+                if FUZZY_VERSION_RE.match(field['name']):
                     del content[self.WORKING_SHEET][idx]
             except KeyError:
                 pass

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -4,7 +4,7 @@ import os
 import posixpath
 import re
 import tempfile
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from io import BytesIO
 from os.path import split, splitext
 from typing import Dict, Generator, List, Optional, Tuple
@@ -22,7 +22,7 @@ from django.db.models.functions import Cast, Coalesce, Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from formpack.constants import KOBO_LOCK_SHEET
+from formpack.constants import KOBO_LOCK_SHEET, MEDIA_COLUMN_NAMES
 from formpack.schema.fields import (
     IdCopyField,
     NotesCopyField,
@@ -371,6 +371,7 @@ class ImportTask(ImportExportTask):
                 except InvalidFileException:
                     kontent = xls_to_dict(item.readable)
                 self._ensure_valid_node_names(kontent)
+                self._ensure_translated_columns(kontent)
 
                 if not destination:
                     extra_args['content'] = _strip_header_keys(kontent)
@@ -407,6 +408,60 @@ class ImportTask(ImportExportTask):
             orm_obj.save()
 
     @staticmethod
+    def _ensure_translated_columns(survey_dict):
+        """
+        Block importing an XLSForm that mixes translated columns (e.g.
+        `label::English (en)`) with untranslated ones (e.g. a bare `hint`),
+        which would otherwise inject a null "Unnamed language" translation and
+        break the formbuilder (DEV-2656). Mirrors the column classification in
+        `formpack.utils.expand_content._get_special_survey_cols()`.
+        """
+        media_re = '|'.join(MEDIA_COLUMN_NAMES)
+
+        uniq_cols = OrderedDict()
+        for sheet in ('survey', 'choices', 'library'):
+            for row in survey_dict.get(sheet, []):
+                uniq_cols.update(OrderedDict.fromkeys(row.keys()))
+
+        languages = set()
+        untranslated = []
+
+        def _mark_untranslated(column_name):
+            if column_name not in untranslated:
+                untranslated.append(column_name)
+
+        for column_name in uniq_cols.keys():
+            if column_name in ('label', 'hint'):
+                _mark_untranslated(column_name)
+            if ':' not in column_name and column_name not in MEDIA_COLUMN_NAMES:
+                continue
+            if column_name.startswith('bind:') or column_name.startswith('body:'):
+                continue
+            mtch = re.match(
+                rf'^(media\s*::?\s*)?({media_re})\s*::?\s*([^:]+)$',
+                column_name,
+            )
+            if mtch:
+                languages.add(mtch.groups()[2])
+                continue
+            mtch = re.match(rf'^(media\s*::?\s*)?({media_re})$', column_name)
+            if mtch:
+                _mark_untranslated(column_name)
+                continue
+            mtch = re.match(r'^([^:]+)\s*::?\s*([^:]+)$', column_name)
+            if mtch:
+                column_shortname = mtch.groups()[0]
+                languages.add(mtch.groups()[1])
+                if column_shortname in uniq_cols:
+                    _mark_untranslated(column_shortname)
+
+        if languages and untranslated:
+            if len(untranslated) == 1:
+                raise ValueError(f'The `{untranslated[0]}` column is not translated')
+            cols = ', '.join(f'`{col}`' for col in untranslated)
+            raise ValueError(f'These columns are not translated: {cols}')
+
+    @staticmethod
     def _ensure_valid_node_names(survey_dict):
         survey_list = survey_dict.get('survey', [])
 
@@ -432,6 +487,7 @@ class ImportTask(ImportExportTask):
         library = kwargs.get('library')
         survey_dict = _b64_xls_to_dict(base64_encoded_upload)
         self._ensure_valid_node_names(survey_dict)
+        self._ensure_translated_columns(survey_dict)
         survey_dict_keys = survey_dict.keys()
 
         destination = kwargs.get('destination', False)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -415,6 +415,10 @@ class ImportTask(ImportExportTask):
         which would otherwise inject a null "Unnamed language" translation and
         break the formbuilder (DEV-2656). Mirrors the column classification in
         `formpack.utils.expand_content._get_special_survey_cols()`.
+
+        TODO: replace the patterns below with the compiled constants
+        (`MEDIA_COLUMN_WITH_LANG_RE`, `MEDIA_COLUMN_RE`,
+        `TRANSLATED_COLUMN_RE`) once they land in `formpack.constants`.
         """
         media_re = '|'.join(MEDIA_COLUMN_NAMES)
 
@@ -437,6 +441,8 @@ class ImportTask(ImportExportTask):
                 continue
             if column_name.startswith('bind:') or column_name.startswith('body:'):
                 continue
+            # translated media column,
+            # e.g. `image::English (en)` or `media::image::French (fr)`
             mtch = re.match(
                 rf'^(media\s*::?\s*)?({media_re})\s*::?\s*([^:]+)$',
                 column_name,
@@ -444,10 +450,13 @@ class ImportTask(ImportExportTask):
             if mtch:
                 languages.add(mtch.groups()[2])
                 continue
+            # untranslated media column, e.g. `image` or `media::image`
             mtch = re.match(rf'^(media\s*::?\s*)?({media_re})$', column_name)
             if mtch:
                 _mark_untranslated(column_name)
                 continue
+            # any other translated column,
+            # e.g. `label::English (en)` or `constraint_message::Français`
             mtch = re.match(r'^([^:]+)\s*::?\s*([^:]+)$', column_name)
             if mtch:
                 column_shortname = mtch.groups()[0]

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -22,7 +22,13 @@ from django.db.models.functions import Cast, Coalesce, Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from formpack.constants import KOBO_LOCK_SHEET, MEDIA_COLUMN_NAMES
+from formpack.constants import (
+    KOBO_LOCK_SHEET,
+    MEDIA_COLUMN_NAMES,
+    MEDIA_COLUMN_RE,
+    MEDIA_COLUMN_WITH_LANG_RE,
+    TRANSLATED_COLUMN_RE,
+)
 from formpack.schema.fields import (
     IdCopyField,
     NotesCopyField,
@@ -415,13 +421,7 @@ class ImportTask(ImportExportTask):
         which would otherwise inject a null "Unnamed language" translation and
         break the formbuilder (DEV-2656). Mirrors the column classification in
         `formpack.utils.expand_content._get_special_survey_cols()`.
-
-        TODO: replace the patterns below with the compiled constants
-        (`MEDIA_COLUMN_WITH_LANG_RE`, `MEDIA_COLUMN_RE`,
-        `TRANSLATED_COLUMN_RE`) once they land in `formpack.constants`.
         """
-        media_re = '|'.join(MEDIA_COLUMN_NAMES)
-
         uniq_cols = OrderedDict()
         for sheet in ('survey', 'choices', 'library'):
             for row in survey_dict.get(sheet, []):
@@ -443,21 +443,18 @@ class ImportTask(ImportExportTask):
                 continue
             # translated media column,
             # e.g. `image::English (en)` or `media::image::French (fr)`
-            mtch = re.match(
-                rf'^(media\s*::?\s*)?({media_re})\s*::?\s*([^:]+)$',
-                column_name,
-            )
+            mtch = MEDIA_COLUMN_WITH_LANG_RE.match(column_name)
             if mtch:
                 languages.add(mtch.groups()[2])
                 continue
             # untranslated media column, e.g. `image` or `media::image`
-            mtch = re.match(rf'^(media\s*::?\s*)?({media_re})$', column_name)
+            mtch = MEDIA_COLUMN_RE.match(column_name)
             if mtch:
                 _mark_untranslated(column_name)
                 continue
             # any other translated column,
             # e.g. `label::English (en)` or `constraint_message::Français`
-            mtch = re.match(r'^([^:]+)\s*::?\s*([^:]+)$', column_name)
+            mtch = TRANSLATED_COLUMN_RE.match(column_name)
             if mtch:
                 column_shortname = mtch.groups()[0]
                 languages.add(mtch.groups()[1])

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import Optional
 
 from constance import config
@@ -12,6 +11,7 @@ from django.utils.translation import gettext as t
 from django.utils.translation import ngettext as nt
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
+from formpack.constants import FUZZY_VERSION_RE
 from rest_framework import exceptions, serializers
 from rest_framework.fields import empty
 from rest_framework.reverse import reverse
@@ -20,7 +20,6 @@ from hub.models.extra_user_detail import ExtraUserDetail
 from kobo.apps.openrosa.apps.logger.models import XForm
 from kobo.apps.organizations.constants import ORG_ADMIN_ROLE
 from kobo.apps.organizations.utils import get_real_owner
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kobo.apps.reports.report_data import build_formpack
 from kobo.apps.subsequences.utils.supplement_data import get_analysis_form_json
 from kobo.apps.trash_bin.exceptions import TrashIntegrityError, TrashTaskInProgressError
@@ -1084,7 +1083,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 valid_fields = [
                     f.path for f in form_pack.get_fields_for_versions(
                         form_pack.versions.keys()
-                    ) if not re.match(FUZZY_VERSION_PATTERN, f.path)
+                    )
+                    if not FUZZY_VERSION_RE.match(f.path)
                 ]
                 unknown_fields = set(fields) - set(valid_fields)
                 if unknown_fields and valid_fields:

--- a/kpi/serializers/v2/paired_data.py
+++ b/kpi/serializers/v2/paired_data.py
@@ -5,10 +5,10 @@ import re
 from django.utils.translation import gettext as t
 from django_request_cache import cache_for_request
 from drf_spectacular.utils import extend_schema_field
+from formpack.constants import FUZZY_VERSION_RE
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kobo.apps.reports.report_data import build_formpack
 from kpi.constants import (
     ASSET_TYPE_SURVEY,
@@ -163,9 +163,9 @@ class PairedDataSerializer(serializers.Serializer):
         # See `_infer_version_id()` in `kobo.apps.reports.report_data.build_formpack`
         # for field name alternatives.
         valid_fields = [
-            f.path for f in form_pack.get_fields_for_versions(
-                form_pack.versions.keys()
-            ) if not re.match(FUZZY_VERSION_PATTERN, f.path)
+            f.path
+            for f in form_pack.get_fields_for_versions(form_pack.versions.keys())
+            if not FUZZY_VERSION_RE.match(f.path)
         ]
 
         source_fields = source.data_sharing.get('fields') or valid_fields

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -1000,14 +1000,25 @@ class AssetImportTaskTest(BaseTestCase):
         self.assertEqual(detail_response.data['status'], 'complete')
 
     def test_import_xls_with_default_language_not_in_translations(self):
-        asset = Asset.objects.get(pk=2)
-        xlsx_io = asset.to_xlsx_io(
-            append={'settings': {'default_language': 'English (en)'}}
+        task_data = self._construct_xlsx_for_import(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English'],
+                        ['text', 'q1', 'Question 1'],
+                    ],
+                ),
+                (
+                    'settings',
+                    [
+                        ['default_language'],
+                        ['English (en)'],
+                    ],
+                ),
+            ),
+            name='I was imported via XLS!',
         )
-        task_data = {
-            'file': xlsx_io,
-            'name': 'I was imported via XLS!',
-        }
         post_url = reverse('api_v2:importtask-list')
         response = self.client.post(post_url, task_data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -1151,6 +1162,179 @@ class AssetImportTaskTest(BaseTestCase):
             'Language in the settings sheet',
         )
         assert asset.content['translations'] == ['English (en)']
+
+    def test_import_xls_blocks_untranslated_hint_column(self):
+        content = (
+            (
+                'survey',
+                [
+                    [
+                        'type',
+                        'name',
+                        'label::English (en)',
+                        'label::French (fr)',
+                        'hint',
+                    ],
+                    ['integer', 'age', 'Age?', 'Âge ?', 'in years'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'Mixed translations', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'error'
+        assert (
+            detail_response.data['messages']['error']
+            == 'The `hint` column is not translated'
+        )
+
+    def test_reimport_xls_blocks_untranslated_column_and_keeps_translations(
+        self,
+    ):
+        asset = self._import_sheets(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'label::French (fr)'],
+                        ['integer', 'age', 'Age?', 'Âge ?'],
+                    ],
+                ),
+            ),
+            'Two languages',
+        )
+        translations_before = asset.content['translations']
+        assert translations_before == ['English (en)', 'French (fr)']
+
+        task_data = self._construct_xlsx_for_import(
+            (
+                (
+                    'survey',
+                    [
+                        ['type', 'name', 'label::English (en)', 'hint'],
+                        ['integer', 'age', 'Age?', 'in years'],
+                    ],
+                ),
+            ),
+            name='Mixed reimport',
+        )
+        task_data['destination'] = reverse(
+            self._get_endpoint('asset-detail'),
+            kwargs={'uid_asset': asset.uid},
+        )
+        response = self.client.post(
+            reverse(self._get_endpoint('importtask-list')), task_data
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'error'
+        assert (
+            detail_response.data['messages']['error']
+            == 'The `hint` column is not translated'
+        )
+
+        asset.refresh_from_db()
+        assert asset.content['translations'] == translations_before
+
+    def test_import_xls_blocks_untranslated_media_column(self):
+        content = (
+            (
+                'survey',
+                [
+                    ['type', 'name', 'label::English (en)', 'image'],
+                    ['integer', 'age', 'Age?', 'age.png'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'Bare media column', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'error'
+        assert (
+            detail_response.data['messages']['error']
+            == 'The `image` column is not translated'
+        )
+
+    def test_import_xls_blocks_column_both_bare_and_translated(self):
+        content = (
+            (
+                'survey',
+                [
+                    ['type', 'name', 'label', 'label::English (en)'],
+                    ['integer', 'age', 'Age?', 'Age?'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'Bare and translated label', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'error'
+        assert (
+            detail_response.data['messages']['error']
+            == 'The `label` column is not translated'
+        )
+
+    def test_import_xls_blocks_untranslated_column_in_choices_sheet(self):
+        content = (
+            (
+                'survey',
+                [
+                    ['type', 'name', 'label::English (en)'],
+                    ['select_one gender', 'gender', 'Gender?'],
+                ],
+            ),
+            (
+                'choices',
+                [
+                    ['list_name', 'name', 'label'],
+                    ['gender', 'female', 'Female'],
+                    ['gender', 'male', 'Male'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'Untranslated choices label', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'error'
+        assert (
+            detail_response.data['messages']['error']
+            == 'The `label` column is not translated'
+        )
+
+    def test_import_xls_allows_fully_untranslated_form(self):
+        content = (
+            (
+                'survey',
+                [
+                    ['type', 'name', 'label', 'hint'],
+                    ['integer', 'age', 'Age?', 'in years'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'No translations', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'complete'
+
+    def test_import_xls_allows_fully_translated_form(self):
+        content = (
+            (
+                'survey',
+                [
+                    ['type', 'name', 'label::English (en)', 'hint::English (en)'],
+                    ['integer', 'age', 'Age?', 'in years'],
+                ],
+            ),
+        )
+        response = self._create_asset_from_xls(
+            content, 'Fully translated', excel_format='xlsx'
+        )
+        detail_response = self.client.get(response.data['url'])
+        assert detail_response.data['status'] == 'complete'
 
     def test_import_strip_newline_from_form_title_setting(self):
         survey_sheet_content = [


### PR DESCRIPTION
### 📣 Summary

Uploading an XLSForm that has translations but leaves some columns untranslated (like a plain `hint` next to `label::English (en)`) is now blocked with a clear error instead of creating a broken project.

### 📖 Description

Until now, importing such a form quietly added an "Unnamed language" to the project, which could break the form builder, or silently dropped the missing translations. The import now fails right away with a message naming the column, e.g. "The `hint` column is not translated". Forms with no translations at all import as before.

### 💭 Notes

- New `ImportTask._ensure_translated_columns()` runs on both import routes (base64 and URL) before any asset is created or modified. It mirrors formpack's `_get_special_survey_cols()` rules, so it blocks exactly the forms that would end up with a null translation: bare `label`/`hint`, bare media columns, or a column present both bare and with a `::language` suffix.
- This also blocks forms that used to import thanks to the save-time repair from DEV-2095 (bare `hint` + `default_language`): that repair silently dropped the hint's other translations, which is the other half of the bug report.
- Second commit makes the import-error toast readable (it rendered in unstyled monospace); applies to all import errors, and the same fix goes to the duplicated toast in the library upload modal.
- `test_import_xls_with_default_language_not_in_translations` used fixture asset pk=2, which itself mixes bare `label` with `label::English` and is now rejected; rebuilt its input so it still covers the default-language mismatch.

- The column and fuzzy-version regexes now come from `formpack.constants` (kobotoolbox/formpack#351) instead of local copies, per review feedback; the duplicates in `kobo/apps/reports/constants.py` are gone too. Depends on kobotoolbox/formpack#351 (now merged); the formpack pin here points at its merge commit.

### 👀 Preview steps

1. ℹ️ have an account
2. make an XLSForm whose survey sheet has `label::English (en)`, `label::French (fr)` and a plain `hint` column (one text question is enough)
3. upload it as a new project (NEW → Upload an XLSForm)
4. 🔴 [on main] the import succeeds and the project gets an Unnamed language (or silently loses the French hint when `default_language` is set)
5. 🟢 [on PR] the import fails with "The `hint` column is not translated" and no project is created
6. rename `hint` to `hint::English (en)`, add `hint::French (fr)`, upload again
7. 🟢 the project imports normally with both languages

