### PR TITLE
feat(sso): enforce SSO restrictions on connecting a managed account DEV-2357

### DIFF
--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -12,9 +12,9 @@ from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 
-from ..help.models import InAppMessageUsers, MessageType, InAppMessage
+from ..help.models import InAppMessage, InAppMessageUsers, MessageType
 from .models import SocialAppManagedDomain
-from .utils import SOCIAL_APP_IDENTIFIER
+from .utils import SOCIAL_APP_IDENTIFIER, user_account_is_managed_by_sso
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -95,16 +95,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         incoming = sociallogin.account
-        app_provider_id = incoming.provider
-        app = SocialApp.objects.get(provider_id=app_provider_id)
-        breakpoint()
-        InAppMessageUsers.objects.filter(
-            user=user,
-            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
-            in_app_message__generic_related_objects__contains={
-                SOCIAL_APP_IDENTIFIER: app.pk
-            },
-        ).delete()
         # Block only if a *different* account is already linked; reconnecting
         # the same one is fine.
         blocking_accounts = SocialAccount.objects.filter(user=user).exclude(
@@ -136,24 +126,22 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
                     },
                 )
             )
-
-        app_provider_id = incoming.provider
-        app = SocialApp.objects.get(provider_id=app_provider_id)
-        InAppMessageUsers.objects.filter(
-            user=user,
-            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
-            in_app_message__generic_related_objects__contains={
-                SOCIAL_APP_IDENTIFIER: app.pk
-            },
-        ).delete()
-        now = timezone.now()
-        # if all users have linked their accounts, expire the inapp message
-        InAppMessage.objects.filter(
-            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
-            in_app_message__generic_related_objects__contains={
-                SOCIAL_APP_IDENTIFIER: app.pk
-            },
-            inappmessageusers__isnull=True
-        ).update(valid_until=now)
-        user.set_unusable_password()
-        user.save()
+        if user_account_is_managed_by_sso(request.user, incoming):
+            app_provider_id = incoming.provider
+            app = SocialApp.objects.get(provider_id=app_provider_id)
+            InAppMessageUsers.objects.filter(
+                user=user,
+                in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
+                in_app_message__generic_related_objects__contains={
+                    SOCIAL_APP_IDENTIFIER: app.pk
+                },
+            ).delete()
+            now = timezone.now()
+            # if all users have linked their accounts, expire the inapp message
+            InAppMessage.objects.filter(
+                message_type=MessageType.MANAGED_SSO_REMINDER,
+                generic_related_objects__contains={SOCIAL_APP_IDENTIFIER: app.pk},
+                inappmessageusers__isnull=True,
+            ).update(valid_until=now)
+            user.set_unusable_password()
+            user.save()

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -97,9 +97,10 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         incoming = sociallogin.account
         app_provider_id = incoming.provider
         app = SocialApp.objects.get(provider_id=app_provider_id)
+        breakpoint()
         InAppMessageUsers.objects.filter(
             user=user,
-            message_type=MessageType.MANAGED_SSO_REMINDER,
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
             in_app_message__generic_related_objects__contains={
                 SOCIAL_APP_IDENTIFIER: app.pk
             },

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -12,7 +12,7 @@ from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 
-from ..help.models import InAppMessageUsers, MessageType
+from ..help.models import InAppMessageUsers, MessageType, InAppMessage
 from .models import SocialAppManagedDomain
 from .utils import SOCIAL_APP_IDENTIFIER
 
@@ -95,9 +95,40 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         incoming = sociallogin.account
+        # Block only if a *different* account is already linked; reconnecting
+        # the same one is fine.
+        blocking_accounts = SocialAccount.objects.filter(user=user).exclude(
+            provider=incoming.provider, uid=incoming.uid
+        )
+
+        # Reuse allauth's own error-rendering helper instead of a bespoke
+        # response. Passing `state` through makes this forward-compatible:
+        # once headless mode is enabled it'll redirect SPA callers with
+        # `?error=...` instead of rendering HTML, with no change needed here
+        if blocking_accounts.exists():
+            raise ImmediateHttpResponse(
+                render_authentication_error(
+                    request,
+                    incoming.provider,
+                    error='multiple_sso_not_allowed',
+                    extra_context={
+                        'state': sociallogin.state,
+                        'error_title': t('SSO account already linked'),
+                        'error_message': t(
+                            'You can only link one SSO account at a time. '
+                            'Disconnect your existing SSO account before linking '
+                            'a new one.'
+                        ),
+                        # Already validated against ALLOWED_HOSTS by allauth when
+                        # it stashed the `next` parameter into the session state
+                        'back_url': sociallogin.get_redirect_url(request)
+                        or resolve_url(settings.LOGIN_REDIRECT_URL),
+                    },
+                )
+            )
+
         app_provider_id = incoming.provider
         app = SocialApp.objects.get(provider_id=app_provider_id)
-        breakpoint()
         InAppMessageUsers.objects.filter(
             user=user,
             in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
@@ -105,35 +136,14 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
                 SOCIAL_APP_IDENTIFIER: app.pk
             },
         ).delete()
-        # Block only if a *different* account is already linked; reconnecting
-        # the same one is fine.
-        blocking_accounts = SocialAccount.objects.filter(user=user).exclude(
-            provider=incoming.provider, uid=incoming.uid
-        )
-        if not blocking_accounts.exists():
-            return
-
-        # Reuse allauth's own error-rendering helper instead of a bespoke
-        # response. Passing `state` through makes this forward-compatible:
-        # once headless mode is enabled it'll redirect SPA callers with
-        # `?error=...` instead of rendering HTML, with no change needed here
-        raise ImmediateHttpResponse(
-            render_authentication_error(
-                request,
-                incoming.provider,
-                error='multiple_sso_not_allowed',
-                extra_context={
-                    'state': sociallogin.state,
-                    'error_title': t('SSO account already linked'),
-                    'error_message': t(
-                        'You can only link one SSO account at a time. '
-                        'Disconnect your existing SSO account before linking '
-                        'a new one.'
-                    ),
-                    # Already validated against ALLOWED_HOSTS by allauth when
-                    # it stashed the `next` parameter into the session state
-                    'back_url': sociallogin.get_redirect_url(request)
-                    or resolve_url(settings.LOGIN_REDIRECT_URL),
-                },
-            )
-        )
+        now = timezone.now()
+        # if all users have linked their accounts, expire the inapp message
+        InAppMessage.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
+            in_app_message__generic_related_objects__contains={
+                SOCIAL_APP_IDENTIFIER: app.pk
+            },
+            inappmessageusers__isnull=True
+        ).update(valid_until=now)
+        user.set_unusable_password()
+        user.save()

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -3,7 +3,7 @@ from allauth.account.forms import SignupForm
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.helpers import render_authentication_error
-from allauth.socialaccount.models import SocialAccount, SocialApp
+from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.base.constants import AuthProcess
 from constance import config
 from django.conf import settings
@@ -12,9 +12,7 @@ from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 
-from ..help.models import InAppMessage, InAppMessageUsers, MessageType
 from .models import SocialAppManagedDomain
-from .utils import SOCIAL_APP_IDENTIFIER, user_account_is_managed_by_sso
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -101,47 +99,30 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             provider=incoming.provider, uid=incoming.uid
         )
 
+        if not blocking_accounts.exists():
+            return
+
         # Reuse allauth's own error-rendering helper instead of a bespoke
         # response. Passing `state` through makes this forward-compatible:
         # once headless mode is enabled it'll redirect SPA callers with
         # `?error=...` instead of rendering HTML, with no change needed here
-        if blocking_accounts.exists():
-            raise ImmediateHttpResponse(
-                render_authentication_error(
-                    request,
-                    incoming.provider,
-                    error='multiple_sso_not_allowed',
-                    extra_context={
-                        'state': sociallogin.state,
-                        'error_title': t('SSO account already linked'),
-                        'error_message': t(
-                            'You can only link one SSO account at a time. '
-                            'Disconnect your existing SSO account before linking '
-                            'a new one.'
-                        ),
-                        # Already validated against ALLOWED_HOSTS by allauth when
-                        # it stashed the `next` parameter into the session state
-                        'back_url': sociallogin.get_redirect_url(request)
-                        or resolve_url(settings.LOGIN_REDIRECT_URL),
-                    },
-                )
-            )
-        if user_account_is_managed_by_sso(request.user, incoming):
-            app_provider_id = incoming.provider
-            app = SocialApp.objects.get(provider_id=app_provider_id)
-            InAppMessageUsers.objects.filter(
-                user=user,
-                in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
-                in_app_message__generic_related_objects__contains={
-                    SOCIAL_APP_IDENTIFIER: app.pk
+        raise ImmediateHttpResponse(
+            render_authentication_error(
+                request,
+                incoming.provider,
+                error='multiple_sso_not_allowed',
+                extra_context={
+                    'state': sociallogin.state,
+                    'error_title': t('SSO account already linked'),
+                    'error_message': t(
+                        'You can only link one SSO account at a time. '
+                        'Disconnect your existing SSO account before linking '
+                        'a new one.'
+                    ),
+                    # Already validated against ALLOWED_HOSTS by allauth when
+                    # it stashed the `next` parameter into the session state
+                    'back_url': sociallogin.get_redirect_url(request)
+                    or resolve_url(settings.LOGIN_REDIRECT_URL),
                 },
-            ).delete()
-            now = timezone.now()
-            # if all users have linked their accounts, expire the inapp message
-            InAppMessage.objects.filter(
-                message_type=MessageType.MANAGED_SSO_REMINDER,
-                generic_related_objects__contains={SOCIAL_APP_IDENTIFIER: app.pk},
-                inappmessageusers__isnull=True,
-            ).update(valid_until=now)
-            user.set_unusable_password()
-            user.save()
+            )
+        )

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -3,7 +3,7 @@ from allauth.account.forms import SignupForm
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.helpers import render_authentication_error
-from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.providers.base.constants import AuthProcess
 from constance import config
 from django.conf import settings
@@ -12,7 +12,9 @@ from django.shortcuts import resolve_url
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 
+from ..help.models import InAppMessageUsers, MessageType
 from .models import SocialAppManagedDomain
+from .utils import SOCIAL_APP_IDENTIFIER
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -93,6 +95,15 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         incoming = sociallogin.account
+        app_provider_id = incoming.provider
+        app = SocialApp.objects.get(provider_id=app_provider_id)
+        InAppMessageUsers.objects.filter(
+            user=user,
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            in_app_message__generic_related_objects__contains={
+                SOCIAL_APP_IDENTIFIER: app.pk
+            },
+        ).delete()
         # Block only if a *different* account is already linked; reconnecting
         # the same one is fine.
         blocking_accounts = SocialAccount.objects.filter(user=user).exclude(

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -95,6 +95,15 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         incoming = sociallogin.account
+        app_provider_id = incoming.provider
+        app = SocialApp.objects.get(provider_id=app_provider_id)
+        InAppMessageUsers.objects.filter(
+            user=user,
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            in_app_message__generic_related_objects__contains={
+                SOCIAL_APP_IDENTIFIER: app.pk
+            },
+        ).delete()
         # Block only if a *different* account is already linked; reconnecting
         # the same one is fine.
         blocking_accounts = SocialAccount.objects.filter(user=user).exclude(

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -98,7 +98,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         blocking_accounts = SocialAccount.objects.filter(user=user).exclude(
             provider=incoming.provider, uid=incoming.uid
         )
-
         if not blocking_accounts.exists():
             return
 

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -108,5 +108,5 @@ def enforce_managed_sso(sender=None, **kwargs):
             inappmessageusers__isnull=True,
         ).update(valid_until=now)
         user.set_unusable_password()
-        user.save()
+        user.save(update_fields=['password'])
         update_session_auth_hash(request, user)

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -108,5 +108,5 @@ def enforce_managed_sso(sender=None, **kwargs):
             inappmessageusers__isnull=True,
         ).update(valid_until=now)
         user.set_unusable_password()
-        user.save(update_fields=['password'])
+        user.save()
         update_session_auth_hash(request, user)

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -4,6 +4,7 @@ from allauth.account.signals import email_confirmed
 from allauth.account.utils import cleanup_email_addresses
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.signals import social_account_added
+from django.contrib.auth import update_session_auth_hash
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -86,6 +87,7 @@ def sync_managed_sso_email_domains(sender=None, **kwargs):
 @receiver(social_account_added)
 def enforce_managed_sso(sender=None, **kwargs):
     sociallogin = kwargs.get('sociallogin')
+    request = kwargs.get('request')
     user = sociallogin.user
     incoming = sociallogin.account
     if user_account_is_managed_by_sso(user, incoming):
@@ -106,4 +108,5 @@ def enforce_managed_sso(sender=None, **kwargs):
             inappmessageusers__isnull=True,
         ).update(valid_until=now)
         user.set_unusable_password()
-        user.save()
+        user.save(update_fields=["password"])
+        update_session_auth_hash(request, user)

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -108,5 +108,5 @@ def enforce_managed_sso(sender=None, **kwargs):
             inappmessageusers__isnull=True,
         ).update(valid_until=now)
         user.set_unusable_password()
-        user.save(update_fields=["password"])
+        user.save()
         update_session_auth_hash(request, user)

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -2,11 +2,15 @@ import constance
 from allauth.account.models import EmailAddress
 from allauth.account.signals import email_confirmed
 from allauth.account.utils import cleanup_email_addresses
+from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.signals import social_account_added
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.utils import timezone
 
+from ..help.models import InAppMessage, InAppMessageUsers, MessageType
 from .models import SocialAppCustomData, SocialAppManagedDomain
+from .utils import SOCIAL_APP_IDENTIFIER, user_account_is_managed_by_sso
 
 
 @receiver(social_account_added)
@@ -77,3 +81,29 @@ def sync_managed_sso_email_domains(sender=None, **kwargs):
         'REGISTRATION_SSO_MANAGED_EMAIL_DOMAINS',
         domain_string,
     )
+
+
+@receiver(social_account_added)
+def enforce_managed_sso(sender=None, **kwargs):
+    sociallogin = kwargs.get('sociallogin')
+    user = sociallogin.user
+    incoming = sociallogin.account
+    if user_account_is_managed_by_sso(user, incoming):
+        app_provider_id = incoming.provider
+        app = SocialApp.objects.get(provider_id=app_provider_id)
+        InAppMessageUsers.objects.filter(
+            user=user,
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER,
+            in_app_message__generic_related_objects__contains={
+                SOCIAL_APP_IDENTIFIER: app.pk
+            },
+        ).delete()
+        now = timezone.now()
+        # if all users have linked their accounts, expire the inapp message
+        InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            generic_related_objects__contains={SOCIAL_APP_IDENTIFIER: app.pk},
+            inappmessageusers__isnull=True,
+        ).update(valid_until=now)
+        user.set_unusable_password()
+        user.save()

--- a/kobo/apps/accounts/tests/constants.py
+++ b/kobo/apps/accounts/tests/constants.py
@@ -1,8 +1,10 @@
+APP_PROVIDER_ID = 'test-app'
+
 SOCIALACCOUNT_PROVIDERS = {
     'openid_connect': {
         'SERVERS': [
             {
-                'id': 'test-app',
+                'id': APP_PROVIDER_ID,
                 'name': 'Test App',
                 'server_url': 'http://testserver/oauth',
                 'APP': {

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -227,3 +227,9 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
         account = SocialAccount.objects.get(user=self.user)
         self.assertEqual(account.provider, 'test-app')
         self.assertEqual(account.uid, 'incoming-uid')
+
+    @responses.activate
+    @patch('allauth.socialaccount.providers.oauth2.views.statekit.unstash_state')
+    def test_connecting_managed_account_sets_unusable_password(self, mock_unstash_state):
+        mock_unstash_state.return_value = {'process': 'connect'}
+

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -1,16 +1,19 @@
 import json
+from datetime import timedelta
 from unittest.mock import patch
 
 import responses
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.models import SocialAccount, SocialApp, SocialLogin
 from allauth.socialaccount.providers.base.constants import AuthProcess
+from ddt import data, ddt
 from django.conf import settings
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from model_bakery import baker
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -18,7 +21,11 @@ from rest_framework.test import APITestCase
 from kobo.apps.accounts.adapter import SocialAccountAdapter
 from kobo.apps.openrosa.apps.main.models import UserProfile
 from kpi.utils.fuzzy_int import FuzzyInt
-from .constants import SOCIALACCOUNT_PROVIDERS
+from ...help.models import InAppMessage, InAppMessageUsers, MessageType
+from ...kobo_auth.shortcuts import User
+from ..models import SocialAppCustomData, SocialAppManagedDomain
+from ..utils import SOCIAL_APP_IDENTIFIER
+from .constants import APP_PROVIDER_ID
 
 
 class AccountsEmailTestCase(APITestCase):
@@ -122,7 +129,8 @@ class SingleSocialAccountTestCase(TestCase):
         self.assertIsNone(self.adapter.pre_social_login(request, sociallogin))
 
 
-@override_settings(SOCIALACCOUNT_PROVIDERS=SOCIALACCOUNT_PROVIDERS)
+@ddt
+@override_settings(SOCIALACCOUNT_PROVIDERS={})
 class SingleSocialAccountConnectFlowTestCase(TestCase):
     """
     This test exercises the same guard through the real OAuth2 callback
@@ -134,11 +142,30 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
     """
 
     def setUp(self):
-        self.user = baker.make(settings.AUTH_USER_MODEL)
+        self.user = baker.make(
+            settings.AUTH_USER_MODEL,
+            email='incoming@testserver.com',
+            password='password',
+        )
         UserProfile.objects.create(user=self.user)
         self.client.force_login(self.user)
-        SocialApp.objects.all().delete()
         self.callback_url = reverse('openid_connect_callback', args=('openid_connect',))
+        self.social_app = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider='openid_connect',
+            provider_id=APP_PROVIDER_ID,
+            settings={
+                'server_url': 'http://testserver/oauth/.well-known/openid-configuration'
+            },
+        )
+        patcher = patch(
+            'allauth.socialaccount.providers.oauth2.views.statekit.unstash_state',
+            return_value={'process': 'connect'},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _mock_provider_endpoints(self):
         """
@@ -178,7 +205,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
                 {
                     'sub': 'incoming-uid',
                     'preferred_username': 'incoming',
-                    'email': 'incoming@testserver',
+                    'email': 'incoming@testserver.com',
                 }
             ),
         )
@@ -191,11 +218,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
         )
 
     @responses.activate
-    @patch('allauth.socialaccount.providers.oauth2.views.statekit.unstash_state')
-    def test_connect_is_blocked_when_another_account_is_linked(
-        self, mock_unstash_state
-    ):
-        mock_unstash_state.return_value = {'process': 'connect'}
+    def test_connect_is_blocked_when_another_account_is_linked(self):
         already_linked = baker.make(
             'socialaccount.SocialAccount',
             user=self.user,
@@ -216,20 +239,70 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
         self.assertEqual(accounts.first().pk, already_linked.pk)
 
     @responses.activate
-    @patch('allauth.socialaccount.providers.oauth2.views.statekit.unstash_state')
-    def test_connect_succeeds_when_no_account_is_linked(self, mock_unstash_state):
-        mock_unstash_state.return_value = {'process': 'connect'}
+    def test_connect_succeeds_when_no_account_is_linked(self):
 
         response = self._simulate_connect_callback()
 
         # The guard must not get in the way of the legitimate first link
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         account = SocialAccount.objects.get(user=self.user)
-        self.assertEqual(account.provider, 'test-app')
+        self.assertEqual(account.provider, APP_PROVIDER_ID)
         self.assertEqual(account.uid, 'incoming-uid')
 
     @responses.activate
-    @patch('allauth.socialaccount.providers.oauth2.views.statekit.unstash_state')
-    def test_connecting_managed_account_sets_unusable_password(self, mock_unstash_state):
-        mock_unstash_state.return_value = {'process': 'connect'}
+    def test_connecting_managed_account_sets_unusable_password(self):
+        assert self.user.has_usable_password()
 
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain='testserver.com'
+        )
+        self._simulate_connect_callback()
+        self.user.refresh_from_db()
+        assert not self.user.has_usable_password()
+
+    @responses.activate
+    @data(True, False)
+    def test_connecting_managed_account_removes_inapp_message_for_user(
+        self, multiple_users
+    ):
+        i = InAppMessage.objects.create(
+            title='title',
+            snippet='snippet',
+            body='body',
+            published=True,
+            valid_from=timezone.now(),
+            valid_until=timezone.now() + timedelta(days=365),
+            always_display_as_new=True,
+            generic_related_objects={SOCIAL_APP_IDENTIFIER: self.social_app.pk},
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+        )
+        InAppMessageUsers.objects.create(in_app_message=i, user=self.user)
+        if multiple_users:
+            second_user = User.objects.create_user(username='second')
+            InAppMessageUsers.objects.create(in_app_message=i, user=second_user)
+
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
+        SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain='testserver.com'
+        )
+        self._simulate_connect_callback()
+        self.user.refresh_from_db()
+        assert not InAppMessageUsers.objects.filter(
+            user=self.user, in_app_message=i
+        ).exists()
+        now = timezone.now()
+        i.refresh_from_db()
+        if multiple_users:
+            assert InAppMessageUsers.objects.filter(
+                user=second_user, in_app_message=i
+            ).exists()
+            # message should not have been expired
+            assert i.valid_until > now
+        else:
+            # if there was only one user still getting the message, it should be expired
+            assert i.valid_until < now

--- a/kobo/apps/accounts/tests/test_social_account.py
+++ b/kobo/apps/accounts/tests/test_social_account.py
@@ -144,7 +144,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
     def setUp(self):
         self.user = baker.make(
             settings.AUTH_USER_MODEL,
-            email='incoming@testserver.com',
+            email='incoming@testserver',
             password='password',
         )
         UserProfile.objects.create(user=self.user)
@@ -205,7 +205,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
                 {
                     'sub': 'incoming-uid',
                     'preferred_username': 'incoming',
-                    'email': 'incoming@testserver.com',
+                    'email': 'incoming@testserver',
                 }
             ),
         )
@@ -257,7 +257,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
             social_app=self.social_app, managed=True
         )
         SocialAppManagedDomain.objects.create(
-            social_app=custom_data, domain='testserver.com'
+            social_app=custom_data, domain='testserver'
         )
         self._simulate_connect_callback()
         self.user.refresh_from_db()
@@ -288,7 +288,7 @@ class SingleSocialAccountConnectFlowTestCase(TestCase):
             social_app=self.social_app, managed=True
         )
         SocialAppManagedDomain.objects.create(
-            social_app=custom_data, domain='testserver.com'
+            social_app=custom_data, domain='testserver'
         )
         self._simulate_connect_callback()
         self.user.refresh_from_db()


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
When a user of a managed domain connects their SSO account, disable other login methods and remove any in-app notifications.


### 💭 Notes
We do not use the SOCIALACCOUNT_PROVIDERS setting in production, we only use db-backed objects. This means if we have a social account it is a safe assumption there is a SocialApp in the database with the correct provider_id. 
We have to remove the InAppMessageUsers object instead of just adding a 'user saw this' interaction because the notification is set to `always_display_as_new` so just marking it as seen will not dismiss it.

### 👀 Preview steps
Make sure SSO is enabled

1. ℹ️ have an admin account
2. Create a user with the ability to sign in via SSO, but only set up a user and password (do not link the SSO account yet)
3. In Django admin, create a SocialAppCustomData object for your SSO and set it to managed. Add the correct email domain.
4. Log in as the user
5. Notice you have a notification prompting you to link your SSO account
6. Connect your SSO account
7. 🟢 [on PR] Notice the notification is gone
8. 🟢 [on PR] In a django shell, verify user.has_usable_password() is False

