### PR TITLE
feat(sso): actions on adding managed domain DEV-2758

### DIFF
--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -3,23 +3,22 @@ from allauth.socialaccount.admin import SocialAccountAdmin as BaseSocialAccountA
 from allauth.socialaccount.admin import SocialAppAdmin, SocialAppForm
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from django import forms
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.db import models
-from django.db.models import Func, Q, Value
-from django.db.models.functions import Lower
+from django.db.models import Q
 from django.forms.formsets import all_valid
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from kobo.apps.accounts.models import EmailContent
-from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
-from kobo.apps.kobo_auth.shortcuts import User
-from .models import EmailAddressAdmin, SocialAppCustomData, SocialAppManagedDomain
-from .utils import user_is_managed_by_sso
+from kobo.apps.accounts.models import (
+    EmailAddressAdmin,
+    EmailContent,
+    SocialAppCustomData,
+    SocialAppManagedDomain,
+)
+from kobo.apps.accounts.utils import user_is_managed_by_sso, users_needing_update
 
 
 @admin.register(EmailContent)
@@ -97,60 +96,15 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
         if not is_managed:
             return 0, 0
 
-        provider_id = social_app.provider_id or social_app.provider
-        social_app_key = f'{SocialApp._meta.app_label}.{SocialApp._meta.model_name}'
-
-        track_1_qs = (
-            User.objects.filter(socialaccount__provider=provider_id)
-            .exclude(extra_details__sso_exempt=True)
-            .exclude(pk=settings.ANONYMOUS_USER_ID)
-            .distinct()
-        )
-        track_1_count = track_1_qs.count()
-
-        if submitted_domains:
-            domain_expr = Func(
-                Lower('email'),
-                Value('@'),
-                Value(2),
-                function='split_part',
-                output_field=models.CharField(),
-            )
-            try:
-                existing_iam_ids = list(
-                    InAppMessage.objects.filter(
-                        message_type=MessageType.MANAGED_SSO_REMINDER,
-                        generic_related_objects__contains={
-                            social_app_key: social_app.pk
-                        },
-                    ).values_list('id', flat=True)
-                )
-            except Exception:
-                existing_iam_ids = [
-                    iam.id
-                    for iam in InAppMessage.objects.filter(
-                        message_type=MessageType.MANAGED_SSO_REMINDER
-                    )
-                    if isinstance(iam.generic_related_objects, dict)
-                    and iam.generic_related_objects.get(social_app_key) == social_app.pk
-                ]
-
-            already_notified_user_ids = InAppMessageUsers.objects.filter(
-                in_app_message_id__in=existing_iam_ids
-            ).values_list('user_id', flat=True)
-
-            track_2_qs = (
-                User.objects.annotate(email_domain=domain_expr)
-                .filter(email_domain__in=list(submitted_domains))
-                .exclude(socialaccount__provider=provider_id)
-                .exclude(pk=settings.ANONYMOUS_USER_ID)
-                .exclude(id__in=already_notified_user_ids)
-                .distinct()
-            )
-            track_2_count = track_2_qs.count()
-        else:
-            track_2_count = 0
-
+        track_1_count = 0
+        track_2_count = 0
+        for domain in submitted_domains:
+            require_update = users_needing_update(social_app, domain)
+            for user in require_update:
+                if user.managed_account:
+                    track_1_count += 1
+                else:
+                    track_2_count += 1
         return track_1_count, track_2_count
 
     def changeform_view(self, request, object_id=None, form_url='', extra_context=None):

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -83,15 +83,14 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
 
     def _get_affected_accounts_counts(self, social_app, submitted_domains, is_managed):
         """
-        Calculate the count of affected accounts for Track 1 and Track 2.
-        - Track 1: Accounts already linked to that SocialApp
-          (excluding sso_exempt=True and anonymous).
-        - Track 2: Accounts not linked whose email domain is in submitted_domains
-          (using functional index), excluding already notified users via
-          InAppMessageUsers (idempotence) and anonymous.
+        Count the accounts `tasks.update_users()` would act on, per track:
+        - Track 1: accounts linked to the SocialApp that still have another
+          login method (usable password or other social account).
+        - Track 2: accounts on a submitted domain that are not linked yet and
+          have not been notified already.
 
-        TODO: Once PR #7517 (tasks.py users_needing_update) is merged, replace
-        inline query logic below with tasks.users_needing_update() helper.
+        Both tracks come from `users_needing_update()` so the numbers match
+        what the task will actually do.
         """
         if not is_managed:
             return 0, 0
@@ -99,12 +98,9 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
         track_1_count = 0
         track_2_count = 0
         for domain in submitted_domains:
-            require_update = users_needing_update(social_app, domain)
-            for user in require_update:
-                if user.managed_account:
-                    track_1_count += 1
-                else:
-                    track_2_count += 1
+            users = users_needing_update(social_app, domain)
+            track_1_count += users.filter(managed_account__gt=0).count()
+            track_2_count += users.filter(managed_account=0).count()
         return track_1_count, track_2_count
 
     def changeform_view(self, request, object_id=None, form_url='', extra_context=None):

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
-from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER, has_social_account
+from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.celery import celery_app

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
-from kobo.apps.accounts.models import SocialAppManagedDomain
+from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
 from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER, users_needing_update
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
@@ -67,8 +67,17 @@ def create_inapp_message(social_app, requesting_user=None):
 
 
 @celery_app.task()
-def update_users(social_app_custom_data, domain, requesting_user=None):
-    social_app = social_app_custom_data.social_app
+def update_users(
+    social_app_custom_data_id: int, domain: str, requesting_user_id: int = None
+):
+    # Only pks cross the task boundary: model instances are not JSON-serializable
+    custom_data = SocialAppCustomData.objects.select_related('social_app').get(
+        pk=social_app_custom_data_id
+    )
+    social_app = custom_data.social_app
+    requesting_user = (
+        User.objects.get(pk=requesting_user_id) if requesting_user_id else None
+    )
     users_to_update = users_needing_update(social_app, domain)
     if not users_to_update.exists():
         logging.info(
@@ -82,13 +91,13 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
         # 'managed_account' is an annotated field created by the query
         if user.managed_account > 0:
             logging.info(
-                '[Managed SSO] Removing alternative login methods for user'
+                '[Managed SSO] Removing alternative login methods for user '
                 f'{user.username} for managed social app {social_app.name}.'
             )
             update_linked_user(user, social_app.provider_id)
         else:
             user_ids_needing_notification.append(user.id)
-    if len(user_ids_needing_notification) > 0:
+    if user_ids_needing_notification:
         notify_unlinked_users(
             user_ids_needing_notification, social_app, requesting_user
         )
@@ -96,10 +105,10 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
 
 @celery_app.task()
 def managed_sso_sweep():
-    managed_domains = SocialAppManagedDomain.objects.select_related(
-        'social_app'
-    ).filter(social_app__managed=True)
-    for domain in managed_domains:
+    managed_domains = SocialAppManagedDomain.objects.filter(
+        social_app__managed=True
+    ).values_list('social_app_id', 'domain')
+    for social_app_custom_data_id, domain in managed_domains:
         # TODO: determine who kicked off the original update_users task and set them
         # as requesting_user
-        update_users(domain.social_app, domain.domain)
+        update_users(social_app_custom_data_id, domain)

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -118,6 +118,7 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
             f' {social_app.name} with '
             f'domain {domain}. Nothing to do.'
         )
+        return
     social_app = social_app_custom_data.social_app
     user_ids_needing_notification = []
     for user in users_to_update:

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -107,6 +107,7 @@ def users_needing_update(social_app_custom_data: SocialAppCustomData, domain: st
     )
     return users
 
+
 @celery_app.task()
 def update_users(social_app_custom_data, domain, requesting_user=None):
     users_to_update = users_needing_update(social_app_custom_data, domain)
@@ -132,6 +133,7 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
         notify_unlinked_users(
             user_ids_needing_notification, social_app, requesting_user
         )
+
 
 @celery_app.task()
 def managed_sso_sweep():

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -67,7 +67,8 @@ def create_inapp_message(social_app, requesting_user=None):
 
 
 @celery_app.task()
-def update_users(social_app, domain, requesting_user=None):
+def update_users(social_app_custom_data, domain, requesting_user=None):
+    social_app = social_app_custom_data.social_app
     users_to_update = users_needing_update(social_app, domain)
     if not users_to_update.exists():
         logging.info(

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -1,23 +1,15 @@
 from datetime import timedelta
 
-from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.db import transaction
-from django.db.models import CharField, Count, F, Func, Q, Value
-from django.db.models.functions import Lower
 from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
-from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
-from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER
+from kobo.apps.accounts.models import SocialAppManagedDomain
+from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER, users_needing_update
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.celery import celery_app
 from kpi.utils.log import logging
-
-
-class SplitPart(Func):
-    function = 'SPLIT_PART'
-    output_field = CharField()
 
 
 def update_linked_user(user: User, managed_provider_id: str):
@@ -74,44 +66,9 @@ def create_inapp_message(social_app, requesting_user=None):
     )
 
 
-def users_needing_update(social_app_custom_data: SocialAppCustomData, domain: str):
-    social_app = social_app_custom_data.social_app
-    users_already_received_message = InAppMessageUsers.objects.filter(
-        in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
-        in_app_message__generic_related_objects__contains={
-            SOCIAL_APP_IDENTIFIER: social_app.pk,
-        },
-    ).values_list('user_id', flat=True)
-    users = (
-        User.objects.prefetch_related('socialaccount_set')
-        .filter(extra_details__sso_exempt=False)
-        .exclude(id__in=users_already_received_message)
-        .annotate(
-            domain=SplitPart(Lower(F('email')), Value('@'), Value(2)),
-            managed_account=Count(
-                'socialaccount',
-                filter=Q(socialaccount__provider=social_app.provider_id),
-            ),
-            # TODO: why doesn't exclude work here?
-            other_accounts=Count(
-                'socialaccount',
-                filter=~Q(socialaccount__provider=social_app.provider_id),
-            ),
-        )
-        .filter(domain=domain)
-        .exclude(
-            password__startswith=UNUSABLE_PASSWORD_PREFIX,
-            other_accounts=0,
-            managed_account=1,
-        )
-    )
-    return users
-
-
 @celery_app.task()
-def update_users(social_app_custom_data, domain, requesting_user=None):
-    users_to_update = users_needing_update(social_app_custom_data, domain)
-    social_app = social_app_custom_data.social_app
+def update_users(social_app, domain, requesting_user=None):
+    users_to_update = users_needing_update(social_app, domain)
     if not users_to_update.exists():
         logging.info(
             f'[Managed SSO] No users to update for social app'
@@ -119,7 +76,6 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
             f'domain {domain}. Nothing to do.'
         )
         return
-    social_app = social_app_custom_data.social_app
     user_ids_needing_notification = []
     for user in users_to_update:
         # 'managed_account' is an annotated field created by the query

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -122,7 +122,8 @@ def update_users(social_app_custom_data, domain, requesting_user=None):
     social_app = social_app_custom_data.social_app
     user_ids_needing_notification = []
     for user in users_to_update:
-        if has_social_account(user, social_app):
+        # 'managed_account' is an annotated field created by the query
+        if user.managed_account > 0:
             logging.info(
                 '[Managed SSO] Removing alternative login methods for user'
                 f'{user.username} for managed social app {social_app.name}.'

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -1,0 +1,144 @@
+from datetime import timedelta
+
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.db import transaction
+from django.db.models import CharField, Count, F, Func, Q, Value
+from django.db.models.functions import Lower
+from django.utils import timezone
+from django.utils.translation import gettext_noop as t
+
+from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
+from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER, has_social_account
+from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.celery import celery_app
+from kpi.utils.log import logging
+
+
+class SplitPart(Func):
+    function = 'SPLIT_PART'
+    output_field = CharField()
+
+
+def update_linked_user(user: User, managed_provider_id: str):
+    user.set_unusable_password()
+    user.socialaccount_set.exclude(provider=managed_provider_id).delete()
+    user.save()
+
+
+def notify_unlinked_users(
+    user_ids: list[int],
+    managed_social_app: 'socialaccount.SocialApp',
+    requesting_user: User = None,
+):
+    with transaction.atomic():
+        # keeping this in a transaction means we don't have to worry later
+        # that we've already created the message but not the recipients
+        in_app_message = create_inapp_message(managed_social_app, requesting_user)
+        logging.info(
+            f'[Managed SSO] Creating in-app message for unregistered users for'
+            f' managed social app {managed_social_app.name}.'
+        )
+        InAppMessageUsers.objects.bulk_create(
+            [
+                InAppMessageUsers(user_id=user_id, in_app_message=in_app_message)
+                for user_id in user_ids
+            ]
+        )
+
+
+def create_inapp_message(social_app, requesting_user=None):
+    title = t('Update your account')
+    snippet = t('Please connect your ##sso_name## account')
+    body = t(
+        'Dear ##username##,\n\n'
+        'Going forward, your organization will be managing all Kobo accounts '
+        'through ##sso_name##. Please connect your ##sso_name## account. '
+        'Your password will be disabled and you will be required to use ##sso_name## '
+        'to log in.'
+    )
+    return InAppMessage.objects.create(
+        #  … save raw strings into DB to let them be translated in
+        # the users' language in the API response, i.e. when front end
+        # exposes the message in the UI.
+        title=title,
+        snippet=snippet,
+        body=body,
+        published=True,
+        valid_from=timezone.now(),
+        valid_until=timezone.now() + timedelta(days=365),
+        always_display_as_new=True,
+        generic_related_objects={SOCIAL_APP_IDENTIFIER: social_app.pk},
+        last_editor=requesting_user,
+        message_type=MessageType.MANAGED_SSO_REMINDER,
+    )
+
+
+def users_needing_update(social_app_custom_data: SocialAppCustomData, domain: str):
+    social_app = social_app_custom_data.social_app
+    users_already_received_message = InAppMessageUsers.objects.filter(
+        in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
+        in_app_message__generic_related_objects__contains={
+            SOCIAL_APP_IDENTIFIER: social_app.pk,
+        },
+    ).values_list('user_id', flat=True)
+    users = (
+        User.objects.prefetch_related('socialaccount_set')
+        .filter(extra_details__sso_exempt=False)
+        .exclude(id__in=users_already_received_message)
+        .annotate(
+            domain=SplitPart(Lower(F('email')), Value('@'), Value(2)),
+            managed_account=Count(
+                'socialaccount',
+                filter=Q(socialaccount__provider=social_app.provider_id),
+            ),
+            # TODO: why doesn't exclude work here?
+            other_accounts=Count(
+                'socialaccount',
+                filter=~Q(socialaccount__provider=social_app.provider_id),
+            ),
+        )
+        .filter(domain=domain)
+        .exclude(
+            password__startswith=UNUSABLE_PASSWORD_PREFIX,
+            other_accounts=0,
+            managed_account=1,
+        )
+    )
+    return users
+
+@celery_app.task()
+def update_users(social_app_custom_data, domain, requesting_user=None):
+    users_to_update = users_needing_update(social_app_custom_data, domain)
+    social_app = social_app_custom_data.social_app
+    if not users_to_update.exists():
+        logging.info(
+            f'[Managed SSO] No users to update for social app'
+            f' {social_app.name} with '
+            f'domain {domain}. Nothing to do.'
+        )
+    social_app = social_app_custom_data.social_app
+    user_ids_needing_notification = []
+    for user in users_to_update:
+        if has_social_account(user, social_app):
+            logging.info(
+                '[Managed SSO] Removing alternative login methods for user'
+                f'{user.username} for managed social app {social_app.name}.'
+            )
+            update_linked_user(user, social_app.provider_id)
+        else:
+            user_ids_needing_notification.append(user.id)
+    if len(user_ids_needing_notification) > 0:
+        notify_unlinked_users(
+            user_ids_needing_notification, social_app, requesting_user
+        )
+
+@celery_app.task()
+def managed_sso_sweep():
+    managed_domains = SocialAppManagedDomain.objects.select_related(
+        'social_app'
+    ).filter(social_app__managed=True)
+    for domain in managed_domains:
+        # TODO: determine who kicked off the original update_users task and set them
+        # as requesting_user
+        update_users(domain.social_app, domain.domain)

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from model_bakery import baker
 from rest_framework import status
 
+from hub.models import ExtraUserDetail
 from kobo.apps.accounts.admin import SocialAccountAdmin
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
@@ -281,6 +282,22 @@ class TestManagedSsoCelery(TestCase):
         assert user_sso_exempt.id not in need_update
         assert user_already_received_message.id not in need_update
 
+    def test_user_with_several_managed_accounts_is_already_sso_only(self):
+        user = self._create_user('two_managed', False, True, False)
+        baker.make(
+            'socialaccount.SocialAccount',
+            user=user,
+            provider=self.social_app.provider_id,
+        )
+        need_update = users_needing_update(self.social_app, domain=self.default_domain)
+        assert not need_update.filter(pk=user.pk).exists()
+
+    def test_user_without_extra_details_is_not_exempt(self):
+        user = self._create_user('no_extra_details', True, True, False)
+        ExtraUserDetail.objects.filter(user=user).delete()
+        need_update = users_needing_update(self.social_app, domain=self.default_domain)
+        assert need_update.filter(pk=user.pk).exists()
+
     def test_update_linked_user(self):
         user = self._create_user('needs_update', True, True, True)
         update_linked_user(user, self.social_app.provider_id)
@@ -319,8 +336,8 @@ class TestManagedSsoCelery(TestCase):
                 'kobo.apps.accounts.tasks.notify_unlinked_users',
                 wraps=notify_unlinked_users,
             ) as patched_notify:
-                update_users(custom_data, managed_domain.domain)
-                update_users(custom_data, managed_domain.domain)
+                update_users(custom_data.pk, managed_domain.domain)
+                update_users(custom_data.pk, managed_domain.domain)
         patched_update.assert_called_once()
         patched_notify.assert_called_once()
 
@@ -352,7 +369,7 @@ class TestManagedSsoCelery(TestCase):
         )
 
         # update_users should be called for all three domains with the correct
-        # custom data object
+        # custom data pk
         SocialAppManagedDomain.objects.create(
             social_app=custom_data, domain=self.default_domain
         )
@@ -365,6 +382,6 @@ class TestManagedSsoCelery(TestCase):
         with patch('kobo.apps.accounts.tasks.update_users') as patched_update:
             managed_sso_sweep()
         assert patched_update.call_count == 3
-        patched_update.assert_any_call(custom_data, self.default_domain)
-        patched_update.assert_any_call(custom_data_managed, 'domain1.com')
-        patched_update.assert_any_call(custom_data_managed, 'domain2.com')
+        patched_update.assert_any_call(custom_data.pk, self.default_domain)
+        patched_update.assert_any_call(custom_data_managed.pk, 'domain1.com')
+        patched_update.assert_any_call(custom_data_managed.pk, 'domain2.com')

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -236,8 +236,6 @@ class TestManagedSsoCelery(TestCase):
         return user
 
     def test_users_needing_update(self):
-        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
-
         user_with_password = self._create_user('with_password', True, True, False)
         # has both managed and unmanaged social accounts
         user_multiple_accounts = self._create_user(
@@ -270,7 +268,7 @@ class TestManagedSsoCelery(TestCase):
         user_sso_exempt.extra_details.sso_exempt = True
         user_sso_exempt.extra_details.save()
 
-        need_update = users_needing_update(custom_data, domain=self.default_domain)
+        need_update = users_needing_update(self.social_app, domain=self.default_domain)
         need_update = [user.id for user in need_update]
 
         assert user_with_password.id in need_update

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -5,13 +5,24 @@ from ddt import data, ddt, unpack
 from django.contrib.admin.sites import site
 from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
+from model_bakery import baker
 from rest_framework import status
 
 from kobo.apps.accounts.admin import SocialAccountAdmin
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
+from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.utils import baker_generators  # noqa
 from ..adapter import AccountAdapter
 from ..forms import UserTokenForm
+from ..tasks import (
+    managed_sso_sweep,
+    notify_unlinked_users,
+    update_linked_user,
+    update_users,
+    users_needing_update,
+)
+from ..utils import SOCIAL_APP_IDENTIFIER
 from .utils import MockProvider
 
 
@@ -183,3 +194,177 @@ class TestManagedSsoUsers(TestCase):
                 'Cannot add a new SSO account for SSO-managed user'
                 in form.errors['user']
             )
+
+
+class TestManagedSsoCelery(TestCase):
+
+    def setUp(self):
+        self.provider = MockProvider(request=RequestFactory().get('/'))
+        self.social_app = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider=self.provider.id,
+            provider_id='kobo',
+        )
+        self.default_domain = 'example.com'
+
+    def _create_user(
+        self,
+        username,
+        has_password,
+        has_managed_account,
+        has_unmanaged_account,
+        domain=None,
+    ):
+        domain = domain or self.default_domain
+        user = User.objects.create(username=username, email=f'{username}@{domain}')
+        if has_password:
+            user.set_password('password')
+        else:
+            user.set_unusable_password()
+        user.save()
+        if has_managed_account:
+            baker.make(
+                'socialaccount.SocialAccount',
+                user=user,
+                provider=self.social_app.provider_id,
+            )
+        if has_unmanaged_account:
+            baker.make(
+                'socialaccount.SocialAccount', user=user, provider='another_provider'
+            )
+        return user
+
+    def test_users_needing_update(self):
+        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+
+        user_with_password = self._create_user('with_password', True, True, False)
+        # has both managed and unmanaged social accounts
+        user_multiple_accounts = self._create_user(
+            'multiple_accounts', False, True, True
+        )
+        user_no_social_accounts = self._create_user('no_accounts', False, False, False)
+        user_only_unmanaged_account = self._create_user(
+            'only_unmanaged', False, False, True
+        )
+
+        # these users should not be flagged for update
+        user_only_managed_account = self._create_user(
+            'only_managed', False, True, False
+        )
+        user_wrong_domain = self._create_user(
+            'wrong_domain', True, False, True, 'different.com'
+        )
+        user_already_received_message = self._create_user(
+            'already_received', True, False, False
+        )
+        message = baker.make(
+            'help.InAppMessage',
+            generic_related_objects={SOCIAL_APP_IDENTIFIER: self.social_app.id},
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+        )
+        InAppMessageUsers.objects.create(
+            user=user_already_received_message, in_app_message=message
+        )
+        user_sso_exempt = self._create_user('sso_exempt', True, False, True)
+        user_sso_exempt.extra_details.sso_exempt = True
+        user_sso_exempt.extra_details.save()
+
+        need_update = users_needing_update(custom_data, domain=self.default_domain)
+        need_update = [user.id for user in need_update]
+
+        assert user_with_password.id in need_update
+        assert user_multiple_accounts.id in need_update
+        assert user_no_social_accounts.id in need_update
+        assert user_only_unmanaged_account.id in need_update
+
+        assert user_only_managed_account.id not in need_update
+        assert user_wrong_domain.id not in need_update
+        assert user_sso_exempt.id not in need_update
+        assert user_already_received_message.id not in need_update
+
+    def test_update_linked_user(self):
+        user = self._create_user('needs_update', True, True, True)
+        update_linked_user(user, self.social_app.provider_id)
+        user.refresh_from_db()
+        assert not user.has_usable_password()
+        linked_accounts = SocialAccount.objects.filter(user=user)
+        assert linked_accounts.count() == 1
+        account = linked_accounts.first()
+        assert account.provider == self.social_app.provider_id
+
+    def test_message_unlinked_users(self):
+        requesting_user = User.objects.create(username='adminuser')
+        user = self._create_user('needs_update', True, False, False)
+        notify_unlinked_users([user.id], self.social_app, requesting_user)
+        # the following will fail if the message has not been created or if
+        # there are multiple
+        message = InAppMessage.objects.get(
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            generic_related_objects__contains={
+                SOCIAL_APP_IDENTIFIER: self.social_app.id
+            },
+        )
+        InAppMessageUsers.objects.get(user=user, in_app_message=message)
+
+    def test_update_users_only_updates_once(self):
+        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        managed_domain = SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain=self.default_domain
+        )
+        self._create_user(
+            'multiple_accounts', False, True, True
+        )
+        self._create_user('no_accounts', True, False, False)
+        with patch('kobo.apps.accounts.tasks.update_linked_user', wraps=update_linked_user) as patched_update:
+            with patch('kobo.apps.accounts.tasks.notify_unlinked_users', wraps=notify_unlinked_users) as patched_notify:
+                update_users(custom_data, managed_domain.domain)
+                update_users(custom_data, managed_domain.domain)
+        patched_update.assert_called_once()
+        patched_notify.assert_called_once()
+
+    def test_managed_sso_sweep(self):
+        social_app_managed = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider=self.provider.id,
+            provider_id='managed',
+        )
+        social_app_unmanaged = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider=self.provider.id,
+            provider_id='unmanaged',
+        )
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
+        custom_data_managed = SocialAppCustomData.objects.create(
+            social_app=social_app_managed, managed=True
+        )
+
+        # unamanged domain should be skipped
+        SocialAppCustomData.objects.create(
+            social_app=social_app_unmanaged, managed=False
+        )
+
+        # update_users should be called for all three domains with the correct
+        # custom data object
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain=self.default_domain
+        )
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data_managed, domain='domain1.com'
+        )
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data_managed, domain='domain2.com'
+        )
+        with patch('kobo.apps.accounts.tasks.update_users') as patched_update:
+            managed_sso_sweep()
+        assert patched_update.call_count == 3
+        patched_update.assert_any_call(custom_data, self.default_domain)
+        patched_update.assert_any_call(custom_data_managed, 'domain1.com')
+        patched_update.assert_any_call(custom_data_managed, 'domain2.com')

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -20,9 +20,8 @@ from ..tasks import (
     notify_unlinked_users,
     update_linked_user,
     update_users,
-    users_needing_update,
 )
-from ..utils import SOCIAL_APP_IDENTIFIER
+from ..utils import SOCIAL_APP_IDENTIFIER, users_needing_update
 from .utils import MockProvider
 
 

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -313,12 +313,15 @@ class TestManagedSsoCelery(TestCase):
         managed_domain = SocialAppManagedDomain.objects.create(
             social_app=custom_data, domain=self.default_domain
         )
-        self._create_user(
-            'multiple_accounts', False, True, True
-        )
+        self._create_user('multiple_accounts', False, True, True)
         self._create_user('no_accounts', True, False, False)
-        with patch('kobo.apps.accounts.tasks.update_linked_user', wraps=update_linked_user) as patched_update:
-            with patch('kobo.apps.accounts.tasks.notify_unlinked_users', wraps=notify_unlinked_users) as patched_notify:
+        with patch(
+            'kobo.apps.accounts.tasks.update_linked_user', wraps=update_linked_user
+        ) as patched_update:
+            with patch(
+                'kobo.apps.accounts.tasks.notify_unlinked_users',
+                wraps=notify_unlinked_users,
+            ) as patched_notify:
                 update_users(custom_data, managed_domain.domain)
                 update_users(custom_data, managed_domain.domain)
         patched_update.assert_called_once()

--- a/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
+++ b/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
@@ -138,6 +138,48 @@ class SocialAppCustomDataAdminTestCase(TestCase):
         self.assertFalse(self.custom_data.managed)
         self.assertEqual(self.custom_data.domains.count(), 0)
 
+    def test_counts_only_include_accounts_the_task_will_update(self):
+        # Linked user on the managed domain who still has a password (Track 1)
+        linked_user = User.objects.create(
+            username='linked_user', email='linked@example.com'
+        )
+        linked_user.set_password('password')
+        linked_user.save()
+        SocialAccount.objects.create(
+            user=linked_user, provider=self.social_app.provider_id, uid='sa201'
+        )
+        # Linked user already converted to SSO-only: nothing left to do
+        converted_user = User.objects.create(
+            username='converted_user', email='converted@example.com'
+        )
+        converted_user.set_unusable_password()
+        converted_user.save()
+        SocialAccount.objects.create(
+            user=converted_user, provider=self.social_app.provider_id, uid='sa202'
+        )
+        # Linked user on a domain that is not managed by this SocialApp
+        other_domain_user = User.objects.create(
+            username='other_domain_user', email='other@unmanaged.org'
+        )
+        other_domain_user.set_password('password')
+        other_domain_user.save()
+        SocialAccount.objects.create(
+            user=other_domain_user, provider=self.social_app.provider_id, uid='sa203'
+        )
+
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=True, domains=['example.com'], confirmed=False
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['track_1_count'], 1)
+        self.assertEqual(response.context['track_2_count'], 0)
+
     def test_post_toggle_managed_confirmed_saves(self):
         url = reverse(
             'admin:accounts_socialappcustomdata_change',

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -5,6 +5,7 @@ from kobo.apps.accounts.models import SocialAppManagedDomain
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
+SOCIAL_APP_IDENTIFIER = 'socialaccounts.SocialApp'
 
 def user_has_inactive_paid_subscription(username):
     if not settings.STRIPE_ENABLED:
@@ -56,3 +57,8 @@ def user_is_managed_by_sso(user):
         ).exists()
         return user_has_social_account
     return False
+
+
+def has_social_account(user, social_app: 'socialaccount.SocialApp') -> bool:
+    provider_id = social_app.provider_id
+    return user.socialaccount_set.filter(provider=provider_id).exists()

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -58,8 +58,3 @@ def user_is_managed_by_sso(user):
         ).exists()
         return user_has_social_account
     return False
-
-
-def has_social_account(user, social_app: 'socialaccount.SocialApp') -> bool:
-    provider_id = social_app.provider_id
-    return user.socialaccount_set.filter(provider=provider_id).exists()

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -1,4 +1,4 @@
-from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.models import SocialAccount, SocialApp
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.db.models import CharField, Count, F, Func, Q, Value
@@ -9,7 +9,9 @@ from kobo.apps.help.models import InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
-SOCIAL_APP_IDENTIFIER = 'socialaccounts.SocialApp'
+# Key used in InAppMessage.generic_related_objects, same convention as
+# the transfer identifier in kobo.apps.help.serializers
+SOCIAL_APP_IDENTIFIER = f'{SocialApp._meta.app_label}.{SocialApp._meta.model_name}'
 
 
 class SplitPart(Func):

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -7,6 +7,7 @@ from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 SOCIAL_APP_IDENTIFIER = 'socialaccounts.SocialApp'
 
+
 def user_has_inactive_paid_subscription(username):
     if not settings.STRIPE_ENABLED:
         return False

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -1,11 +1,20 @@
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
+from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.db.models import CharField, Count, F, Func, Q, Value
+from django.db.models.functions import Lower
 
 from kobo.apps.accounts.models import SocialAppManagedDomain
+from kobo.apps.help.models import InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
 SOCIAL_APP_IDENTIFIER = 'socialaccounts.SocialApp'
+
+
+class SplitPart(Func):
+    function = 'SPLIT_PART'
+    output_field = CharField()
 
 
 def user_has_inactive_paid_subscription(username):
@@ -58,3 +67,36 @@ def user_is_managed_by_sso(user):
         ).exists()
         return user_has_social_account
     return False
+
+
+def users_needing_update(social_app: 'socialaccount.SocialApp', domain: str):
+    users_already_received_message = InAppMessageUsers.objects.filter(
+        in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
+        in_app_message__generic_related_objects__contains={
+            SOCIAL_APP_IDENTIFIER: social_app.pk,
+        },
+    ).values_list('user_id', flat=True)
+    users = (
+        User.objects.prefetch_related('socialaccount_set')
+        .filter(extra_details__sso_exempt=False)
+        .exclude(id__in=users_already_received_message)
+        .annotate(
+            domain=SplitPart(Lower(F('email')), Value('@'), Value(2)),
+            managed_account=Count(
+                'socialaccount',
+                filter=Q(socialaccount__provider=social_app.provider_id),
+            ),
+            # TODO: why doesn't exclude work here?
+            other_accounts=Count(
+                'socialaccount',
+                filter=~Q(socialaccount__provider=social_app.provider_id),
+            ),
+        )
+        .filter(domain=domain)
+        .exclude(
+            password__startswith=UNUSABLE_PASSWORD_PREFIX,
+            other_accounts=0,
+            managed_account=1,
+        )
+    )
+    return users

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -79,8 +79,7 @@ def users_needing_update(social_app: 'socialaccount.SocialApp', domain: str):
         },
     ).values_list('user_id', flat=True)
     users = (
-        User.objects.prefetch_related('socialaccount_set')
-        .filter(extra_details__sso_exempt=False)
+        User.objects.exclude(extra_details__sso_exempt=True)
         .exclude(id__in=users_already_received_message)
         .annotate(
             domain=SplitPart(Lower(F('email')), Value('@'), Value(2)),
@@ -88,7 +87,9 @@ def users_needing_update(social_app: 'socialaccount.SocialApp', domain: str):
                 'socialaccount',
                 filter=Q(socialaccount__provider=social_app.provider_id),
             ),
-            # TODO: why doesn't exclude work here?
+            # `.exclude(socialaccount__provider=...)` would drop every user who
+            # has *any* account on the managed provider; a filtered Count is
+            # the only way to count the other accounts.
             other_accounts=Count(
                 'socialaccount',
                 filter=~Q(socialaccount__provider=social_app.provider_id),
@@ -98,7 +99,7 @@ def users_needing_update(social_app: 'socialaccount.SocialApp', domain: str):
         .exclude(
             password__startswith=UNUSABLE_PASSWORD_PREFIX,
             other_accounts=0,
-            managed_account=1,
+            managed_account__gte=1,
         )
     )
     return users

--- a/kobo/apps/help/serializers.py
+++ b/kobo/apps/help/serializers.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from allauth.socialaccount.models import SocialApp
 from django.utils.translation import gettext as t
 from rest_framework import serializers
 
 from kobo.apps.project_ownership.models import Transfer
+from kpi.utils.log import logging
 from kpi.utils.object_permission import get_database_user
+from ..accounts.utils import SOCIAL_APP_IDENTIFIER
 from .models import InAppMessage, InAppMessageUserInteractions
 
 
@@ -108,13 +111,17 @@ class InAppMessageSerializer(serializers.ModelSerializer):
     def _replace_placeholders(
         self, in_app_message: InAppMessage, value: str
     ) -> str:
-        # This method only support transfers so far
+        # eventually this should be genericized, for now, just supports transfers
+        # and managed SSO warnings
         transfer_identifier = (
             f'{Transfer._meta.app_label}.{Transfer._meta.model_name}'
         )
         if transfer_identifier in in_app_message.generic_related_objects:
             transfer_id = in_app_message.generic_related_objects[transfer_identifier]
             return self._replace_placeholders_for_transfer(value, transfer_id)
+        if SOCIAL_APP_IDENTIFIER in in_app_message.generic_related_objects:
+            socialapp_id = in_app_message.generic_related_objects[SOCIAL_APP_IDENTIFIER]
+            return self._replace_placeholders_for_managed_sso(value, socialapp_id)
 
         return t(value)
 
@@ -142,3 +149,18 @@ class InAppMessageSerializer(serializers.ModelSerializer):
         value = value.replace('##new_owner##', new_owner)
 
         return value
+
+    def _replace_placeholders_for_managed_sso(self, value, social_app_pk: int):
+        request = self.context['request']
+        user = get_database_user(request.user)
+        value = value.replace('##username##', user.username)
+        try:
+            socialapp = SocialApp.objects.get(pk=social_app_pk)
+            value = value.replace('##sso_name##', socialapp.name)
+            return value
+        except SocialApp.DoesNotExist:
+            logging.warning(
+                f'No social app found with id {social_app_pk}. Cannot'
+                ' create in-app message'
+            )
+            return ''

--- a/kobo/apps/help/serializers.py
+++ b/kobo/apps/help/serializers.py
@@ -153,7 +153,7 @@ class InAppMessageSerializer(serializers.ModelSerializer):
     def _replace_placeholders_for_managed_sso(self, value, social_app_pk: int):
         request = self.context['request']
         user = get_database_user(request.user)
-        value = value.replace('##username##', user.username)
+        value = t(value).replace('##username##', user.username)
         try:
             socialapp = SocialApp.objects.get(pk=social_app_pk)
             value = value.replace('##sso_name##', socialapp.name)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1702,6 +1702,11 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/5'),
         'options': {'queue': 'kpi_low_priority_queue'},
     },
+    'enforce-managed-sso': {
+        'task': 'kobo.apps.accounts.tasks.managed_sso_sweep',
+        'schedule': crontab(hour=0, minute=45),
+        'options': {'queue': 'kpi_low_priority_queue'},
+    },
 }
 
 if STRIPE_ENABLED:

--- a/kpi/tests/utils/baker_generators.py
+++ b/kpi/tests/utils/baker_generators.py
@@ -6,6 +6,7 @@ from model_bakery.random_gen import (
     gen_integer,
     gen_related,
     gen_slug,
+    gen_string,
 )
 
 from kpi.fields.kpi_uid import KpiUidField
@@ -29,3 +30,4 @@ baker.generators.add('djstripe.fields.StripeForeignKey', gen_related)
 baker.generators.add(
     'kpi.fields.kpi_uid.KpiUidField', KpiUidField.generate_unique_id
 )
+baker.generators.add('markdownx.models.MarkdownxField', gen_string)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Update users who have managed SSO accounts to limit their login capabilities to that SSO, and notify users with the corresponding domain who do not yet have SSO set up that they need to do so.


### 💭 Notes
Right now, only the sweep task runs. There is a separate task for kicking off the celery task immediately on changing a `SocialAppCustomData` object.

The task begins by finding users with the given email domain who are not sso-exempt and meet *any* of the following criteria:
1. Have a usable password
2. Have social accounts other than the managed SSO
3. Do not have an account with the managed SSO and have not yet been notified of the change

Users who already have a managed SSO account have all other social accounts deleted and their passwords unset, so they must login via SSO. Users who do not are notified via InAppMessage that they will need to link their account.  

The notification is set to expire after a year as an arbitrary deadline. In reality we will be removing it once users link their SSO.

Notably not in scope:

* Dismissing the notification once a user links their account and removing their other login methods
* Determining the correct `requesting_user` for any InAppMessages created by the sweep task rather than the ones that will be run on activation. This information is only shown in Django admin and arguably shouldn't really be set anyway if the messages are created by an automatic process. It is not necessary to resolve this for the initial release

### 👀 Preview steps
Make sure you have SSO enabled

1. ℹ️ have an admin account
2. In Django admin, update your SSO (via the SocialAppCustomData object) to `managed=False` and add the domain `kobotoolbox.org` (or whatever domain your SSO accepts)
3. Create a new user (user1) with a username and password and email ending with `@kobotoolbox.org`
4. Add an SSO login for the new user
5. Create another new user (user2) with a username and password and the correct email domain. Do not add an SSO login.
6. In Django admin, set the SSO to `managed=True`
7. In a Django shell, import and run `managed_sso_sweep`
8. 🟢 [on PR] In the django shell, check that user1.has_usable_password() is False 
9. Log in as user2
10. 🟢 [on PR] Notice there is a notification prompting you to add an SSO account

