### PR TITLE
fix(sso): allow users to unlink unmanaged accounts DEV-2356

### DIFF
--- a/kobo/apps/accounts/permissions.py
+++ b/kobo/apps/accounts/permissions.py
@@ -1,6 +1,6 @@
 from rest_framework.permissions import DjangoObjectPermissions
 
-from kobo.apps.accounts.utils import user_is_managed_by_sso
+from kobo.apps.accounts.utils import user_account_is_managed_by_sso
 
 
 class NotManagedSSOPermission(DjangoObjectPermissions):
@@ -8,4 +8,4 @@ class NotManagedSSOPermission(DjangoObjectPermissions):
         return request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):
-        return not user_is_managed_by_sso(request.user)
+        return not user_account_is_managed_by_sso(request.user, obj)

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -145,6 +145,34 @@ class TestManagedSsoUsers(TestCase):
         else:
             assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    def test_unlink_unmanaged_sso(self):
+        self.socialaccount.delete()
+        another_social_app = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider='another-provider',
+            provider_id='another-provider-id',
+        )
+        another_socialaccount = SocialAccount.objects.create(
+            user=self.user,
+            provider=another_social_app.provider_id,
+            uid='sa12345',
+        )
+        self.client.force_login(User.objects.get(username='managed'))
+
+        response = self.client.delete(
+            reverse(
+                'socialaccount-detail',
+                kwargs={
+                    'provider': another_socialaccount.provider,
+                    'uid_social_account': another_socialaccount.uid,
+                },
+            ),
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
     @data(('managed', False), ('exempt', True))
     @unpack
     def test_add_password_in_admin(self, username, expect_password_field):

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -154,6 +154,13 @@ class TestManagedSsoUsers(TestCase):
             provider='another-provider',
             provider_id='another-provider-id',
         )
+        another_custom_data = SocialAppCustomData.objects.create(
+            social_app=another_social_app, managed=False
+        )
+        SocialAppManagedDomain.objects.filter(domain='example.com').update(
+            social_app=another_custom_data
+        )
+
         another_socialaccount = SocialAccount.objects.create(
             user=self.user,
             provider=another_social_app.provider_id,

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -57,7 +57,7 @@ def user_is_managed_by_sso(user):
     email = user.email
     domain = get_normalized_domain(email)
     managed_social_app = SocialAppManagedDomain.objects.filter(
-        domain__iexact=domain
+        domain__iexact=domain, social_app__managed=True
     ).first()
     if getattr(user, 'extra_details', None) and user.extra_details.sso_exempt:
         return False
@@ -69,6 +69,19 @@ def user_is_managed_by_sso(user):
         ).exists()
         return user_has_social_account
     return False
+
+
+def user_account_is_managed_by_sso(user, socialaccount):
+    if getattr(user, 'extra_details', None) and user.extra_details.sso_exempt:
+        return False
+    email = user.email
+    domain = get_normalized_domain(email)
+    provider = socialaccount.provider
+    return SocialAppManagedDomain.objects.filter(
+        domain__iexact=domain,
+        social_app__managed=True,
+        social_app__social_app__provider_id=provider,
+    ).exists()
 
 
 def users_needing_update(social_app: 'socialaccount.SocialApp', domain: str):


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Fixes a bug that was preventing users from unlinking unmanaged SSO accounts


### 👀 Preview steps
Make sure SSO is enabled

1. ℹ️ have an SSO account
2. In Django admin, add a SocialAppCustomData object with a domain but do not check 'Managed'
3. Log in as the SSO user
4. Attempt to unlink the SSO 
6. 🔴 [on main] Error
7. 🟢 [on PR] Success

