### PR TITLE
feat(processing): hide Transcript tab for text questions DEV-2374

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingContent/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/index.tsx
@@ -1,14 +1,16 @@
 import { Tabs } from '@mantine/core'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import type { AdvancedFeatureResponse } from '#/api/models/advancedFeatureResponse'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
+import { findRowByXpath } from '#/assetUtils'
 import type { AssetResponse } from '#/dataInterface'
 import protectorHelpers from '#/protector/protectorHelpers'
 import { PROCESSING_ROUTES } from '#/router/routerConstants'
-import { getTabRoutePath, goToTabRoute, isProcessingRouteActive } from '../routes.utils'
+import { getAvailableTabsForQuestionType } from '../common/utils'
+import { ProcessingTab, getTabRoutePath, goToTabRoute, isProcessingRouteActive } from '../routes.utils'
 import TabAnalysis from './TabAnalysis'
 import TabTranscript from './TabTranscript'
 import TabTranslations from './TabTranslations'
@@ -40,6 +42,10 @@ export default function SingleProcessingContent({
   supplement,
   advancedFeatures,
 }: Props) {
+  const questionType = findRowByXpath(asset.content ?? {}, questionXpath)?.type
+  const availableTabs = getAvailableTabsForQuestionType(questionType)
+  const isTranscriptAvailable = availableTabs.includes(ProcessingTab.Transcript)
+
   /** DRY wrapper for protector function. */
   function safeExecute(callback: () => void) {
     protectorHelpers.safeExecute(hasUnsavedWork, callback)
@@ -75,13 +81,23 @@ export default function SingleProcessingContent({
     activeTab = PROCESSING_ROUTES.ANALYSIS
   }
 
+  // Guards against landing on Transcript for a question type that doesn't
+  // support it (e.g. a stale link, or switching questions while on that tab).
+  useEffect(() => {
+    if (!isTranscriptAvailable && isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT)) {
+      goToTabRoute(PROCESSING_ROUTES.TRANSLATIONS)
+    }
+  }, [isTranscriptAvailable])
+
   return (
     <section className={styles.root}>
       <Tabs variant={'folder'} value={activeTab} tt={'uppercase'} h={48}>
         <Tabs.List justify='left'>
-          <Tabs.Tab value={PROCESSING_ROUTES.TRANSCRIPT} renderRoot={renderTabLink(PROCESSING_ROUTES.TRANSCRIPT)}>
-            {t('Transcript')}
-          </Tabs.Tab>
+          {isTranscriptAvailable && (
+            <Tabs.Tab value={PROCESSING_ROUTES.TRANSCRIPT} renderRoot={renderTabLink(PROCESSING_ROUTES.TRANSCRIPT)}>
+              {t('Transcript')}
+            </Tabs.Tab>
+          )}
 
           <Tabs.Tab value={PROCESSING_ROUTES.TRANSLATIONS} renderRoot={renderTabLink(PROCESSING_ROUTES.TRANSLATIONS)}>
             {t('Translations')}
@@ -94,7 +110,7 @@ export default function SingleProcessingContent({
       </Tabs>
 
       <section className={styles.body}>
-        {activeTab === PROCESSING_ROUTES.TRANSCRIPT && (
+        {isTranscriptAvailable && activeTab === PROCESSING_ROUTES.TRANSCRIPT && (
           <TabTranscript
             asset={asset}
             questionXpath={questionXpath}

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -388,6 +388,18 @@ export const DefaultDisplays: Map<ProcessingTab, DisplaysList> = new Map([
 ])
 
 /**
+ * Returns the Processing tabs available for a given question type, in display
+ * order. Transcript is omitted for question types that have no audio/video
+ * response to transcribe (e.g. text).
+ */
+export function getAvailableTabsForQuestionType(questionType: AnyRowTypeName | undefined): ProcessingTab[] {
+  if (isTextQuestionType(questionType)) {
+    return [ProcessingTab.Translations, ProcessingTab.Analysis]
+  }
+  return [ProcessingTab.Transcript, ProcessingTab.Translations, ProcessingTab.Analysis]
+}
+
+/**
  * Gets the default displays for a given processing tab.
  *
  * @param tabName - The processing tab name

--- a/jsapp/js/components/processing/index.tsx
+++ b/jsapp/js/components/processing/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import DocumentTitle from 'react-document-title'
 import type { BulkActionResponse } from '#/api/models/bulkActionResponse'
 import { BulkActionResponseStatusEnum } from '#/api/models/bulkActionResponseStatusEnum'
@@ -11,15 +11,19 @@ import {
   useAssetsDataSupplementRetrieve,
 } from '#/api/react-query/survey-data'
 import assetStore from '#/assetStore'
+import { findRowByXpath } from '#/assetUtils'
 import CenteredMessage from '#/components/common/centeredMessage.component'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import { PROCESSING_BULK_ACTIONS_POLL_INTERVAL } from '#/constants'
+import { PROCESSING_ROUTES } from '#/router/routerConstants'
 import { addDefaultUuidPrefix, getSubmissionRootUuid } from '#/utils'
 import type { LanguageCode } from '../languages/languagesStore'
 import SingleProcessingContent from './SingleProcessingContent'
 import SingleProcessingHeader from './SingleProcessingHeader'
 import SingleProcessingSidebar from './SingleProcessingSidebar'
+import { getAvailableTabsForQuestionType } from './common/utils'
 import styles from './index.module.scss'
+import { ProcessingTab, goToTabRoute, isProcessingRouteActive } from './routes.utils'
 
 interface RouteParams extends Record<string, string | undefined> {
   uid: string
@@ -103,6 +107,18 @@ export default function SingleProcessingRoute({ params: routeParams }: { params:
   /** Whether current submission has a response for current question. */
   const questionHasAnswer = !!(questionXpath && submission?.[questionXpath])
   const pageTitle = 'Data | KoboToolbox'
+
+  // Guards against landing on Transcript for a question type that doesn't
+  // support it. This must live here (rather than in `SingleProcessingContent`)
+  // because that component isn't mounted when the question has no answer, so
+  // its own guard would never run for a cold-cache load onto that state.
+  const questionType = asset?.content ? findRowByXpath(asset.content, questionXpath)?.type : undefined
+  const isTranscriptAvailable = getAvailableTabsForQuestionType(questionType).includes(ProcessingTab.Transcript)
+  useEffect(() => {
+    if (asset && !isTranscriptAvailable && isProcessingRouteActive(PROCESSING_ROUTES.TRANSCRIPT)) {
+      goToTabRoute(PROCESSING_ROUTES.TRANSLATIONS)
+    }
+  }, [asset, isTranscriptAvailable])
 
   // We had `assset?.content?.survey` check here. In theory it could be undefined, but I don't think it's possible to
   // access processing UI with an asset that wasn't deployed and have submissions - all that needs `.survey`.

--- a/jsapp/js/components/processing/routes.tsx
+++ b/jsapp/js/components/processing/routes.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
 import { Navigate, Route, generatePath, useParams } from 'react-router-dom'
+import assetStore from '#/assetStore'
+import { findRowByXpath } from '#/assetUtils'
 import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
+import { getAvailableTabsForQuestionType } from '#/components/processing/common/utils'
+import { ProcessingTab, decodeURLParamWithSlash } from '#/components/processing/routes.utils'
 import PermProtectedRoute from '#/router/permProtectedRoute'
 import { PROCESSING_ROUTES } from '#/router/routerConstants'
 import SingleProcessingRoute from '.'
@@ -9,7 +13,17 @@ import SingleProcessingRoute from '.'
 // This is needed so we have access to params :shrug:
 const ProcessingRootRedirect = () => {
   const params = useParams()
-  return <Navigate to={generatePath(PROCESSING_ROUTES.TRANSCRIPT, params)} replace />
+
+  // The asset should already be cached from wherever the user navigated here
+  // (e.g. the submissions table), so we can pick the default tab synchronously.
+  const asset = params.uid ? assetStore.getAsset(params.uid) : undefined
+  const xpath = params.xpath ? decodeURLParamWithSlash(params.xpath) : undefined
+  const questionType = asset?.content && xpath ? findRowByXpath(asset.content, xpath)?.type : undefined
+  const defaultTabRoute = getAvailableTabsForQuestionType(questionType).includes(ProcessingTab.Transcript)
+    ? PROCESSING_ROUTES.TRANSCRIPT
+    : PROCESSING_ROUTES.TRANSLATIONS
+
+  return <Navigate to={generatePath(defaultTabRoute, params)} replace />
 }
 
 export default function routes() {


### PR DESCRIPTION
### 📣 Summary

The Processing view now only shows the "Transcript" tab for questions that actually have something to transcribe.

### 💭 Notes

For audio questions, the Processing view still shows all three tabs (Transcript, Translations, Analysis) — no change there. For text questions, the Transcript tab is now hidden entirely (there's no audio/video to transcribe), leaving only Translations (now the default landing tab) and Analysis.

- Added `getAvailableTabsForQuestionType()` in `components/processing/common/utils.ts` to centralize which tabs apply to a given question type.
- `SingleProcessingContent` uses it to hide the Transcript nav item/body for text questions, and also redirects off the Transcript tab (to Translations) if a stale link or a question switch lands on it for a question type that doesn't support it.
- `ProcessingRootRedirect` (the bare `/processing/:xpath/:submissionEditId` route) now picks Transcript or Translations as the default tab based on question type, instead of always defaulting to Transcript.
- Per the tabs appear/disappear (not disabled) per Tessa's comment on the ticket.

### 👀 Preview steps

1. ℹ️ have a project with both an audio question and a text question, with at least one submission answering both
2. open Processing for the audio question (e.g. via "Open" on the audio cell in the table)
3. 🟢 see all three tabs: Transcript, Translations, Analysis (unchanged)
4. open Processing for the text question (e.g. via "Open" on the text cell in the table, behind the `nlpTextActionsEnabled` feature flag)
5. 🔴 [on main] the Transcript tab is shown even though there's nothing to transcribe
6. 🟢 [on PR] only Translations and Analysis are shown, and Translations is the tab you land on by default


---
_Recreated from #7511, which got closed as a side effect of a branch rename._
