### PR TITLE
feat(map): display points across antimeridian DEV-123

### DIFF
--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -11,6 +11,7 @@ import { queryClientDecorator } from '#/query/queryClient.mocks'
 import { ROUTES } from '#/router/routerConstants'
 import { withMinHeightWrapper } from '#/storybookUtils'
 import FormMapWrapper from './formMapWrapper'
+import { mapTileHandlers } from './mapTiles.mocks'
 
 const mockAssetUid = 'aTestMapAssetUid123'
 
@@ -194,23 +195,26 @@ const submissionsAcrossAntimeridian: SubmissionResponse[] = [
   }),
 ]
 
-// Both of the 180th meridian stories are served the same asset and the same submissions
-const pacificHandlers = [
-  http.get(endpoints.ASSET_URL, ({ params }) => {
-    if (params.uid !== mockAssetUid) return undefined
-    return HttpResponse.json(assetWithPacificGeopoints)
-  }),
-  http.get<{ uid: string; limit?: string; start?: string }>(endpoints.ASSET_DATA_URL, ({ params }) => {
-    if (params.uid !== mockAssetUid) return undefined
-    const response: PaginatedResponse<SubmissionResponse> = {
-      count: submissionsAcrossAntimeridian.length,
-      next: null,
-      previous: null,
-      results: submissionsAcrossAntimeridian,
-    }
-    return HttpResponse.json(response)
-  }),
-]
+/** Everything a map story needs mocked: the asset, its submissions and the tiles the map is drawn on. */
+function mapHandlers(asset: AssetResponse, submissions: SubmissionResponse[]) {
+  return [
+    http.get(endpoints.ASSET_URL, ({ params }) => {
+      if (params.uid !== mockAssetUid) return undefined
+      return HttpResponse.json(asset)
+    }),
+    http.get<{ uid: string; limit?: string; start?: string }>(endpoints.ASSET_DATA_URL, ({ params }) => {
+      if (params.uid !== mockAssetUid) return undefined
+      const response: PaginatedResponse<SubmissionResponse> = {
+        count: submissions.length,
+        next: null,
+        previous: null,
+        results: submissions,
+      }
+      return HttpResponse.json(response)
+    }),
+    ...mapTileHandlers,
+  ]
+}
 
 const meta: Meta<typeof FormMapWrapper> = {
   title: 'Features/FormMap',
@@ -237,15 +241,11 @@ const meta: Meta<typeof FormMapWrapper> = {
     withRouter,
     queryClientDecorator,
     withMinHeightWrapper(400, { height: 400 }),
-    // Hide map tiles for Chromatic tests - prevents flakiness from map images rendering differently (we had tiny
-    // differences causing tests to fail)
+    // Tiles are mocked (see `mapTiles.mocks.ts`), so this only fills the map while they are on their way in
     (Story) => (
       <>
         <style>
           {`
-            .leaflet-tile-pane {
-              opacity: 0 !important;
-            }
             #data-map {
               background: #a8e4f0 !important;
             }
@@ -262,24 +262,7 @@ type Story = StoryObj<typeof FormMapWrapper>
 
 export const WithOnlyStartGeopoint: Story = {
   parameters: {
-    msw: {
-      handlers: [
-        http.get(endpoints.ASSET_URL, ({ params }) => {
-          if (params.uid !== mockAssetUid) return undefined
-          return HttpResponse.json(assetWithOnlyStartGeopoint)
-        }),
-        http.get<{ uid: string; limit?: string; start?: string }>(endpoints.ASSET_DATA_URL, ({ params }) => {
-          if (params.uid !== mockAssetUid) return undefined
-          const response: PaginatedResponse<SubmissionResponse> = {
-            count: submissionsWithStartGeopoint.length,
-            next: null,
-            previous: null,
-            results: submissionsWithStartGeopoint,
-          }
-          return HttpResponse.json(response)
-        }),
-      ],
-    },
+    msw: { handlers: mapHandlers(assetWithOnlyStartGeopoint, submissionsWithStartGeopoint) },
   },
   args: {
     asset: assetWithOnlyStartGeopoint,
@@ -322,24 +305,7 @@ export const WithOnlyStartGeopoint: Story = {
 
 export const WithBothGeopointTypes: Story = {
   parameters: {
-    msw: {
-      handlers: [
-        http.get(endpoints.ASSET_URL, ({ params }) => {
-          if (params.uid !== mockAssetUid) return undefined
-          return HttpResponse.json(assetWithBothGeopointTypes)
-        }),
-        http.get<{ uid: string; limit?: string; start?: string }>(endpoints.ASSET_DATA_URL, ({ params }) => {
-          if (params.uid !== mockAssetUid) return undefined
-          const response: PaginatedResponse<SubmissionResponse> = {
-            count: submissionsWithBothGeopointTypes.length,
-            next: null,
-            previous: null,
-            results: submissionsWithBothGeopointTypes,
-          }
-          return HttpResponse.json(response)
-        }),
-      ],
-    },
+    msw: { handlers: mapHandlers(assetWithBothGeopointTypes, submissionsWithBothGeopointTypes) },
   },
   args: {
     asset: assetWithBothGeopointTypes,
@@ -413,7 +379,7 @@ export const WithBothGeopointTypes: Story = {
 
 export const WithPointsAcrossAntimeridian: Story = {
   parameters: {
-    msw: { handlers: pacificHandlers },
+    msw: { handlers: mapHandlers(assetWithPacificGeopoints, submissionsAcrossAntimeridian) },
   },
   args: {
     asset: assetWithPacificGeopoints,
@@ -453,7 +419,7 @@ export const WithPointsAcrossAntimeridian: Story = {
 
 export const WithPointsRepeatedInEveryWorldCopy: Story = {
   parameters: {
-    msw: { handlers: pacificHandlers },
+    msw: { handlers: mapHandlers(assetWithPacificGeopoints, submissionsAcrossAntimeridian) },
   },
   args: {
     asset: assetWithPacificGeopoints,
@@ -489,6 +455,7 @@ export const WithPointsRepeatedInEveryWorldCopy: Story = {
           // together to end up in a single cluster here, which leaves one marker icon per copy of the world on screen.
           const mapWidth = canvasElement.querySelector('#data-map')?.getBoundingClientRect().width ?? 0
           const worldWidth = 256
+          // Gather all visible clusters
           const centers = Array.from(canvasElement.querySelectorAll('.leaflet-marker-icon'))
             .map((marker) => {
               const { left, width } = marker.getBoundingClientRect()

--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -247,7 +247,7 @@ const meta: Meta<typeof FormMapWrapper> = {
         <style>
           {`
             #data-map {
-              background: #a8e4f0 !important;
+              background: #94c7d1 !important;
             }
           `}
         </style>
@@ -384,35 +384,12 @@ export const WithPointsAcrossAntimeridian: Story = {
   args: {
     asset: assetWithPacificGeopoints,
   },
-  play: async ({ canvasElement, step }) => {
-    await step('Verify that all of the points are plotted', async () => {
-      await waitFor(
-        async () => {
-          // Two icons at the very least: the points in Vanuatu and the ones in Samoa are too far apart to be clustered
-          // together
-          const markers = canvasElement.querySelectorAll('.leaflet-marker-icon')
-          expect(markers.length).toBeGreaterThanOrEqual(2)
-        },
-        { timeout: 5000 },
-      )
-    })
-
-    await step('Verify that the map zoomed in on the Pacific instead of the whole world', async () => {
-      await waitFor(
-        async () => {
-          // The zoom of the requested tiles tells us which of the two readings of these coordinates the map went with.
-          // Fitting the 20° span across the 180th meridian needs a zoom of 3 or more, while reading them as a 340° span
-          // the other way around (what Leaflet does on its own) forces the map out to zoom 0 or 1.
-          const tiles = Array.from(canvasElement.querySelectorAll<HTMLImageElement>('.leaflet-tile-pane img'))
-          const zooms = tiles
-            .map((tile) => Number(tile.src.match(/\/(\d+)\/\d+\/\d+\.png/)?.[1]))
-            .filter((zoom) => Number.isFinite(zoom))
-
-          expect(zooms.length).toBeGreaterThan(0)
-          expect(Math.max(...zooms)).toBeGreaterThanOrEqual(3)
-        },
-        { timeout: 5000 },
-      )
+  // Chromatic is what checks this story: the snapshot tells whether the map fitted the 20° span across the meridian, or
+  // read it as the 340° span the other way around and zoomed out to the whole world. Waiting for the markers only keeps
+  // the snapshot from being taken before the map has finished drawing itself.
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelectorAll('.leaflet-marker-icon').length).toBeGreaterThan(0), {
+      timeout: 5000,
     })
   },
 }
@@ -424,52 +401,22 @@ export const WithPointsRepeatedInEveryWorldCopy: Story = {
   args: {
     asset: assetWithPacificGeopoints,
   },
-  play: async ({ canvasElement, step }) => {
-    await step('Wait for the points to be plotted', async () => {
-      await waitFor(
-        async () => {
-          const markers = canvasElement.querySelectorAll('.leaflet-marker-icon')
-          expect(markers.length).toBeGreaterThanOrEqual(2)
-        },
-        { timeout: 5000 },
-      )
+  // Zooming all the way out is what this story is about, so that part is not a check and has to stay — it is what puts
+  // several copies of the world on screen for Chromatic to snapshot. What the points then do is the snapshot's business:
+  // a cluster in every copy, one every 256 pixels. `getWorldCopyOffsets()` has the unit tests for the arithmetic.
+  play: async ({ canvasElement }) => {
+    await waitFor(() => expect(canvasElement.querySelectorAll('.leaflet-marker-icon').length).toBeGreaterThan(0), {
+      timeout: 5000,
     })
 
-    await step('Zoom the map out as far as it goes', async () => {
-      await waitFor(
-        async () => {
-          // One click per attempt, until the control tells us there is nowhere left to zoom out to
-          const zoomOutButton = canvasElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-out')
-          zoomOutButton?.click()
-          expect(zoomOutButton).toHaveClass('leaflet-disabled')
-        },
-        { timeout: 10000 },
-      )
-    })
-
-    await step('Verify that the points are drawn in every copy of the world the map shows', async () => {
-      await waitFor(
-        async () => {
-          // The map repeats itself once every 256 pixels at this zoom, and so should the points drawn on it — that is
-          // what keeps them in sight when the user pans across the 180th meridian. All four of them are close enough
-          // together to end up in a single cluster here, which leaves one marker icon per copy of the world on screen.
-          const mapWidth = canvasElement.querySelector('#data-map')?.getBoundingClientRect().width ?? 0
-          const worldWidth = 256
-          // Gather all visible clusters
-          const centers = Array.from(canvasElement.querySelectorAll('.leaflet-marker-icon'))
-            .map((marker) => {
-              const { left, width } = marker.getBoundingClientRect()
-              return left + width / 2
-            })
-            .sort((a, b) => a - b)
-
-          expect(centers.length).toBeGreaterThanOrEqual(Math.floor(mapWidth / worldWidth))
-          for (let copy = 1; copy < centers.length; copy++) {
-            expect(centers[copy] - centers[copy - 1]).toBeCloseTo(worldWidth, 0)
-          }
-        },
-        { timeout: 5000 },
-      )
-    })
+    await waitFor(
+      () => {
+        // One click per attempt, until the control tells us there is nowhere left to zoom out to
+        const zoomOutButton = canvasElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-out')
+        zoomOutButton?.click()
+        expect(zoomOutButton).toHaveClass('leaflet-disabled')
+      },
+      { timeout: 10000 },
+    )
   },
 }

--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -100,6 +100,46 @@ const assetWithBothGeopointTypes = getApiV2AssetsRetrieveResponseMock({
   },
 }) as unknown as AssetResponse
 
+// Asset used to check how points collected on both sides of the 180th meridian are displayed
+const assetWithPacificGeopoints = getApiV2AssetsRetrieveResponseMock({
+  uid: mockAssetUid,
+  name: 'Test Form with Points Across the 180th Meridian',
+  deployment__active: true,
+  deployment__submission_count: 4,
+  has_deployment: true,
+  map_styles: {},
+  summary: {
+    geo: true,
+    labels: ['Your name', 'Where are you?'],
+    columns: ['type', 'label'],
+    lock_all: false,
+    lock_any: false,
+    languages: [],
+    row_count: 2,
+    name_quality: { ok: 2, bad: 0, good: 0, total: 2, firsts: {} },
+    default_translation: undefined,
+  },
+  content: {
+    survey: [
+      {
+        $kuid: 'q1',
+        type: QuestionTypeName.text,
+        name: 'your_name',
+        label: ['Your name'],
+        required: false,
+      },
+      {
+        $kuid: 'q2',
+        type: QuestionTypeName.geopoint,
+        name: 'location',
+        label: ['Where are you?'],
+        required: false,
+      },
+    ],
+    choices: [],
+  },
+}) as unknown as AssetResponse
+
 // Submission data with populated start-geopoint
 const submissionsWithStartGeopoint: SubmissionResponse[] = [
   assetDataFactory(1, {
@@ -127,6 +167,48 @@ const submissionsWithBothGeopointTypes: SubmissionResponse[] = [
     location: '-34.3757 18.8248 0 0', // slightly off the start
     'start-geopoint': '-34.3787 18.8278 0 0', // Moonlight Beach
     _geolocation: [-34.3757, 18.8248],
+  }),
+]
+
+// Two submissions in Vanuatu (east of the 180th meridian) and two in Samoa (west of it)
+const submissionsAcrossAntimeridian: SubmissionResponse[] = [
+  assetDataFactory(1, {
+    your_name: 'Alice',
+    location: '-17.7333 168.3273 0 0', // Port Vila
+    _geolocation: [-17.7333, 168.3273],
+  }),
+  assetDataFactory(2, {
+    your_name: 'Bob',
+    location: '-17.5667 168.1667 0 0', // Mele
+    _geolocation: [-17.5667, 168.1667],
+  }),
+  assetDataFactory(3, {
+    your_name: 'Carla',
+    location: '-13.8333 -171.7667 0 0', // Apia
+    _geolocation: [-13.8333, -171.7667],
+  }),
+  assetDataFactory(4, {
+    your_name: 'Dan',
+    location: '-14.0333 -171.4833 0 0', // Lotofaga
+    _geolocation: [-14.0333, -171.4833],
+  }),
+]
+
+// Both of the 180th meridian stories are served the same asset and the same submissions
+const pacificHandlers = [
+  http.get(endpoints.ASSET_URL, ({ params }) => {
+    if (params.uid !== mockAssetUid) return undefined
+    return HttpResponse.json(assetWithPacificGeopoints)
+  }),
+  http.get<{ uid: string; limit?: string; start?: string }>(endpoints.ASSET_DATA_URL, ({ params }) => {
+    if (params.uid !== mockAssetUid) return undefined
+    const response: PaginatedResponse<SubmissionResponse> = {
+      count: submissionsAcrossAntimeridian.length,
+      next: null,
+      previous: null,
+      results: submissionsAcrossAntimeridian,
+    }
+    return HttpResponse.json(response)
   }),
 ]
 
@@ -322,6 +404,102 @@ export const WithBothGeopointTypes: Story = {
 
           expect(whereAreYouOption).toBeInTheDocument()
           expect(startGeopointOption).toBeInTheDocument()
+        },
+        { timeout: 5000 },
+      )
+    })
+  },
+}
+
+export const WithPointsAcrossAntimeridian: Story = {
+  parameters: {
+    msw: { handlers: pacificHandlers },
+  },
+  args: {
+    asset: assetWithPacificGeopoints,
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify that all of the points are plotted', async () => {
+      await waitFor(
+        async () => {
+          // Two icons at the very least: the points in Vanuatu and the ones in Samoa are too far apart to be clustered
+          // together
+          const markers = canvasElement.querySelectorAll('.leaflet-marker-icon')
+          expect(markers.length).toBeGreaterThanOrEqual(2)
+        },
+        { timeout: 5000 },
+      )
+    })
+
+    await step('Verify that the map zoomed in on the Pacific instead of the whole world', async () => {
+      await waitFor(
+        async () => {
+          // The zoom of the requested tiles tells us which of the two readings of these coordinates the map went with.
+          // Fitting the 20° span across the 180th meridian needs a zoom of 3 or more, while reading them as a 340° span
+          // the other way around (what Leaflet does on its own) forces the map out to zoom 0 or 1.
+          const tiles = Array.from(canvasElement.querySelectorAll<HTMLImageElement>('.leaflet-tile-pane img'))
+          const zooms = tiles
+            .map((tile) => Number(tile.src.match(/\/(\d+)\/\d+\/\d+\.png/)?.[1]))
+            .filter((zoom) => Number.isFinite(zoom))
+
+          expect(zooms.length).toBeGreaterThan(0)
+          expect(Math.max(...zooms)).toBeGreaterThanOrEqual(3)
+        },
+        { timeout: 5000 },
+      )
+    })
+  },
+}
+
+export const WithPointsRepeatedInEveryWorldCopy: Story = {
+  parameters: {
+    msw: { handlers: pacificHandlers },
+  },
+  args: {
+    asset: assetWithPacificGeopoints,
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Wait for the points to be plotted', async () => {
+      await waitFor(
+        async () => {
+          const markers = canvasElement.querySelectorAll('.leaflet-marker-icon')
+          expect(markers.length).toBeGreaterThanOrEqual(2)
+        },
+        { timeout: 5000 },
+      )
+    })
+
+    await step('Zoom the map out as far as it goes', async () => {
+      await waitFor(
+        async () => {
+          // One click per attempt, until the control tells us there is nowhere left to zoom out to
+          const zoomOutButton = canvasElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-out')
+          zoomOutButton?.click()
+          expect(zoomOutButton).toHaveClass('leaflet-disabled')
+        },
+        { timeout: 10000 },
+      )
+    })
+
+    await step('Verify that the points are drawn in every copy of the world the map shows', async () => {
+      await waitFor(
+        async () => {
+          // The map repeats itself once every 256 pixels at this zoom, and so should the points drawn on it — that is
+          // what keeps them in sight when the user pans across the 180th meridian. All four of them are close enough
+          // together to end up in a single cluster here, which leaves one marker icon per copy of the world on screen.
+          const mapWidth = canvasElement.querySelector('#data-map')?.getBoundingClientRect().width ?? 0
+          const worldWidth = 256
+          const centers = Array.from(canvasElement.querySelectorAll('.leaflet-marker-icon'))
+            .map((marker) => {
+              const { left, width } = marker.getBoundingClientRect()
+              return left + width / 2
+            })
+            .sort((a, b) => a - b)
+
+          expect(centers.length).toBeGreaterThanOrEqual(Math.floor(mapWidth / worldWidth))
+          for (let copy = 1; copy < centers.length; copy++) {
+            expect(centers[copy] - centers[copy - 1]).toBeCloseTo(worldWidth, 0)
+          }
         },
         { timeout: 5000 },
       )

--- a/jsapp/js/components/map/formMapWrapper.tsx
+++ b/jsapp/js/components/map/formMapWrapper.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { assetsDataList, getAssetsDataListQueryKey } from '#/api/react-query/survey-data'
 import type { AssetResponse } from '#/dataInterface'
 import type { WithRouterProps } from '#/router/legacy'
-import FormMap from '.'
+import FormMap, { SUBMISSIONS_PER_PAGE } from '.'
 
 interface FormMapWrapperProps extends WithRouterProps {
   asset: AssetResponse
@@ -12,7 +12,6 @@ interface FormMapWrapperProps extends WithRouterProps {
 }
 
 const DEFAULT_PAGE_SIZE = 1
-const SUBMISSIONS_PER_PAGE = 1000
 
 /**
  * Wrapper for the `FormMap` component so we can use hooks without doing a full refactor of `FormMap`

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -46,7 +46,7 @@ import './map.scss'
 import './map.marker-colors.scss'
 import type { DataResponse } from '#/api/models/dataResponse'
 
-const SUBMISSIONS_PER_PAGE = 1000
+export const SUBMISSIONS_PER_PAGE = 1000
 const MAX_SUBMISSIONS = 30 * SUBMISSIONS_PER_PAGE // Don't want more than 30 parallel queries
 
 /** Room left around the plotted points, so that the outermost markers aren't drawn half way off the map. */

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -52,7 +52,7 @@ const MAX_SUBMISSIONS = 30 * SUBMISSIONS_PER_PAGE // Don't want more than 30 par
 /** Room left around the plotted points, so that the outermost markers aren't drawn half way off the map. */
 const FIT_BOUNDS_PADDING: L.PointTuple = [32, 32]
 
-/** Class greying out the markers of the legend entries the user has filtered out. */
+/** Class hiding the markers of the legend entries the user has filtered out. */
 const UNSELECTED_MARKER_CLASS = 'unselected'
 
 const STREETS_LAYER = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -772,7 +772,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
         this.state.heatmap?.setLatLngs(drawnPoints)
         // A fresh copy comes with fresh icons, which know nothing about the legend filter
         if (this.state.filteredByMarker) {
-          this.dimUnselectedMarkers(group, this.state.filteredByMarker)
+          this.hideUnselectedMarkers(group, this.state.filteredByMarker)
         }
       })
 
@@ -1032,12 +1032,14 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
 
     this.setState({ filteredByMarker: filteredByMarker })
     if (markers) {
-      this.dimUnselectedMarkers(markers, filteredByMarker)
+      this.hideUnselectedMarkers(markers, filteredByMarker)
     }
   }
 
-  /** Greys out every marker that is not of one of the selected legend types. */
-  private dimUnselectedMarkers(markers: FeatureGroupExtended, filteredByMarker: string[]) {
+  /**
+   * Based on filter selected by user. Hides markers on the map, dims the filter row in Legend menu.
+   */
+  private hideUnselectedMarkers(markers: FeatureGroupExtended, filteredByMarker: string[]) {
     markers.eachLayer((layer) => {
       // Markers of a group that isn't on the map (or that the marker clustering keeps out of sight) have no icon yet.
       if (!layer._icon) {

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -19,6 +19,8 @@ import CenteredMessage from '../../../js/components/common/centeredMessage.compo
 import Modal from '../../../js/components/common/modal'
 // Partial components
 import MapSettings from './MapSettings'
+import { type PlottedPoint, getPlottedPoints, getPointsBounds } from './mapUtils'
+import { WorldCopies } from './worldCopies'
 
 import { actions } from '../../../js/actions'
 import { getRowName, getSurveyFlatPaths } from '../../../js/assetUtils'
@@ -26,7 +28,7 @@ import { getRowName, getSurveyFlatPaths } from '../../../js/assetUtils'
 import { dataInterface } from '../../../js/dataInterface'
 import pageState from '../../../js/pageState.store'
 import { type WithRouterProps, withRouter } from '../../../js/router/legacy'
-import { findFirstGeopoint, notify, parseLatLng, recordKeys } from '../../../js/utils'
+import { findFirstGeopoint, notify, recordKeys } from '../../../js/utils'
 
 // Constants and types
 import { ASSET_FILE_TYPES, MODAL_TYPES, QUERY_LIMIT_DEFAULT, isMapDisplayableGeopointType } from '../../../js/constants'
@@ -46,6 +48,12 @@ import type { DataResponse } from '#/api/models/dataResponse'
 
 const SUBMISSIONS_PER_PAGE = 1000
 const MAX_SUBMISSIONS = 30 * SUBMISSIONS_PER_PAGE // Don't want more than 30 parallel queries
+
+/** Room left around the plotted points, so that the outermost markers aren't drawn half way off the map. */
+const FIT_BOUNDS_PADDING: L.PointTuple = [32, 32]
+
+/** Class greying out the markers of the legend entries the user has filtered out. */
+const UNSELECTED_MARKER_CLASS = 'unselected'
 
 const STREETS_LAYER = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
@@ -190,6 +198,9 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   private unlisteners: Function[] = []
   private lastRenderedBoundsSignature?: string
 
+  /** Repeats the markers across the copies of the world the map shows. Replaced whenever the marker group is. */
+  private worldCopies?: WorldCopies
+
   private syncLegendViewportListeners() {
     const shouldListen = Boolean(this.state.markerMap) && this.state.markersVisible && this.state.showExpandedLegend
     if (shouldListen === this.viewportListenersActive) {
@@ -239,6 +250,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     if (this.mapContainerEl) {
       this.mapContainerEl.removeEventListener('wheel', this.onMapPinchZoom)
     }
+    // Has to go before the map does, as it asks the map about its bounds
+    this.worldCopies?.destroy()
     if (this.state.map) {
       this.state.map.remove()
     }
@@ -567,6 +580,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     this.buildMarkers(map)
     // TODO: when heat map is selected and the user refteches data (changes question or selects a disaggregation) the
     // map will rebuild and display both markers and heat map. See DEV-1960
+    // The heat map covers the same points as the markers, copies of the world included, so it has to come second.
     this.buildHeatMap(map)
   }
 
@@ -590,6 +604,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   }
 
   buildMarkers(map: L.Map) {
+    const points: PlottedPoint[] = getPlottedPoints(this.props.allData, this.state.foundSelectedQuestion)
     const prepPoints: L.Marker[] = []
     const viewby = this.props.viewby || undefined
     const colorSet = this.calcColorSet()
@@ -597,11 +612,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     let mapMarkers: MapValueCounts = {}
     let mM: MarkerMap = []
     const submissions: DataResponse[] = this.props.allData
-    let pointCount = 0
-    let minLat = Number.POSITIVE_INFINITY
-    let maxLat = Number.NEGATIVE_INFINITY
-    let minLng = Number.POSITIVE_INFINITY
-    let maxLng = Number.NEGATIVE_INFINITY
+    const bounds = getPointsBounds(points)
 
     if (viewby) {
       mapMarkers = this.prepFilteredMarkers(submissions, this.props.viewby)
@@ -651,56 +662,46 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
       this.setState({ markerMap: undefined })
     }
 
-    submissions.forEach((item) => {
+    points.forEach((point) => {
+      const item = point.submission
       let markerProps = {}
 
-      const parsedCoordinates: number[] = parseLatLng(item, this.state.foundSelectedQuestion)
+      if (viewby && mM) {
+        const vb = this.nameOfFieldInGroup(viewby)
+        const itemId = String(item[vb])
+        let index: number | IconNoValue = mM.findIndex((m) => m.value === itemId)
 
-      if (!!parsedCoordinates.length) {
-        pointCount += 1
-        minLat = Math.min(minLat, parsedCoordinates[0])
-        maxLat = Math.max(maxLat, parsedCoordinates[0])
-        minLng = Math.min(minLng, parsedCoordinates[1])
-        maxLng = Math.max(maxLng, parsedCoordinates[1])
-
-        if (viewby && mM) {
-          const vb = this.nameOfFieldInGroup(viewby)
-          const itemId = String(item[vb])
-          let index: number | IconNoValue = mM.findIndex((m) => m.value === itemId)
-
-          // spread indexes to use full colorset gamut if necessary
-          if (colorSet !== undefined && colorSet !== 'a') {
-            index = this.calculateIconIndex(index, mM)
-          }
-
-          // Previously it was possible that `'-novalue' + 1` would happen resulting in code not knowing what to do.
-          // I've changed it to default to 1 in case `index` is not a number.
-          let iconNumber = 1
-          if (typeof index === 'number') {
-            iconNumber = index + 1
-          }
-
-          markerProps = {
-            icon: this.buildIcon(iconNumber),
-            sId: item._id,
-            typeId: mapMarkers[itemId].id,
-          }
-        } else {
-          markerProps = {
-            icon: this.buildIcon(),
-            sId: item._id,
-            typeId: null,
-          }
+        // spread indexes to use full colorset gamut if necessary
+        if (colorSet !== undefined && colorSet !== 'a') {
+          index = this.calculateIconIndex(index, mM)
         }
 
-        prepPoints.push(L.marker([parsedCoordinates[0], parsedCoordinates[1]], markerProps))
+        // Previously it was possible that `'-novalue' + 1` would happen resulting in code not knowing what to do.
+        // I've changed it to default to 1 in case `index` is not a number.
+        let iconNumber = 1
+        if (typeof index === 'number') {
+          iconNumber = index + 1
+        }
+
+        markerProps = {
+          icon: this.buildIcon(iconNumber),
+          sId: item._id,
+          typeId: mapMarkers[itemId].id,
+        }
+      } else {
+        markerProps = {
+          icon: this.buildIcon(),
+          sId: item._id,
+          typeId: null,
+        }
       }
+
+      prepPoints.push(L.marker([point.lat, point.lng], markerProps))
     })
 
-    const nextBoundsSignature =
-      pointCount === 0
-        ? 'empty'
-        : `${pointCount}:${minLat.toFixed(6)}:${maxLat.toFixed(6)}:${minLng.toFixed(6)}:${maxLng.toFixed(6)}`
+    const nextBoundsSignature = bounds
+      ? `${points.length}:${bounds.south.toFixed(6)}:${bounds.north.toFixed(6)}:${bounds.west.toFixed(6)}:${bounds.east.toFixed(6)}`
+      : 'empty'
     const boundsChanged = this.lastRenderedBoundsSignature !== nextBoundsSignature
     this.lastRenderedBoundsSignature = nextBoundsSignature
 
@@ -738,14 +739,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
 
       markers.on('click', this.launchSubmissionModal.bind(this)).addTo(map)
 
-      if (prepPoints.length === 0) {
-        if (boundsChanged) {
-          // Legacy fallback location used when there are no plotted points.
-          // Single-point bounds around Cambridge, MA.
-          map.fitBounds([[42.373, -71.124]])
-        }
-        this.setState({ noData: true })
-      } else {
+      if (bounds) {
         // Note: this is a bit confusing. For some reason (possibly performance related), we didn't want the map to
         // reset the zoom when switching between disaggregated questions. This is the reason for the first two guards.
         // The last condition is only possible if we are coming from having no points to having points in the same page,
@@ -753,14 +747,36 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
         // Additionally, we now only auto-fit when plotted bounds actually changed between rebuilds.
         const shouldFitBounds = boundsChanged && (!viewby || !this.state.componentRefreshed || this.state.noData)
         if (shouldFitBounds) {
-          map.fitBounds(markers.getBounds())
+          // Fitting the plotted points rather than `markers.getBounds()`, as the latter grows with the copies of the
+          // world we are about to add to the group.
+          map.fitBounds(L.latLngBounds([bounds.south, bounds.west], [bounds.north, bounds.east]), {
+            padding: FIT_BOUNDS_PADDING,
+          })
         }
         this.setState({ noData: false })
+      } else {
+        if (boundsChanged) {
+          // Legacy fallback location used when there are no plotted points.
+          // Single-point bounds around Cambridge, MA.
+          map.fitBounds([[42.373, -71.124]])
+        }
+        this.setState({ noData: true })
       }
 
-      this.setState({
-        markers: markers as FeatureGroupExtended,
+      const group = markers as FeatureGroupExtended
+
+      // Only now that the view has been fitted do we know which copies of the world are in sight. The copies of the
+      // previous group went away with it, so this instance starts from scratch.
+      this.worldCopies?.destroy()
+      this.worldCopies = new WorldCopies(map, group, prepPoints, (drawnPoints) => {
+        this.state.heatmap?.setLatLngs(drawnPoints)
+        // A fresh copy comes with fresh icons, which know nothing about the legend filter
+        if (this.state.filteredByMarker) {
+          this.dimUnselectedMarkers(group, this.state.filteredByMarker)
+        }
       })
+
+      this.setState({ markers: group })
     } else {
       this.setState({ error: t('Error: could not load data.') })
     }
@@ -822,15 +838,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   }
 
   buildHeatMap(map: L.Map) {
-    const heatmapPoints: Array<[number, number, number]> = []
-    const submissions: DataResponse[] = this.props.allData
-    submissions.forEach((item) => {
-      const parsedCoordinates: number[] = parseLatLng(item, this.state.foundSelectedQuestion)
-      if (!!parsedCoordinates.length) {
-        heatmapPoints.push([parsedCoordinates[0], parsedCoordinates[1], 1])
-      }
-    })
-    const heatmap = L.heatLayer(heatmapPoints, {
+    // Same points the markers were built from, the copies of the world included
+    const heatmap = L.heatLayer(this.worldCopies?.getDrawnPoints() ?? [], {
       minOpacity: 0.25,
       radius: 20,
       blur: 8,
@@ -1012,7 +1021,6 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     const id = String(markerId)
     const markers = this.state.markers
     let filteredByMarker = this.state.filteredByMarker
-    const unselectedClass = 'unselected'
 
     if (!filteredByMarker) {
       filteredByMarker = [id]
@@ -1023,11 +1031,22 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     }
 
     this.setState({ filteredByMarker: filteredByMarker })
-    markers?.eachLayer((layer) => {
+    if (markers) {
+      this.dimUnselectedMarkers(markers, filteredByMarker)
+    }
+  }
+
+  /** Greys out every marker that is not of one of the selected legend types. */
+  private dimUnselectedMarkers(markers: FeatureGroupExtended, filteredByMarker: string[]) {
+    markers.eachLayer((layer) => {
+      // Markers of a group that isn't on the map (or that the marker clustering keeps out of sight) have no icon yet.
+      if (!layer._icon) {
+        return
+      }
       if (filteredByMarker.includes(layer.options.typeId.toString())) {
-        layer._icon.classList.remove(unselectedClass)
+        layer._icon.classList.remove(UNSELECTED_MARKER_CLASS)
       } else {
-        layer._icon.classList.add(unselectedClass)
+        layer._icon.classList.add(UNSELECTED_MARKER_CLASS)
       }
     })
   }
@@ -1036,7 +1055,7 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     const markers = this.state.markers
     this.setState({ filteredByMarker: undefined })
     markers?.eachLayer((layer) => {
-      layer._icon.classList.remove('unselected')
+      layer._icon?.classList.remove(UNSELECTED_MARKER_CLASS)
     })
   }
 

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -771,10 +771,10 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
       this.worldCopies = new WorldCopies(map, group, prepPoints, (drawnPoints) => {
         this.state.heatmap?.setLatLngs(drawnPoints)
         // A fresh copy comes with fresh icons, which know nothing about the legend filter
-        if (this.state.filteredByMarker) {
-          this.hideUnselectedMarkers(group, this.state.filteredByMarker)
-        }
+        this.reapplyMarkerFilter(group)
       })
+      // Same for this whole group: a rebuild (new submissions came in, say) keeps the filter the legend is showing
+      this.reapplyMarkerFilter(group)
 
       this.setState({ markers: group })
     } else {
@@ -854,6 +854,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
   showMarkers() {
     if (this.state.map && this.state.markers) {
       this.state.map.addLayer(this.state.markers)
+      // Leaving the map threw the icons away, and the ones Leaflet just built are missing the legend filter
+      this.reapplyMarkerFilter(this.state.markers)
     }
     if (this.state.map && this.state.heatmap) {
       this.state.map.removeLayer(this.state.heatmap)
@@ -1033,6 +1035,17 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     this.setState({ filteredByMarker: filteredByMarker })
     if (markers) {
       this.hideUnselectedMarkers(markers, filteredByMarker)
+    }
+  }
+
+  /**
+   * Puts the legend filter back on a group of markers that has just been given icons. Marker icons live only as long as
+   * the marker is on the map, and they come back without the class that hides them, while the legend goes on showing the
+   * filter as on. Does nothing when no filter is on, since then there is nothing to hide.
+   */
+  private reapplyMarkerFilter(markers: FeatureGroupExtended) {
+    if (this.state.filteredByMarker) {
+      this.hideUnselectedMarkers(markers, this.state.filteredByMarker)
     }
   }
 

--- a/jsapp/js/components/map/index.tsx
+++ b/jsapp/js/components/map/index.tsx
@@ -708,6 +708,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
     if (prepPoints.length >= 0) {
       let markers
       if (viewby) {
+        // Disaggregated markers are never clustered: the legend colours stand for the answers, and a cluster would hide
+        // them behind a count. This is also why the legend filter never has to deal with clustered markers.
         markers = L.featureGroup(prepPoints)
       } else {
         markers = L.markerClusterGroup({
@@ -1054,7 +1056,8 @@ class FormMap extends React.Component<FormMapProps, FormMapState> {
    */
   private hideUnselectedMarkers(markers: FeatureGroupExtended, filteredByMarker: string[]) {
     markers.eachLayer((layer) => {
-      // Markers of a group that isn't on the map (or that the marker clustering keeps out of sight) have no icon yet.
+      // A marker only has an icon while its group is on the map, and the group is off it whenever the heat map is
+      // showing. `showMarkers()` puts the filter back on the icons Leaflet builds on the way in.
       if (!layer._icon) {
         return
       }

--- a/jsapp/js/components/map/mapTiles.mocks.ts
+++ b/jsapp/js/components/map/mapTiles.mocks.ts
@@ -1,0 +1,129 @@
+import { http, HttpResponse } from 'msw'
+
+/**
+ * Stand-in map tiles for stories, drawn from a handful of boxes instead of fetched from OpenStreetMap.
+ *
+ * Real tiles make map stories a poor fit for visual regression testing: they need the network, and they come back with
+ * differences too small to see but big enough for Chromatic to flag. These are plain SVG shapes, so every run gets
+ * pixel for pixel the same map, and a snapshot still shows which part of the world the story is looking at.
+ */
+
+/** Tile size Leaflet works with, in pixels. */
+const TILE_SIZE = 256
+
+const OCEAN_COLOR = '#a8e4f0'
+const LAND_COLOR = '#dfe8ce'
+const GRID_COLOR = '#8fc9da'
+const LABEL_COLOR = '#7f9aa6'
+/** The 180th meridian, marked so that it is clear where one copy of the world ends and the next one begins. */
+const MERIDIAN_COLOR = '#6b7280'
+
+/**
+ * The world as boxes of `[south, west, north, east]` degrees. Nowhere near accurate, and small islands are drawn far
+ * bigger than they are so that they don't vanish at low zoom — enough to tell the continents apart and no more.
+ */
+const LANDMASSES: Array<[number, number, number, number]> = [
+  [-85, -180, -63, 180], // Antarctica
+  [60, -55, 82, -20], // Greenland
+  [55, -168, 70, -142], // Alaska
+  [49, -130, 70, -70], // Canada
+  [30, -122, 49, -76], // United States
+  [12, -105, 30, -85], // Central America
+  [-20, -78, 10, -35], // northern South America
+  [-55, -75, -20, -55], // southern South America
+  [40, -10, 60, 30], // Europe
+  [58, 5, 70, 30], // Scandinavia
+  [5, -17, 35, 50], // northern Africa
+  [-35, 10, 5, 42], // southern Africa
+  [-25, 43, -12, 50], // Madagascar
+  [15, 35, 40, 60], // Middle East
+  [45, 30, 70, 180], // northern Asia
+  [8, 68, 30, 88], // India
+  [20, 95, 45, 122], // China
+  [31, 130, 45, 145], // Japan
+  [-10, 95, 5, 140], // Indonesia
+  [-10, 132, -2, 150], // New Guinea
+  [-38, 113, -12, 153], // Australia
+  [-46, 166, -34, 178], // New Zealand!
+  [-20, 166, -13, 170], // Vanuatu
+  [-19, 177, -16, 180], // Fiji
+  [-15, -173, -12, -170], // Samoa
+]
+
+/** Web Mercator, the projection Leaflet's tiles use. Returns pixels from the top left corner of the world. */
+function project(lat: number, lng: number, worldSize: number) {
+  const latRad = (lat * Math.PI) / 180
+  const mercator = Math.log(Math.tan(Math.PI / 4 + latRad / 2))
+  return {
+    x: ((lng + 180) / 360) * worldSize,
+    y: (0.5 - mercator / (2 * Math.PI)) * worldSize,
+  }
+}
+
+/**
+ * Coordinates of the top left corner of a tile, written out. Zoomed far enough in, a tile is a single flat colour, and
+ * this is then the only thing telling the reader (and whoever compares two snapshots) where in the world they are.
+ */
+function cornerLabel(zoom: number, tileX: number, tileY: number): string {
+  const tiles = 2 ** zoom
+  const longitude = (tileX / tiles) * 360 - 180
+  // Web Mercator in reverse, undoing the `y` of `project()`
+  const latitude = (Math.atan(Math.sinh(Math.PI * (1 - (2 * tileY) / tiles))) * 180) / Math.PI
+  // Enough decimals for neighbouring tiles to come out with labels of their own
+  const decimals = Math.min(4, Math.max(0, Math.ceil(Math.log10(tiles / 360)) + 1))
+  const label = `${degrees(latitude, decimals, 'N', 'S')} ${degrees(longitude, decimals, 'E', 'W')}`
+
+  return `<text x="4" y="13" font-family="monospace" font-size="10" fill="${LABEL_COLOR}">${label}</text>`
+}
+
+function degrees(value: number, decimals: number, positive: string, negative: string): string {
+  return `${Math.abs(value).toFixed(decimals)}°${value < 0 ? negative : positive}`
+}
+
+/** One tile of the blocky world, as an SVG document. */
+function drawTile(zoom: number, tileX: number, tileY: number): string {
+  const worldSize = TILE_SIZE * 2 ** zoom
+  const shapes: string[] = []
+
+  LANDMASSES.forEach(([south, west, north, east]) => {
+    const topLeft = project(north, west, worldSize)
+    const bottomRight = project(south, east, worldSize)
+    const x = topLeft.x - tileX * TILE_SIZE
+    const y = topLeft.y - tileY * TILE_SIZE
+    // Rounding keeps the SVG short, and a floor of one pixel keeps the smallest islands on the map
+    const width = Math.max(1, Math.round(bottomRight.x - topLeft.x))
+    const height = Math.max(1, Math.round(bottomRight.y - topLeft.y))
+
+    if (x > TILE_SIZE || y > TILE_SIZE || x + width < 0 || y + height < 0) {
+      return
+    }
+    shapes.push(`<rect x="${Math.round(x)}" y="${Math.round(y)}" width="${width}" height="${height}"/>`)
+  })
+
+  // Leaflet asks for the same tile in every copy of the world it draws, so the meridian ends up marked in each of them
+  const meridian = tileX === 0 ? `<path d="M0 0V${TILE_SIZE}" stroke="${MERIDIAN_COLOR}" stroke-dasharray="4 4"/>` : ''
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${TILE_SIZE}" height="${TILE_SIZE}">` +
+    `<rect width="${TILE_SIZE}" height="${TILE_SIZE}" fill="${OCEAN_COLOR}"/>` +
+    `<g fill="${LAND_COLOR}">${shapes.join('')}</g>` +
+    // Tile edges double as a graticule, which is what makes panning visible in a screenshot
+    `<path d="M0 0H${TILE_SIZE}M0 0V${TILE_SIZE}" stroke="${GRID_COLOR}"/>${meridian}` +
+    `${cornerLabel(zoom, tileX, tileY)}</svg>`
+  )
+}
+
+/**
+ * Serves the stand-in tiles at the OpenStreetMap URLs the map asks for. Include these in the handlers of any story that
+ * renders a map, or it will reach out to the real tile servers.
+ */
+export const mapTileHandlers = [
+  http.get<{ zoom: string; tileX: string; tileY: string }>(
+    'https://:subdomain.tile.openstreetmap.org/:zoom/:tileX/:tileY.png',
+    ({ params }) => {
+      const svg = drawTile(Number(params.zoom), Number(params.tileX), Number(params.tileY))
+      // Browsers go by the content type, not by the `.png` the URL promises
+      return new HttpResponse(svg, { headers: { 'Content-Type': 'image/svg+xml; charset=utf-8' } })
+    },
+  ),
+]

--- a/jsapp/js/components/map/mapTiles.mocks.ts
+++ b/jsapp/js/components/map/mapTiles.mocks.ts
@@ -101,7 +101,10 @@ function drawTile(zoom: number, tileX: number, tileY: number): string {
   })
 
   // Leaflet asks for the same tile in every copy of the world it draws, so the meridian ends up marked in each of them
-  const meridian = tileX === 0 ? `<path d="M0 0V${TILE_SIZE}" stroke="${MERIDIAN_COLOR}" stroke-dasharray="4 4"/>` : ''
+  const meridian =
+    tileX === 0
+      ? `<path d="M0 0V${TILE_SIZE}" stroke="${MERIDIAN_COLOR}" stroke-width="4" stroke-dasharray="4 4"/>`
+      : ''
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" width="${TILE_SIZE}" height="${TILE_SIZE}">` +

--- a/jsapp/js/components/map/mapTiles.mocks.ts
+++ b/jsapp/js/components/map/mapTiles.mocks.ts
@@ -11,12 +11,12 @@ import { http, HttpResponse } from 'msw'
 /** Tile size Leaflet works with, in pixels. */
 const TILE_SIZE = 256
 
-const OCEAN_COLOR = '#a8e4f0'
-const LAND_COLOR = '#dfe8ce'
-const GRID_COLOR = '#8fc9da'
-const LABEL_COLOR = '#7f9aa6'
+const OCEAN_COLOR = '#94c7d1'
+const LAND_COLOR = '#dbdbbd'
+const GRID_COLOR = '#5999a6'
+const LABEL_COLOR = '#365c63'
 /** The 180th meridian, marked so that it is clear where one copy of the world ends and the next one begins. */
-const MERIDIAN_COLOR = '#6b7280'
+const MERIDIAN_COLOR = '#293a3d'
 
 /**
  * The world as boxes of `[south, west, north, east]` degrees. Nowhere near accurate, and small islands are drawn far

--- a/jsapp/js/components/map/mapUtils.tests.ts
+++ b/jsapp/js/components/map/mapUtils.tests.ts
@@ -1,0 +1,145 @@
+import type { DataResponse } from '#/api/models/dataResponse'
+import { getPlottedPoints, getPointsBounds, getWorldCopyOffsets, unwrapLongitudes } from './mapUtils'
+
+describe('unwrapLongitudes', () => {
+  it('handles having no points at all', () => {
+    chai.expect(unwrapLongitudes([])).to.deep.equal([])
+  })
+
+  it('leaves a single point alone', () => {
+    chai.expect(unwrapLongitudes([-172.75])).to.deep.equal([-172.75])
+  })
+
+  it('leaves points that do not straddle the 180th meridian alone', () => {
+    // Kathmandu, Nairobi and Lisbon
+    chai.expect(unwrapLongitudes([85.324, 36.8219, -9.1393])).to.deep.equal([85.324, 36.8219, -9.1393])
+  })
+
+  it('leaves points straddling the prime meridian alone', () => {
+    // Greenwich, both sides of it
+    chai.expect(unwrapLongitudes([-0.25, 0.25])).to.deep.equal([-0.25, 0.25])
+  })
+
+  it('moves points straddling the 180th meridian into a single span', () => {
+    // Vanuatu (east of the meridian) and Samoa (west of it), the case this whole function exists for
+    chai.expect(unwrapLongitudes([168.25, -172.75])).to.deep.equal([168.25, 187.25])
+  })
+
+  it('keeps the order of the points it moves', () => {
+    chai.expect(unwrapLongitudes([-172.75, 168.25, -172.5, 168.5])).to.deep.equal([187.25, 168.25, 187.5, 168.5])
+  })
+
+  it('moves points that are far apart but still closest across the 180th meridian', () => {
+    // Auckland and Santiago de Chile are 244° apart the usual way, but only 116° apart across the Pacific
+    chai.expect(unwrapLongitudes([-70.5, 174.75])).to.deep.equal([289.5, 174.75])
+  })
+
+  it('leaves points spread around the globe alone', () => {
+    // Tokyo, Accra and Mexico City fit in no span narrow enough to be worth moving, so we don't second guess Leaflet
+    chai.expect(unwrapLongitudes([139.75, -0.25, -99.25])).to.deep.equal([139.75, -0.25, -99.25])
+  })
+
+  it('leaves points alone when both readings are exactly half of the globe', () => {
+    chai.expect(unwrapLongitudes([-90, 90])).to.deep.equal([-90, 90])
+  })
+
+  it('brings longitudes outside of the [-180, 180] range back into it', () => {
+    chai.expect(unwrapLongitudes([200.5, -100])).to.deep.equal([-159.5, -100])
+  })
+
+  it('passes values that are not numbers through and still moves the rest', () => {
+    chai.expect(unwrapLongitudes([168.25, Number.NaN, -172.75])).to.deep.equal([168.25, Number.NaN, 187.25])
+  })
+})
+
+describe('getWorldCopyOffsets', () => {
+  // Vanuatu and Samoa as `unwrapLongitudes()` leaves them, with the map fitted to them
+  const pacificPoints = { west: 168.25, east: 187.25 }
+
+  it('draws the points only where they were plotted when the map shows that part of the world', () => {
+    chai.expect(getWorldCopyOffsets(pacificPoints, { west: 160, east: 195 }, 5)).to.deep.equal([0])
+  })
+
+  it('draws the points in the copy of the world the map was panned into', () => {
+    // The same view, a full rotation to the east
+    chai.expect(getWorldCopyOffsets(pacificPoints, { west: 520, east: 555 }, 5)).to.deep.equal([360])
+  })
+
+  it('draws the points in every copy of the world a zoomed out map shows', () => {
+    chai.expect(getWorldCopyOffsets({ west: 0, east: 0 }, { west: -400, east: 400 }, 5)).to.deep.equal([-360, 0, 360])
+  })
+
+  it('draws the points in the closest copy of the world when none of them is in sight', () => {
+    // The map is showing the Atlantic, which the Pacific points are closest to going west
+    chai.expect(getWorldCopyOffsets(pacificPoints, { west: -20, east: -10 }, 5)).to.deep.equal([-360])
+  })
+
+  it('keeps the copies closest to the middle of the map when there are too many of them', () => {
+    const view = { west: -1000, east: 1000 }
+    chai.expect(getWorldCopyOffsets({ west: 0, east: 0 }, view, 3)).to.deep.equal([-360, 0, 360])
+    chai.expect(getWorldCopyOffsets({ west: 0, east: 0 }, view, 1)).to.deep.equal([0])
+  })
+
+  it('always draws at least one copy, even when told it can afford none', () => {
+    chai.expect(getWorldCopyOffsets(pacificPoints, { west: 160, east: 195 }, 0)).to.deep.equal([0])
+  })
+
+  it('leaves the points where they were plotted when it cannot tell where that is', () => {
+    chai
+      .expect(getWorldCopyOffsets({ west: Number.NaN, east: Number.NaN }, { west: 160, east: 195 }, 5))
+      .to.deep.equal([0])
+  })
+})
+
+describe('getPointsBounds', () => {
+  it('has no bounds to give when there are no points', () => {
+    chai.expect(getPointsBounds([])).to.equal(undefined)
+  })
+
+  it('gives a single point as its own bounds', () => {
+    chai.expect(getPointsBounds([{ lat: -17.73, lng: 168.32 }])).to.deep.equal({
+      south: -17.73,
+      north: -17.73,
+      west: 168.32,
+      east: 168.32,
+    })
+  })
+
+  it('covers every point given, whatever order they come in', () => {
+    const points = [
+      { lat: -13.83, lng: 187.25 },
+      { lat: -17.73, lng: 168.32 },
+      { lat: -14.03, lng: 188.51 },
+    ]
+    chai.expect(getPointsBounds(points)).to.deep.equal({ south: -17.73, north: -13.83, west: 168.32, east: 188.51 })
+  })
+})
+
+describe('getPlottedPoints', () => {
+  // Only the fields the function reads; the rest of a submission is of no interest to it
+  const submission = (id: number, location?: string) => ({ _id: id, location: location }) as unknown as DataResponse
+
+  it('reads the coordinates of the selected question', () => {
+    chai
+      .expect(getPlottedPoints([submission(1, '-17.7333 168.3273 0 0')], 'location'))
+      .to.deep.equal([{ submission: submission(1, '-17.7333 168.3273 0 0'), lat: -17.7333, lng: 168.3273 }])
+  })
+
+  it('skips submissions that have no answer for the selected question', () => {
+    const points = getPlottedPoints([submission(1, '-17.7333 168.3273 0 0'), submission(2)], 'location')
+    chai.expect(points.map((point) => point.submission._id)).to.deep.equal([1])
+  })
+
+  it('has nothing to plot when no question is selected', () => {
+    chai.expect(getPlottedPoints([submission(1, '-17.7333 168.3273 0 0')], null)).to.deep.equal([])
+  })
+
+  it('unwraps the longitudes of points straddling the 180th meridian', () => {
+    // Port Vila and Apia end up in one span, which is what puts them next to each other on the map
+    const points = getPlottedPoints(
+      [submission(1, '-17.7333 168.3273 0 0'), submission(2, '-13.8333 -171.7667 0 0')],
+      'location',
+    )
+    chai.expect(points.map((point) => point.lng)).to.deep.equal([168.3273, 188.2333])
+  })
+})

--- a/jsapp/js/components/map/mapUtils.ts
+++ b/jsapp/js/components/map/mapUtils.ts
@@ -22,7 +22,10 @@ export interface PointsBounds extends LongitudeSpan {
   north: number
 }
 
-/** A submission with an answer for the selected geopoint question. `lng` can fall outside [-180, 180], see below. */
+/**
+ * A submission with an answer for the selected geopoint question. `lng` can fall outside [-180, 180], see
+ * `unwrapLongitudes()`.
+ */
 export interface PlottedPoint {
   submission: DataResponse
   lat: number
@@ -54,14 +57,17 @@ function wrapLongitude(longitude: number): number {
 }
 
 /**
- * Rewrites longitudes so that points on both sides of the 180th meridian can be displayed next to each other.
+ * Rewrites longitudes so that points on both sides of the 180th meridian read as neighbours.
  *
- * Vanuatu (168°) and Samoa (-172°) are either a 340° span across Africa or a 20° span across the Pacific. Leaflet
- * assumes the first, so we pick the narrowest reading, which puts some longitudes outside [-180, 180] (-172° becomes
- * 188°). Leaflet draws such a marker in the copy of the world east of the meridian, right next to Vanuatu.
+ * Longitude wraps around at that meridian, which makes nearby places look far apart: Vanuatu (168°) and Samoa (-172°)
+ * are 20° from each other on the ground, but 340° apart as plain numbers. Code that only compares the numbers — fitting
+ * the map to its points, say — reads that as opposite sides of the globe and zooms out to show all of it.
  *
- * Order is kept. Values that are not finite, and projects whose narrowest reading is the one Leaflet would have used
- * anyway (nearly all of them), are passed through untouched.
+ * So we add 360° to the points on the far side of the meridian, which leaves the numbers as close as the places are:
+ * -172° becomes 188°. Going past 180° is deliberate. Leaflet reads it as the copy of the world next door to the east
+ * and draws the marker there, right beside Vanuatu.
+ *
+ * Order is kept, and points nowhere near the meridian — nearly every project — come back untouched.
  */
 export function unwrapLongitudes(longitudes: number[]): number[] {
   const wrapped = longitudes.map((longitude) => (Number.isFinite(longitude) ? wrapLongitude(longitude) : longitude))
@@ -71,8 +77,9 @@ export function unwrapLongitudes(longitudes: number[]): number[] {
     return wrapped
   }
 
-  // Walking east, the narrowest span holding every point starts right after the widest gap between two neighbours. We
-  // start with the gap crossing the 180th meridian, so data that needs no shifting keeps its longitudes as they are.
+  // Picture the longitudes as marks around a circle: the tightest arc holding all of them begins right after the widest
+  // empty stretch between two neighbouring marks. The search starts from the stretch that crosses the 180th meridian,
+  // so that data needing no shift at all keeps the longitudes it came with.
   let spanStart = sorted[0]
   let widestGap = sorted[0] + FULL_ROTATION - sorted[sorted.length - 1]
   for (let index = 1; index < sorted.length; index++) {
@@ -83,32 +90,40 @@ export function unwrapLongitudes(longitudes: number[]): number[] {
     }
   }
 
+  // Whatever the widest gap leaves over is the span the points cover. Too wide, and no shifting can bring them together
   if (FULL_ROTATION - widestGap > MAX_UNWRAPPED_SPAN) {
     return wrapped
   }
 
-  // Everything west of the span start belongs to the next copy of the world, east of the 180th meridian.
+  // Points west of where the span starts are the ones on the far side of the meridian, so they move a rotation east
   return wrapped.map((longitude) => (longitude < spanStart ? longitude + FULL_ROTATION : longitude))
 }
 
 /**
- * Full rotations to add to the plotted longitudes, so that the points are drawn in every copy of the world on screen
- * (Leaflet repeats the base map east and west forever, markers it does not).
+ * Works out where to draw copies of the plotted points, as degrees to add to their longitudes.
  *
- * Sorted west to east, and never empty: with no copy near the view, the closest one is still worth drawing.
+ * Leaflet repeats the base map east and west without end, so panning past the 180th meridian brings the same world
+ * round again. A marker, though, only exists in the one copy it was plotted in, and panning leaves it behind. The way
+ * out is to draw extra sets of markers, each moved by a whole trip around the globe. A return of `[-360, 0, 360]` means
+ * three sets: one a rotation to the west, the plotted one where it already is, one a rotation to the east.
+ *
+ * Sorted west to east, and never empty — with no copy in sight the nearest one is drawn anyway, since the alternative
+ * is points nowhere on screen.
  *
  * @param view longitudes of the left and of the right edge of the map
  * @param maxCopies how many copies we can afford to draw; the ones closest to the middle of the map win
  */
 export function getWorldCopyOffsets(plotted: LongitudeSpan, view: LongitudeSpan, maxCopies: number): number[] {
-  // Without a span to compare against the view, the copy the points were plotted in is the only one we can place
+  // A missing or broken longitude leaves nothing to compare against the view, so stay with the copy already plotted
   if (![plotted.west, plotted.east, view.west, view.east].every(Number.isFinite)) {
     return [0]
   }
 
-  // The nth copy covers the plotted span moved by n full rotations, and is worth drawing when that overlaps the view.
+  // Copy number n sits n whole rotations east of where the points were plotted, and is worth drawing when it lands in
+  // the view. These two are the westmost and the eastmost copy that do.
   const westmostVisible = Math.ceil((view.west - plotted.east) / FULL_ROTATION)
   const eastmostVisible = Math.floor((view.east - plotted.west) / FULL_ROTATION)
+  // The copy whose middle is closest to the middle of the view. Comes in when the view has no copy in it at all.
   const nearest = Math.round((view.west + view.east - plotted.west - plotted.east) / (2 * FULL_ROTATION))
 
   const copies: number[] = []
@@ -119,6 +134,9 @@ export function getWorldCopyOffsets(plotted: LongitudeSpan, view: LongitudeSpan,
     copies.push(nearest)
   }
 
+  // More copies than we can afford: line them up by how far they are from the middle of the view, drop the far ones,
+  // then put the survivors back in west to east order. One always survives, so even a budget of none leaves the points
+  // somewhere the user can see them.
   if (copies.length > maxCopies) {
     copies.sort((a, b) => Math.abs(a - nearest) - Math.abs(b - nearest))
     copies.splice(Math.max(1, maxCopies))
@@ -130,8 +148,11 @@ export function getWorldCopyOffsets(plotted: LongitudeSpan, view: LongitudeSpan,
 }
 
 /**
- * Coordinates of the selected geopoint question, from every submission that has an answer for it. Longitudes come
- * unwrapped, see `unwrapLongitudes()`.
+ * Reads the answers to one geopoint question and turns them into points to plot. Submissions that skipped the question
+ * give `parseLatLng()` nothing to parse and are left out.
+ *
+ * Longitudes are unwrapped in one go rather than point by point, because how far each one has to move depends on where
+ * all the others are — see `unwrapLongitudes()`.
  */
 export function getPlottedPoints(submissions: DataResponse[], selectedQuestion: string | null): PlottedPoint[] {
   const points: PlottedPoint[] = []

--- a/jsapp/js/components/map/mapUtils.ts
+++ b/jsapp/js/components/map/mapUtils.ts
@@ -1,0 +1,151 @@
+import type { DataResponse } from '#/api/models/dataResponse'
+import { parseLatLng } from '#/utils'
+
+/** Degrees of longitude in a full trip around the globe. */
+const FULL_ROTATION = 360
+
+/**
+ * The widest span we are willing to move across the 180th meridian. Anything wider is data spread all over the globe,
+ * where no reading of it brings the points together, so we leave those coordinates as Leaflet always displayed them.
+ */
+const MAX_UNWRAPPED_SPAN = FULL_ROTATION / 2
+
+/** A range of longitudes, which is not limited to [-180, 180] — see `unwrapLongitudes()`. */
+export interface LongitudeSpan {
+  west: number
+  east: number
+}
+
+/** The corners of the smallest rectangle holding a set of points. */
+export interface PointsBounds extends LongitudeSpan {
+  south: number
+  north: number
+}
+
+/** A submission with an answer for the selected geopoint question. `lng` can fall outside [-180, 180], see below. */
+export interface PlottedPoint {
+  submission: DataResponse
+  lat: number
+  lng: number
+}
+
+/** The area the given points cover, or `undefined` when there are none. */
+export function getPointsBounds(points: Array<{ lat: number; lng: number }>): PointsBounds | undefined {
+  if (!points.length) {
+    return undefined
+  }
+  const bounds: PointsBounds = { south: points[0].lat, north: points[0].lat, west: points[0].lng, east: points[0].lng }
+  points.forEach(({ lat, lng }) => {
+    bounds.south = Math.min(bounds.south, lat)
+    bounds.north = Math.max(bounds.north, lat)
+    bounds.west = Math.min(bounds.west, lng)
+    bounds.east = Math.max(bounds.east, lng)
+  })
+  return bounds
+}
+
+/** Brings any longitude back into the [-180, 180) range. */
+function wrapLongitude(longitude: number): number {
+  // Returning in-range values untouched (the usual case) avoids the rounding error the modulo below introduces
+  if (longitude >= -180 && longitude < 180) {
+    return longitude
+  }
+  return ((((longitude + 180) % FULL_ROTATION) + FULL_ROTATION) % FULL_ROTATION) - 180
+}
+
+/**
+ * Rewrites longitudes so that points on both sides of the 180th meridian can be displayed next to each other.
+ *
+ * Vanuatu (168°) and Samoa (-172°) are either a 340° span across Africa or a 20° span across the Pacific. Leaflet
+ * assumes the first, so we pick the narrowest reading, which puts some longitudes outside [-180, 180] (-172° becomes
+ * 188°). Leaflet draws such a marker in the copy of the world east of the meridian, right next to Vanuatu.
+ *
+ * Order is kept. Values that are not finite, and projects whose narrowest reading is the one Leaflet would have used
+ * anyway (nearly all of them), are passed through untouched.
+ */
+export function unwrapLongitudes(longitudes: number[]): number[] {
+  const wrapped = longitudes.map((longitude) => (Number.isFinite(longitude) ? wrapLongitude(longitude) : longitude))
+  const sorted = wrapped.filter((longitude) => Number.isFinite(longitude)).sort((a, b) => a - b)
+
+  if (!sorted.length) {
+    return wrapped
+  }
+
+  // Walking east, the narrowest span holding every point starts right after the widest gap between two neighbours. We
+  // start with the gap crossing the 180th meridian, so data that needs no shifting keeps its longitudes as they are.
+  let spanStart = sorted[0]
+  let widestGap = sorted[0] + FULL_ROTATION - sorted[sorted.length - 1]
+  for (let index = 1; index < sorted.length; index++) {
+    const gap = sorted[index] - sorted[index - 1]
+    if (gap > widestGap) {
+      widestGap = gap
+      spanStart = sorted[index]
+    }
+  }
+
+  if (FULL_ROTATION - widestGap > MAX_UNWRAPPED_SPAN) {
+    return wrapped
+  }
+
+  // Everything west of the span start belongs to the next copy of the world, east of the 180th meridian.
+  return wrapped.map((longitude) => (longitude < spanStart ? longitude + FULL_ROTATION : longitude))
+}
+
+/**
+ * Full rotations to add to the plotted longitudes, so that the points are drawn in every copy of the world on screen
+ * (Leaflet repeats the base map east and west forever, markers it does not).
+ *
+ * Sorted west to east, and never empty: with no copy near the view, the closest one is still worth drawing.
+ *
+ * @param view longitudes of the left and of the right edge of the map
+ * @param maxCopies how many copies we can afford to draw; the ones closest to the middle of the map win
+ */
+export function getWorldCopyOffsets(plotted: LongitudeSpan, view: LongitudeSpan, maxCopies: number): number[] {
+  // Without a span to compare against the view, the copy the points were plotted in is the only one we can place
+  if (![plotted.west, plotted.east, view.west, view.east].every(Number.isFinite)) {
+    return [0]
+  }
+
+  // The nth copy covers the plotted span moved by n full rotations, and is worth drawing when that overlaps the view.
+  const westmostVisible = Math.ceil((view.west - plotted.east) / FULL_ROTATION)
+  const eastmostVisible = Math.floor((view.east - plotted.west) / FULL_ROTATION)
+  const nearest = Math.round((view.west + view.east - plotted.west - plotted.east) / (2 * FULL_ROTATION))
+
+  const copies: number[] = []
+  for (let copy = westmostVisible; copy <= eastmostVisible; copy++) {
+    copies.push(copy)
+  }
+  if (!copies.length) {
+    copies.push(nearest)
+  }
+
+  if (copies.length > maxCopies) {
+    copies.sort((a, b) => Math.abs(a - nearest) - Math.abs(b - nearest))
+    copies.splice(Math.max(1, maxCopies))
+    copies.sort((a, b) => a - b)
+  }
+
+  // The `copy === 0` check is only there to avoid a negative zero, which reads badly in logs and tests
+  return copies.map((copy) => (copy === 0 ? 0 : copy * FULL_ROTATION))
+}
+
+/**
+ * Coordinates of the selected geopoint question, from every submission that has an answer for it. Longitudes come
+ * unwrapped, see `unwrapLongitudes()`.
+ */
+export function getPlottedPoints(submissions: DataResponse[], selectedQuestion: string | null): PlottedPoint[] {
+  const points: PlottedPoint[] = []
+
+  submissions.forEach((submission) => {
+    const parsedCoordinates: number[] = parseLatLng(submission, selectedQuestion)
+    if (parsedCoordinates.length) {
+      points.push({ submission: submission, lat: parsedCoordinates[0], lng: parsedCoordinates[1] })
+    }
+  })
+
+  const unwrapped = unwrapLongitudes(points.map((point) => point.lng))
+  points.forEach((point, index) => {
+    point.lng = unwrapped[index]
+  })
+  return points
+}

--- a/jsapp/js/components/map/worldCopies.ts
+++ b/jsapp/js/components/map/worldCopies.ts
@@ -2,8 +2,8 @@ import L from 'leaflet'
 import { type PointsBounds, getPointsBounds, getWorldCopyOffsets } from './mapUtils'
 
 /**
- * Marker budget for the whole map, deliberately below the cap on submissions the map fetches (`MAX_SUBMISSIONS`):
- * copies multiply markers, so the biggest projects are better off with just the one copy closest to the view.
+ * Budget for the markers on the map, the plotted ones counted in, held below the cap on submissions the map fetches
+ * (`MAX_SUBMISSIONS`) on purpose: copies multiply markers, so the biggest projects get just the copy nearest the view.
  */
 const MAX_DRAWN_MARKERS = 20000
 

--- a/jsapp/js/components/map/worldCopies.ts
+++ b/jsapp/js/components/map/worldCopies.ts
@@ -1,7 +1,10 @@
 import L from 'leaflet'
 import { type PointsBounds, getPointsBounds, getWorldCopyOffsets } from './mapUtils'
 
-/** Marker budget for the whole map. Copies multiply markers, so a project with many submissions gets fewer copies. */
+/**
+ * Marker budget for the whole map, deliberately below the cap on submissions the map fetches (`MAX_SUBMISSIONS`):
+ * copies multiply markers, so the biggest projects are better off with just the one copy closest to the view.
+ */
 const MAX_DRAWN_MARKERS = 20000
 
 /**

--- a/jsapp/js/components/map/worldCopies.ts
+++ b/jsapp/js/components/map/worldCopies.ts
@@ -1,0 +1,118 @@
+import L from 'leaflet'
+import { type PointsBounds, getPointsBounds, getWorldCopyOffsets } from './mapUtils'
+
+/** Marker budget for the whole map. Copies multiply markers, so a project with many submissions gets fewer copies. */
+const MAX_DRAWN_MARKERS = 20000
+
+/**
+ * Keeps a group of markers drawn in every copy of the world the map is showing.
+ *
+ * Leaflet repeats the base map east and west forever, but a marker only exists in the one copy of the world it was
+ * plotted in. Without copies, panning past the edge of the world leaves the data behind and ends up showing an empty
+ * map. Copies join the group they were cloned from, so clustering, clicks and the legend filter treat them like any
+ * other marker. One instance follows one group: call `destroy()` and start a new one when the group is replaced.
+ */
+export class WorldCopies {
+  /** Markers of every copy drawn, keyed by the longitude they were moved by. Never holds the plotted markers. */
+  private readonly copies = new Map<number, L.Marker[]>()
+  private readonly plottedBounds?: PointsBounds
+  private pendingSync = 0
+
+  constructor(
+    private readonly map: L.Map,
+    private readonly group: L.FeatureGroup,
+    private readonly plotted: L.Marker[],
+    /** Called after copies were added or removed, with every point now drawn on the map. */
+    private readonly onChange: (drawnPoints: L.HeatLatLngTuple[]) => void,
+  ) {
+    this.plottedBounds = getPointsBounds(plotted.map((marker) => marker.getLatLng()))
+    this.map.on('moveend', this.onMoveEnd)
+    this.sync()
+  }
+
+  /** Every point drawn on the map, the copies included, in the shape the heat map layer takes. */
+  getDrawnPoints(): L.HeatLatLngTuple[] {
+    return [this.plotted, ...this.copies.values()].flat().map((marker): L.HeatLatLngTuple => {
+      const { lat, lng } = marker.getLatLng()
+      // The third value is the heat map weight, and every submission weighs the same to us
+      return [lat, lng, 1]
+    })
+  }
+
+  /** Stops following the map. The copies stay in their group, which is on its way out anyway. */
+  destroy() {
+    window.cancelAnimationFrame(this.pendingSync)
+    this.map.off('moveend', this.onMoveEnd)
+  }
+
+  private readonly onMoveEnd = () => {
+    // The next frame lets the marker clustering handle the move first: it only shows markers inside the bounds it saw
+    // last, so copies added any earlier would stay invisible until the next move.
+    window.cancelAnimationFrame(this.pendingSync)
+    this.pendingSync = window.requestAnimationFrame(this.sync)
+  }
+
+  /** Draws the copies that have come into sight and takes down the ones that have gone out of it. */
+  private readonly sync = () => {
+    if (
+      // Nothing plotted, so nothing to copy
+      !this.plottedBounds ||
+      // A map without a view yet throws when asked about its bounds
+      !Number.isFinite(this.map.getZoom())
+    ) {
+      return
+    }
+
+    const view = this.map.getBounds()
+    const offsets = getWorldCopyOffsets(
+      this.plottedBounds,
+      { west: view.getWest(), east: view.getEast() },
+      Math.floor(MAX_DRAWN_MARKERS / this.plotted.length),
+    )
+    let changed = false
+
+    this.copies.forEach((markers, offset) => {
+      if (!offsets.includes(offset)) {
+        this.removeFromGroup(markers)
+        this.copies.delete(offset)
+        changed = true
+      }
+    })
+
+    offsets.forEach((offset) => {
+      // Zero is the copy the points were plotted in, already on the map
+      if (offset === 0 || this.copies.has(offset)) {
+        return
+      }
+      const copy = this.plotted.map((marker) => {
+        const { lat, lng } = marker.getLatLng()
+        return L.marker([lat, lng + offset], marker.options)
+      })
+      this.addToGroup(copy)
+      this.copies.set(offset, copy)
+      changed = true
+    })
+
+    if (changed) {
+      this.onChange(this.getDrawnPoints())
+    }
+  }
+
+  /** `L.MarkerClusterGroup` takes a whole batch much faster than markers one by one. */
+  private addToGroup(markers: L.Marker[]) {
+    if (this.group instanceof L.MarkerClusterGroup) {
+      this.group.addLayers(markers)
+    } else {
+      markers.forEach((marker) => this.group.addLayer(marker))
+    }
+  }
+
+  /** See `addToGroup()`. */
+  private removeFromGroup(markers: L.Marker[]) {
+    if (this.group instanceof L.MarkerClusterGroup) {
+      this.group.removeLayers(markers)
+    } else {
+      markers.forEach((marker) => this.group.removeLayer(marker))
+    }
+  }
+}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Project → Data → Map now keep submissions collected on both sides of the 180th meridian together, and keep showing them while you pan around the world.

### 📖 Description

A project with points on both sides of the 180th meridian used to open zoomed out to the whole world, with the data split between the far left and far right edges of the map. The map now reads those coordinates the short way round and opens on the area the data actually covers.

Panning sideways no longer leaves the data behind either: markers, clusters and heat map are drawn in every copy of the world on screen. Auto-fitting also leaves a small margin now, so points on the outer edge of a project's area aren't cut in half by the edge of the map.

### 💭 Notes

Changes here:

- `mapUtils.ts` (with tests) — the geometry, pulled out of the component:
  - `unwrapLongitudes()` picks the narrowest reading of a set of longitudes
  - `getWorldCopyOffsets()` returns which copies of the world are worth drawing for the current view
  - `getPointsBounds()`, `getPlottedPoints()` — lifted out of `buildMarkers()`, which was doing coordinate parsing, min/max tracking and marker building in one pass
- `worldCopies.ts` — `WorldCopies` clones the marker group into multiple copies
- `index.tsx`:
  - `buildMarkers()` fits the plotted bounds instead of `markers.getBounds()`, which would grow with every clone we add and zoom the map out further on each pan
  - the heat map is built from the drawn points, copies included
  - `resetFilterByMarker()` and `hideUnselectedMarkers()` guard on `_icon` — clustered markers don't have one, and the old code threw a `TypeError` on them
  - `SUBMISSIONS_PER_PAGE` is exported and reused by `formMapWrapper.tsx`, which had its own copy
- `mapTiles.mocks.ts` + `FormMapWrapper.stories.tsx` — msw serves generated SVG tiles for offline and pixel-identical runs (for Chromatic). Map stories are no longer a big blue rectangle. Two new stories cover the antimeridian fit and the repeated copies.

Samoa and Vanuatu are neighbours again!

Closes #3547

### 👀 Preview steps

1. ℹ️ have an account and a deployed project with a geopoint question
2. add four submissions: two around Vanuatu (168°E) and two around Samoa (172°W), so they sit on either side of the 180th meridian
3. go to Project → Data → Map
4. 🔴 [on main] the map shows the entire world, with the two groups pinned to opposite edges
5. 🟢 [on PR] the map opens on the Pacific, both groups side by side
6. drag the map sideways past the edge of the world, a few times, in either direction
7. 🔴 [on main] the points vanish as soon as you cross the edge
8. 🟢 [on PR] the points reappear in every copy of the world you pan into
9. zoom out as far as the map goes
10. 🟢 notice a set of points in each copy of the world on screen, none of them clipped by the edge of the map
11. switch to the heat map view and repeat steps 6 and 9
12. 🟢 notice the heat follows the same copies — nothing lost at sea
