### PR TITLE
feat(frontend): mantine spacing and label adjustments DEV-1848

### DIFF
--- a/jsapp/js/account/accountFieldsEditor.module.scss
+++ b/jsapp/js/account/accountFieldsEditor.module.scss
@@ -51,8 +51,8 @@
   width: 100%;
   color: colors.$kobo-gray-800;
   // These stand in for a Mantine input label above a group of controls, so they
-  // are kept in sync by hand with `.label` in theme/kobo/InputBase.module.css.
-  font-size: 12px;
+  // match what an `md` field's label gets - see `INPUT_SIZE_TO_LABEL_SIZES` in theme/kobo/InputWrapper.ts.
+  font-size: var(--mantine-font-size-md);
   margin-bottom: 5px;
   display: block;
 }

--- a/jsapp/js/components/RESTServices/RESTServiceLogs.tsx
+++ b/jsapp/js/components/RESTServices/RESTServiceLogs.tsx
@@ -239,7 +239,7 @@ export default function RESTServiceLogs({ assetUid, hookUid }: RESTServiceLogsPr
       </Group>
 
       {logs.length === 0 ? (
-        <Text ta='center' p='xl'>
+        <Text ta='center' p='xxl'>
           {t('There are no logs yet')}
         </Text>
       ) : (

--- a/jsapp/js/components/RESTServices/RESTServicesList.tsx
+++ b/jsapp/js/components/RESTServices/RESTServicesList.tsx
@@ -155,7 +155,7 @@ export default function RESTServicesList({ assetUid }: RESTServicesListProps) {
   return (
     <Stack gap='md'>
       {hooks.length === 0 && (
-        <Stack align='center' gap='md' p='xl' ta='center'>
+        <Stack align='center' gap='md' p='xxl' ta='center'>
           <Box c='gray.4'>
             <KoboIcon icon={resolveLegacySvgIconByName('data-sync')} size={120} />
           </Box>

--- a/jsapp/js/components/common/Switch.stories.tsx
+++ b/jsapp/js/components/common/Switch.stories.tsx
@@ -54,13 +54,13 @@ export const Disabled: Story = {
  * Every combination of state and size.
  */
 export const PreviewAllVariants = () => (
-  <Stack gap='xl'>
+  <Stack gap='xxl'>
     {switchSizes.map((size) => (
       <Box key={size}>
         <Title order={4} mb='sm'>
           size: <code>{size}</code>
         </Title>
-        <Group gap='xl' align='top'>
+        <Group gap='xxl' align='top'>
           <Switch size={size} label='Off' />
           <Switch size={size} label='On' defaultChecked />
           <Switch size={size} label='Off, disabled' disabled />

--- a/jsapp/js/components/common/Tabs.stories.tsx
+++ b/jsapp/js/components/common/Tabs.stories.tsx
@@ -58,8 +58,8 @@ export const Primary: Story = {}
 export const PreviewAllVariants = () => (
   <>
     {tabsVariants.map((variant) => (
-      <Box key={variant} mb='xl'>
-        <Group gap='xl' align='top'>
+      <Box key={variant} mb='xxl'>
+        <Group gap='xxl' align='top'>
           {tabsSizes.map((size) => (
             <Stack key={size} gap='sm'>
               <SampleTabs variant={variant} size={size} />

--- a/jsapp/js/components/formLanding/FormHistory.tsx
+++ b/jsapp/js/components/formLanding/FormHistory.tsx
@@ -178,7 +178,7 @@ export default function FormHistory(props: FormHistoryProps) {
 
   if (historyInfiniteQuery.isLoading) {
     return (
-      <Center p='xl'>
+      <Center p='xxl'>
         <Loader />
       </Center>
     )

--- a/jsapp/js/components/permissions/sharingForm.component.tsx
+++ b/jsapp/js/components/permissions/sharingForm.component.tsx
@@ -183,7 +183,7 @@ export default class SharingForm extends React.Component<SharingFormProps, Shari
 
     return (
       <Stack
-        gap='xl'
+        gap='xxl'
         // The parent modal has `closeOnEscape` disabled (see `openSharingModal`), so we handle Escape here. Nested
         // confirmation modals render in their own portal, so their Escape presses never bubble up to this handler.
         onKeyDown={(evt: React.KeyboardEvent) => {

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranscript/TranscriptCreate/StepCreateAutomated.tsx
@@ -148,7 +148,7 @@ export default function StepCreateAutomated({
     <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
       <header className={bodyStyles.header}>{t('Automatic transcription of audio file from')}</header>
 
-      <Flex component='section' direction='row' align='center' justify='center' mb='xl'>
+      <Flex component='section' direction='row' align='center' justify='center' mb='xxl'>
         <Group gap='xs'>
           <TextInput
             readOnly

--- a/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
+++ b/jsapp/js/components/processing/SingleProcessingContent/TabTranslations/TranslationAdd/StepCreateAutomated.tsx
@@ -203,7 +203,7 @@ export default function StepCreateAutomated({
     <div className={cx(bodyStyles.root, bodyStyles.stepConfig)}>
       <header className={bodyStyles.header}>{t('Automatic translation of transcript to')}</header>
 
-      <Flex component='section' direction='row' align='center' justify='center' mb='xl'>
+      <Flex component='section' direction='row' align='center' justify='center' mb='xxl'>
         <Group gap='xs'>
           <TextInput
             readOnly

--- a/jsapp/js/editorMixins/AssetNavigator.tsx
+++ b/jsapp/js/editorMixins/AssetNavigator.tsx
@@ -191,17 +191,17 @@ export default function AssetNavigator() {
 
       {/* Results */}
       {isLoading ? (
-        <Center py='xl'>
+        <Center py='xxl'>
           <Loader size='sm' />
         </Center>
       ) : isError ? (
-        <Center py='xl'>
+        <Center py='xxl'>
           <Text c='red' size='sm'>
             Error loading assets
           </Text>
         </Center>
       ) : assetsResponse?.data.results?.length === 0 ? (
-        <Center py='xl'>
+        <Center py='xxl'>
           <Text size='sm'>No assets found</Text>
         </Center>
       ) : (

--- a/jsapp/js/theme/kobo/InputBase.module.css
+++ b/jsapp/js/theme/kobo/InputBase.module.css
@@ -70,7 +70,10 @@
 }
 
 .label {
-  font-size: var(--mantine-font-size-xs);
+  /* Size comes from `--input-label-size`, which Mantine derives from the field's own `size` - see
+     `InputWrapper.ts` for the scale. */
+  /* Mantine ships labels at 500. Regular weight is what our designs ask for. */
+  font-weight: 400;
   color: var(--mantine-color-gray-1);
   margin-bottom: 5px;
 }

--- a/jsapp/js/theme/kobo/InputWrapper.ts
+++ b/jsapp/js/theme/kobo/InputWrapper.ts
@@ -1,0 +1,24 @@
+import { InputWrapper, rem } from '@mantine/core'
+import type { MantineSize } from '@mantine/core'
+
+const INPUT_SIZE_TO_LABEL_SIZES: Partial<Record<MantineSize, string>> = {
+  xs: rem(11), // 10px would be too small
+  sm: rem(12),
+  md: rem(14),
+  lg: rem(16),
+  xl: rem(18),
+}
+
+/**
+ * Every input renders its label through `Input.Wrapper` - so this is the one place that reaches `TextInput`, `Select`,
+ * `Textarea` and the rest at once
+ */
+export const InputWrapperThemeKobo = InputWrapper.extend({
+  vars: (_theme, props) => {
+    return {
+      label: { '--input-label-size': INPUT_SIZE_TO_LABEL_SIZES[props.size as MantineSize] },
+      error: {},
+      description: {},
+    }
+  },
+})

--- a/jsapp/js/theme/kobo/index.ts
+++ b/jsapp/js/theme/kobo/index.ts
@@ -11,6 +11,7 @@ import { DividerThemeKobo } from './Divider'
 import { DropzoneThemeKobo } from './Dropzone'
 import { InputThemeKobo } from './Input'
 import { InputBaseThemeKobo } from './InputBase'
+import { InputWrapperThemeKobo } from './InputWrapper'
 import { LoaderThemeKobo } from './Loader'
 import { MenuThemeKobo } from './Menu'
 import { ModalThemeKobo } from './Modal'
@@ -153,6 +154,10 @@ export const themeKobo = createTheme({
 
   spacing: {
     xxs: '8px',
+    // Mantine's scale jumps 20px -> 32px, leaving no 24px rung for our designs. `xl` fills it and
+    // `xxl` keeps the 32px that used to be `xl`, so both values stay reachable.
+    xl: rem(24),
+    xxl: rem(32),
   },
 
   other: {
@@ -173,6 +178,7 @@ export const themeKobo = createTheme({
     Dropzone: DropzoneThemeKobo,
     Input: InputThemeKobo,
     InputBase: InputBaseThemeKobo,
+    InputWrapper: InputWrapperThemeKobo,
     Loader: LoaderThemeKobo,
     Menu: MenuThemeKobo,
     Modal: ModalThemeKobo,


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Labels above form fields now scale with the size of the field they belong to, instead of always being the smallest size.

### 💭 Notes

Changes here:

- `theme/kobo/InputWrapper.ts` — one place to size every label - scale is `INPUT_SIZE_TO_LABEL_SIZES` and reaches CSS as `--input-label-size`.
- `theme/kobo/InputBase.module.css` — label uses the above variable
- `theme/kobo/index.ts` — `spacing.xl` becomes 24px, and `spacing.xxl` inherits the 32px that `xl` used to hold
- the ten `xl` → `xxl` edits are only renames

Re-reverts the commit reverted in #7565

### 👀 Preview steps

1. ℹ️ have an account and a project
2. open the account menu → Account Settings
3. 🔴 [on main] every label above a field is 12px and slightly bold
4. 🟢 [on PR] labels are 14px and regular weight, and no field has moved
5. open Project → Settings → REST Services with none configured, then Project → Settings → Sharing
6. 🟢 notice the spacing is exactly as it was
