### PR TITLE
ci(releases): proper use of EOF in bash DEV-2790

### DIFF
--- a/.github/actions/fetch-linear-issue/action.yml
+++ b/.github/actions/fetch-linear-issue/action.yml
@@ -39,5 +39,8 @@ runs:
         exit 1
       fi
 
-      echo "body<<EOF" >> "$GITHUB_OUTPUT"
-      echo "${BODY}EOF" >> "$GITHUB_OUTPUT"
+      {
+        echo 'body<<EOF'
+        echo "${BODY}"
+        echo EOF
+      } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -123,8 +123,9 @@ jobs:
         BODY="${BODY//\$RELEASE_URL/$RELEASE_URL}"
 
         {
-          echo "body<<EOF"
-          echo "${BODY}EOF"
+          echo 'body<<EOF'
+          echo "${BODY}"
+          echo EOF
         } >> "$GITHUB_OUTPUT"
 
     - name: Upsert Linear QA issue

--- a/.github/workflows/release-3-tag.yml
+++ b/.github/workflows/release-3-tag.yml
@@ -526,8 +526,9 @@ jobs:
         BODY="${BODY//\$VERSION/$VERSION}"
 
         {
-          echo "body<<EOF"
-          echo "${BODY}EOF"
+          echo 'body<<EOF'
+          echo "${BODY}"
+          echo EOF
         } >> "$GITHUB_OUTPUT"
 
     - name: Upsert Linear deployment issue


### PR DESCRIPTION
### 💭 Notes

The run was failing for (at least) two reasons:
- outdated Linear API key -> I set a new one in settings
- EOF must be on it's own line -> this PR

For reference, see Github Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings