### PR TITLE
test(storybook): improve map stories DEV-2762

### DIFF
--- a/jsapp/js/components/map/FormMapWrapper.stories.tsx
+++ b/jsapp/js/components/map/FormMapWrapper.stories.tsx
@@ -216,6 +216,55 @@ function mapHandlers(asset: AssetResponse, submissions: SubmissionResponse[]) {
   ]
 }
 
+/**
+ * Ceiling shared by the waits below. `waitFor` carries on the moment its condition holds, so a high ceiling costs
+ * nothing on a quick machine and only buys patience on a cold CI worker. Kept under the runner's 30s per-story limit,
+ * so a real regression fails on the assertion rather than on the clock.
+ */
+const WAIT = { timeout: 10000 }
+
+/** The markers the map has drawn, clusters included. Scoped to the map, so it also covers the container being there. */
+const plottedMarkers = (canvasElement: HTMLElement) => canvasElement.querySelectorAll('#data-map .leaflet-marker-icon')
+
+/**
+ * What state the map is in, to go with a wait that gave up. On CI the failure is otherwise only "expected 0 to be
+ * greater than 0", which does not say whether the data never arrived, the container has no size, or Leaflet drew nothing.
+ */
+function describeMap(canvasElement: HTMLElement) {
+  const container = canvasElement.querySelector('#data-map')
+  const tiles = Array.from(canvasElement.querySelectorAll('#data-map .leaflet-tile'))
+  const zooms = new Set(tiles.map((tile) => tile.getAttribute('src')?.match(/\/(\d+)\/\d+\/\d+/)?.[1]))
+  const overlay = Array.from(canvasElement.querySelectorAll('.map-no-geopoint'), (line) => line.textContent).join(' / ')
+  const size = container ? `${container.clientWidth}×${container.clientHeight}` : 'no container'
+  return `map ${size}, ${tiles.length} tiles at zoom ${[...zooms].join()}, overlay "${overlay}"`
+}
+
+/**
+ * Waits for the map to plot its submissions, in the two steps it goes through: the data lands (the map stops saying it
+ * is fetching points), then Leaflet draws it. Both are the map's own signals, so no story has to guess at how long
+ * either takes.
+ */
+async function waitForPlottedPoints(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement)
+  await waitFor(
+    () => expect(canvas.queryByText(/Fetching points/i), describeMap(canvasElement)).not.toBeInTheDocument(),
+    WAIT,
+  )
+  await waitFor(() => expect(plottedMarkers(canvasElement).length, describeMap(canvasElement)).toBeGreaterThan(0), WAIT)
+}
+
+/**
+ * Waits for one zoom step to land. Leaflet drops a zoom it is asked for while still animating the previous one, so
+ * clicks have to be spaced out by this. The animation starts on the frame after the click, hence the two frames before
+ * trusting that the class it puts on the pane is gone.
+ */
+async function waitForZoomToLand(canvasElement: HTMLElement) {
+  await new Promise(requestAnimationFrame)
+  await new Promise(requestAnimationFrame)
+  const mapPane = canvasElement.querySelector('.leaflet-map-pane')
+  await waitFor(() => expect(mapPane).not.toHaveClass('leaflet-zoom-anim'), WAIT)
+}
+
 const meta: Meta<typeof FormMapWrapper> = {
   title: 'Features/FormMap',
   component: FormMapWrapper,
@@ -266,35 +315,16 @@ export const WithOnlyStartGeopoint: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
-    await step('Verify that the map container is rendered', async () => {
-      await waitFor(
-        async () => {
-          const mapContainer = canvasElement.querySelector('#data-map')
-          expect(mapContainer).toBeInTheDocument()
-        },
-        { timeout: 5000 },
-      )
-    })
+    await step('Wait for the map to plot the start-geopoints', () => waitForPlottedPoints(canvasElement))
 
+    // Checked once the points are drawn, so a missing error means there is none rather than that we looked too early
     await step('Verify that the map does NOT show "no geographical data" error', async () => {
-      await waitFor(
-        async () => {
-          const errorText = canvas.queryByText(/This project does not include geographical data/i)
-          expect(errorText).not.toBeInTheDocument()
-        },
-        { timeout: 5000 },
-      )
+      expect(canvas.queryByText(/This project does not include geographical data/i)).not.toBeInTheDocument()
     })
 
     await step('Verify that map settings button is enabled (indicates geo questions detected)', async () => {
-      await waitFor(
-        async () => {
-          // The settings button should be enabled when hasGeoPoint is true
-          const settingsButton = canvas.getByLabelText('Map display settings')
-          expect(settingsButton).toBeEnabled()
-        },
-        { timeout: 5000 },
-      )
+      // The settings button should be enabled when hasGeoPoint is true
+      expect(canvas.getByLabelText('Map display settings')).toBeEnabled()
     })
   },
 }
@@ -310,37 +340,20 @@ export const WithBothGeopointTypes: Story = {
     const canvas = within(canvasElement)
     const page = within(document.body)
 
-    await step('Verify that the map loads successfully', async () => {
-      await waitFor(
-        async () => {
-          const mapContainer = canvasElement.querySelector('#data-map')
-          expect(mapContainer).toBeInTheDocument()
-        },
-        { timeout: 5000 },
-      )
-    })
+    await step('Verify that the map loads successfully', () => waitForPlottedPoints(canvasElement))
 
     await step('Verify map settings button is enabled', async () => {
-      await waitFor(
-        async () => {
-          const settingsButton = canvas.getByLabelText('Map display settings')
-          expect(settingsButton).toBeEnabled()
-        },
-        { timeout: 5000 },
-      )
+      expect(canvas.getByLabelText('Map display settings')).toBeEnabled()
     })
 
     await step('Open Map display settings', async () => {
       const settingsButton = canvas.getByLabelText('Map display settings')
       settingsButton.click()
 
-      await waitFor(
-        async () => {
-          const modal = page.getByRole('dialog', { name: /Map Settings/i })
-          expect(modal).toBeInTheDocument()
-        },
-        { timeout: 5000 },
-      )
+      await waitFor(async () => {
+        const modal = page.getByRole('dialog', { name: /Map Settings/i })
+        expect(modal).toBeInTheDocument()
+      }, WAIT)
     })
 
     await step('Switch to geopoint question tab', async () => {
@@ -348,27 +361,21 @@ export const WithBothGeopointTypes: Story = {
       const geopointTab = within(modal).getByRole('tab', { name: /geopoint question/i })
       geopointTab.click()
 
-      await waitFor(
-        async () => {
-          expect(geopointTab).toHaveAttribute('aria-selected', 'true')
-        },
-        { timeout: 5000 },
-      )
+      await waitFor(async () => {
+        expect(geopointTab).toHaveAttribute('aria-selected', 'true')
+      }, WAIT)
     })
 
     await step('Verify both geopoint questions are available', async () => {
       const modal = page.getByRole('dialog', { name: /Map Settings/i })
 
-      await waitFor(
-        async () => {
-          const whereAreYouOption = within(modal).getByText('Where are you?')
-          const startGeopointOption = within(modal).getByText('start-geopoint')
+      await waitFor(async () => {
+        const whereAreYouOption = within(modal).getByText('Where are you?')
+        const startGeopointOption = within(modal).getByText('start-geopoint')
 
-          expect(whereAreYouOption).toBeInTheDocument()
-          expect(startGeopointOption).toBeInTheDocument()
-        },
-        { timeout: 5000 },
-      )
+        expect(whereAreYouOption).toBeInTheDocument()
+        expect(startGeopointOption).toBeInTheDocument()
+      }, WAIT)
     })
   },
 }
@@ -384,9 +391,7 @@ export const WithPointsAcrossAntimeridian: Story = {
   // read it as the 340° span the other way around and zoomed out to the whole world. Waiting for the markers only keeps
   // the snapshot from being taken before the map has finished drawing itself.
   play: async ({ canvasElement }) => {
-    await waitFor(() => expect(canvasElement.querySelectorAll('.leaflet-marker-icon').length).toBeGreaterThan(0), {
-      timeout: 5000,
-    })
+    await waitForPlottedPoints(canvasElement)
   },
 }
 
@@ -397,22 +402,29 @@ export const WithPointsRepeatedInEveryWorldCopy: Story = {
   args: {
     asset: assetWithPacificGeopoints,
   },
-  // Zooming all the way out is what this story is about, so that part is not a check and has to stay — it is what puts
-  // several copies of the world on screen for Chromatic to snapshot. What the points then do is the snapshot's business:
-  // a cluster in every copy, one every 256 pixels. `getWorldCopyOffsets()` has the unit tests for the arithmetic.
-  play: async ({ canvasElement }) => {
-    await waitFor(() => expect(canvasElement.querySelectorAll('.leaflet-marker-icon').length).toBeGreaterThan(0), {
-      timeout: 5000,
+  // Zooming all the way out is the setup rather than the check: it is what puts several copies of the world on screen
+  // for Chromatic to snapshot. The play function only counts the clusters; where exactly they land is the snapshot's
+  // business, and `getWorldCopyOffsets()` has the unit tests for the arithmetic.
+  play: async ({ canvasElement, step }) => {
+    await step('Wait for the map to plot the points', () => waitForPlottedPoints(canvasElement))
+
+    await step('Zoom out as far as the map goes', async () => {
+      const zoomOutButton = canvasElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-out')
+      expect(zoomOutButton).toBeInTheDocument()
+
+      // `maxZoom` is 17, so the minimum is never more than 17 clicks away; the spare attempts cover clicks the map
+      // dropped while animating the one before.
+      for (let attempt = 0; attempt < 30 && !zoomOutButton?.classList.contains('leaflet-disabled'); attempt++) {
+        zoomOutButton?.click()
+        await waitForZoomToLand(canvasElement)
+      }
+      expect(zoomOutButton).toHaveClass('leaflet-disabled')
     })
 
-    await waitFor(
-      () => {
-        // One click per attempt, until the control tells us there is nowhere left to zoom out to
-        const zoomOutButton = canvasElement.querySelector<HTMLAnchorElement>('.leaflet-control-zoom-out')
-        zoomOutButton?.click()
-        expect(zoomOutButton).toHaveClass('leaflet-disabled')
-      },
-      { timeout: 10000 },
-    )
+    await step('Verify the points show up in every copy of the world on screen', async () => {
+      // At this zoom the world fits on screen several times over, and every copy gets its own cluster of the same four
+      // points — so more than the single cluster the points alone would make.
+      await waitFor(() => expect(plottedMarkers(canvasElement).length).toBeGreaterThan(1), WAIT)
+    })
   },
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 💭 Notes

Background: `WithPointsRepeatedInEveryWorldCopy` failed on CI with `expected 0 to be greater than 0` — no markers within 5s. Locally the map plots its points in ~0.7s (chromium), ~0.8s (firefox), ~0.85s (webkit), but one cold run under CPU load took 5.3s (over the timeout set)

Changes here, all in `FormMapWrapper.stories.tsx`:

- **`waitForPlottedPoints()`** — shared wait used by every story: first the map's own "Fetching points…" overlay has to go away, then the markers have to be drawn. Replaces the `#data-map` in-the-document checks, which passed long before anything was plotted.
- **`WAIT`** — one ceiling for the whole file, 5s → 10s. `waitFor` resolves when condition holds, so if nothing is broken it will be much faster than 10
- **`describeMap()`** — attaches the map's state to a failing assertion, so the next CI failure names the state instead of just counting to zero
- **`WithPointsRepeatedInEveryWorldCopy`**
  - the `waitFor` that clicked zoom-out from inside its own callback is now a plain loop that waits for each zoom animation to land
  - new closing step asserts more than one cluster on screen, which is what the story's name has claimed all along
- **`WithOnlyStartGeopoint` / `WithBothGeopointTypes`** — checks that only needed the map loaded now run once, after `waitForPlottedPoints()`

### 👀 Preview steps

1. ℹ️ nothing changes in the app itself — if you want to confirm, Project → Data → Map looks and behaves the same as on main
2. run `npm run storybook` locally
3. go to Features → FormMap → With Points Repeated In Every World Copy
4. 🟢 notice the map is zoomed all the way out, with several copies of the world side by side and a cluster of 4 points in each
5. 🟢 notice the CI passes for this PR
6. Rerun CI multiple (5? 🤣) times, each time ensuring it passes