### PR TITLE
feat(organizations): make sso column available to all DEV-2813

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.stories.tsx
+++ b/jsapp/js/account/organization/MembersRoute.stories.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { toast } from 'react-hot-toast'
 import { expect, userEvent, waitFor, within } from 'storybook/test'
 import organizationMock from '#/endpoints/organization.mocks'
-import organizationMembersMock from '#/endpoints/organizationMembers.mocks'
+import organizationMembersMock, { buildMember } from '#/endpoints/organizationMembers.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
 import { RequireOrg } from '#/router/RequireOrg'
 import ToasterConfig from '#/toasterConfig'
@@ -17,6 +17,20 @@ import MembersRoute, { TOO_SHORT_WARNING } from './MembersRoute'
 const helpBubbleMock = http.get('*/help/in_app_messages{/}?', () =>
   HttpResponse.json({ count: 0, next: null, previous: null, results: [] }),
 )
+
+/**
+ * Returns the cell of `username`'s row that sits under the `columnLabel` header. Both security columns render an
+ * icon-only badge, so there is no text to search for - the column has to be found by position.
+ */
+function cellUnderColumn(canvas: ReturnType<typeof within>, username: string, columnLabel: string) {
+  const columnIndex = canvas
+    .getAllByRole('columnheader')
+    .findIndex((header: HTMLElement) => header.textContent?.trim() === columnLabel)
+  expect(columnIndex).toBeGreaterThan(-1)
+
+  const row = canvas.getByText(username).closest('tr')
+  return row!.children[columnIndex]
+}
 
 /** Types into the search box and waits for the debounce to commit. */
 async function search(canvas: ReturnType<typeof within>, phrase: string) {
@@ -67,6 +81,33 @@ export const Default: Story = {
     await canvas.findByText('alice')
     expect(canvas.getByText('bob')).toBeInTheDocument()
     expect(canvas.getByRole('textbox', { name: /search members/i })).toHaveAttribute('placeholder', 'Search members')
+  },
+}
+
+/**
+ * The SSO column belongs to every team, including one on a server with no SSO provider configured - which is the case
+ * here, as the global `/environment` mock ships an empty `social_apps`. Members who have connected an SSO account get
+ * the active badge anyway, everyone else reads as inactive.
+ */
+export const SsoColumnWithoutSsoProvider: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        organizationMock(),
+        organizationMembersMock([
+          buildMember('alice', 'Alice Alvarez', { user__has_sso_enabled: true }),
+          buildMember('bob', 'Bob Brown', { user__has_sso_enabled: false }),
+        ]),
+        helpBubbleMock,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText('alice')
+
+    expect(cellUnderColumn(canvas, 'alice', 'SSO').querySelector('.k-icon-check')).toBeInTheDocument()
+    expect(cellUnderColumn(canvas, 'bob', 'SSO').querySelector('.k-icon-minus')).toBeInTheDocument()
   },
 }
 

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Group, Stack, Text, Title, Tooltip } from '@mantine/core'
+import { Box, Divider, Group, Stack, Text, Title } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { IconSearch } from '@tabler/icons-react'
 import { keepPreviousData } from '@tanstack/react-query'
@@ -7,7 +7,6 @@ import React, { useState } from 'react'
 import UniversalTable, { DEFAULT_PAGE_SIZE, type UniversalTableColumn } from '#/UniversalTable'
 import InviteModal from '#/account/organization/InviteModal'
 import { getSimpleMMOLabel } from '#/account/organization/organization.utils'
-import { isSsoAvailable } from '#/account/security/sso/sso.utils'
 import subscriptionStore from '#/account/subscriptionStore'
 import type { ErrorDetail } from '#/api/models/errorDetail'
 import { InviteStatusChoicesEnum } from '#/api/models/inviteStatusChoicesEnum'
@@ -263,26 +262,18 @@ function MembersRoute() {
         return member ? renderStatusBadge(member.user__has_mfa_enabled) : undefined
       },
     },
-  ]
-
-  // The SSO column is always shown, but is inert until the organization has the SSO add-on.
-  const isSsoColumnDisabled = !isSsoAvailable(envStore.data)
-  columns.push({
-    key: 'user__has_sso_enabled',
-    label: (
-      <Tooltip label={isSsoColumnDisabled ? t('Activate SSO add-on to enable') : t('SSO status')}>
-        <span className={isSsoColumnDisabled ? styles.disabledColumnHeader : undefined}>{t('SSO')}</span>
-      </Tooltip>
-    ),
-    size: 90,
-    cellFormatter: (obj: MemberListResponse) => {
-      if (isSsoColumnDisabled) {
-        return undefined
-      }
-      const { member } = getMemberOrInviteDetails(obj)
-      return member ? renderStatusBadge(member.user__has_sso_enabled) : undefined
+    {
+      // Every team gets this column, whether or not it has the SSO add-on. Without the add-on nobody can have an SSO
+      // account, so it simply reads as inactive for everyone.
+      key: 'user__has_sso_enabled',
+      label: t('SSO'),
+      size: 90,
+      cellFormatter: (obj: MemberListResponse) => {
+        const { member } = getMemberOrInviteDetails(obj)
+        return member ? renderStatusBadge(member.user__has_sso_enabled) : undefined
+      },
     },
-  })
+  ]
 
   // Actions column is only for owner and admins.
   if (isUserAdminOrOwner) {
@@ -393,5 +384,5 @@ function MembersRoute() {
   )
 }
 
-// `observer` so the SSO column appears as soon as `envStore` is ready.
+// `observer` so the team/organization label picks up `envStore` and `subscriptionStore` as soon as they are ready.
 export default observer(MembersRoute)

--- a/jsapp/js/account/organization/membersRoute.module.scss
+++ b/jsapp/js/account/organization/membersRoute.module.scss
@@ -11,12 +11,6 @@
   margin-bottom: 20px;
 }
 
-// Header of a column whose feature the organization hasn't activated yet. The
-// tooltip on it explains how to enable it.
-.disabledColumnHeader {
-  color: colors.$kobo-gray-500;
-}
-
 h2.headerText {
   color: colors.$kobo-storm;
   text-transform: uppercase;


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Every team now sees the `SSO` column in the Members table, showing which members sign in through single sign-on.

### 💭 Notes

Changes here:
- `MembersRoute.tsx`
  - `SSO` is no longer gated on `isSsoAvailable()`
  - `observer` stays, but for the team/organization label
- `membersRoute.module.scss`
  - Deleted `.disabledColumnHeader`
- `MembersRoute.stories.tsx`
  - New `SsoColumnWithoutSsoProvider` story for testing empty env `social_apps` and a member with SSO

`isSsoAvailable` stays in `sso.utils.ts` — `ssoSection.component.tsx` still needs it

### 👀 Preview steps

1. ℹ️ have an account and a team/organization with a few members, on a server with **no** SSO provider configured (a plain local instance will do)
2. go to Account Settings → Members
3. 🔴 [on main] notice the `SSO` header is greyed out, every cell under it is empty, and hovering it offers to sell you the add-on
4. 🟢 [on PR] notice the `SSO` header looks like all the others, and each member row has a grey minus badge — same as somebody without 2FA
5. 🟢 notice pending invitee rows still leave `2FA` and `SSO` empty
6. ℹ️ on a server **with** an SSO provider configured, have one member sign in through SSO
7. 🟢 notice that member's row shows a blue check badge, the rest keep the grey minus
