### PR TITLE
refactor(constants): import XLSForm and version regexes from formpack DEV-2656

### DIFF
--- a/dependencies/pip/requirements.in
+++ b/dependencies/pip/requirements.in
@@ -2,7 +2,7 @@
 # https://github.com/bndr/pipreqs is a handy utility, too.
 
 # formpack
-git+https://github.com/kobotoolbox/formpack.git@c00683281c5df4cdac86144d8e52c13e283f3e5e#egg=formpack
+git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb#egg=formpack
 
 # More up-to-date version of django-digest than PyPI seems to have.
 # Also, python-digest is an unlisted dependency thereof.

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -197,7 +197,7 @@ fido2==2.2.0
     # via django-allauth
 flower==2.0.1
     # via -r dependencies/pip/requirements.in
-formpack @ git+https://github.com/kobotoolbox/formpack.git@c00683281c5df4cdac86144d8e52c13e283f3e5e
+formpack @ git+https://github.com/kobotoolbox/formpack.git@4ddb8bfa0f8dfb433cbddf6298257fe95f9ce2fb
     # via -r dependencies/pip/requirements.in
 funcsigs==1.0.2
     # via begins

--- a/kobo/apps/reports/constants.py
+++ b/kobo/apps/reports/constants.py
@@ -7,7 +7,3 @@ CHARTABLE_TYPES = [
 
 SPECIFIC_REPORTS_KEY = 'specified'
 DEFAULT_REPORTS_KEY = 'default'
-
-FUZZY_VERSION_ID_KEY = '_version_'
-FUZZY_VERSION_PATTERN = r'^__?version__?(\d{3})?$'
-INFERRED_VERSION_ID_KEY = '__inferred_version__'

--- a/kobo/apps/reports/report_data.py
+++ b/kobo/apps/reports/report_data.py
@@ -4,11 +4,11 @@ from copy import deepcopy
 
 from django.utils.translation import gettext as t
 from formpack import FormPack
+from formpack.constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY
 from rest_framework import serializers
 
 from kpi.utils.bugfix import repair_file_column_content_and_save
 from kpi.utils.log import logging
-from .constants import FUZZY_VERSION_ID_KEY, INFERRED_VERSION_ID_KEY
 
 
 def build_formpack(asset, submission_stream=None, use_all_form_versions=True):

--- a/kpi/mixins/formpack_xlsform_utils.py
+++ b/kpi/mixins/formpack_xlsform_utils.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import copy
-import re
 from collections import OrderedDict
 
+from formpack.constants import FUZZY_VERSION_RE
 from formpack.utils.flatten_content import flatten_content
 from formpack.utils.spreadsheet_content import flatten_to_spreadsheet_content
 
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kpi.utils.absolute_paths import insert_full_paths_in_place
 from kpi.utils.asset_translation_utils import (  # TRANSLATIONS_EQUAL,
     TRANSLATION_ADDED,
@@ -178,7 +177,7 @@ class FormpackXLSFormUtilsMixin:
         for idx in range(len(content[self.WORKING_SHEET]) - 1, 0, -1):
             field = content[self.WORKING_SHEET][idx]
             try:
-                if re.match(FUZZY_VERSION_PATTERN, field['name']):
+                if FUZZY_VERSION_RE.match(field['name']):
                     del content[self.WORKING_SHEET][idx]
             except KeyError:
                 pass

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -22,7 +22,13 @@ from django.db.models.functions import Cast, Coalesce, Concat
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext as t
-from formpack.constants import KOBO_LOCK_SHEET, MEDIA_COLUMN_NAMES
+from formpack.constants import (
+    KOBO_LOCK_SHEET,
+    MEDIA_COLUMN_NAMES,
+    MEDIA_COLUMN_RE,
+    MEDIA_COLUMN_WITH_LANG_RE,
+    TRANSLATED_COLUMN_RE,
+)
 from formpack.schema.fields import (
     IdCopyField,
     NotesCopyField,
@@ -415,13 +421,7 @@ class ImportTask(ImportExportTask):
         which would otherwise inject a null "Unnamed language" translation and
         break the formbuilder (DEV-2656). Mirrors the column classification in
         `formpack.utils.expand_content._get_special_survey_cols()`.
-
-        TODO: replace the patterns below with the compiled constants
-        (`MEDIA_COLUMN_WITH_LANG_RE`, `MEDIA_COLUMN_RE`,
-        `TRANSLATED_COLUMN_RE`) once they land in `formpack.constants`.
         """
-        media_re = '|'.join(MEDIA_COLUMN_NAMES)
-
         uniq_cols = OrderedDict()
         for sheet in ('survey', 'choices', 'library'):
             for row in survey_dict.get(sheet, []):
@@ -443,21 +443,18 @@ class ImportTask(ImportExportTask):
                 continue
             # translated media column,
             # e.g. `image::English (en)` or `media::image::French (fr)`
-            mtch = re.match(
-                rf'^(media\s*::?\s*)?({media_re})\s*::?\s*([^:]+)$',
-                column_name,
-            )
+            mtch = MEDIA_COLUMN_WITH_LANG_RE.match(column_name)
             if mtch:
                 languages.add(mtch.groups()[2])
                 continue
             # untranslated media column, e.g. `image` or `media::image`
-            mtch = re.match(rf'^(media\s*::?\s*)?({media_re})$', column_name)
+            mtch = MEDIA_COLUMN_RE.match(column_name)
             if mtch:
                 _mark_untranslated(column_name)
                 continue
             # any other translated column,
             # e.g. `label::English (en)` or `constraint_message::Français`
-            mtch = re.match(r'^([^:]+)\s*::?\s*([^:]+)$', column_name)
+            mtch = TRANSLATED_COLUMN_RE.match(column_name)
             if mtch:
                 column_shortname = mtch.groups()[0]
                 languages.add(mtch.groups()[1])

--- a/kpi/serializers/v2/asset.py
+++ b/kpi/serializers/v2/asset.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import Optional
 
 from constance import config
@@ -12,6 +11,7 @@ from django.utils.translation import gettext as t
 from django.utils.translation import ngettext as nt
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
+from formpack.constants import FUZZY_VERSION_RE
 from rest_framework import exceptions, serializers
 from rest_framework.fields import empty
 from rest_framework.reverse import reverse
@@ -20,7 +20,6 @@ from hub.models.extra_user_detail import ExtraUserDetail
 from kobo.apps.openrosa.apps.logger.models import XForm
 from kobo.apps.organizations.constants import ORG_ADMIN_ROLE
 from kobo.apps.organizations.utils import get_real_owner
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kobo.apps.reports.report_data import build_formpack
 from kobo.apps.subsequences.utils.supplement_data import get_analysis_form_json
 from kobo.apps.trash_bin.exceptions import TrashIntegrityError, TrashTaskInProgressError
@@ -1084,7 +1083,8 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
                 valid_fields = [
                     f.path for f in form_pack.get_fields_for_versions(
                         form_pack.versions.keys()
-                    ) if not re.match(FUZZY_VERSION_PATTERN, f.path)
+                    )
+                    if not FUZZY_VERSION_RE.match(f.path)
                 ]
                 unknown_fields = set(fields) - set(valid_fields)
                 if unknown_fields and valid_fields:

--- a/kpi/serializers/v2/paired_data.py
+++ b/kpi/serializers/v2/paired_data.py
@@ -5,10 +5,10 @@ import re
 from django.utils.translation import gettext as t
 from django_request_cache import cache_for_request
 from drf_spectacular.utils import extend_schema_field
+from formpack.constants import FUZZY_VERSION_RE
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from kobo.apps.reports.constants import FUZZY_VERSION_PATTERN
 from kobo.apps.reports.report_data import build_formpack
 from kpi.constants import (
     ASSET_TYPE_SURVEY,
@@ -163,9 +163,9 @@ class PairedDataSerializer(serializers.Serializer):
         # See `_infer_version_id()` in `kobo.apps.reports.report_data.build_formpack`
         # for field name alternatives.
         valid_fields = [
-            f.path for f in form_pack.get_fields_for_versions(
-                form_pack.versions.keys()
-            ) if not re.match(FUZZY_VERSION_PATTERN, f.path)
+            f.path
+            for f in form_pack.get_fields_for_versions(form_pack.versions.keys())
+            if not FUZZY_VERSION_RE.match(f.path)
         ]
 
         source_fields = source.data_sharing.get('fields') or valid_fields


### PR DESCRIPTION
### 📣 Summary

Internal refactor, no behavior change: kpi now imports the XLSForm column-header and fuzzy-version regexes from `formpack.constants` instead of keeping copies.

### 💭 Notes

- Follow-up to kobotoolbox/formpack#351, stacked on #7473 (retarget to `main` once that merges).
- `_ensure_translated_columns()` now uses `MEDIA_COLUMN_WITH_LANG_RE` / `MEDIA_COLUMN_RE` / `TRANSLATED_COLUMN_RE`; the fuzzy-version trio moved out of `kobo/apps/reports/constants.py` and callers use the compiled `FUZZY_VERSION_RE.match(...)`.
- The formpack pin points at the current head of the formpack PR branch (`4ddb8bf`); once formpack#351 merges, the pin gets updated to the merged hash (one-line change) before this leaves draft.
- kpi-only policy regexes (bad-name heuristic, paired-data filename check, `is_valid_node_name`, jsapp) intentionally untouched.
- Patterns are byte-for-byte the strings they replace; imports/paired-data/reports tests pass on both settings axes (56 passed ×2).

### 👀 Preview steps

Behavior can't change: same regexes, now compiled in one place. Import an XLSForm and confirm nothing differs (e.g. the DEV-2656 blocked-import error still triggers).