### PR TITLE
fix(assetFile): validate redirect_url at serve time before redirecting DEV-2778

### DIFF
--- a/kpi/serializers/v2/asset_file.py
+++ b/kpi/serializers/v2/asset_file.py
@@ -251,7 +251,7 @@ class AssetFileSerializer(serializers.ModelSerializer):
         metadata = self._validate_metadata(metadata, validate_redirect_url=True)
 
         redirect_url = metadata['redirect_url']
-        validator = URLValidator()
+        validator = URLValidator(schemes=['http', 'https'])
         try:
             validator(redirect_url)
         except (AttributeError, DjangoValidationError):

--- a/kpi/tests/api/v2/test_api_assets.py
+++ b/kpi/tests/api/v2/test_api_assets.py
@@ -44,6 +44,7 @@ from kpi.tests.base_test_case import (
 )
 from kpi.tests.kpi_test_case import KpiTestCase
 from kpi.tests.utils.mixins import AssetFileTestCaseMixin
+from kpi.tests.utils.mock import patch_ssrf_dns
 from kpi.urls.router_api_v2 import URL_NAMESPACE as ROUTER_URL_NAMESPACE
 from kpi.utils.fuzzy_int import FuzzyInt
 from kpi.utils.hash import calculate_hash
@@ -2549,6 +2550,102 @@ class AssetFileTest(AssetFileTestCaseMixin, BaseTestCase):
         )
         json_response = response.json()
         expected_response = {'metadata': ['`redirect_url` is not allowed']}
+        assert json_response == expected_response
+
+    @patch_ssrf_dns()
+    def test_content_redirects_to_public_remote_url(self):
+        # A legitimate remote media file must still be served via a 302
+        redirect_url = (
+            'https://png.pngtree.com/png-clipart/20190810/ourmid/'
+            'pngtree-glide-wild-eagle-png-image_1657715.jpg'
+        )
+        payload = {
+            'file_type': AssetFile.FORM_MEDIA,
+            'description': 'A beautiful bird',
+            'metadata': json.dumps({'redirect_url': redirect_url}),
+        }
+        response = self.create_asset_file(payload=payload)
+        af_uid = response.json()['uid']
+        content_url = reverse(
+            self._get_endpoint('asset-file-content'),
+            args=(self.asset.uid, af_uid),
+        )
+        response = self.client.get(content_url)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response['Location'], redirect_url)
+
+    def test_content_with_internal_redirect_url_returns_404(self):
+        # Legacy/sync rows bypass the serializer, so an internal target must be
+        # rejected at serve time
+        asset_file = AssetFile.objects.create(
+            asset=self.asset,
+            user=self.asset.owner,
+            file_type=AssetFile.FORM_MEDIA,
+            metadata={
+                'filename': 'x.png',
+                'hash': 'md5:whatever',
+                'mimetype': 'image/png',
+                'redirect_url': 'http://127.0.0.1/x.png',
+            },
+        )
+        content_url = reverse(
+            self._get_endpoint('asset-file-content'),
+            args=(self.asset.uid, asset_file.uid),
+        )
+        response = self.client.get(content_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_content_with_malformed_redirect_url_returns_404(self):
+        asset_file = AssetFile.objects.create(
+            asset=self.asset,
+            user=self.asset.owner,
+            file_type=AssetFile.FORM_MEDIA,
+            metadata={
+                'filename': 'x.png',
+                'hash': 'md5:whatever',
+                'mimetype': 'image/png',
+                'redirect_url': 'eagle.png',
+            },
+        )
+        content_url = reverse(
+            self._get_endpoint('asset-file-content'),
+            args=(self.asset.uid, asset_file.uid),
+        )
+        response = self.client.get(content_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_content_with_ftp_redirect_url_returns_404(self):
+        asset_file = AssetFile.objects.create(
+            asset=self.asset,
+            user=self.asset.owner,
+            file_type=AssetFile.FORM_MEDIA,
+            metadata={
+                'filename': 'x.png',
+                'hash': 'md5:whatever',
+                'mimetype': 'image/png',
+                'redirect_url': 'ftp://example.org/x.png',
+            },
+        )
+        content_url = reverse(
+            self._get_endpoint('asset-file-content'),
+            args=(self.asset.uid, asset_file.uid),
+        )
+        response = self.client.get(content_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_upload_form_media_ftp_redirect_url_rejected(self):
+        # `ftp`/`ftps` are in Django's default `URLValidator` schemes; the
+        # serializer must restrict them so they can never be stored
+        payload = {
+            'file_type': AssetFile.FORM_MEDIA,
+            'description': 'A beautiful bird',
+            'metadata': json.dumps({'redirect_url': 'ftp://example.org/eagle.png'}),
+        }
+        response = self.create_asset_file(
+            payload=payload, status_code=status.HTTP_400_BAD_REQUEST
+        )
+        json_response = response.json()
+        expected_response = {'metadata': ['`redirect_url` is invalid']}
         assert json_response == expected_response
 
     def test_upload_form_media_bad_mime_type(self):

--- a/kpi/views/v2/asset_file.py
+++ b/kpi/views/v2/asset_file.py
@@ -1,5 +1,7 @@
 # coding: utf-8
-from django.http import HttpResponseRedirect
+from django.core.validators import URLValidator
+from django.core.validators import ValidationError as DjangoValidationError
+from django.http import Http404, HttpResponseRedirect
 from drf_spectacular.utils import (
     OpenApiExample,
     OpenApiParameter,
@@ -9,6 +11,7 @@ from drf_spectacular.utils import (
 from private_storage.views import PrivateStorageDetailView
 from rest_framework.decorators import action
 from rest_framework_extensions.mixins import NestedViewSetMixin
+from ssrf_protect.exceptions import SSRFProtectException
 
 from kobo.apps.audit_log.base_views import AuditLoggedNoUpdateModelViewSet
 from kobo.apps.audit_log.models import AuditType
@@ -29,6 +32,7 @@ from kpi.utils.schema_extensions.response import (
     open_api_201_created_response,
     open_api_204_empty_response,
 )
+from kpi.utils.ssrf import validate_url_against_ssrf
 from kpi.utils.viewset_mixins import AssetNestedObjectViewsetMixin
 
 
@@ -205,8 +209,16 @@ class AssetFileViewSet(
 
         asset_file = self.get_object()
 
-        if asset_file.metadata.get('redirect_url'):
-            return HttpResponseRedirect(asset_file.metadata.get('redirect_url'))
+        if redirect_url := asset_file.metadata.get('redirect_url'):
+            # The stored URL may predate validation (legacy rows, or rows
+            # written by `sync_kobocat_form_media`), so re-validate before
+            # sending clients there
+            try:
+                URLValidator(schemes=['http', 'https'])(redirect_url)
+                validate_url_against_ssrf(redirect_url)
+            except (DjangoValidationError, SSRFProtectException):
+                raise Http404
+            return HttpResponseRedirect(redirect_url)
 
         view = self.PrivateContentView.as_view(
             model=AssetFile,


### PR DESCRIPTION
### 📣 Summary

Media files hosted at a web address now only redirect to that address when it is a normal http or https link.

### 📖 Description

When a form uses a media file hosted elsewhere, downloading it from KoboToolbox sends you to that address. Until now the address was followed without any check, so a broken or unwanted one stored on a project could send people anywhere. KoboToolbox now checks it first and refuses to redirect when it is not a plain http or https address, or when it points inside the server's own network. Media hosted on ordinary public web addresses keeps working as before.

### 💭 Notes

- Serve-time check in the `content` action: `URLValidator(schemes=['http', 'https'])` plus `validate_url_against_ssrf()` from DEV-2777, `Http404` on failure. The stored value can predate the serializer's validation (rows created before #7520, or written by `sync_kobocat_form_media`, which stores whatever `media_filename` it gets), so validating at creation alone is not enough.
- `AssetFileSerializer` no longer accepts `ftp`/`ftps`. Django's default `URLValidator` schemes include them.
- Residual: an editor can still point media at any valid public URL for anyone who can view the project. That is the remote media feature itself. Self-hosted instances pointing media at an internal host can allow it through `SSRF_ALLOWED_IP_ADDRESS`, same as DEV-2777.
- Cost: remote URL files only, one regex and one DNS resolution per download. Uploaded files are untouched.
- The OpenRosa media endpoint (`get_media_file_response` in `kobo/apps/openrosa/apps/api/tools.py`) has the same redirect on legacy `MetaData` rows. Out of scope here, ticket to follow.

### 👀 Preview steps

Back end only, nothing changes in the UI.

1. ℹ️ log in as a user who owns a survey project
2. In the kpi container, create a form media row that bypasses the API validation, the way legacy data does, and note the printed URL:
   ```
   python manage.py shell -c "from kpi.models import Asset, AssetFile; a = Asset.objects.filter(asset_type='survey', owner__username='<you>').first(); af = AssetFile.objects.create(asset=a, user=a.owner, file_type='form_media', metadata={'filename': 'x.png', 'hash': 'md5:x', 'mimetype': 'image/png', 'redirect_url': 'http://127.0.0.1/x.png'}); print(af.download_url)"
   ```
3. Open that URL in the browser while logged in
4. 🔴 [on release/2.026.33] the browser is redirected to `http://127.0.0.1/x.png`
5. 🟢 [on PR] the response is a `404` with `{"detail": "Not found."}`
6. Repeat step 2 with `'redirect_url': 'https://example.com/x.png'`
7. 🟢 still a `302` to `https://example.com/x.png`
