### PR TITLE
fix(subsequences): skip unconfigured actions when reading supplement data DEV-2794

### DIFF
--- a/kobo/apps/subsequences/models.py
+++ b/kobo/apps/subsequences/models.py
@@ -241,8 +241,16 @@ class SubmissionSupplement(AbstractTimeStampedModel):
                     continue
                 try:
                     feature = advanced_features_for_this_question.get(action=action_id)
-                except QuestionAdvancedFeature.DoesNotExist as e:
-                    raise InvalidAction from e
+                except QuestionAdvancedFeature.DoesNotExist:
+                    # The supplement references an action that is no longer
+                    # configured for this question; skip it so reads still
+                    # succeed
+                    logging.warning(
+                        f'Supplement data for asset #{asset.pk} references '
+                        f'unconfigured action {action_id!r} on question '
+                        f'{question_xpath!r}'
+                    )
+                    continue
 
                 action = feature.to_action()
 

--- a/kobo/apps/subsequences/models.py
+++ b/kobo/apps/subsequences/models.py
@@ -1,15 +1,16 @@
 import hashlib
 import json
+from functools import lru_cache
 
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Count, Q
 from django.utils import timezone
-from kpi.utils.log import logging
 
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import remove_uuid_prefix
 from kpi.fields import KpiUidField, LazyDefaultJSONBField
 from kpi.models.abstract_models import AbstractTimeStampedModel
+from kpi.utils.log import logging
 from .actions import ACTION_IDS_TO_CLASSES
 from .constants import (
     QUESTION_TYPE_TAGS,
@@ -242,10 +243,9 @@ class SubmissionSupplement(AbstractTimeStampedModel):
                 try:
                     feature = advanced_features_for_this_question.get(action=action_id)
                 except QuestionAdvancedFeature.DoesNotExist:
-                    # The supplement references an action no longer configured
-                    # for this question. Skip it silently: this runs once per
-                    # submission in table/export streams and Sentry turns
-                    # warnings into events
+                    # Stale data: the action is no longer configured for this
+                    # question. Skip it so reads still succeed
+                    _warn_unconfigured_action(asset.pk, question_xpath, action_id)
                     continue
 
                 action = feature.to_action()
@@ -811,3 +811,18 @@ class SubsequenceBulkActionItem(AbstractTimeStampedModel):
             submission={SUBMISSION_UUID_FIELD: self.submission_root_uuid},
             asset=self.parent.asset,
         )
+
+
+@lru_cache(maxsize=1024)
+def _warn_unconfigured_action(
+    asset_id: int, question_xpath: str, action_id: str
+) -> None:
+    """
+    Log each orphaned (asset, question, action) once per process: this runs
+    per submission in table and export streams and Sentry turns warnings
+    into events
+    """
+    logging.warning(
+        f'Supplement data for asset #{asset_id} references unconfigured '
+        f'action {action_id!r} on question {question_xpath!r}'
+    )

--- a/kobo/apps/subsequences/models.py
+++ b/kobo/apps/subsequences/models.py
@@ -242,14 +242,10 @@ class SubmissionSupplement(AbstractTimeStampedModel):
                 try:
                     feature = advanced_features_for_this_question.get(action=action_id)
                 except QuestionAdvancedFeature.DoesNotExist:
-                    # The supplement references an action that is no longer
-                    # configured for this question; skip it so reads still
-                    # succeed
-                    logging.warning(
-                        f'Supplement data for asset #{asset.pk} references '
-                        f'unconfigured action {action_id!r} on question '
-                        f'{question_xpath!r}'
-                    )
+                    # The supplement references an action no longer configured
+                    # for this question. Skip it silently: this runs once per
+                    # submission in table/export streams and Sentry turns
+                    # warnings into events
                     continue
 
                 action = feature.to_action()

--- a/kobo/apps/subsequences/tests/test_models.py
+++ b/kobo/apps/subsequences/tests/test_models.py
@@ -433,21 +433,31 @@ class SubmissionSupplementTestCase(TestCase):
         )
         assert output[self.xpath].get('transcript') is None
 
-    # skip until we actually fill out or delete this test
-    @pytest.mark.skip()
     def test_retrieve_data_with_stale_questions(self):
         SubmissionSupplement.objects.create(
             asset=self.asset,
             submission_uuid=self.submission_root_uuid,
-            content=self.EXPECTED_SUBMISSION_SUPPLEMENT,
+            content=deepcopy(self.EXPECTED_SUBMISSION_SUPPLEMENT),
         )
-        advanced_features = deepcopy(self.ADVANCED_FEATURES)
-        config = advanced_features['_actionConfigs'].pop(self.xpath)
-        advanced_features['_actionConfigs']['group_name/renamed_question_name'] = config
+        self.asset.advanced_features_set.all().delete()
         submission_supplement = SubmissionSupplement.retrieve_data(
             self.asset, self.submission_root_uuid
         )
-        assert submission_supplement == EMPTY_SUPPLEMENT
+        assert submission_supplement == {self.xpath: {}, '_version': '20250820'}
+
+    def test_retrieve_data_skips_unconfigured_action(self):
+        SubmissionSupplement.objects.create(
+            asset=self.asset,
+            submission_uuid=self.submission_root_uuid,
+            content=deepcopy(self.EXPECTED_SUBMISSION_SUPPLEMENT),
+        )
+        self.asset.advanced_features_set.filter(action='manual_translation').delete()
+        submission_supplement = SubmissionSupplement.retrieve_data(
+            self.asset, self.submission_root_uuid
+        )
+        assert self.xpath in submission_supplement
+        assert 'manual_transcription' in submission_supplement[self.xpath]
+        assert 'manual_translation' not in submission_supplement[self.xpath]
 
     # skip until we update how we migrate advanced_actions
     @pytest.mark.skip()


### PR DESCRIPTION
### 📣 Summary

The Data table and submission data now load normally for projects that have leftover transcript or translation data from a question or feature that was later removed.

### 📖 Description

When a submission holds transcript or translation data but the matching advanced feature configuration was later removed (question renamed or deleted, or the feature turned off), opening the Data table or fetching that submission's supplemental data failed with a server error. Reading now skips the leftover entries and returns everything else. Editing supplemental data is unchanged: writing to an unconfigured action is still rejected.

### 💭 Notes

- Root cause: the DEV-1229 refactor (238b2aa67) replaced the old "config removed, skip it" branch in `SubmissionSupplement.retrieve_data()` with `raise InvalidAction`. No read path catches it (GET supplement in `kpi/views/v2/data.py`, `stream_with_supplements`, the bulk action tasks), which is the 500 in Sentry. The write path (`revise_data`) keeps raising and still maps to a 400.
- The skip logs a warning, deduplicated per process with `lru_cache` on `(asset, question, action)`. `retrieve_data()` runs once per submission in the table and export streams and Sentry turns `logging.warning` into events, so a per-row warning would have meant one Sentry event per orphaned row per read. This way each orphaned config shows up once per worker, which is enough to list the affected assets for a repair.
- Un-skipped the stale-questions test that covered exactly this case, and added one for a partially removed config (one action deleted, the other still configured, its data must survive).

### 👀 Preview steps

Back end only, nothing changes in the UI while configs are intact.

1. ℹ️ have any project (no deployment needed)
2. In the kpi container, plant a supplement whose content references an action with no config, then read it back the way the /data endpoints do:
   ```
   python manage.py shell -c "from kpi.models import Asset; from kobo.apps.subsequences.models import SubmissionSupplement; a = Asset.objects.filter(owner__username='<you>').first(); SubmissionSupplement.objects.update_or_create(asset=a, submission_uuid='dev2794-demo', defaults={'content': {'_version': '20250820', 'q1': {'manual_transcription': {'stale': 'data'}}}}); print(SubmissionSupplement.retrieve_data(a, 'dev2794-demo'))"
   ```
3. 🔴 [on release/2.026.33] the command dies with an `InvalidAction` traceback, the same error that 500s the Data tab
4. 🟢 [on PR] it prints `{'q1': {}, '_version': '20250820'}` and logs one `references unconfigured action` warning (re-running the command in the same shell does not log it again)
5. clean up the planted row:
   ```
   python manage.py shell -c "from kobo.apps.subsequences.models import SubmissionSupplement; SubmissionSupplement.objects.filter(submission_uuid='dev2794-demo').delete()"
   ```
