### PR TITLE
feat(sso): withdraw reminders when managed SSO is turned off DEV-2475

### DIFF
--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -11,7 +11,11 @@ from django.utils import timezone
 
 from ..help.models import InAppMessage, InAppMessageUsers, MessageType
 from .models import SocialAppCustomData, SocialAppManagedDomain
-from .utils import SOCIAL_APP_IDENTIFIER, user_account_is_managed_by_sso
+from .utils import (
+    SOCIAL_APP_IDENTIFIER,
+    remove_managed_sso_reminders,
+    user_account_is_managed_by_sso,
+)
 
 
 @receiver(social_account_added)
@@ -82,6 +86,25 @@ def sync_managed_sso_email_domains(sender=None, **kwargs):
         'REGISTRATION_SSO_MANAGED_EMAIL_DOMAINS',
         domain_string,
     )
+
+
+@receiver(post_delete, sender=SocialAppCustomData)
+def remove_reminders_on_custom_data_delete(sender=None, instance=None, **kwargs):
+    """
+    Covers a direct deletion and the cascade from deleting the SocialApp.
+    """
+    remove_managed_sso_reminders(instance.pk)
+
+
+@receiver(post_delete, sender=SocialAppManagedDomain)
+def remove_reminders_on_domain_delete(sender=None, instance=None, **kwargs):
+    remove_managed_sso_reminders(instance.social_app_id, domain=instance.domain)
+
+
+@receiver(post_save, sender=SocialAppCustomData)
+def remove_reminders_on_managed_off(sender=None, instance=None, **kwargs):
+    if not instance.managed:
+        remove_managed_sso_reminders(instance.pk)
 
 
 @receiver(social_account_added)

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -5,7 +5,11 @@ from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
 from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomain
-from kobo.apps.accounts.utils import SOCIAL_APP_IDENTIFIER, users_needing_update
+from kobo.apps.accounts.utils import (
+    SOCIAL_APP_IDENTIFIER,
+    remove_stale_managed_sso_reminders,
+    users_needing_update,
+)
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.celery import celery_app
@@ -138,6 +142,7 @@ def update_users(
 
 @celery_app.task()
 def managed_sso_sweep():
+    remove_stale_managed_sso_reminders()
     managed_domains = SocialAppManagedDomain.objects.filter(
         social_app__managed=True
     ).values_list('social_app_id', 'domain')

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.db import transaction
+from django.db.models import QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
@@ -92,8 +93,8 @@ def update_users(
     # The flag and the domain are re-checked here because the admin can turn
     # managed off, drop the domain or delete the app before the worker runs.
     custom_data = (
-        SocialAppCustomData.objects.select_related('social_app')
-        .filter(pk=social_app_custom_data_id, managed=True, domains__domain=domain)
+        _managed_custom_data(social_app_custom_data_id, domain)
+        .select_related('social_app')
         .first()
     )
     if custom_data is None:
@@ -114,10 +115,19 @@ def update_users(
             f'domain {domain}. Nothing to do.'
         )
         return
+    # The admin can also turn managed off while this task is running, so the
+    # check is repeated before each destructive change.
+    stopped_mid_run = (
+        f'[Managed SSO] Domain {domain} stopped being managed by social app'
+        f' {social_app.name} while updating users. Stopping.'
+    )
     user_ids_needing_notification = []
     for user in users_to_update:
         # 'managed_account' is an annotated field created by the query
         if user.managed_account > 0:
+            if not _managed_custom_data(social_app_custom_data_id, domain).exists():
+                logging.info(stopped_mid_run)
+                return
             logging.info(
                 '[Managed SSO] Removing alternative login methods for user '
                 f'{user.username} for managed social app {social_app.name}.'
@@ -131,6 +141,9 @@ def update_users(
                 '[Managed SSO] Skipping in-app notification for social app '
                 f'{social_app.name} with domain {domain}.'
             )
+            return
+        if not _managed_custom_data(social_app_custom_data_id, domain).exists():
+            logging.info(stopped_mid_run)
             return
         notify_unlinked_users(
             user_ids_needing_notification,
@@ -150,3 +163,14 @@ def managed_sso_sweep():
         # TODO: determine who kicked off the original update_users task and set them
         # as requesting_user
         update_users(social_app_custom_data_id, domain)
+
+
+def _managed_custom_data(
+    social_app_custom_data_id: int, domain: str
+) -> QuerySet[SocialAppCustomData]:
+    """
+    The custom data, only while `domain` is one of its managed domains.
+    """
+    return SocialAppCustomData.objects.filter(
+        pk=social_app_custom_data_id, managed=True, domains__domain=domain
+    )

--- a/kobo/apps/accounts/tasks.py
+++ b/kobo/apps/accounts/tasks.py
@@ -84,10 +84,20 @@ def update_users(
     send_in_app_message: bool = True,
     in_app_message_body: str = None,
 ):
-    # Only pks cross the task boundary: model instances are not JSON-serializable
-    custom_data = SocialAppCustomData.objects.select_related('social_app').get(
-        pk=social_app_custom_data_id
+    # Only pks cross the task boundary: model instances are not JSON-serializable.
+    # The flag and the domain are re-checked here because the admin can turn
+    # managed off, drop the domain or delete the app before the worker runs.
+    custom_data = (
+        SocialAppCustomData.objects.select_related('social_app')
+        .filter(pk=social_app_custom_data_id, managed=True, domains__domain=domain)
+        .first()
     )
+    if custom_data is None:
+        logging.info(
+            f'[Managed SSO] Domain {domain} is no longer managed by social app'
+            f' custom data {social_app_custom_data_id}. Nothing to do.'
+        )
+        return
     social_app = custom_data.social_app
     requesting_user = (
         User.objects.get(pk=requesting_user_id) if requesting_user_id else None

--- a/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
+++ b/kobo/apps/accounts/templates/admin/accounts/socialappcustomdata/confirmation.html
@@ -35,6 +35,10 @@
     <p><strong>{% translate "Removed domain(s):" %}</strong> {{ removed_domains|join:", " }}</p>
   {% endif %}
 
+  {% if managed_toggled_off or removed_domains %}
+    <p>{% translate "Pending in-app reminders asking users to link their SSO account will be withdrawn." %}</p>
+  {% endif %}
+
   <p><strong>{% translate "Affected Accounts:" %}</strong></p>
   <ul>
     <li>{% translate "Linked accounts that will be converted to SSO-only:" %} <strong>{{ track_1_count }}</strong></li>

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -1,12 +1,15 @@
 from unittest.mock import ANY, MagicMock, patch
 
 from allauth.socialaccount.models import SocialAccount, SocialApp
+from constance.test import override_config
 from ddt import data, ddt, unpack
 from django.contrib.admin.sites import site
 from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
+from django.utils import timezone
 from model_bakery import baker
 from rest_framework import status
+from rest_framework.test import APIClient
 
 from hub.models import ExtraUserDetail
 from kobo.apps.accounts.admin import SocialAccountAdmin
@@ -232,6 +235,99 @@ class TestManagedSsoUsers(TestCase):
                 in form.errors['user']
             )
 
+    @data('managed_off', 'domain_deleted', 'app_deleted')
+    def test_restrictions_lift_when_no_longer_managed(self, change):
+        """
+        Every SSO-managed enforcement point must release once the domain is
+        no longer managed, however that state is reached.
+        """
+        self._make_unmanaged(change)
+
+        # password reset is allowed again
+        response = self.client.post(
+            reverse('account_reset_password'),
+            data={'email': 'managed@example.com'},
+            HTTP_ACCEPT='application/json',
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # the SSO account can be unlinked again
+        self.client.force_login(self.user)
+        response = self.client.delete(
+            reverse(
+                'socialaccount-detail',
+                kwargs={
+                    'provider': self.socialaccount.provider,
+                    'uid_social_account': self.socialaccount.uid,
+                },
+            ),
+        )
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # the admin add-social-account form validates again
+        admin = SocialAccountAdmin(SocialAccount, site)
+        request = RequestFactory().get('/')
+        FormClass = admin.get_form(request=request, obj=None)
+        form = FormClass(
+            data={
+                'user': self.user,
+                'provider': 'anotherprovider',
+                'uid': '12345',
+                'extra_data': {'extra': 'data'},
+            }
+        )
+        assert form.is_valid()
+
+    @data(('managed', False), ('unmanaged', True))
+    @unpack
+    @override_config(
+        ENABLE_PASSWORD_MINIMUM_LENGTH_VALIDATION=False,
+        ENABLE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATION=False,
+        ENABLE_MOST_RECENT_PASSWORD_VALIDATION=False,
+        ENABLE_COMMON_PASSWORD_VALIDATION=False,
+        ENABLE_PASSWORD_CUSTOM_CHARACTER_RULES_VALIDATION=False,
+    )
+    def test_me_password_change_blocked_only_while_managed(
+        self, _label, make_unmanaged
+    ):
+        """
+        The `/me/` password change is blocked while the account is SSO-managed
+        and must succeed once the domain is no longer managed.
+        """
+        self.user.set_password('current-password')
+        self.user.save()
+        if make_unmanaged:
+            self.custom_data.managed = False
+            self.custom_data.save()
+
+        api_client = APIClient()
+        api_client.force_authenticate(user=self.user)
+        response = api_client.patch(
+            reverse('currentuser-detail'),
+            data={
+                'current_password': 'current-password',
+                'new_password': 'a-brand-new-password',
+            },
+            format='json',
+        )
+        if make_unmanaged:
+            assert response.status_code == status.HTTP_200_OK
+        else:
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert (
+                'Cannot update password for sso-managed account'
+                in response.content.decode()
+            )
+
+    def _make_unmanaged(self, change):
+        if change == 'managed_off':
+            self.custom_data.managed = False
+            self.custom_data.save()
+        elif change == 'domain_deleted':
+            SocialAppManagedDomain.objects.get(domain='example.com').delete()
+        elif change == 'app_deleted':
+            self.social_app.delete()
+
 
 class TestManagedSsoCelery(TestCase):
 
@@ -360,7 +456,9 @@ class TestManagedSsoCelery(TestCase):
         InAppMessageUsers.objects.get(user=user, in_app_message=message)
 
     def test_update_users_only_updates_once(self):
-        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
         managed_domain = SocialAppManagedDomain.objects.create(
             social_app=custom_data, domain=self.default_domain
         )
@@ -379,7 +477,9 @@ class TestManagedSsoCelery(TestCase):
         patched_notify.assert_called_once()
 
     def test_update_users_skips_in_app_message_when_disabled(self):
-        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
         managed_domain = SocialAppManagedDomain.objects.create(
             social_app=custom_data, domain=self.default_domain
         )
@@ -399,7 +499,9 @@ class TestManagedSsoCelery(TestCase):
         assert not linked_user.has_usable_password()
 
     def test_update_users_uses_custom_in_app_message_body(self):
-        custom_data = SocialAppCustomData.objects.create(social_app=self.social_app)
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
         managed_domain = SocialAppManagedDomain.objects.create(
             social_app=custom_data, domain=self.default_domain
         )
@@ -464,3 +566,174 @@ class TestManagedSsoCelery(TestCase):
         patched_update.assert_any_call(custom_data.pk, self.default_domain)
         patched_update.assert_any_call(custom_data_managed.pk, 'domain1.com')
         patched_update.assert_any_call(custom_data_managed.pk, 'domain2.com')
+
+
+@ddt
+class TestManagedSsoWithdrawal(TestCase):
+
+    def setUp(self):
+        self.provider = MockProvider(request=RequestFactory().get('/'))
+        self.social_app = SocialApp.objects.create(
+            client_id='test.service.id',
+            secret='test.service.secret',
+            name='Test App',
+            provider=self.provider.id,
+            provider_id='kobo',
+        )
+        self.custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
+        self.example_domain = SocialAppManagedDomain.objects.create(
+            social_app=self.custom_data, domain='example.com'
+        )
+        self.other_domain = SocialAppManagedDomain.objects.create(
+            social_app=self.custom_data, domain='other.com'
+        )
+        self.alice = User.objects.create(username='alice', email='alice@example.com')
+        self.bob = User.objects.create(username='bob', email='bob@other.com')
+        self.carol = User.objects.create(username='carol', email='carol@elsewhere.com')
+        # Create the reminders through the real path: one message and one
+        # recipient row per managed domain.
+        update_users(self.custom_data.pk, 'example.com')
+        update_users(self.custom_data.pk, 'other.com')
+        self.client = Client()
+
+    def test_turning_managed_off_withdraws_reminders(self):
+        """
+        Turning `managed` off deletes every recipient row and expires the
+        emptied reminders.
+        """
+        self.custom_data.managed = False
+        self.custom_data.save()
+
+        assert not InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()
+        messages = InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        )
+        assert messages.exists()
+        now = timezone.now()
+        assert all(message.valid_until <= now for message in messages)
+
+        self.client.force_login(self.alice)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 0
+
+    def test_withdrawn_reminder_is_not_broadcast(self):
+        """
+        A withdrawn reminder must be expired, not left recipient-less: an
+        emptied message is otherwise broadcast to every user.
+        """
+        self.custom_data.managed = False
+        self.custom_data.save()
+
+        self.client.force_login(self.carol)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 0
+
+    def test_removing_domain_withdraws_only_that_domain(self):
+        """
+        Removing one managed domain withdraws only its reminder; the other
+        domain's reminder stays live and is not broadcast.
+        """
+        bob_message = InAppMessageUsers.objects.get(user=self.bob).in_app_message
+        alice_message = InAppMessageUsers.objects.get(user=self.alice).in_app_message
+
+        self.other_domain.delete()
+
+        assert not InAppMessageUsers.objects.filter(user=self.bob).exists()
+        assert InAppMessageUsers.objects.filter(user=self.alice).exists()
+
+        now = timezone.now()
+        bob_message.refresh_from_db()
+        alice_message.refresh_from_db()
+        assert bob_message.valid_until <= now
+        assert alice_message.valid_until > now
+
+        # bob's emptied reminder must not leak to everyone
+        self.client.force_login(self.carol)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 0
+
+        self.client.force_login(self.alice)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 1
+
+    def test_deleting_social_app_withdraws_reminders(self):
+        """
+        Deleting the social app cascades and withdraws every reminder, even
+        though messages reference the app only through a JSON field.
+        """
+        self.social_app.delete()
+
+        assert not InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()
+        messages = InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        )
+        assert messages.exists()
+        now = timezone.now()
+        assert all(message.valid_until <= now for message in messages)
+
+        for user in (self.alice, self.carol):
+            self.client.force_login(user)
+            response = self.client.get('/help/in_app_messages/')
+            assert response.json()['count'] == 0
+
+    def test_reenabling_managed_notifies_users_again(self):
+        """
+        Stale recipient rows must be gone after a turn-off so re-enabling
+        can notify the same users again.
+        """
+        self.custom_data.managed = False
+        self.custom_data.save()
+        self.custom_data.managed = True
+        self.custom_data.save()
+
+        update_users(self.custom_data.pk, 'example.com')
+
+        alice_rows = InAppMessageUsers.objects.filter(user=self.alice)
+        assert alice_rows.count() == 1
+        message = alice_rows.first().in_app_message
+        now = timezone.now()
+        assert message.valid_from <= now <= message.valid_until
+
+    @data('managed_off', 'domain_deleted', 'app_deleted')
+    def test_update_users_is_noop_when_no_longer_managed(self, change):
+        """
+        A queued task must re-check state and not strip a password after the
+        admin turns managed off, drops the domain or deletes the app.
+        """
+        linked_user = User.objects.create(username='linked', email='linked@example.com')
+        linked_user.set_password('password')
+        linked_user.save()
+        baker.make(
+            'socialaccount.SocialAccount',
+            user=linked_user,
+            provider=self.social_app.provider_id,
+        )
+        custom_data_pk = self.custom_data.pk
+        message_count_before = InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        ).count()
+
+        if change == 'managed_off':
+            self.custom_data.managed = False
+            self.custom_data.save()
+        elif change == 'domain_deleted':
+            self.example_domain.delete()
+        elif change == 'app_deleted':
+            self.social_app.delete()
+
+        update_users(custom_data_pk, 'example.com')
+
+        linked_user.refresh_from_db()
+        assert linked_user.has_usable_password()
+        assert (
+            InAppMessage.objects.filter(
+                message_type=MessageType.MANAGED_SSO_REMINDER
+            ).count()
+            == message_count_before
+        )

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import ANY, MagicMock, patch
 
 from allauth.socialaccount.models import SocialAccount, SocialApp
@@ -27,7 +28,11 @@ from ..tasks import (
     update_linked_user,
     update_users,
 )
-from ..utils import SOCIAL_APP_IDENTIFIER, users_needing_update
+from ..utils import (
+    SOCIAL_APP_IDENTIFIER,
+    remove_stale_managed_sso_reminders,
+    users_needing_update,
+)
 from .utils import MockProvider
 
 
@@ -737,3 +742,69 @@ class TestManagedSsoWithdrawal(TestCase):
             ).count()
             == message_count_before
         )
+
+    def test_sweep_withdraws_reminders_of_a_deleted_app(self):
+        """
+        A reminder left behind by an app deleted before the cleanup signals
+        existed is withdrawn by the nightly sweep; live ones are left alone.
+        """
+        now = timezone.now()
+        orphan = baker.make(
+            'help.InAppMessage',
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            generic_related_objects={SOCIAL_APP_IDENTIFIER: 999999},
+            published=True,
+            valid_from=now,
+            valid_until=now + timedelta(days=365),
+        )
+        InAppMessageUsers.objects.create(user=self.carol, in_app_message=orphan)
+
+        with patch('kobo.apps.accounts.tasks.update_users'):
+            managed_sso_sweep()
+
+        orphan.refresh_from_db()
+        assert not InAppMessageUsers.objects.filter(in_app_message=orphan).exists()
+        assert orphan.valid_until <= timezone.now()
+        assert InAppMessageUsers.objects.filter(user=self.alice).exists()
+        self.client.force_login(self.alice)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 1
+
+    def test_sweep_withdraws_reminders_of_an_unmanaged_app(self):
+        """
+        `update()` bypasses the signals, like a flag turned off before they
+        existed; the sweep must catch up.
+        """
+        SocialAppCustomData.objects.filter(pk=self.custom_data.pk).update(managed=False)
+
+        remove_stale_managed_sso_reminders()
+
+        assert not InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()
+        messages = InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        )
+        assert messages.exists()
+        now = timezone.now()
+        assert all(message.valid_until <= now for message in messages)
+
+    def test_sweep_withdraws_recipients_off_the_managed_domains(self):
+        """
+        A recipient whose email left the managed domains is withdrawn and the
+        emptied reminder expired; the other recipient keeps a live one.
+        """
+        User.objects.filter(pk=self.bob.pk).update(email='bob@elsewhere.com')
+
+        remove_stale_managed_sso_reminders()
+
+        assert not InAppMessageUsers.objects.filter(user=self.bob).exists()
+        assert InAppMessageUsers.objects.filter(user=self.alice).exists()
+
+        self.client.force_login(self.carol)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 0
+
+        self.client.force_login(self.alice)
+        response = self.client.get('/help/in_app_messages/')
+        assert response.json()['count'] == 1

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -523,6 +523,43 @@ class TestManagedSsoCelery(TestCase):
         )
         assert message.body == 'custom body text'
 
+    def test_update_users_stops_when_managed_turns_off_mid_run(self):
+        """
+        The flag is re-checked before each destructive change, so a toggle
+        during the run leaves the remaining users alone and sends no reminder.
+        """
+        custom_data = SocialAppCustomData.objects.create(
+            social_app=self.social_app, managed=True
+        )
+        managed_domain = SocialAppManagedDomain.objects.create(
+            social_app=custom_data, domain=self.default_domain
+        )
+        linked_users = [
+            self._create_user('first_linked', True, True, False),
+            self._create_user('second_linked', True, True, False),
+        ]
+        self._create_user('unlinked', True, False, False)
+
+        def convert_then_toggle_off(user, provider_id):
+            update_linked_user(user, provider_id)
+            SocialAppCustomData.objects.filter(pk=custom_data.pk).update(managed=False)
+
+        with patch(
+            'kobo.apps.accounts.tasks.update_linked_user',
+            side_effect=convert_then_toggle_off,
+        ):
+            update_users(custom_data.pk, managed_domain.domain)
+
+        still_with_password = [
+            user
+            for user in linked_users
+            if User.objects.get(pk=user.pk).has_usable_password()
+        ]
+        assert len(still_with_password) == 1
+        assert not InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()
+
     def test_create_inapp_message_defaults_to_constant_body(self):
         message = create_inapp_message(self.social_app)
         assert message.body == DEFAULT_IN_APP_MESSAGE_BODY

--- a/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
+++ b/kobo/apps/accounts/tests/test_socialappcustomdata_admin.py
@@ -149,6 +149,11 @@ class SocialAppCustomDataAdminTestCase(TestCase):
         self.assertEqual(response.context['track_2_count'], 1)
         self.assertEqual(response.context['submitted_domains'], ['example.com'])
         self.assertTrue(response.context['managed_toggled_on'])
+        self.assertNotIn(
+            'Pending in-app reminders asking users to link their SSO account'
+            ' will be withdrawn.',
+            response.content.decode(),
+        )
 
         # Verify nothing changed in DB yet
         self.custom_data.refresh_from_db()
@@ -299,6 +304,11 @@ class SocialAppCustomDataAdminTestCase(TestCase):
             response, 'admin/accounts/socialappcustomdata/confirmation.html'
         )
         self.assertTrue(response.context['managed_toggled_off'])
+        self.assertIn(
+            'Pending in-app reminders asking users to link their SSO account'
+            ' will be withdrawn.',
+            response.content.decode(),
+        )
 
         # Confirm turn off
         post_data['_confirmed'] = '1'

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -96,10 +96,16 @@ def remove_stale_managed_sso_reminders():
     live_reminders = InAppMessage.objects.filter(
         message_type=MessageType.MANAGED_SSO_REMINDER, valid_until__gte=now
     )
+    reminders_by_app = defaultdict(list)
+    for reminder_pk, related_objects in live_reminders.values_list(
+        'pk', 'generic_related_objects'
+    ):
+        reminders_by_app[related_objects.get(SOCIAL_APP_IDENTIFIER)].append(reminder_pk)
     with transaction.atomic():
-        for reminder in live_reminders:
-            recipients = InAppMessageUsers.objects.filter(in_app_message=reminder)
-            social_app_pk = reminder.generic_related_objects.get(SOCIAL_APP_IDENTIFIER)
+        for social_app_pk, reminder_pks in reminders_by_app.items():
+            recipients = InAppMessageUsers.objects.filter(
+                in_app_message_id__in=reminder_pks
+            )
             domains = managed_domains.get(social_app_pk)
             if domains:
                 still_managed = Q()

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -1,11 +1,13 @@
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
+from django.db import transaction
 from django.db.models import CharField, Count, F, Func, Q, Value
 from django.db.models.functions import Lower
+from django.utils import timezone
 
 from kobo.apps.accounts.models import SocialAppManagedDomain
-from kobo.apps.help.models import InAppMessageUsers, MessageType
+from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
 
@@ -51,6 +53,29 @@ def get_normalized_domain(email):
     if not separator:
         return ''
     return domain.strip().lower()
+
+
+def remove_managed_sso_reminders(social_app_pk: int, domain: str | None = None):
+    """
+    Withdraw the "connect your SSO account" reminders sent for a social app,
+    for every recipient or only for users whose email is on `domain`.
+
+    A reminder left with no recipient is expired rather than deleted: the
+    in-app message endpoint shows a message with no `InAppMessageUsers` row
+    to everyone.
+    """
+    messages = InAppMessage.objects.filter(
+        message_type=MessageType.MANAGED_SSO_REMINDER,
+        generic_related_objects__contains={SOCIAL_APP_IDENTIFIER: social_app_pk},
+    )
+    recipients = InAppMessageUsers.objects.filter(in_app_message__in=messages)
+    if domain:
+        recipients = recipients.filter(user__email__iendswith=f'@{domain}')
+    with transaction.atomic():
+        recipients.delete()
+        messages.filter(inappmessageusers__isnull=True).update(
+            valid_until=timezone.now()
+        )
 
 
 def user_is_managed_by_sso(user):

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from django.conf import settings
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
@@ -76,6 +78,36 @@ def remove_managed_sso_reminders(social_app_pk: int, domain: str | None = None):
         messages.filter(inappmessageusers__isnull=True).update(
             valid_until=timezone.now()
         )
+
+
+def remove_stale_managed_sso_reminders():
+    """
+    Withdraw live reminders that no longer match a managed social app and
+    domain: the app was deleted or turned unmanaged before the cleanup
+    signals existed, or a recipient's email moved off the managed domains.
+    """
+    now = timezone.now()
+    managed_domains = defaultdict(set)
+    for social_app_pk, domain in SocialAppManagedDomain.objects.filter(
+        social_app__managed=True
+    ).values_list('social_app_id', 'domain'):
+        managed_domains[social_app_pk].add(domain)
+
+    live_reminders = InAppMessage.objects.filter(
+        message_type=MessageType.MANAGED_SSO_REMINDER, valid_until__gte=now
+    )
+    with transaction.atomic():
+        for reminder in live_reminders:
+            recipients = InAppMessageUsers.objects.filter(in_app_message=reminder)
+            social_app_pk = reminder.generic_related_objects.get(SOCIAL_APP_IDENTIFIER)
+            domains = managed_domains.get(social_app_pk)
+            if domains:
+                still_managed = Q()
+                for domain in domains:
+                    still_managed |= Q(user__email__iendswith=f'@{domain}')
+                recipients = recipients.exclude(still_managed)
+            recipients.delete()
+        live_reminders.filter(inappmessageusers__isnull=True).update(valid_until=now)
 
 
 def user_is_managed_by_sso(user):


### PR DESCRIPTION
### 📣 Summary
Turning managed SSO off, removing a managed email domain, or deleting the SSO provider now withdraws the in-app reminders it sent.

### 📖 Description
When an organization's SSO provider stops being managed, or one of its email domains is removed, users on those domains no longer see the "Update your account" reminder asking them to link their SSO account. They can set a password and link other social accounts again. Deleting the provider itself has the same effect. Reminders left behind by earlier changes are cleared by the nightly job.

### 💭 Notes
- The reminders point at the `SocialApp` through `InAppMessage.generic_related_objects`, not a foreign key, so nothing cleaned them up on turn-off or on cascade. Three receivers in `accounts/signals.py` now call `remove_managed_sso_reminders()`: recipient rows are deleted and any message left without recipients is expired, in one transaction.
- Expired rather than deleted on purpose: the in-app message endpoint shows a message with no `InAppMessageUsers` row to every user, so an emptied message would leak instance-wide.
- The recipient rows have to go as well. `users_needing_update()` skips users who already have one, so re-enabling later would silently skip them.
- `update_users` now re-checks that the domain is still managed at the start and again before each destructive change. The admin queues it on commit, so an admin could turn managed off (or drop the domain, or delete the app) before or while the worker runs and still get passwords stripped. One `exists()` per converted user, nothing per unaffected user.
- The nightly `managed_sso_sweep` starts with `remove_stale_managed_sso_reminders()`: any live reminder whose app is gone or unmanaged, or whose recipient's email is no longer on one of the app's managed domains, is withdrawn the same way, one delete per app that has live reminders. That covers reminders orphaned before this change shipped, which would otherwise stay visible for up to a year.
- Reminders are scoped by the recipient's current email on purpose: that is how every other managed-SSO check decides who is managed, and a reminder does not record the domain it was sent for. A user who moves to another managed domain of the same app is still managed and keeps the reminder; one who moves off the managed domains is picked up by the sweep.
- Password reset, the `/me` password change, unlinking and the admin forms all query the flag live, so no change there. Tests now cover that each one releases.
- The confirmation page gets one line saying pending reminders will be withdrawn.
- Removing a domain while managed still saves without going through the confirmation page (pre-existing). Could be a follow-up if we want that confirmed too.

### 👀 Preview steps
1. ℹ️ have a superuser, a social app with custom data where `Managed` is checked and a domain `example.com`, and a user `alice@example.com` with a password and no social account
2. As superuser, save the custom data and confirm: alice gets the "Update your account" in-app message on her next page load
3. Edit the custom data again, uncheck `Managed`, click `Save`
4. 🟢 [on PR] the confirmation page says pending in-app reminders will be withdrawn
5. Click `Yes, I'm sure`, then reload the app as alice
6. 🔴 [on main] the "Update your account" message is still there
7. 🟢 [on PR] the message is gone, and alice can request a password reset again
