### PR TITLE
ci(du): remove du as a pipeline trigger INFRA-598

### DIFF
--- a/.github/workflows/nonprod-releases.yml
+++ b/.github/workflows/nonprod-releases.yml
@@ -5,7 +5,6 @@ on:
   #TODO: Trigger from testing action after tests pass
   push:
     branches:
-      - 'feature/du'
       - 'feature/tri'
       - 'feature/unu'
       - 'public-beta'


### PR DESCRIPTION
Prevents pushes to du from triggering the nonprod deploy pipeline since the du environment has been decommissioned and no longer exists to deploy to.