### PR TITLE
fix(sso): fix label in constance

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -221,7 +221,7 @@ CONSTANCE_CONFIG = {
         '',
         'List of email domains configured across all managed SocialApps. '
         'Note: these domains are managed per-app through the email_domains field in '
-        'Admin > SocialApp.',
+        'Account Extras > Social app custom datas.',
         'disabled_textarea',
     ),
     'SHOW_KOBOTOOLBOX_LOGO': (


### PR DESCRIPTION
### 🗒️ Checklist

1. [ ] run linter locally
2. [ ] update developer docs (API, README, inline, etc.), if any
3. [ ] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [ ] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [ ] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [ ] fill in the template below and delete template comments
7. [ ] review thyself: read the diff and repro the preview as written
8. [ ] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Corrects a label in Constance, pointing users to the correct place to edit managed domains.
