### PR TITLE
fix(account): after updating password leave form DEV-2227

### DIFF
--- a/jsapp/js/account/changePasswordRoute.component.tsx
+++ b/jsapp/js/account/changePasswordRoute.component.tsx
@@ -11,6 +11,7 @@ import { withRouter } from '#/router/legacy'
 import type { WithRouterProps } from '#/router/legacy'
 import sessionStore from '#/stores/session'
 import styles from './changePasswordRoute.module.scss'
+import { ACCOUNT_ROUTES } from './routes.constants'
 import UpdatePasswordForm from './security/password/updatePasswordForm.component'
 
 bem.AccountSettings = makeBem(null, 'account-settings')
@@ -22,6 +23,10 @@ bem.AccountSettings__actions = makeBem(bem.AccountSettings, 'actions')
 const ChangePasswordRoute = class ChangePassword extends React.Component<WithRouterProps> {
   close() {
     this.props.router.navigate(-1)
+  }
+
+  onPasswordUpdated() {
+    this.props.router.navigate(ACCOUNT_ROUTES.SECURITY)
   }
 
   render() {
@@ -44,7 +49,7 @@ const ChangePasswordRoute = class ChangePassword extends React.Component<WithRou
             </bem.AccountSettings__item>
 
             <div className={styles.fieldsWrapper}>
-              <UpdatePasswordForm />
+              <UpdatePasswordForm onSuccess={this.onPasswordUpdated.bind(this)} />
             </div>
           </bem.AccountSettings__item>
         </bem.AccountSettings>


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

After successfully updating account password, we now redirect back to Security route.

### 💭 Notes

Without this callback usage, user had to navigate themselves.

### 👀 Preview steps

1. Go to Account Settings → Security route
2. At the right corner of the Password, press Update
3. A dialogue box appears
4. Change the password. Then Save Password
5. You are notified "changed password successfully"
6. [on main] 🔴 You are still on same page
7. [on PR] 🍏 You are redirected to Security
