### PR TITLE
ci(releases): fix linear stage name DEV-2788

### DIFF
--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -89,7 +89,7 @@ jobs:
         access_key: ${{ secrets.LINEAR_PIPELINE_KEY_KPI }}
         command: update
         release_version: ${{ needs.version.outputs.current_minor }}
-        stage: "Pending QA"
+        stage: "Pending QA (preview on kf.beta)"
 
 
   qa-issue:


### PR DESCRIPTION
### 💭 Notes

Branch workflow was failing because of Linear release stage name mismatch.