### PR TITLE
feat(sidebar): add text submission widget for processing view DEV-2289

### DIFF
--- a/jsapp/js/components/processing/SingleProcessingSidebar/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/index.tsx
@@ -61,8 +61,9 @@ export default function ProcessingSidebar({
     return getAllTranslationsFromSupplementData(supplement, questionXpath)
   }, [supplement, questionXpath])
 
-  // Every time user changes the tab, we need to load the default static displays list
-  // for that tab, keeping the dynamically selected translations.
+  // Every time user changes the tab or switches to a question of a different
+  // type, we need to reload the default static displays list, keeping the
+  // dynamically selected translations.
   useEffect(() => {
     const defaultDisplays = getDefaultDisplaysForTab(activeTab, questionType)
     const allStaticDisplays = recordValues(StaticDisplays)
@@ -71,7 +72,7 @@ export default function ProcessingSidebar({
     )
     const newSelectedDisplays = [...defaultDisplays, ...selectedTranslationDisplays]
     setSelectedDisplays(newSelectedDisplays)
-  }, [activeTab])
+  }, [activeTab, questionType])
 
   return (
     <div className={styles.root}>

--- a/jsapp/js/components/processing/SingleProcessingSidebar/index.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 
 import type { DataResponse } from '#/api/models/dataResponse'
 import type { DataSupplementResponse } from '#/api/models/dataSupplementResponse'
+import { findRowByXpathOrLeafName } from '#/assetUtils'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import type { AssetResponse } from '#/dataInterface'
 import { recordValues } from '#/utils'
@@ -17,6 +18,7 @@ import styles from './index.module.scss'
 import SidebarDisplaySettings from './sidebarDisplaySettings'
 import SidebarSubmissionData from './sidebarSubmissionData'
 import SidebarSubmissionMedia from './sidebarSubmissionMedia'
+import SidebarSubmissionText from './sidebarSubmissionText'
 import TransxDisplay from './transxDisplay'
 
 interface ProcessingSidebarProps {
@@ -46,6 +48,11 @@ export default function ProcessingSidebar({
   const [selectedDisplays, setSelectedDisplays] = useState<DisplaysList>([])
   const [hiddenQuestions, setHiddenQuestions] = useState<string[]>([])
 
+  const questionType = useMemo(
+    () => asset.content && findRowByXpathOrLeafName(asset.content, questionXpath)?.type,
+    [asset.content, questionXpath],
+  )
+
   const transcript = useMemo(() => {
     return getLatestTranscriptVersionItem(supplement, questionXpath)
   }, [supplement, questionXpath])
@@ -57,7 +64,7 @@ export default function ProcessingSidebar({
   // Every time user changes the tab, we need to load the default static displays list
   // for that tab, keeping the dynamically selected translations.
   useEffect(() => {
-    const defaultDisplays = getDefaultDisplaysForTab(activeTab)
+    const defaultDisplays = getDefaultDisplaysForTab(activeTab, questionType)
     const allStaticDisplays = recordValues(StaticDisplays)
     const selectedTranslationDisplays = selectedDisplays.filter(
       (display) => !allStaticDisplays.includes(display as StaticDisplays),
@@ -70,6 +77,7 @@ export default function ProcessingSidebar({
     <div className={styles.root}>
       <SidebarDisplaySettings
         asset={asset}
+        questionType={questionType}
         selectedDisplays={selectedDisplays}
         setSelectedDisplays={setSelectedDisplays}
         hiddenQuestions={hiddenQuestions}
@@ -101,6 +109,10 @@ export default function ProcessingSidebar({
 
         {selectedDisplays.includes(StaticDisplays.Audio) && (
           <SidebarSubmissionMedia asset={asset} xpath={questionXpath} submission={submission} />
+        )}
+
+        {selectedDisplays.includes(StaticDisplays.Text) && (
+          <SidebarSubmissionText asset={asset} xpath={questionXpath} submission={submission} />
         )}
 
         {selectedDisplays.includes(StaticDisplays.Data) && (

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarDisplaySettings.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarDisplaySettings.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { Box, Flex, Modal, ScrollArea, Stack, Switch, Text } from '@mantine/core'
 import { getFlatQuestionsList, getLanguageIndex } from '#/assetUtils'
@@ -10,7 +10,8 @@ import type { ComboboxItem } from '#/components/common/select.types'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import { AsyncLanguageDisplayLabel } from '#/components/languages/languagesUtils'
 import { ProcessingTab, getActiveTab } from '#/components/processing/routes.utils'
-import { XML_VALUES_OPTION_VALUE } from '#/constants'
+import { QUESTION_TYPES, XML_VALUES_OPTION_VALUE } from '#/constants'
+import type { AnyRowTypeName } from '#/constants'
 import type { AssetResponse } from '#/dataInterface'
 import { recordValues } from '#/utils'
 import type { DisplaysList, TranscriptVersionItem, TranslationVersionItem } from '../common/types'
@@ -18,6 +19,8 @@ import { StaticDisplays } from '../common/utils'
 
 interface SidebarDisplaySettingsProps {
   asset: AssetResponse
+  /** Current question's type, used to only offer the Audio/Text toggle that applies to it. */
+  questionType: AnyRowTypeName | undefined
   selectedDisplays: DisplaysList
   setSelectedDisplays: (displays: DisplaysList) => void
   hiddenQuestions: string[]
@@ -30,6 +33,7 @@ interface SidebarDisplaySettingsProps {
 
 export default function SidebarDisplaySettings({
   asset,
+  questionType,
   selectedDisplays,
   setSelectedDisplays,
   hiddenQuestions,
@@ -64,6 +68,18 @@ export default function SidebarDisplaySettings({
   const availableDisplays = useMemo<Array<LanguageCode | StaticDisplays>>(() => {
     let displays: Array<LanguageCode | StaticDisplays> = [...recordValues(StaticDisplays), ...availableLanguages]
 
+    // Audio and Text are mutually exclusive: only the one matching the current
+    // question's type makes sense to offer.
+    displays = displays.filter((display) => {
+      if (display === StaticDisplays.Audio) {
+        return questionType === QUESTION_TYPES.audio.id || questionType === QUESTION_TYPES['background-audio'].id
+      }
+      if (display === StaticDisplays.Text) {
+        return questionType === QUESTION_TYPES.text.id
+      }
+      return true
+    })
+
     // Filter out transcript if we are on the transcript tab or if it was deleted
     if (
       activeTab === ProcessingTab.Transcript ||
@@ -75,7 +91,17 @@ export default function SidebarDisplaySettings({
     }
 
     return displays
-  }, [availableLanguages, activeTab, transcript])
+  }, [availableLanguages, activeTab, transcript, questionType])
+
+  // Drop selections that are no longer valid for the current question/tab
+  // (e.g. Audio while viewing a text question), instead of leaving a stale
+  // entry in `selectedDisplays` that the settings UI has no toggle for anymore.
+  useEffect(() => {
+    const prunedDisplays = selectedDisplays.filter((display) => availableDisplays.includes(display))
+    if (prunedDisplays.length !== selectedDisplays.length) {
+      setSelectedDisplays(prunedDisplays)
+    }
+  }, [availableDisplays])
 
   if (activeTab === undefined) {
     return null
@@ -101,6 +127,12 @@ export default function SidebarDisplaySettings({
       return (
         <Text fw={700} component='span'>
           {t('Submission data')}
+        </Text>
+      )
+    } else if (display === StaticDisplays.Text) {
+      return (
+        <Text fw={700} component='span'>
+          {t('Original response')}
         </Text>
       )
     } else {

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarDisplaySettings.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarDisplaySettings.tsx
@@ -10,12 +10,12 @@ import type { ComboboxItem } from '#/components/common/select.types'
 import type { LanguageCode } from '#/components/languages/languagesStore'
 import { AsyncLanguageDisplayLabel } from '#/components/languages/languagesUtils'
 import { ProcessingTab, getActiveTab } from '#/components/processing/routes.utils'
-import { QUESTION_TYPES, XML_VALUES_OPTION_VALUE } from '#/constants'
+import { XML_VALUES_OPTION_VALUE } from '#/constants'
 import type { AnyRowTypeName } from '#/constants'
 import type { AssetResponse } from '#/dataInterface'
 import { recordValues } from '#/utils'
 import type { DisplaysList, TranscriptVersionItem, TranslationVersionItem } from '../common/types'
-import { StaticDisplays } from '../common/utils'
+import { StaticDisplays, isAudioQuestionType, isTextQuestionType } from '../common/utils'
 
 interface SidebarDisplaySettingsProps {
   asset: AssetResponse
@@ -71,12 +71,8 @@ export default function SidebarDisplaySettings({
     // Audio and Text are mutually exclusive: only the one matching the current
     // question's type makes sense to offer.
     displays = displays.filter((display) => {
-      if (display === StaticDisplays.Audio) {
-        return questionType === QUESTION_TYPES.audio.id || questionType === QUESTION_TYPES['background-audio'].id
-      }
-      if (display === StaticDisplays.Text) {
-        return questionType === QUESTION_TYPES.text.id
-      }
+      if (display === StaticDisplays.Audio) return isAudioQuestionType(questionType)
+      if (display === StaticDisplays.Text) return isTextQuestionType(questionType)
       return true
     })
 

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
@@ -1,0 +1,53 @@
+import { Box, Group, ScrollArea, Text } from '@mantine/core'
+import React from 'react'
+
+import type { DataResponse } from '#/api/models/dataResponse'
+import { findRowByXpathOrLeafName } from '#/assetUtils'
+import Icon from '#/components/common/icon'
+import { QUESTION_TYPES } from '#/constants'
+import type { AssetResponse } from '#/dataInterface'
+
+interface SidebarSubmissionTextProps {
+  xpath: string
+  asset: AssetResponse | undefined
+  submission?: DataResponse
+}
+
+/** Analogous to `SidebarSubmissionMedia`, but for `text` question responses. */
+export default function SidebarSubmissionText({ asset, xpath, submission }: SidebarSubmissionTextProps) {
+  if (!asset?.content || !submission) {
+    return null
+  }
+
+  if (findRowByXpathOrLeafName(asset.content, xpath)?.type !== QUESTION_TYPES.text.id) {
+    return null
+  }
+
+  const value = submission[xpath]
+  if (typeof value !== 'string' || value === '') {
+    return null
+  }
+
+  return (
+    <Box
+      bg='white'
+      p='lg'
+      h={200}
+      style={{ borderRadius: 'var(--mantine-radius-default)', display: 'flex', flexDirection: 'column' }}
+    >
+      <Group gap='xs' mb='sm' style={{ flexShrink: 0 }}>
+        <Icon name='qt-text' size='m' />
+        <Text fw={600} c='blue' component='span'>
+          {t('Original response')}
+        </Text>
+      </Group>
+
+      {/* Keyed by submission so switching records remounts the scroll area, resetting its scroll position. */}
+      <ScrollArea key={submission._uuid} style={{ flex: 1 }} type='auto' offsetScrollbars>
+        <Text dir='auto' style={{ whiteSpace: 'pre-wrap' }}>
+          {value}
+        </Text>
+      </ScrollArea>
+    </Box>
+  )
+}

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import type { DataResponse } from '#/api/models/dataResponse'
 import { findRowByXpathOrLeafName } from '#/assetUtils'
 import Icon from '#/components/common/icon'
-import { QUESTION_TYPES } from '#/constants'
 import type { AssetResponse } from '#/dataInterface'
+import { isTextQuestionType } from '../common/utils'
 
 interface SidebarSubmissionTextProps {
   xpath: string
@@ -18,7 +18,7 @@ export default function SidebarSubmissionText({ asset, xpath, submission }: Side
     return null
   }
 
-  if (findRowByXpathOrLeafName(asset.content, xpath)?.type !== QUESTION_TYPES.text.id) {
+  if (!isTextQuestionType(findRowByXpathOrLeafName(asset.content, xpath)?.type)) {
     return null
   }
 

--- a/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
+++ b/jsapp/js/components/processing/SingleProcessingSidebar/sidebarSubmissionText.tsx
@@ -1,6 +1,5 @@
-import { Box, Group, ScrollArea, Text } from '@mantine/core'
+import { Group, ScrollArea, Stack, Text } from '@mantine/core'
 import React from 'react'
-
 import type { DataResponse } from '#/api/models/dataResponse'
 import { findRowByXpathOrLeafName } from '#/assetUtils'
 import Icon from '#/components/common/icon'
@@ -29,15 +28,10 @@ export default function SidebarSubmissionText({ asset, xpath, submission }: Side
   }
 
   return (
-    <Box
-      bg='white'
-      p='lg'
-      h={200}
-      style={{ borderRadius: 'var(--mantine-radius-default)', display: 'flex', flexDirection: 'column' }}
-    >
-      <Group gap='xs' mb='sm' style={{ flexShrink: 0 }}>
+    <Stack bg='white' p='lg' mah={200} gap='sm' style={{ borderRadius: 'var(--mantine-radius-default)' }}>
+      <Group gap='xs' style={{ flexShrink: 0 }}>
         <Icon name='qt-text' size='m' />
-        <Text fw={600} c='blue' component='span'>
+        <Text fw={600} c='blue.3' component='span'>
           {t('Original response')}
         </Text>
       </Group>
@@ -48,6 +42,6 @@ export default function SidebarSubmissionText({ asset, xpath, submission }: Side
           {value}
         </Text>
       </ScrollArea>
-    </Box>
+    </Stack>
   )
 }

--- a/jsapp/js/components/processing/common/utils.ts
+++ b/jsapp/js/components/processing/common/utils.ts
@@ -377,14 +377,18 @@ export const isNlpSupported = (questionType: AnyRowTypeName | undefined): boolea
 export enum StaticDisplays {
   // Keep the enum ordering, since it controls the order of display options in the UI
   Audio = 'Audio',
+  Text = 'Text',
   Data = 'Data',
   Transcript = 'Transcript',
 }
 
 export const DefaultDisplays: Map<ProcessingTab, DisplaysList> = new Map([
-  [ProcessingTab.Transcript, [StaticDisplays.Audio, StaticDisplays.Data]],
-  [ProcessingTab.Translations, [StaticDisplays.Audio, StaticDisplays.Data, StaticDisplays.Transcript]],
-  [ProcessingTab.Analysis, [StaticDisplays.Audio, StaticDisplays.Data, StaticDisplays.Transcript]],
+  [ProcessingTab.Transcript, [StaticDisplays.Audio, StaticDisplays.Text, StaticDisplays.Data]],
+  [
+    ProcessingTab.Translations,
+    [StaticDisplays.Audio, StaticDisplays.Text, StaticDisplays.Data, StaticDisplays.Transcript],
+  ],
+  [ProcessingTab.Analysis, [StaticDisplays.Audio, StaticDisplays.Text, StaticDisplays.Data, StaticDisplays.Transcript]],
 ])
 
 /**
@@ -400,16 +404,28 @@ export function getAvailableTabsForQuestionType(questionType: AnyRowTypeName | u
 }
 
 /**
- * Gets the default displays for a given processing tab.
+ * Gets the default displays for a given processing tab, dropping whichever of
+ * Audio/Text can't apply to the given question type (they're mutually
+ * exclusive, and the baked-in defaults above include both).
  *
  * @param tabName - The processing tab name
+ * @param questionType - The current question's type, if known
  * @returns Array of default displays for the tab, or empty array if undefined
  */
-export const getDefaultDisplaysForTab = (tabName: ProcessingTab | undefined): DisplaysList => {
+export const getDefaultDisplaysForTab = (
+  tabName: ProcessingTab | undefined,
+  questionType?: AnyRowTypeName,
+): DisplaysList => {
   if (tabName === undefined) {
     return []
   }
-  return DefaultDisplays.get(tabName) || []
+  const defaults = DefaultDisplays.get(tabName) || []
+
+  return defaults.filter((display) => {
+    if (display === StaticDisplays.Audio) return isAudioQuestionType(questionType)
+    if (display === StaticDisplays.Text) return isTextQuestionType(questionType)
+    return true
+  })
 }
 
 /**


### PR DESCRIPTION
### 📣 Summary
Added a widget to view the full original response for text questions in the submission processing view.

### 💭 Notes
- Audio and Text display options are mutually exclusive per question type: only the one matching the current question's type is offered/enabled, keeping parity with how Audio already worked.
- Entering the processing view for a `text` question from the submissions data table (the "Open" action on a text cell) is gated behind the `nlpTextActionsEnabled` feature flag. Testers need `?ff_nlpTextActionsEnabled=true` in the URL to reach it that way.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ have a project with a `text` question and at least one submission with a response
2. ℹ️ enable the `nlpTextActionsEnabled` feature flag (append `?ff_nlpTextActionsEnabled=true` to the URL) to see the "Open" action on text cells in the submissions table
3. open the submission in the processing view for that question
4. 🔴 [on main] notice there's no way to see the full original text response in the sidebar
5. 🟢 [on PR] notice the "Original response" widget in the sidebar showing the submitted text
6. open the display settings and confirm the Audio option is not offered for `text` questions (and vice versa for audio questions)
7. switch between a text question and an audio question on the same tab, confirming the correct default panel (Original response vs Audio) shows for each without needing a manual refresh