### PR TITLE
fix(nlp): collapse runaway phrase repetition in automatic transcripts DEV-2733

### DIFF
--- a/kobo/apps/subsequences/integrations/google/google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/google/google_transcribe.py
@@ -39,13 +39,14 @@ from ...exceptions import (
     GoogleQuotaExceededError,
     GoogleTranscriptionServiceNotConfigured,
     SubsequenceTimeoutError,
-    TranscriptionResultNotFound
+    TranscriptionResultNotFound,
 )
+from ...utils.repetition import collapse_runaway_repetitions
 from .base import GoogleService
 from .locations import (
     get_asr_language_code_overrides,
+    get_speech_location_for_model,
     get_speech_location_for_region,
-    get_speech_location_for_model
 )
 from .rate_limit import (
     GoogleServiceRateLimitExceeded,
@@ -699,7 +700,17 @@ class GoogleTranscriptionService(GoogleService):
                 'No transcription JSON result files were found in Google Cloud Storage.'
             )
 
-        return ' '.join(transcript_parts).strip()
+        transcript = ' '.join(transcript_parts).strip()
+        collapsed = collapse_runaway_repetitions(
+            transcript, constance.config.ASR_MAX_CONSECUTIVE_REPEATS
+        )
+        if collapsed != transcript:
+            # Never log transcript content: it is user data
+            logging.warning(
+                'Collapsed runaway phrase repetition in automatic transcript '
+                f'for {xpath=}: {len(transcript)} -> {len(collapsed)} characters'
+            )
+        return collapsed
 
     def _get_bulk_action_item(self, bulk_action_uid: str | None):
         """

--- a/kobo/apps/subsequences/integrations/tests/test_google_transcribe.py
+++ b/kobo/apps/subsequences/integrations/tests/test_google_transcribe.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,20 @@ def _get_service_with_blobs(blobs):
     service.bucket.list_blobs.return_value = blobs
     service._get_batch_paths = MagicMock(return_value=('input.flac', 'output'))
     return service
+
+
+def _override_asr_max_repeats(value: int = 5):
+    """
+    Patch the constance value read by `_read_batch_result` without a database
+
+    The constance database backend requires DB access, so patch the config
+    object referenced by the module to keep these read-path tests DB-free.
+    """
+    return patch(
+        'kobo.apps.subsequences.integrations.google.google_transcribe'
+        '.constance.config',
+        SimpleNamespace(ASR_MAX_CONSECUTIVE_REPEATS=value),
+    )
 
 
 def _get_service_for_process_data():
@@ -124,6 +139,7 @@ def test_read_batch_result_raises_when_no_json_result_files_exist():
     assert 'No transcription JSON result files were found' in str(exc_info.value)
 
 
+@_override_asr_max_repeats()
 def test_read_batch_result_returns_empty_transcript_for_silent_audio_result():
     service = _get_service_with_blobs(
         [
@@ -149,6 +165,7 @@ def test_read_batch_result_returns_empty_transcript_for_silent_audio_result():
     assert service._read_batch_result('audio', 'en-US') == ''
 
 
+@_override_asr_max_repeats()
 def test_read_batch_result_joins_transcripts_from_json_result_files():
     service = _get_service_with_blobs(
         [
@@ -164,6 +181,30 @@ def test_read_batch_result_joins_transcripts_from_json_result_files():
     )
 
     assert service._read_batch_result('audio', 'en-US') == 'Hello world'
+
+
+@_override_asr_max_repeats()
+def test_read_batch_result_collapses_runaway_repetition():
+    transcript = 'the story begins ' + 'na niko, ' * 300
+    service = _get_service_with_blobs(
+        [
+            MockBlob(
+                'output/result.json',
+                json.dumps(
+                    {
+                        'results': [
+                            {'alternatives': [{'transcript': transcript.strip()}]},
+                        ]
+                    }
+                ),
+            ),
+        ]
+    )
+
+    result = service._read_batch_result('audio', 'en-US')
+
+    assert result == 'the story begins ' + ('na niko, ' * 5).strip()
+    assert result.count('niko') == 5
 
 
 def test_process_data_returns_failed_for_missing_google_service_config():

--- a/kobo/apps/subsequences/tests/test_repetition.py
+++ b/kobo/apps/subsequences/tests/test_repetition.py
@@ -1,0 +1,57 @@
+from kobo.apps.subsequences.utils.repetition import collapse_runaway_repetitions
+
+
+def test_collapses_bigram_loop_and_keeps_leading_text():
+    text = 'the story begins here ' + 'na niko, ' * 300
+    result = collapse_runaway_repetitions(text.strip(), max_repeats=5)
+
+    assert result == 'the story begins here ' + ('na niko, ' * 5).strip()
+    assert result.count('niko') == 5
+
+
+def test_returns_byte_identical_when_at_or_below_threshold():
+    text = 'na niko,  na niko, na niko, na niko, na niko,'
+    result = collapse_runaway_repetitions(text, max_repeats=5)
+
+    assert result is text
+
+
+def test_normalization_ignores_case_and_trailing_punctuation():
+    text = 'Na niko, ' + 'na niko. ' * 400
+    result = collapse_runaway_repetitions(text.strip(), max_repeats=3)
+
+    # The run is one loop despite case/punctuation drift, trimmed to 3 copies
+    # while the kept occurrences preserve their original spelling.
+    assert result == 'Na niko, na niko. na niko.'
+
+
+def test_collapses_unigram_run():
+    text = 'yes ' + 'no ' * 200
+    result = collapse_runaway_repetitions(text.strip(), max_repeats=4)
+
+    assert result == 'yes no no no no'
+
+
+def test_collapses_trigram_run():
+    text = 'one two three ' * 100
+    result = collapse_runaway_repetitions(text.strip(), max_repeats=2)
+
+    assert result == 'one two three one two three'
+
+
+def test_collapses_loop_starting_at_odd_offset():
+    text = 'intro ' + 'na niko, ' * 300
+    result = collapse_runaway_repetitions(text.strip(), max_repeats=5)
+
+    assert result == 'intro ' + ('na niko, ' * 5).strip()
+
+
+def test_disabled_when_max_repeats_is_zero():
+    text = 'na niko, ' * 500
+    result = collapse_runaway_repetitions(text, max_repeats=0)
+
+    assert result is text
+
+
+def test_empty_string_returns_empty_string():
+    assert collapse_runaway_repetitions('', max_repeats=5) == ''

--- a/kobo/apps/subsequences/utils/repetition.py
+++ b/kobo/apps/subsequences/utils/repetition.py
@@ -1,0 +1,76 @@
+import string
+
+MAX_REPEATED_NGRAM_WORDS = 5
+
+
+def collapse_runaway_repetitions(
+    text: str,
+    max_repeats: int,
+    max_ngram: int = MAX_REPEATED_NGRAM_WORDS,
+) -> str:
+    """
+    Clamp pathological consecutive n-gram runs in a transcript
+
+    Automatic speech recognition models can get stuck in a decoder loop and
+    fill the transcript with one short phrase repeated hundreds of times. Any
+    n-gram (for n from 1 to `max_ngram`) that repeats more than `max_repeats`
+    consecutive times is trimmed to its first `max_repeats` occurrences.
+
+    Comparison is case-insensitive and ignores leading/trailing punctuation so
+    that a loop drifting in casing or punctuation still counts as one run; the
+    kept occurrences preserve their original spelling. When nothing is trimmed,
+    the original `text` object is returned unchanged so clean transcripts are
+    byte-identical (whitespace is never re-normalized).
+    """
+    if max_repeats <= 0 or not text.strip():
+        return text
+
+    tokens = text.split()
+    keys = [token.casefold().strip(string.punctuation) for token in tokens]
+    trimmed = False
+
+    for n in range(1, max_ngram + 1):
+        kept_tokens: list[str] = []
+        kept_keys: list[str] = []
+        i = 0
+        length = len(keys)
+        while i < length:
+            end = i + n
+            ngram = keys[i:end]
+            if len(ngram) < n:
+                kept_tokens.append(tokens[i])
+                kept_keys.append(keys[i])
+                i += 1
+                continue
+
+            run = 1
+            j = end
+            nxt = j + n
+            while keys[j:nxt] == ngram:
+                run += 1
+                j = nxt
+                nxt = j + n
+
+            if run > max_repeats:
+                trimmed = True
+                keep_end = i + max_repeats * n
+                kept_tokens.extend(tokens[i:keep_end])
+                kept_keys.extend(keys[i:keep_end])
+            elif run > 1:
+                kept_tokens.extend(tokens[i:j])
+                kept_keys.extend(keys[i:j])
+            else:
+                kept_tokens.append(tokens[i])
+                kept_keys.append(keys[i])
+                i += 1
+                continue
+
+            i = j
+
+        tokens = kept_tokens
+        keys = kept_keys
+
+    if not trimmed:
+        return text
+
+    return ' '.join(tokens)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -382,6 +382,16 @@ CONSTANCE_CONFIG = {
             ' the operations API. '
         )
     ),
+    'ASR_MAX_CONSECUTIVE_REPEATS': (
+        5,
+        (
+            'Maximum number of times a short phrase may repeat consecutively '
+            'in an automatic transcript before the extra repeats are trimmed. '
+            'Automatic speech recognition models can get stuck in a loop and '
+            'fill the transcript with one repeated phrase. Set to 0 to disable '
+            'trimming.'
+        ),
+    ),
     'ASR_MT_GOOGLE_PROJECT_ID': (
         env.str('CONSTANCE_ASR_MT_GOOGLE_PROJECT_ID', 'kobo-asr-mt'),
         'ID of the Google Cloud project used to access ASR/MT APIs',
@@ -800,6 +810,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         'ASR_LANGUAGE_CODE_OVERRIDES',
         'ASR_MT_GOOGLE_CREDENTIALS',
         'ASR_MT_GOOGLE_REQUEST_TIMEOUT',
+        'ASR_MAX_CONSECUTIVE_REPEATS',
         'AUTOMATIC_QA_REQUESTS_PER_SECOND'
     ),
     'Security': (


### PR DESCRIPTION
### 📣 Summary
Automatic transcripts no longer fill up with the same short phrase repeated hundreds of times.

### 📖 Description
When automatic transcription got stuck on a short phrase (reported with Swahili audio mixed with French), the transcript came back as pages of the same two words repeated until the end of the recording. Those runaway repeats are now trimmed and the rest of the transcript is kept as is.

### 💭 Notes
- Google STT v2 (`chirp_3`) can fall into a decoder loop on low-resource languages: the ticket's audio yields `na niko,` about 300 times, even with the `sw:auto` override from DEV-2403 active, so remapping the language code doesn't prevent it.
- The fix clamps consecutive repeats of any phrase of 1 to 5 words in `_read_batch_result()`, the single choke point for both completion paths. Comparison ignores case and punctuation drift; a transcript with nothing to trim comes back byte-identical.
- The threshold is a new Constance key, `ASR_MAX_CONSECUTIVE_REPEATS` (default 5, 0 disables), so it can be tuned without a deploy, same as `ASR_LANGUAGE_CODE_OVERRIDES`.
- When trimming happens we log a warning with the before/after character counts, never the transcript text.

### 👀 Preview steps
Backend only, reproducible with the bundled tests (in the kpi container):

1. `pytest kobo/apps/subsequences/tests/test_repetition.py kobo/apps/subsequences/integrations/tests/test_google_transcribe.py -q`

🔴 On `main`, a batch result whose transcript is `<valid text> na niko, na niko, …` (×300) is stored verbatim: 2,739 characters of loop.
🟢 On this PR, the same payload is stored as the valid text plus 5 repeats (84 characters), and a warning with the sizes is logged.
