### PR TITLE
fix(designSystem): change project top tabs to old component DEV-2662

### DIFF
--- a/jsapp/js/project/projectTopTabs.component.tsx
+++ b/jsapp/js/project/projectTopTabs.component.tsx
@@ -1,5 +1,6 @@
-import { Tabs } from '@mantine/core'
 import React, { useEffect, useState } from 'react'
+
+import classnames from 'classnames'
 import { Link } from 'react-router-dom'
 import assetStore from '#/assetStore'
 import { userCan, userCanPartially } from '#/components/permissions/utils'
@@ -13,6 +14,7 @@ import {
   isFormSummaryRoute,
 } from '#/router/routerUtils'
 import sessionStore from '#/stores/session'
+import styles from './projectTopTabs.module.scss'
 
 export default function ProjectTopTabs() {
   // First check if uid is available
@@ -37,49 +39,83 @@ export default function ProjectTopTabs() {
   const dataRoute = ROUTES.FORM_DATA.replace(':uid', assetUid)
   const settingsRoute = ROUTES.FORM_SETTINGS.replace(':uid', assetUid)
 
-  // Keep track of active tab via route to sync selected tab with browser forward/back navigation
-  let activeTab: string | null = null
-  if (isFormSummaryRoute(assetUid)) {
-    activeTab = summaryRoute
-  } else if (isFormLandingRoute(assetUid)) {
-    activeTab = formRoute
-  } else if (isAnyFormDataRoute(assetUid)) {
-    activeTab = dataRoute
-  } else if (isAnyFormSettingsRoute(assetUid)) {
-    activeTab = settingsRoute
-  }
-
   return (
-    // Magic margin top to make the rounded corners visible
-    <Tabs mt='8px' size='lg' value={activeTab}>
-      <Tabs.List justify='center'>
-        <Tabs.Tab
-          value={summaryRoute}
-          disabled={!sessionStore.isLoggedIn}
-          renderRoot={(props) =>
-            sessionStore.isLoggedIn ? <Link to={summaryRoute} {...props} /> : <span {...props} />
-          }
-        >
-          {t('Summary')}
-        </Tabs.Tab>
-        <Tabs.Tab value={formRoute} renderRoot={(props) => <Link to={formRoute} {...props} />}>
-          {t('Form')}
-        </Tabs.Tab>
-        <Tabs.Tab
-          value={dataRoute}
-          disabled={!isDataTabEnabled}
-          renderRoot={(props) => (isDataTabEnabled ? <Link to={dataRoute} {...props} /> : <span {...props} />)}
-        >
-          {t('Data')}
-        </Tabs.Tab>
-        <Tabs.Tab
-          value={settingsRoute}
-          disabled={!isSettingsTabEnabled}
-          renderRoot={(props) => (isSettingsTabEnabled ? <Link to={settingsRoute} {...props} /> : <span {...props} />)}
-        >
-          {t('Settings')}
-        </Tabs.Tab>
-      </Tabs.List>
-    </Tabs>
+    <nav className={styles.root}>
+      <ul className={styles.tabs}>
+        <li>
+          {sessionStore.isLoggedIn ? (
+            <Link
+              to={summaryRoute}
+              className={classnames(styles.tab, {
+                [styles.active]: isFormSummaryRoute(assetUid),
+              })}
+            >
+              {t('Summary')}
+            </Link>
+          ) : (
+            <span
+              className={classnames(styles.tab, styles.disabled, {
+                [styles.active]: isFormSummaryRoute(assetUid),
+              })}
+            >
+              {t('Summary')}
+            </span>
+          )}
+        </li>
+
+        <li>
+          <Link
+            to={formRoute}
+            className={classnames(styles.tab, {
+              [styles.active]: isFormLandingRoute(assetUid),
+            })}
+          >
+            {t('Form')}
+          </Link>
+        </li>
+
+        <li>
+          {isDataTabEnabled ? (
+            <Link
+              to={dataRoute}
+              className={classnames(styles.tab, {
+                [styles.active]: isAnyFormDataRoute(assetUid),
+              })}
+            >
+              {t('Data')}
+            </Link>
+          ) : (
+            <span
+              className={classnames(styles.tab, styles.disabled, {
+                [styles.active]: isAnyFormDataRoute(assetUid),
+              })}
+            >
+              {t('Data')}
+            </span>
+          )}
+        </li>
+
+        <li>
+          {isSettingsTabEnabled ? (
+            <Link
+              to={settingsRoute}
+              className={classnames(styles.tab, {
+                [styles.active]: isAnyFormSettingsRoute(assetUid),
+              })}
+            >
+              {t('Settings')}
+            </Link>
+          ) : (
+            <span
+              className={classnames(styles.tab, styles.disabled, {
+                [styles.active]: isAnyFormSettingsRoute(assetUid),
+              })}
+            >
+              {t('Settings')}
+            </span>
+          )}
+        </li>
+      </ul>
+    </nav>
   )
 }

--- a/jsapp/js/project/projectTopTabs.module.scss
+++ b/jsapp/js/project/projectTopTabs.module.scss
@@ -1,0 +1,80 @@
+@use 'scss/breakpoints';
+@use 'scss/mixins';
+@use 'scss/colors';
+
+.root {
+  width: 100%;
+
+  @media print {
+    display: none;
+  }
+}
+
+.tabs {
+  background: colors.$kobo-white;
+  border-bottom: 1px solid colors.$kobo-gray-300;
+  text-align: center;
+  height: 48px;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  text-transform: uppercase;
+  line-height: 48px;
+  cursor: pointer;
+  position: relative;
+  color: colors.$kobo-gray-700;
+  font-weight: normal;
+
+  &:hover,
+  &.active {
+    color: colors.$kobo-gray-800;
+  }
+
+  &.active {
+    font-weight: 700;
+    border-bottom: 4px solid colors.$kobo-teal;
+  }
+
+  &.disabled {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+}
+
+@include breakpoints.breakpoint(veryNarrow) {
+  .tabs {
+    padding-left: 10px;
+    padding-right: 10px;
+    gap: 15px;
+  }
+
+  .tab {
+    @include mixins.textEllipsis;
+  }
+}
+
+@include breakpoints.breakpoint(narrow) {
+  .tabs {
+    gap: 30px;
+  }
+}
+
+@include breakpoints.breakpoint(narrowAndUp) {
+  .tab {
+    font-size: 15px;
+  }
+}
+
+@include breakpoints.breakpoint(mediumAndUp) {
+  .tabs {
+    gap: 60px;
+  }
+}


### PR DESCRIPTION
### 📣 Summary
Brings back the old project top tabs compoenent

### 👀 Preview steps
1. ℹ️ have an account and a project
2. go to project view
4. 🔴 [on main] notice that the top tabs are new mantine components
5. 🟢 [on PR] notice that the old top tabs are back

(cherry picked from commit be6f7643c0d092cf00808baa1f9f2ab2df284374)