### PR TITLE
ci(translations): don't omit some translatable strings DEV-2798

### DIFF
--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   locale:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04 # See DEV-2798. Remove this comment once we bump all runners to 26.04
     steps:
 
     ## Setup


### PR DESCRIPTION
### 💭 Notes

Fix a bug where some translatable strings were omitted from translating.

The root cause is bug #58407 in gettext v0.21 on Ubuntu 24.04.
The bug is fixed in gettext v0.23, and Ubuntu 26.04 ships with gettext v0.23.2.

### 👀 Preview steps

```bash
cat jsapp/js/components/formLanding/formLanding.js | grep -o '\bt(' # -> 45 matches

gettext --version # -> 0.21
source .venv/bin/activate
./scripts/generate_locale.sh
cat locale/en/LC_MESSAGES/djangojs.po | grep formLanding.js | wc # -> 1 line

# install newer gettext
curl -sL https://ftp.gnu.org/pub/gnu/gettext/gettext-1.0.tar.xz | tar xJ
cd gettext-1.0 && ./configure --prefix=/usr/local && make -j$(nproc) && sudo make install
sudo ldconfig

gettext --version # -> 1.00
source .venv/bin/activate
./scripts/generate_locale.sh
cat locale/en/LC_MESSAGES/djangojs.po | grep formLanding.js | wc # -> 45 lines
```