### PR TITLE
fix(frontend): show project name in tab title for data views

### DIFF
--- a/jsapp/js/components/formSubScreens.js
+++ b/jsapp/js/components/formSubScreens.js
@@ -47,25 +47,38 @@ export class FormSubScreens extends React.Component {
     }
 
     var iframeUrl = ''
+    var docTitle = this.state.name || t('Untitled')
 
     if (this.state.uid != undefined) {
       switch (this.props.router.location.pathname) {
         case ROUTES.FORM_TABLE.replace(':uid', this.state.uid):
           return (
-            <Suspense fallback={null}>
-              <DataTable asset={this.state} />
-            </Suspense>
+            <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+              <Suspense fallback={null}>
+                <DataTable asset={this.state} />
+              </Suspense>
+            </DocumentTitle>
           )
         case ROUTES.FORM_GALLERY.replace(':uid', this.state.uid):
           return (
-            <Suspense fallback={<div>Image Gallery</div>}>
-              <FormGallery asset={this.state} />
-            </Suspense>
+            <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+              <Suspense fallback={<div>Image Gallery</div>}>
+                <FormGallery asset={this.state} />
+              </Suspense>
+            </DocumentTitle>
           )
         case ROUTES.FORM_MAP.replace(':uid', this.state.uid):
-          return <FormMapWrapper asset={this.state} />
+          return (
+            <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+              <FormMapWrapper asset={this.state} />
+            </DocumentTitle>
+          )
         case ROUTES.FORM_MAP_BY.replace(':uid', this.state.uid).replace(':viewby', this.props.params.viewby):
-          return <FormMapWrapper asset={this.state} viewby={this.props.params.viewby} />
+          return (
+            <DocumentTitle title={`${docTitle} | KoboToolbox`}>
+              <FormMapWrapper asset={this.state} viewby={this.props.params.viewby} />
+            </DocumentTitle>
+          )
         case ROUTES.FORM_DOWNLOADS.replace(':uid', this.state.uid):
           return (
             <Suspense fallback={null}>
@@ -90,8 +103,6 @@ export class FormSubScreens extends React.Component {
           return <FormActivity />
       }
     }
-
-    var docTitle = this.state.name || t('Untitled')
 
     return (
       <DocumentTitle title={`${docTitle} | KoboToolbox`}>


### PR DESCRIPTION
Closes #7336

### Summary

The browser tab now shows the project name when viewing a project's **Data** section, matching the behaviour of the Summary, Form, and Settings sections.

### Description

Previously, opening a project's **Data → Table**, **Gallery**, or **Map** view left the browser tab titled just "KoboToolbox", making it hard to tell several open project tabs apart. These views now use the same `<project name> | KoboToolbox` title already used elsewhere in the project view.

**Data → Report** and **Data → Downloads** were already setting their titles correctly and are unchanged.

### Description for instance maintainers

`FormSubScreens.render()` returns early from its route `switch`, before the `DocumentTitle` wrapper at the bottom of the method. The `FORM_TABLE`, `FORM_GALLERY`, `FORM_MAP`, and `FORM_MAP_BY` branches therefore never mounted a `DocumentTitle`, so the title fell back to the app-level default in `app.jsx`.

`docTitle` is now computed once at the top of `render()` and those four branches are wrapped in the existing `DocumentTitle` component. No new imports, no new dependencies, no API or response-format changes.

### Notes

- `FORM_REPORT` (`Reports`) and `FORM_DOWNLOADS` (`ProjectDownloads`) already render their own `DocumentTitle`, so they were left untouched to avoid redundant nesting.
- `DocumentTitle` wraps the `Suspense` boundary rather than sitting inside it, so the title is set immediately instead of waiting for the lazy chunk to load.
- The Settings sub-routes `sharing`, `media`, and `connect-projects` also lack titles, but those are outside this issue's scope and left for a follow-up.

### Preview steps

1. have an account and a project with at least one submission
2. open the project and go to the **SUMMARY** tab
3. notice the browser tab reads `<project name> | KoboToolbox`
4. go to the **DATA** tab (Table view)
5. [on main] notice the browser tab reads only `KoboToolbox`
6. [on PR] notice the browser tab reads `<project name> | KoboToolbox`
7. switch to the **Gallery** and **Map** sub-tabs
8. notice the title stays `<project name> | KoboToolbox` on both
9. switch to the **Report** and **Downloads** sub-tabs
10. notice these are unchanged and still read `<project name> | KoboToolbox`
