### PR TITLE
fix(imports): validate URLs against SSRF before fetching them DEV-2777

### DIFF
--- a/kobo/apps/audit_log/tests/test_project_history_logs.py
+++ b/kobo/apps/audit_log/tests/test_project_history_logs.py
@@ -56,6 +56,7 @@ from kpi.constants import (
 )
 from kpi.models import Asset, AssetFile, ObjectPermission, PairedData
 from kpi.models.asset import AssetSetting
+from kpi.tests.utils.mock import patch_ssrf_dns
 from kpi.utils.strings import to_str
 from kpi.utils.xml import (
     edit_submission_xml,
@@ -926,6 +927,7 @@ class TestProjectHistoryLogs(BaseAuditLogTestCase):
         self.assertEqual(log_metadata['asset-file']['download_url'], media.download_url)
         self.assertEqual(log_metadata['asset-file']['md5_hash'], media.md5_hash)
 
+    @patch_ssrf_dns()
     @responses.activate
     @data(
         # File or url, change asset name?

--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -7,10 +7,10 @@ import constance
 import requests
 from django.db import transaction
 from rest_framework import status
-from ssrf_protect.ssrf_protect import SSRFProtect, SSRFProtectException
+from ssrf_protect.exceptions import SSRFProtectException
 
 from kpi.utils.log import logging
-from kpi.utils.strings import split_lines_to_list
+from kpi.utils.ssrf import validate_url_against_ssrf
 from ..constants import KOBO_INTERNAL_ERROR_STATUS_CODE, RETRIABLE_STATUS_CODES
 from ..exceptions import HookRemoteServerDownError
 from .hook import Hook
@@ -155,17 +155,6 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
                 }
             )
 
-        ssrf_protect_options = {}
-        if constance.config.SSRF_ALLOWED_IP_ADDRESS.strip():
-            ssrf_protect_options['allowed_ip_addresses'] = split_lines_to_list(
-                constance.config.SSRF_ALLOWED_IP_ADDRESS
-            )
-
-        if constance.config.SSRF_DENIED_IP_ADDRESS.strip():
-            ssrf_protect_options['denied_ip_addresses'] = split_lines_to_list(
-                constance.config.SSRF_DENIED_IP_ADDRESS
-            )
-
         # Update the status to PROCESSING to indicate the Celery task has begun
         # execution. This distinguishes it from the initial PENDING state created in
         # call_services() before the task was scheduled, confirming the task was
@@ -181,7 +170,7 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
         log_status = HookLogStatus.FAILED
 
         try:
-            SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
+            validate_url_against_ssrf(self._hook.endpoint)
             response = requests.post(self._hook.endpoint, timeout=30, **request_kwargs)
             response.raise_for_status()
             status_code = response.status_code

--- a/kobo/apps/openrosa/apps/main/models/meta_data.py
+++ b/kobo/apps/openrosa/apps/main/models/meta_data.py
@@ -21,7 +21,6 @@ from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.hash import calculate_hash
 from kpi.utils.ssrf import validate_url_against_ssrf
 
-
 CHUNK_SIZE = 1024
 
 urlvalidate = URLValidator()

--- a/kobo/apps/openrosa/apps/main/models/meta_data.py
+++ b/kobo/apps/openrosa/apps/main/models/meta_data.py
@@ -19,6 +19,7 @@ from kpi.deployment_backends.kc_access.storage import (
 from kpi.fields.file import ExtendedFileField
 from kpi.models.abstract_models import AbstractTimeStampedModel
 from kpi.utils.hash import calculate_hash
+from kpi.utils.ssrf import validate_url_against_ssrf
 
 
 CHUNK_SIZE = 1024
@@ -85,6 +86,7 @@ def type_for_form(xform, data_type):
 def create_media(media):
     """Download media link"""
     if is_valid_url(media.data_value):
+        validate_url_against_ssrf(media.data_value)
         filename = media.filename
         data_file = NamedTemporaryFile()
         content_type = mimetypes.guess_type(filename)

--- a/kpi/models/import_export_task.py
+++ b/kpi/models/import_export_task.py
@@ -13,7 +13,6 @@ from zoneinfo import ZoneInfo
 import constance
 import dateutil.parser
 import formpack
-import requests
 from django.conf import settings
 from django.contrib.postgres.indexes import BTreeIndex, HashIndex
 from django.db import models, transaction
@@ -84,6 +83,7 @@ from kpi.utils.rename_xls_sheet import (
     rename_xlsx_sheet,
 )
 from kpi.utils.sluggify import is_valid_node_name
+from kpi.utils.ssrf import ssrf_safe_get
 from kpi.utils.storage import is_filesystem_storage
 from kpi.utils.strings import to_str
 from kpi.zip_importer import HttpContentParse
@@ -297,7 +297,7 @@ class ImportTask(ImportExportTask):
             # TODO: merge with `url` handling above; currently kept separate
             # because `_load_assets_from_url()` uses complex logic to deal with
             # multiple XLS files in a directory structure within a ZIP archive
-            response = requests.get(self.data['single_xls_url'])
+            response = ssrf_safe_get(self.data['single_xls_url'])
             response.raise_for_status()
             encoded_xls = to_str(base64.b64encode(response.content))
 
@@ -338,7 +338,7 @@ class ImportTask(ImportExportTask):
     def _load_assets_from_url(self, url, messages, **kwargs):
         destination = kwargs.get('destination', False)
         has_necessary_perm = kwargs.get('has_necessary_perm', False)
-        req = requests.get(url, allow_redirects=True)
+        req = ssrf_safe_get(url)
         fif = HttpContentParse(request=req).parse()
         fif.remove_invalid_assets()
         fif.remove_empty_collections()

--- a/kpi/serializers/v2/asset_file.py
+++ b/kpi/serializers/v2/asset_file.py
@@ -14,6 +14,7 @@ from django.core.validators import (
 from django.utils.translation import gettext as t
 from rest_framework import serializers
 from rest_framework.reverse import reverse
+from ssrf_protect.exceptions import SSRFProtectException
 
 from kpi.fields import (
     RelativePrefixHyperlinkedRelatedField,
@@ -22,6 +23,7 @@ from kpi.fields import (
 )
 from kpi.models.asset_file import AssetFile
 from kpi.utils.log import logging
+from kpi.utils.ssrf import validate_url_against_ssrf
 
 
 class AssetFileSerializer(serializers.ModelSerializer):
@@ -256,6 +258,13 @@ class AssetFileSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({
                 'metadata': t('`redirect_url` is invalid')
             })
+
+        try:
+            validate_url_against_ssrf(redirect_url)
+        except SSRFProtectException:
+            raise serializers.ValidationError(
+                {'metadata': t('`redirect_url` is not allowed')}
+            )
 
     # PRIVATE METHODS
     # These methods could be protected too but IMO, they should not be

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -2536,6 +2536,21 @@ class AssetFileTest(AssetFileTestCaseMixin, BaseTestCase):
         }
         assert json_response == expected_response
 
+    def test_upload_form_media_ssrf_redirect_url(self):
+        # A syntactically valid URL that resolves to an internal address must
+        # be rejected by the SSRF guard with a clean 400 at the API boundary
+        payload = {
+            'file_type': AssetFile.FORM_MEDIA,
+            'description': 'A beautiful bird',
+            'metadata': json.dumps({'redirect_url': 'http://127.0.0.1/eagle.png'}),
+        }
+        response = self.create_asset_file(
+            payload=payload, status_code=status.HTTP_400_BAD_REQUEST
+        )
+        json_response = response.json()
+        expected_response = {'metadata': ['`redirect_url` is not allowed']}
+        assert json_response == expected_response
+
     def test_upload_form_media_bad_mime_type(self):
         # We are using remote URL, but it goes through the same validators as
         # `base64Encoded` or `content`

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -938,6 +938,7 @@ class AssetImportTaskTest(BaseTestCase):
             )
         )
 
+    @responses.activate
     def test_import_from_internal_url_is_blocked_by_ssrf(self):
         """
         A URL resolving to an internal address must be rejected by the SSRF

--- a/kpi/tests/api/v2/test_api_imports.py
+++ b/kpi/tests/api/v2/test_api_imports.py
@@ -15,6 +15,7 @@ from kpi.constants import ASSET_TYPE_BLOCK, ASSET_TYPE_QUESTION
 from kpi.models import Asset, ImportTask
 from kpi.models.import_export_task import ImportExportStatusChoices
 from kpi.tests.base_test_case import BaseTestCase
+from kpi.tests.utils.mock import patch_ssrf_dns
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.strings import to_str
 
@@ -117,6 +118,7 @@ class AssetImportTaskTest(BaseTestCase):
             task_data
         )
 
+    @patch_ssrf_dns()
     @responses.activate
     def test_import_asset_from_xls_url(self):
         # Host the XLS on a mock HTTP server
@@ -911,6 +913,7 @@ class AssetImportTaskTest(BaseTestCase):
         self._post_import_task_and_compare_created_asset_to_source(task_data,
                                                                    self.asset)
 
+    @patch_ssrf_dns()
     @responses.activate
     def test_import_non_xls_url(self):
         """
@@ -934,6 +937,54 @@ class AssetImportTaskTest(BaseTestCase):
                 'Unsupported format, or corrupt file'
             )
         )
+
+    def test_import_from_internal_url_is_blocked_by_ssrf(self):
+        """
+        A URL resolving to an internal address must be rejected by the SSRF
+        guard: the task ends in error and never fetches the URL.
+        """
+        task_data = {
+            'url': 'http://127.0.0.1/form.xls',
+            'name': 'I should have been blocked (SSRF)',
+        }
+        post_url = reverse(self._get_endpoint('importtask-list'))
+        response = self.client.post(post_url, task_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # Task completes right away due to `CELERY_TASK_ALWAYS_EAGER`
+        detail_response = self.client.get(response.data['url'])
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_response.data['status'], 'error')
+        self.assertIn('is not allowed', detail_response.data['messages']['error'])
+
+    @responses.activate
+    def test_import_from_url_redirecting_to_internal_is_blocked(self):
+        """
+        The SSRF guard must validate every hop of the redirect chain: a public
+        host that redirects to an internal address must be blocked, and the
+        internal URL must never be requested.
+        """
+        public_url = 'http://8.8.8.8/form.xls'
+        internal_url = 'http://127.0.0.1/meta'
+        responses.add(
+            responses.GET,
+            public_url,
+            status=status.HTTP_302_FOUND,
+            headers={'Location': internal_url},
+        )
+        task_data = {
+            'url': public_url,
+            'name': 'I redirect somewhere nasty',
+        }
+        post_url = reverse(self._get_endpoint('importtask-list'))
+        response = self.client.post(post_url, task_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        detail_response = self.client.get(response.data['url'])
+        self.assertEqual(detail_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_response.data['status'], 'error')
+        self.assertIn('is not allowed', detail_response.data['messages']['error'])
+        # Only the initial (public) URL should have been requested
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, public_url)
 
     @unittest.skip
     def test_import_invalid_host_url(self):
@@ -1019,6 +1070,7 @@ class AssetImportTaskTest(BaseTestCase):
         expected_name = 'A project with a new line'
         assert asset_response.data['name'] == expected_name
 
+    @patch_ssrf_dns()
     @responses.activate
     def test_import_to_existing_asset_from_xls_url_records_audit_log_info(self):
         self.asset.owner = self.user

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -3,9 +3,12 @@ import re
 from copy import deepcopy
 
 import pytest
+import responses
 from django.conf import settings
 from django.db.models import Q
 from django.test import RequestFactory, TestCase, override_settings
+from rest_framework import status
+from ssrf_protect.exceptions import SSRFProtectException
 
 from kpi.constants import API_NAMESPACES
 from kpi.exceptions import (
@@ -22,6 +25,7 @@ from kpi.utils.autoname import (
 from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
+from kpi.utils.ssrf import ssrf_safe_get, validate_url_against_ssrf
 from kpi.utils.strings import split_lines_to_list, strtobool
 from kpi.utils.urls import versioned_reverse
 from kpi.utils.xml import (
@@ -816,3 +820,35 @@ class XmlUtilsTestCase(TestCase):
         re_source = re.sub(pattern, r'\1', source)
         re_target = re.sub(pattern, r'\1', target)
         self.assertEqual(re_source, re_target)
+
+
+class SsrfUtilsTestCase(TestCase):
+
+    def test_validate_url_against_ssrf_raises_on_private_ip(self):
+        with pytest.raises(SSRFProtectException):
+            validate_url_against_ssrf('http://127.0.0.1/form.xls')
+
+    def test_validate_url_against_ssrf_passes_on_public_ip(self):
+        # Should not raise
+        validate_url_against_ssrf('http://8.8.8.8/form.xls')
+
+    @responses.activate
+    def test_ssrf_safe_get_follows_public_redirect(self):
+        first_url = 'http://8.8.8.8/form.xls'
+        final_url = 'http://1.1.1.1/form.xls'
+        responses.add(
+            responses.GET,
+            first_url,
+            status=status.HTTP_302_FOUND,
+            headers={'Location': final_url},
+        )
+        responses.add(
+            responses.GET,
+            final_url,
+            status=status.HTTP_200_OK,
+            body=b'final content',
+        )
+        response = ssrf_safe_get(first_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content, b'final content')
+        self.assertEqual(len(responses.calls), 2)

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -832,6 +832,20 @@ class SsrfUtilsTestCase(TestCase):
         assert calculate_hash('http://127.0.0.1/x.png', prefix=True).endswith('-url')
         assert len(responses.calls) == 0
 
+    @responses.activate
+    def test_calculate_hash_does_not_follow_redirect(self):
+        # `requests.head()` does not follow redirects, so a public host that
+        # redirects to an internal address never gets its destination fetched
+        public_url = 'http://8.8.8.8/eagle.png'
+        responses.add(
+            responses.HEAD,
+            public_url,
+            status=status.HTTP_302_FOUND,
+            headers={'Location': 'http://127.0.0.1/secret'},
+        )
+        assert calculate_hash(public_url, prefix=True).endswith('-url')
+        assert [call.request.url for call in responses.calls] == [public_url]
+
     def test_validate_url_against_ssrf_raises_on_private_ip(self):
         with pytest.raises(SSRFProtectException):
             validate_url_against_ssrf('http://127.0.0.1/form.xls')

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -22,6 +22,7 @@ from kpi.utils.autoname import (
     autoname_fields_to_field,
     autovalue_choices_in_place,
 )
+from kpi.utils.hash import calculate_hash
 from kpi.utils.pyxform_compatibility import allow_choice_duplicates
 from kpi.utils.query_parser import parse
 from kpi.utils.sluggify import sluggify, sluggify_label
@@ -823,6 +824,13 @@ class XmlUtilsTestCase(TestCase):
 
 
 class SsrfUtilsTestCase(TestCase):
+
+    @responses.activate
+    def test_calculate_hash_does_not_fetch_blocked_url(self):
+        # A blocked URL degrades to the plain-string hash, like an unreachable
+        # server would, and no request is ever made
+        assert calculate_hash('http://127.0.0.1/x.png', prefix=True).endswith('-url')
+        assert len(responses.calls) == 0
 
     def test_validate_url_against_ssrf_raises_on_private_ip(self):
         with pytest.raises(SSRFProtectException):

--- a/kpi/tests/utils/mock.py
+++ b/kpi/tests/utils/mock.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 import json
+from ipaddress import ip_address
 from mimetypes import guess_type
+from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, unquote
 
 from django.conf import settings
@@ -9,6 +11,22 @@ from rest_framework import status
 from kpi.models.asset_snapshot import AssetSnapshot
 from kpi.tests.utils.xml import get_form_and_submission_tag_names
 from kpi.utils.xml import fromstring_preserve_root_xmlns
+
+
+def patch_ssrf_dns(ip: str = '1.2.3.4'):
+    """
+    Return a fresh `patch` object forcing `SSRFProtect._get_ip_address` to
+    resolve to `ip`.
+
+    `responses` mocks HTTP but not DNS, so any test whose mocked host does not
+    actually resolve would otherwise raise `SSRFProtectException` before the
+    request is made. Applied as a decorator or context manager. `new` is used
+    so the patch does not inject a mock argument into the decorated test.
+    """
+    return patch(
+        'ssrf_protect.ssrf_protect.SSRFProtect._get_ip_address',
+        new=MagicMock(return_value=ip_address(ip)),
+    )
 
 
 def enketo_edit_instance_response(request):

--- a/kpi/utils/hash.py
+++ b/kpi/utils/hash.py
@@ -7,6 +7,8 @@ import requests
 from django.conf import settings
 from django.core.cache import cache
 
+from kpi.utils.ssrf import validate_url_against_ssrf
+
 
 def calculate_hash(
     source: Union[str, bytes, BinaryIO],
@@ -102,6 +104,7 @@ def calculate_hash(
     # Ensure we do not receive a gzip response to be able to read headers such
     # as `Content-Length`
     headers = {'Accept-Encoding': 'identity'}
+    validate_url_against_ssrf(source)
     try:
         response = requests.head(source, headers=headers)
         response.raise_for_status()

--- a/kpi/utils/hash.py
+++ b/kpi/utils/hash.py
@@ -6,6 +6,7 @@ from typing import BinaryIO, Optional, Union
 import requests
 from django.conf import settings
 from django.core.cache import cache
+from ssrf_protect.exceptions import SSRFProtectException
 
 from kpi.utils.ssrf import validate_url_against_ssrf
 
@@ -104,11 +105,13 @@ def calculate_hash(
     # Ensure we do not receive a gzip response to be able to read headers such
     # as `Content-Length`
     headers = {'Accept-Encoding': 'identity'}
-    validate_url_against_ssrf(source)
     try:
+        # A URL that is blocked or cannot be resolved is hashed as a plain
+        # string, exactly like one whose server does not answer
+        validate_url_against_ssrf(source)
         response = requests.head(source, headers=headers)
         response.raise_for_status()
-    except requests.exceptions.RequestException as e:
+    except (requests.exceptions.RequestException, SSRFProtectException):
         return _finalize_hash(source, 'url')
 
     try:

--- a/kpi/utils/ssrf.py
+++ b/kpi/utils/ssrf.py
@@ -1,0 +1,51 @@
+from urllib.parse import urljoin
+
+import constance
+import requests
+from ssrf_protect.ssrf_protect import SSRFProtect
+
+from kpi.utils.strings import split_lines_to_list
+
+
+def ssrf_safe_get(url: str, **kwargs) -> requests.Response:
+    """
+    Perform a GET request, validating every URL in the redirect chain against
+    SSRF rules before it is requested.
+
+    `requests` follows redirects transparently, so validating only the initial
+    URL is trivially bypassed by a public host that redirects to an internal
+    address. Redirects are therefore followed manually here, validating each
+    hop before it is fetched. Redirect handling is owned by this function, so
+    callers must not pass `allow_redirects`.
+    """
+    max_redirects = requests.models.DEFAULT_REDIRECT_LIMIT
+
+    for _ in range(max_redirects + 1):
+        validate_url_against_ssrf(url)
+        response = requests.get(url, allow_redirects=False, **kwargs)
+        if not response.is_redirect:
+            return response
+
+        url = urljoin(response.url, response.headers['location'])
+
+    raise requests.TooManyRedirects(f'Exceeded {max_redirects} redirects')
+
+
+def validate_url_against_ssrf(url: str) -> None:
+    """
+    Validate `url` against the configured SSRF allow/deny rules.
+
+    Raises `SSRFProtectException` if the URL resolves to a disallowed address.
+    """
+    options: dict[str, list[str]] = {}
+    if constance.config.SSRF_ALLOWED_IP_ADDRESS.strip():
+        options['allowed_ip_addresses'] = split_lines_to_list(
+            constance.config.SSRF_ALLOWED_IP_ADDRESS
+        )
+
+    if constance.config.SSRF_DENIED_IP_ADDRESS.strip():
+        options['denied_ip_addresses'] = split_lines_to_list(
+            constance.config.SSRF_DENIED_IP_ADDRESS
+        )
+
+    SSRFProtect.validate(url, options=options)


### PR DESCRIPTION
### 📣 Summary

Importing a project from a URL now refuses addresses that point back inside the server's own network.

### 📖 Description

When you import a project by pasting a URL, KoboToolbox fetches that address for you. Until now it would fetch any address, including ones that only exist inside the server's private network. Those are now refused and the import stops with a clear error message. The same check applies to form media added by URL. Imports and media from ordinary public web addresses work exactly as before.

### 💭 Notes

- We already ship `ssrf-protect`, but it was only wired into the REST Services hook. This adds `kpi/utils/ssrf.py` and uses it on the three unguarded sinks: both `ImportTask` fetches and the `requests.head()` inside `calculate_hash()`.
- `ssrf_safe_get()` follows redirects itself and validates every hop. Validating only the initial URL would not have fixed this, since `requests` follows redirects by default and any public host that 302s to an internal address walks straight past a single check. `test_import_from_url_redirecting_to_internal_is_blocked` is the test that catches that.
- `AssetFileSerializer` now rejects an internal `redirect_url` with a 400, so the guard doesn't surface as a 500 from the model layer.
- The hook change is just a move onto the shared helper. Same options, same exception handling, no behavior change.
- Self-hosted instances that deliberately point form media at an internal host can allow it through the existing `SSRF_ALLOWED_IP_ADDRESS` setting in the admin.
- `calculate_hash()` treats a blocked or unresolvable URL like an unreachable server: hash of the URL string, no request made. Otherwise a dead media host would raise out of `MetaData.save()` and abort `sync_media_files` for the whole asset.
- Known limitations shared with the webhook path, tickets to follow: the guard resolves the host once (so DNS rebinding and IPv6-only answers are not covered), the library does not block the CGNAT range, and none of these fetches has a timeout.

### 👀 Preview steps

Back end only, nothing changes in the UI.

1. ℹ️ log in as any user
2. `POST /api/v2/imports/` with `url=http://127.0.0.1:8000/service_health/minimal/` and `name=x.xlsx`
3. `GET` the import URL returned in the response
4. 🔴 [on release/2.026.33] `status` is `error` with `"error_type": "KeyError"`, meaning the internal service was reached and answered
5. 🟢 [on PR] `status` is `error` with `"error_type": "SSRFProtectException"` and a message ending in `is not allowed because it resolves to a private IP address`, and nothing was fetched
