### PR TITLE
feat(organizations): support q search on organization asset usage DEV-2700

### DIFF
--- a/jsapp/js/api/models/organizationsAssetUsageListParams.ts
+++ b/jsapp/js/api/models/organizationsAssetUsageListParams.ts
@@ -20,6 +20,10 @@ export type OrganizationsAssetUsageListParams = {
    */
   ordering?: string
   /**
+   * Filter the results with search query
+   */
+  q?: string
+  /**
    * Paginate results with start parameter
    */
   start?: number

--- a/jsapp/js/api/react-query/user-team-organization-usage/index.ts
+++ b/jsapp/js/api/react-query/user-team-organization-usage/index.ts
@@ -518,6 +518,8 @@ export const useOrganizationsPartialUpdate = <TError = ErrorValidation | ErrorDe
 
 Tracks the total usage of each asset for the user in the given organization
 
+Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).
+
  */
 export type organizationsAssetUsageListResponse200 = {
   data: PaginatedCustomAssetUsageList

--- a/jsapp/js/api/react-query/user-team-organization-usage/index.ts
+++ b/jsapp/js/api/react-query/user-team-organization-usage/index.ts
@@ -518,7 +518,7 @@ export const useOrganizationsPartialUpdate = <TError = ErrorValidation | ErrorDe
 
 Tracks the total usage of each asset for the user in the given organization
 
-Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).
+Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long and match anywhere in the name, case-insensitively. The standard query syntax is also supported: `?q=name__icontains:household` for a contains match, while `?q=name:Household survey` is an exact name match.
 
  */
 export type organizationsAssetUsageListResponse200 = {

--- a/kobo/apps/organizations/tests/test_organizations_api.py
+++ b/kobo/apps/organizations/tests/test_organizations_api.py
@@ -227,6 +227,60 @@ class OrganizationDetailAPITestCase(BaseTestCase):
         response = self.client.get(url)
         assert response.status_code == expected_status_code
 
+    def _create_org_surveys(self):
+        for name in ('Project Alpha', 'Something else'):
+            baker.make(
+                Asset,
+                owner=self.someuser,
+                asset_type=ASSET_TYPE_SURVEY,
+                name=name,
+            )
+
+    def test_asset_usage_filter_by_project_name(self):
+        self.client.force_login(self.someuser)
+        self._create_org_surveys()
+        url = reverse(
+            self._get_endpoint('organizations-asset-usage'),
+            kwargs={'uid_organization': self.organization.id},
+        )
+        response = self.client.get(url, {'q': 'alpha'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['asset__name'] == 'Project Alpha'
+
+    def test_asset_usage_filter_no_match(self):
+        self.client.force_login(self.someuser)
+        self._create_org_surveys()
+        url = reverse(
+            self._get_endpoint('organizations-asset-usage'),
+            kwargs={'uid_organization': self.organization.id},
+        )
+        response = self.client.get(url, {'q': 'nonexistent'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0
+
+    def test_asset_usage_filter_query_too_short(self):
+        self.client.force_login(self.someuser)
+        self._create_org_surveys()
+        url = reverse(
+            self._get_endpoint('organizations-asset-usage'),
+            kwargs={'uid_organization': self.organization.id},
+        )
+        response = self.client.get(url, {'q': 'ab'})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_asset_usage_filter_composes_with_ordering(self):
+        self.client.force_login(self.someuser)
+        self._create_org_surveys()
+        url = reverse(
+            self._get_endpoint('organizations-asset-usage'),
+            kwargs={'uid_organization': self.organization.id},
+        )
+        response = self.client.get(url, {'q': 'alpha', 'ordering': 'name'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['asset__name'] == 'Project Alpha'
+
     @data(
         ('name', 'Someuser Company inc.', status.HTTP_200_OK),
         ('name', '', status.HTTP_400_BAD_REQUEST),

--- a/kobo/apps/organizations/views.py
+++ b/kobo/apps/organizations/views.py
@@ -180,6 +180,13 @@ class OrganizationAssetViewSet(AssetViewSet):
         ),
         parameters=[
             OpenApiParameter(
+                name='q',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description=t('Filter the results with search query'),
+            ),
+            OpenApiParameter(
                 name='start',
                 type=int,
                 location=OpenApiParameter.QUERY,
@@ -300,6 +307,8 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     lookup_url_kwarg = 'uid_organization'
     permission_classes = [HasOrgRolePermission]
     http_method_names = ['get', 'patch']
+    # Bare `q` terms search project names (see SearchFilter)
+    search_default_field_lookups = ['name__icontains']
 
     @action(
         detail=True, methods=['GET'], permission_classes=[IsOrgAdminPermission]
@@ -398,10 +407,9 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             **self.get_serializer_context(),
         }
 
-        filtered_assets = (
-            filters.AssetOrganizationUsageFilter().filter_queryset(
-                request, assets, self
-            )
+        filtered_assets = SearchFilter().filter_queryset(request, assets, self)
+        filtered_assets = filters.AssetOrganizationUsageFilter().filter_queryset(
+            request, filtered_assets, self
         )
 
         page = self.paginate_queryset(filtered_assets)

--- a/kpi/docs/api/v2/organizations/org_asset_usage.md
+++ b/kpi/docs/api/v2/organizations/org_asset_usage.md
@@ -1,3 +1,5 @@
 ## Retrieve organization asset usage tracker
 
 Tracks the total usage of each asset for the user in the given organization
+
+Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).

--- a/kpi/docs/api/v2/organizations/org_asset_usage.md
+++ b/kpi/docs/api/v2/organizations/org_asset_usage.md
@@ -2,4 +2,4 @@
 
 Tracks the total usage of each asset for the user in the given organization
 
-Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).
+Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long and match anywhere in the name, case-insensitively. The standard query syntax is also supported: `?q=name__icontains:household` for a contains match, while `?q=name:Household survey` is an exact name match.

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -12039,7 +12039,7 @@
         "/api/v2/organizations/{uid_organization}/asset_usage/": {
             "get": {
                 "operationId": "api_v2_organizations_asset_usage_list",
-                "description": "## Retrieve organization asset usage tracker\n\nTracks the total usage of each asset for the user in the given organization\n",
+                "description": "## Retrieve organization asset usage tracker\n\nTracks the total usage of each asset for the user in the given organization\n\nUse the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).\n",
                 "parameters": [
                     {
                         "in": "query",
@@ -12056,6 +12056,14 @@
                             "type": "string"
                         },
                         "description": "Which field to use when ordering the results."
+                    },
+                    {
+                        "in": "query",
+                        "name": "q",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filter the results with search query"
                     },
                     {
                         "in": "query",

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -12039,7 +12039,7 @@
         "/api/v2/organizations/{uid_organization}/asset_usage/": {
             "get": {
                 "operationId": "api_v2_organizations_asset_usage_list",
-                "description": "## Retrieve organization asset usage tracker\n\nTracks the total usage of each asset for the user in the given organization\n\nUse the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).\n",
+                "description": "## Retrieve organization asset usage tracker\n\nTracks the total usage of each asset for the user in the given organization\n\nUse the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long and match anywhere in the name, case-insensitively. The standard query syntax is also supported: `?q=name__icontains:household` for a contains match, while `?q=name:Household survey` is an exact name match.\n",
                 "parameters": [
                     {
                         "in": "query",

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -8835,6 +8835,8 @@ paths:
         ## Retrieve organization asset usage tracker
 
         Tracks the total usage of each asset for the user in the given organization
+
+        Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).
       parameters:
       - in: query
         name: limit
@@ -8846,6 +8848,11 @@ paths:
         schema:
           type: string
         description: Which field to use when ordering the results.
+      - in: query
+        name: q
+        schema:
+          type: string
+        description: Filter the results with search query
       - in: query
         name: start
         schema:

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -8836,7 +8836,7 @@ paths:
 
         Tracks the total usage of each asset for the user in the given organization
 
-        Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long. The standard query syntax is supported (e.g. `?q=name:household`).
+        Use the `q` query parameter to filter by project name (e.g. `?q=household survey`). Bare search terms must be at least 3 characters long and match anywhere in the name, case-insensitively. The standard query syntax is also supported: `?q=name__icontains:household` for a contains match, while `?q=name:Household survey` is an exact name match.
       parameters:
       - in: query
         name: limit


### PR DESCRIPTION
## 📣 Summary
Projects in the organization usage table can now be searched by name.

## 📖 Description
The usage page lists every project in the organization. This adds name search to the data behind that table, so the search box coming in DEV-2701 can narrow the list instead of always showing everything.

## 💭 Notes
- Reuses the existing `SearchFilter`, chained before `AssetOrganizationUsageFilter` in `OrganizationViewSet.asset_usage`. Bare `q` terms search `name__icontains`.
- Fielded queries still go through the query parser's allowlist, and the queryset was already scoped to the org owner, so nothing new is exposed.
- Schema and orval client regenerated.

## 👀 Preview steps
1. Log in as an owner or admin of an org with a few projects.
2. Open `/api/v2/organizations/<org_id>/asset_usage/?q=<part of a project name>`.

🔴 On main: `q` is ignored and every project comes back.
🟢 On this PR: only projects whose name contains the term (case insensitive). A `q` under 3 characters returns a 400.
