### PR TITLE
fix(tos): hide fields for MMO users DEV-2580

### DIFF
--- a/jsapp/js/account/DeleteAccountBanner.stories.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.stories.tsx
@@ -12,6 +12,8 @@ import DeleteAccountBanner from './DeleteAccountBanner'
 const meta: Meta<typeof DeleteAccountBanner> = {
   title: 'Components/DeleteAccountBanner',
   component: DeleteAccountBanner,
+  // Docs view doesn't work :sadface: :angryface: --> turning it off
+  tags: ['!autodocs'],
   argTypes: {},
   parameters: {
     msw: {

--- a/jsapp/js/components/activity/FormActivity.stories.tsx
+++ b/jsapp/js/components/activity/FormActivity.stories.tsx
@@ -14,6 +14,8 @@ import FormActivity from './FormActivity'
 const meta: Meta<typeof FormActivity> = {
   title: 'Features/FormActivity',
   component: FormActivity,
+  // Docs view doesn't work well and doesn't give us anything useful
+  tags: ['!autodocs'],
   argTypes: {},
   parameters: {
     msw: {

--- a/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.stories.tsx
+++ b/jsapp/js/components/library/LibraryUploadModal/LibraryUploadModal.stories.tsx
@@ -1,6 +1,7 @@
 import { ModalsProvider } from '@mantine/modals'
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { expect, userEvent, within } from 'storybook/test'
 import ButtonNew from '#/components/common/ButtonNew'
 import { MODAL_TYPES } from '#/constants'
 import { KOBO_MODAL_SHARED_PROPS } from '#/theme/kobo/Modal'
@@ -31,6 +32,8 @@ function StoryTrigger(args: { mode: 'form' | 'uploading' }) {
 const meta: Meta<typeof StoryTrigger> = {
   title: 'Features/LibraryUploadModal',
   component: StoryTrigger,
+  // Docs view doesn't work well and doesn't give us anything useful
+  tags: ['!autodocs'],
   decorators: [
     (Story) => {
       const queryClient = new QueryClient({
@@ -76,10 +79,24 @@ export const UploadForm: Story = {
   args: {
     mode: 'form',
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /open library upload modal/i }))
+
+    // The upload form flow is now visible inside the modal.
+    expect(await canvas.findByText(/import an xlsform from your computer/i)).toBeInTheDocument()
+  },
 }
 
 export const UploadingXls: Story = {
   args: {
     mode: 'uploading',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: /open library upload modal/i }))
+
+    // The uploading/processing flow is now visible inside the modal.
+    expect(await canvas.findByText(/uploading xls file/i)).toBeInTheDocument()
   },
 }

--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -133,13 +133,9 @@ const submissionsWithBothGeopointTypes: SubmissionResponse[] = [
 const meta: Meta<typeof FormMapWrapper> = {
   title: 'Features/FormMap',
   component: FormMapWrapper,
+  // Docs view does NOT work reliably for these stories due to map initialization rule (there can be only one)
+  tags: ['!autodocs'],
   parameters: {
-    docs: {
-      description: {
-        component:
-          '⚠️ **Docs view does NOT work reliably for these stories due to map initialization rule (there can be only one). Use single stories please.** Also note that many interactive elements are not mocked and will not work.',
-      },
-    },
     reactRouter: reactRouterParameters({
       location: {
         pathParams: { uid: mockAssetUid },

--- a/jsapp/js/components/submissions/DataTableWrapper.stories.tsx
+++ b/jsapp/js/components/submissions/DataTableWrapper.stories.tsx
@@ -362,16 +362,13 @@ const processingBulkAction2 = getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveR
 const meta: Meta<typeof DataTableWrapper> = {
   title: 'Components/DataTableWrapper',
   component: DataTableWrapper,
+  // Docs view does NOT work reliably for these stories due to per-story MSW handler and asset/submission isolation
+  // issues.
+  tags: ['!autodocs'],
   args: {
     asset: minimalAsset,
   },
   parameters: {
-    docs: {
-      description: {
-        component:
-          '⚠️ **Docs view does NOT work reliably for these stories due to per-story MSW handler and asset/submission isolation issues. Use single stories (Default, and Processing Column) please.** Also note that many interactive elements of the table are not mocked and will not work.',
-      },
-    },
     a11y: { disable: true },
     reactRouter: getRouterParams(minimalAsset.uid),
     msw: {

--- a/jsapp/js/project/FormMedia/FormMedia.stories.tsx
+++ b/jsapp/js/project/FormMedia/FormMedia.stories.tsx
@@ -13,6 +13,8 @@ const mockAsset = getApiV2AssetsRetrieveResponseMock({
 const meta: Meta<typeof FormMedia> = {
   title: 'Features/FormMedia',
   component: FormMedia,
+  // Docs view doesn't work well and doesn't give us anything useful
+  tags: ['!autodocs'],
   decorators: [queryClientDecorator],
   args: {
     asset: mockAsset,

--- a/jsapp/js/router/tosAgreement.component.tsx
+++ b/jsapp/js/router/tosAgreement.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { RequireOrg } from '#/router/RequireOrg'
 import TOSForm from '#/tos/tosForm.component'
 import BasicLayout from './basicLayout.component'
 import styles from './tosAgreement.module.scss'
@@ -13,7 +14,11 @@ export default function TOSAgreement() {
   return (
     <BasicLayout>
       <div className={styles.root}>
-        <TOSForm />
+        {/* `TOSForm` reads the organization (to hide org fields from MMO
+            members), so it must be a descendant of `RequireOrg`. */}
+        <RequireOrg>
+          <TOSForm />
+        </RequireOrg>
       </div>
     </BasicLayout>
   )

--- a/jsapp/js/tos/tosForm.component.tsx
+++ b/jsapp/js/tos/tosForm.component.tsx
@@ -1,9 +1,10 @@
 import { type default as React, useEffect, useState } from 'react'
 
-import type { AccountFieldsErrors, AccountFieldsValues } from '#/account/account.constants'
+import type { AccountFieldsErrors, AccountFieldsValues, UserFieldName } from '#/account/account.constants'
 import { getInitialAccountFieldsValues, getProfilePatchData } from '#/account/account.utils'
 import AccountFieldsEditor from '#/account/accountFieldsEditor.component'
 import { fetchGet, fetchPatch, fetchPost, handleApiFail } from '#/api'
+import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import Button from '#/components/common/button'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import type { FailResponse } from '#/dataInterface'
@@ -20,6 +21,12 @@ const TOS_SLUG_TRANSLATED = `${TOS_SLUG}_<language>`
 const ME_ENDPOINT = '/me/'
 const TOS_ACCEPT_ENDPOINT = '/me/tos/'
 const TOS_MESSAGES_ENDPOINT = '/api/v2/terms-of-service/'
+
+/**
+ * Organization fields are managed at the organization level, so members of an
+ * MMO are not allowed to edit them and we omit them from the form.
+ */
+const MMO_HIDDEN_FIELDS: UserFieldName[] = ['organization', 'organization_website', 'organization_type']
 
 interface MePatchFailResponse {
   responseJSON: {
@@ -49,12 +56,21 @@ export default function TOSForm() {
   const [fieldsErrors, setFieldsErrors] = useState<AccountFieldsErrors>({})
   const [editedFields, setEditedFields] = useState<Partial<AccountFieldsValues>>({})
 
-  const fieldsToShow = envStore.data.getUserMetadataRequiredFieldNames()
+  const { currentLoggedAccount, logOut } = useSession()
+  const [organization] = useOrganizationAssumed()
+
+  const requiredFields = envStore.data.getUserMetadataRequiredFieldNames()
   if (envStore.data.getUserMetadataFieldsAsSimpleDict().newsletter_subscription) {
-    fieldsToShow.push('newsletter_subscription')
+    requiredFields.push('newsletter_subscription')
   }
 
-  const { currentLoggedAccount, logOut } = useSession()
+  // Members of an MMO cannot edit organization fields (they are managed at the
+  // organization level), so we hide them here — the same way the account
+  // settings view does. Otherwise MMO members are shown org fields they cannot
+  // save, which blocks them from accepting the TOS. See DEV-2580.
+  const fieldsToShow = organization?.is_mmo
+    ? requiredFields.filter((fieldName) => !MMO_HIDDEN_FIELDS.includes(fieldName))
+    : requiredFields
 
   // Get TOS message from endpoint
   useEffect(() => {

--- a/jsapp/js/tos/tosForm.component.tsx
+++ b/jsapp/js/tos/tosForm.component.tsx
@@ -64,10 +64,6 @@ export default function TOSForm() {
     requiredFields.push('newsletter_subscription')
   }
 
-  // Members of an MMO cannot edit organization fields (they are managed at the
-  // organization level), so we hide them here — the same way the account
-  // settings view does. Otherwise MMO members are shown org fields they cannot
-  // save, which blocks them from accepting the TOS. See DEV-2580.
   const fieldsToShow = organization?.is_mmo
     ? requiredFields.filter((fieldName) => !MMO_HIDDEN_FIELDS.includes(fieldName))
     : requiredFields

--- a/jsapp/js/tos/tosForm.stories.tsx
+++ b/jsapp/js/tos/tosForm.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import { runInAction } from 'mobx'
+import { expect, waitFor, within } from 'storybook/test'
+import { getApiV2TermsOfServiceListMockHandler } from '#/api/react-query/other/msw'
+import organizationMock from '#/endpoints/organization.mocks'
+import envStore, { type UserMetadataField } from '#/envStore'
+import { queryClientDecorator } from '#/query/queryClient.mocks'
+import { RequireOrg } from '#/router/RequireOrg'
+import TOSForm from './tosForm.component'
+
+// The form only renders *required* user metadata fields, so we mark the org
+// fields as required here to actually exercise the MMO logic. `beforeEach`
+// restores the original values so other stories aren't affected.
+const REQUIRED_FIELDS_WITH_ORG: UserMetadataField[] = [
+  { name: 'name', required: true, label: 'Full name' },
+  { name: 'organization_type', required: true, label: 'Organization type' },
+  { name: 'organization', required: true, label: 'Organization name' },
+  { name: 'organization_website', required: true, label: 'Organization website' },
+]
+
+// A minimal announcement so the form gets past its loading guard. Without a
+// message whose slug is `terms_of_service` the form would spin forever.
+const termsOfServiceMock = getApiV2TermsOfServiceListMockHandler([
+  {
+    url: 'http://kf.kobo.local/api/v2/terms-of-service/terms_of_service/',
+    slug: 'terms_of_service',
+    body: '<p>Please accept our Terms of Service.</p>',
+  },
+])
+
+const meta: Meta<typeof TOSForm> = {
+  title: 'Components/TOSForm',
+  component: TOSForm,
+  // Docs view doesn't work :sadface: :angryface: --> turning it off
+  tags: ['!autodocs'],
+  parameters: {
+    msw: {
+      handlers: [termsOfServiceMock, organizationMock()],
+    },
+    // The injected TOS message and heading order trip a11y checks that are not
+    // relevant to what these stories demonstrate.
+    a11y: { disable: true },
+  },
+  beforeEach: async () => {
+    // `envStore` fires a one-shot `fetchData()` on import that resolves against
+    // the global environment mock and *overwrites* `user_metadata_fields`. If we
+    // seed our fields before that request settles, it clobbers them mid-render.
+    // Wait for it to land first — after this there is no further fetch to undo
+    // our values.
+    await waitFor(() => expect(envStore.isReady).toBe(true)).catch(() => {})
+
+    const original = { isReady: envStore.isReady, fields: envStore.data.user_metadata_fields }
+    runInAction(() => {
+      envStore.isReady = true
+      envStore.data.user_metadata_fields = REQUIRED_FIELDS_WITH_ORG
+    })
+    return () => {
+      runInAction(() => {
+        envStore.isReady = original.isReady
+        envStore.data.user_metadata_fields = original.fields
+      })
+    }
+  },
+  decorators: [
+    (Story) => (
+      <RequireOrg>
+        <Story />
+      </RequireOrg>
+    ),
+    queryClientDecorator,
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof TOSForm>
+
+/** A regular user sees the organization fields alongside the other required fields. */
+export const NonMmoMember: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByRole('button', { name: /i agree/i })
+
+    expect(canvas.getByText(/full name/i)).toBeInTheDocument()
+    expect(canvas.getByText(/organization name/i)).toBeInTheDocument()
+  },
+}
+
+/** MMO members can't edit org fields (managed at the org level), so they're hidden. See DEV-2580. */
+export const MmoMember: Story = {
+  parameters: {
+    msw: {
+      handlers: [termsOfServiceMock, organizationMock({ is_mmo: true })],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByRole('button', { name: /i agree/i })
+
+    expect(canvas.getByText(/full name/i)).toBeInTheDocument()
+    expect(canvas.queryByText(/organization name/i)).not.toBeInTheDocument()
+  },
+}
+
+/** With no required fields, only the announcement and the accept/decline buttons show. */
+export const NoRequiredFields: Story = {
+  beforeEach: () => {
+    runInAction(() => {
+      envStore.data.user_metadata_fields = []
+    })
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByRole('button', { name: /i agree/i })
+
+    expect(canvas.queryByText(/full name/i)).not.toBeInTheDocument()
+    expect(canvas.getByRole('button', { name: /i don't agree/i })).toBeInTheDocument()
+  },
+}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Members of a multi-member organization can now accept the Terms of Service — the form no longer asks them for organization details they aren't allowed to change.

### 💭 Notes

Changes here:
- **Terms of Service form** (`tosForm.component.tsx`, `tosAgreement.component.tsx`)
  - Organization fields (name, website, type) are hidden for MMO members, since those are managed at the org level and members can't save them — same rule Account Settings already follows
  - The form now reads the current organization, so it's wrapped in `RequireOrg`.
- **Storybook**
  - New `tosForm.stories.tsx` with three cases
  - `LibraryUploadModal.stories.tsx`: the stories now open the modal themselves via a small `play` step, so you land on the actual modal instead of a lonely button (useful for Chromatic).
  - Turned off the Docs tab (`tags: ['!autodocs']`) on a handful of stories where it never worked, and removed the old "Docs is broken, sorry" warning blurbs that were trying to cover for it

### 👀 Preview steps

1. ℹ️ You could go with the actual setup steps (you need to create user through admin etc.) or test it in storybook
2. Run storybook
3. Go to Components → Tos Form
