### PR TITLE
ci(releases): set Linear release name explicitly DEV-2787

### DIFF
--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -83,6 +83,7 @@ jobs:
       with:
         access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_minor }}
+        name: ${{ needs.version.outputs.current_minor }}
         base_ref: origin/${{ needs.version.outputs.prev_branch }}
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0
       with:

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -167,6 +167,7 @@ jobs:
       with:
         access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_patch }}
+        name: ${{ needs.version.outputs.current_minor }}
         base_ref: ${{ needs.version.outputs.current_released == 'true' && needs.version.outputs.prev_patch || format('origin/{0}', needs.version.outputs.prev_branch) }}
 
     # Patch releases skip QA and go straight to "Pending Image"

--- a/.github/workflows/release-3-tag.yml
+++ b/.github/workflows/release-3-tag.yml
@@ -435,6 +435,7 @@ jobs:
       with:
         access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         release_version: ${{ needs.version.outputs.current_patch }}
+        name: ${{ needs.version.outputs.current_minor }}
         base_ref: ${{ needs.version.outputs.prev_patch }}
 
     - uses: linear/linear-release-action@af56a9a388625921f3757a2f988e4d7aca958377 # v.0.15.0


### PR DESCRIPTION
### 💭 Notes

Turns out, name defaults to "New Release" instead of release version.

Let's set name explicitly to the release version.