### PR TITLE
feat(processing): hide Transcript tab for text questions DEV-2374

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/index.tsx
@@ -1,13 +1,15 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useEffect } from 'react'
 import type { AdvancedFeatureResponse } from '#/api/models/advancedFeatureResponse'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
+import { findRowByXpath } from '#/assetUtils'
 import type { AssetResponse } from '#/dataInterface'
 import protectorHelpers from '#/protector/protectorHelpers'
 import { PROCESSING_ROUTES } from '#/router/routerConstants'
-import { goToTabRoute, isProcessingRouteActive } from '../routes.utils'
+import { getAvailableTabsForQuestionType } from '../common/utils'
+import { ProcessingTab, goToTabRoute, isProcessingRouteActive } from '../routes.utils'
 import TabAnalysis from './TabAnalysis'
 import TabTranscript from './TabTranscript'
 import TabTranslations from './TabTranslations'
@@ -39,6 +41,10 @@ export default function SingleProcessingContent({
   supplement,
   advancedFeatures,
 }: Props) {
+  const questionType = findRowByXpath(asset.content ?? {}, questionXpath)?.type
+  const availableTabs = getAvailableTabsForQuestionType(questionType)
+  const isTranscriptAvailable = availableTabs.includes(ProcessingTab.Transcript)
+
   /** DRY wrapper for protector function. */
   function safeExecute(callback: () => void) {
     protectorHelpers.safeExecute(hasUnsavedWork, callback)
@@ -56,18 +62,28 @@ export default function SingleProcessingContent({
     safeExecute(() => goToTabRoute(PROCESSING_ROUTES.ANALYSIS))
   }
 
+  // Guards against landing on Transcript for a question type that doesn't
+  // support it (e.g. a stale link, or switching questions while on that tab).
+  useEffect(() => {
+    if (!isTranscriptAvailable && isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT)) {
+      goToTabRoute(PROCESSING_ROUTES.TRANSLATIONS)
+    }
+  }, [isTranscriptAvailable])
+
   return (
     <section className={styles.root}>
       <ul className={styles.tabs}>
-        <li
-          className={classNames({
-            [styles.tab]: true,
-            [styles.activeTab]: isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT),
-          })}
-          onClick={handleTranscriptClick}
-        >
-          {t('Transcript')}
-        </li>
+        {isTranscriptAvailable && (
+          <li
+            className={classNames({
+              [styles.tab]: true,
+              [styles.activeTab]: isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT),
+            })}
+            onClick={handleTranscriptClick}
+          >
+            {t('Transcript')}
+          </li>
+        )}
 
         <li
           className={classNames({
@@ -91,7 +107,7 @@ export default function SingleProcessingContent({
       </ul>
 
       <section className={styles.body}>
-        {isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT) && (
+        {isTranscriptAvailable && isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT) && (
           <TabTranscript
             asset={asset}
             questionXpath={questionXpath}

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -10,6 +10,8 @@ import type { SupplementalDataVersionItemManual } from '#/api/models/supplementa
 
 import type { LanguageCode, LocaleCode } from '#/components/languages/languagesStore'
 import { ProcessingTab } from '#/components/processing/routes.utils'
+import { QUESTION_TYPES } from '#/constants'
+import type { AnyRowTypeName } from '#/constants'
 import type {
   DisplaysList,
   QualVersionItem,
@@ -365,6 +367,21 @@ export const DefaultDisplays: Map<ProcessingTab, DisplaysList> = new Map([
   [ProcessingTab.Translations, [StaticDisplays.Audio, StaticDisplays.Data, StaticDisplays.Transcript]],
   [ProcessingTab.Analysis, [StaticDisplays.Audio, StaticDisplays.Data, StaticDisplays.Transcript]],
 ])
+
+/** Question types with nothing to transcribe from (no audio/video source). */
+const NON_TRANSCRIBABLE_QUESTION_TYPES: AnyRowTypeName[] = [QUESTION_TYPES.text.id]
+
+/**
+ * Returns the Processing tabs available for a given question type, in display
+ * order. Transcript is omitted for question types that have no audio/video
+ * response to transcribe (e.g. text).
+ */
+export function getAvailableTabsForQuestionType(questionType: AnyRowTypeName | undefined): ProcessingTab[] {
+  if (questionType && NON_TRANSCRIBABLE_QUESTION_TYPES.includes(questionType)) {
+    return [ProcessingTab.Translations, ProcessingTab.Analysis]
+  }
+  return [ProcessingTab.Transcript, ProcessingTab.Translations, ProcessingTab.Analysis]
+}
 
 /**
  * Gets the default displays for a given processing tab.

--- a/jsapp/js/components/processing/routes.tsx
+++ b/jsapp/js/components/processing/routes.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 import { Navigate, Route, generatePath, useParams } from 'react-router-dom'
+import assetStore from '#/assetStore'
+import { findRowByXpath } from '#/assetUtils'
 import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
+import { getAvailableTabsForQuestionType } from '#/components/processing/common/utils'
+import { ProcessingTab, decodeURLParamWithSlash } from '#/components/processing/routes.utils'
 import PermProtectedRoute from '#/router/permProtectedRoute'
 import { PROCESSING_ROUTES } from '#/router/routerConstants'
 import SingleProcessingRoute from '.'
@@ -9,7 +13,17 @@ import SingleProcessingRoute from '.'
 // This is needed so we have access to params :shrug:
 const ProcessingRootRedirect = () => {
   const params = useParams()
-  return <Navigate to={generatePath(PROCESSING_ROUTES.TRANSCRIPT, params)} replace />
+
+  // The asset should already be cached from wherever the user navigated here
+  // (e.g. the submissions table), so we can pick the default tab synchronously.
+  const asset = params.uid ? assetStore.getAsset(params.uid) : undefined
+  const xpath = params.xpath ? decodeURLParamWithSlash(params.xpath) : undefined
+  const questionType = asset?.content && xpath ? findRowByXpath(asset.content, xpath)?.type : undefined
+  const defaultTabRoute = getAvailableTabsForQuestionType(questionType).includes(ProcessingTab.Transcript)
+    ? PROCESSING_ROUTES.TRANSCRIPT
+    : PROCESSING_ROUTES.TRANSLATIONS
+
+  return <Navigate to={generatePath(defaultTabRoute, params)} replace />
 }
 
 export default function routes() {


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

The Processing view now only shows the "Transcript" tab for questions that actually have something to transcribe.

### 📖 Description

For audio questions, the Processing view still shows all three tabs (Transcript, Translations, Analysis) — no change there. For text questions, the Transcript tab is now hidden entirely (there's no audio/video to transcribe), leaving only Translations (now the default landing tab) and Analysis.

### 💭 Notes

- Added `getAvailableTabsForQuestionType()` in `components/processing/common/utils.ts` to centralize which tabs apply to a given question type.
- `SingleProcessingContent` uses it to hide the Transcript nav item/body for text questions, and also redirects off the Transcript tab (to Translations) if a stale link or a question switch lands on it for a question type that doesn't support it.
- `ProcessingRootRedirect` (the bare `/processing/:xpath/:submissionEditId` route) now picks Transcript or Translations as the default tab based on question type, instead of always defaulting to Transcript.
- Per the tabs appear/disappear (not disabled) per Tessa's comment on the ticket.

### 👀 Preview steps

1. ℹ️ have a project with both an audio question and a text question, with at least one submission answering both
2. open Processing for the audio question (e.g. via "Open" on the audio cell in the table)
3. 🟢 see all three tabs: Transcript, Translations, Analysis (unchanged)
4. open Processing for the text question (e.g. via "Open" on the text cell in the table, behind the `nlpTextActionsEnabled` feature flag)
5. 🔴 [on main] the Transcript tab is shown even though there's nothing to transcribe
6. 🟢 [on PR] only Translations and Analysis are shown, and Translations is the tab you land on by default
