### PR TITLE
fix(celery): schedule trash bin and project ownership dispatchers on `kpi_queue` DEV-2618

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1543,7 +1543,7 @@ CELERY_BEAT_SCHEDULE = {
     'trash-bin-task-restarter': {
         'task': 'kobo.apps.trash_bin.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_queue'}
+        'options': {'queue': 'kpi_queue'},
     },
     'perform-maintenance': {
         'task': 'kpi.tasks.perform_maintenance',
@@ -1575,7 +1575,7 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-task-restarter': {
         'task': 'kobo.apps.project_ownership.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_queue'}
+        'options': {'queue': 'kpi_queue'},
     },
     # Schedule every 30 minutes
     'project-ownership-mark-as-failed': {
@@ -1633,7 +1633,7 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-garbage-collector': {
         'task': 'kobo.apps.project_ownership.tasks.garbage_collector',
         'schedule': crontab(minute=0, hour=0),
-        'options': {'queue': 'kpi_queue'}
+        'options': {'queue': 'kpi_queue'},
     },
     # Schedule every day at midnight UTC
     'delete-expired-logs': {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1537,13 +1537,13 @@ CELERY_BEAT_SCHEDULE = {
     'trash-bin-garbage-collector': {
         'task': 'kobo.apps.trash_bin.tasks.garbage_collector',
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_low_priority_queue'},
+        'options': {'queue': 'kpi_queue'},
     },
     # Schedule every 30 minutes
     'trash-bin-task-restarter': {
         'task': 'kobo.apps.trash_bin.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_queue'}
     },
     'perform-maintenance': {
         'task': 'kpi.tasks.perform_maintenance',
@@ -1575,7 +1575,7 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-task-restarter': {
         'task': 'kobo.apps.project_ownership.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_queue'}
     },
     # Schedule every 30 minutes
     'project-ownership-mark-as-failed': {
@@ -1633,7 +1633,7 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-garbage-collector': {
         'task': 'kobo.apps.project_ownership.tasks.garbage_collector',
         'schedule': crontab(minute=0, hour=0),
-        'options': {'queue': 'kpi_low_priority_queue'}
+        'options': {'queue': 'kpi_queue'}
     },
     # Schedule every day at midnight UTC
     'delete-expired-logs': {

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1537,12 +1537,18 @@ CELERY_BEAT_SCHEDULE = {
     'trash-bin-garbage-collector': {
         'task': 'kobo.apps.trash_bin.tasks.garbage_collector',
         'schedule': crontab(minute='*/30'),
+        # On `kpi_queue`, not `kpi_low_priority_queue`: this task orchestrates
+        # the long deletions and transfers running there, and must not end up
+        # stuck behind the very backlog it exists to clear
         'options': {'queue': 'kpi_queue'},
     },
     # Schedule every 30 minutes
     'trash-bin-task-restarter': {
         'task': 'kobo.apps.trash_bin.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
+        # On `kpi_queue`, not `kpi_low_priority_queue`: this task orchestrates
+        # the long deletions and transfers running there, and must not end up
+        # stuck behind the very backlog it exists to clear
         'options': {'queue': 'kpi_queue'},
     },
     'perform-maintenance': {
@@ -1575,6 +1581,9 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-task-restarter': {
         'task': 'kobo.apps.project_ownership.tasks.task_restarter',
         'schedule': crontab(minute='*/30'),
+        # On `kpi_queue`, not `kpi_low_priority_queue`: this task orchestrates
+        # the long deletions and transfers running there, and must not end up
+        # stuck behind the very backlog it exists to clear
         'options': {'queue': 'kpi_queue'},
     },
     # Schedule every 30 minutes
@@ -1633,6 +1642,9 @@ CELERY_BEAT_SCHEDULE = {
     'project-ownership-garbage-collector': {
         'task': 'kobo.apps.project_ownership.tasks.garbage_collector',
         'schedule': crontab(minute=0, hour=0),
+        # On `kpi_queue`, not `kpi_low_priority_queue`: this task orchestrates
+        # the long deletions and transfers running there, and must not end up
+        # stuck behind the very backlog it exists to clear
         'options': {'queue': 'kpi_queue'},
     },
     # Schedule every day at midnight UTC


### PR DESCRIPTION
### 📖 Description
Moves four scheduled orchestration tasks from `kpi_low_priority_queue` to `kpi_queue`:

- trash_bin.task_restarter
- trash_bin.garbage_collector
- project_ownership.task_restarter
- project_ownership.garbage_collector

These tasks only enqueue work and finish in milliseconds, but they were scheduled onto the same queue as the long-running deletions and transfers they dispatch. When that queue backs up, the recovery path is stuck behind the backlog it exists to clear.

The deletion and transfer tasks themselves are unchanged and stay on `kpi_low_priority_queue`.