### PR TITLE
ci(releases): changelog job shouldn't be concurrent DEV-2722

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -50,8 +50,11 @@ jobs:
     - name: Commit to dedicated branch
       env:
         VERSION: ${{ inputs.version }}
+        DRAFT: ${{ inputs.draft }}
       run: |
-        git checkout -B changelog/$VERSION
+        BRANCH="changelog/$VERSION"
+        if [[ "$DRAFT" == "true" ]]; then BRANCH="$BRANCH-draft"; fi
+        git checkout -B "$BRANCH"
         git add -f CHANGELOG.md
         git commit -m "chore(releases): generate CHANGELOG.md for $VERSION"
-        git push -f --set-upstream origin changelog/$VERSION
+        git push -f --set-upstream origin "$BRANCH"

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -345,7 +345,7 @@ jobs:
             && format(':warning: failed to update changelog: @*devs* please investigate [run #{0}]({1}/{2}/actions/runs/{3})!', github.run_number, github.server_url, github.repository, github.run_id)
             || needs.changelog.result == 'skipped'
               && ':skip_forward: changelog update skipped due failed automated tests.'
-              || format(':check: updated [changelog](https://github.com/kobotoolbox/kpi/blob/changelog/{0}/CHANGELOG.md) for `{1}..{0}`', needs.version.outputs.current_patch, needs.version.outputs.prev_patch)
+              || format(':check: updated [changelog](https://github.com/kobotoolbox/kpi/blob/changelog/{0}-draft/CHANGELOG.md) for `{1}..{0}`', needs.version.outputs.current_patch, needs.version.outputs.prev_patch)
           }}
         - ${{ (needs.deploy-to-beta.result == 'failure' || needs.deploy-to-beta.result == 'timed_out')
             && format(':warning: failed to queue to deploy to beta: @*devs* please investigate [run #{0}]({1}/{2}/actions/runs/{3})!', github.run_number, github.server_url, github.repository, github.run_id)


### PR DESCRIPTION
### 💭 Notes

Fix the changelog job between stabilize and tag workflows, by pushing to different branches.

There was an cascading problem: when tag workflow pushes pulled translations,
it triggered stabilize workflow that then overwrites changelog.

There was a similar race-condition problem: while tag workflow runs and a untimely
push triggers stabilize workflow, stabilize's changelog job may overwrite changelog.