### PR TITLE
feat(sso): make the signup-closed message configurable DEV-2363

### DIFF
--- a/kobo/apps/accounts/templates/account/signup_closed.html
+++ b/kobo/apps/accounts/templates/account/signup_closed.html
@@ -1,0 +1,20 @@
+{% extends "account/base.html" %}
+{% load static %}
+{% load i18n %}
+{% block content %}
+<div class="registration registration--complete">
+  <div class="registration--logo">
+    <a href="/">{% block logo %}{{ block.super }}{% endblock %}</a>
+    {% if not signup_closed_message %}
+      <h1>{% trans "Sign Up Closed" %}</h1>
+    {% endif %}
+  </div>
+  {% if signup_closed_message %}
+    {{ signup_closed_message|safe }}
+  {% else %}
+    <p class="registration__message registration__message--complete">
+      {% trans "We are sorry, but the sign up is currently closed." %}
+    </p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/kobo/apps/accounts/templates/account/signup_closed.html
+++ b/kobo/apps/accounts/templates/account/signup_closed.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load i18n %}
 {% block content %}
-<div class="registration registration--complete">
+<section class="registration">
   <div class="registration--logo">
     <a href="/">{% block logo %}{{ block.super }}{% endblock %}</a>
     {% if not signup_closed_message %}
@@ -16,5 +16,5 @@
       {% trans "We are sorry, but the sign up is currently closed." %}
     </p>
   {% endif %}
-</div>
+</section>
 {% endblock %}

--- a/kpi/context_processors.py
+++ b/kpi/context_processors.py
@@ -63,9 +63,16 @@ def sitewide_messages(request):
     custom text in django templates
     """
     if request.path_info == reverse('account_signup'):
-        sitewide_message = I18nUtils.get_sitewide_message()
-        if sitewide_message is not None:
-            return {'welcome_message': markdownify(sitewide_message)}
+        context = {}
+        welcome_message = I18nUtils.get_sitewide_message()
+        if welcome_message is not None:
+            context['welcome_message'] = markdownify(welcome_message)
+        signup_closed_message = I18nUtils.get_sitewide_message(
+            slug='signup_closed_message'
+        )
+        if signup_closed_message is not None:
+            context['signup_closed_message'] = markdownify(signup_closed_message)
+        return context
 
     return {}
 

--- a/kpi/tests/test_registration.py
+++ b/kpi/tests/test_registration.py
@@ -9,6 +9,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext as t
 
+from hub.models.sitewide_message import SitewideMessage
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
 from kobo.apps.accounts.tests.constants import SOCIALACCOUNT_PROVIDERS
 from kobo.apps.accounts.tests.utils import MockProvider
@@ -150,6 +151,29 @@ class RegistrationTestCase(TestCase):
             response.content
         )
         self.assertFalse(User.objects.filter(username='alice').exists())
+
+    @override_config(REGISTRATION_OPEN=False)
+    def test_signup_closed_shows_default_message(self):
+        response = self.client.get(reverse('account_signup'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            t('We are sorry, but the sign up is currently closed.').encode(),
+            response.content,
+        )
+
+    @override_config(REGISTRATION_OPEN=False)
+    def test_signup_closed_shows_custom_message(self):
+        SitewideMessage.objects.create(
+            slug='signup_closed_message',
+            body='Registration is paused for maintenance.',
+        )
+        response = self.client.get(reverse('account_signup'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Registration is paused for maintenance.', response.content)
+        self.assertNotIn(
+            t('We are sorry, but the sign up is currently closed.').encode(),
+            response.content,
+        )
 
     @override_settings(SOCIALACCOUNT_PROVIDERS=SOCIALACCOUNT_PROVIDERS)
     def test_cannot_use_password_with_managed_social_app(self):


### PR DESCRIPTION
### 📣 Summary
Admins can now customize the message shown on the sign-up page when registration is closed.

### 📖 Description
When account registration is turned off, anyone opening the sign-up page sees a fixed "Sign Up Closed" notice. Admins can now replace that text with their own, for example to point people to their organization's SSO login. If nothing is configured, the default notice stays as it was.

### 💭 Notes
- Same pattern as `welcome_message`: the `sitewide_messages` context processor now also looks up a `SitewideMessage` with slug `signup_closed_message` on the signup URL. Localized `signup_closed_message_<lang>` rows take precedence, as before.
- New `account/signup_closed.html` overrides allauth's stock template. The fallback keeps allauth's exact strings so its translations still apply.
- One message for the whole server, not per SSO app, as agreed on the ticket.

### 👀 Preview steps
1. ℹ️ have a superuser account
2. In Django admin > Constance, uncheck `REGISTRATION_OPEN` and save
3. Open `/accounts/signup/` in a private window: the page shows the default "Sign Up Closed" text
4. In Django admin > Sitewide messages, add one with slug `signup_closed_message` and a markdown body
5. Reload `/accounts/signup/`
6. 🔴 [on main] you still see the default text
7. 🟢 [on PR] you see your message instead
