### PR TITLE
fix(trashBin): record a real error when a trash deletion fails without one DEV-2512

### DIFF
--- a/kobo/apps/long_running_migrations/jobs/0032_restart_empty_error_trash_failures.py
+++ b/kobo/apps/long_running_migrations/jobs/0032_restart_empty_error_trash_failures.py
@@ -35,9 +35,12 @@ def run():
             if not batch:
                 break
 
-            # `date_modified` is deliberately left untouched: these objects have
-            # not been updated for a while, which is what makes `task_restarter`
-            # treat them as stuck and restart them
-            model.objects.filter(pk__in=batch).update(status=TrashStatus.IN_PROGRESS)
-            released += len(batch)
+            # The predicates are reapplied so that a row restarted by a superuser
+            # in the meantime, which may have failed again with a real error by
+            # now, keeps its newer state. `date_modified` is deliberately left
+            # untouched: these objects have not been updated for a while, which
+            # is what makes `task_restarter` treat them as stuck and restart them
+            released += model.objects.filter(
+                empty_errors, pk__in=batch, status=TrashStatus.FAILED
+            ).update(status=TrashStatus.IN_PROGRESS)
             logging.info(f'[LRM 0032] released {released} {model.__name__} objects')

--- a/kobo/apps/long_running_migrations/jobs/0032_restart_empty_error_trash_failures.py
+++ b/kobo/apps/long_running_migrations/jobs/0032_restart_empty_error_trash_failures.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.db.models import Q
+
+from kobo.apps.trash_bin.models import TrashStatus
+from kobo.apps.trash_bin.models.account import AccountTrash
+from kobo.apps.trash_bin.models.attachment import AttachmentTrash
+from kobo.apps.trash_bin.models.project import ProjectTrash
+from kpi.utils.log import logging
+
+CHUNK_SIZE = settings.LONG_RUNNING_MIGRATION_BATCH_SIZE
+
+
+def run():
+    """
+    Restart the trash bin objects which failed before the error message was
+    reliably recorded.
+
+    Argless exceptions stringify to '', so these objects were flagged as
+    `FAILED` with an empty `failure_error` and matched no transient pattern,
+    which meant nothing ever restarted them. Putting them back in progress is
+    enough for `task_restarter` to pick them up, since they have not been
+    updated for a long time and therefore look stuck. Any new failure now
+    records a real message
+    """
+    empty_errors = Q(metadata__failure_error='') | ~Q(metadata__has_key='failure_error')
+
+    for model in (AccountTrash, ProjectTrash, AttachmentTrash):
+        released = 0
+        while True:
+            batch = list(
+                model.objects.filter(
+                    empty_errors, status=TrashStatus.FAILED
+                ).values_list('pk', flat=True)[:CHUNK_SIZE]
+            )
+            if not batch:
+                break
+
+            # `date_modified` is deliberately left untouched: these objects have
+            # not been updated for a while, which is what makes `task_restarter`
+            # treat them as stuck and restart them
+            model.objects.filter(pk__in=batch).update(status=TrashStatus.IN_PROGRESS)
+            released += len(batch)
+            logging.info(f'[LRM 0032] released {released} {model.__name__} objects')

--- a/kobo/apps/long_running_migrations/migrations/0032_restart_empty_error_trash_failures.py
+++ b/kobo/apps/long_running_migrations/migrations/0032_restart_empty_error_trash_failures.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def add_long_running_migration(apps, schema_editor):
+    LongRunningMigration = apps.get_model(
+        'long_running_migrations', 'LongRunningMigration'
+    )
+    LongRunningMigration.objects.get_or_create(
+        name='0032_restart_empty_error_trash_failures',
+    )
+
+
+def noop(*args, **kwargs):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('long_running_migrations', '0031_restart_transient_trash_failures'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_long_running_migration, noop),
+    ]

--- a/kobo/apps/long_running_migrations/tests/test_0032_restart_empty_error_trash_failures.py
+++ b/kobo/apps/long_running_migrations/tests/test_0032_restart_empty_error_trash_failures.py
@@ -1,0 +1,87 @@
+import importlib
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from kobo.apps.trash_bin.models import TrashStatus
+from kobo.apps.trash_bin.models.account import AccountTrash
+from kobo.apps.trash_bin.models.project import ProjectTrash
+from kobo.apps.trash_bin.utils import move_to_trash
+
+job_0032 = importlib.import_module(
+    'kobo.apps.long_running_migrations.jobs.0032_restart_empty_error_trash_failures'
+)
+
+
+class RestartEmptyErrorTrashFailuresTestCase(TestCase):
+    """
+    The job must restart FAILED trash objects that carry no error (empty or
+    missing `failure_error`) and leave every other failure untouched
+    """
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.admin = get_user_model().objects.get(username='adminuser')
+        self.someuser = get_user_model().objects.get(username='someuser')
+        self.anotheruser = get_user_model().objects.get(username='anotheruser')
+
+    def test_run_restarts_only_objects_without_an_error(self):
+        # Row 1: FAILED with an empty error -> restarted
+        empty_error = self._move_account_to_trash(self.someuser)
+        stale = timezone.now() - timedelta(days=30)
+        AccountTrash.objects.filter(pk=empty_error.pk).update(
+            status=TrashStatus.FAILED,
+            metadata={'failure_error': ''},
+            date_modified=stale,
+        )
+
+        # Row 2: FAILED with no `failure_error` key at all -> restarted
+        missing_error = self._move_account_to_trash(self.anotheruser)
+        AccountTrash.objects.filter(pk=missing_error.pk).update(
+            status=TrashStatus.FAILED, metadata={}
+        )
+
+        # Row 3: FAILED with a real error -> left untouched
+        real_error = self._move_asset_to_trash(self.someuser)
+        ProjectTrash.objects.filter(pk=real_error.pk).update(
+            status=TrashStatus.FAILED,
+            metadata={'failure_error': 'deadlock detected'},
+        )
+
+        job_0032.run()
+
+        empty_error.refresh_from_db()
+        missing_error.refresh_from_db()
+        real_error.refresh_from_db()
+
+        assert empty_error.status == TrashStatus.IN_PROGRESS
+        assert missing_error.status == TrashStatus.IN_PROGRESS
+        assert real_error.status == TrashStatus.FAILED
+
+        # `date_modified` must stay stale, otherwise `task_restarter` would not
+        # treat the restarted object as stuck
+        assert empty_error.date_modified == stale
+
+    def _move_account_to_trash(self, user):
+        move_to_trash(
+            request_author=self.admin,
+            objects_list=[{'pk': user.pk, 'username': user.username}],
+            grace_period=1,
+            trash_type='user',
+        )
+        return AccountTrash.objects.get(user=user)
+
+    def _move_asset_to_trash(self, user):
+        asset = user.assets.first()
+        move_to_trash(
+            request_author=user,
+            objects_list=[
+                {'pk': asset.pk, 'asset_uid': asset.uid, 'asset_name': asset.name}
+            ],
+            grace_period=1,
+            trash_type='asset',
+        )
+        return ProjectTrash.objects.get(asset=asset)

--- a/kobo/apps/trash_bin/tests/test_utils.py
+++ b/kobo/apps/trash_bin/tests/test_utils.py
@@ -28,9 +28,11 @@ from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, XForm
 from kobo.apps.openrosa.apps.logger.models.attachment import AttachmentDeleteStatus
 from kobo.apps.openrosa.apps.logger.signals import pre_delete_attachment
 from kobo.apps.openrosa.apps.main.models import UserProfile
+from kpi.exceptions import MissingXFormException
 from kpi.models import Asset
 from kpi.tests.mixins.create_asset_and_submission_mixin import AssetSubmissionTestMixin
 from ..constants import DELETE_PROJECT_STR_PREFIX, DELETE_USER_STR_PREFIX
+from ..exceptions import TrashTaskInProgressError
 from ..models import TrashStatus
 from ..models.account import AccountTrash
 from ..models.attachment import AttachmentTrash
@@ -47,6 +49,7 @@ from ..utils import (
     process_deletion,
     put_back,
     trash_bin_task_failure,
+    trash_bin_task_retry,
 )
 
 
@@ -1267,6 +1270,48 @@ class TaskRestarterTestCase(TestCase):
         self._fail(account_trash, 'deadlock detected')
 
         assert self._run_restarter() == 1
+
+    def test_failure_error_is_never_empty(self):
+        """
+        Argless exceptions stringify to '', which stranded FAILED objects with
+        no error and matched no transient pattern. `failure_error` must always
+        record something
+        """
+        account_trash = self._move_account_to_trash()
+
+        trash_bin_task_failure(
+            AccountTrash,
+            args=[account_trash.pk],
+            exception=TrashTaskInProgressError(),
+        )
+        account_trash.refresh_from_db()
+        assert account_trash.status == TrashStatus.FAILED
+        assert account_trash.metadata['failure_error'] == 'TrashTaskInProgressError()'
+
+        trash_bin_task_failure(
+            AccountTrash,
+            args=[account_trash.pk],
+            exception=MissingXFormException(),
+        )
+        account_trash.refresh_from_db()
+        assert account_trash.metadata['failure_error']
+        assert account_trash.metadata['failure_error'] == str(MissingXFormException())
+
+    def test_retry_error_is_never_empty(self):
+        """
+        The retry path suffers the same argless-exception bug and must also
+        record a real error
+        """
+        account_trash = self._move_account_to_trash()
+
+        trash_bin_task_retry(
+            AccountTrash,
+            request={'args': [account_trash.pk]},
+            reason=TrashTaskInProgressError(),
+        )
+        account_trash.refresh_from_db()
+        assert account_trash.status == TrashStatus.RETRY
+        assert account_trash.metadata['failure_error'] == 'TrashTaskInProgressError()'
 
     def _fail(self, account_trash, error):
         """

--- a/kobo/apps/trash_bin/utils/trash.py
+++ b/kobo/apps/trash_bin/utils/trash.py
@@ -322,7 +322,7 @@ def trash_bin_task_failure(model: TrashBinModel, **kwargs):
     with transaction.atomic():
         obj_trash = model.objects.select_for_update().get(pk=obj_trash_id)
 
-        error = str(exception)
+        error = _format_failure_error(exception)
         obj_trash.metadata['failure_error'] = error
 
         # Transient failures (OOM kill, MongoDB unreachable, deadlock, Celery
@@ -342,10 +342,10 @@ def trash_bin_task_failure(model: TrashBinModel, **kwargs):
 
 def trash_bin_task_retry(model: TrashBinModel, **kwargs):
     obj_trash_id = kwargs['request'].get('args')[0]
-    exception = str(kwargs['reason'])
     with transaction.atomic():
         obj_trash = model.objects.select_for_update().get(pk=obj_trash_id)
-        obj_trash.metadata['failure_error'] = str(exception)
+        error = _format_failure_error(kwargs['reason'])
+        obj_trash.metadata['failure_error'] = error
         obj_trash.status = TrashStatus.RETRY
         obj_trash.save(update_fields=['status', 'metadata', 'date_modified'])
 
@@ -383,6 +383,14 @@ def _build_log_entries(obj_dicts, request_author, related_model, trash_type):
         AuditLog.objects.bulk_create(audit_logs)
     if project_history_logs:
         ProjectHistoryLog.objects.bulk_create(project_history_logs)
+
+
+def _format_failure_error(exception: Exception | str) -> str:
+    """
+    Argless exceptions (e.g. a bare `TrashTaskInProgressError`) stringify to
+    an empty string; fall back to `repr()` so `failure_error` is never empty
+    """
+    return str(exception) or repr(exception)
 
 
 def _get_settings(trash_type: str, retain_placeholder: bool = True) -> tuple:

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -195,7 +195,10 @@ class MailerConnectionSessionLimitError(MailerError):
 
 
 class MissingXFormException(Exception):
-    pass
+    def __init__(
+        self, message=t('Deployment links to a KoboCAT XForm that no longer exists')
+    ):
+        super().__init__(message)
 
 
 class NotSupportedFormatException(Exception):

--- a/kpi/exceptions.py
+++ b/kpi/exceptions.py
@@ -195,8 +195,9 @@ class MailerConnectionSessionLimitError(MailerError):
 
 
 class MissingXFormException(Exception):
+    # Not translated on purpose: only stored as an ops diagnostic and grepped
     def __init__(
-        self, message=t('Deployment links to a KoboCAT XForm that no longer exists')
+        self, message='Deployment links to a KoboCAT XForm that no longer exists'
     ):
         super().__init__(message)
 


### PR DESCRIPTION
### 📣 Summary
Deletions from the trash bin that fail now always say why, and the ones that failed silently in the past get one more automatic try.

### 📖 Description
Some projects, accounts and attachments failed to be deleted from the trash bin with a blank error. Superusers could see they had failed, but not why, and nothing retried them. Every failure now records a message, and the deletions that failed with a blank one are put back in the queue so they run again at the usual pace.

### 💭 Notes
- Root cause: `str()` of an exception raised without arguments is `''`. The main producer is `MissingXFormException`, raised bare by the deployment backend and re-raised on purpose in `_delete_submissions()`: a first deletion attempt dies after the XForm is gone but before the asset is, then every later attempt fails at that same spot with a blank message. A bare `TrashTaskInProgressError` does the same on the retry path.
- Fix: `trash_bin_task_failure()` and `trash_bin_task_retry()` fall back to `repr()` when `str()` is empty, and `MissingXFormException` gets a default message like its sibling `InvalidXFormException`.
- LRM `0032` flips `FAILED` rows with an empty or missing `failure_error` back to `IN_PROGRESS`, same shape as `0031` from DEV-2511. `task_restarter` then re-runs them at most `MAX_RESTARTED_TASKS` per run, so the queue cannot be flooded. Rows stuck on the missing-XForm case will fail again, but this time with a readable message, so we can decide what to do with them from real data.

### 👀 Preview steps
1. ℹ️ have a superuser and a project
2. In the Django shell, move the project to trash, then call `trash_bin_task_failure(ProjectTrash, args=[pt.pk], exception=MissingXFormException())`, which is what Celery does when `empty_project` dies on a missing XForm
3. 🔴 [on main] the trash object is `failed` and `metadata['failure_error']` is `''`, and nothing ever restarts it
4. 🟢 [on PR] `failure_error` reads `Deployment links to a KoboCAT XForm that no longer exists`
5. 🟢 [on PR] set a trash row to `failed` with an empty `failure_error` and run job `0032`: the row is back to `in_progress`, while a row with a real error stays `failed`

<details>
<summary>Shell snippet for steps 2 to 4 (rolls everything back)</summary>

```python
from django.contrib.auth import get_user_model
from django.db import transaction
from kobo.apps.trash_bin.models.project import ProjectTrash
from kobo.apps.trash_bin.utils.trash import move_to_trash, trash_bin_task_failure
from kpi.exceptions import MissingXFormException
from kpi.models import Asset

owner = get_user_model().objects.filter(is_superuser=True).first()
try:
    with transaction.atomic():
        asset = Asset.objects.create(owner=owner, name='DEV-2512', asset_type='survey')
        move_to_trash(owner, [{'pk': asset.pk, 'asset_uid': asset.uid, 'asset_name': asset.name}], 1, 'asset')
        pt = ProjectTrash.objects.get(asset=asset)
        trash_bin_task_failure(ProjectTrash, args=[pt.pk], exception=MissingXFormException())
        pt.refresh_from_db()
        print(pt.status, repr(pt.metadata.get('failure_error')))
        raise RuntimeError('rollback')
except RuntimeError:
    pass
```
</details>
