### PR TITLE
chore(frontend): drop use-immer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,6 @@
         "reflux-core": "^1.0.0",
         "rtl-detect": "^1.1.2",
         "select2": "^3.5.2-browserify",
-        "use-immer": "^0.10.0",
         "wretch": "^2.9.0",
         "zxcvbn": "^4.4.2"
       },
@@ -30037,16 +30036,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-immer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.10.0.tgz",
-      "integrity": "sha512-/eVwNR4TG9Tm/dd+aHYLLaI0FLfYKlkTqKMkn78Ah/EYVzWd/zJIgpkdoFEKbhQJOGo8XN7/mWrTx0exp1c+Ug==",
-      "license": "MIT",
-      "peerDependencies": {
-        "immer": ">=8.0.0",
-        "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
       }
     },
     "node_modules/use-isomorphic-layout-effect": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "reflux-core": "^1.0.0",
     "rtl-detect": "^1.1.2",
     "select2": "^3.5.2-browserify",
-    "use-immer": "^0.10.0",
     "wretch": "^2.9.0",
     "zxcvbn": "^4.4.2"
   },


### PR DESCRIPTION
### 💭 Notes

Drop `use-immer` - a completely unused dependency.