### PR TITLE
feat(sso): optional and customizable in-app message on confirmation page DEV-2416

### DIFF
--- a/kobo/apps/accounts/admin.py
+++ b/kobo/apps/accounts/admin.py
@@ -18,6 +18,7 @@ from kobo.apps.accounts.models import (
     SocialAppCustomData,
     SocialAppManagedDomain,
 )
+from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY
 from kobo.apps.accounts.utils import user_is_managed_by_sso, users_needing_update
 
 
@@ -104,7 +105,18 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
         return track_1_count, track_2_count
 
     def changeform_view(self, request, object_id=None, form_url='', extra_context=None):
-        if request.method == 'POST' and request.POST.get('_confirmed') != '1':
+        confirmed = request.method == 'POST' and request.POST.get('_confirmed') == '1'
+        # The toggle field only exists once the confirmation page has been
+        # rendered, so it defaults to True on the first (unconfirmed) POST.
+        send_in_app_message = (
+            'send_in_app_message' in request.POST if confirmed else True
+        )
+        in_app_message_body = request.POST.get('in_app_message_body', '').strip()
+        message_error = None
+        if confirmed and send_in_app_message and not in_app_message_body:
+            message_error = _('The in-app message cannot be empty.')
+
+        if request.method == 'POST' and (not confirmed or message_error):
             add = object_id is None
             to_field = request.POST.get('_to_field', request.GET.get('_to_field'))
             if add:
@@ -184,7 +196,13 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                         post_data = [
                             (key, value)
                             for key in request.POST
-                            if key not in ('csrfmiddlewaretoken', '_confirmed')
+                            if key
+                            not in (
+                                'csrfmiddlewaretoken',
+                                '_confirmed',
+                                'send_in_app_message',
+                                'in_app_message_body',
+                            )
                             for value in request.POST.getlist(key)
                         ]
 
@@ -217,6 +235,11 @@ class SocialAppCustomDataAdmin(admin.ModelAdmin):
                             'new_managed': new_managed,
                             'post_data': post_data,
                             'cancel_url': cancel_url,
+                            'send_in_app_message': send_in_app_message,
+                            'in_app_message_body': (
+                                in_app_message_body or DEFAULT_IN_APP_MESSAGE_BODY
+                            ),
+                            'message_error': message_error,
                             'media': self.media,
                         }
                         if extra_context:

--- a/kobo/apps/accounts/static/admin/accounts/socialappcustomdata/confirmation.js
+++ b/kobo/apps/accounts/static/admin/accounts/socialappcustomdata/confirmation.js
@@ -1,0 +1,14 @@
+// Hide the in-app message textarea while the "Send in-app message" toggle
+// is unchecked on the managed SSO confirmation page.
+document.addEventListener('DOMContentLoaded', () => {
+  const checkbox = document.getElementById('id_send_in_app_message')
+  const field = document.getElementById('in-app-message-field')
+  if (!checkbox || !field) {
+    return
+  }
+  const toggle = () => {
+    field.hidden = !checkbox.checked
+  }
+  checkbox.addEventListener('change', toggle)
+  toggle()
+})

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -11,6 +11,14 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kobo.celery import celery_app
 from kpi.utils.log import logging
 
+DEFAULT_IN_APP_MESSAGE_BODY = t(
+    'Dear ##username##,\n\n'
+    'Going forward, your organization will be managing all Kobo accounts '
+    'through ##sso_name##. Please connect your ##sso_name## account. '
+    'Your password will be disabled and you will be required to use ##sso_name## '
+    'to log in.'
+)
+
 
 def update_linked_user(user: User, managed_provider_id: str):
     user.set_unusable_password()
@@ -22,11 +30,14 @@ def notify_unlinked_users(
     user_ids: list[int],
     managed_social_app: 'socialaccount.SocialApp',
     requesting_user: User = None,
+    message_body: str = None,
 ):
     with transaction.atomic():
         # keeping this in a transaction means we don't have to worry later
         # that we've already created the message but not the recipients
-        in_app_message = create_inapp_message(managed_social_app, requesting_user)
+        in_app_message = create_inapp_message(
+            managed_social_app, requesting_user, body=message_body
+        )
         logging.info(
             f'[Managed SSO] Creating in-app message for unregistered users for'
             f' managed social app {managed_social_app.name}.'
@@ -39,16 +50,10 @@ def notify_unlinked_users(
         )
 
 
-def create_inapp_message(social_app, requesting_user=None):
+def create_inapp_message(social_app, requesting_user=None, body=None):
     title = t('Update your account')
     snippet = t('Please connect your ##sso_name## account')
-    body = t(
-        'Dear ##username##,\n\n'
-        'Going forward, your organization will be managing all Kobo accounts '
-        'through ##sso_name##. Please connect your ##sso_name## account. '
-        'Your password will be disabled and you will be required to use ##sso_name## '
-        'to log in.'
-    )
+    body = body or DEFAULT_IN_APP_MESSAGE_BODY
     return InAppMessage.objects.create(
         #  … save raw strings into DB to let them be translated in
         # the users' language in the API response, i.e. when front end
@@ -68,7 +73,11 @@ def create_inapp_message(social_app, requesting_user=None):
 
 @celery_app.task()
 def update_users(
-    social_app_custom_data_id: int, domain: str, requesting_user_id: int = None
+    social_app_custom_data_id: int,
+    domain: str,
+    requesting_user_id: int = None,
+    send_in_app_message: bool = True,
+    in_app_message_body: str = None,
 ):
     # Only pks cross the task boundary: model instances are not JSON-serializable
     custom_data = SocialAppCustomData.objects.select_related('social_app').get(
@@ -98,8 +107,17 @@ def update_users(
         else:
             user_ids_needing_notification.append(user.id)
     if user_ids_needing_notification:
+        if not send_in_app_message:
+            logging.info(
+                '[Managed SSO] Skipping in-app notification for social app '
+                f'{social_app.name} with domain {domain}.'
+            )
+            return
         notify_unlinked_users(
-            user_ids_needing_notification, social_app, requesting_user
+            user_ids_needing_notification,
+            social_app,
+            requesting_user,
+            message_body=in_app_message_body,
         )
 
 

--- a/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
+++ b/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
@@ -47,6 +47,39 @@
       <input type="hidden" name="{{ key }}" value="{{ value }}">
     {% endfor %}
     <input type="hidden" name="_confirmed" value="1">
+    {% if new_managed %}
+      {% if message_error %}
+        <p class="errornote">{{ message_error }}</p>
+      {% endif %}
+      <p>
+        <label>
+          <input type="checkbox" name="send_in_app_message"
+                 id="id_send_in_app_message" {% if send_in_app_message %}checked{% endif %}>
+          {% translate "Send in-app message to non-linked accounts" %}
+        </label>
+      </p>
+      <div id="in-app-message-field">
+        <p>
+          <label for="id_in_app_message_body">{% translate "In-app message" %}</label>
+        </p>
+        <textarea name="in_app_message_body" id="id_in_app_message_body"
+                  rows="8" cols="60">{{ in_app_message_body }}</textarea>
+        <p class="help">
+          {% translate "Available placeholders:" %} ##username##, ##sso_name##
+        </p>
+      </div>
+      <script>
+        (function () {
+          var checkbox = document.getElementById('id_send_in_app_message');
+          var field = document.getElementById('in-app-message-field');
+          function toggle() {
+            field.hidden = !checkbox.checked;
+          }
+          checkbox.addEventListener('change', toggle);
+          toggle();
+        })();
+      </script>
+    {% endif %}
     <div class="submit-row">
       <input type="submit" value="{% translate "Yes, I'm sure" %}" class="default">
       <a href="{{ cancel_url }}" class="button cancel-link">{% translate "No, take me back" %}</a>

--- a/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
+++ b/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
@@ -68,17 +68,8 @@
           {% translate "Available placeholders:" %} ##username##, ##sso_name##
         </p>
       </div>
-      <script>
-        (function () {
-          var checkbox = document.getElementById('id_send_in_app_message');
-          var field = document.getElementById('in-app-message-field');
-          function toggle() {
-            field.hidden = !checkbox.checked;
-          }
-          checkbox.addEventListener('change', toggle);
-          toggle();
-        })();
-      </script>
+      {# Inline scripts are blocked by CSP (script-src has no 'unsafe-inline') #}
+      <script src="{% static 'admin/accounts/socialappcustomdata/confirmation.js' %}"></script>
     {% endif %}
     <div class="submit-row">
       <input type="submit" value="{% translate "Yes, I'm sure" %}" class="default">

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -17,6 +17,8 @@ from kpi.tests.utils import baker_generators  # noqa
 from ..adapter import AccountAdapter
 from ..forms import UserTokenForm
 from ..tasks import (
+    DEFAULT_IN_APP_MESSAGE_BODY,
+    create_inapp_message,
     managed_sso_sweep,
     notify_unlinked_users,
     update_linked_user,
@@ -340,6 +342,48 @@ class TestManagedSsoCelery(TestCase):
                 update_users(custom_data.pk, managed_domain.domain)
         patched_update.assert_called_once()
         patched_notify.assert_called_once()
+
+    def test_update_users_skips_in_app_message_when_disabled(self):
+        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        managed_domain = SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain=self.default_domain
+        )
+        # Track 1: linked user with a usable password must still be converted.
+        linked_user = self._create_user('linked', True, True, False)
+        # Track 2: unlinked user must not receive an in-app message.
+        unlinked_user = self._create_user('unlinked', True, False, False)
+
+        update_users(custom_data.pk, managed_domain.domain, send_in_app_message=False)
+
+        assert not InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()
+        assert not InAppMessageUsers.objects.filter(user=unlinked_user).exists()
+
+        linked_user.refresh_from_db()
+        assert not linked_user.has_usable_password()
+
+    def test_update_users_uses_custom_in_app_message_body(self):
+        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        managed_domain = SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain=self.default_domain
+        )
+        self._create_user('unlinked', True, False, False)
+
+        update_users(
+            custom_data.pk,
+            managed_domain.domain,
+            in_app_message_body='custom body text',
+        )
+
+        message = InAppMessage.objects.get(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        )
+        assert message.body == 'custom body text'
+
+    def test_create_inapp_message_defaults_to_constant_body(self):
+        message = create_inapp_message(self.social_app)
+        assert message.body == DEFAULT_IN_APP_MESSAGE_BODY
 
     def test_managed_sso_sweep(self):
         social_app_managed = SocialApp.objects.create(

--- a/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
+++ b/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
@@ -3,6 +3,7 @@ from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
 
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
+from kobo.apps.accounts.tasks import DEFAULT_IN_APP_MESSAGE_BODY
 from kobo.apps.accounts.tests.utils import MockProvider
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
@@ -29,7 +30,14 @@ class SocialAppCustomDataAdminTestCase(TestCase):
         self.client = Client()
         self.client.force_login(self.admin_user)
 
-    def _get_change_post_data(self, managed=True, domains=None, confirmed=False):
+    def _get_change_post_data(
+        self,
+        managed=True,
+        domains=None,
+        confirmed=False,
+        send_in_app_message=None,
+        in_app_message_body=None,
+    ):
         domains = domains or []
         data = {
             'social_app': self.social_app.pk,
@@ -49,6 +57,10 @@ class SocialAppCustomDataAdminTestCase(TestCase):
         data[f'domains-{len(domains)}-id'] = ''
         if confirmed:
             data['_confirmed'] = '1'
+        if send_in_app_message is not None:
+            data['send_in_app_message'] = send_in_app_message
+        if in_app_message_body is not None:
+            data['in_app_message_body'] = in_app_message_body
         return data
 
     def test_get_change_view(self):
@@ -320,3 +332,106 @@ class SocialAppCustomDataAdminTestCase(TestCase):
         )
         response = self.client.post(url, post_data)
         self.assertEqual(response.status_code, 403)
+
+    def test_confirmation_shows_in_app_message_field_when_enabling_managed(self):
+        # Catches the field being absent or unchecked/blank by default when
+        # managed SSO is turned on.
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=True, domains=['example.com'], confirmed=False
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context['send_in_app_message'])
+        self.assertEqual(
+            response.context['in_app_message_body'], DEFAULT_IN_APP_MESSAGE_BODY
+        )
+        self.assertContains(response, 'name="in_app_message_body"')
+
+    def test_confirmation_hides_in_app_message_field_when_disabling_managed(self):
+        # Turning managed off must never expose the in-app message controls.
+        self.custom_data.managed = True
+        self.custom_data.save()
+
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=False, domains=[], confirmed=False
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'name="send_in_app_message"')
+
+    def test_confirmed_with_empty_message_rejects_and_does_not_save(self):
+        # Catches an empty message body being accepted while the toggle is on.
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=True,
+            domains=['example.com'],
+            confirmed=True,
+            send_in_app_message='on',
+            in_app_message_body='',
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, 'admin/accounts/socialappcustomdata/confirmation.html'
+        )
+        self.assertIsNotNone(response.context['message_error'])
+
+        self.custom_data.refresh_from_db()
+        self.assertFalse(self.custom_data.managed)
+        self.assertEqual(self.custom_data.domains.count(), 0)
+
+    def test_confirmed_with_custom_message_saves(self):
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=True,
+            domains=['example.com'],
+            confirmed=True,
+            send_in_app_message='on',
+            in_app_message_body='Custom message body',
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.custom_data.refresh_from_db()
+        self.assertTrue(self.custom_data.managed)
+        self.assertEqual(
+            list(self.custom_data.domains.values_list('domain', flat=True)),
+            ['example.com'],
+        )
+
+    def test_confirmed_with_message_toggled_off_saves_without_error(self):
+        # Toggle off means no message field submitted: empty body must not block
+        # the save.
+        url = reverse(
+            'admin:accounts_socialappcustomdata_change',
+            args=[self.custom_data.pk],
+        )
+        post_data = self._get_change_post_data(
+            managed=True, domains=['example.com'], confirmed=True
+        )
+        response = self.client.post(url, post_data)
+
+        self.assertEqual(response.status_code, 302)
+        self.custom_data.refresh_from_db()
+        self.assertTrue(self.custom_data.managed)
+        self.assertEqual(
+            list(self.custom_data.domains.values_list('domain', flat=True)),
+            ['example.com'],
+        )


### PR DESCRIPTION
### 📣 Summary
When enabling managed SSO, admins can now choose whether to send the in-app "connect your SSO account" message, and edit its text before confirming.

### 📖 Description
When a superuser enables managed SSO or adds a managed domain, the confirmation screen now has a "Send in-app message" checkbox and an editable message prefilled with the default text. Unchecking the box skips the message. When it is checked, the message cannot be empty.

### 💭 Notes
- The text only reaches users once DEV-2759 (calling `update_users` from the confirmed POST) lands. `update_users` now accepts `send_in_app_message` and `in_app_message_body`. The nightly sweep keeps the defaults.
- Validation reuses the existing interception branch. A confirmed POST with an empty body re-renders the confirmation page with an error instead of saving.
- The toggle script lives in a static file because `script-src` has no `unsafe-inline` when CSP is enabled.
- Custom text still gets `##username##` / `##sso_name##` substitution but is not translated, since it is not in the catalog.

### 👀 Preview steps
1. ℹ️ have a superuser and a social app with a "Social app custom data" entry
2. In Django admin, open the entry, tick "Managed", add a domain, click "Save"
3. 🔴 [on main] the confirmation page only lists the affected-account counts
4. 🟢 [on PR] a checked "Send in-app message to non-linked accounts" box and a prefilled "In-app message" textarea appear, and unchecking the box hides the textarea
5. Clear the textarea, click "Yes, I'm sure"
6. 🟢 "The in-app message cannot be empty." is shown and nothing is saved
7. Type a message, click "Yes, I'm sure": the changes are saved
