### PR TITLE
ci(workflows): set least-privilege token permissions, scope CodeQL to first-party code DEV-2486

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: CodeQL config
+paths-ignore:
+  # Vendored third-party code we don't maintain (DEV-2486).
+  # main/static/kobocat/js/ (application.js etc.) is first-party, keep scanning it.
+  - kobo/apps/openrosa/apps/main/static/kobocat/bootstrap
+  - kobo/apps/openrosa/apps/viewer/static/kobocat/js/jquery.dataTables.js

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -3,6 +3,10 @@
 name: biome
 
 on: workflow_call
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,6 +24,10 @@ on:
         required: true
 
 
+permissions:
+  contents: read
+
+
 jobs:
   changelog:
     runs-on: ubuntu-24.04

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "7 6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   get-commit-title:
     name: Get latest 'main' commit info

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   darker:
     uses: ./.github/workflows/darker.yml

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,6 +2,8 @@ name: CI of a PR
 
 on: pull_request
 
+permissions:
+  contents: read
 
 jobs:
   changes:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -1,6 +1,10 @@
 name: Python linter (Darker)
 
 on: workflow_call
+
+permissions:
+  contents: read
+
 jobs:
   darker:
     runs-on: ubuntu-24.04

--- a/.github/workflows/find-releases.yml
+++ b/.github/workflows/find-releases.yml
@@ -30,6 +30,9 @@ on:
       next_patch:
         value: ${{ jobs.version.outputs.next_patch }}
 
+permissions:
+  contents: read
+
 jobs:
   version:
     runs-on: ubuntu-24.04

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -12,6 +12,8 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
 
 jobs:
   locale:

--- a/.github/workflows/nonprod-releases.yml
+++ b/.github/workflows/nonprod-releases.yml
@@ -11,6 +11,9 @@ on:
       - 'main'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -1,6 +1,10 @@
 name: npm-test
 
 on: workflow_call
+
+permissions:
+  contents: read
+
 jobs:
   read-playwright-version:
     name: 'Read Playwright Version'

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -3,6 +3,10 @@
 name: openapi
 
 on: workflow_call
+
+permissions:
+  contents: read
+
 jobs:
 
 

--- a/.github/workflows/pr-environments.yml
+++ b/.github/workflows/pr-environments.yml
@@ -17,12 +17,16 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      pull-requests: read  # gh pr view
     outputs:
       zulip_topic: ${{ steps.set_variables.outputs.zulip_topic }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,6 +3,10 @@
 name: pytest
 
 on: workflow_call
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-1-branch.yml
+++ b/.github/workflows/release-1-branch.yml
@@ -16,6 +16,10 @@ on:
     - cron: '17 5 * * 3'
 
 
+permissions:
+  contents: read
+
+
 jobs:
 
 

--- a/.github/workflows/release-2-stabilize.yml
+++ b/.github/workflows/release-2-stabilize.yml
@@ -11,6 +11,10 @@ on:
     branches: [ 'release/**' ]
 
 
+permissions:
+  contents: read
+
+
 jobs:
 
 
@@ -186,6 +190,9 @@ jobs:
       - version
       - tests
     if: ${{ !cancelled() && !failure() && needs.version.result == 'success' }}
+    permissions:
+      contents: read
+      pull-requests: write  # gh pr create/edit for the merge-conflict PR
     runs-on: ubuntu-24.04
     outputs:
       new_migrations: ${{ steps.detect-migrations.outputs.new_migrations }}

--- a/.github/workflows/release-3-delete.yml
+++ b/.github/workflows/release-3-delete.yml
@@ -15,6 +15,10 @@ on:
         type: string
 
 
+permissions:
+  contents: read
+
+
 jobs:
 
 

--- a/.github/workflows/release-3-tag.yml
+++ b/.github/workflows/release-3-tag.yml
@@ -17,6 +17,10 @@ on:
         default: false
 
 
+permissions:
+  contents: read
+
+
 jobs:
 
   # Validate the selected branch and pass it downstream.

--- a/.github/workflows/release-4-publish.yml
+++ b/.github/workflows/release-4-publish.yml
@@ -11,6 +11,10 @@ on:
         type: string
 
 
+permissions:
+  contents: read
+
+
 jobs:
 
   # Validate that the tag exists and matches the selected branch.

--- a/.github/workflows/zulip.yml
+++ b/.github/workflows/zulip.yml
@@ -17,6 +17,9 @@ on:
       ZULIP_API_KEY_GITHUB_ACTIONS_BOT:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   zulip:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### 📣 Summary

Internal security hardening of the automated build and release pipelines. Nothing changes in the app itself.

### 📖 Description

Each automated job in the code repository now gets only the access it needs to do its work, and the weekly security scan skips bundled third-party libraries so alerts point at code we actually maintain.

### 💭 Notes

- every workflow now declares explicit `permissions:`, defaulting to `contents: read` at the workflow level; the 3 files whose only job already had a complete job-level block (codeql, ghcr-cleanup, storybook-deploy) are untouched
- audited all 9 `GITHUB_TOKEN` usages: release pushes and tags go through the kobo-bot app token, so only 2 jobs needed job-level grants: stabilize `merge-forward` gets `pull-requests: write` (creates the merge-conflict PR) and pr-environments `build` gets `pull-requests: read` (the ticket said write, but the job only runs `gh pr view`)
- new `.github/codeql/codeql-config.yml` excludes `bootstrap/` and `jquery.dataTables.js`; `application.js` in the neighboring tree is our code and stays scanned
- Coveralls in pytest now gets a read-only token. It is continue-on-error and read tokens are standard for it, so worst case is a missing coverage comment, not a red build
- clears ~101 open code-scanning alerts (81 missing-permissions, 20 on vendored JS) once merged and the Saturday CodeQL run happens

### 👀 Preview steps

1. 🔴 [on main] [code scanning](https://github.com/kobotoolbox/kpi/security/code-scanning?query=is%3Aopen+rule%3Aactions%2Fmissing-workflow-permissions) shows 81 open `actions/missing-workflow-permissions` alerts, plus 20 `js/*` alerts on `jquery.dataTables.js` and `bootstrap.js`
2. 🟢 [on PR] `grep -L '^permissions:' .github/workflows/*.yml` lists only `codeql.yml`, `ghcr-cleanup.yml`, `storybook-deploy.yml` (their jobs declare permissions themselves)
3. 🟢 [on PR] CI runs the full suite (the `all` path filter fires because `ci-*.yml` changed) and stays green with the restricted tokens
4. 🟢 [after merge + next scheduled scan] the alerts above close on their own; the `application.js` alert stays open on purpose
