### PR TITLE
feat(sso): add functional index for email domains DEV-2355

### DIFF
--- a/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
+++ b/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
@@ -9,7 +9,9 @@ def manually_create_indexes_instructions(apps, schema_editor):
         ⚠️ ATTENTION ⚠️
         Run the SQL query below in PostgreSQL directly:
 
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS "auth_user_email_domain_idx" ON "auth_user" (split_part(lower("email"), '@', 2));
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS
+        "auth_user_email_domain_idx" ON
+        "auth_user" (split_part(lower("email"), '@', 2));
     """)
 
 

--- a/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
+++ b/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
@@ -1,15 +1,33 @@
+from django.conf import settings
 from django.db import migrations, models
 from django.db.models import Func, Value
 from django.db.models.functions import Lower
 
 
-class Migration(migrations.Migration):
+def manually_create_indexes_instructions(apps, schema_editor):
+    print(
+        """
+        ⚠️ ATTENTION ⚠️
+        Run the SQL query below in PostgreSQL directly:
 
-    dependencies = [
-        ('kobo_auth', '0001_initial'),
-    ]
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "auth_user_email_domain_idx" ON "auth_user" (split_part(lower("email"), '@', 2));
+        """
+    )
 
-    operations = [
+
+def manually_drop_indexes_instructions(apps, schema_editor):
+    print(
+        """
+        ⚠️ ATTENTION ⚠️
+        Run the SQL query below in PostgreSQL directly:
+
+        DROP INDEX CONCURRENTLY IF EXISTS "auth_user_email_domain_idx";
+        """
+    )
+
+
+def get_conditional_operations():
+    state_ops = [
         migrations.AddIndex(
             model_name='user',
             index=models.Index(
@@ -22,5 +40,31 @@ class Migration(migrations.Migration):
                 ),
                 name='auth_user_email_domain_idx',
             ),
-        ),
+        )
+    ]
+
+    if getattr(settings, 'SKIP_HEAVY_MIGRATIONS', False):
+        return [
+            migrations.SeparateDatabaseAndState(
+                database_operations=[
+                    migrations.RunPython(
+                        manually_create_indexes_instructions,
+                        manually_drop_indexes_instructions,
+                    )
+                ],
+                state_operations=state_ops,
+            )
+        ]
+
+    return state_ops
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kobo_auth', '0001_initial'),
+    ]
+
+    operations = [
+        *get_conditional_operations(),
     ]

--- a/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
+++ b/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+from django.db.models import Func, Value
+from django.db.models.functions import Lower
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kobo_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='user',
+            index=models.Index(
+                Func(
+                    Lower('email'),
+                    Value('@'),
+                    Value(2),
+                    function='split_part',
+                    output_field=models.CharField(),
+                ),
+                name='auth_user_email_domain_idx',
+            ),
+        ),
+    ]

--- a/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
+++ b/kobo/apps/kobo_auth/migrations/0002_add_auth_user_email_domain_idx.py
@@ -5,25 +5,21 @@ from django.db.models.functions import Lower
 
 
 def manually_create_indexes_instructions(apps, schema_editor):
-    print(
-        """
+    print("""
         ⚠️ ATTENTION ⚠️
         Run the SQL query below in PostgreSQL directly:
 
         CREATE INDEX CONCURRENTLY IF NOT EXISTS "auth_user_email_domain_idx" ON "auth_user" (split_part(lower("email"), '@', 2));
-        """
-    )
+    """)
 
 
 def manually_drop_indexes_instructions(apps, schema_editor):
-    print(
-        """
+    print("""
         ⚠️ ATTENTION ⚠️
         Run the SQL query below in PostgreSQL directly:
 
         DROP INDEX CONCURRENTLY IF EXISTS "auth_user_email_domain_idx";
-        """
-    )
+        """)
 
 
 def get_conditional_operations():

--- a/kobo/apps/kobo_auth/models.py
+++ b/kobo/apps/kobo_auth/models.py
@@ -1,5 +1,8 @@
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
+from django.db import models
+from django.db.models import Func, Value
+from django.db.models.functions import Lower
 from django_request_cache import cache_for_request
 
 from kobo.apps.openrosa.libs.constants import OPENROSA_APP_LABELS
@@ -18,6 +21,18 @@ class User(AbstractUser):
     class Meta:
         db_table = 'auth_user'
         swappable = 'AUTH_USER_MODEL'
+        indexes = [
+            models.Index(
+                Func(
+                    Lower('email'),
+                    Value('@'),
+                    Value(2),
+                    function='split_part',
+                    output_field=models.CharField(),
+                ),
+                name='auth_user_email_domain_idx',
+            ),
+        ]
 
     def has_perm(self, perm, obj=None):
         # If it is a KoboCAT permissions, check permission in KoboCAT DB first

--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -10,7 +10,16 @@ from celery import shared_task
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.files.storage import default_storage
-from django.db.models import CharField, Count, DateField, F, Func, IntegerField, Sum, Value
+from django.db.models import (
+    CharField,
+    Count,
+    DateField,
+    F,
+    Func,
+    IntegerField,
+    Sum,
+    Value,
+)
 from django.db.models.functions import Cast, Concat, Lower
 
 from hub.models import ExtraUserDetail

--- a/kobo/apps/superuser_stats/tasks.py
+++ b/kobo/apps/superuser_stats/tasks.py
@@ -10,8 +10,8 @@ from celery import shared_task
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.files.storage import default_storage
-from django.db.models import CharField, Count, DateField, F, IntegerField, Sum, Value
-from django.db.models.functions import Cast, Concat
+from django.db.models import CharField, Count, DateField, F, Func, IntegerField, Sum, Value
+from django.db.models.functions import Cast, Concat, Lower
 
 from hub.models import ExtraUserDetail
 from kobo.apps.kobo_auth.shortcuts import User
@@ -179,7 +179,15 @@ def generate_domain_report(output_filename: str, start_date: str, end_date: str)
     # get a count of the assets
     domain_assets = {
         domain: Asset.objects.filter(
-            owner__email__endswith='@' + domain,
+            owner__in=User.objects.annotate(
+                email_domain=Func(
+                    Lower('email'),
+                    Value('@'),
+                    Value(2),
+                    function='split_part',
+                    output_field=CharField(),
+                )
+            ).filter(email_domain=domain.lower()),
             date_created__date__range=(start_date, end_date),
         ).count()
         for domain in domain_users.keys()
@@ -201,7 +209,15 @@ def generate_domain_report(output_filename: str, start_date: str, end_date: str)
                 )
             )
             .filter(
-                user__email__endswith='@' + domain,
+                user__in=User.objects.annotate(
+                    email_domain=Func(
+                        Lower('email'),
+                        Value('@'),
+                        Value(2),
+                        function='split_part',
+                        output_field=CharField(),
+                    )
+                ).filter(email_domain=domain.lower()),
                 date__range=(start_date, end_date),
             )
             .aggregate(Sum('counter'))['counter__sum']


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Adds a new index to lookup email domains used by the enforce task and the registration checks 

### 📖 Description
When searching for users with specific domains, this index built using the expression `split_part(lower(email), '@', 2)` will help reduce the query execution time by around 21x compared to a sequential scan. This is important for registration checks and also for a enforce background task that will be triggered when an organization adds a managed domain. This task will query auth_user to find all existing user accounts with that domain and enforce SSO restriction rules on them.

### 👷 Description for instance maintainers
Note that the index creation is going to block writes to the auth_user table, so you will have to disable heavy migrations manually if this is a concern for your instance.

**IMPORTANT NOTE:** This index won't be supported by SQLite, only by Postgres. 

### 👀 Preview steps

1. You can run this in the dbshell to check that the index has been created, the query plan should include a Bitmap Index Scan description:

```
koboform=# EXPLAIN ANALYZE 
SELECT id, username, email 
FROM auth_user 
WHERE split_part(lower(email), '@', 2) = 'domain10.com';
                  
                                                 QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on auth_user  (cost=5.27..446.19 rows=500 width=41) (actual time=0.663..7.203 rows=200 loops=1)
   Recheck Cond: (split_part(lower((email)::text), '@'::text, 2) = 'domain10.com'::text)
   Heap Blocks: exact=200
   ->  Bitmap Index Scan on auth_user_email_domain_idx  (cost=0.00..5.14 rows=500 width=0) (actual time=0.589..0.589 rows=200 loops=1)
         Index Cond: (split_part(lower((email)::text), '@'::text, 2) = 'domain10.com'::text)
 Planning Time: 2.810 ms
 Execution Time: 7.356 ms
(7 rows)
```