### PR TITLE
fix(trashBin): give each trash type its own restart budget DEV-2618

### DIFF
--- a/kobo/apps/trash_bin/tasks/__init__.py
+++ b/kobo/apps/trash_bin/tasks/__init__.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from celery import Task
+from celery.exceptions import SoftTimeLimitExceeded
 from constance import config
 from django.conf import settings
 from django.db import transaction
@@ -69,15 +70,32 @@ def task_restarter():
     failed on a transient (infrastructure) error
     """
 
-    for model, task, retention in (
-        (AccountTrash, empty_account, config.ACCOUNT_TRASH_RETENTION),
-        (ProjectTrash, empty_project, config.PROJECT_TRASH_RETENTION),
-        (AttachmentTrash, empty_attachment, config.ATTACHMENT_TRASH_RETENTION),
+    for model, task, retention, max_restarts in (
+        (
+            AccountTrash,
+            empty_account,
+            config.ACCOUNT_TRASH_RETENTION,
+            settings.MAX_RESTARTED_ACCOUNT_DELETIONS,
+        ),
+        (
+            ProjectTrash,
+            empty_project,
+            config.PROJECT_TRASH_RETENTION,
+            settings.MAX_RESTARTED_PROJECT_DELETIONS,
+        ),
+        (
+            AttachmentTrash,
+            empty_attachment,
+            config.ATTACHMENT_TRASH_RETENTION,
+            settings.MAX_RESTARTED_ATTACHMENT_DELETIONS,
+        ),
     ):
-        _restart_stuck_tasks(model, task, retention)
+        _restart_stuck_tasks(model, task, retention, max_restarts)
 
 
-def _restart_stuck_tasks(model: TrashBinModel, task: Task, retention: int):
+def _restart_stuck_tasks(
+    model: TrashBinModel, task: Task, retention: int, max_restarts: int
+):
     """
     Restart tasks which have been stopped accidentally, i.e.: they are still
     flagged as pending or in progress but nothing has updated them for a while
@@ -112,7 +130,7 @@ def _restart_stuck_tasks(model: TrashBinModel, task: Task, retention: int):
             started_objects | due_objects,
             date_modified__lte=stuck_threshold,
         )
-        .order_by('date_modified')[:settings.MAX_RESTARTED_TASKS]
+        .order_by('date_modified')[:max_restarts]
     )
 
     for stuck_id, date_modified in stuck_objects:
@@ -130,6 +148,14 @@ def _restart_stuck_tasks(model: TrashBinModel, task: Task, retention: int):
 
         try:
             task.delay(stuck_id, force=True)
+        except SoftTimeLimitExceeded:
+            # `task_restarter` itself is running out of time, the object is not
+            # at fault: release the claim so the next run picks it up, and let
+            # the exception bubble up instead of logging a misleading failure
+            model.objects.filter(pk=stuck_id, date_modified=claimed_at).update(
+                date_modified=date_modified
+            )
+            raise
         except Exception:
             # If the task fails to enqueue, restore the original date_modified
             # so that it can be picked up again in the next run, and carry on

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -2402,9 +2402,7 @@ MAX_RESTARTED_TRANSFERS = 20
 # Number of stuck trash bin deletions `task_restarter` re-enqueues per run per type
 MAX_RESTARTED_ACCOUNT_DELETIONS = env.int('MAX_RESTARTED_ACCOUNT_DELETIONS', 100)
 MAX_RESTARTED_PROJECT_DELETIONS = env.int('MAX_RESTARTED_PROJECT_DELETIONS', 100)
-MAX_RESTARTED_ATTACHMENT_DELETIONS = env.int(
-    'MAX_RESTARTED_ATTACHMENT_DELETIONS', 100
-)
+MAX_RESTARTED_ATTACHMENT_DELETIONS = env.int('MAX_RESTARTED_ATTACHMENT_DELETIONS', 100)
 
 # Number of times a trash bin task that failed on a transient (infrastructure)
 # error is automatically restarted before it requires manual intervention

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -2395,9 +2395,16 @@ S3_DELETE_BATCH_SIZE = 1000
 AZURE_DELETE_BATCH_SIZE = 256
 USAGE_QUERY_USER_ID_BATCH_SIZE = 20000
 
-# Number of stuck tasks should be restarted at a time
+# Number of stuck project ownership tasks and transfers restarted at a time
 MAX_RESTARTED_TASKS = 100
 MAX_RESTARTED_TRANSFERS = 20
+
+# Number of stuck trash bin deletions `task_restarter` re-enqueues per run per type
+MAX_RESTARTED_ACCOUNT_DELETIONS = env.int('MAX_RESTARTED_ACCOUNT_DELETIONS', 100)
+MAX_RESTARTED_PROJECT_DELETIONS = env.int('MAX_RESTARTED_PROJECT_DELETIONS', 100)
+MAX_RESTARTED_ATTACHMENT_DELETIONS = env.int(
+    'MAX_RESTARTED_ATTACHMENT_DELETIONS', 100
+)
 
 # Number of times a trash bin task that failed on a transient (infrastructure)
 # error is automatically restarted before it requires manual intervention

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -2400,9 +2400,9 @@ MAX_RESTARTED_TASKS = 100
 MAX_RESTARTED_TRANSFERS = 20
 
 # Number of stuck trash bin deletions `task_restarter` re-enqueues per run per type
-MAX_RESTARTED_ACCOUNT_DELETIONS = env.int('MAX_RESTARTED_ACCOUNT_DELETIONS', 100)
+MAX_RESTARTED_ACCOUNT_DELETIONS = env.int('MAX_RESTARTED_ACCOUNT_DELETIONS', 50)
 MAX_RESTARTED_PROJECT_DELETIONS = env.int('MAX_RESTARTED_PROJECT_DELETIONS', 100)
-MAX_RESTARTED_ATTACHMENT_DELETIONS = env.int('MAX_RESTARTED_ATTACHMENT_DELETIONS', 100)
+MAX_RESTARTED_ATTACHMENT_DELETIONS = env.int('MAX_RESTARTED_ATTACHMENT_DELETIONS', 300)
 
 # Number of times a trash bin task that failed on a transient (infrastructure)
 # error is automatically restarted before it requires manual intervention


### PR DESCRIPTION
### 📣 Summary
Splits `MAX_RESTARTED_TASKS` into three per-type settings for trash bin deletions, and stops `task_restarter` from swallowing its own soft time limit.

### 📖 Description
Implements the findings from #7422 and supersedes it.

The investigation showed that limiting how many deletions `task_restarter` enqueues does not limit DB pressure: concurrency is set by the size of the worker pool, not by how many messages are published. Two things from #7422 are worth keeping on their own merits, and this PR is just those two.

1. Per-type restart budgets. _restart_stuck_tasks() sliced all three trash types with settings.MAX_RESTARTED_TASKS, which project_ownership/tasks.py also uses with a different "batch per run" meaning - one shared name, two unrelated behaviours. Each trash type now has its own setting:

- MAX_RESTARTED_ACCOUNT_DELETIONS
- MAX_RESTARTED_PROJECT_DELETIONS
- MAX_RESTARTED_ATTACHMENT_DELETIONS

All default to 100, so behaviour is unchanged. They are separate because the three deletions do not cost the same. 

2. Do not swallow `SoftTimeLimitExceeded`. In the enqueue block it was caught by the generic except Exception and logged as Could not restart <Model> #<id>, which is wrong on both counts: nothing is wrong with the object, and the restarter had already claimed it, so it sat untouched until the next stuck threshold ~76 minutes later. It now restores `date_modified` and re-raises.