### PR TITLE
feat(openrosa): record all form versions a submission spans DEV-2796

### DIFF
--- a/jsapp/js/api/models/dataResponse.ts
+++ b/jsapp/js/api/models/dataResponse.ts
@@ -21,6 +21,7 @@ export interface DataResponse {
   'meta/instanceID': string
   'meta/rootUuid': string
   'meta/deprecatedID'?: string
+  'meta/formVersions'?: string
   _xform_id_string: string
   _uuid: string
   _attachments: _DataResponseAttachmentsItem[]

--- a/jsapp/js/api/models/dataResponseXMLMeta.ts
+++ b/jsapp/js/api/models/dataResponseXMLMeta.ts
@@ -13,4 +13,5 @@ The endpoints are grouped by area of intended use. Each category contains relate
 export interface DataResponseXMLMeta {
   instanceID: string
   deprecatedID?: string
+  formVersions?: string
 }

--- a/jsapp/js/api/react-query/survey-data/msw.ts
+++ b/jsapp/js/api/react-query/survey-data/msw.ts
@@ -637,6 +637,7 @@ export const getApiV2AssetsDataListResponseMock = (
     'meta/instanceID': faker.string.alpha({ length: { min: 10, max: 20 } }),
     'meta/rootUuid': faker.string.alpha({ length: { min: 10, max: 20 } }),
     'meta/deprecatedID': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+    'meta/formVersions': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
     _xform_id_string: faker.string.alpha({ length: { min: 10, max: 20 } }),
     _uuid: faker.string.alpha({ length: { min: 10, max: 20 } }),
     _attachments: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({
@@ -990,6 +991,7 @@ export const getApiV2AssetsDataRetrieveResponseMock = (overrideResponse: Partial
   'meta/instanceID': faker.string.alpha({ length: { min: 10, max: 20 } }),
   'meta/rootUuid': faker.string.alpha({ length: { min: 10, max: 20 } }),
   'meta/deprecatedID': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+  'meta/formVersions': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
   _xform_id_string: faker.string.alpha({ length: { min: 10, max: 20 } }),
   _uuid: faker.string.alpha({ length: { min: 10, max: 20 } }),
   _attachments: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({
@@ -1341,6 +1343,7 @@ export const getApiV2AssetsDataDuplicateCreateResponseMock = (
   'meta/instanceID': faker.string.alpha({ length: { min: 10, max: 20 } }),
   'meta/rootUuid': faker.string.alpha({ length: { min: 10, max: 20 } }),
   'meta/deprecatedID': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
+  'meta/formVersions': faker.helpers.arrayElement([faker.string.alpha({ length: { min: 10, max: 20 } }), undefined]),
   _xform_id_string: faker.string.alpha({ length: { min: 10, max: 20 } }),
   _uuid: faker.string.alpha({ length: { min: 10, max: 20 } }),
   _attachments: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({

--- a/jsapp/js/components/submissions/tableConstants.ts
+++ b/jsapp/js/components/submissions/tableConstants.ts
@@ -23,6 +23,8 @@ export const EXCLUDED_COLUMNS = [
   '_geolocation',
   'meta/instanceID',
   'meta/deprecatedID',
+  // Internal only: the list of form versions a submission has been through
+  'meta/formVersions',
   '_validation_status',
 ]
 

--- a/kobo/apps/openrosa/apps/logger/models/instance.py
+++ b/kobo/apps/openrosa/apps/logger/models/instance.py
@@ -22,6 +22,7 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     clean_and_parse_xml,
     get_root_uuid_from_xml,
     get_uuid_from_xml,
+    strip_form_versions,
 )
 from kobo.apps.openrosa.libs.utils.common_tags import (
     ATTACHMENTS,
@@ -229,9 +230,10 @@ class Instance(AbstractTimeStampedModel):
 
     def _populate_xml_hash(self):
         """
-        Populate the `xml_hash` attribute of this `Instance` based on the content of the `xml`
-        attribute.
+        Populate the `xml_hash` attribute of this `Instance` based on the content of the
+        `xml` attribute.
         """
+
         self.xml_hash = self.get_hash(self.xml)
 
     @classmethod
@@ -334,9 +336,18 @@ class Instance(AbstractTimeStampedModel):
     @staticmethod
     def get_hash(input_string: str) -> str:
         """
-        Compute the SHA256 hash of the given string. A wrapper to standardize hash computation.
+        Compute the SHA256 hash of the given string. A wrapper to standardize hash
+        computation.
+
+        `meta/formVersions` is stripped first. The server adds that node after
+        the client payload has been hashed, so leaving it in would make the hash
+        depend on which form version happened to be deployed at the time.
+        Stripping here rather than at each call site keeps every path that
+        recomputes `xml_hash`, maintenance commands included, in agreement with
+        the duplicate detection in `logger_tools.create_instance()`.
         """
-        return calculate_hash(input_string, 'sha256')
+
+        return calculate_hash(strip_form_versions(input_string), 'sha256')
 
     @property
     def point(self):

--- a/kobo/apps/openrosa/apps/logger/models/xform.py
+++ b/kobo/apps/openrosa/apps/logger/models/xform.py
@@ -11,12 +11,14 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.urls import reverse
 from django.utils.encoding import smart_str
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as t
 from taggit.managers import TaggableManager
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import XLSFormError
 from kobo.apps.openrosa.koboform.pyxform_utils import convert_csv_to_xls
+from kobo.apps.openrosa.libs.utils.common_tags import VERSION
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
@@ -163,6 +165,47 @@ class XForm(AbstractTimeStampedModel):
         xform_dict = deepcopy(self.__dict__)
         xform_dict = {key: val for key, val in xform_dict.items() if key in fields}
         return DataDictionary(**xform_dict)
+
+    @cached_property
+    def deployed_version_uid(self) -> str | None:
+        """
+        Return the KPI `AssetVersion` uid this XForm was generated from.
+
+        KPI appends a `__version__` calculate row when it deploys a form (see
+        `kpi.mixins.xls_exportable.XlsExportable.to_xlsx_io`), so the uid is
+        baked into `self.json` as the calculation of that row.
+
+        Forms deployed before that row existed fall back to the asset's latest
+        deployed version, so `None` is left for the few rows that sidestep the
+        deploy path entirely.
+
+        Only top-level children are scanned on purpose: KPI always appends the
+        row at the end of the survey sheet, and a question sharing that name
+        inside a group would be a user-defined field, not the version.
+        """
+
+        try:
+            children = json.loads(self.json)['children']
+        except (ValueError, TypeError, KeyError):
+            children = []
+
+        for child in children:
+            if child.get('name') != VERSION:
+                continue
+            # pyxform stores the calculation as an XPath string literal,
+            # e.g. `"'vGcztYhnRo9CCLv7biByAt'"`
+            calculation = child.get('bind', {}).get('calculate', '')
+            if version_uid := calculation.strip("'"):
+                return version_uid
+
+        if not self.kpi_asset_uid:
+            return None
+
+        asset = self.asset
+        if asset.pk is None:
+            return None
+
+        return asset.latest_deployed_version_uid
 
     def file_name(self):
         return self.id_string + '.xml'

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
@@ -1,0 +1,790 @@
+import io
+import json
+import uuid as uuid_module
+from types import SimpleNamespace
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.exceptions import DuplicateInstanceError
+from kobo.apps.openrosa.apps.logger.models import Instance, XForm
+from kobo.apps.openrosa.apps.logger.models.instance import InstanceHistory
+from kobo.apps.openrosa.apps.logger.xform_instance_parser import strip_form_versions
+from kobo.apps.openrosa.apps.main.models import UserProfile
+from kobo.apps.openrosa.libs.utils import common_tags
+from kobo.apps.openrosa.libs.utils.common_tags import (
+    META_FORM_VERSIONS,
+    VERSION,
+)
+from kobo.apps.openrosa.libs.utils.logger_tools import (
+    add_form_versions,
+    create_instance,
+)
+from kpi.utils.xml import (
+    edit_submission_xml,
+    fromstring_preserve_root_xmlns,
+    xml_tostring,
+)
+
+ID_STRING = 'aVersionedForm'
+FORM_UUID = '7117fdf814234f5ea0c9f5801b022293'
+# KPI `AssetVersion` uids are a `v` prefix followed by 21 characters
+VERSION_1 = 'v' + '1' * 21
+VERSION_2 = 'v' + '2' * 21
+VERSION_3 = 'v' + '3' * 21
+
+
+def xform_xml() -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<h:html xmlns="http://www.w3.org/2002/xforms"'
+        ' xmlns:h="http://www.w3.org/1999/xhtml"'
+        ' xmlns:jr="http://openrosa.org/javarosa">'
+        '<h:head>'
+        f'<h:title>{ID_STRING}</h:title>'
+        '<model>'
+        '<instance>'
+        f'<{ID_STRING} id="{ID_STRING}">'
+        '<formhub><uuid/></formhub>'
+        '<q1/>'
+        '<__version__/>'
+        '<meta><instanceID/><deprecatedID/><rootUuid/></meta>'
+        f'</{ID_STRING}>'
+        '</instance>'
+        f'<bind nodeset="/{ID_STRING}/meta/instanceID" type="string"/>'
+        '</model>'
+        '</h:head>'
+        '<h:body/>'
+        '</h:html>'
+    )
+
+
+def xform_json(version_uid: str | None) -> str:
+    """
+    Build the pyxform JSON of a form deployed by KPI at `version_uid`.
+
+    Pass `None` to describe a form that was not deployed by KPI, i.e. one
+    without the `__version__` calculate row.
+    """
+
+    children = [{'name': 'q1', 'type': 'text'}]
+    if version_uid:
+        children.append(
+            {
+                'name': VERSION,
+                'type': 'calculate',
+                'bind': {'calculate': f"'{version_uid}'"},
+            }
+        )
+
+    return json.dumps(
+        {
+            'default_language': 'default',
+            'id_string': ID_STRING,
+            'name': ID_STRING,
+            'title': ID_STRING,
+            'type': 'survey',
+            'children': children,
+        }
+    )
+
+
+def submission_xml(
+    version_uid: str | None = VERSION_1,
+    instance_id: str = 'uuid:55d873b2-3a25-4370-8cd9-c41ed4156d07',
+    declaration: bool = False,
+    form_versions: str | None = None,
+    deprecated_id: str | None = None,
+) -> str:
+    """
+    Build a submission.
+
+    `form_versions` is what the client claims. It is never trusted on its own:
+    `add_form_versions()` takes the history from `previous_xml`, so use that to
+    describe the record being edited.
+    """
+
+    version_node = f'<__version__>{version_uid}</__version__>' if version_uid else ''
+    form_versions_node = (
+        f'<formVersions>{form_versions}</formVersions>' if form_versions else ''
+    )
+    deprecated_id_node = (
+        f'<deprecatedID>{deprecated_id}</deprecatedID>' if deprecated_id else ''
+    )
+    return (
+        ('<?xml version="1.0" encoding="utf-8"?>' if declaration else '')
+        + f'<{ID_STRING} id="{ID_STRING}">'
+        f'<formhub><uuid>{FORM_UUID}</uuid></formhub>'
+        '<q1>hello</q1>'
+        f'{version_node}'
+        f'<meta><instanceID>{instance_id}</instanceID>'
+        f'{deprecated_id_node}{form_versions_node}</meta>'
+        f'</{ID_STRING}>'
+    )
+
+
+def get_form_versions(xml: str) -> str | None:
+    element = fromstring_preserve_root_xmlns(xml).find(META_FORM_VERSIONS)
+    return None if element is None else element.text
+
+
+class TestDeployedVersionUid(TestCase):
+    """
+    Unit tests for the version baked into an XForm by KPI at deploy time.
+    """
+
+    def test_returns_the_uid_of_the_version_the_form_was_deployed_from(self):
+        xform = XForm(json=xform_json(VERSION_1))
+        assert xform.deployed_version_uid == VERSION_1
+
+    def test_returns_none_when_no_version_can_be_determined(self):
+        xform = XForm(json=xform_json(None))
+        assert xform.deployed_version_uid is None
+
+    def test_returns_none_when_the_form_json_is_unusable(self):
+        assert XForm(json='').deployed_version_uid is None
+        assert XForm(json='{}').deployed_version_uid is None
+
+    def test_falls_back_to_the_asset_when_the_row_is_missing(self):
+        """
+        Forms deployed before KPI started appending the `__version__` row still
+        belong to an asset that knows its latest deployed version.
+        """
+
+        xform = XForm(json=xform_json(None), kpi_asset_uid='aSomeAsset')
+        # `XForm.asset` memoises on `_cached_asset`, so seeding it stands in for
+        # a form whose `kpi_asset_uid` resolves
+        xform._cached_asset = SimpleNamespace(
+            pk=1, latest_deployed_version_uid=VERSION_2
+        )
+        assert xform.deployed_version_uid == VERSION_2
+
+    def test_prefers_the_row_over_the_asset(self):
+        xform = XForm(json=xform_json(VERSION_1), kpi_asset_uid='aSomeAsset')
+        xform._cached_asset = SimpleNamespace(
+            pk=1, latest_deployed_version_uid=VERSION_2
+        )
+        assert xform.deployed_version_uid == VERSION_1
+
+
+class TestAddFormVersions(TestCase):
+    """
+    Unit tests for the versions recorded on a single submission.
+    """
+
+    def test_no_op_when_the_submission_matches_the_deployed_version(self):
+        xform = XForm(json=xform_json(VERSION_1))
+        xml = submission_xml(version_uid=VERSION_1)
+        # The XML must come back untouched, byte for byte
+        assert add_form_versions(xml, xform) == xml
+
+    def test_no_op_when_no_version_can_be_determined(self):
+        xform = XForm(json=xform_json(None))
+        xml = submission_xml(version_uid=VERSION_1)
+        assert add_form_versions(xml, xform) == xml
+
+    def test_removes_a_forged_history_when_no_version_can_be_determined(self):
+        """
+        A form we cannot place, one imported outside the deploy path or whose
+        asset no longer resolves, is no reason to keep a history the client
+        made up.
+        """
+
+        xform = XForm(json=xform_json(None))
+        xml = submission_xml(
+            version_uid=VERSION_1, form_versions=f'{VERSION_2} {VERSION_3}'
+        )
+        assert get_form_versions(add_form_versions(xml, xform)) is None
+
+    def test_no_op_when_the_submission_declares_no_version(self):
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = submission_xml(version_uid=None)
+        assert add_form_versions(xml, xform) == xml
+
+    def test_tags_both_versions_when_the_submission_is_stale(self):
+        """
+        A device collecting offline with an older version, sending once a newer
+        one has been deployed.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = add_form_versions(submission_xml(version_uid=VERSION_1), xform)
+        assert get_form_versions(xml) == f'{VERSION_1} {VERSION_2}'
+
+    def test_extends_an_existing_lineage_without_reordering_it(self):
+        xform = XForm(json=xform_json(VERSION_3))
+        xml = add_form_versions(
+            submission_xml(version_uid=VERSION_1, deprecated_id='uuid:0'),
+            xform,
+            previous_xml=submission_xml(
+                version_uid=VERSION_1,
+                form_versions=f'{VERSION_1} {VERSION_2}',
+            ),
+        )
+        assert get_form_versions(xml) == (f'{VERSION_1} {VERSION_2} {VERSION_3}')
+
+    def test_no_op_when_the_versions_are_already_recorded(self):
+        """
+        An already tagged submission resubmitted without a redeployment in
+        between must come back untouched, rather than be re-serialised with the
+        very same value.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = submission_xml(
+            version_uid=VERSION_1,
+            form_versions=f'{VERSION_1} {VERSION_2}',
+            deprecated_id='uuid:0',
+        )
+        assert (
+            add_form_versions(
+                xml,
+                xform,
+                previous_xml=submission_xml(
+                    version_uid=VERSION_1,
+                    form_versions=f'{VERSION_1} {VERSION_2}',
+                ),
+            )
+            == xml
+        )
+
+    def test_keeps_a_declared_version_missing_from_the_history(self):
+        """
+        Enketo recalculates `__version__` when the asset's own content carries
+        such a row, so the declared version can be one the history does not
+        know about yet. It must not be dropped.
+        """
+
+        xform = XForm(json=xform_json(VERSION_3))
+        xml = add_form_versions(
+            submission_xml(version_uid=VERSION_2, deprecated_id='uuid:0'),
+            xform,
+            previous_xml=submission_xml(version_uid=VERSION_1),
+        )
+        assert get_form_versions(xml) == (f'{VERSION_1} {VERSION_2} {VERSION_3}')
+
+    def test_tagging_leaves_the_stripped_payload_untouched(self):
+        """
+        `xml_hash` is computed on the stripped XML on both sides, so tagging a
+        submission must not change what stripping it yields. The node is written
+        textually for that reason: re-serialising the tree would normalise the
+        document and silently move the hash.
+        """
+
+        xform = XForm(json=xform_json(VERSION_3))
+        for xml in (
+            submission_xml(version_uid=VERSION_1),
+            submission_xml(version_uid=VERSION_1, declaration=True),
+            submission_xml(
+                version_uid=VERSION_1,
+                form_versions=f'{VERSION_1} {VERSION_2}',
+                deprecated_id='uuid:0',
+            ),
+        ):
+            xml_with_versions = add_form_versions(xml, xform)
+            assert strip_form_versions(xml_with_versions) == strip_form_versions(xml)
+
+    def test_strip_recovers_the_client_payload_byte_for_byte(self):
+        """
+        Clients never send the node themselves, so stripping a submission we
+        tagged must give its exact original bytes back.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        for xml in (
+            submission_xml(version_uid=VERSION_1),
+            submission_xml(version_uid=VERSION_1, declaration=True),
+        ):
+            assert strip_form_versions(add_form_versions(xml, xform)) == xml
+
+    def test_leaves_a_question_named_form_versions_alone(self):
+        """
+        `formVersions` is a legal question name. Only the node inside `<meta>`
+        belongs to us, so the answer must survive tagging and stripping.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = (
+            f'<{ID_STRING} id="{ID_STRING}">'
+            f'<{common_tags.FORM_VERSIONS}>an answer</{common_tags.FORM_VERSIONS}>'
+            f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+            '<meta><instanceID>uuid:1</instanceID></meta>'
+            f'</{ID_STRING}>'
+        )
+
+        xml_with_versions = add_form_versions(xml, xform)
+
+        assert f'<{common_tags.FORM_VERSIONS}>an answer' in xml_with_versions
+        assert get_form_versions(xml_with_versions) == f'{VERSION_1} {VERSION_2}'
+        assert strip_form_versions(xml_with_versions) == xml
+
+    def test_replaces_the_meta_node_when_a_question_shares_its_name(self):
+        xform = XForm(json=xform_json(VERSION_3))
+        xml = (
+            f'<{ID_STRING} id="{ID_STRING}">'
+            f'<{common_tags.FORM_VERSIONS}>an answer</{common_tags.FORM_VERSIONS}>'
+            f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+            '<meta><instanceID>uuid:1</instanceID>'
+            '<deprecatedID>uuid:0</deprecatedID>'
+            f'<{common_tags.FORM_VERSIONS}>{VERSION_1} {VERSION_2}'
+            f'</{common_tags.FORM_VERSIONS}></meta>'
+            f'</{ID_STRING}>'
+        )
+
+        xml_with_versions = add_form_versions(
+            xml,
+            xform,
+            previous_xml=submission_xml(
+                version_uid=VERSION_1,
+                form_versions=f'{VERSION_1} {VERSION_2}',
+            ),
+        )
+
+        assert f'<{common_tags.FORM_VERSIONS}>an answer' in xml_with_versions
+        assert get_form_versions(xml_with_versions) == (
+            f'{VERSION_1} {VERSION_2} {VERSION_3}'
+        )
+
+    def test_no_op_on_a_namespaced_meta(self):
+        """
+        A client may send `<orx:meta>` rather than `<meta>`, which the textual
+        writer does not anchor on. The submission must then come back untouched:
+        no version history, but no corruption and a hash that stays consistent.
+
+        Supporting the prefix is not worth it on its own, since the rest of KPI
+        is equally prefix-blind: `bulk_update_submissions()` would create a
+        second, unprefixed `<meta>` on the same document.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = (
+            f'<{ID_STRING} id="{ID_STRING}" xmlns:orx="http://openrosa.org/xforms">'
+            f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+            '<orx:meta><orx:instanceID>uuid:1</orx:instanceID></orx:meta>'
+            f'</{ID_STRING}>'
+        )
+
+        assert add_form_versions(xml, xform) == xml
+        assert strip_form_versions(xml) == xml
+
+    def test_ignores_a_history_forged_by_the_client(self):
+        """
+        A new submission has no history of its own, so anything it carries under
+        `meta/formVersions` was made up. Trusting it would let a client claim
+        the deployed version and have its own declared one silently dropped.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = submission_xml(version_uid=VERSION_1, form_versions=VERSION_2)
+
+        assert get_form_versions(add_form_versions(xml, xform)) == (
+            f'{VERSION_1} {VERSION_2}'
+        )
+
+    def test_discards_versions_carrying_markup(self):
+        """
+        `ElementTree` decodes entities, and the node is written back textually,
+        so a value holding markup would leave the document malformed.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = submission_xml(version_uid='A &amp; B')
+
+        assert add_form_versions(xml, xform) == xml
+
+    def test_edit_ignores_a_history_forged_by_the_client(self):
+        """
+        The record being edited is the only source of history. A client that
+        claims the deployed version is the whole story must not be able to erase
+        the versions the submission really went through.
+        """
+
+        xform = XForm(json=xform_json(VERSION_3))
+        xml = add_form_versions(
+            submission_xml(
+                version_uid=VERSION_1,
+                form_versions=VERSION_3,
+                deprecated_id='uuid:0',
+            ),
+            xform,
+            previous_xml=submission_xml(
+                version_uid=VERSION_1,
+                form_versions=f'{VERSION_1} {VERSION_2}',
+            ),
+        )
+        assert get_form_versions(xml) == (f'{VERSION_1} {VERSION_2} {VERSION_3}')
+
+    def test_removes_a_history_the_client_made_up(self):
+        """
+        A new submission has none, so anything it carries is discarded rather
+        than left in place.
+        """
+
+        xform = XForm(json=xform_json(VERSION_1))
+        xml = add_form_versions(
+            submission_xml(
+                version_uid=VERSION_1, form_versions=f'{VERSION_2} {VERSION_3}'
+            ),
+            xform,
+        )
+        assert get_form_versions(xml) is None
+
+    def test_replaces_a_node_the_client_misplaced_in_meta(self):
+        """
+        Our node is written as the last child of `<meta>`, but a client is free
+        to put its own anywhere in there. Scoping to the `<meta>` block rather
+        than to the closing tag is what replaces it instead of appending a
+        second one and leaving the forged value to be read back first.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = (
+            f'<{ID_STRING} id="{ID_STRING}">'
+            f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+            '<meta>'
+            f'<{common_tags.FORM_VERSIONS}>{VERSION_3}'
+            f'</{common_tags.FORM_VERSIONS}>'
+            '<instanceID>uuid:1</instanceID>'
+            '<rootUuid>uuid:0</rootUuid>'
+            '</meta>'
+            f'</{ID_STRING}>'
+        )
+
+        xml_with_versions = add_form_versions(xml, xform)
+
+        assert xml_with_versions.count(f'<{common_tags.FORM_VERSIONS}>') == 1
+        assert get_form_versions(xml_with_versions) == f'{VERSION_1} {VERSION_2}'
+        assert '<rootUuid>uuid:0</rootUuid>' in xml_with_versions
+
+    def test_replaces_a_node_whatever_shape_the_client_gave_it(self):
+        """
+        `ElementTree` reads an element by name, ignoring attributes and
+        spacing, and `find()` returns the first one. A node we failed to remove
+        would therefore be read back ahead of ours on the next edit.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        for node in (
+            f'<{common_tags.FORM_VERSIONS} source="client">{VERSION_3}'
+            f'</{common_tags.FORM_VERSIONS}>',
+            f'<{common_tags.FORM_VERSIONS} >{VERSION_3}'
+            f'</{common_tags.FORM_VERSIONS}>',
+            f'<{common_tags.FORM_VERSIONS}>{VERSION_3}'
+            f'</{common_tags.FORM_VERSIONS} >',
+            f'<{common_tags.FORM_VERSIONS} />',
+            f'<{common_tags.FORM_VERSIONS} source="x"/>',
+        ):
+            xml = (
+                f'<{ID_STRING} id="{ID_STRING}">'
+                f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+                f'<meta>{node}<instanceID>uuid:1</instanceID></meta>'
+                f'</{ID_STRING}>'
+            )
+
+            xml_with_versions = add_form_versions(xml, xform)
+
+            assert xml_with_versions.count(f'<{common_tags.FORM_VERSIONS}') == 1, node
+            assert get_form_versions(xml_with_versions) == (
+                f'{VERSION_1} {VERSION_2}'
+            ), node
+
+    def test_leaves_the_document_alone_on_a_shape_it_cannot_remove(self):
+        """
+        A node wrapping other elements cannot be removed textually without
+        risking a dangling tag. Nothing is written in that case, rather than
+        appending a second node beside it. It is never read as history anyway,
+        since only uid-shaped values are kept.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = (
+            f'<{ID_STRING} id="{ID_STRING}">'
+            f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+            '<meta>'
+            f'<{common_tags.FORM_VERSIONS}><a>x</a>'
+            f'</{common_tags.FORM_VERSIONS}>'
+            '<instanceID>uuid:1</instanceID>'
+            '</meta>'
+            f'</{ID_STRING}>'
+        )
+
+        assert add_form_versions(xml, xform) == xml
+
+    def test_ignores_a_meta_written_inside_a_comment_or_cdata(self):
+        """
+        A submission may carry `<meta>` as text. The first textual match would
+        then land inside it, writing the node where no parser reads it back and
+        leaving the real metadata untouched.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        for decoy in (
+            '<!-- <meta><x/></meta> -->',
+            '<note><![CDATA[<meta><x/></meta>]]></note>',
+        ):
+            xml = (
+                f'<{ID_STRING} id="{ID_STRING}">'
+                f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+                f'{decoy}'
+                '<meta><instanceID>uuid:1</instanceID></meta>'
+                f'</{ID_STRING}>'
+            )
+
+            xml_with_versions = add_form_versions(xml, xform)
+
+            # Read through the parser, which ignores comments and CDATA
+            assert get_form_versions(xml_with_versions) == (
+                f'{VERSION_1} {VERSION_2}'
+            ), decoy
+            assert decoy in xml_with_versions, decoy
+            assert strip_form_versions(xml_with_versions) == xml, decoy
+
+    def test_ignores_a_meta_nested_below_the_document_element(self):
+        """
+        A group may itself be named `meta`. Writing into a nested one would
+        leave the history where nothing reads it, since the parser only looks at
+        direct children of the document element.
+        """
+
+        xform = XForm(json=xform_json(VERSION_2))
+        decoy = '<group><meta><x/></meta></group>'
+        real = '<meta><instanceID>uuid:1</instanceID></meta>'
+
+        for body in (f'{decoy}{real}', f'{real}{decoy}'):
+            xml = (
+                f'<{ID_STRING} id="{ID_STRING}">'
+                f'<{common_tags.VERSION}>{VERSION_1}</{common_tags.VERSION}>'
+                f'{body}'
+                f'</{ID_STRING}>'
+            )
+
+            xml_with_versions = add_form_versions(xml, xform)
+
+            assert get_form_versions(xml_with_versions) == (
+                f'{VERSION_1} {VERSION_2}'
+            ), body
+            assert decoy in xml_with_versions, body
+            assert strip_form_versions(xml_with_versions) == xml, body
+
+    def test_is_idempotent(self):
+        xform = XForm(json=xform_json(VERSION_2))
+        once = add_form_versions(submission_xml(version_uid=VERSION_1), xform)
+        assert add_form_versions(once, xform) == once
+
+    def test_leaves_the_declared_version_untouched(self):
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = add_form_versions(submission_xml(version_uid=VERSION_1), xform)
+        assert fromstring_preserve_root_xmlns(xml).find(VERSION).text == VERSION_1
+
+    def test_keeps_the_xml_declaration_when_the_client_sent_one(self):
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = add_form_versions(
+            submission_xml(version_uid=VERSION_1, declaration=True), xform
+        )
+        assert xml.startswith('<?xml')
+
+    def test_adds_no_declaration_when_the_client_sent_none(self):
+        xform = XForm(json=xform_json(VERSION_2))
+        xml = add_form_versions(
+            submission_xml(version_uid=VERSION_1, declaration=False), xform
+        )
+        assert not xml.startswith('<?xml')
+
+
+class TestFormVersionsOnSubmission(TestCase):
+    """
+    End to end tests through `create_instance()`, the single choke point every
+    submission and every edit goes through.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(username='bob')
+        UserProfile.objects.get_or_create(user=self.user)
+        self.xform = XForm.objects.create(
+            xml=xform_xml(),
+            user=self.user,
+            json=xform_json(VERSION_1),
+            uuid=FORM_UUID,
+            require_auth=False,
+        )
+
+        class FakeRequest:
+            pass
+
+        self.request = FakeRequest()
+        self.request.user = self.user
+        self.request.user.has_perm = lambda *args, **kwargs: True
+
+    def test_matching_version_records_nothing(self):
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        assert get_form_versions(instance.xml) is None
+        assert META_FORM_VERSIONS not in instance.json
+
+    def test_stale_offline_submission_records_both_versions(self):
+        self._deploy(VERSION_2)
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        assert get_form_versions(instance.xml) == f'{VERSION_1} {VERSION_2}'
+        # The node is a plain leaf, so it reaches the JSON representation, and
+        # therefore Mongo, without any extra plumbing
+        assert instance.json[META_FORM_VERSIONS] == f'{VERSION_1} {VERSION_2}'
+
+    def test_edit_with_a_newer_version_records_both_versions(self):
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        self._deploy(VERSION_2)
+        edited = self._submit(self._edit_xml(instance))
+        assert edited.pk == instance.pk
+        assert get_form_versions(edited.xml) == f'{VERSION_1} {VERSION_2}'
+
+    def test_edit_keeps_the_history_even_if_the_client_strips_it(self):
+        """
+        The history comes from the record being edited, not from the incoming
+        XML, so a client posting an edit stripped of both `__version__` and
+        `meta/formVersions` cannot make the versions disappear.
+        """
+
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        self._deploy(VERSION_2)
+        edited = self._submit(self._edit_xml(instance, strip_versions=True))
+        assert get_form_versions(edited.xml) == f'{VERSION_1} {VERSION_2}'
+
+    def test_successive_edits_accumulate_versions(self):
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        self._deploy(VERSION_2)
+        self._submit(self._edit_xml(instance))
+        instance.refresh_from_db()
+        self._deploy(VERSION_3)
+        edited = self._submit(self._edit_xml(instance))
+        assert get_form_versions(edited.xml) == (f'{VERSION_1} {VERSION_2} {VERSION_3}')
+
+    def test_retried_edit_rebuilds_the_same_xml(self):
+        """
+        The versions are written before `xml_hash` is computed, so a retry that
+        rebuilt them differently would no longer be recognised as a duplicate.
+        `add_form_versions()` is a pure function of the XML and the form, which
+        is what keeps the result stable.
+        """
+
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        self._deploy(VERSION_2)
+        edit_xml = self._edit_xml(instance)
+        edited = self._submit(edit_xml)
+
+        assert InstanceHistory.objects.filter(xform_instance=edited).count() == 1
+
+        # Same payload again: the deprecated id no longer resolves to an
+        # `Instance`, only to an `InstanceHistory` row. Reaching the duplicate
+        # branch proves the rebuilt XML hashed identically; without the
+        # fallback the edit would be replayed and raise `DeprecatedIdGoneError`
+        with self.assertRaises(DuplicateInstanceError):
+            self._submit(edit_xml)
+
+        assert InstanceHistory.objects.filter(xform_instance=edited).count() == 1
+
+    def test_recomputing_the_hash_from_the_stored_xml_matches_the_client(self):
+        """
+        Maintenance paths recompute `xml_hash` straight from `instance.xml`
+        (`clean_duplicated_submissions`, `fix_root_node_names`,
+        `populate_xml_hashes_for_instances`, ...). They must land on the value
+        duplicate detection compares, otherwise a later retry or a split upload
+        no longer finds the record.
+        """
+
+        self._deploy(VERSION_2)
+        xml = submission_xml(version_uid=VERSION_1)
+        instance = self._submit(xml)
+        assert get_form_versions(instance.xml) is not None
+
+        assert instance.xml_hash == Instance.get_hash(xml)
+        # What a maintenance command does, with no knowledge of the node
+        assert Instance.get_hash(instance.xml) == Instance.get_hash(xml)
+
+    def test_split_submission_still_attaches_after_a_redeploy(self):
+        """
+        Enketo splits a submission whose media exceed its upload limit into
+        several POSTs carrying the same XML, and the server matches the later
+        ones to the existing record by `xml_hash`. That hash must therefore not
+        depend on the version deployed at the time: a redeployment between two
+        POSTs would otherwise orphan the remaining files.
+        """
+
+        self._deploy(VERSION_2)
+        xml = submission_xml(version_uid=VERSION_1)
+        instance = self._submit(xml)
+        assert get_form_versions(instance.xml) == f'{VERSION_1} {VERSION_2}'
+
+        self._deploy(VERSION_3)
+        same_instance = self._submit(
+            xml,
+            media_files=[
+                SimpleUploadedFile('photo.jpg', b'jpeg', content_type='image/jpeg')
+            ],
+        )
+
+        assert same_instance.pk == instance.pk
+        assert same_instance.attachments.count() == 1
+        # The later POST attaches files, it never rewrites the stored XML
+        same_instance.refresh_from_db()
+        assert get_form_versions(same_instance.xml) == f'{VERSION_1} {VERSION_2}'
+
+    def test_resubmission_after_a_redeploy_is_still_a_duplicate(self):
+        self._deploy(VERSION_2)
+        xml = submission_xml(version_uid=VERSION_1)
+        self._submit(xml)
+
+        self._deploy(VERSION_3)
+        with self.assertRaises(DuplicateInstanceError):
+            self._submit(xml)
+
+    def test_retried_edit_after_a_redeploy_is_still_a_duplicate(self):
+        instance = self._submit(submission_xml(version_uid=VERSION_1))
+        self._deploy(VERSION_2)
+        edit_xml = self._edit_xml(instance)
+        self._submit(edit_xml)
+
+        self._deploy(VERSION_3)
+        with self.assertRaises(DuplicateInstanceError):
+            self._submit(edit_xml)
+
+    def _deploy(self, version_uid: str):
+        """
+        Simulate a redeployment of the form at `version_uid`.
+        """
+
+        XForm.objects.filter(pk=self.xform.pk).update(json=xform_json(version_uid))
+
+    def _edit_xml(self, instance: Instance, strip_versions: bool = False) -> str:
+        """
+        Build the XML an editor posts back for `instance`.
+
+        Both real paths start from the stored XML: a bulk edit round-trips it,
+        and Enketo merges it into its model. `strip_versions` reproduces a
+        hypothetical client that drops the version nodes instead.
+        """
+
+        xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+        if strip_versions:
+            for path in (VERSION, META_FORM_VERSIONS):
+                if (element := xml_parsed.find(path)) is not None:
+                    parent = (
+                        xml_parsed
+                        if '/' not in path
+                        else xml_parsed.find(path.rsplit('/', 1)[0])
+                    )
+                    parent.remove(element)
+        edit_submission_xml(xml_parsed, 'q1', 'edited')
+        edit_submission_xml(xml_parsed, 'meta/deprecatedID', f'uuid:{instance.uuid}')
+        edit_submission_xml(
+            xml_parsed, 'meta/instanceID', f'uuid:{uuid_module.uuid4()}'
+        )
+        edit_submission_xml(xml_parsed, 'meta/rootUuid', f'uuid:{instance.root_uuid}')
+        return xml_tostring(xml_parsed)
+
+    def _submit(self, xml: str, media_files: list = None) -> Instance:
+        return create_instance(
+            self.user.username,
+            io.BytesIO(xml.encode()),
+            media_files=media_files or [],
+            request=self.request,
+            check_usage_limits=False,
+        )

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
@@ -780,7 +780,7 @@ class TestFormVersionsOnSubmission(TestCase):
         edit_submission_xml(xml_parsed, 'meta/rootUuid', f'uuid:{instance.root_uuid}')
         return xml_tostring(xml_parsed)
 
-    def _submit(self, xml: str, media_files: list = None) -> Instance:
+    def _submit(self, xml: str, media_files: list | None = None) -> Instance:
         return create_instance(
             self.user.username,
             io.BytesIO(xml.encode()),

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -14,7 +14,10 @@ from django.utils.translation import gettext as t
 from pyxform.survey_element import SurveyElement
 
 from kobo.apps.openrosa.apps.logger.exceptions import InstanceEmptyError
-from kobo.apps.openrosa.libs.utils.common_tags import XFORM_ID_STRING
+from kobo.apps.openrosa.libs.utils.common_tags import (
+    FORM_VERSIONS,
+    XFORM_ID_STRING,
+)
 from kpi.utils.log import logging
 from kpi.utils.xml import minidom_parsestring
 
@@ -23,6 +26,98 @@ def add_uuid_prefix(uuid_: str) -> str:
     if ':' in uuid_:
         return uuid_
     return f'uuid:{uuid_}'
+
+
+# Scoping to the `<meta>` block is what tells our node apart from a question
+# that happens to be named `formVersions`, wherever inside `meta` it sits.
+# `<metadata>` is not matched, since `<meta` must be followed by a space or `>`.
+meta_block_regex = re.compile(r'(<meta(?:\s[^>]*)?>)(.*?)(</meta>)', re.DOTALL)
+# A `<meta>` written inside a comment or a CDATA section is text, not markup,
+# so the first textual match is not necessarily the metadata node
+comment_or_cdata_regex = re.compile(r'<!--.*?-->|<!\[CDATA\[.*?\]\]>', re.DOTALL)
+# Element tags, to walk the document depth. `<?xml …?>` and `<!DOCTYPE …>` do
+# not match, since a name has to start with a letter or an underscore
+tag_regex = re.compile(r'<(/?)([A-Za-z_][\w.:-]*)[^>]*?(/?)>')
+# Any `formVersions` element, whatever attributes or spacing a client gave it.
+# Anchoring on the exact tag would leave a forged `<formVersions source="x">`
+# in place, and `ElementTree` would then read it back ahead of ours.
+form_versions_regex = re.compile(
+    rf'<{FORM_VERSIONS}(?:\s[^>]*)?/>'
+    rf'|<{FORM_VERSIONS}(?:\s[^>]*)?>[^<]*</{FORM_VERSIONS}\s*>'
+)
+
+
+def set_form_versions(xml: str, form_versions: str = '') -> str:
+    """
+    Rewrite `meta/formVersions` in the raw submission XML.
+
+    Every `formVersions` inside the first `<meta>` block is removed, then
+    `form_versions` is written back as its last child. An empty value only
+    removes, which is what `strip_form_versions()` relies on.
+
+    Deliberately textual: re-serialising the parsed tree would normalise the
+    document (`<q/>` becomes `<q />`, the XML declaration is dropped, attribute
+    order changes), and the hash would no longer identify what the client sent.
+
+    Removing before writing means a client that puts its own `formVersions`
+    anywhere in `meta` gets it replaced rather than duplicated.
+
+    The XML comes back unchanged when there is no `<meta>` to anchor on: a
+    submission without one is rejected moments later by the `instanceID` check
+    in `create_instance()`, and one using a namespaced `<orx:meta>` simply keeps
+    no version history.
+    """
+
+    match = _find_meta_block(xml)
+    if not match:
+        return xml
+
+    opening, body, closing = match.groups()
+    body = form_versions_regex.sub('', body)
+
+    if FORM_VERSIONS in body:
+        # A shape we cannot remove without risking the document, such as a node
+        # wrapping other elements. Leave everything alone rather than append a
+        # second node next to it: neither is ever read as history, since
+        # `_get_form_versions()` only keeps uid-shaped values
+        return xml
+
+    if form_versions:
+        body += f'<{FORM_VERSIONS}>{form_versions}</{FORM_VERSIONS}>'
+
+    return f'{xml[:match.start()]}{opening}{body}{closing}{xml[match.end():]}'
+
+
+def _find_meta_block(xml: str) -> Union[re.Match, None]:
+    """
+    Return the match for the metadata node: the document element's direct
+    `<meta>` child.
+
+    A group may itself be named `meta`, and a `<meta>` inside a comment or a
+    CDATA section is text, not markup: neither is what the readers look at.
+
+    The caller rewrites the raw string, so it needs a position in that string.
+    `ElementTree` returns elements, never where they start, hence the scan.
+    Safe by construction: XML forbids a raw `<` in an attribute value, so no
+    tag can hide there.
+    """
+
+    ignored = [m.span() for m in comment_or_cdata_regex.finditer(xml)]
+    depth = 0
+
+    for tag in tag_regex.finditer(xml):
+        if any(start <= tag.start() < end for start, end in ignored):
+            continue
+
+        closing, name, self_closing = tag.groups()
+        if closing:
+            depth -= 1
+        elif not self_closing:
+            if depth == 1 and name == 'meta':
+                return meta_block_regex.match(xml, tag.start())
+            depth += 1
+
+    return None
 
 
 def get_meta_node_from_xml(
@@ -57,10 +152,11 @@ def get_meta_node_from_xml(
     return uuid_tag, xml
 
 
-def get_meta_from_xml(xml_str: str, meta_name: str) -> str:
+def get_meta_from_xml(xml_str: str, meta_name: str) -> str | None:
     if node_and_root := get_meta_node_from_xml(xml_str, meta_name):
         node, _ = node_and_root
         return node.firstChild.nodeValue.strip() if node.firstChild else None
+    return None
 
 
 def get_uuid_from_xml(xml):
@@ -82,7 +178,7 @@ def get_uuid_from_xml(xml):
     return None
 
 
-def get_root_uuid_from_xml(xml) -> tuple[str, bool]:
+def get_root_uuid_from_xml(xml) -> tuple[str | None, bool]:
     """
     Returns the value of <meta/rootUuid> from the given XML. If that node is missing,
     falls back to <meta/instanceID>. The boolean indicates whether a fallback was used.
@@ -149,6 +245,28 @@ def remove_uuid_prefix(uuid_: str) -> str:
     intact in the database to prevent potential ID collisions.
     """
     return re.sub(r'^uuid:', '', uuid_)
+
+
+def strip_form_versions(xml: str) -> str:
+    """
+    Return the submission XML without its `meta/formVersions` node.
+
+    That node is added by the server, after the client payload has been hashed
+    (see `logger_tools.add_form_versions()`). Hashing the stripped XML keeps
+    `xml_hash` identifying what the client actually sent, which is what
+    duplicate detection compares: Enketo splits a submission larger than 10 MB
+    into several POSTs carrying the same XML, and a redeployment in between
+    would otherwise change the hash and orphan the remaining attachments.
+
+    The node is inserted textually precisely so that removing it gives the
+    original payload back byte for byte. Only the one inside `<meta>` is
+    removed, so a question named `formVersions` is left alone.
+    """
+
+    if FORM_VERSIONS not in xml:
+        return xml
+
+    return set_form_versions(xml)
 
 
 def _xml_node_to_dict(node: Node, repeats: list = []) -> dict:

--- a/kobo/apps/openrosa/libs/models/clone_xform.py
+++ b/kobo/apps/openrosa/libs/models/clone_xform.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+# TODO seems dead code, to delete. Nothing imports `CloneXForm`, and no URL
+# routes form cloning.
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models.xform import XForm

--- a/kobo/apps/openrosa/libs/utils/common_tags.py
+++ b/kobo/apps/openrosa/libs/utils/common_tags.py
@@ -33,6 +33,14 @@ VALIDATION_STATUS = '_validation_status'
 INSTANCE_ID = 'instanceID'
 META_INSTANCE_ID = 'meta/instanceID'
 META_ROOT_UUID = 'meta/rootUuid'
+# Ordered list (oldest first) of the KPI `AssetVersion` uids a submission has
+# been through. Only written when a submission spans more than one version.
+FORM_VERSIONS = 'formVersions'
+META_FORM_VERSIONS = f'meta/{FORM_VERSIONS}'
+# The single form version the client declares, injected by KPI as a `calculate`
+# row at deploy time
+VERSION = '__version__'
+
 INDEX = '_index'
 PARENT_INDEX = '_parent_index'
 PARENT_TABLE_NAME = '_parent_table_name'

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 import traceback
+import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from typing import Generator, Optional, Union
@@ -82,6 +83,8 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     get_submission_date_from_xml,
     get_uuid_from_xml,
     get_xform_media_question_xpaths,
+    set_form_versions,
+    strip_form_versions,
 )
 from kobo.apps.openrosa.apps.viewer.models.data_dictionary import DataDictionary
 from kobo.apps.openrosa.apps.viewer.models.parsed_instance import ParsedInstance
@@ -111,6 +114,76 @@ uuid_regex = re.compile(r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>',
                         re.DOTALL)
 
 mongo_instances = settings.MONGO_DB.instances
+
+# A KPI `AssetVersion` uid. Kept loose on purpose, since the point is to reject
+# anything carrying XML markup rather than to validate the uid itself
+version_uid_regex = re.compile(r'^[A-Za-z0-9_-]+$')
+
+
+def add_form_versions(xml: str, xform: XForm, previous_xml: str = None) -> str:
+    """
+    Tag the submission with every form version it has been through.
+
+    A submission spans more than one version in two situations:
+    - it is edited, through Enketo or through a bulk edit, while a newer
+      version of the form is deployed;
+    - it is collected offline with an older version and sent only after a
+      newer one has been deployed.
+
+    The versions are written to `meta/formVersions` as a space-separated list,
+    oldest first. `__version__` is left untouched. When there is nothing to
+    record, which is the case for the vast majority of submissions, the XML is
+    returned unchanged so that it keeps the exact bytes the client sent.
+
+    `previous_xml` is the submission being edited, and it is the only source of
+    history: what the incoming XML claims under `meta/formVersions` is
+    discarded, since a client could otherwise drop the versions it has really
+    been through. A new submission passes `None` and starts from nothing.
+
+    The node is read through `ElementTree` but written textually, so that
+    `strip_form_versions()` gives the client payload back byte for byte and
+    `xml_hash` keeps identifying what was actually submitted.
+    """
+
+    deployed_version_uid = xform.deployed_version_uid
+
+    xml_parsed = fromstring_preserve_root_xmlns(xml)
+    _, submission_version = _get_form_versions(xml_parsed)
+
+    form_versions = []
+    if previous_xml is not None:
+        # 1) Retrieve every version the record being edited has already been through…
+        # Don't trust what the client sent, retrieve form versions from previous version
+        form_versions, previous_version = _get_form_versions(
+            fromstring_preserve_root_xmlns(previous_xml)
+        )
+        if previous_version and previous_version not in form_versions:
+            # `meta/formVersions` is absent from a record that only ever knew
+            # one version, so its `__version__` is the only trace of it
+            form_versions.append(previous_version)
+
+    if submission_version and submission_version not in form_versions:
+        # 2) … then, the version the client says it collected with
+        form_versions.append(submission_version)
+
+    if deployed_version_uid and deployed_version_uid not in form_versions:
+        # 3) … and last, the version deployed when the submission arrived. A
+        # form we cannot place has none, which is a reason to add nothing,
+        # never a reason to drop the history above
+        form_versions.append(deployed_version_uid)
+
+    if len(form_versions) < 2:
+        # A single version, so nothing worth recording. Stripping also clears a
+        # node the client made up, or one inherited by `duplicate_submission()`
+        return strip_form_versions(xml)
+
+    form_versions_text = ' '.join(form_versions)
+    recorded = xml_parsed.find(common_tags.META_FORM_VERSIONS)
+    if recorded is not None and recorded.text == form_versions_text:
+        # Already what we would write, so leave the bytes alone
+        return xml
+
+    return set_form_versions(xml, form_versions_text)
 
 
 def check_submission_permissions(
@@ -230,9 +303,12 @@ def create_instance(
 
     xml = smart_str(xml_file.read())
     validate_xml_chars(xml)
-    xml_hash = Instance.get_hash(xml)
     xform = get_xform_from_submission(xml, username, uuid)
     check_submission_permissions(request, xform)
+    # `Instance.get_hash()` excludes `meta/formVersions`, so duplicate detection
+    # compares what the client sent and stays unaffected by a redeployment
+    # landing between two POSTs of the same submission
+    xml_hash = Instance.get_hash(xml)
     if (
         settings.STRIPE_ENABLED
         and constance.config.USAGE_LIMIT_ENFORCEMENT
@@ -1055,7 +1131,7 @@ _COMMON_INSTANCE_FIELDS = frozenset(
     {
         'formhub',
         'meta',
-        '__version__',
+        common_tags.VERSION,
         'start',
         'end',
         'today',
@@ -1123,7 +1199,9 @@ def _get_instance(
             uuid=old_uuid,
             root_uuid=instance.root_uuid,
         )
-        instance.xml = xml
+        # The record being edited is already in memory, so its version history
+        # costs nothing to read and is trusted over the incoming XML
+        instance.xml = add_form_versions(xml, xform, previous_xml=instance.xml)
         instance.uuid = new_uuid
     else:
         get_user = (
@@ -1146,7 +1224,7 @@ def _get_instance(
         # Avoid `Instance.objects.create()` so that we can set a Python-only
         # attribute, `defer_counting`, before saving
         instance = Instance()
-        instance.xml = xml
+        instance.xml = add_form_versions(xml, xform)
         instance.user = submitted_by
         instance.status = status
         instance.xform = xform
@@ -1265,6 +1343,41 @@ def _has_edit_xform_permission(
         return getattr(request.user, 'has_partial_perms', False)
 
     return False
+
+
+def _get_form_versions(xml_parsed: ET.Element) -> tuple[list[str], str | None]:
+    """
+    Return what a parsed submission already says about form versions.
+
+    The first item is the history accumulated in `meta/formVersions`, oldest
+    first, empty when the submission has never spanned two versions. The second
+    is the single version the client declared in `__version__`, `None` when the
+    submission carries no such node.
+
+    Both come from the client, and `ElementTree` hands them over with their
+    entities decoded, so anything that does not look like a uid is discarded.
+    Otherwise `_write_form_versions()` would interpolate markup straight back
+    into the document and leave it malformed.
+    """
+
+    form_versions = []
+    submission_version = None
+
+    form_versions_element = xml_parsed.find(common_tags.META_FORM_VERSIONS)
+    if form_versions_element is not None and form_versions_element.text:
+        form_versions = [
+            uid
+            for uid in form_versions_element.text.split()
+            if version_uid_regex.match(uid)
+        ]
+
+    version = xml_parsed.find(common_tags.VERSION)
+    if version is not None and version.text:
+        candidate = version.text.strip()
+        if version_uid_regex.match(candidate):
+            submission_version = candidate
+
+    return form_versions, submission_version
 
 
 def _update_mongo_for_xform(xform, only_update_missing=True):

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -98,6 +98,7 @@ from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
 from kpi.deployment_backends.kc_access.utils import kc_transaction_atomic
+from kpi.fields.kpi_uid import UUID_LENGTH
 from kpi.utils.hash import calculate_hash
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_database_user
@@ -115,9 +116,10 @@ uuid_regex = re.compile(r'<formhub>\s*<uuid>\s*([^<]+)\s*</uuid>\s*</formhub>',
 
 mongo_instances = settings.MONGO_DB.instances
 
-# A KPI `AssetVersion` uid. Kept loose on purpose, since the point is to reject
-# anything carrying XML markup rather than to validate the uid itself
-version_uid_regex = re.compile(r'^[A-Za-z0-9_-]+$')
+# A KPI `AssetVersion` uid: the `v` prefix of its `KpiUidField`, then exactly
+# `UUID_LENGTH` characters from `shortuuid`'s alphabet, which is alphanumeric.
+# Anything else is discarded rather than written back into the document
+version_uid_regex = re.compile(rf'^v[A-Za-z0-9]{{{UUID_LENGTH}}}$')
 
 
 def add_form_versions(xml: str, xform: XForm, previous_xml: str = None) -> str:

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -122,7 +122,7 @@ mongo_instances = settings.MONGO_DB.instances
 version_uid_regex = re.compile(rf'^v[A-Za-z0-9]{{{UUID_LENGTH}}}$')
 
 
-def add_form_versions(xml: str, xform: XForm, previous_xml: str = None) -> str:
+def add_form_versions(xml: str, xform: XForm, previous_xml: str | None = None) -> str:
     """
     Tag the submission with every form version it has been through.
 

--- a/kobo/apps/openrosa/libs/utils/quick_converter.py
+++ b/kobo/apps/openrosa/libs/utils/quick_converter.py
@@ -1,4 +1,8 @@
 # coding: utf-8
+# TODO seems dead code, to delete. Nothing imports this module.
+# Not to be confused with `QuickConverterForm` in
+# `kobo/apps/openrosa/apps/main/forms.py`, a different class that is still
+# used by `kobo/apps/openrosa/apps/api/tools.py`.
 from django import forms
 from django.utils.translation import gettext_lazy
 
@@ -6,7 +10,7 @@ from kobo.apps.openrosa.apps.viewer.models.data_dictionary import DataDictionary
 
 
 class QuickConverter(forms.Form):
-    xls_file = forms.FileField(label=gettext_lazy("XLS File"))
+    xls_file = forms.FileField(label=gettext_lazy('XLS File'))
 
     def publish(self, user):
         if self.is_valid():

--- a/kpi/schema_extensions/v2/data/serializers.py
+++ b/kpi/schema_extensions/v2/data/serializers.py
@@ -51,6 +51,9 @@ DataResponse = inline_serializer_class(
         'meta/deprecatedID': serializers.CharField(
             required=False,
         ),
+        'meta/formVersions': serializers.CharField(
+            required=False,
+        ),
         '_xform_id_string': serializers.CharField(),
         '_uuid': serializers.CharField(),
         '_attachments': DataAttachmentsField(),
@@ -85,6 +88,7 @@ DataResponseXMLMetaSerializer = inline_serializer_class(
     fields={
         'instanceID': serializers.CharField(),
         'deprecatedID': serializers.CharField(required=False),
+        'formVersions': serializers.CharField(required=False),
     },
 )
 

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -32,7 +32,10 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
 )
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
 from kobo.apps.openrosa.apps.viewer.models import ParsedInstance
-from kobo.apps.openrosa.libs.utils.common_tags import META_ROOT_UUID
+from kobo.apps.openrosa.libs.utils.common_tags import (
+    META_FORM_VERSIONS,
+    META_ROOT_UUID,
+)
 from kobo.apps.openrosa.libs.utils.logger_tools import dict2xform
 from kobo.apps.organizations.constants import UsageType
 from kobo.apps.project_ownership.utils import create_invite
@@ -2429,6 +2432,35 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         assert 'deprecatedID' in instance.xml
         self._simulate_edit_submission(instance)
 
+    def test_edit_submission_with_newer_version_records_form_versions(self):
+        """
+        A submission collected with one version and edited while a newer one is
+        deployed must end up tagged with both, oldest first.
+        """
+
+        original_version_uid = self.asset.latest_deployed_version.uid
+        instance = Instance.objects.get(
+            root_uuid=remove_uuid_prefix(self.submission['_uuid'])
+        )
+        # A submission that never spanned two versions carries no lineage
+        assert META_FORM_VERSIONS not in instance.json
+
+        self.asset.content['survey'].append(
+            {'type': 'note', 'name': 'n', 'label': ['A new note']}
+        )
+        self.asset.save()
+        self.asset.deploy(active=True)
+        self.asset.save()
+        new_version_uid = self.asset.latest_deployed_version.uid
+        assert new_version_uid != original_version_uid
+
+        self._simulate_edit_submission(instance)
+
+        instance.refresh_from_db()
+        assert instance.json[META_FORM_VERSIONS] == (
+            f'{original_version_uid} {new_version_uid}'
+        )
+
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'
     )
@@ -3208,6 +3240,37 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
                         root_uuid.text
                     )
                     break
+
+    def test_bulk_update_submissions_records_form_versions(self):
+        """
+        A bulk edit performed while a newer version is deployed must tag the
+        submissions with both versions, oldest first.
+        """
+
+        original_version_uid = self.asset.latest_deployed_version.uid
+
+        self.asset.content['survey'].append(
+            {'type': 'note', 'name': 'n', 'label': ['A new note']}
+        )
+        self.asset.save()
+        self.asset.deploy(active=True)
+        self.asset.save()
+        new_version_uid = self.asset.latest_deployed_version.uid
+        assert new_version_uid != original_version_uid
+
+        response = self.client.patch(
+            self.submission_url, data=self.submitted_payload, format='json'
+        )
+        assert response.status_code == status.HTTP_200_OK
+        self._check_bulk_update(response)
+
+        instances = Instance.objects.filter(
+            pk__in=self.updated_submission_data['submission_ids']
+        )
+        for instance in instances:
+            assert instance.json[META_FORM_VERSIONS] == (
+                f'{original_version_uid} {new_version_uid}'
+            )
 
     @pytest.mark.skipif(
         not settings.STRIPE_ENABLED, reason='Requires stripe functionality'

--- a/kpi/tests/api/v2/test_api_submissions.py
+++ b/kpi/tests/api/v2/test_api_submissions.py
@@ -2443,7 +2443,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
             root_uuid=remove_uuid_prefix(self.submission['_uuid'])
         )
         # A submission that never spanned two versions carries no lineage
-        assert META_FORM_VERSIONS not in instance.json
+        assert META_FORM_VERSIONS not in self._get_submission(instance)
 
         self.asset.content['survey'].append(
             {'type': 'note', 'name': 'n', 'label': ['A new note']}
@@ -2456,8 +2456,7 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
 
         self._simulate_edit_submission(instance)
 
-        instance.refresh_from_db()
-        assert instance.json[META_FORM_VERSIONS] == (
+        assert self._get_submission(instance)[META_FORM_VERSIONS] == (
             f'{original_version_uid} {new_version_uid}'
         )
 
@@ -2671,6 +2670,20 @@ class SubmissionEditApiTests(SubmissionEditTestCaseMixin, BaseSubmissionTestCase
         response = self.client.get(submission_edit_link_url, {'format': 'json'})
         assert response.status_code == status.HTTP_409_CONFLICT
         assert 'cannot be edited' in response.data['detail']
+
+    def _get_submission(self, instance: Instance) -> dict:
+        """
+        Read the submission back through the API, which is what this test is
+        about, rather than off the `Instance.json` column.
+        """
+
+        response = self.client.get(self.submission_list_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+        return next(
+            submission
+            for submission in response.data['results']
+            if submission['_id'] == instance.pk
+        )
 
 
 class SubmissionViewApiTests(SubmissionViewTestCaseMixin, BaseSubmissionTestCase):
@@ -3264,11 +3277,14 @@ class BulkUpdateSubmissionsApiTests(BaseSubmissionTestCase):
         assert response.status_code == status.HTTP_200_OK
         self._check_bulk_update(response)
 
-        instances = Instance.objects.filter(
-            pk__in=self.updated_submission_data['submission_ids']
-        )
-        for instance in instances:
-            assert instance.json[META_FORM_VERSIONS] == (
+        response = self.client.get(self.submission_list_url, {'format': 'json'})
+        assert response.status_code == status.HTTP_200_OK
+
+        edited_ids = self.updated_submission_data['submission_ids']
+        edited = [s for s in response.data['results'] if s['_id'] in edited_ids]
+        assert len(edited) == len(edited_ids)
+        for submission in edited:
+            assert submission[META_FORM_VERSIONS] == (
                 f'{original_version_uid} {new_version_uid}'
             )
 

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -24272,6 +24272,9 @@
                     "meta/deprecatedID": {
                         "type": "string"
                     },
+                    "meta/formVersions": {
+                        "type": "string"
+                    },
                     "_xform_id_string": {
                         "type": "string",
                         "title": " xform id string"
@@ -24552,6 +24555,9 @@
                         "type": "string"
                     },
                     "deprecatedID": {
+                        "type": "string"
+                    },
+                    "formVersions": {
                         "type": "string"
                     }
                 },

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -17360,6 +17360,8 @@ components:
           type: string
         meta/deprecatedID:
           type: string
+        meta/formVersions:
+          type: string
         _xform_id_string:
           type: string
           title: ' xform id string'
@@ -17551,6 +17553,8 @@ components:
         instanceID:
           type: string
         deprecatedID:
+          type: string
+        formVersions:
           type: string
       required:
       - instanceID


### PR DESCRIPTION
### 📣 Summary

Submissions now record every form version they have been exposed to, when those differ from the current one.

### 📖 Description

A submission is recorded with a single form version, the one it was collected with. A record can nevertheless be exposed to more than one: when it is edited after the form has been redeployed, or when it was filled in offline with an older version and only sent once a newer one was deployed.

Submissions now record all of those versions, in order, whenever they differ from the current one. This prepares the ground for future improvements so that data no longer goes missing from exports or from the table view when versions differ. Records that only ever involved a single version are unchanged, and exports themselves are not changed by this pull request.

### 💭 Notes

Everything happens in `logger_tools.create_instance()`, the single choke point for new submissions, single edits, bulk edits, duplicates and the v2 API. The versions are written to a `meta/formVersions` node, space separated and oldest first, next to `meta/rootUuid`. It is written before `Instance.get_hash(xml)` on purpose: `xml_hash` is expected to equal `get_hash(xml)` by `_populate_xml_hash()` and by several maintenance commands, and duplicate detection reads it.

No database read is involved. The node is only written when the versions actually differ, so single-version submissions keep the exact bytes their client sent. `__version__` is untouched, there is no migration and no backfill. 

`meta/formVersions` is excluded from `xml_hash` on both sides: `create_instance()` hashes the submission stripped of that node, and `Instance._populate_xml_hash()` strips it before hashing the stored XML. The hash therefore identifies what the client sent, and does not move when a redeployment lands between two POSTs of the same submission. That matters for Enketo, which splits a submission whose media exceed its upload limit into several POSTs carrying the same XML and matches the later ones to the existing record by that hash. The node is written textually rather than by re-serialising the parsed tree, so stripping it returns the original payload byte for byte and the hash stays derivable from the stored XML.

The node is internal, so it is added to the front-end `EXCLUDED_COLUMNS`, next to `meta/instanceID` and `meta/deprecatedID`. It is deliberately not popped in `_inject_properties()`: exports read submissions through the same `get_submissions()`, so dropping it there would hide it from the very work this prepares.


### 👀 Preview steps

1. ℹ️ have an account and a project with a single text question, deployed
2. submit one record
3. in the form builder, add a second question and redeploy
4. edit the first record from the data table and save it
5. open `/api/v2/assets/<asset_uid>/data/<submission_id>/?format=json`
6. 🔴 [on main] notice the record only has `__version__`, holding a single version uid
7. 🟢 [on PR] notice it also has `meta/formVersions`, listing both version uids, oldest first
8. submit a new record without redeploying anything
9. 🟢 notice this one has no `meta/formVersions` at all, since it never spanned two versions
10. open the webform in offline mode, fill in the form but do not submit. 
12. Deploy a new version of the form.
13. Submit the data
11. 🟢 notice this one also has `meta/formVersions`, listing both version uids

