### PR TITLE
fix(massEmails): disable one-off sends if remaining records are failed DEV-2729

### DIFF
--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -106,7 +106,8 @@ def mark_old_enqueued_mass_email_record_as_failed():
         .distinct()
     )
 
-    # this won't actually be evaluated until we call update() so it's safe to declare it here
+    # this won't actually be evaluated until we call
+    # update() so it's safe to declare it here
     configs_to_update = (
         MassEmailConfig.objects.filter(uid__in=affected_one_time_campaigns)
         .annotate(
@@ -119,11 +120,13 @@ def mark_old_enqueued_mass_email_record_as_failed():
 
     with transaction.atomic():
         updated_records_count = records_to_update.update(status=EmailStatus.FAILED)
-        configs_to_update.update(live=False)
+        updated_configs_count = configs_to_update.update(live=False)
 
     logging.info(
-        f'Updated {updated_records_count} MassEmailRecord(s) from `enqueued` to `failed` '
+        f'Updated {updated_records_count} MassEmailRecord(s)'
+        ' from `enqueued` to `failed` '
         f'that were older than {threshold_date}.'
+        f' Turned {updated_configs_count} campaigns off.'
     )
 
 

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -100,8 +100,7 @@ def mark_old_enqueued_mass_email_record_as_failed():
     )
 
     affected_one_time_campaigns = list(
-        records_to_update.select_related('email_job__email_config')
-        .filter(email_job__email_config__frequency=-1)
+        records_to_update.filter(email_job__email_config__frequency=-1)
         .values_list('email_job__email_config__uid', flat=True)
         .distinct()
     )
@@ -112,7 +111,8 @@ def mark_old_enqueued_mass_email_record_as_failed():
         MassEmailConfig.objects.filter(uid__in=affected_one_time_campaigns)
         .annotate(
             enqueued_count=Count(
-                'jobs__records__id', filter=Q(jobs__records__status='enqueued')
+                'jobs__records__id',
+                filter=Q(jobs__records__status=EmailStatus.ENQUEUED),
             )
         )
         .filter(enqueued_count=0)

--- a/kobo/apps/mass_emails/tasks.py
+++ b/kobo/apps/mass_emails/tasks.py
@@ -95,13 +95,34 @@ def mark_old_enqueued_mass_email_record_as_failed():
     threshold_date = timezone.now() - timedelta(
         days=config.MASS_EMAIL_ENQUEUED_RECORD_EXPIRY
     )
-    updated_records = MassEmailRecord.objects.filter(
-        status=EmailStatus.ENQUEUED,
-        date_created__lt=threshold_date
-    ).update(status=EmailStatus.FAILED)
+    records_to_update = MassEmailRecord.objects.filter(
+        status=EmailStatus.ENQUEUED, date_created__lt=threshold_date
+    )
+
+    affected_one_time_campaigns = list(
+        records_to_update.select_related('email_job__email_config')
+        .filter(email_job__email_config__frequency=-1)
+        .values_list('email_job__email_config__uid', flat=True)
+        .distinct()
+    )
+
+    # this won't actually be evaluated until we call update() so it's safe to declare it here
+    configs_to_update = (
+        MassEmailConfig.objects.filter(uid__in=affected_one_time_campaigns)
+        .annotate(
+            enqueued_count=Count(
+                'jobs__records__id', filter=Q(jobs__records__status='enqueued')
+            )
+        )
+        .filter(enqueued_count=0)
+    )
+
+    with transaction.atomic():
+        updated_records_count = records_to_update.update(status=EmailStatus.FAILED)
+        configs_to_update.update(live=False)
 
     logging.info(
-        f'Updated {updated_records} MassEmailRecord(s) from `enqueued` to `failed` '
+        f'Updated {updated_records_count} MassEmailRecord(s) from `enqueued` to `failed` '
         f'that were older than {threshold_date}.'
     )
 

--- a/kobo/apps/mass_emails/tests/test_celery_tasks.py
+++ b/kobo/apps/mass_emails/tests/test_celery_tasks.py
@@ -117,6 +117,7 @@ class BaseMassEmailsTestCase(BaseTestCase):
         MassEmailRecord.objects.filter(id=record.id).update(
             date_modified=timezone.now() - timedelta(days=days_ago)
         )
+        return record
 
     def _enqueue_records_for_config(self, email_config, count):
         job = MassEmailJob.objects.create(email_config=email_config)
@@ -1082,3 +1083,59 @@ class TestMassEmailSenderConnection(BaseMassEmailsTestCase):
         # rather than being written off as failed
         assert MassEmailRecord.objects.filter(status=EmailStatus.SENT).count() == 1
         assert MassEmailRecord.objects.filter(status=EmailStatus.ENQUEUED).count() == 2
+
+
+class TestMarkOldRecordsAsFailed(BaseMassEmailsTestCase):
+
+    @override_config(MASS_EMAIL_ENQUEUED_RECORD_EXPIRY=5)
+    def test_mark_old_records_as_failed_expires_old_records(self):
+        config = self._create_email_config(name='test')
+        record_old = self._create_email_record(
+            user=self.user1, days_ago=10, status='enqueued', email_config=config
+        )
+        record_new = self._create_email_record(
+            user=self.user1, days_ago=3, status='enqueued', email_config=config
+        )
+
+        mark_old_enqueued_mass_email_record_as_failed()
+        record_old.refresh_from_db()
+        record_new.refresh_from_db()
+        assert record_old.status == 'failed'
+        assert record_new.status == 'enqueued'
+
+    @override_config(MASS_EMAIL_ENQUEUED_RECORD_EXPIRY=5)
+    def test_mark_old_records_as_failed_disables_failed_oneoff_sends(self):
+        config_to_expire = self._create_email_config(
+            name='test', frequency=-1, live=True
+        )
+        config_to_keep = self._create_email_config(
+            name='test2', frequency=-1, live=True
+        )
+
+        # create 2 old records for config_to_expire
+        self._create_email_record(
+            user=self.user1,
+            status='enqueued',
+            email_config=config_to_expire,
+            days_ago=10,
+        )
+        self._create_email_record(
+            user=self.user2,
+            status='enqueued',
+            email_config=config_to_expire,
+            days_ago=10,
+        )
+
+        # create 1 old record and 1 newer for config_to_keep
+        self._create_email_record(
+            user=self.user1, status='enqueued', email_config=config_to_keep, days_ago=10
+        )
+        self._create_email_record(
+            user=self.user2, status='enqueued', email_config=config_to_keep, days_ago=3
+        )
+
+        mark_old_enqueued_mass_email_record_as_failed()
+        config_to_expire.refresh_from_db()
+        config_to_keep.refresh_from_db()
+        assert not config_to_expire.live
+        assert config_to_keep.live


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fix a bug that was causing one-off email campaigns to be sent multiple times.

### 💭 Notes

The bug was caused by the following scenario:
1. one-off email config Config A is set to live
2. the next day, records are enqueued
3. a large email backlog causes enqueued records not to be sent 
4. after several days, the cleanup job marks all remaining enqueued records as 'failed'
5. the next time the sender runs, it sees Config A has no enqueued records and is still live, so it regenerates the campaign

The solution is to expire email configs (ie set `live=False`) immediately after we have marked remaining enqueued records as 'failed', similar to how we do in the sender where we set `live=False` if, after a mass send, we notice there are no more enqueued records.


### 👀 Preview steps
Turn off the kpi_worker while testing so you have control over when the various tasks run, otherwise you risk records being changed underneath you

1. ℹ️ have an admin account and a few others
2. Set the following values in Constance:
* MASS_EMAIL_ENQUEUED_RECORD_EXPIRY = 0
* MASS_EMAIL_TEST_EMAILS = `<newline-delineated list of user emails>`
* MASS_EMAIL_CONDENSE_SEND = True
6. Create an email config with frequency = -1 and query `test_emails` and set it to Live
7. Wait until the next 15m boundary
8. In a django shell, run `generate_mass_email_user_lists`
9. To simulate records getting old and being marked as failed, run `mark_old_enqueued_mass_email_record_as_failed`
10. To simulate it being the next day, clear the cache with `for key in cache.keys('mass_emails*'): cache.delete(key)`
11. Rerun `generate_mass_email_user_lists`
12. 🔴 [on main] Notice new records are enqueued for the one off email
13. 🟢 [on PR] Notice no new records are added for the one off email

