### PR TITLE
feat(sso): run update task on save managed SSO custom data DEV-2759

### DIFF
--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -279,14 +279,13 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                     domains_to_update.append(domain)
 
             def update_all_domains():
+                send_message = request.POST.get('send_in_app_message', 'off') == 'on'
                 for domain in domains_to_update:
                     update_users.delay(
                         social_app_custom_data_id=instance.pk,
                         domain=domain,
                         requesting_user_id=request.user.pk,
-                        send_in_app_message=request.POST.get(
-                            'send_in_app_message', False
-                        ),
+                        send_in_app_message=send_message,
                         in_app_message_body=request.POST.get('in_app_message_body'),
                     )
 

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -6,8 +6,10 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import PermissionDenied, ValidationError
+from django.db import transaction
 from django.db.models import Q
 from django.forms.formsets import all_valid
+from django.http import HttpRequest
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -18,7 +20,8 @@ from kobo.apps.accounts.models import (
     SocialAppCustomData,
     SocialAppManagedDomain,
 )
-from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY
+from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY, update_users
+
 from kobo.apps.accounts.utils import user_is_managed_by_sso, users_needing_update
 
 
@@ -249,10 +252,42 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                             'admin/accounts/socialappcustomdata/confirmation.html',
                             context,
                         )
-
         return super().changeform_view(
             request, object_id=object_id, form_url=form_url, extra_context=extra_context
         )
+
+    def save_model(self, request, obj, form, change):
+        obj._initially_managed_pre_save = obj._initially_managed
+        obj._initial_domains_pre_save = obj._initial_domains
+        super().save_model(request, obj, form, change)
+
+    def save_related(self, request: HttpRequest, form, formsets, change) -> None:
+        instance = formsets[0].instance
+        if not instance.managed:
+            super().save_related(request, form, formsets, change)
+            return
+
+        with transaction.atomic():
+            super().save_related(request, form, formsets, change)
+            managed_domains_formset = formsets[0]
+            domains_to_update = []
+            newly_managed = not instance._initially_managed_pre_save
+            for domain_form in managed_domains_formset.forms:
+                domain = domain_form.instance.domain
+                if not domain or domain_form.cleaned_data.get('DELETE'):
+                    continue
+                if newly_managed or domain not in instance._initial_domains_pre_save:
+                    domains_to_update.append(domain)
+
+            def update_all_domains():
+                for domain in domains_to_update:
+                    update_users.delay(
+                        social_app_custom_data_id=instance.pk,
+                        domain=domain,
+                        requesting_user_id=request.user.pk,
+                    )
+
+            transaction.on_commit(update_all_domains)
 
 
 class SocialAccountForm(forms.ModelForm):

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -285,6 +285,8 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                         social_app_custom_data_id=instance.pk,
                         domain=domain,
                         requesting_user_id=request.user.pk,
+                        send_in_app_message=request.POST['send_in_app_message'],
+                        in_app_message_body=request.POST['in_app_message_body'],
                     )
 
             transaction.on_commit(update_all_domains)

--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -21,7 +21,6 @@ from kobo.apps.accounts.models import (
     SocialAppManagedDomain,
 )
 from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY, update_users
-
 from kobo.apps.accounts.utils import user_is_managed_by_sso, users_needing_update
 
 
@@ -285,8 +284,10 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                         social_app_custom_data_id=instance.pk,
                         domain=domain,
                         requesting_user_id=request.user.pk,
-                        send_in_app_message=request.POST['send_in_app_message'],
-                        in_app_message_body=request.POST['in_app_message_body'],
+                        send_in_app_message=request.POST.get(
+                            'send_in_app_message', False
+                        ),
+                        in_app_message_body=request.POST.get('in_app_message_body'),
                     )
 
             transaction.on_commit(update_all_domains)

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -102,6 +102,19 @@ class SocialAppCustomData(models.Model):
     def __str__(self):
         return f'{self.social_app.name} Custom Data'
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._initially_managed = self.managed
+        if self.pk:
+            self._initial_domains = list(self.domains.values_list('domain', flat=True))
+        else:
+            self._initial_domains = []
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self._initially_managed = self.managed
+        self._initial_domains = list(self.domains.values_list('domain', flat=True))
+
 
 def validate_domain(value):
     normalized_value = value.strip().lower()

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -42,11 +42,16 @@ def notify_unlinked_users(
             f'[Managed SSO] Creating in-app message for unregistered users for'
             f' managed social app {managed_social_app.name}.'
         )
-        InAppMessageUsers.objects.bulk_create(
+        created = InAppMessageUsers.objects.bulk_create(
             [
                 InAppMessageUsers(user_id=user_id, in_app_message=in_app_message)
                 for user_id in user_ids
             ]
+        )
+        logging.info(
+            f'[Managed SSO] Created {len(created)} notifications for'
+            ' unregistered users for managed social '
+            f'app {managed_social_app.name}'
         )
 
 

--- a/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
+++ b/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
@@ -464,11 +464,15 @@ class SocialAppCustomDataAdminTestCase(TestCase):
             social_app_custom_data_id=new_custom_data.pk,
             domain='example.com',
             requesting_user_id=self.admin_user.pk,
+            send_in_app_message=False,
+            in_app_message_body=None,
         )
         patched.assert_any_call(
             social_app_custom_data_id=new_custom_data.pk,
             domain='another.com',
             requesting_user_id=self.admin_user.pk,
+            send_in_app_message=False,
+            in_app_message_body=None,
         )
 
     # initially managed, managed on save, expect task for existing, expect task for new
@@ -502,6 +506,8 @@ class SocialAppCustomDataAdminTestCase(TestCase):
                     managed=managed_on_save,
                     domains=['example.com', 'another.com'],
                     confirmed=True,
+                    send_in_app_message='on',
+                    in_app_message_body='Custom message body',
                 )
                 post_data['domains-0-id'] = initial_domain.pk
                 post_data['domains-INITIAL_FORMS'] = ['1']
@@ -516,10 +522,14 @@ class SocialAppCustomDataAdminTestCase(TestCase):
                 social_app_custom_data_id=self.custom_data.pk,
                 domain='example.com',
                 requesting_user_id=self.admin_user.pk,
+                send_in_app_message=True,
+                in_app_message_body='Custom message body',
             )
         if expect_task_for_new_domain:
             patched.assert_any_call(
                 social_app_custom_data_id=self.custom_data.pk,
                 domain='another.com',
                 requesting_user_id=self.admin_user.pk,
+                send_in_app_message=True,
+                in_app_message_body='Custom message body',
             )

--- a/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
+++ b/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from allauth.socialaccount.models import SocialAccount, SocialApp
+from ddt import data, ddt, unpack
 from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
 
@@ -7,8 +10,10 @@ from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY
 from kobo.apps.accounts.tests.utils import MockProvider
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
+from kpi.tests.utils.transaction import immediate_on_commit
 
 
+@ddt
 class SocialAppCustomDataAdminTestCase(TestCase):
     fixtures = ['test_data']
 
@@ -435,3 +440,86 @@ class SocialAppCustomDataAdminTestCase(TestCase):
             list(self.custom_data.domains.values_list('domain', flat=True)),
             ['example.com'],
         )
+
+    def test_trigger_celery_tasks_for_all_domains_on_add(self):
+        assert SocialAppCustomData.objects.count() == 1
+        new_app = SocialApp.objects.create(
+            client_id='new.service.id',
+            secret='new.service.secret',
+            name='New App',
+            provider=self.provider.id,
+            provider_id='new_provider',
+        )
+        url = reverse('admin:accounts_socialappcustomdata_add')
+        with patch('kobo.apps.accounts.admin.update_users.delay') as patched:
+            with immediate_on_commit():
+                post_data = self._get_change_post_data(
+                    managed=True, domains=['example.com', 'another.com'], confirmed=True
+                )
+                post_data['social_app'] = new_app.pk
+                self.client.post(url, post_data)
+                new_custom_data = SocialAppCustomData.objects.get(social_app=new_app)
+        assert patched.call_count == 2
+        patched.assert_any_call(
+            social_app_custom_data_id=new_custom_data.pk,
+            domain='example.com',
+            requesting_user_id=self.admin_user.pk,
+        )
+        patched.assert_any_call(
+            social_app_custom_data_id=new_custom_data.pk,
+            domain='another.com',
+            requesting_user_id=self.admin_user.pk,
+        )
+
+    # initially managed, managed on save, expect task for existing, expect task for new
+    @data(
+        (False, True, True, True),
+        (True, True, False, True),
+        (True, False, False, False),
+        (False, False, False, False),
+    )
+    @unpack
+    def test_trigger_celery_tasks_for_only_new_domains_if_already_managed(
+        self,
+        initially_managed,
+        managed_on_save,
+        expect_task_for_existing_domain,
+        expect_task_for_new_domain,
+    ):
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change', args=[self.custom_data.pk]
+        )
+        if initially_managed:
+            self.custom_data.managed = True
+            self.custom_data.save()
+        # set up one domain in advance
+        initial_domain = SocialAppManagedDomain.objects.create(
+            social_app=self.custom_data, domain='example.com'
+        )
+        with patch('kobo.apps.accounts.admin.update_users.delay') as patched:
+            with immediate_on_commit():
+                post_data = self._get_change_post_data(
+                    managed=managed_on_save,
+                    domains=['example.com', 'another.com'],
+                    confirmed=True,
+                )
+                post_data['domains-0-id'] = initial_domain.pk
+                post_data['domains-INITIAL_FORMS'] = ['1']
+                post_data['added_domains'] = ['another.com']
+                self.client.post(url, post_data)
+        total_expected_calls = int(expect_task_for_existing_domain) + int(
+            expect_task_for_new_domain
+        )
+        assert patched.call_count == total_expected_calls
+        if expect_task_for_existing_domain:
+            patched.assert_any_call(
+                social_app_custom_data_id=self.custom_data.pk,
+                domain='example.com',
+                requesting_user_id=self.admin_user.pk,
+            )
+        if expect_task_for_new_domain:
+            patched.assert_any_call(
+                social_app_custom_data_id=self.custom_data.pk,
+                domain='another.com',
+                requesting_user_id=self.admin_user.pk,
+            )


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Update/notify affected users when SSOs are set to be managed or new domains are added.

### 💭 Notes
Hooks up the existing celery task to saving in admin.

### 👀 Preview steps
Make sure you have SSO enabled and to restart the kpi_worker (or to have `CELERY_TASK_ALWAYS_EAGER` set to False)

1. ℹ️ have an admin account
2. In Django admin, update your SSO (via the SocialAppCustomData object) to `managed=False` and add the domain `kobotoolbox.org` (or whatever domain your SSO accepts)
3. Create a new user (user1) with a username and password and email ending with `@kobotoolbox.org`
4. Add an SSO login for the new user
5. Create another new user (user2) with a username and password and the correct email domain. Do not add an SSO login.
6. In Django admin, set the SSO to `managed=True` and confirm from the confirmation page
8. 🟢 [on PR] In the django shell, check that user1.has_usable_password() is False 
9. Log in as user2
10. 🟢 [on PR] Notice there is a notification prompting you to add an SSO account
