### PR TITLE
feat(AudioCell): add details dialog for audio responses DEV-2370

### DIFF
--- a/jsapp/js/components/common/ProcessingPromptModal.tsx
+++ b/jsapp/js/components/common/ProcessingPromptModal.tsx
@@ -1,19 +1,17 @@
-import type { ComponentType, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 import type { ModalProps } from '@mantine/core'
 import { Group, Stack } from '@mantine/core'
-import type { IconProps as SvgIconProps, TablerIcon } from '@tabler/icons-react'
+import { IconPencilStar } from '@tabler/icons-react'
 import ButtonNew from '#/components/common/ButtonNew'
+import KoboIcon from '#/components/common/KoboIcon'
 import ModalNew from '#/components/common/ModalNew'
-import type { IconName } from '#/k-icons'
 
 export interface ProcessingPromptModalProps extends Omit<ModalProps, 'title'> {
   /** Rendered as-is, so callers can combine an icon with the title text. */
   title: ReactNode
   /** Main content of the dialog, e.g. a media preview relevant to the question type. */
   children: ReactNode
-  actionLabel: string
-  actionIcon?: IconName | TablerIcon | ComponentType<SvgIconProps>
   onAction: () => void
 }
 
@@ -25,7 +23,7 @@ export interface ProcessingPromptModalProps extends Omit<ModalProps, 'title'> {
  * question types other than audio in the future.
  */
 export default function ProcessingPromptModal(props: ProcessingPromptModalProps) {
-  const { title, children, actionLabel, actionIcon, onAction, ...modalProps } = props
+  const { title, children, onAction, ...modalProps } = props
 
   return (
     <ModalNew title={title} size='md' {...modalProps}>
@@ -33,8 +31,8 @@ export default function ProcessingPromptModal(props: ProcessingPromptModalProps)
         {children}
 
         <Group justify='flex-end'>
-          <ButtonNew size='md' rightIcon={actionIcon} onClick={onAction}>
-            {actionLabel}
+          <ButtonNew size='md' leftSection={<KoboIcon icon={IconPencilStar} size={16} />} onClick={onAction}>
+            {t('Translate & analyze')}
           </ButtonNew>
         </Group>
       </Stack>

--- a/jsapp/js/components/common/ProcessingPromptModal.tsx
+++ b/jsapp/js/components/common/ProcessingPromptModal.tsx
@@ -1,0 +1,43 @@
+import type { ComponentType, ReactNode } from 'react'
+
+import type { ModalProps } from '@mantine/core'
+import { Group, Stack } from '@mantine/core'
+import type { IconProps as SvgIconProps, TablerIcon } from '@tabler/icons-react'
+import ButtonNew from '#/components/common/ButtonNew'
+import ModalNew from '#/components/common/ModalNew'
+import type { IconName } from '#/k-icons'
+
+export interface ProcessingPromptModalProps extends Omit<ModalProps, 'title'> {
+  /** Rendered as-is, so callers can combine an icon with the title text. */
+  title: ReactNode
+  /** Main content of the dialog, e.g. a media preview relevant to the question type. */
+  children: ReactNode
+  actionLabel: string
+  actionIcon?: IconName | TablerIcon | ComponentType<SvgIconProps>
+  onAction: () => void
+}
+
+/**
+ * Generic dialog used to invite the user to send a submission response into
+ * the Processing flow (e.g. to transcribe, translate, or otherwise analyze
+ * it). The body content is provided by the caller since it depends on the
+ * question type (audio, text, etc.), which lets this dialog be reused for
+ * question types other than audio in the future.
+ */
+export default function ProcessingPromptModal(props: ProcessingPromptModalProps) {
+  const { title, children, actionLabel, actionIcon, onAction, ...modalProps } = props
+
+  return (
+    <ModalNew title={title} size='md' {...modalProps}>
+      <Stack>
+        {children}
+
+        <Group justify='flex-end'>
+          <ButtonNew size='md' rightIcon={actionIcon} onClick={onAction}>
+            {actionLabel}
+          </ButtonNew>
+        </Group>
+      </Stack>
+    </ModalNew>
+  )
+}

--- a/jsapp/js/components/common/miniAudioPlayer.scss
+++ b/jsapp/js/components/common/miniAudioPlayer.scss
@@ -1,5 +1,5 @@
-@use 'scss/colors';
-@use 'js/components/common/button';
+@use "scss/colors";
+@use "js/components/common/button";
 
 .mini-audio-player {
   display: flex;
@@ -7,6 +7,7 @@
   align-items: center;
   flex-direction: row;
   flex-wrap: nowrap;
+  min-width: 0;
   color: colors.$kobo-blue;
   height: button.$button-height-s;
 
@@ -30,5 +31,9 @@
 .mini-audio-player__time {
   font-size: 14px;
   margin-left: 2px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: colors.$kobo-gray-600;
 }

--- a/jsapp/js/components/common/miniAudioPlayer.scss
+++ b/jsapp/js/components/common/miniAudioPlayer.scss
@@ -1,5 +1,5 @@
-@use "scss/colors";
-@use "js/components/common/button";
+@use 'scss/colors';
+@use 'js/components/common/button';
 
 .mini-audio-player {
   display: flex;

--- a/jsapp/js/components/submissions/DataTableCell/AudioCell.scss
+++ b/jsapp/js/components/submissions/DataTableCell/AudioCell.scss
@@ -1,4 +1,4 @@
-@use "scss/mixins";
+@use 'scss/mixins';
 
 .audio-cell {
   @include mixins.centerRowFlex;

--- a/jsapp/js/components/submissions/DataTableCell/AudioCell.scss
+++ b/jsapp/js/components/submissions/DataTableCell/AudioCell.scss
@@ -1,6 +1,13 @@
-@use 'scss/mixins';
+@use "scss/mixins";
 
 .audio-cell {
   @include mixins.centerRowFlex;
   height: 100%;
+
+  // Let the player/text section shrink and ellipsis instead of pushing the
+  // action buttons onto a new line when the cell is narrow.
+  > :first-child {
+    min-width: 0;
+    overflow: hidden;
+  }
 }

--- a/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
@@ -56,15 +56,17 @@ export default function AudioCell(props: AudioCellProps) {
 
       {typeof props.mediaAttachment !== 'string' &&
         shouldProcessingBeAccessible(props.submissionData, props.mediaAttachment) && (
-          <>
-            <ActionIcon
-              variant='transparent'
-              tooltip={t('View details')}
-              icon={IconArrowsDiagonal}
-              size='sm'
-              onClick={() => setIsDetailsDialogOpen(true)}
-              ms='sm'
-            />
+          <Group ml='auto' gap={0} wrap='nowrap'>
+            {/* No audio to show if the attachment was deleted. */}
+            {!props.mediaAttachment.is_deleted && (
+              <ActionIcon
+                variant='transparent'
+                tooltip={t('View details')}
+                icon={IconArrowsDiagonal}
+                size='sm'
+                onClick={() => setIsDetailsDialogOpen(true)}
+              />
+            )}
             <ActionIcon
               variant='transparent'
               tooltip={t('Open')}
@@ -74,7 +76,7 @@ export default function AudioCell(props: AudioCellProps) {
                 goToProcessing(props.assetUid, props.xpath, submissionEditId)
               }}
             />
-          </>
+          </Group>
         )}
 
       {downloadUrl && (

--- a/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
@@ -1,9 +1,14 @@
 import './AudioCell.scss'
-import { IconArrowsDiagonal, IconPencilStar } from '@tabler/icons-react'
-import React from 'react'
+
+import { Group, Text } from '@mantine/core'
+import { IconArrowsDiagonal, IconLanguage, IconPencilStar, IconVolume } from '@tabler/icons-react'
+import React, { useState } from 'react'
 import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
 import ActionIcon from '#/components/common/ActionIcon'
+import KoboIcon from '#/components/common/KoboIcon'
+import ProcessingPromptModal from '#/components/common/ProcessingPromptModal'
+import AudioPlayer from '#/components/common/audioPlayer'
 import Icon from '#/components/common/icon'
 import MiniAudioPlayer from '#/components/common/miniAudioPlayer'
 import { goToProcessing } from '#/components/processing/routes.utils'
@@ -31,6 +36,11 @@ export default function AudioCell(props: AudioCellProps) {
 
   const attachmentUid = typeof props.mediaAttachment === 'string' ? undefined : props.mediaAttachment?.uid
   const durationSeconds = useAttachmentDuration(attachmentUid)
+
+  // TODO: temporary, for testing ProcessingPromptModal - remove once the real
+  // action button that opens this dialog is implemented (in another PR).
+  const [isTestDialogOpen, setIsTestDialogOpen] = useState(false)
+  const downloadUrl = typeof props.mediaAttachment === 'string' ? undefined : props.mediaAttachment?.download_url
 
   return (
     <bem.AudioCell>
@@ -67,6 +77,38 @@ export default function AudioCell(props: AudioCellProps) {
             />
           </>
         )}
+
+      {/* TODO: temporary test button for ProcessingPromptModal - remove once the real action button lands. */}
+      {downloadUrl && (
+        <>
+          <ActionIcon
+            variant='transparent'
+            tooltip={t('Test dialog')}
+            icon={IconVolume}
+            size='sm'
+            onClick={() => setIsTestDialogOpen(true)}
+          />
+
+          <ProcessingPromptModal
+            opened={isTestDialogOpen}
+            onClose={() => setIsTestDialogOpen(false)}
+            title={
+              <Group gap='xs'>
+                <KoboIcon icon={IconVolume} size='sm' color='storm' />
+                <Text fw={600}>{t('Tell us more about your experience')}</Text>
+              </Group>
+            }
+            actionLabel={t('Translate & analyze')}
+            actionIcon={IconLanguage}
+            onAction={() => {
+              setIsTestDialogOpen(false)
+              goToProcessing(props.assetUid, props.xpath, submissionEditId)
+            }}
+          >
+            <AudioPlayer mediaURL={downloadUrl} />
+          </ProcessingPromptModal>
+        </>
+      )}
     </bem.AudioCell>
   )
 }

--- a/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/AudioCell.tsx
@@ -1,7 +1,7 @@
 import './AudioCell.scss'
 
 import { Group, Text } from '@mantine/core'
-import { IconArrowsDiagonal, IconLanguage, IconPencilStar, IconVolume } from '@tabler/icons-react'
+import { IconArrowsDiagonal, IconPencilStar, IconVolume } from '@tabler/icons-react'
 import React, { useState } from 'react'
 import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
@@ -25,6 +25,8 @@ interface AudioCellProps {
   submissionData: SubmissionResponse
   /** Required by the mini player. String passed is an error message */
   mediaAttachment: SubmissionAttachment | string
+  /** The question label, as displayed in the column header. */
+  questionLabel: string
 }
 
 /**
@@ -37,9 +39,7 @@ export default function AudioCell(props: AudioCellProps) {
   const attachmentUid = typeof props.mediaAttachment === 'string' ? undefined : props.mediaAttachment?.uid
   const durationSeconds = useAttachmentDuration(attachmentUid)
 
-  // TODO: temporary, for testing ProcessingPromptModal - remove once the real
-  // action button that opens this dialog is implemented (in another PR).
-  const [isTestDialogOpen, setIsTestDialogOpen] = useState(false)
+  const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false)
   const downloadUrl = typeof props.mediaAttachment === 'string' ? undefined : props.mediaAttachment?.download_url
 
   return (
@@ -62,8 +62,7 @@ export default function AudioCell(props: AudioCellProps) {
               tooltip={t('View details')}
               icon={IconArrowsDiagonal}
               size='sm'
-              // TODO(DEV-2370): open the audio response details dialog
-              onClick={() => {}}
+              onClick={() => setIsDetailsDialogOpen(true)}
               ms='sm'
             />
             <ActionIcon
@@ -78,36 +77,23 @@ export default function AudioCell(props: AudioCellProps) {
           </>
         )}
 
-      {/* TODO: temporary test button for ProcessingPromptModal - remove once the real action button lands. */}
       {downloadUrl && (
-        <>
-          <ActionIcon
-            variant='transparent'
-            tooltip={t('Test dialog')}
-            icon={IconVolume}
-            size='sm'
-            onClick={() => setIsTestDialogOpen(true)}
-          />
-
-          <ProcessingPromptModal
-            opened={isTestDialogOpen}
-            onClose={() => setIsTestDialogOpen(false)}
-            title={
-              <Group gap='xs'>
-                <KoboIcon icon={IconVolume} size='sm' color='storm' />
-                <Text fw={600}>{t('Tell us more about your experience')}</Text>
-              </Group>
-            }
-            actionLabel={t('Translate & analyze')}
-            actionIcon={IconLanguage}
-            onAction={() => {
-              setIsTestDialogOpen(false)
-              goToProcessing(props.assetUid, props.xpath, submissionEditId)
-            }}
-          >
-            <AudioPlayer mediaURL={downloadUrl} />
-          </ProcessingPromptModal>
-        </>
+        <ProcessingPromptModal
+          opened={isDetailsDialogOpen}
+          onClose={() => setIsDetailsDialogOpen(false)}
+          title={
+            <Group gap='xs'>
+              <KoboIcon icon={IconVolume} size='sm' color='storm' />
+              <Text fw={600}>{props.questionLabel}</Text>
+            </Group>
+          }
+          onAction={() => {
+            setIsDetailsDialogOpen(false)
+            goToProcessing(props.assetUid, props.xpath, submissionEditId)
+          }}
+        >
+          <AudioPlayer mediaURL={downloadUrl} />
+        </ProcessingPromptModal>
       )}
     </bem.AudioCell>
   )

--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -110,6 +110,7 @@ export default function DataTableCell(props: DataTableCellProps) {
               xpath={audioXpath}
               submissionData={submission}
               mediaAttachment={mediaAttachment}
+              questionLabel={columnName}
             />
           )
         }


### PR DESCRIPTION
### 📣 Summary

Clicking "View details" on an audio response now opens a dialog with an audio player and a "Translate & analyze" action, instead of doing nothing.

### 📖 Description

Adds a reusable `ProcessingPromptModal` dialog and wires it up to the "View details" button on the audio submission data cell. The dialog shows the question label, an inline audio player for the response, and a "Translate & analyze" button that takes the user into the existing Processing view for that submission/question.

### 💭 Notes

- Builds on top of #DEV-2369 (`phil/dev-2369-nlp-data-cell-buttons`), which added the NLP action buttons row (including the previously no-op "View details" button) to `AudioCell`.
- `ProcessingPromptModal` is intentionally generic (title + children + `onAction`) so it can be reused for other question types (text, etc.) in the future.
- The dialog only renders when a `download_url` is available on the attachment.

### 👀 Preview steps

1. ℹ️ have a project with an audio question and at least one submission with a recorded response
2. go to the submissions table
3. click the "View details" (expand) icon on an audio cell
4. 🔴 [on main] nothing happens
5. 🟢 [on PR] a dialog opens showing the question label, an audio player for the response, and a "Translate & analyze" button
6. click "Translate & analyze"
7. 🟢 the dialog closes and you're taken to the Processing view for that submission/question
8. Add a transcription to the audio
9. Delete the attached audio
10. 🟢 the "View Details" button should disappear, but NLP button is still displayed
11. 🟢 Without a trancription/translation, both buttons are hiddens in the cell
