### PR TITLE
fix(trashBin): suspend owner submissions during project deletion DEV-2513

### DIFF
--- a/kobo/apps/openrosa/apps/logger/constants.py
+++ b/kobo/apps/openrosa/apps/logger/constants.py
@@ -1,2 +1,8 @@
 # One hash per user, token -> registration timestamp, see `suspend_submissions()`
 SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX = 'kobo:submissions_suspended:holders:'
+# TODO Remove this key (and `_legacy_holder_alive()`) in the release following
+#  the one where this commit has been deployed to production: only workers
+#  running the previous `update_attachment_storage_bytes` still write it
+LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY = (
+    'kobo:update_attachment_storage_bytes:heartbeat'
+)

--- a/kobo/apps/openrosa/apps/logger/constants.py
+++ b/kobo/apps/openrosa/apps/logger/constants.py
@@ -1,2 +1,4 @@
 
 SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY = 'kobo:update_attachment_storage_bytes:heartbeat'
+# One hash per user, token -> registration timestamp, see `suspend_submissions()`
+SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX = 'kobo:submissions_suspended:holders:'

--- a/kobo/apps/openrosa/apps/logger/constants.py
+++ b/kobo/apps/openrosa/apps/logger/constants.py
@@ -1,4 +1,2 @@
-
-SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY = 'kobo:update_attachment_storage_bytes:heartbeat'
 # One hash per user, token -> registration timestamp, see `suspend_submissions()`
 SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX = 'kobo:submissions_suspended:holders:'

--- a/kobo/apps/openrosa/apps/logger/management/commands/update_attachment_storage_bytes.py
+++ b/kobo/apps/openrosa/apps/logger/management/commands/update_attachment_storage_bytes.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-import time
+from collections.abc import Callable
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery, Sum, Value
 from django.db.models.functions import Coalesce
-from django_redis import get_redis_connection
 
-from kobo.apps.openrosa.apps.logger.constants import SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY
 from kobo.apps.openrosa.apps.logger.models.attachment import Attachment
 from kobo.apps.openrosa.apps.logger.models.xform import XForm
+from kobo.apps.openrosa.apps.logger.utils.suspension import (
+    release_orphaned_suspensions,
+    suspend_submissions,
+)
 from kobo.apps.openrosa.apps.main.models.user_profile import UserProfile
 from kpi.utils.django_orm_helper import UpdateJSONFieldAttributes
 
@@ -28,7 +30,6 @@ class Command(BaseCommand):
         self._verbosity = 0
         self._force = False
         self._sync = False
-        self._redis_client = get_redis_connection()
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -123,62 +124,13 @@ class Command(BaseCommand):
                     )
                 continue
 
-            if not no_lock:
-                self._lock_user_profile(user)
+            if no_lock:
+                self._update_user_storage(user, user_xforms, chunks)
+                continue
 
-            try:
-                for xform in user_xforms.iterator(chunk_size=chunks):
-
-                    self._heartbeat(user)
-
-                    # write out xform progress
-                    if self._verbosity > 1:
-                        self.stdout.write(
-                            f"Calculating attachments for xform_id #{xform['pk']}"
-                            f" (user {user.username})"
-                        )
-                    # aggregate total media file size for all media per xform
-                    form_attachments = Attachment.objects.filter(
-                        instance__xform_id=xform['pk'],
-                    ).aggregate(total=Sum('media_file_size'))
-
-                    if form_attachments['total']:
-                        if (
-                            xform['attachment_storage_bytes']
-                            == form_attachments['total']
-                        ):
-                            if self._verbosity > 2:
-                                self.stdout.write(
-                                    '\tSkipping xform update! '
-                                    'Attachment storage is already accurate'
-                                )
-                        else:
-                            if self._verbosity > 2:
-                                self.stdout.write(
-                                    f'\tUpdating xform attachment storage to '
-                                    f"{form_attachments['total']} bytes"
-                                )
-
-                            XForm.all_objects.filter(
-                                pk=xform['pk']
-                            ).update(
-                                attachment_storage_bytes=form_attachments['total']
-                            )
-
-                    else:
-                        if self._verbosity > 2:
-                            self.stdout.write('\tNo attachments found')
-                        if not xform['attachment_storage_bytes'] == 0:
-                            XForm.all_objects.filter(
-                                pk=xform['pk']
-                            ).update(
-                                attachment_storage_bytes=0
-                            )
-
-                self._update_user_profile(user)
-            finally:
-                if not no_lock:
-                    self._release_lock(user)
+            self._mark_counting_started(user)
+            with suspend_submissions(user) as heartbeat:
+                self._update_user_storage(user, user_xforms, chunks, heartbeat)
 
         if self._verbosity >= 1:
             self.stdout.write('Done!')
@@ -203,52 +155,23 @@ class Command(BaseCommand):
 
         return users.order_by('pk')
 
-    def _heartbeat(self, user: settings.AUTH_USER_MODEL):
-        if self._verbosity > 2:
-            self.stdout.write(f'Heartbeat for user `{user.username}`...')
-
-        self._redis_client.hset(
-            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={
-                user.username: int(time.time())
-            }
-        )
-
-    def _lock_user_profile(self, user: settings.AUTH_USER_MODEL):
-        # Retrieve or create user's profile.
-        (
-            user_profile,
-            created,
-        ) = UserProfile.objects.get_or_create(user_id=user.pk)
-
+    def _mark_counting_started(self, user: settings.AUTH_USER_MODEL):
+        user_profile, _ = UserProfile.objects.get_or_create(user_id=user.pk)
         # Some old profiles don't have metadata
         if user_profile.metadata is None:
             user_profile.metadata = {}
-
-        # Set the flag to true if it was never set.
-        if not user_profile.submissions_suspended:
-            # We are using the flag `submissions_suspended` to prevent
-            # new submissions from coming in while the
-            # `attachment_storage_bytes` is being calculated.
-            user_profile.submissions_suspended = True
-            user_profile.metadata['attachments_counting_status'] = 'not-completed'
-            user_profile.save(update_fields=['metadata', 'submissions_suspended'])
-
-        self._heartbeat(user)
-
-    def _release_lock(self, user: settings.AUTH_USER_MODEL):
-        # Release any locks on the users' profile from getting submissions
-        if self._verbosity > 1:
-            self.stdout.write(f'Releasing submission lock for {user.username}…')
-
-        UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=False)
-        self._redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
+        user_profile.metadata['attachments_counting_status'] = 'not-completed'
+        user_profile.save(update_fields=['metadata'])
 
     def _release_locks(self):
-        # Release any locks on the users' profile from getting submissions
+        # Release the profiles a previous run left suspended, without touching
+        # the ones held by a running deletion
         if self._verbosity > 1:
             self.stdout.write('Releasing submission locks…')
 
-        UserProfile.objects.all().update(submissions_suspended=False)
+        orphaned = release_orphaned_suspensions()
+        if self._verbosity > 1:
+            self.stdout.write(f'Released submission locks: {len(orphaned)}')
 
     def _reset_user_profile_counters(self):
 
@@ -306,3 +229,53 @@ class Command(BaseCommand):
                 updates=updates,
             ),
         )
+
+    def _update_user_storage(
+        self,
+        user: settings.AUTH_USER_MODEL,
+        user_xforms,
+        chunks: int,
+        heartbeat: Callable[[], None] = lambda: None,
+    ):
+        for xform in user_xforms.iterator(chunk_size=chunks):
+
+            heartbeat()
+
+            # write out xform progress
+            if self._verbosity > 1:
+                self.stdout.write(
+                    f'Calculating attachments for xform_id #{xform["pk"]}'
+                    f' (user {user.username})'
+                )
+            # aggregate total media file size for all media per xform
+            form_attachments = Attachment.objects.filter(
+                instance__xform_id=xform['pk'],
+            ).aggregate(total=Sum('media_file_size'))
+
+            if form_attachments['total']:
+                if xform['attachment_storage_bytes'] == form_attachments['total']:
+                    if self._verbosity > 2:
+                        self.stdout.write(
+                            '\tSkipping xform update! '
+                            'Attachment storage is already accurate'
+                        )
+                else:
+                    if self._verbosity > 2:
+                        self.stdout.write(
+                            f'\tUpdating xform attachment storage to '
+                            f"{form_attachments['total']} bytes"
+                        )
+
+                    XForm.all_objects.filter(pk=xform['pk']).update(
+                        attachment_storage_bytes=form_attachments['total']
+                    )
+
+            else:
+                if self._verbosity > 2:
+                    self.stdout.write('\tNo attachments found')
+                if not xform['attachment_storage_bytes'] == 0:
+                    XForm.all_objects.filter(pk=xform['pk']).update(
+                        attachment_storage_bytes=0
+                    )
+
+        self._update_user_profile(user)

--- a/kobo/apps/openrosa/apps/logger/tasks.py
+++ b/kobo/apps/openrosa/apps/logger/tasks.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import logging
-import time
 import zipfile
 from collections import defaultdict
 from datetime import timedelta
@@ -13,7 +12,6 @@ from dateutil import relativedelta
 from django.conf import settings
 from django.core.management import call_command
 from django.utils import timezone
-from django_redis import get_redis_connection
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.celery import celery_app
@@ -21,11 +19,10 @@ from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
 from kpi.utils.log import logging
-from ..main.models import UserProfile
-from .constants import SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY
 from .models import Instance, XForm
 from .models.daily_xform_submission_counter import DailyXFormSubmissionCounter
 from .models.instance import InstanceHistory
+from .utils.suspension import release_orphaned_suspensions
 
 
 @celery_app.task()
@@ -134,48 +131,13 @@ def generate_stats_zip(output_filename):
 @celery_app.task
 def fix_stale_submissions_suspended_flag():
     """
-    Task to fix stale `submissions_suspended` flag to ensure that accounts are
-    not indefinitely locked, preventing users from accessing or collecting their
-    data.
+    Release the accounts left suspended by a storage recount or a trash bin
+    deletion which died, so that nobody stays locked out of collecting data.
     """
-
-    redis_client = get_redis_connection()
-    lock = redis_client.hgetall(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY)
-
-    def _release_all_locks():
-        if UserProfile.objects.filter(submissions_suspended=True).exists():
-            logging.warning(
-                'Some profiles still have the `submission_suspended` flag enabled.'
-            )
-            UserProfile.objects.filter(submissions_suspended=True).update(
-                submissions_suspended=False
-            )
-
-    if not lock:
-        _release_all_locks()
-        return
-
-    usernames = []
-
-    for username, timestamp in lock.items():
-        username = username.decode()
-        timestamp = int(timestamp.decode())
-
-        if timestamp + settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT <= int(
-            time.time()
-        ):
-            logging.info(
-                f'Removing `submission_suspended` flag on user #{username}’s profile'
-            )
-            usernames.append(username)
-
-    if usernames:
-        UserProfile.objects.filter(user__username__in=usernames).update(
-            submissions_suspended=False
+    for username in release_orphaned_suspensions():
+        logging.info(
+            f'Removed `submissions_suspended` flag on user {username}’s profile'
         )
-        redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, *usernames)
-    else:
-        _release_all_locks()
 
 
 @celery_app.task(

--- a/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
@@ -8,6 +8,7 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.constants import (
+    LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
     SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
 )
 from kobo.apps.openrosa.apps.logger.tasks import fix_stale_submissions_suspended_flag
@@ -29,6 +30,7 @@ class SuspendSubmissionsTestCase(TestCase):
 
     def tearDown(self):
         self.redis_client.delete(self.holders_key, f'{self.holders_key}:lock')
+        self.redis_client.hdel(LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder')
 
     def test_suspends_then_releases(self):
         with suspend_submissions(self.user):
@@ -118,6 +120,38 @@ class SuspendSubmissionsTestCase(TestCase):
 
         fix_stale_submissions_suspended_flag()
 
+        assert not self._is_suspended()
+
+    def test_failed_entry_does_not_release_a_live_holder(self):
+        with suspend_submissions(self.user):
+            with patch(
+                f'{SUSPENSION_MODULE}._register_holder',
+                side_effect=RedisConnectionError,
+            ):
+                with self.assertRaises(RedisConnectionError):
+                    with suspend_submissions(self.user):
+                        pass
+
+            assert self._is_suspended()
+            assert self.redis_client.hlen(self.holders_key) == 1
+
+        assert not self._is_suspended()
+
+    def test_legacy_heartbeat_counts_as_a_live_holder(self):
+        UserProfile.objects.create(user=self.user, submissions_suspended=True)
+        self.redis_client.hset(
+            LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder', int(time.time())
+        )
+
+        assert release_orphaned_suspensions() == []
+        assert self._is_suspended()
+
+        expired = int(time.time()) - settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
+        self.redis_client.hset(
+            LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder', expired
+        )
+
+        assert release_orphaned_suspensions() == ['holder']
         assert not self._is_suspended()
 
     def _is_suspended(self):

--- a/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
@@ -1,9 +1,10 @@
 import time
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import fakeredis
 from django.conf import settings
 from django.test import TestCase
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.constants import (
@@ -61,15 +62,22 @@ class SuspendSubmissionsTestCase(TestCase):
         assert not self._is_suspended()
         assert not self.redis_client.exists(self.holders_key)
 
-    def test_redis_failure_leaves_submissions_open(self):
-        with patch(REDIS_PATCH_TARGET, side_effect=ConnectionError):
-            with self.assertRaises(ConnectionError):
+    def test_redis_failure_on_entry_leaves_submissions_open(self):
+        with patch(REDIS_PATCH_TARGET, side_effect=RedisConnectionError):
+            with self.assertRaises(RedisConnectionError):
                 with suspend_submissions(self.user):
                     pass
 
         assert not UserProfile.objects.filter(
             user=self.user, submissions_suspended=True
         ).exists()
+
+    def test_redis_failure_on_exit_still_releases(self):
+        with suspend_submissions(self.user):
+            assert self._is_suspended()
+            self.redis_client.hdel = Mock(side_effect=RedisConnectionError)
+
+        assert not self._is_suspended()
 
     def _has_heartbeat(self):
         return self.redis_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder')

--- a/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
@@ -1,44 +1,41 @@
 import time
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-import fakeredis
 from django.conf import settings
 from django.test import TestCase
+from django_redis import get_redis_connection
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.constants import (
-    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
     SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
 )
+from kobo.apps.openrosa.apps.logger.tasks import fix_stale_submissions_suspended_flag
 from kobo.apps.openrosa.apps.logger.utils.suspension import (
     release_orphaned_suspensions,
     suspend_submissions,
 )
 from kobo.apps.openrosa.apps.main.models import UserProfile
 
-REDIS_PATCH_TARGET = (
-    'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection'
-)
+SUSPENSION_MODULE = 'kobo.apps.openrosa.apps.logger.utils.suspension'
 
 
 class SuspendSubmissionsTestCase(TestCase):
 
     def setUp(self):
         self.user = User.objects.create(username='holder')
-        self.redis_client = fakeredis.FakeStrictRedis()
-        patcher = patch(REDIS_PATCH_TARGET, return_value=self.redis_client)
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        self.redis_client = get_redis_connection()
         self.holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}holder'
+
+    def tearDown(self):
+        self.redis_client.delete(self.holders_key, f'{self.holders_key}:lock')
 
     def test_suspends_then_releases(self):
         with suspend_submissions(self.user):
             assert self._is_suspended()
-            assert self._has_heartbeat()
+            assert self.redis_client.hlen(self.holders_key) == 1
 
         assert not self._is_suspended()
-        assert not self._has_heartbeat()
         assert not self.redis_client.exists(self.holders_key)
 
     def test_first_holder_to_finish_does_not_release(self):
@@ -49,11 +46,10 @@ class SuspendSubmissionsTestCase(TestCase):
 
         first.__exit__(None, None, None)
         assert self._is_suspended()
-        assert self._has_heartbeat()
+        assert self.redis_client.hlen(self.holders_key) == 1
 
         second.__exit__(None, None, None)
         assert not self._is_suspended()
-        assert not self._has_heartbeat()
 
     def test_dead_holder_does_not_pin_the_flag(self):
         expired = int(time.time()) - settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
@@ -64,23 +60,6 @@ class SuspendSubmissionsTestCase(TestCase):
 
         assert not self._is_suspended()
         assert not self.redis_client.exists(self.holders_key)
-
-    def test_redis_failure_on_entry_leaves_submissions_open(self):
-        with patch(REDIS_PATCH_TARGET, side_effect=RedisConnectionError):
-            with self.assertRaises(RedisConnectionError):
-                with suspend_submissions(self.user):
-                    pass
-
-        assert not UserProfile.objects.filter(
-            user=self.user, submissions_suspended=True
-        ).exists()
-
-    def test_redis_failure_on_exit_still_releases(self):
-        with suspend_submissions(self.user):
-            assert self._is_suspended()
-            self.redis_client.hdel = Mock(side_effect=RedisConnectionError)
-
-        assert not self._is_suspended()
 
     def test_heartbeat_refreshes_the_lease(self):
         lease = settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
@@ -102,25 +81,44 @@ class SuspendSubmissionsTestCase(TestCase):
         assert not self._is_suspended()
         assert not self.redis_client.exists(f'{self.holders_key}:lock')
 
+    def test_redis_failure_on_entry_leaves_submissions_open(self):
+        with patch(
+            f'{SUSPENSION_MODULE}.get_redis_connection',
+            side_effect=RedisConnectionError,
+        ):
+            with self.assertRaises(RedisConnectionError):
+                with suspend_submissions(self.user):
+                    pass
+
+        assert not UserProfile.objects.filter(
+            user=self.user, submissions_suspended=True
+        ).exists()
+
+    def test_redis_failure_on_exit_still_releases(self):
+        with patch(
+            f'{SUSPENSION_MODULE}._live_holders', side_effect=RedisConnectionError
+        ):
+            with suspend_submissions(self.user):
+                assert self._is_suspended()
+
+        assert not self._is_suspended()
+
     def test_release_orphaned_suspensions_keeps_live_holders(self):
         orphan = User.objects.create(username='orphan')
         UserProfile.objects.create(user=orphan, submissions_suspended=True)
-        self.redis_client.hset(
-            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={'orphan': int(time.time())}
-        )
 
         with suspend_submissions(self.user):
             assert release_orphaned_suspensions() == ['orphan']
             assert self._is_suspended()
-            assert self._has_heartbeat()
 
         assert not UserProfile.objects.get(user=orphan).submissions_suspended
-        assert not self.redis_client.hexists(
-            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'orphan'
-        )
 
-    def _has_heartbeat(self):
-        return self.redis_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder')
+    def test_stale_flag_task_releases_orphans(self):
+        UserProfile.objects.create(user=self.user, submissions_suspended=True)
+
+        fix_stale_submissions_suspended_flag()
+
+        assert not self._is_suspended()
 
     def _is_suspended(self):
         return UserProfile.objects.get(user=self.user).submissions_suspended

--- a/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
@@ -11,7 +11,10 @@ from kobo.apps.openrosa.apps.logger.constants import (
     SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
     SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
 )
-from kobo.apps.openrosa.apps.logger.utils.suspension import suspend_submissions
+from kobo.apps.openrosa.apps.logger.utils.suspension import (
+    release_orphaned_suspensions,
+    suspend_submissions,
+)
 from kobo.apps.openrosa.apps.main.models import UserProfile
 
 REDIS_PATCH_TARGET = (
@@ -78,6 +81,43 @@ class SuspendSubmissionsTestCase(TestCase):
             self.redis_client.hdel = Mock(side_effect=RedisConnectionError)
 
         assert not self._is_suspended()
+
+    def test_heartbeat_refreshes_the_lease(self):
+        lease = settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
+        with suspend_submissions(self.user) as heartbeat:
+            (token,) = self.redis_client.hkeys(self.holders_key)
+            self.redis_client.hset(self.holders_key, token, int(time.time()) - lease)
+            heartbeat()
+            registered_at = int(self.redis_client.hget(self.holders_key, token))
+            assert registered_at >= int(time.time()) - 1
+
+        assert not self._is_suspended()
+
+    def test_expired_mutex_does_not_block(self):
+        self.redis_client.set(f'{self.holders_key}:lock', 'dead-worker', ex=1)
+
+        with suspend_submissions(self.user):
+            assert self._is_suspended()
+
+        assert not self._is_suspended()
+        assert not self.redis_client.exists(f'{self.holders_key}:lock')
+
+    def test_release_orphaned_suspensions_keeps_live_holders(self):
+        orphan = User.objects.create(username='orphan')
+        UserProfile.objects.create(user=orphan, submissions_suspended=True)
+        self.redis_client.hset(
+            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={'orphan': int(time.time())}
+        )
+
+        with suspend_submissions(self.user):
+            assert release_orphaned_suspensions() == ['orphan']
+            assert self._is_suspended()
+            assert self._has_heartbeat()
+
+        assert not UserProfile.objects.get(user=orphan).submissions_suspended
+        assert not self.redis_client.hexists(
+            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'orphan'
+        )
 
     def _has_heartbeat(self):
         return self.redis_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder')

--- a/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_suspension.py
@@ -1,0 +1,78 @@
+import time
+from unittest.mock import patch
+
+import fakeredis
+from django.conf import settings
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.constants import (
+    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
+)
+from kobo.apps.openrosa.apps.logger.utils.suspension import suspend_submissions
+from kobo.apps.openrosa.apps.main.models import UserProfile
+
+REDIS_PATCH_TARGET = (
+    'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection'
+)
+
+
+class SuspendSubmissionsTestCase(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create(username='holder')
+        self.redis_client = fakeredis.FakeStrictRedis()
+        patcher = patch(REDIS_PATCH_TARGET, return_value=self.redis_client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}holder'
+
+    def test_suspends_then_releases(self):
+        with suspend_submissions(self.user):
+            assert self._is_suspended()
+            assert self._has_heartbeat()
+
+        assert not self._is_suspended()
+        assert not self._has_heartbeat()
+        assert not self.redis_client.exists(self.holders_key)
+
+    def test_first_holder_to_finish_does_not_release(self):
+        first = suspend_submissions(self.user)
+        second = suspend_submissions(self.user)
+        first.__enter__()
+        second.__enter__()
+
+        first.__exit__(None, None, None)
+        assert self._is_suspended()
+        assert self._has_heartbeat()
+
+        second.__exit__(None, None, None)
+        assert not self._is_suspended()
+        assert not self._has_heartbeat()
+
+    def test_dead_holder_does_not_pin_the_flag(self):
+        expired = int(time.time()) - settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
+        self.redis_client.hset(self.holders_key, mapping={'dead': expired})
+
+        with suspend_submissions(self.user):
+            pass
+
+        assert not self._is_suspended()
+        assert not self.redis_client.exists(self.holders_key)
+
+    def test_redis_failure_leaves_submissions_open(self):
+        with patch(REDIS_PATCH_TARGET, side_effect=ConnectionError):
+            with self.assertRaises(ConnectionError):
+                with suspend_submissions(self.user):
+                    pass
+
+        assert not UserProfile.objects.filter(
+            user=self.user, submissions_suspended=True
+        ).exists()
+
+    def _has_heartbeat(self):
+        return self.redis_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, 'holder')
+
+    def _is_suspended(self):
+        return UserProfile.objects.get(user=self.user).submissions_suspended

--- a/kobo/apps/openrosa/apps/logger/tests/test_update_attachment_storage_bytes.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_update_attachment_storage_bytes.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
-import fakeredis
 from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase
+from django_redis import get_redis_connection
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.constants import (
@@ -22,16 +22,14 @@ class UpdateAttachmentStorageBytesTestCase(TestCase, AssetSubmissionTestMixin):
     def setUp(self):
         self.user = User.objects.create(username='storageuser')
         self._create_test_asset_and_submission(user=self.user)
-        self.redis_client = fakeredis.FakeStrictRedis()
-        patcher = patch(
-            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
-            return_value=self.redis_client,
+        self.redis_client = get_redis_connection()
+        self.holders_key = (
+            f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{self.user.username}'
         )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def tearDown(self):
         settings.MONGO_DB.instances.delete_many({})
+        self.redis_client.delete(self.holders_key, f'{self.holders_key}:lock')
 
     def test_suspends_owner_while_counting_then_releases(self):
         captured = {}
@@ -58,6 +56,4 @@ class UpdateAttachmentStorageBytesTestCase(TestCase, AssetSubmissionTestMixin):
         assert profile.metadata['attachments_counting_status'] == 'complete'
         xform = Asset.objects.get(owner=self.user).deployment.xform
         assert profile.attachment_storage_bytes == xform.attachment_storage_bytes
-        assert not self.redis_client.exists(
-            f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{self.user.username}'
-        )
+        assert not self.redis_client.exists(self.holders_key)

--- a/kobo/apps/openrosa/apps/logger/tests/test_update_attachment_storage_bytes.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_update_attachment_storage_bytes.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+import fakeredis
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+
+from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.constants import (
+    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
+)
+from kobo.apps.openrosa.apps.logger.management.commands import (
+    update_attachment_storage_bytes,
+)
+from kobo.apps.openrosa.apps.main.models import UserProfile
+from kpi.models import Asset
+from kpi.tests.mixins.create_asset_and_submission_mixin import AssetSubmissionTestMixin
+
+
+class UpdateAttachmentStorageBytesTestCase(TestCase, AssetSubmissionTestMixin):
+
+    def setUp(self):
+        self.user = User.objects.create(username='storageuser')
+        self._create_test_asset_and_submission(user=self.user)
+        self.redis_client = fakeredis.FakeStrictRedis()
+        patcher = patch(
+            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
+            return_value=self.redis_client,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        settings.MONGO_DB.instances.delete_many({})
+
+    def test_suspends_owner_while_counting_then_releases(self):
+        captured = {}
+        original = update_attachment_storage_bytes.Command._update_user_profile
+
+        def spy(command, user):
+            captured['suspended'] = UserProfile.objects.get(
+                user=user
+            ).submissions_suspended
+            return original(command, user)
+
+        with patch.object(
+            update_attachment_storage_bytes.Command, '_update_user_profile', spy
+        ):
+            call_command(
+                'update_attachment_storage_bytes',
+                username=self.user.username,
+                verbosity=0,
+            )
+
+        assert captured['suspended'] is True
+        profile = UserProfile.objects.get(user=self.user)
+        assert profile.submissions_suspended is False
+        assert profile.metadata['attachments_counting_status'] == 'complete'
+        xform = Asset.objects.get(owner=self.user).deployment.xform
+        assert profile.attachment_storage_bytes == xform.attachment_storage_bytes
+        assert not self.redis_client.exists(
+            f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{self.user.username}'
+        )

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django_redis import get_redis_connection
-from redis.exceptions import RedisError
+from redis.exceptions import LockError, RedisError
 
 from kpi.utils.log import logging
 from ...main.models import UserProfile
@@ -12,6 +12,30 @@ from ..constants import (
     SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
     SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
 )
+
+
+def release_orphaned_suspensions() -> list[str]:
+    """
+    Release the profiles left suspended by holders which died before
+    releasing them, and return their usernames.
+    """
+    redis_client = get_redis_connection()
+    lease = settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
+    suspended = UserProfile.objects.filter(submissions_suspended=True).values_list(
+        'user__username', flat=True
+    )
+    orphaned = []
+    for username in list(suspended):
+        holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{username}'
+        with _mutex(redis_client, holders_key):
+            if _live_holders(redis_client, holders_key, lease):
+                continue
+            UserProfile.objects.filter(user__username=username).update(
+                submissions_suspended=False
+            )
+            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, username)
+        orphaned.append(username)
+    return orphaned
 
 
 @contextmanager
@@ -28,30 +52,27 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
 
     Concurrent holders (e.g. several projects of the same owner deleted at
     once) each register a token: only the last one to finish releases the
-    flag. Tokens older than the lease are treated as dead holders.
-
-    The flag and heartbeat are shared with `update_attachment_storage_bytes`,
-    which releases them unconditionally when it finishes.
+    flag. Tokens older than the lease are treated as dead holders, so a block
+    which may run longer than the lease must call the yielded `heartbeat()`
+    regularly.
     """
     redis_client = get_redis_connection()
     holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{user.username}'
     lease = settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
     token = uuid4().hex
 
+    def heartbeat():
+        _register_holder(redis_client, holders_key, token, lease, user.username)
+
     # Redis first: if it fails, nothing has been suspended yet
-    _register_holder(redis_client, holders_key, token, lease, user.username)
+    with _mutex(redis_client, holders_key):
+        heartbeat()
     try:
         UserProfile.objects.get_or_create(user_id=user.pk)
         _set_flag(user, True)
-        yield
+        yield heartbeat
     finally:
         _release_holder(redis_client, holders_key, token, lease, user)
-
-
-def _heartbeat(redis_client, username: str):
-    redis_client.hset(
-        SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: int(time.time())}
-    )
 
 
 def _live_holders(redis_client, holders_key: str, lease: int) -> int:
@@ -70,13 +91,35 @@ def _live_holders(redis_client, holders_key: str, lease: int) -> int:
     return redis_client.hlen(holders_key)
 
 
+@contextmanager
+def _mutex(redis_client, holders_key: str):
+    """
+    Serialize the registrations and releases of one user's holders, so a
+    release cannot clear the flag under a holder registering at the same time.
+    """
+    lock_key = f'{holders_key}:lock'
+    token = uuid4().hex
+    ttl = settings.SUBMISSIONS_SUSPENSION_LOCK_TTL
+    deadline = time.monotonic() + 3 * ttl
+    while not redis_client.set(lock_key, token, nx=True, ex=ttl):
+        if time.monotonic() >= deadline:
+            raise LockError(f'Could not acquire {lock_key}')
+        time.sleep(0.05)
+    try:
+        yield
+    finally:
+        # The lock may have expired and been taken over meanwhile
+        if redis_client.get(lock_key) == token.encode():
+            redis_client.delete(lock_key)
+
+
 def _register_holder(
     redis_client, holders_key: str, token: str, lease: int, username: str
 ):
     now = int(time.time())
     pipe = redis_client.pipeline()
     pipe.hset(holders_key, mapping={token: now})
-    # Backstop so a hash of dead tokens does not outlive its owner's deletions
+    # Backstop so a hash of dead tokens does not outlive its owner's holders
     pipe.expire(holders_key, lease)
     pipe.hset(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: now})
     pipe.execute()
@@ -97,26 +140,18 @@ def _release_holder(
     collect data until `fix_stale_submissions_suspended_flag` runs is not.
     """
     try:
-        redis_client.hdel(holders_key, token)
-        if _live_holders(redis_client, holders_key, lease):
-            return
+        with _mutex(redis_client, holders_key):
+            redis_client.hdel(holders_key, token)
+            if _live_holders(redis_client, holders_key, lease):
+                return
+            _set_flag(user, False)
+            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
     except RedisError:
         logging.error(
             f'Redis unavailable while releasing submissions of user'
             f' #{user.pk}, released unconditionally'
         )
         _set_flag(user, False)
-        return
-
-    _set_flag(user, False)
-    redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
-    # A holder registered between the check and the release above would be
-    # left unprotected. Its flag can still dip for the few round-trips before
-    # this restore: the deadlock it opens is the retryable one this suspension
-    # narrows, not a new failure
-    if redis_client.hlen(holders_key):
-        _set_flag(user, True)
-        _heartbeat(redis_client, user.username)
 
 
 def _set_flag(user: settings.AUTH_USER_MODEL, suspended: bool):

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -19,6 +19,9 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
     `TemporarilyUnavailableError` (clients retry later), and registers a
     heartbeat so `fix_stale_submissions_suspended_flag` only releases the
     flag if this process dies before the `finally` block runs.
+
+    The flag and heartbeat are shared with `update_attachment_storage_bytes`:
+    whichever holder finishes first releases the other one too.
     """
     UserProfile.objects.get_or_create(user_id=user.pk)
     UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=True)

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -1,0 +1,34 @@
+import time
+from contextlib import contextmanager
+
+from django.conf import settings
+from django_redis import get_redis_connection
+
+from ...main.models import UserProfile
+from ..constants import SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY
+
+
+@contextmanager
+def suspend_submissions(user: settings.AUTH_USER_MODEL):
+    """
+    Block incoming submissions for `user`'s forms while the wrapped block
+    runs.
+
+    Sets `UserProfile.submissions_suspended`, which makes
+    `Instance.check_active()` reject submissions with
+    `TemporarilyUnavailableError` (clients retry later), and registers a
+    heartbeat so `fix_stale_submissions_suspended_flag` only releases the
+    flag if this process dies before the `finally` block runs.
+    """
+    UserProfile.objects.get_or_create(user_id=user.pk)
+    UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=True)
+    redis_client = get_redis_connection()
+    redis_client.hset(
+        SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+        mapping={user.username: int(time.time())},
+    )
+    try:
+        yield
+    finally:
+        UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=False)
+        redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -8,7 +8,10 @@ from redis.exceptions import LockNotOwnedError, RedisError
 
 from kpi.utils.log import logging
 from ...main.models import UserProfile
-from ..constants import SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX
+from ..constants import (
+    LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
+)
 
 
 def release_orphaned_suspensions() -> list[str]:
@@ -25,7 +28,9 @@ def release_orphaned_suspensions() -> list[str]:
     for username in list(suspended):
         holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{username}'
         with _mutex(redis_client, holders_key):
-            if _live_holders(redis_client, holders_key, lease):
+            if _live_holders(redis_client, holders_key, lease) or _legacy_holder_alive(
+                redis_client, username, lease
+            ):
                 continue
             UserProfile.objects.filter(user__username=username).update(
                 submissions_suspended=False
@@ -59,15 +64,27 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
     def heartbeat():
         _register_holder(redis_client, holders_key, token, lease)
 
+    # Outside the `try`: a failed entry has nothing to release, and releasing
+    # anyway could clear the flag under a live holder
+    with _mutex(redis_client, holders_key):
+        heartbeat()
+        UserProfile.objects.get_or_create(user_id=user.pk)
+        _set_flag(user, True)
     try:
-        # Redis first: if it fails, nothing has been suspended yet
-        with _mutex(redis_client, holders_key):
-            heartbeat()
-            UserProfile.objects.get_or_create(user_id=user.pk)
-            _set_flag(user, True)
         yield heartbeat
     finally:
         _release_holder(redis_client, holders_key, token, lease, user)
+
+
+def _legacy_holder_alive(redis_client, username: str, lease: int) -> bool:
+    """
+    A worker running the previous `update_attachment_storage_bytes` (rolling
+    deployment) only records its suspension in the legacy heartbeat hash.
+    """
+    registered_at = redis_client.hget(
+        LEGACY_SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, username
+    )
+    return bool(registered_at) and int(registered_at) + lease > int(time.time())
 
 
 def _live_holders(redis_client, holders_key: str, lease: int) -> int:
@@ -137,7 +154,9 @@ def _release_holder(
     try:
         with _mutex(redis_client, holders_key):
             redis_client.hdel(holders_key, token)
-            if _live_holders(redis_client, holders_key, lease):
+            if _live_holders(redis_client, holders_key, lease) or _legacy_holder_alive(
+                redis_client, user.username, lease
+            ):
                 return
             _set_flag(user, False)
     except RedisError:

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -1,11 +1,15 @@
 import time
 from contextlib import contextmanager
+from uuid import uuid4
 
 from django.conf import settings
 from django_redis import get_redis_connection
 
 from ...main.models import UserProfile
-from ..constants import SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY
+from ..constants import (
+    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
+)
 
 
 @contextmanager
@@ -20,18 +24,71 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
     heartbeat so `fix_stale_submissions_suspended_flag` only releases the
     flag if this process dies before the `finally` block runs.
 
-    The flag and heartbeat are shared with `update_attachment_storage_bytes`:
-    whichever holder finishes first releases the other one too.
+    Concurrent holders (e.g. several projects of the same owner deleted at
+    once) each register a token: only the last one to finish releases the
+    flag. Tokens older than the lease are treated as dead holders.
+
+    The flag and heartbeat are shared with `update_attachment_storage_bytes`,
+    which releases them unconditionally when it finishes.
     """
-    UserProfile.objects.get_or_create(user_id=user.pk)
-    UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=True)
     redis_client = get_redis_connection()
-    redis_client.hset(
-        SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
-        mapping={user.username: int(time.time())},
-    )
+    holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{user.username}'
+    lease = settings.CELERY_LONG_RUNNING_TASK_SOFT_TIME_LIMIT
+    token = uuid4().hex
+
+    # Redis first: if it fails, nothing has been suspended yet
+    _register_holder(redis_client, holders_key, token, lease, user.username)
     try:
+        UserProfile.objects.get_or_create(user_id=user.pk)
+        UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=True)
         yield
     finally:
-        UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=False)
-        redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
+        redis_client.hdel(holders_key, token)
+        if not _live_holders(redis_client, holders_key, lease):
+            UserProfile.objects.filter(user_id=user.pk).update(
+                submissions_suspended=False
+            )
+            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
+            # A holder registered between the check and the release above
+            # would be left unprotected. Its flag can still dip for the few
+            # round-trips before this restore: the deadlock it opens is the
+            # retryable one this suspension narrows, not a new failure
+            if redis_client.hlen(holders_key):
+                UserProfile.objects.filter(user_id=user.pk).update(
+                    submissions_suspended=True
+                )
+                _heartbeat(redis_client, user.username)
+
+
+def _heartbeat(redis_client, username: str):
+    redis_client.hset(
+        SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: int(time.time())}
+    )
+
+
+def _live_holders(redis_client, holders_key: str, lease: int) -> int:
+    """
+    Prune tokens whose lease expired (their process died before releasing)
+    and return how many holders are still alive.
+    """
+    now = int(time.time())
+    dead = [
+        token
+        for token, registered_at in redis_client.hgetall(holders_key).items()
+        if int(registered_at) + lease <= now
+    ]
+    if dead:
+        redis_client.hdel(holders_key, *dead)
+    return redis_client.hlen(holders_key)
+
+
+def _register_holder(
+    redis_client, holders_key: str, token: str, lease: int, username: str
+):
+    now = int(time.time())
+    pipe = redis_client.pipeline()
+    pipe.hset(holders_key, mapping={token: now})
+    # Backstop so a hash of dead tokens does not outlive its owner's deletions
+    pipe.expire(holders_key, lease)
+    pipe.hset(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: now})
+    pipe.execute()

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -4,7 +4,9 @@ from uuid import uuid4
 
 from django.conf import settings
 from django_redis import get_redis_connection
+from redis.exceptions import RedisError
 
+from kpi.utils.log import logging
 from ...main.models import UserProfile
 from ..constants import (
     SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
@@ -40,24 +42,10 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
     _register_holder(redis_client, holders_key, token, lease, user.username)
     try:
         UserProfile.objects.get_or_create(user_id=user.pk)
-        UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=True)
+        _set_flag(user, True)
         yield
     finally:
-        redis_client.hdel(holders_key, token)
-        if not _live_holders(redis_client, holders_key, lease):
-            UserProfile.objects.filter(user_id=user.pk).update(
-                submissions_suspended=False
-            )
-            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
-            # A holder registered between the check and the release above
-            # would be left unprotected. Its flag can still dip for the few
-            # round-trips before this restore: the deadlock it opens is the
-            # retryable one this suspension narrows, not a new failure
-            if redis_client.hlen(holders_key):
-                UserProfile.objects.filter(user_id=user.pk).update(
-                    submissions_suspended=True
-                )
-                _heartbeat(redis_client, user.username)
+        _release_holder(redis_client, holders_key, token, lease, user)
 
 
 def _heartbeat(redis_client, username: str):
@@ -92,3 +80,44 @@ def _register_holder(
     pipe.expire(holders_key, lease)
     pipe.hset(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: now})
     pipe.execute()
+
+
+def _release_holder(
+    redis_client,
+    holders_key: str,
+    token: str,
+    lease: int,
+    user: settings.AUTH_USER_MODEL,
+):
+    """
+    Drop this holder's token and release the flag if no live holder remains.
+
+    Without Redis there is no way to tell whether another holder is alive, so
+    the flag is released anyway: a deadlock is retryable, an owner who cannot
+    collect data until `fix_stale_submissions_suspended_flag` runs is not.
+    """
+    try:
+        redis_client.hdel(holders_key, token)
+        if _live_holders(redis_client, holders_key, lease):
+            return
+    except RedisError:
+        logging.error(
+            f'Redis unavailable while releasing submissions of user'
+            f' #{user.pk}, released unconditionally'
+        )
+        _set_flag(user, False)
+        return
+
+    _set_flag(user, False)
+    redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
+    # A holder registered between the check and the release above would be
+    # left unprotected. Its flag can still dip for the few round-trips before
+    # this restore: the deadlock it opens is the retryable one this suspension
+    # narrows, not a new failure
+    if redis_client.hlen(holders_key):
+        _set_flag(user, True)
+        _heartbeat(redis_client, user.username)
+
+
+def _set_flag(user: settings.AUTH_USER_MODEL, suspended: bool):
+    UserProfile.objects.filter(user_id=user.pk).update(submissions_suspended=suspended)

--- a/kobo/apps/openrosa/apps/logger/utils/suspension.py
+++ b/kobo/apps/openrosa/apps/logger/utils/suspension.py
@@ -4,14 +4,11 @@ from uuid import uuid4
 
 from django.conf import settings
 from django_redis import get_redis_connection
-from redis.exceptions import LockError, RedisError
+from redis.exceptions import LockNotOwnedError, RedisError
 
 from kpi.utils.log import logging
 from ...main.models import UserProfile
-from ..constants import (
-    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
-    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
-)
+from ..constants import SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX
 
 
 def release_orphaned_suspensions() -> list[str]:
@@ -33,7 +30,6 @@ def release_orphaned_suspensions() -> list[str]:
             UserProfile.objects.filter(user__username=username).update(
                 submissions_suspended=False
             )
-            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, username)
         orphaned.append(username)
     return orphaned
 
@@ -46,15 +42,14 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
 
     Sets `UserProfile.submissions_suspended`, which makes
     `Instance.check_active()` reject submissions with
-    `TemporarilyUnavailableError` (clients retry later), and registers a
-    heartbeat so `fix_stale_submissions_suspended_flag` only releases the
-    flag if this process dies before the `finally` block runs.
+    `TemporarilyUnavailableError` (clients retry later).
 
     Concurrent holders (e.g. several projects of the same owner deleted at
     once) each register a token: only the last one to finish releases the
     flag. Tokens older than the lease are treated as dead holders, so a block
     which may run longer than the lease must call the yielded `heartbeat()`
-    regularly.
+    regularly. `release_orphaned_suspensions()` cleans up after holders which
+    died before releasing.
     """
     redis_client = get_redis_connection()
     holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{user.username}'
@@ -62,14 +57,14 @@ def suspend_submissions(user: settings.AUTH_USER_MODEL):
     token = uuid4().hex
 
     def heartbeat():
-        _register_holder(redis_client, holders_key, token, lease, user.username)
+        _register_holder(redis_client, holders_key, token, lease)
 
-    # Redis first: if it fails, nothing has been suspended yet
-    with _mutex(redis_client, holders_key):
-        heartbeat()
     try:
-        UserProfile.objects.get_or_create(user_id=user.pk)
-        _set_flag(user, True)
+        # Redis first: if it fails, nothing has been suspended yet
+        with _mutex(redis_client, holders_key):
+            heartbeat()
+            UserProfile.objects.get_or_create(user_id=user.pk)
+            _set_flag(user, True)
         yield heartbeat
     finally:
         _release_holder(redis_client, holders_key, token, lease, user)
@@ -96,32 +91,32 @@ def _mutex(redis_client, holders_key: str):
     """
     Serialize the registrations and releases of one user's holders, so a
     release cannot clear the flag under a holder registering at the same time.
+
+    Runs the block unlocked when the lock cannot be acquired in time: the race
+    it prevents is narrower than a deletion failing on its bookkeeping.
     """
-    lock_key = f'{holders_key}:lock'
-    token = uuid4().hex
     ttl = settings.SUBMISSIONS_SUSPENSION_LOCK_TTL
-    deadline = time.monotonic() + 3 * ttl
-    while not redis_client.set(lock_key, token, nx=True, ex=ttl):
-        if time.monotonic() >= deadline:
-            raise LockError(f'Could not acquire {lock_key}')
-        time.sleep(0.05)
+    lock = redis_client.lock(
+        f'{holders_key}:lock', timeout=ttl, sleep=0.05, blocking_timeout=3 * ttl
+    )
+    if not (acquired := lock.acquire()):
+        logging.error(f'Could not acquire {lock.name}, proceeding unlocked')
     try:
         yield
     finally:
-        # The lock may have expired and been taken over meanwhile
-        if redis_client.get(lock_key) == token.encode():
-            redis_client.delete(lock_key)
+        if acquired:
+            try:
+                lock.release()
+            except LockNotOwnedError:
+                # Expired and taken over meanwhile
+                pass
 
 
-def _register_holder(
-    redis_client, holders_key: str, token: str, lease: int, username: str
-):
-    now = int(time.time())
+def _register_holder(redis_client, holders_key: str, token: str, lease: int):
     pipe = redis_client.pipeline()
-    pipe.hset(holders_key, mapping={token: now})
+    pipe.hset(holders_key, mapping={token: int(time.time())})
     # Backstop so a hash of dead tokens does not outlive its owner's holders
     pipe.expire(holders_key, lease)
-    pipe.hset(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, mapping={username: now})
     pipe.execute()
 
 
@@ -137,7 +132,7 @@ def _release_holder(
 
     Without Redis there is no way to tell whether another holder is alive, so
     the flag is released anyway: a deadlock is retryable, an owner who cannot
-    collect data until `fix_stale_submissions_suspended_flag` runs is not.
+    collect data until `release_orphaned_suspensions()` runs is not.
     """
     try:
         with _mutex(redis_client, holders_key):
@@ -145,7 +140,6 @@ def _release_holder(
             if _live_holders(redis_client, holders_key, lease):
                 return
             _set_flag(user, False)
-            redis_client.hdel(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, user.username)
     except RedisError:
         logging.error(
             f'Redis unavailable while releasing submissions of user'

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+import fakeredis
 from constance import config
 from constance.test import override_config
 from ddt import data, ddt, unpack
@@ -20,9 +21,13 @@ from kobo.apps.audit_log.models import (
     ProjectHistoryLog,
 )
 from kobo.apps.kobo_auth.shortcuts import User
+from kobo.apps.openrosa.apps.logger.constants import (
+    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+)
 from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, XForm
 from kobo.apps.openrosa.apps.logger.models.attachment import AttachmentDeleteStatus
 from kobo.apps.openrosa.apps.logger.signals import pre_delete_attachment
+from kobo.apps.openrosa.apps.main.models import UserProfile
 from kpi.models import Asset
 from kpi.tests.mixins.create_asset_and_submission_mixin import AssetSubmissionTestMixin
 from ..constants import DELETE_PROJECT_STR_PREFIX, DELETE_USER_STR_PREFIX
@@ -487,6 +492,69 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
                 {'_userform_id': mongo_userform_id}
             )
             == 0
+        )
+
+    def test_owner_submissions_suspended_during_deletion(self):
+        project_trash = self.test_move_to_trash()
+        owner = project_trash.asset.owner
+        fake_client = fakeredis.FakeStrictRedis()
+        captured = {}
+
+        def capture_state(*args, **kwargs):
+            profile = UserProfile.objects.get(user=owner)
+            captured['suspended'] = profile.submissions_suspended
+            captured['heartbeat'] = bool(
+                fake_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username)
+            )
+
+        with patch(
+            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
+            return_value=fake_client,
+        ), patch(
+            'kobo.apps.trash_bin.utils.project._delete_submissions',
+            side_effect=capture_state,
+        ):
+            empty_project(project_trash.pk)
+
+        assert captured['suspended'] is True
+        assert captured['heartbeat'] is True
+
+    def test_owner_submissions_released_after_deletion(self):
+        project_trash = self.test_move_to_trash()
+        owner = project_trash.asset.owner
+        fake_client = fakeredis.FakeStrictRedis()
+
+        with patch(
+            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
+            return_value=fake_client,
+        ):
+            empty_project(project_trash.pk)
+
+        profile = UserProfile.objects.get(user=owner)
+        assert profile.submissions_suspended is False
+        assert not fake_client.hexists(
+            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username
+        )
+
+    def test_owner_submissions_released_when_deletion_fails(self):
+        project_trash = self.test_move_to_trash()
+        owner = project_trash.asset.owner
+        fake_client = fakeredis.FakeStrictRedis()
+
+        with patch(
+            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
+            return_value=fake_client,
+        ), patch(
+            'kobo.apps.trash_bin.utils.project._delete_submissions',
+            side_effect=RuntimeError('boom'),
+        ):
+            with self.assertRaises(RuntimeError):
+                empty_project(project_trash.pk)
+
+        profile = UserProfile.objects.get(user=owner)
+        assert profile.submissions_suspended is False
+        assert not fake_client.hexists(
+            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username
         )
 
     def test_garbage_collector_cleans_orphaned_periodic_task_after_deletion(self):

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-import fakeredis
 from constance import config
 from constance.test import override_config
 from ddt import data, ddt, unpack
@@ -12,6 +11,7 @@ from django.db.models.signals import pre_delete
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django_celery_beat.models import PeriodicTask
+from django_redis import get_redis_connection
 from freezegun import freeze_time
 
 from kobo.apps.audit_log.models import (
@@ -22,7 +22,7 @@ from kobo.apps.audit_log.models import (
 )
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.constants import (
-    SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY,
+    SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX,
 )
 from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, XForm
 from kobo.apps.openrosa.apps.logger.models.attachment import AttachmentDeleteStatus
@@ -502,54 +502,40 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
     def test_owner_submissions_suspended_during_deletion(self):
         project_trash = self.test_move_to_trash()
         owner = project_trash.asset.owner
-        fake_client = fakeredis.FakeStrictRedis()
+        holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{owner.username}'
         captured = {}
 
         def capture_state(*args, **kwargs):
             profile = UserProfile.objects.get(user=owner)
             captured['suspended'] = profile.submissions_suspended
-            captured['heartbeat'] = bool(
-                fake_client.hexists(SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username)
-            )
+            captured['holders'] = get_redis_connection().hlen(holders_key)
 
         with patch(
-            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
-            return_value=fake_client,
-        ), patch(
             'kobo.apps.trash_bin.utils.project._delete_submissions',
             side_effect=capture_state,
         ):
             empty_project(project_trash.pk)
 
         assert captured['suspended'] is True
-        assert captured['heartbeat'] is True
+        assert captured['holders'] == 1
 
     def test_owner_submissions_released_after_deletion(self):
         project_trash = self.test_move_to_trash()
         owner = project_trash.asset.owner
-        fake_client = fakeredis.FakeStrictRedis()
+        holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{owner.username}'
 
-        with patch(
-            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
-            return_value=fake_client,
-        ):
-            empty_project(project_trash.pk)
+        empty_project(project_trash.pk)
 
         profile = UserProfile.objects.get(user=owner)
         assert profile.submissions_suspended is False
-        assert not fake_client.hexists(
-            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username
-        )
+        assert not get_redis_connection().exists(holders_key)
 
     def test_owner_submissions_released_when_deletion_fails(self):
         project_trash = self.test_move_to_trash()
         owner = project_trash.asset.owner
-        fake_client = fakeredis.FakeStrictRedis()
+        holders_key = f'{SUBMISSIONS_SUSPENDED_HOLDERS_KEY_PREFIX}{owner.username}'
 
         with patch(
-            'kobo.apps.openrosa.apps.logger.utils.suspension.get_redis_connection',
-            return_value=fake_client,
-        ), patch(
             'kobo.apps.trash_bin.utils.project._delete_submissions',
             side_effect=RuntimeError('boom'),
         ):
@@ -558,9 +544,7 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
 
         profile = UserProfile.objects.get(user=owner)
         assert profile.submissions_suspended is False
-        assert not fake_client.hexists(
-            SUBMISSIONS_SUSPENDED_HEARTBEAT_KEY, owner.username
-        )
+        assert not get_redis_connection().exists(holders_key)
 
     def test_garbage_collector_cleans_orphaned_periodic_task_after_deletion(self):
         """

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -370,6 +370,11 @@ class ProjectTrashTestCase(TestCase, AssetSubmissionTestMixin):
 
     fixtures = ['test_data']
 
+    def tearDown(self):
+        # Postgres is rolled back between tests, MongoDB is not: leftover
+        # documents make the next real deletion fail on unknown submission ids
+        settings.MONGO_DB.instances.delete_many({})
+
     def test_move_to_trash(self):
         asset = Asset.objects.get(pk=1)
         asset.save()  # create a version

--- a/kobo/apps/trash_bin/utils/project.py
+++ b/kobo/apps/trash_bin/utils/project.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db import transaction
@@ -24,8 +26,8 @@ def delete_asset(request_author: settings.AUTH_USER_MODEL, asset: Asset):
     project_exports = []
 
     if asset.has_deployment:
-        with suspend_submissions(asset.owner):
-            _delete_submissions(request_author, asset)
+        with suspend_submissions(asset.owner) as heartbeat:
+            _delete_submissions(request_author, asset, heartbeat)
             asset.deployment.delete()
         project_exports = SubmissionExportTask.objects.filter(
             Q(data__source=f'{host}/api/v2/assets/{asset.uid}/')
@@ -61,7 +63,11 @@ def delete_asset(request_author: settings.AUTH_USER_MODEL, asset: Asset):
         rmdir(f'{owner_username}/asset_files/{asset_uid}', default_storage)
 
 
-def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: 'kpi.Asset'):
+def _delete_submissions(
+    request_author: settings.AUTH_USER_MODEL,
+    asset: 'kpi.Asset',
+    heartbeat: Callable[[], None],
+):
 
     # Test if XForm is still valid
     try:
@@ -102,6 +108,8 @@ def _delete_submissions(request_author: settings.AUTH_USER_MODEL, asset: 'kpi.As
         # ^^^ End of dead code ^^^
 
     while True:
+        # Keep the owner's submissions suspended for as long as this loop runs
+        heartbeat()
         audit_logs = []
         submissions = list(
             asset.deployment.get_submissions(

--- a/kobo/apps/trash_bin/utils/project.py
+++ b/kobo/apps/trash_bin/utils/project.py
@@ -7,6 +7,7 @@ from django.db.models import F, Q
 
 from kobo.apps.audit_log.audit_actions import AuditAction
 from kobo.apps.audit_log.models import AuditLog, AuditType
+from kobo.apps.openrosa.apps.logger.utils.suspension import suspend_submissions
 from kpi.exceptions import InvalidXFormException, MissingXFormException
 from kpi.models import Asset, ImportTask, SubmissionExportTask
 from kpi.utils.log import logging
@@ -23,8 +24,9 @@ def delete_asset(request_author: settings.AUTH_USER_MODEL, asset: Asset):
     project_exports = []
 
     if asset.has_deployment:
-        _delete_submissions(request_author, asset)
-        asset.deployment.delete()
+        with suspend_submissions(asset.owner):
+            _delete_submissions(request_author, asset)
+            asset.deployment.delete()
         project_exports = SubmissionExportTask.objects.filter(
             Q(data__source=f'{host}/api/v2/assets/{asset.uid}/')
             | Q(data__source=f'{host}/assets/{asset.uid}/')

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1699,7 +1699,8 @@ CELERY_BEAT_SCHEDULE = {
         ),
         'schedule': crontab(minute='*/15', hour='2-5', day_of_week=0),
         'description': (
-            'Unlock accounts locked by `sync_storage_counters` task'
+            'Unlock accounts left suspended by a storage recount or a trash bin'
+            ' deletion which died'
         ),
         'options': {'queue': 'kpi_long_running_tasks_queue'},
     },
@@ -2440,6 +2441,8 @@ TRASH_BIN_MAX_AUTO_RESTARTS = env.int('TRASH_BIN_MAX_AUTO_RESTARTS', 10)
 # How long a trash bin object stays locked while it is being deleted. Must be
 # greater than or equal to the Celery hard time limit of the task
 TRASH_BIN_DELETION_LOCK_TTL = CELERY_LONG_RUNNING_TASK_TIME_LIMIT + 60 * 5
+# Serializes the bookkeeping of `suspend_submissions()`, a few Redis round-trips
+SUBMISSIONS_SUSPENSION_LOCK_TTL = 10  # seconds
 
 # Number of transfer log records rendered inline on a transfer admin page
 PROJECT_OWNERSHIP_MAX_DISPLAYED_LOGS = 100


### PR DESCRIPTION
### 📣 Summary

Permanently deleting a project or an account no longer fails when that account keeps receiving submissions while the deletion runs.

### 📖 Description

While a project is being permanently deleted, incoming submissions for all projects of that project's owner are paused. Data collection apps get the usual "temporarily unavailable" answer and retry on their own, so no data is lost. The pause is lifted as soon as the deletion ends, whether it succeeded or not. Until now a submission arriving in the middle of a deletion could make the deletion fail and get rescheduled.

### 💭 Notes

- Root cause: the trash task decrements the owner's counters (profile submission count, monthly catch-all counters at XForm `pre_delete`) while live submissions increment the same rows, and Postgres picks the deletion as the deadlock victim. DEV-2511 made that failure retryable, this removes the contention.
- Reuses `UserProfile.submissions_suspended`, enforced in `Instance.check_active()`. Every deletion of the same owner registers a token with a timestamp in a per-user redis hash and only the last live holder releases the flag. Tokens older than the lease (the task soft time limit) count as dead holders, and long loops refresh their token through the yielded `heartbeat()`: `_delete_submissions()` per batch, the storage recount per form.
- Bookkeeping runs under `redis_client.lock()` (`SUBMISSIONS_SUSPENSION_LOCK_TTL`), like the other locks in the repo. If the lock cannot be acquired in time the block runs unlocked and logs an error; if redis is down on entry nothing is suspended, and on exit the flag is released anyway, since a retryable deadlock costs less than an owner locked out of data collection.
- `update_attachment_storage_bytes` is a holder too, so the weekly recount can no longer unlock a running deletion. `fix_stale_submissions_suspended_flag` now calls `release_orphaned_suspensions()`, which frees only profiles with no live holder. That made the old heartbeat hash dead code, so nothing writes it any more. It is still read, so a recount worker on the previous release keeps its lock during a rolling deployment; the read and its key carry a TODO to remove them in the next release. `populate_submission_counters` still releases everything at startup, it is a one-off command.
- Only the deployed branch of `delete_asset()` is wrapped: account deletion is covered per project, drafts and blocks skip it, attachment trash does not touch these counters.
- The deadlock itself needs racing transactions and was not reproduced locally. The mechanism was: with the fix, a submission probe for the owner's other form during `_delete_submissions()` raises `TemporarilyUnavailableError`, without it the probe passes.
- `ProjectTrashTestCase` got a Mongo `tearDown`. Postgres is rolled back between tests, Mongo is not, and the new test that runs a real deletion tripped on a document left behind by `test_move_to_trash`.

### 👀 Preview steps

Back end only, nothing changes in the UI.

1. ℹ️ have the local stack running
2. In the kpi container run the new tests:
   ```
   pytest kobo/apps/trash_bin/tests/test_utils.py -k owner_submissions
   ```
3. 🟢 [on PR] `3 passed`
4. 🔴 [on main] the wiring does not exist there. To see the failure mode, put main's `kobo/apps/trash_bin/utils/project.py` on the branch and rerun step 2: `test_owner_submissions_suspended_during_deletion` fails with `assert False is True`, meaning submissions were still accepted while the project was being deleted. Restore the file afterwards.
5. Live check, optional: while an `empty_project` task runs for your user, `UserProfile.objects.get(user__username='<you>').submissions_suspended` is `True` and a Collect or Enketo submission to any of your forms gets the temporary-unavailable response until the task ends.
