### PR TITLE
refactor(auth): transform session to profile store DEV-1861

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,7 +17,7 @@ import { DARK_MODE_EVENT_NAME } from 'storybook-dark-mode'
 import { addons } from 'storybook/preview-api'
 import environmentMock from '#/endpoints/environment.mocks'
 import meMock from '#/endpoints/me.mocks'
-import { hydrateSessionStoreForStories } from '#/stores/session.mocks'
+import { hydrateProfileStoreForStories } from '#/stores/profile.mocks'
 import { cssVariablesResolverKobo, themeKobo } from '../jsapp/js/theme'
 
 // Imported with `as` to avoid having confusing `initialize` (i.e. what does it initialize?)
@@ -58,12 +58,12 @@ const preview: Preview = {
     ),
   ],
   loaders: [mswAddon.mswLoader],
-  // `sessionStore` is a singleton that kicks off its `/me/` request on import,
+  // `profileStore` is a singleton that kicks off its `/me/` request on import,
   // which can lose the race against the MSW worker starting up. Re-apply a
   // settled logged-in state before each story so components gated on the session
-  // never get stuck on a loading spinner. See `session.mocks.ts` for details.
+  // never get stuck on a loading spinner. See `profile.mocks.ts` for details.
   beforeEach: () => {
-    hydrateSessionStoreForStories()
+    hydrateProfileStoreForStories()
   },
   tags: ['autodocs'],
   parameters: {

--- a/jsapp/js/account/DeleteAccountBanner.tsx
+++ b/jsapp/js/account/DeleteAccountBanner.tsx
@@ -5,17 +5,17 @@ import { useAssetsList } from '#/api/react-query/manage-projects-and-library-con
 import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import Button from '#/components/common/ButtonNew'
 import { PROJECTS_ROUTES } from '#/router/routerConstants'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import styles from './DeleteAccountBanner.module.scss'
 import DeleteAccountModal from './DeleteAccountModal'
 
 export default function DeleteAccountBanner() {
   const [isModalOpened, { open, close }] = useDisclosure(false)
-  const session = useSession()
+  const profile = useProfile()
   const [organization] = useOrganizationAssumed()
   const isAccountOrganizationOwner = organization.is_mmo && organization.is_owner
 
-  const username = session.currentLoggedAccount.username
+  const username = profile.currentLoggedAccount.username
   const { data: assetsData, isPending } = useAssetsList({
     q: `(owner__username:${username} AND asset_type:survey)`,
     limit: 1,

--- a/jsapp/js/account/DeleteAccountModal.tsx
+++ b/jsapp/js/account/DeleteAccountModal.tsx
@@ -5,15 +5,15 @@ import { useState } from 'react'
 import { fetchDelete } from '#/api'
 import { endpoints } from '#/api.endpoints'
 import ButtonNew from '#/components/common/ButtonNew'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { notify } from '#/utils'
 
 export default function DeleteAccountModal(props: ModalProps) {
   const [isDeleting, setIsDeleting] = useState(false)
-  const session = useSession()
+  const profile = useProfile()
 
   function isUsernameOk(username: string) {
-    return username === session.currentLoggedAccount.username
+    return username === profile.currentLoggedAccount.username
   }
 
   const usernameField = useField({
@@ -24,10 +24,10 @@ export default function DeleteAccountModal(props: ModalProps) {
 
   const handleConfirmDeleteAccount = () => {
     setIsDeleting(true)
-    fetchDelete(endpoints.ME, { confirm: session.currentLoggedAccount.extra_details__uid })
+    fetchDelete(endpoints.ME, { confirm: profile.currentLoggedAccount.extra_details__uid })
       .then(() => {
         setIsDeleting(false)
-        // We can't use `session.logOut` because it needs authentication to work, and after successful API call, account
+        // We can't use `profile.logOut` because it needs authentication to work, and after successful API call, account
         // is no longer authenticated. We force reload to leave the UI:
         window.location.replace('')
       })

--- a/jsapp/js/account/accountSettingsRoute.tsx
+++ b/jsapp/js/account/accountSettingsRoute.tsx
@@ -11,7 +11,7 @@ import { HELP_ARTICLE_ANON_SUBMISSIONS_URL } from '#/constants'
 import envStore from '#/envStore'
 import { notify, recordKeys } from '#/utils'
 import { dataInterface } from '../dataInterface'
-import { useSession } from '../stores/useSession'
+import { useProfile } from '../stores/useProfile'
 import DeleteAccountBanner from './DeleteAccountBanner'
 import type { AccountFieldsErrors, AccountFieldsValues } from './account.constants'
 import { getInitialAccountFieldsValues, getProfilePatchData } from './account.utils'
@@ -30,7 +30,7 @@ const AccountSettings = () => {
   const [editedFields, setEditedFields] = useState<Partial<AccountFieldsValues>>({})
   const isSelfDeleteFeatureEnabled = envStore.data.allow_self_account_deletion
 
-  const { currentLoggedAccount, refreshAccount } = useSession()
+  const { currentLoggedAccount, refreshAccount } = useProfile()
 
   const [displayedFields, setDisplayedFields] = useState<Array<keyof AccountFieldsValues>>([])
 

--- a/jsapp/js/account/billingContextProvider.component.tsx
+++ b/jsapp/js/account/billingContextProvider.component.tsx
@@ -1,10 +1,10 @@
 import React, { type ReactNode } from 'react'
 import { ProductsContext, useProducts } from '#/account/useProducts.hook'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { OneTimeAddOnsContext, useOneTimeAddOns } from './useOneTimeAddonList.hook'
 
 export const BillingContextProvider = (props: { children: ReactNode }) => {
-  if (!sessionStore.isLoggedIn) {
+  if (!profileStore.isLoggedIn) {
     return <>{props.children}</>
   }
 

--- a/jsapp/js/account/changePasswordRoute.component.tsx
+++ b/jsapp/js/account/changePasswordRoute.component.tsx
@@ -9,7 +9,7 @@ import Avatar from '#/components/common/avatar'
 import Button from '#/components/common/button'
 import { withRouter } from '#/router/legacy'
 import type { WithRouterProps } from '#/router/legacy'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import styles from './changePasswordRoute.module.scss'
 import { ACCOUNT_ROUTES } from './routes.constants'
 import UpdatePasswordForm from './security/password/updatePasswordForm.component'
@@ -30,11 +30,11 @@ const ChangePasswordRoute = class ChangePassword extends React.Component<WithRou
   }
 
   render() {
-    if (!sessionStore.isLoggedIn) {
+    if (!profileStore.isLoggedIn) {
       return null
     }
 
-    const accountName = sessionStore.currentAccount.username
+    const accountName = profileStore.currentAccount.username
 
     return (
       <DocumentTitle title={`${accountName} | KoboToolbox`}>

--- a/jsapp/js/account/organization/MemberActionsDropdown.tsx
+++ b/jsapp/js/account/organization/MemberActionsDropdown.tsx
@@ -6,7 +6,7 @@ import { MemberRoleEnum } from '#/api/models/memberRoleEnum'
 import envStore from '#/envStore'
 import router from '#/router/router'
 import { ROUTES } from '#/router/routerConstants'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import MemberRemoveModal from './MemberRemoveModal'
 import { getSimpleMMOLabel } from './organization.utils'
 
@@ -24,11 +24,11 @@ interface MemberActionsDropdownProps {
  * A dropdown with all actions that can be taken towards an organization member.
  */
 export default function MemberActionsDropdown({ target, targetUsername, currentUserRole }: MemberActionsDropdownProps) {
-  const session = useSession()
+  const profile = useProfile()
   const [isRemoveModalVisible, setIsRemoveModalVisible] = useState(false)
 
   // Wait for session
-  if (!session.currentLoggedAccount?.username) {
+  if (!profile.currentLoggedAccount?.username) {
     return null
   }
 
@@ -41,7 +41,7 @@ export default function MemberActionsDropdown({ target, targetUsername, currentU
   // If logged in user is an admin and tries to remove themselves, we need
   // different UI - thus we check it here.
   const isAdminRemovingSelf = Boolean(
-    targetUsername === session.currentLoggedAccount?.username && currentUserRole === MemberRoleEnum.admin,
+    targetUsername === profile.currentLoggedAccount?.username && currentUserRole === MemberRoleEnum.admin,
   )
 
   // Different button label when user is removing themselves

--- a/jsapp/js/account/organization/invites/OrgInviteModal.tsx
+++ b/jsapp/js/account/organization/invites/OrgInviteModal.tsx
@@ -14,7 +14,7 @@ import { useLogout } from '#/auth/useLogout'
 import Alert from '#/components/common/alert'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import envStore from '#/envStore'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { notify, sleep } from '#/utils'
 
 /**
@@ -25,7 +25,7 @@ import { notify, sleep } from '#/utils'
  */
 export default function OrgInviteModal(props: { orgId: string; inviteId: string; onUserResponse: () => void }) {
   const [isModalOpen, setIsModalOpen] = useState(true)
-  const session = useSession()
+  const profile = useProfile()
   const logout = useLogout()
 
   // We use `mmoLabel` as fallback until `organization_name` is available at the endpoint
@@ -47,7 +47,7 @@ export default function OrgInviteModal(props: { orgId: string; inviteId: string;
         if (variables.data.status === InviteStatusChoicesEnum.accepted) {
           setAwaitingDataRefresh(true)
           await sleep(1000) // Give it a second to allow for initial backend data transfers
-          session.refreshAccount() // refresh session to refresh org data and project list
+          profile.refreshAccount() // refresh session to refresh org data and project list
           notify(t('Invitation successfully accepted'))
         } else {
           notify(t('Invitation successfully declined'))

--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react'
 
-import { keepPreviousData } from '@tanstack/react-query'
+import { keepPreviousData, useMutation } from '@tanstack/react-query'
 import UniversalTable, { DEFAULT_PAGE_SIZE } from '#/UniversalTable'
 import securityStyles from '#/account/security/securityRoute.module.scss'
+import { fetchPost } from '#/api'
+import { endpoints } from '#/api.endpoints'
 import { ServerError } from '#/api/ServerError'
 import type { AccessLogResponse } from '#/api/models/accessLogResponse'
 import type { ErrorDetail } from '#/api/models/errorDetail'

--- a/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
+++ b/jsapp/js/account/security/accessLogs/accessLogsSection.component.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react'
 
-import { keepPreviousData, useMutation } from '@tanstack/react-query'
+import { keepPreviousData } from '@tanstack/react-query'
 import UniversalTable, { DEFAULT_PAGE_SIZE } from '#/UniversalTable'
 import securityStyles from '#/account/security/securityRoute.module.scss'
-import { fetchPost } from '#/api'
-import { endpoints } from '#/api.endpoints'
 import { ServerError } from '#/api/ServerError'
 import type { AccessLogResponse } from '#/api/models/accessLogResponse'
 import type { ErrorDetail } from '#/api/models/errorDetail'

--- a/jsapp/js/account/security/email/emailSection.component.tsx
+++ b/jsapp/js/account/security/email/emailSection.component.tsx
@@ -8,7 +8,7 @@ import ButtonNew from '#/components/common/ButtonNew'
 import TextInput from '#/components/common/TextInput'
 import Icon from '#/components/common/icon'
 import type { FailResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime, notify } from '#/utils'
 import { deleteUnverifiedUserEmails, getUserEmails, setUserEmail } from './emailSection.api'
 import type { EmailResponse } from './emailSection.api'
@@ -23,13 +23,13 @@ interface EmailState {
 }
 
 export default function EmailSection() {
-  const [session] = useState(() => sessionStore)
+  const [profile] = useState(() => profileStore)
 
   const [organization] = useOrganizationAssumed()
 
   let initialEmail = ''
-  if ('email' in session.currentAccount) {
-    initialEmail = session.currentAccount.email
+  if ('email' in profile.currentAccount) {
+    initialEmail = profile.currentAccount.email
   }
 
   const [email, setEmail] = useState<EmailState>({
@@ -136,11 +136,11 @@ export default function EmailSection() {
     }
   }
 
-  const currentAccount = session.currentAccount
+  const currentAccount = profile.currentAccount
   const unverifiedEmail = email.emails.find((userEmail) => !userEmail.verified && !userEmail.primary)
-  const isReady = session.isInitialLoadComplete && 'email' in currentAccount
+  const isReady = profile.isInitialLoadComplete && 'email' in currentAccount
   const isSSO =
-    session.isInitialLoadComplete && 'social_accounts' in currentAccount && currentAccount.social_accounts.length >= 1
+    profile.isInitialLoadComplete && 'social_accounts' in currentAccount && currentAccount.social_accounts.length >= 1
   const userCanChangeEmail = organization.is_mmo ? organization.request_user_role !== MemberRoleEnum.member : true
 
   return (

--- a/jsapp/js/account/security/mfa/mfaSection.component.tsx
+++ b/jsapp/js/account/security/mfa/mfaSection.component.tsx
@@ -11,7 +11,7 @@ import Tooltip from '#/components/common/tooltip'
 import { MODAL_TYPES } from '#/constants'
 import envStore from '#/envStore'
 import pageState from '#/pageState.store'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime } from '#/utils'
 import styles from './mfaSection.module.scss'
 
@@ -127,8 +127,8 @@ export default class SecurityRoute extends React.Component<{}, SecurityState> {
   render() {
     const isSuperuserMfaLocked =
       envStore.data.superuser_auth_enforcement &&
-      'is_superuser' in sessionStore.currentAccount &&
-      sessionStore.currentAccount.is_superuser
+      'is_superuser' in profileStore.currentAccount &&
+      profileStore.currentAccount.is_superuser
 
     const isDisabled = isSuperuserMfaLocked && this.state.isMfaActive
 

--- a/jsapp/js/account/security/password/passwordSection.component.tsx
+++ b/jsapp/js/account/security/password/passwordSection.component.tsx
@@ -8,14 +8,14 @@ import securityStyles from '#/account/security/securityRoute.module.scss'
 import Button from '#/components/common/button'
 import envStore from '#/envStore'
 import { PATHS } from '#/router/routerConstants'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { getConnectedApp } from '../sso/sso.utils'
 import styles from './passwordSection.module.scss'
 
 const HIDDEN_TOKEN_VALUE = '● '.repeat(10)
 
 export default function PasswordSection() {
-  const { currentLoggedAccount } = useSession()
+  const { currentLoggedAccount } = useProfile()
   const connectedApp = getConnectedApp(envStore.data, currentLoggedAccount)
 
   return (

--- a/jsapp/js/account/security/password/updatePasswordForm.component.tsx
+++ b/jsapp/js/account/security/password/updatePasswordForm.component.tsx
@@ -10,7 +10,7 @@ import PasswordStrength from '#/components/passwordStrength.component'
 import { ROOT_URL } from '#/constants'
 import type { FailResponse } from '#/dataInterface'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { notify } from '#/utils'
 import styles from './updatePasswordForm.module.scss'
 
@@ -114,7 +114,7 @@ export default function UpdatePasswordForm(props: UpdatePasswordFormProps) {
     savePassword()
   }
 
-  if (!sessionStore.isLoggedIn || !isEnvStoreReady) {
+  if (!profileStore.isLoggedIn || !isEnvStoreReady) {
     return null
   }
 

--- a/jsapp/js/account/security/sso/sso.utils.ts
+++ b/jsapp/js/account/security/sso/sso.utils.ts
@@ -1,6 +1,6 @@
 import type { AccountResponse } from '#/dataInterface'
 import type { EnvStoreData, SocialApp } from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 
 /** The SSO providers configured on this server. */
 export function getSsoProviders(envStoreData: EnvStoreData) {
@@ -18,7 +18,7 @@ export function isSsoAvailable(envStoreData: EnvStoreData) {
  * SSO accounts connected to the current user. It's at most one, but the endpoint gives us a list.
  */
 export function getConnectedSsoAccounts() {
-  return 'social_accounts' in sessionStore.currentAccount ? sessionStore.currentAccount.social_accounts : []
+  return 'social_accounts' in profileStore.currentAccount ? profileStore.currentAccount.social_accounts : []
 }
 
 /**

--- a/jsapp/js/account/security/sso/ssoSection.component.tsx
+++ b/jsapp/js/account/security/sso/ssoSection.component.tsx
@@ -4,14 +4,14 @@ import cx from 'classnames'
 import securityStyles from '#/account/security/securityRoute.module.scss'
 import Button from '#/components/common/button'
 import envStore, { type SocialApp } from '#/envStore'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import ManagedSsoConfirmModal from './ManagedSsoConfirmModal'
 import { deleteSocialAccount } from './sso.api'
 import { getConnectedApp, getSsoProviders, isSsoAvailable } from './sso.utils'
 import styles from './ssoSection.module.scss'
 
 export default function SsoSection() {
-  const { currentLoggedAccount, refreshAccount } = useSession()
+  const { currentLoggedAccount, refreshAccount } = useProfile()
   const socialApps = getSsoProviders(envStore.data)
   const connectedApp = getConnectedApp(envStore.data, currentLoggedAccount)
   const isManaged = connectedApp?.managed ?? false

--- a/jsapp/js/account/usage/useOrganizationsServiceUsageSummary.ts
+++ b/jsapp/js/account/usage/useOrganizationsServiceUsageSummary.ts
@@ -7,7 +7,7 @@ import {
   useOrganizationsServiceUsageRetrieve,
 } from '#/api/react-query/user-team-organization-usage'
 import { USAGE_WARNING_RATIO } from '#/constants'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { convertSecondsToMinutes, formatRelativeTime, recordEntries } from '#/utils'
 import { UsageLimitTypes } from '../stripe.types'
 
@@ -101,8 +101,8 @@ export const useOrganizationsServiceUsageSummary = (
   >,
 ) => {
   // Note: not using `useOrganizationAssumed` due being used within routes that accessible by anonymous user as well.
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
 
   // Note: for "!" see https://github.com/orval-labs/orval/issues/2397
   const query = useOrganizationsServiceUsageRetrieve(organizationId!, {

--- a/jsapp/js/account/usage/yourPlan.component.tsx
+++ b/jsapp/js/account/usage/yourPlan.component.tsx
@@ -9,7 +9,7 @@ import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import ButtonNew from '#/components/common/ButtonNew'
 import Badge, { type BadgeColor } from '#/components/common/badge'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatDate } from '#/utils'
 import { getSubscriptionChangeDetails } from '../stripe.utils'
 import { ProductsContext } from '../useProducts.hook'
@@ -28,7 +28,7 @@ const BADGE_COLOR_KEYS: { [key in SubscriptionChangeType]: BadgeColor } = {
 export const YourPlan = () => {
   const [subscriptions] = useState(() => subscriptionStore)
   const [env] = useState(() => envStore)
-  const [session] = useState(() => sessionStore)
+  const [profile] = useState(() => profileStore)
   const [productsContext] = useContext(ProductsContext)
   const [organization] = useOrganizationAssumed()
 
@@ -42,7 +42,7 @@ export const YourPlan = () => {
     } else if (subscriptions.canceledPlans.length) {
       date = subscriptions.canceledPlans[subscriptions.canceledPlans.length - 1].ended_at
     } else {
-      date = session.currentAccount.date_joined
+      date = profile.currentAccount.date_joined
     }
     return formatDate(date)
   }, [env.isReady, subscriptions.isInitialised])

--- a/jsapp/js/api/mutation-defaults/user-team-organization-usage.ts
+++ b/jsapp/js/api/mutation-defaults/user-team-organization-usage.ts
@@ -16,7 +16,7 @@ import {
   type organizationsMembersListResponse,
   type organizationsMembersRetrieveResponse,
 } from '#/api/react-query/user-team-organization-usage'
-import session from '#/stores/session'
+import profile from '#/stores/profile'
 import { getAssetUIDFromUrl } from '#/utils'
 import {
   invalidateItem,
@@ -222,7 +222,7 @@ export function applyUserTeamOrganizationMutationDefaults(client: QueryClient): 
         },
         onSuccess: (_data, { username }) => {
           // If user is removing themselves, we need to clear the session
-          if (username === session.currentAccount?.username) session.refreshAccount()
+          if (username === profile.currentAccount?.username) profile.refreshAccount()
         },
       },
     }),

--- a/jsapp/js/api/useOrganizationAssumed.ts
+++ b/jsapp/js/api/useOrganizationAssumed.ts
@@ -6,7 +6,7 @@ import {
   getOrganizationsRetrieveQueryKey,
   useOrganizationsRetrieve,
 } from '#/api/react-query/user-team-organization-usage'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 
 /**
  * For convenience, returns `Organization` directly that's assumed to be already cached, stale or not.
@@ -21,8 +21,8 @@ import { useSession } from '#/stores/useSession'
 export const useOrganizationAssumed = (
   options?: Omit<UseQueryOptions<organizationsRetrieveResponse, ErrorDetail>, 'queryKey'>,
 ) => {
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
 
   // Note: `!` is a workaround, see https://github.com/orval-labs/orval/issues/2397
   const query = useOrganizationsRetrieve(organizationId!, {

--- a/jsapp/js/assetQuickActions.tsx
+++ b/jsapp/js/assetQuickActions.tsx
@@ -14,7 +14,7 @@ import escape from 'lodash.escape'
 import toast from 'react-hot-toast'
 import { PERMISSIONS_CODENAMES } from '#/components/permissions/permConstants'
 import pageState from '#/pageState.store'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { actions } from './actions'
 import { renderJSXMessage } from './alertify'
 import assetUtils from './assetUtils'
@@ -300,7 +300,7 @@ export function removeAssetSharing(uid: string) {
       // Only non-owners should have the asset removed from their asset list.
       // This menu option is only open to non-owners so we don't need to check again.
       const isNonOwner = true
-      actions.permissions.removeAssetPermission(uid, undefined, true, isNonOwner, sessionStore.currentAccount.username)
+      actions.permissions.removeAssetPermission(uid, undefined, true, isNonOwner, profileStore.currentAccount.username)
     },
     oncancel: () => {
       dialog.destroy()

--- a/jsapp/js/assetUtils.tests.js
+++ b/jsapp/js/assetUtils.tests.js
@@ -2,7 +2,7 @@
 var mockedCurrentAccount
 var mockedGetQueryData
 
-jest.mock('#/stores/session', () => {
+jest.mock('#/stores/profile', () => {
   mockedCurrentAccount = { username: 'alice' }
   return {
     __esModule: true,

--- a/jsapp/js/assetUtils.ts
+++ b/jsapp/js/assetUtils.ts
@@ -39,7 +39,7 @@ import type {
 } from '#/dataInterface'
 import envStore from '#/envStore'
 import type { IconName } from '#/k-icons'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { ANON_USERNAME_URL } from '#/users/utils'
 import { currentLang } from '#/utils'
 import { ActionIdEnum } from './api/models/actionIdEnum'
@@ -74,7 +74,7 @@ export function cleanupAndUniqueTags(tags: string[]) {
  * Returns nicer "me" label for your own assets.
  */
 export function getAssetOwnerDisplayName(username: string) {
-  if (sessionStore.currentAccount?.username && sessionStore.currentAccount.username === username) {
+  if (profileStore.currentAccount?.username && profileStore.currentAccount.username === username) {
     return t('me')
   } else {
     return username
@@ -691,7 +691,7 @@ export function isAssetPublicReady(asset: AssetResponse): string[] {
 }
 
 export function isSelfOwned(asset: AssetResponse | ProjectViewAsset) {
-  return asset && sessionStore.currentAccount && asset.owner__username === sessionStore.currentAccount.username
+  return asset && profileStore.currentAccount && asset.owner__username === profileStore.currentAccount.username
 }
 
 export function buildAssetUrl(assetUid: string) {
@@ -766,7 +766,7 @@ export type AssetDeleteCheckResult =
  * or `canDelete: false` with the reason why that specific asset is blocked.
  */
 export function userCanDeleteAssets(assets: Array<AssetResponse | ProjectViewAsset>): AssetDeleteCheckResult[] {
-  const account = sessionStore.currentAccount
+  const account = profileStore.currentAccount
   const orgUid = 'organization' in account ? account.organization?.uid : undefined
   const orgResponse = orgUid
     ? queryClient.getQueryData<OrganizationsRetrieveQueryResult>(getOrganizationsRetrieveQueryKey(orgUid))

--- a/jsapp/js/auth/AuthContainer/AuthContainer.stories.tsx
+++ b/jsapp/js/auth/AuthContainer/AuthContainer.stories.tsx
@@ -10,7 +10,7 @@ import TextInput from '#/components/common/TextInput'
 import { environmentResponse, makeEnvironmentMock } from '#/endpoints/environment.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
 import { AUTH_ROUTES, ROUTES } from '#/router/routerConstants'
-import { setAnonymousSessionForStories } from '#/stores/session.mocks'
+import { setAnonymousProfileForStories } from '#/stores/profile.mocks'
 import AuthCard from './AuthCard'
 import AuthContainer from './AuthContainer'
 // Stand-in for the photo an administrator would upload. Storybook serves it from the same origin, so
@@ -85,7 +85,7 @@ const meta: Meta<typeof AuthContainer> = {
   },
   // Nobody is logged in on a sign-in screen. Storybook runs the returned teardown, which matters:
   // `preview.tsx` forces the logged-in state before every story.
-  beforeEach: setAnonymousSessionForStories,
+  beforeEach: setAnonymousProfileForStories,
   decorators: [withRouter, queryClientDecorator],
 }
 

--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.stories.tsx
@@ -103,8 +103,8 @@ export const UpdateTagsFlow: Story = {
         await expect(canvas.getByRole('dialog', { name: 'Edit tags' })).toBeInTheDocument()
       })
 
-      // Wait for the session store to load and the form to become interactive.
-      // The modal shows a loading spinner until sessionStore.isInitialLoadComplete is true.
+      // Wait for the profile store to load and the form to become interactive.
+      // The modal shows a loading spinner until profileStore.isInitialLoadComplete is true.
       await waitFor(async () => {
         await expect(canvas.getByRole('textbox')).toBeInTheDocument()
       })

--- a/jsapp/js/components/AssetTagsModal/AssetTagsModal.tsx
+++ b/jsapp/js/components/AssetTagsModal/AssetTagsModal.tsx
@@ -8,7 +8,7 @@ import ButtonNew from '#/components/common/ButtonNew'
 import TagsInput from '#/components/common/TagsInput'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import type { AssetResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { notify } from '#/utils'
 
 export type AssetTagsModalAsset = Pick<AssetResponse, 'uid'> & Partial<Pick<AssetResponse, 'tag_string'>>
@@ -22,14 +22,14 @@ export interface AssetTagsModalProps {
  * Lets a user edit an asset's comma-separated tags and save them through Orval/react-query.
  */
 export function AssetTagsModal({ asset, onRequestClose }: AssetTagsModalProps) {
-  const [isSessionLoaded, setIsSessionLoaded] = useState(!!sessionStore.isLoggedIn)
+  const [isSessionLoaded, setIsSessionLoaded] = useState(!!profileStore.isLoggedIn)
   const [tags, setTags] = useState<string[]>(() => (asset.tag_string ? asset.tag_string.split(',') : []))
 
   useEffect(() => {
-    // Some modal entrypoints can run before the session store finishes hydrating.
+    // Some modal entrypoints can run before the profile store finishes hydrating.
     // Waiting here keeps the form from rendering against incomplete auth state.
     const disposeSessionWhen = when(
-      () => sessionStore.isInitialLoadComplete,
+      () => profileStore.isInitialLoadComplete,
       () => setIsSessionLoaded(true),
     )
 

--- a/jsapp/js/components/Drawer.tsx
+++ b/jsapp/js/components/Drawer.tsx
@@ -10,7 +10,7 @@ import RequireAuth from '#/router/requireAuth'
 import { PROJECTS_ROUTES, ROUTES } from '#/router/routerConstants'
 import { MODAL_TYPES } from '../constants'
 import SidebarFormsList from '../sidebar/SidebarFormsList'
-import sessionStore from '../stores/session'
+import profileStore from '../stores/profile'
 import Icon from './common/icon'
 
 const AccountSidebar = lazy(() => import('#/account/accountSidebar'))
@@ -40,12 +40,12 @@ export default function Drawer() {
   }
 
   // no sidebar for not logged in users
-  if (!sessionStore.isLoggedIn || 'email' in sessionStore.currentAccount === false) {
+  if (!profileStore.isLoggedIn || 'email' in profileStore.currentAccount === false) {
     return null
   }
-  const username = sessionStore.currentAccount.username
-  const userFullName = sessionStore.currentAccount.extra_details.name ?? ''
-  const userUid = sessionStore.currentAccount.extra_details__uid
+  const username = profileStore.currentAccount.username
+  const userFullName = profileStore.currentAccount.extra_details.name ?? ''
+  const userUid = profileStore.currentAccount.extra_details__uid
 
   return (
     <bem.KDrawer>
@@ -78,7 +78,7 @@ export default function Drawer() {
           <bem.FormSidebarWrapper>
             {/* For CSS flex's sake */}
             <div>
-              <Button size='lg' fullWidth disabled={!sessionStore.isLoggedIn} onClick={openNewFormModal}>
+              <Button size='lg' fullWidth disabled={!profileStore.isLoggedIn} onClick={openNewFormModal}>
                 {t('new').toUpperCase()}
               </Button>
             </div>
@@ -89,7 +89,7 @@ export default function Drawer() {
       </bem.KDrawer__sidebar>
 
       <bem.KDrawer__secondaryIcons>
-        {sessionStore.isLoggedIn && <HelpBubble username={username} userFullName={userFullName} userUid={userUid} />}
+        {profileStore.isLoggedIn && <HelpBubble username={username} userFullName={userFullName} userUid={userUid} />}
 
         {envStore.isReady && envStore.data.source_code_url && (
           <a href={envStore.data.source_code_url} className='k-drawer__link' target='_blank' data-tip={t('Source')}>

--- a/jsapp/js/components/bigModal/mfaModals.tsx
+++ b/jsapp/js/components/bigModal/mfaModals.tsx
@@ -10,7 +10,7 @@ import bem, { makeBem } from '#/bem'
 import TextInput from '#/components/common/TextInput'
 import Button from '#/components/common/button'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 
 bem.MFAModal = makeBem(null, 'mfa-modal')
 
@@ -182,7 +182,7 @@ const MFAModals = class MFAModals extends React.Component<MFAModalsProps, MFAMod
 
   downloadCodes() {
     if (this.state.backupCodes) {
-      const USERNAME = sessionStore.currentAccount.username
+      const USERNAME = profileStore.currentAccount.username
       // gets date in yyyymmdd
       const DATE = new Date().toJSON().slice(0, 10).replace(/-/g, '')
 

--- a/jsapp/js/components/formLanding/FormHistory.tsx
+++ b/jsapp/js/components/formLanding/FormHistory.tsx
@@ -13,7 +13,7 @@ import {
 import ActionIcon from '#/components/common/ActionIcon'
 import InfiniteScrollTrigger from '#/components/common/InfiniteScrollTrigger'
 import AssetStatusBadge from '#/components/common/assetStatusBadge'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime } from '#/utils'
 
 const ITEMS_PER_PAGE = 10
@@ -63,7 +63,7 @@ function getVersionName(
  * Displays a table with a list of previous form versions, including both deployed and undeployed versions.
  */
 export default function FormHistory(props: FormHistoryProps) {
-  const isLoggedIn = sessionStore.isLoggedIn
+  const isLoggedIn = profileStore.isLoggedIn
 
   useEffect(() => {
     // TODO: when gradually switching to Orval for all these actions below, make sure to write invalidating code in

--- a/jsapp/js/components/formLanding/formLanding.js
+++ b/jsapp/js/components/formLanding/formLanding.js
@@ -28,7 +28,7 @@ import { openFormLanguagesModal } from '#/project/FormLanguagesManager'
 import CollectMethodSelector from '#/project/collectMethodSelector.component'
 import { withRouter } from '#/router/legacy'
 import { ROUTES } from '#/router/routerConstants'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { ANON_USERNAME, buildUserUrl } from '#/users/utils'
 import { formatTime, notify, recordKeys } from '#/utils'
 import LimitNotifications from '../usageLimits/limitNotifications.component'
@@ -392,7 +392,7 @@ class FormLanding extends React.Component {
       downloads = this.state.downloads
     }
 
-    const isLoggedIn = sessionStore.isLoggedIn
+    const isLoggedIn = profileStore.isLoggedIn
 
     return (
       <React.Fragment>
@@ -525,7 +525,7 @@ class FormLanding extends React.Component {
   render() {
     var docTitle = this.state.name || t('Untitled')
     const userCanEdit = userCan('change_asset', this.state)
-    const isLoggedIn = sessionStore.isLoggedIn
+    const isLoggedIn = profileStore.isLoggedIn
 
     if (this.state.uid === undefined) {
       return <LoadingSpinner />

--- a/jsapp/js/components/header/accountMenu.tsx
+++ b/jsapp/js/components/header/accountMenu.tsx
@@ -11,7 +11,7 @@ import type { LabelValuePair } from '#/dataInterface'
 import { dataInterface } from '#/dataInterface'
 import envStore from '#/envStore'
 import { isAnyRouteBlockerActive } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { KOBO_Z_INDEX } from '#/theme/kobo/zIndex'
 import { currentLang } from '#/utils'
 import ButtonNew from '../common/ButtonNew'
@@ -64,12 +64,12 @@ export default function AccountMenu() {
     }
   }
 
-  if (!sessionStore.isLoggedIn) {
+  if (!profileStore.isLoggedIn) {
     return null
   }
 
-  const accountName = sessionStore.currentAccount.username
-  const accountEmail = 'email' in sessionStore.currentAccount ? sessionStore.currentAccount.email : ''
+  const accountName = profileStore.currentAccount.username
+  const accountEmail = 'email' in profileStore.currentAccount ? profileStore.currentAccount.email : ''
 
   const currentLanguage = currentLang()
 

--- a/jsapp/js/components/header/gitRev.component.tsx
+++ b/jsapp/js/components/header/gitRev.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import bem, { makeBem } from '#/bem'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 
 bem.GitRev = makeBem(null, 'git-rev')
 bem.GitRev__item = makeBem(bem.GitRev, 'item', 'div')
@@ -12,15 +12,15 @@ bem.GitRev__item = makeBem(bem.GitRev, 'item', 'div')
  */
 export default function GitRev() {
   if (
-    'git_rev' in sessionStore.currentAccount &&
-    sessionStore.currentAccount.git_rev !== false &&
-    sessionStore.currentAccount.git_rev.branch &&
-    sessionStore.currentAccount.git_rev.short
+    'git_rev' in profileStore.currentAccount &&
+    profileStore.currentAccount.git_rev !== false &&
+    profileStore.currentAccount.git_rev.branch &&
+    profileStore.currentAccount.git_rev.short
   ) {
     return (
       <bem.GitRev>
-        <bem.GitRev__item>branch: {sessionStore.currentAccount.git_rev.branch}</bem.GitRev__item>
-        <bem.GitRev__item>commit: {sessionStore.currentAccount.git_rev.short}</bem.GitRev__item>
+        <bem.GitRev__item>branch: {profileStore.currentAccount.git_rev.branch}</bem.GitRev__item>
+        <bem.GitRev__item>commit: {profileStore.currentAccount.git_rev.short}</bem.GitRev__item>
       </bem.GitRev>
     )
   }

--- a/jsapp/js/components/header/mainHeader.component.tsx
+++ b/jsapp/js/components/header/mainHeader.component.tsx
@@ -23,7 +23,7 @@ import {
   isMyLibraryRoute,
   isPublicCollectionsRoute,
 } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import AccountMenu from './accountMenu'
 import GitRev from './gitRev.component'
 import styles from './mainHeader.module.scss'
@@ -88,7 +88,7 @@ const MainHeader = class MainHeader extends React.Component<MainHeaderProps> {
   }
 
   render() {
-    const isLoggedIn = sessionStore.isLoggedIn
+    const isLoggedIn = profileStore.isLoggedIn
 
     let asset: AssetResponse | undefined
     if (this.props.assetUid) {

--- a/jsapp/js/components/library/assetInfoBox.tsx
+++ b/jsapp/js/components/library/assetInfoBox.tsx
@@ -8,7 +8,7 @@ import bem from '#/bem'
 import Button from '#/components/common/button'
 import { ASSET_TYPES } from '#/constants'
 import type { AccountResponse, AssetResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime, notify } from '#/utils'
 
 interface AssetInfoBoxProps {
@@ -36,7 +36,7 @@ export default class AssetInfoBox extends React.Component<AssetInfoBoxProps, Ass
 
   componentDidMount() {
     if (assetUtils.isSelfOwned(this.props.asset)) {
-      this.setState({ ownerData: sessionStore.currentAccount })
+      this.setState({ ownerData: profileStore.currentAccount })
     } else {
       this.unlisteners.push(
         actions.misc.getUser.completed.listen(this.onGetUserCompleted.bind(this)),

--- a/jsapp/js/components/library/librarySidebar.tsx
+++ b/jsapp/js/components/library/librarySidebar.tsx
@@ -5,7 +5,7 @@ import bem from '#/bem'
 import Button from '#/components/common/button'
 import { MODAL_TYPES } from '#/constants'
 import pageState from '#/pageState.store'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import myLibraryStore from './myLibraryStore'
 
 interface LibrarySidebarState {
@@ -58,7 +58,7 @@ export default class LibrarySidebar extends React.Component<{}, LibrarySidebarSt
           size='l'
           isFullWidth
           isUpperCase
-          isDisabled={!sessionStore.isLoggedIn}
+          isDisabled={!profileStore.isLoggedIn}
           onClick={this.showLibraryNewModal.bind(this)}
           label={t('new')}
         />

--- a/jsapp/js/components/library/managedCollectionsStore.ts
+++ b/jsapp/js/components/library/managedCollectionsStore.ts
@@ -6,7 +6,7 @@ import { ASSET_TYPES } from '#/constants'
 import type { AssetResponse, AssetsResponse, DeleteAssetResponse } from '#/dataInterface'
 import { router } from '#/router/legacy'
 import { isAnyLibraryRoute } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { userCan } from '../permissions/utils'
 
 export interface ManagedCollectionsStoreData {
@@ -37,7 +37,7 @@ class ManagedCollectionsStore extends Reflux.Store {
     actions.resources.createResource.completed.listen(this.onAssetChangedOrCreated.bind(this))
     actions.resources.deleteAsset.completed.listen(this.onDeleteAssetCompleted.bind(this))
 
-    when(() => sessionStore.isLoggedIn, this.startupStore.bind(this))
+    when(() => profileStore.isLoggedIn, this.startupStore.bind(this))
 
     // HACK: We add this ugly `setTimeout` to ensure router exists.
     setTimeout(() => router!.subscribe(this.startupStore.bind(this)))
@@ -56,9 +56,9 @@ class ManagedCollectionsStore extends Reflux.Store {
       // the app directly at Library, we need to fetch data immediately.
       isAnyLibraryRoute() &&
       // This store requires user who is logged in, and due to race condition we
-      // often end up initializing it before session store is ready, thus we
+      // often end up initializing it before profile store is ready, thus we
       // need to wait for it a bit.
-      sessionStore.isLoggedIn &&
+      profileStore.isLoggedIn &&
       // Avoid unnecessary duplicate calls
       !this.data.isFetchingData
     ) {
@@ -70,7 +70,7 @@ class ManagedCollectionsStore extends Reflux.Store {
 
   onGetCollectionsCompleted(response: AssetsResponse) {
     this.data.collections = response.results.filter(
-      (asset) => asset.owner__username === sessionStore.currentAccount.username || userCan('manage_asset', asset),
+      (asset) => asset.owner__username === profileStore.currentAccount.username || userCan('manage_asset', asset),
     )
 
     this.data.isFetchingData = false
@@ -86,7 +86,7 @@ class ManagedCollectionsStore extends Reflux.Store {
   onAssetChangedOrCreated(asset: AssetResponse) {
     if (
       asset.asset_type === ASSET_TYPES.collection.id &&
-      (asset.owner__username === sessionStore.currentAccount.username || userCan('manage_asset', asset))
+      (asset.owner__username === profileStore.currentAccount.username || userCan('manage_asset', asset))
     ) {
       let wasUpdated = false
       for (let i = 0; i < this.data.collections.length; i++) {

--- a/jsapp/js/components/modalForms/LibraryAssetForm.tsx
+++ b/jsapp/js/components/modalForms/LibraryAssetForm.tsx
@@ -18,7 +18,7 @@ import { ASSET_TYPES, type AssetTypeName } from '#/constants'
 import type { AssetResponse, AssetSettings, LabelValuePair } from '#/dataInterface'
 import envStore from '#/envStore'
 import { getRouteAssetUid, isAnyLibraryRoute } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { notify } from '#/utils'
 
 interface LibraryAssetFormProps {
@@ -61,7 +61,7 @@ export const LibraryAssetForm = ({ asset, assetType, onBack, onRequestClose }: L
 
   const formAssetType: AssetTypeName | undefined = asset ? asset.asset_type : assetType
 
-  const [isSessionLoaded, setIsSessionLoaded] = useState(!!sessionStore.isLoggedIn)
+  const [isSessionLoaded, setIsSessionLoaded] = useState(!!profileStore.isLoggedIn)
   const [isPending, setIsPending] = useState(false)
 
   const [fields, setFields] = useState<FormFields>(() => {
@@ -93,7 +93,7 @@ export const LibraryAssetForm = ({ asset, assetType, onBack, onRequestClose }: L
 
   useEffect(() => {
     const disposeSessionWhen = when(
-      () => sessionStore.isInitialLoadComplete,
+      () => profileStore.isInitialLoadComplete,
       () => setIsSessionLoaded(true),
     )
 

--- a/jsapp/js/components/modalForms/LibraryNewItemForm.tsx
+++ b/jsapp/js/components/modalForms/LibraryNewItemForm.tsx
@@ -10,11 +10,11 @@ import { ASSET_TYPES, MODAL_TYPES } from '#/constants'
 import pageState from '#/pageState.store'
 import { ROUTES } from '#/router/routerConstants'
 import { getRouteAssetUid, isAnyLibraryItemRoute } from '#/router/routerUtils'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import KoboIcon from '../common/KoboIcon'
 
 export default function LibraryNewItemForm() {
-  const session = useSession()
+  const profile = useProfile()
   const navigate = useNavigate()
 
   function goToAssetCreator() {
@@ -60,7 +60,7 @@ export default function LibraryNewItemForm() {
     openLibraryUploadModal({ onBack: reopenThisModal })
   }
 
-  if (!session.currentLoggedAccount) {
+  if (!profile.currentLoggedAccount) {
     return <LoadingSpinner />
   }
 

--- a/jsapp/js/components/newFeatureDialog.component.tsx
+++ b/jsapp/js/components/newFeatureDialog.component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 
 import cx from 'classnames'
 import Icon from '#/components/common/icon'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { useSafeUsernameStorageKey } from '../hooks/useSafeUsernameStorageKey'
 import styles from './newFeatureDialog.module.scss'
 
@@ -50,7 +50,7 @@ export default function NewFeatureDialog({
   disabled = false,
 }: NewFeatureDialogProps) {
   const [showDialog, setShowDialog] = useState<boolean>(false)
-  const username = sessionStore.currentAccount.username
+  const username = profileStore.currentAccount.username
   const localStorageKey = useSafeUsernameStorageKey(`kpiDialogStatus-${featureKey}`, username)
 
   /*

--- a/jsapp/js/components/permissions/transferProjects/transferProjects.api.ts
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.api.ts
@@ -1,6 +1,6 @@
 import { fetchGet, fetchPatch, fetchPost, handleApiFail } from '#/api'
 import type { FailResponse, PaginatedResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { buildUserUrl, getUsernameFromUrl } from '#/users/utils'
 import { notify } from '#/utils'
 
@@ -156,7 +156,7 @@ export async function isInviteForLoggedInUser(inviteUid: string) {
         return
       }
 
-      inviteIsCorrect = sessionStore.currentAccount.username === getUsernameFromUrl(data.recipient)
+      inviteIsCorrect = profileStore.currentAccount.username === getUsernameFromUrl(data.recipient)
     })
   } catch (error) {
     handleApiFail(error as FailResponse, t('Invite is invaild.'))

--- a/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
+++ b/jsapp/js/components/permissions/transferProjects/transferProjects.component.tsx
@@ -9,7 +9,7 @@ import KoboModalFooter from '#/components/modals/koboModalFooter'
 import KoboModalHeader from '#/components/modals/koboModalHeader'
 import type { AssetResponse } from '#/dataInterface'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { TransferStatuses, cancelInvite, sendInvite } from './transferProjects.api'
 import styles from './transferProjects.module.scss'
 
@@ -72,7 +72,7 @@ export default function TransferProjects(props: TransferProjectsProps) {
   }
 
   function submitInvite(username: string) {
-    if (username === sessionStore.currentAccount.username) {
+    if (username === profileStore.currentAccount.username) {
       setTransfer({
         ...transfer,
         usernameError: t('Cannot transfer a project to the same account.'),
@@ -126,7 +126,7 @@ export default function TransferProjects(props: TransferProjectsProps) {
     }
   }
 
-  if (props.asset.owner__username === sessionStore.currentAccount.username) {
+  if (props.asset.owner__username === profileStore.currentAccount.username) {
     return (
       <div className={styles.root}>
         <div className={styles.bar}>

--- a/jsapp/js/components/permissions/userPermissionRow.component.tsx
+++ b/jsapp/js/components/permissions/userPermissionRow.component.tsx
@@ -10,7 +10,7 @@ import Avatar from '#/components/common/avatar'
 import type { AssetResponse, PermissionBase, PermissionResponse } from '#/dataInterface'
 import { router } from '#/router/legacy'
 import { ROUTES } from '#/router/routerConstants'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { KOBO_MODAL_OVERLAY_PROPS } from '#/theme/kobo/Modal'
 import { KOBO_Z_INDEX } from '#/theme/kobo/zIndex'
 import { permissionsActions } from '../../actions/permissions'
@@ -68,7 +68,7 @@ export default class UserPermissionRow extends React.Component<UserPermissionRow
   removeAllPermissions() {
     this.setState({ isRemovePermissionsPromptVisible: false, isBeingDeleted: true })
 
-    const isCurrentUser = this.props.username === sessionStore.currentAccount.username
+    const isCurrentUser = this.props.username === profileStore.currentAccount.username
 
     actions.permissions.removeAssetPermission(this.props.asset.uid, undefined, true, undefined, this.props.username)
 

--- a/jsapp/js/components/permissions/utils.ts
+++ b/jsapp/js/components/permissions/utils.ts
@@ -12,7 +12,7 @@ import type {
   ProjectViewAsset,
   SubmissionResponse,
 } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { ANON_USERNAME_URL, buildUserUrl } from '#/users/utils'
 import { recordEntries, recordKeys } from '#/utils'
 import permConfig from './permConfig'
@@ -87,7 +87,7 @@ export function userCan(
     }
   }
 
-  const currentUsername = sessionStore.currentAccount.username
+  const currentUsername = profileStore.currentAccount.username
 
   // If you own the asset, you can do everything with it
   if (asset.owner__username === currentUsername) {
@@ -113,7 +113,7 @@ export function userCan(
 }
 
 export function userCanPartially(permName: PermissionCodename, asset?: AssetResponse) {
-  const currentUsername = sessionStore.currentAccount.username
+  const currentUsername = profileStore.currentAccount.username
 
   // Owners cannot have partial permissions because they have full permissions.
   // Both are contradictory.
@@ -131,7 +131,7 @@ export function userCanPartially(permName: PermissionCodename, asset?: AssetResp
  * from Project View access, not from project being shared with user directly.
  */
 export function userCanRemoveSharedProject(asset: AssetResponse) {
-  const currentUsername = sessionStore.currentAccount.username
+  const currentUsername = profileStore.currentAccount.username
   const userHasDirectViewAsset = asset.permissions.some(
     (perm) => perm.user === buildUserUrl(currentUsername) && _doesPermMatch(perm, 'view_asset'),
   )
@@ -270,7 +270,7 @@ export function userHasPermForSubmission(
   }
 
   // Case 3: User has only partial permission, and things are complicated
-  const currentUsername = sessionStore.currentAccount.username
+  const currentUsername = profileStore.currentAccount.username
   const partialPerms = asset.permissions.find(
     (perm) => perm.user === buildUserUrl(currentUsername) && _doesPermMatch(perm, 'partial_submissions', permName),
   )

--- a/jsapp/js/components/projectDownloads/ProjectDownloads.tsx
+++ b/jsapp/js/components/projectDownloads/ProjectDownloads.tsx
@@ -7,7 +7,7 @@ import ProjectExportsCreator from '#/components/projectDownloads/ProjectExportsC
 import ProjectExportsList from '#/components/projectDownloads/ProjectExportsList'
 import { DEFAULT_EXPORT_SETTINGS } from '#/components/projectDownloads/exportsConstants'
 import type { AssetResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import type { ExportTypeDefinition } from './exportsConstants'
 
 interface ProjectDownloadsProps {
@@ -64,9 +64,9 @@ export default function ProjectDownloads(props: ProjectDownloadsProps) {
         <bem.FormView__row>
           <bem.FormView__cell m={['page-title']}>{t('Downloads')}</bem.FormView__cell>
 
-          {sessionStore.isLoggedIn && renderLoggedInExports()}
+          {profileStore.isLoggedIn && renderLoggedInExports()}
 
-          {!sessionStore.isLoggedIn && (
+          {!profileStore.isLoggedIn && (
             <AnonymousExports
               asset={props.asset}
               selectedExportType={selectedExportType}

--- a/jsapp/js/components/reports/reportViewItem.component.tsx
+++ b/jsapp/js/components/reports/reportViewItem.component.tsx
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react'
 import React from 'react'
 import bem from '#/bem'
 import Button from '#/components/common/button'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import ReportTable from './reportTable.component'
 import { CHART_COLOR_SETS, CHART_STYLES } from './reportsConstants'
 import type { ReportsResponse, ReportsResponseData } from './reportsConstants'
@@ -316,7 +316,7 @@ export class ReportViewItem extends React.Component<ReportViewItemProps> {
             </span>
             <span>{t('(# were without data.)').replace('#', String(this.props.data.not_provided))}</span>
           </bem.ReportView__headingMeta>
-          {this.props.data.show_graph && sessionStore.isLoggedIn && (
+          {this.props.data.show_graph && profileStore.isLoggedIn && (
             <span className='report-button__question-settings'>
               <Button
                 type='text'

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranscriptionModal/BulkTranscriptionModal.tsx
@@ -23,7 +23,7 @@ import { hasTranscriptInAnyLanguage } from '#/components/submissions/bulkProcess
 import { useCalculateAudioDuration } from '#/components/submissions/useCalculateAudioDuration.hook'
 import type { SubmissionResponse } from '#/dataInterface'
 import envStore from '#/envStore'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { formatTimeFromSeconds, getSubmissionRootUuid, notify } from '#/utils'
 import ButtonNew from '../../../common/ButtonNew'
 import LanguageSelector from '../../../languages/LanguageSelector'
@@ -95,8 +95,8 @@ export function BulkTranscriptionModal(props: BulkTranscriptionModalProps) {
   const serviceCode = 'goog'
 
   // Get organization ID to check ASR limits
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
   const { data, isLoading: isLoadingUsage } = useOrganizationsServiceUsageRetrieve(organizationId!, {
     query: {
       queryKey: getOrganizationsServiceUsageRetrieveQueryKey(organizationId!),

--- a/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
+++ b/jsapp/js/components/submissions/BulkProcessingModals/BulkTranslationModal/BulkTranslationModal.tsx
@@ -25,7 +25,7 @@ import { getBlockedBulkTranslationLanguages } from '#/components/submissions/bul
 import { getSupplementalDetailsContent } from '#/components/submissions/submissionUtils'
 import type { SubmissionResponse } from '#/dataInterface'
 import envStore from '#/envStore'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { notify } from '#/utils'
 import BulkProcessingAlerts from '../alerts/BulkProcessingAlerts'
 import { useBulkProcessingAlerts } from '../alerts/useBulkProcessingAlerts'
@@ -83,8 +83,8 @@ export function BulkTranslationModal(props: BulkTranslationModalProps) {
   })
 
   // Get organization ID to check ASR limits
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
   const { data, isLoading: isLoadingUsage } = useOrganizationsServiceUsageRetrieve(organizationId!, {
     query: {
       queryKey: getOrganizationsServiceUsageRetrieveQueryKey(organizationId!),

--- a/jsapp/js/components/submissions/useDataTableBulkActions.tests.ts
+++ b/jsapp/js/components/submissions/useDataTableBulkActions.tests.ts
@@ -7,7 +7,7 @@ import {
   useAssetsAdvancedFeaturesBulkActionsList,
 } from '#/api/react-query/survey-data'
 import { getApiV2AssetsAdvancedFeaturesBulkActionsRetrieveResponseMock } from '#/api/react-query/survey-data/msw'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { getBulkActionsPollingIntervalMs, useDataTableBulkActions } from './useDataTableBulkActions'
 
 jest.mock('#/api/react-query/survey-data', () => {
@@ -22,9 +22,9 @@ jest.mock('#/api/react-query/survey-data', () => {
   }
 })
 
-jest.mock('#/stores/useSession', () => {
+jest.mock('#/stores/useProfile', () => {
   return {
-    useSession: jest.fn(),
+    useProfile: jest.fn(),
   }
 })
 
@@ -65,7 +65,7 @@ function buildBulkAction(
 }
 
 describe('useDataTableBulkActions', () => {
-  const useSessionMock = useSession as jest.MockedFunction<typeof useSession>
+  const useProfileMock = useProfile as jest.MockedFunction<typeof useProfile>
   const useBulkActionsListMock = useAssetsAdvancedFeaturesBulkActionsList as jest.MockedFunction<
     typeof useAssetsAdvancedFeaturesBulkActionsList
   >
@@ -76,9 +76,8 @@ describe('useDataTableBulkActions', () => {
 
   function mockSession(username: string | undefined, isPending = false) {
     // Hook only needs username and pending state; the remaining methods are stubbed.
-    useSessionMock.mockReturnValue({
-      currentLoggedAccount: { username } as ReturnType<typeof useSession>['currentLoggedAccount'],
-      isAnonymous: false,
+    useProfileMock.mockReturnValue({
+      currentLoggedAccount: { username } as ReturnType<typeof useProfile>['currentLoggedAccount'],
       isPending,
       refreshAccount: jest.fn(),
     })

--- a/jsapp/js/components/submissions/useDataTableBulkActions.ts
+++ b/jsapp/js/components/submissions/useDataTableBulkActions.ts
@@ -7,7 +7,7 @@ import {
   useAssetsAdvancedFeaturesBulkActionsList,
 } from '#/api/react-query/survey-data'
 import envStore from '#/envStore'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { getEstimatedTranscriptionDurationSeconds } from '#/utils'
 
 interface UseDataTableBulkActionsResult {
@@ -83,9 +83,9 @@ export function getBulkActionsPollingIntervalMs(activeBulkActions: BulkActionRes
  */
 export function useDataTableBulkActions(assetUid: string): UseDataTableBulkActionsResult {
   const isBulkProcessingEnabled = envStore.data.asr_mt_features_enabled
-  const session = useSession()
+  const profile = useProfile()
   // While session is loading we avoid making user-specific decisions.
-  const currentUsername = session.isPending ? undefined : session.currentLoggedAccount?.username
+  const currentUsername = profile.isPending ? undefined : profile.currentLoggedAccount?.username
   const effectiveAssetUid = isBulkProcessingEnabled ? assetUid : ''
 
   // Empty uid disables the query in Orval/react-query options.

--- a/jsapp/js/components/support/helpBubbleStore.ts
+++ b/jsapp/js/components/support/helpBubbleStore.ts
@@ -4,7 +4,7 @@ import { makeAutoObservable, when } from 'mobx'
 import { handleApiFail } from '#/api'
 import { ROOT_URL } from '#/constants'
 import type { FailResponse, PaginatedResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 
 const FETCH_MESSAGES_LOOP_TIME = 1 * 60 * 1000 // 1 minute
 
@@ -39,7 +39,7 @@ class HelpBubbleStore {
   constructor() {
     makeAutoObservable(this)
     when(
-      () => sessionStore.isLoggedIn,
+      () => profileStore.isLoggedIn,
       () => this.fetchMessages(),
     )
   }

--- a/jsapp/js/components/templatesList.js
+++ b/jsapp/js/components/templatesList.js
@@ -13,7 +13,7 @@ import Reflux from 'reflux'
 import { getAssetOwnerDisplayName } from '#/assetUtils'
 import bem from '#/bem'
 import LoadingSpinner from '#/components/common/loadingSpinner'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime } from '#/utils'
 import { dataInterface } from '../dataInterface'
 
@@ -25,7 +25,7 @@ class TemplatesList extends React.Component {
       templates: [],
       templatesCount: 0,
       selectedTemplateUid: null,
-      currentAccountUsername: sessionStore.currentAccount ? sessionStore.currentAccount.username : null,
+      currentAccountUsername: profileStore.currentAccount ? profileStore.currentAccount.username : null,
     }
     autoBind(this)
   }

--- a/jsapp/js/components/usageLimits/limitNotifications.component.tsx
+++ b/jsapp/js/components/usageLimits/limitNotifications.component.tsx
@@ -11,7 +11,7 @@ import {
 import LimitBanner from '#/components/usageLimits/overLimitBanner.component'
 import LimitModal from '#/components/usageLimits/overLimitModal.component'
 import useWhenStripeIsEnabled from '#/hooks/useWhenStripeIsEnabled.hook'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 
 const cookies = new Cookies()
 
@@ -27,8 +27,8 @@ const LimitNotifications = ({ pageCanShowModal = false, accountPage = false }: L
   const { data: serviceUsageData } = useOrganizationsServiceUsageSummary()
 
   // Note: not using `useOrganizationAssumed` due being used within routes that are accessible by anonymous users.
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
   const orgQuery = useOrganizationsRetrieve(organizationId!, {
     query: {
       queryKey: getOrganizationsRetrieveQueryKey(organizationId!), // Note: see Orval issue https://github.com/orval-labs/orval/issues/2396

--- a/jsapp/js/components/usageLimits/overLimitModal.component.tsx
+++ b/jsapp/js/components/usageLimits/overLimitModal.component.tsx
@@ -9,7 +9,7 @@ import Button from '#/components/common/ButtonNew'
 import KoboModalFooter from '#/components/modals/koboModalFooter'
 import KoboModalHeader from '#/components/modals/koboModalHeader'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import KoboModal from '../modals/koboModal'
 import { getAllLimitsText, pluralizeLimit } from './limitNotificationUtils'
 import styles from './overLimitModal.module.scss'
@@ -62,7 +62,7 @@ const LinkRendererTargetBlank = (props: AnchorHTMLAttributes<HTMLAnchorElement>)
 
 function OverLimitModal(props: OverLimitModalProps) {
   const [isModalOpen, setIsModalOpen] = useState(true)
-  const accountName = sessionStore.currentAccount.username
+  const accountName = profileStore.currentAccount.username
   const [show, setShow] = useState(props.show)
   const toggleModal = () => {
     setIsModalOpen(!isModalOpen)

--- a/jsapp/js/project/FormSummary/FormSummaryProjectInfo.tsx
+++ b/jsapp/js/project/FormSummary/FormSummaryProjectInfo.tsx
@@ -9,7 +9,7 @@ import { EXTRA_PROJECT_METADATA_FIELD_TYPES } from '#/constants'
 import type { AssetResponse, PaginatedResponse, SubmissionResponse } from '#/dataInterface'
 import { dataInterface } from '#/dataInterface'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { currentLang, formatTime } from '#/utils'
 
 interface FormSummaryProjectInfoProps {
@@ -100,7 +100,7 @@ export default function FormSummaryProjectInfo(props: FormSummaryProjectInfoProp
           {/* owner */}
           <bem.FormView__cell m='padding'>
             <bem.FormView__label>{t('Owner')}</bem.FormView__label>
-            {props.asset.owner_label === sessionStore.currentAccount.username ? (
+            {props.asset.owner_label === profileStore.currentAccount.username ? (
               t('me')
             ) : (
               <Avatar username={props.asset.owner_label} size='s' isUsernameVisible />
@@ -110,9 +110,9 @@ export default function FormSummaryProjectInfo(props: FormSummaryProjectInfoProp
           {/* last edited */}
           <bem.FormView__cell m='padding'>
             <bem.FormView__label>{t('Last edited')}</bem.FormView__label>
-            {props.asset.last_modified_by === sessionStore.currentAccount.username && t('me')}
+            {props.asset.last_modified_by === profileStore.currentAccount.username && t('me')}
             {props.asset.last_modified_by !== null &&
-              props.asset.last_modified_by !== sessionStore.currentAccount.username && (
+              props.asset.last_modified_by !== profileStore.currentAccount.username && (
                 <Avatar username={props.asset.last_modified_by} size='s' isUsernameVisible />
               )}
           </bem.FormView__cell>

--- a/jsapp/js/project/ProjectSettings/ProjectSettings.tsx
+++ b/jsapp/js/project/ProjectSettings/ProjectSettings.tsx
@@ -19,7 +19,7 @@ import mixins from '#/mixins'
 import pageState from '#/pageState.store'
 import { router, withRouter } from '#/router/legacy'
 import { ROUTES } from '#/router/routerConstants'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { escapeHtml, isAValidUrl, join, notify } from '#/utils'
 import styles from './ProjectSettings.module.scss'
 import { STEPS, type StepName, getStepTitle } from './constants'
@@ -55,7 +55,7 @@ class ProjectSettings extends React.Component<ProjectSettingsProps, ProjectSetti
     super(props)
 
     this.state = {
-      isSessionLoaded: !!sessionStore.isLoggedIn,
+      isSessionLoaded: !!profileStore.isLoggedIn,
       isSubmitPending: false,
       formAsset: this.props.formAsset,
       // project details
@@ -95,7 +95,7 @@ class ProjectSettings extends React.Component<ProjectSettingsProps, ProjectSetti
       this.cloneTemplateAsSurvey(this.props.initialTemplateUid)
     }
     when(
-      () => sessionStore.isInitialLoadComplete,
+      () => profileStore.isInitialLoadComplete,
       () => {
         this.setState({ isSessionLoaded: true })
       },

--- a/jsapp/js/project/ProjectSettings/steps/StepProjectDetails.tsx
+++ b/jsapp/js/project/ProjectSettings/steps/StepProjectDetails.tsx
@@ -12,7 +12,7 @@ import { userCan } from '#/components/permissions/utils'
 import { PROJECT_SETTINGS_CONTEXTS } from '#/constants'
 import type { AssetResponse } from '#/dataInterface'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { addRequiredToLabel } from '#/textUtils'
 import styles from '../ProjectSettings.module.scss'
 import BackButton from '../components/BackButton'
@@ -73,7 +73,7 @@ export default function StepProjectDetails({
   // MMO members should always see the delete button, even without delete_asset permission,
   // so they can click it and see the error explaining why they can't delete
   const isMMO = () => {
-    const account = sessionStore.currentAccount
+    const account = profileStore.currentAccount
     const orgUid = 'organization' in account ? account.organization?.uid : undefined
     if (orgUid) {
       const orgResponse = queryClient.getQueryData(getOrganizationsRetrieveQueryKey(orgUid)) as any

--- a/jsapp/js/project/projectTopTabs.component.tsx
+++ b/jsapp/js/project/projectTopTabs.component.tsx
@@ -13,7 +13,7 @@ import {
   isFormLandingRoute,
   isFormSummaryRoute,
 } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import styles from './projectTopTabs.module.scss'
 
 export default function ProjectTopTabs() {
@@ -32,7 +32,7 @@ export default function ProjectTopTabs() {
   const isDataTabEnabled = userCan('view_submissions', asset) || userCanPartially('view_submissions', asset)
 
   const isSettingsTabEnabled =
-    sessionStore.isLoggedIn && (userCan('change_asset', asset) || userCan('change_metadata_asset', asset))
+    profileStore.isLoggedIn && (userCan('change_asset', asset) || userCan('change_metadata_asset', asset))
 
   const summaryRoute = ROUTES.FORM_SUMMARY.replace(':uid', assetUid)
   const formRoute = ROUTES.FORM_LANDING.replace(':uid', assetUid)
@@ -43,7 +43,7 @@ export default function ProjectTopTabs() {
     <nav className={styles.root}>
       <ul className={styles.tabs}>
         <li>
-          {sessionStore.isLoggedIn ? (
+          {profileStore.isLoggedIn ? (
             <Link
               to={summaryRoute}
               className={classnames(styles.tab, {

--- a/jsapp/js/projects/customViewStore.ts
+++ b/jsapp/js/projects/customViewStore.ts
@@ -5,7 +5,7 @@ import { handleApiFail, isAbortResponse } from '#/api'
 import searchBoxStore from '#/components/header/searchBoxStore'
 import { COMMON_QUERIES } from '#/constants'
 import type { AssetResponse, FailResponse, PaginatedResponse, ProjectViewAsset } from '#/dataInterface'
-import session from '#/stores/session'
+import profile from '#/stores/profile'
 import { DEFAULT_VISIBLE_FIELDS, PROJECT_FIELDS } from './projectViews/constants'
 import type { ProjectFieldName, ProjectsFilterDefinition } from './projectViews/constants'
 import { buildQueriesFromFilters } from './projectViews/utils'
@@ -342,8 +342,8 @@ class CustomViewStore {
 
     let newData: ProjectViewsSettings = {}
     // Get saved data
-    if ('email' in session.currentAccount && session.currentAccount.extra_details.project_views_settings) {
-      newData = session.currentAccount.extra_details.project_views_settings
+    if ('email' in profile.currentAccount && profile.currentAccount.extra_details.project_views_settings) {
+      newData = profile.currentAccount.extra_details.project_views_settings
     }
 
     newData[this.viewUid] = {
@@ -352,7 +352,7 @@ class CustomViewStore {
       fields: this.fields,
     }
 
-    session.setDetail(SAVE_DATA_NAME, newData)
+    profile.setDetail(SAVE_DATA_NAME, newData)
   }
 
   private resetSettings() {
@@ -362,7 +362,7 @@ class CustomViewStore {
   }
 
   /**
-   * Gets the settings for current view from session store (if they exists) with
+   * Gets the settings for current view from profile store (if they exist) with
    * fall back to defaults.
    */
   private loadSettings() {
@@ -374,8 +374,8 @@ class CustomViewStore {
     this.resetSettings()
 
     // Then we load the saved settings (if they exist)
-    if ('email' in session.currentAccount && session.currentAccount.extra_details[SAVE_DATA_NAME]?.[this.viewUid]) {
-      const savedViewData = session.currentAccount.extra_details[SAVE_DATA_NAME][this.viewUid]
+    if ('email' in profile.currentAccount && profile.currentAccount.extra_details[SAVE_DATA_NAME]?.[this.viewUid]) {
+      const savedViewData = profile.currentAccount.extra_details[SAVE_DATA_NAME][this.viewUid]
       if (savedViewData.filters) {
         this.filters = savedViewData.filters
       }

--- a/jsapp/js/projects/projectViews/projectViewsStore.ts
+++ b/jsapp/js/projects/projectViews/projectViewsStore.ts
@@ -4,7 +4,7 @@ import { makeAutoObservable, when } from 'mobx'
 import { handleApiFail } from '#/api'
 import { ROOT_URL } from '#/constants'
 import type { PaginatedResponse } from '#/dataInterface'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 
 export interface ProjectView {
   uid: string
@@ -27,7 +27,7 @@ class ProjectViewsStore {
   constructor() {
     makeAutoObservable(this)
     when(
-      () => sessionStore.isLoggedIn,
+      () => profileStore.isLoggedIn,
       () => this.fetchData(),
     )
   }

--- a/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
+++ b/jsapp/js/projects/projectsTable/bulkActions/BulkDeleteModal.tsx
@@ -8,7 +8,7 @@ import ButtonNew from '#/components/common/ButtonNew'
 import Checkbox from '#/components/common/checkbox'
 import customViewStore from '#/projects/customViewStore'
 import { invalidateSidebarQueries } from '#/sidebar/SidebarFormsList'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { notify } from '#/utils'
 
 type AssetsBulkAction = 'archive' | 'delete' | 'unarchive'
@@ -23,8 +23,8 @@ export interface BulkDeleteModalProps {
 }
 
 export function BulkDeleteModal({ assetUids, modalId, onRequestClose }: BulkDeleteModalProps) {
-  const session = useSession()
-  const orgUid = session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const orgUid = profile.currentLoggedAccount?.organization?.uid
 
   const [isDataChecked, setIsDataChecked] = useState(false)
   const [isFormChecked, setIsFormChecked] = useState(false)

--- a/jsapp/js/projects/projectsTable/projectsTableRow.tsx
+++ b/jsapp/js/projects/projectsTable/projectsTableRow.tsx
@@ -12,7 +12,7 @@ import type { AssetResponse, ProjectViewAsset } from '#/dataInterface'
 import { PROJECT_FIELDS } from '#/projects/projectViews/constants'
 import type { ProjectFieldDefinition, ProjectFieldName } from '#/projects/projectViews/constants'
 import { ROUTES } from '#/router/routerConstants'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { formatTime, recordValues } from '#/utils'
 import styles from './projectsTableRow.module.scss'
 
@@ -44,7 +44,7 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
       case 'status':
         return <AssetStatusBadge deploymentStatus={props.asset.deployment_status} />
       case 'ownerUsername':
-        return props.asset.owner_label === sessionStore.currentAccount.username ? (
+        return props.asset.owner_label === profileStore.currentAccount.username ? (
           t('me')
         ) : (
           <Avatar username={props.asset.owner_label} size='s' isUsernameVisible />
@@ -58,7 +58,7 @@ export default function ProjectsTableRow(props: ProjectsTableRowProps) {
       case 'lastModifiedBy':
         if (props.asset.last_modified_by === null) {
           return null
-        } else if (props.asset.last_modified_by === sessionStore.currentAccount.username) {
+        } else if (props.asset.last_modified_by === profileStore.currentAccount.username) {
           return t('me')
         } else {
           return <Avatar username={props.asset.last_modified_by} size='s' isUsernameVisible />

--- a/jsapp/js/projects/universalProjectsRoute.tsx
+++ b/jsapp/js/projects/universalProjectsRoute.tsx
@@ -14,7 +14,7 @@ import ProjectOwnershipTransferModalWithBanner from '#/components/permissions/tr
 import LimitNotifications from '#/components/usageLimits/limitNotifications.component'
 import { dropImportXLSForms } from '#/dropzone.utils'
 import ProjectsTable from '#/projects/projectsTable/projectsTable'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import { notify, validFileTypes } from '#/utils'
 import customViewStore, { PAGE_SIZE } from './customViewStore'
 import projectViewsStore from './projectViews/projectViewsStore'
@@ -53,7 +53,7 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
   const [projectViews] = useState(projectViewsStore)
   const [customView] = useState(customViewStore)
   const [selectedRows, setSelectedRows] = useState<string[]>([])
-  const session = useSession()
+  const profile = useProfile()
   const [organization] = useOrganizationAssumed()
 
   useEffect(() => {
@@ -128,8 +128,8 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
 
             <OrgInviteModalWrapper />
 
-            {session.currentLoggedAccount && (
-              <OrgInviteAcceptedBanner username={session.currentLoggedAccount.username} organization={organization} />
+            {profile.currentLoggedAccount && (
+              <OrgInviteAcceptedBanner username={profile.currentLoggedAccount.username} organization={organization} />
             )}
 
             <LimitNotifications pageCanShowModal />
@@ -183,7 +183,7 @@ function UniversalProjectsRoute(props: UniversalProjectsRouteProps) {
               assets={customView.assets}
               // refreshing session will result in refreshing table, so while that is pending
               // we want to show a loading spinner
-              isLoading={!customView.isFirstLoadComplete || session.isPending}
+              isLoading={!customView.isFirstLoadComplete || profile.isPending}
               highlightedFields={getFilteredFieldsNames()}
               visibleFields={getTableVisibleFields()}
               orderableFields={props.defaultOrderableFields}

--- a/jsapp/js/router/RequireOrg.tsx
+++ b/jsapp/js/router/RequireOrg.tsx
@@ -4,7 +4,7 @@ import {
   useOrganizationsRetrieve,
 } from '#/api/react-query/user-team-organization-usage'
 import LoadingSpinner from '#/components/common/loadingSpinner'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 
 /**
  * Organization object is used globally.
@@ -13,8 +13,8 @@ import { useSession } from '#/stores/useSession'
  * @see also `useOrganizationQuery`
  */
 export const RequireOrg = ({ children }: { children: React.ReactNode }) => {
-  const session = useSession()
-  const organizationId = session.isPending ? undefined : session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const organizationId = profile.isPending ? undefined : profile.currentLoggedAccount?.organization?.uid
 
   const orgQuery = useOrganizationsRetrieve(organizationId!, {
     query: {
@@ -33,7 +33,7 @@ export const RequireOrg = ({ children }: { children: React.ReactNode }) => {
         // DEBT: don't throw toast within `fetchGetUrl`.
         // DEBT: don't retry the failing url 3-4 times before switching to the new url.
         if (query.state.data?.status === 404) {
-          session.refreshAccount()
+          profile.refreshAccount()
         }
         return false
       },

--- a/jsapp/js/router/accessDenied.tsx
+++ b/jsapp/js/router/accessDenied.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import bem, { makeBem } from '#/bem'
 import envStore from '#/envStore'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { replaceBracketsWithLink } from '#/textUtils'
 
 bem.AccessDenied = makeBem(null, 'access-denied')
@@ -50,7 +50,7 @@ const AccessDenied = (props: AccessDeniedProps) => {
   }
 
   function sessionStatus() {
-    if (sessionStore.isLoggedIn) {
+    if (profileStore.isLoggedIn) {
       return loggedIn
     } else {
       return loggedOut

--- a/jsapp/js/router/allRoutes.js
+++ b/jsapp/js/router/allRoutes.js
@@ -7,7 +7,7 @@ import { actions } from '#/actions'
 import LoadingSpinner from '#/components/common/loadingSpinner'
 import permConfig from '#/components/permissions/permConfig'
 import { isRootRoute, redirectToLogin } from '#/router/routerUtils'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import router from './router'
 
 const AllRoutes = class AllRoutes extends React.Component {
@@ -51,7 +51,7 @@ const AllRoutes = class AllRoutes extends React.Component {
       newStateObj.isSessionReady = data.isSessionReady
     }
 
-    if (!(newStateObj.isPermsConfigReady && newStateObj.isSessionReady && !sessionStore.isLoggedIn && isRootRoute())) {
+    if (!(newStateObj.isPermsConfigReady && newStateObj.isSessionReady && !profileStore.isLoggedIn && isRootRoute())) {
       this.setState(newStateObj)
     }
   }
@@ -59,14 +59,14 @@ const AllRoutes = class AllRoutes extends React.Component {
   render() {
     // This is the place that stops any app rendering until all necessary
     // backend calls are done.
-    if (!this.state.isPermsConfigReady || !sessionStore.isAuthStateKnown) {
+    if (!this.state.isPermsConfigReady || !profileStore.isAuthStateKnown) {
       return <LoadingSpinner />
     }
 
     // If all necessary data is obtained, and user is not logged in, and on
     // the root route, redirect immediately to the login page outside
     // the React app, and skip setting the state (so no content blink).
-    if (!sessionStore.isLoggedIn && isRootRoute()) {
+    if (!profileStore.isLoggedIn && isRootRoute()) {
       redirectToLogin()
       // redirect is async, continue showing loading
       return <LoadingSpinner />

--- a/jsapp/js/router/basicLayout.component.tsx
+++ b/jsapp/js/router/basicLayout.component.tsx
@@ -10,7 +10,7 @@ import bem from '#/bem'
 import AccountMenu from '#/components/header/accountMenu'
 import MainHeaderBase from '#/components/header/mainHeaderBase.component'
 import MainHeaderLogo from '#/components/header/mainHeaderLogo.component'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import { cssVariablesResolverKobo, themeKobo } from '#/theme'
 import { KOBO_MODAL_SHARED_PROPS } from '#/theme/kobo/Modal'
 import ToasterConfig from '../toasterConfig'
@@ -39,7 +39,7 @@ export default function BasicLayout(props: BasicLayoutProps) {
             <bem.PageWrapper className='mdl-layout mdl-layout--fixed-header'>
               <MainHeaderBase>
                 <MainHeaderLogo />
-                {sessionStore.isLoggedIn && (
+                {profileStore.isLoggedIn && (
                   <RequireOrg>
                     <AccountMenu />
                   </RequireOrg>

--- a/jsapp/js/router/requireAuth.tsx
+++ b/jsapp/js/router/requireAuth.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { Suspense, useEffect, useState } from 'react'
-import sessionStore from '#/stores/session'
+import profileStore from '#/stores/profile'
 import LoadingSpinner from '../components/common/loadingSpinner'
 import { RequireOrg } from './RequireOrg'
 import { redirectToLogin } from './routerUtils'
@@ -10,15 +10,15 @@ interface Props {
 }
 
 export default function RequireAuth({ children }: Props) {
-  const [session] = useState(() => sessionStore)
+  const [profile] = useState(() => profileStore)
 
   useEffect(() => {
-    if (!session.isLoggedIn) {
+    if (!profile.isLoggedIn) {
       redirectToLogin()
     }
-  }, [session.isLoggedIn])
+  }, [profile.isLoggedIn])
 
-  return session.isLoggedIn ? (
+  return profile.isLoggedIn ? (
     <Suspense fallback={null}>
       <RequireOrg>{children}</RequireOrg>
     </Suspense>

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -11,9 +11,6 @@
 import envStore from '#/envStore'
 import { PATHS, PROJECTS_ROUTES, ROUTES } from '#/router/routerConstants'
 import profileStore from '#/stores/profile'
-// import profile from '../stores/session';
-// import {when} from 'mobx';
-// import {redirectDocument} from 'react-router';
 
 /**
  * Returns login url with a `next` parameter - after logging in, the  app will

--- a/jsapp/js/router/routerUtils.ts
+++ b/jsapp/js/router/routerUtils.ts
@@ -10,8 +10,8 @@
 
 import envStore from '#/envStore'
 import { PATHS, PROJECTS_ROUTES, ROUTES } from '#/router/routerConstants'
-import sessionStore from '#/stores/session'
-// import session from '../stores/session';
+import profileStore from '#/stores/profile'
+// import profile from '../stores/session';
 // import {when} from 'mobx';
 // import {redirectDocument} from 'react-router';
 
@@ -55,8 +55,8 @@ export function getCurrentPath(): string {
  * (session, when, redirectDocument) and restore this function.
  */
 // export const authLoader = async () => {
-//   await when(() => session.isAuthStateKnown);
-//   if (!session.isLoggedIn) {
+//   await when(() => profile.isAuthStateKnown);
+//   if (!profile.isLoggedIn) {
 //     return redirectDocument(getLoginUrl());
 //   }
 //   return null;
@@ -252,9 +252,9 @@ export function getRouteAssetUid() {
  */
 export function isInvalidatedPasswordRouteBlockerActive() {
   return (
-    sessionStore.isLoggedIn &&
-    'validated_password' in sessionStore.currentAccount &&
-    sessionStore.currentAccount.validated_password === false
+    profileStore.isLoggedIn &&
+    'validated_password' in profileStore.currentAccount &&
+    profileStore.currentAccount.validated_password === false
   )
 }
 
@@ -262,10 +262,10 @@ export function isInvalidatedPasswordRouteBlockerActive() {
 export function isTOSAgreementRouteBlockerActive() {
   return (
     envStore.data.terms_of_service__sitewidemessage__exists &&
-    sessionStore.isLoggedIn &&
+    profileStore.isLoggedIn &&
     // We check for email, because `currentAccount` can be two different things
-    'email' in sessionStore.currentAccount &&
-    sessionStore.currentAccount.accepted_tos !== true
+    'email' in profileStore.currentAccount &&
+    profileStore.currentAccount.accepted_tos !== true
   )
 }
 

--- a/jsapp/js/sidebar/SidebarFormsList.tsx
+++ b/jsapp/js/sidebar/SidebarFormsList.tsx
@@ -17,7 +17,7 @@ import {
   useProjectViewsAssetsCountsRetrieve,
 } from '#/api/react-query/user-team-organization-usage'
 import { PROJECTS_ROUTES } from '#/router/routerConstants'
-import { useSession } from '#/stores/useSession'
+import { useProfile } from '#/stores/useProfile'
 import LoadingSpinner from '../components/common/loadingSpinner'
 import SidebarFormsListCategory from './SidebarFormsListCategory'
 import type { SidebarContext } from './common'
@@ -89,8 +89,8 @@ export function invalidateSidebarQueries(orgUid?: string, customViewUid?: string
  * A list of projects grouped by status (deployed, draft, archived). It's meant to be displayed in the sidebar area.
  */
 export default function SidebarFormsList() {
-  const session = useSession()
-  const orgUid = session.currentLoggedAccount?.organization?.uid
+  const profile = useProfile()
+  const orgUid = profile.currentLoggedAccount?.organization?.uid
   const location = useLocation()
   const currentPath = location.pathname
 

--- a/jsapp/js/stores/profile.mocks.ts
+++ b/jsapp/js/stores/profile.mocks.ts
@@ -2,25 +2,25 @@ import { runInAction } from 'mobx'
 import type { AccountResponse } from '#/dataInterface'
 import { meMockResponse } from '#/endpoints/me.mocks'
 import { ANON_USERNAME } from '#/users/utils'
-import sessionStore from './session'
+import profileStore from './profile'
 
 /**
- * Sets the `sessionStore` singleton to a settled, logged-in state matching the
+ * Sets the `profileStore` singleton to a settled, logged-in state matching the
  * globally registered `/me/` mock (see `.storybook/preview.tsx`).
  *
- * Why? `sessionStore` calls `verifyLogin()` in its constructor, so the `/me/`
+ * Why? `profileStore` calls `verifyLogin()` in its constructor, so the `/me/`
  * request fires on import and can lose the race against the MSW worker
  * starting up. When it does, the request hits the real server, fails, and
  * the store stays anonymous, leaving anything gated on the session stuck on
  * a loading spinner.
  */
-export function hydrateSessionStoreForStories() {
+export function hydrateProfileStoreForStories() {
   runInAction(() => {
-    sessionStore.currentAccount = meMockResponse as unknown as AccountResponse
-    sessionStore.isAuthStateKnown = true
-    sessionStore.isLoggedIn = true
-    sessionStore.isInitialLoadComplete = true
-    sessionStore.isPending = false
+    profileStore.currentAccount = meMockResponse as unknown as AccountResponse
+    profileStore.isAuthStateKnown = true
+    profileStore.isLoggedIn = true
+    profileStore.isInitialLoadComplete = true
+    profileStore.isPending = false
   })
 }
 
@@ -32,16 +32,16 @@ export function hydrateSessionStoreForStories() {
  * optional: `preview.tsx` forces the logged-in state in a project-level `beforeEach` that runs before
  * a story's own, so nothing else would put it back for the next story.
  *
- * No `/me/` override needed - `sessionStore` only calls `verifyLogin()` once, on import.
+ * No `/me/` override needed - `profileStore` only calls `verifyLogin()` once, on import.
  */
-export function setAnonymousSessionForStories() {
+export function setAnonymousProfileForStories() {
   runInAction(() => {
-    sessionStore.currentAccount = { username: ANON_USERNAME, date_joined: '' }
-    sessionStore.isAuthStateKnown = true
-    sessionStore.isLoggedIn = false
-    sessionStore.isInitialLoadComplete = true
-    sessionStore.isPending = false
+    profileStore.currentAccount = { username: ANON_USERNAME, date_joined: '' }
+    profileStore.isAuthStateKnown = true
+    profileStore.isLoggedIn = false
+    profileStore.isInitialLoadComplete = true
+    profileStore.isPending = false
   })
 
-  return hydrateSessionStoreForStories
+  return hydrateProfileStoreForStories
 }

--- a/jsapp/js/stores/profile.ts
+++ b/jsapp/js/stores/profile.ts
@@ -6,12 +6,13 @@ import type { ProjectViewsSettings } from '#/projects/customViewStore'
 import { ANON_USERNAME } from '#/users/utils'
 import { currentLang, log } from '#/utils'
 
-class SessionStore {
+class ProfileStore {
   currentAccount: AccountResponse | { username: string; date_joined: string } = {
     username: ANON_USERNAME,
     date_joined: '',
   }
   isAuthStateKnown = false
+  /** @deprecated Auth status will be provided by the allauth /session endpoint. Use that instead. */
   isLoggedIn = false
   isInitialLoadComplete = false
   isPending = false
@@ -89,4 +90,4 @@ class SessionStore {
   }
 }
 
-export default new SessionStore()
+export default new ProfileStore()

--- a/jsapp/js/stores/useProfile.tsx
+++ b/jsapp/js/stores/useProfile.tsx
@@ -2,43 +2,41 @@ import { useEffect, useState } from 'react'
 
 import { reaction } from 'mobx'
 import type { AccountResponse } from '../dataInterface'
-import sessionStore from './session'
+import profileStore from './profile'
 
 /**
- * Hook to use the session store in functional components.
- * This hook provides a way to access teh current logged account, information
- * regarding the anonymous state of the login and session methods.
+ * Hook to use the profile store in functional components.
+ * This hook provides a way to access the current logged account, information
+ * regarding the pending state, and profile methods.
  *
  * This hook uses MobX reactions to track the current account and update the
  * state accordingly.
  * In the future we should update this hook to use react-query and drop the usage of mob-x
  */
-export const useSession = () => {
+export const useProfile = () => {
   const [currentLoggedAccount, setCurrentLoggedAccount] = useState<AccountResponse>(
-    sessionStore.currentAccount as AccountResponse,
+    profileStore.currentAccount as AccountResponse,
   )
-  const [isAnonymous, setIsAnonymous] = useState<boolean>(true)
   const [isPending, setIsPending] = useState<boolean>(false)
 
   useEffect(() => {
     // We need to setup a reaction for every observable we want to track
-    // Generic reaction to sessionStore won't fire the re-rendering of the hook
+    // Generic reaction to profileStore won't fire the re-rendering of the hook
     const currentAccountReactionDisposer = reaction(
-      () => sessionStore.currentAccount,
+      () => profileStore.currentAccount,
       (currentAccount) => {
-        if (sessionStore.isLoggedIn) {
+        if (profileStore.isLoggedIn) {
           setCurrentLoggedAccount(currentAccount as AccountResponse)
-          setIsAnonymous(false)
-          setIsPending(sessionStore.isPending)
+          setIsPending(profileStore.isPending)
         }
       },
       { fireImmediately: true },
     )
 
     const isPendingReactionDisposer = reaction(
-      () => sessionStore.isPending,
+      () => profileStore.isPending,
       () => {
-        setIsPending(sessionStore.isPending)
+        setIsPending(profileStore.isPending)
       },
       { fireImmediately: true },
     )
@@ -51,8 +49,7 @@ export const useSession = () => {
 
   return {
     currentLoggedAccount,
-    isAnonymous,
     isPending,
-    refreshAccount: sessionStore.refreshAccount.bind(sessionStore),
+    refreshAccount: profileStore.refreshAccount.bind(profileStore),
   }
 }

--- a/jsapp/js/tos/tosForm.component.tsx
+++ b/jsapp/js/tos/tosForm.component.tsx
@@ -11,7 +11,7 @@ import LoadingSpinner from '#/components/common/loadingSpinner'
 import type { FailResponse } from '#/dataInterface'
 import envStore from '#/envStore'
 import { currentLang, notify } from '#/utils'
-import { useSession } from '../stores/useSession'
+import { useProfile } from '../stores/useProfile'
 import styles from './tosForm.module.scss'
 
 /** A slug for the `sitewide_messages` endpoint */
@@ -57,7 +57,7 @@ export default function TOSForm() {
   const [fieldsErrors, setFieldsErrors] = useState<AccountFieldsErrors>({})
   const [editedFields, setEditedFields] = useState<Partial<AccountFieldsValues>>({})
 
-  const { currentLoggedAccount } = useSession()
+  const { currentLoggedAccount } = useProfile()
   const logout = useLogout()
   const [organization] = useOrganizationAssumed()
 
@@ -98,7 +98,7 @@ export default function TOSForm() {
     getTOS()
   }, [])
 
-  // After session store is ready, we fill in all the fields for the form
+  // After profile store is ready, we fill in all the fields for the form
   // (including the non-required ones that will be hidden, but passed to the API
   // so that they will not get erased).
   useEffect(() => {
@@ -172,10 +172,10 @@ export default function TOSForm() {
       try {
         // Accepting TOS is simply POSTing to this endpoint
         await fetchPost(TOS_ACCEPT_ENDPOINT, {})
-        // TODO ideally we could make the sessionStore fetch new account data
+        // TODO ideally we could make the profileStore fetch new account data
         // or even override the `accepted_tos` flag without fetching. But this
         // requires the `app.js` file to be reworked in a bit different fashion,
-        // so that it could react to `sessionStore.accepted_tos` change. For now
+        // so that it could react to `profileStore.accepted_tos` change. For now
         // we do ugly and simple forced reload :)
         window.location.replace('')
       } catch (err) {


### PR DESCRIPTION
### 📣 Summary
Renames sessionStore as profileStore and removes logout functionality from store in preparation for shifting auth handling to `/session` endpoint.

### 💭 Notes

This is a very large PR, but it is mostly mechanical renaming.

**`isLoggedIn` is now `@deprecated`** — it's still populated by the `/me/` response and used by several stores that gate on login via MobX `when()`. It will be superseded by the allauth `/session` RQ hook in the follow-up PR; nothing changes today.

### 👀 Preview steps

1. ℹ️ Log in to any account
2. Open the account menu in header
3. 🟢 Click **Logout** — page reloads to the login screen
4. Log back in, navigate to **Account Settings → Security → Recent account activity**
5. 🟢 Click **Log out of all devices** — page reloads to the login screen
6. Log back in, accept an org invite that results in an error state
7. 🟢 Click **Sign out** in the error modal — page reloads to the login screen
8. Log back in as a user with a pending TOS acceptance
9. 🟢 Click **I don't agree, log me out** — page reloads to the login screen
