### PR TITLE
fix(attachments): accept media questions from every version a submission spans DEV-2766

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
@@ -1,6 +1,7 @@
 import io
 import json
 import uuid as uuid_module
+import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -933,24 +934,53 @@ class TestAttachmentsAcrossFormVersions(TestCase):
 
         xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
         edit_submission_xml(xml_parsed, MEDIA_QUESTION, 'second.jpg')
-        edit_submission_xml(xml_parsed, 'meta/deprecatedID', f'uuid:{instance.uuid}')
-        edit_submission_xml(
-            xml_parsed, 'meta/instanceID', f'uuid:{uuid_module.uuid4()}'
-        )
-        edit_submission_xml(xml_parsed, 'meta/rootUuid', f'uuid:{instance.root_uuid}')
-        self._submit(
-            xml_tostring(xml_parsed),
-            media_files=[
-                SimpleUploadedFile('second.jpg', b'jpeg2', content_type='image/jpeg')
-            ],
-        )
+        self._edit(instance, xml_parsed, 'second.jpg')
 
-        assert dict(
-            Attachment.all_objects.filter(instance=instance).values_list(
-                'media_file_basename', 'delete_status'
-            )
-        ) == {
+        assert self._delete_statuses(instance) == {
             'first.jpg': AttachmentDeleteStatus.SOFT_DELETED,
+            'second.jpg': None,
+        }
+
+    def test_replaced_attachment_is_still_soft_deleted_across_versions(self):
+        """
+        Accepting the older versions' names must not stop an edit from retiring
+        the file it replaced on a question the deployed form still has.
+        """
+
+        instance = self._submit_with_photo(MEDIA_QUESTION, 'first.jpg')
+        self._redeploy_keeping_the_media_question()
+
+        xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+        edit_submission_xml(xml_parsed, MEDIA_QUESTION, 'second.jpg')
+        edited = self._edit(instance, xml_parsed, 'second.jpg')
+
+        # The record now spans two versions, so the older names are accepted
+        assert get_form_versions(edited.xml) is not None
+        assert self._delete_statuses(instance) == {
+            'first.jpg': AttachmentDeleteStatus.SOFT_DELETED,
+            'second.jpg': None,
+        }
+
+    def test_file_of_a_renamed_question_is_kept_on_edit(self):
+        """
+        Editing across a rename leaves the record carrying both shapes: the
+        deployed one Enketo renders, and the original nodes it appends. Which
+        old node the new file replaced cannot be known, since no stable
+        identity ties two names of the same question together across a rename.
+        Keeping the file is the deliberate choice: a stale file stays visible
+        and can be removed, a file nobody touched would vanish silently.
+        """
+
+        instance = self._submit_with_photo(MEDIA_QUESTION, 'first.jpg')
+        self._redeploy_renaming_the_media_question()
+
+        xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+        renamed = ET.SubElement(xml_parsed, RENAMED_MEDIA_QUESTION)
+        renamed.text = 'second.jpg'
+        self._edit(instance, xml_parsed, 'second.jpg')
+
+        assert self._delete_statuses(instance) == {
+            'first.jpg': None,
             'second.jpg': None,
         }
 
@@ -974,15 +1004,44 @@ class TestAttachmentsAcrossFormVersions(TestCase):
 
         parse.assert_not_called()
 
+    def _delete_statuses(self, instance: Instance) -> dict:
+        return dict(
+            Attachment.all_objects.filter(instance=instance).values_list(
+                'media_file_basename', 'delete_status'
+            )
+        )
+
+    def _edit(self, instance: Instance, xml_parsed, filename: str) -> Instance:
+        """
+        Post `xml_parsed` back as an edit of `instance`, uploading `filename`.
+        """
+
+        edit_submission_xml(xml_parsed, 'meta/deprecatedID', f'uuid:{instance.uuid}')
+        edit_submission_xml(
+            xml_parsed, 'meta/instanceID', f'uuid:{uuid_module.uuid4()}'
+        )
+        edit_submission_xml(xml_parsed, 'meta/rootUuid', f'uuid:{instance.root_uuid}')
+
+        return self._submit(
+            xml_tostring(xml_parsed),
+            media_files=[
+                SimpleUploadedFile(filename, b'jpeg2', content_type='image/jpeg')
+            ],
+        )
+
+    def _redeploy_keeping_the_media_question(self) -> str:
+        self.asset.content['survey'][0]['label'] = ['Q1 reworded']
+        return self._redeploy(MEDIA_QUESTION)
+
     def _redeploy_renaming_the_media_question(self) -> str:
         self.asset.content['survey'][1]['name'] = RENAMED_MEDIA_QUESTION
-        return self._redeploy(xform_xml(media_question=RENAMED_MEDIA_QUESTION))
+        return self._redeploy(RENAMED_MEDIA_QUESTION)
 
     def _redeploy_without_the_media_question(self) -> str:
         del self.asset.content['survey'][1]
-        return self._redeploy(xform_xml(media_question='decoy_photo'))
+        return self._redeploy('decoy_photo')
 
-    def _redeploy(self, xform_xml_: str) -> str:
+    def _redeploy(self, media_question: str) -> str:
         """
         Redeploy the asset and move the XForm onto the new version, the way a
         redeployment does.
@@ -992,8 +1051,8 @@ class TestAttachmentsAcrossFormVersions(TestCase):
         self.asset.deploy(backend='mock')
         version_uid = self.asset.latest_deployed_version_uid
         XForm.objects.filter(pk=self.xform.pk).update(
-            xml=xform_xml_,
-            json=xform_json(version_uid, media_question=RENAMED_MEDIA_QUESTION),
+            xml=xform_xml(media_question=media_question),
+            json=xform_json(version_uid, media_question=media_question),
         )
         return version_uid
 

--- a/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_form_versions.py
@@ -2,13 +2,17 @@ import io
 import json
 import uuid as uuid_module
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.exceptions import DuplicateInstanceError
-from kobo.apps.openrosa.apps.logger.models import Instance, XForm
+from kobo.apps.openrosa.apps.logger.models import Attachment, Instance, XForm
+from kobo.apps.openrosa.apps.logger.models.attachment import (
+    AttachmentDeleteStatus,
+)
 from kobo.apps.openrosa.apps.logger.models.instance import InstanceHistory
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import strip_form_versions
 from kobo.apps.openrosa.apps.main.models import UserProfile
@@ -18,9 +22,12 @@ from kobo.apps.openrosa.libs.utils.common_tags import (
     VERSION,
 )
 from kobo.apps.openrosa.libs.utils.logger_tools import (
+    _get_other_form_version_uids,
     add_form_versions,
     create_instance,
+    get_soft_deleted_attachments,
 )
+from kpi.models.asset import Asset
 from kpi.utils.xml import (
     edit_submission_xml,
     fromstring_preserve_root_xmlns,
@@ -33,9 +40,32 @@ FORM_UUID = '7117fdf814234f5ea0c9f5801b022293'
 VERSION_1 = 'v' + '1' * 21
 VERSION_2 = 'v' + '2' * 21
 VERSION_3 = 'v' + '3' * 21
+MEDIA_QUESTION = 'upload_image'
+RENAMED_MEDIA_QUESTION = 'upload_image_edited'
 
 
-def xform_xml() -> str:
+def xform_xml(media_question: str | None = None) -> str:
+    """
+    Build the XForm XML. `media_question` adds an upload question, which is
+    what `get_xform_media_question_xpaths()` reads through its `ref`.
+    """
+
+    media_node = f'<{media_question}/>' if media_question else ''
+    media_bind = (
+        f'<bind nodeset="/{ID_STRING}/{media_question}" type="binary"/>'
+        if media_question
+        else ''
+    )
+    body = (
+        '<h:body>'
+        f'<upload mediatype="image/*" ref="/{ID_STRING}/{media_question}">'
+        '<label>Photo</label>'
+        '</upload>'
+        '</h:body>'
+        if media_question
+        else '<h:body/>'
+    )
+
     return (
         '<?xml version="1.0" encoding="utf-8"?>'
         '<h:html xmlns="http://www.w3.org/2002/xforms"'
@@ -48,19 +78,21 @@ def xform_xml() -> str:
         f'<{ID_STRING} id="{ID_STRING}">'
         '<formhub><uuid/></formhub>'
         '<q1/>'
+        f'{media_node}'
         '<__version__/>'
         '<meta><instanceID/><deprecatedID/><rootUuid/></meta>'
         f'</{ID_STRING}>'
         '</instance>'
         f'<bind nodeset="/{ID_STRING}/meta/instanceID" type="string"/>'
+        f'{media_bind}'
         '</model>'
         '</h:head>'
-        '<h:body/>'
+        f'{body}'
         '</h:html>'
     )
 
 
-def xform_json(version_uid: str | None) -> str:
+def xform_json(version_uid: str | None, media_question: str | None = None) -> str:
     """
     Build the pyxform JSON of a form deployed by KPI at `version_uid`.
 
@@ -69,6 +101,8 @@ def xform_json(version_uid: str | None) -> str:
     """
 
     children = [{'name': 'q1', 'type': 'text'}]
+    if media_question:
+        children.append({'name': media_question, 'type': 'photo'})
     if version_uid:
         children.append(
             {
@@ -96,6 +130,8 @@ def submission_xml(
     declaration: bool = False,
     form_versions: str | None = None,
     deprecated_id: str | None = None,
+    media_question: str | None = None,
+    filename: str | None = None,
 ) -> str:
     """
     Build a submission.
@@ -106,6 +142,9 @@ def submission_xml(
     """
 
     version_node = f'<__version__>{version_uid}</__version__>' if version_uid else ''
+    media_node = (
+        f'<{media_question}>{filename}</{media_question}>' if media_question else ''
+    )
     form_versions_node = (
         f'<formVersions>{form_versions}</formVersions>' if form_versions else ''
     )
@@ -117,6 +156,7 @@ def submission_xml(
         + f'<{ID_STRING} id="{ID_STRING}">'
         f'<formhub><uuid>{FORM_UUID}</uuid></formhub>'
         '<q1>hello</q1>'
+        f'{media_node}'
         f'{version_node}'
         f'<meta><instanceID>{instance_id}</instanceID>'
         f'{deprecated_id_node}{form_versions_node}</meta>'
@@ -787,4 +827,193 @@ class TestFormVersionsOnSubmission(TestCase):
             media_files=media_files or [],
             request=self.request,
             check_usage_limits=False,
+        )
+
+
+class TestOtherFormVersionUids(TestCase):
+    """
+    Unit tests for the versions the XForm cannot answer for.
+    """
+
+    def test_returns_nothing_when_the_submission_names_no_version(self):
+        instance = SimpleNamespace(xform=XForm(json=xform_json(VERSION_1)))
+        xml_parsed = fromstring_preserve_root_xmlns(submission_xml(version_uid=None))
+
+        assert _get_other_form_version_uids(instance, xml_parsed) == []
+
+    def test_returns_nothing_when_only_the_deployed_version_is_named(self):
+        instance = SimpleNamespace(xform=XForm(json=xform_json(VERSION_1)))
+        xml_parsed = fromstring_preserve_root_xmlns(
+            submission_xml(version_uid=VERSION_1)
+        )
+
+        assert _get_other_form_version_uids(instance, xml_parsed) == []
+
+    def test_returns_the_versions_the_xform_does_not_describe(self):
+        instance = SimpleNamespace(xform=XForm(json=xform_json(VERSION_3)))
+        xml_parsed = fromstring_preserve_root_xmlns(
+            submission_xml(
+                version_uid=VERSION_1,
+                form_versions=f'{VERSION_1} {VERSION_2}',
+            )
+        )
+
+        assert _get_other_form_version_uids(instance, xml_parsed) == [
+            VERSION_1,
+            VERSION_2,
+        ]
+
+
+class TestAttachmentsAcrossFormVersions(TestCase):
+    """
+    A file must survive a submission whose questions belong to a version other
+    than the one deployed.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(username='bob')
+        UserProfile.objects.get_or_create(user=self.user)
+
+        self.asset = Asset.objects.create(
+            owner=self.user,
+            content={
+                'survey': [
+                    {'type': 'text', 'name': 'q1', 'label': ['Q1']},
+                    {'type': 'image', 'name': MEDIA_QUESTION, 'label': ['Photo']},
+                ]
+            },
+        )
+        self.asset.deploy(backend='mock', active=True)
+        self.version_1 = self.asset.latest_deployed_version_uid
+
+        self.xform = XForm.objects.create(
+            xml=xform_xml(media_question=MEDIA_QUESTION),
+            user=self.user,
+            json=xform_json(self.version_1, media_question=MEDIA_QUESTION),
+            uuid=FORM_UUID,
+            require_auth=False,
+            kpi_asset_uid=self.asset.uid,
+        )
+
+        class FakeRequest:
+            pass
+
+        self.request = FakeRequest()
+        self.request.user = self.user
+        self.request.user.has_perm = lambda *args, **kwargs: True
+
+    def test_attachment_survives_a_question_renamed_since_collection(self):
+        """
+        The record was collected under a version the deployed form no longer
+        describes, so its file hangs on a name only that version knows.
+        """
+
+        version_2 = self._redeploy_renaming_the_media_question()
+        instance = self._submit_with_photo(MEDIA_QUESTION, 'photo.jpg')
+
+        assert get_form_versions(instance.xml) == f'{self.version_1} {version_2}'
+        attachment = Attachment.all_objects.get(instance=instance)
+        assert attachment.media_file_basename == 'photo.jpg'
+        assert attachment.delete_status is None
+
+    def test_attachment_survives_when_the_question_was_deleted_since(self):
+        self._redeploy_without_the_media_question()
+        instance = self._submit_with_photo(MEDIA_QUESTION, 'photo.jpg')
+
+        attachment = Attachment.all_objects.get(instance=instance)
+        assert attachment.delete_status is None
+
+    def test_replaced_attachment_is_still_soft_deleted(self):
+        """
+        Widening the accepted names must not stop an edit from retiring the
+        file it actually replaced.
+        """
+
+        instance = self._submit_with_photo(MEDIA_QUESTION, 'first.jpg')
+
+        xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+        edit_submission_xml(xml_parsed, MEDIA_QUESTION, 'second.jpg')
+        edit_submission_xml(xml_parsed, 'meta/deprecatedID', f'uuid:{instance.uuid}')
+        edit_submission_xml(
+            xml_parsed, 'meta/instanceID', f'uuid:{uuid_module.uuid4()}'
+        )
+        edit_submission_xml(xml_parsed, 'meta/rootUuid', f'uuid:{instance.root_uuid}')
+        self._submit(
+            xml_tostring(xml_parsed),
+            media_files=[
+                SimpleUploadedFile('second.jpg', b'jpeg2', content_type='image/jpeg')
+            ],
+        )
+
+        assert dict(
+            Attachment.all_objects.filter(instance=instance).values_list(
+                'media_file_basename', 'delete_status'
+            )
+        ) == {
+            'first.jpg': AttachmentDeleteStatus.SOFT_DELETED,
+            'second.jpg': None,
+        }
+
+    def test_form_without_media_question_never_parses_the_submission(self):
+        """
+        This runs for every single submission, so a form that cannot hold a
+        file must not pay for parsing its XML.
+        """
+
+        XForm.objects.filter(pk=self.xform.pk).update(xml=xform_xml())
+        instance = self._submit(submission_xml(version_uid=self.version_1))
+
+        # `wraps` keeps the real behaviour, so a call would be counted rather
+        # than break the function and hide what the assertion is about
+        with patch(
+            'kobo.apps.openrosa.libs.utils.logger_tools'
+            '.fromstring_preserve_root_xmlns',
+            wraps=fromstring_preserve_root_xmlns,
+        ) as parse:
+            assert get_soft_deleted_attachments(instance) == []
+
+        parse.assert_not_called()
+
+    def _redeploy_renaming_the_media_question(self) -> str:
+        self.asset.content['survey'][1]['name'] = RENAMED_MEDIA_QUESTION
+        return self._redeploy(xform_xml(media_question=RENAMED_MEDIA_QUESTION))
+
+    def _redeploy_without_the_media_question(self) -> str:
+        del self.asset.content['survey'][1]
+        return self._redeploy(xform_xml(media_question='decoy_photo'))
+
+    def _redeploy(self, xform_xml_: str) -> str:
+        """
+        Redeploy the asset and move the XForm onto the new version, the way a
+        redeployment does.
+        """
+
+        self.asset.save()
+        self.asset.deploy(backend='mock')
+        version_uid = self.asset.latest_deployed_version_uid
+        XForm.objects.filter(pk=self.xform.pk).update(
+            xml=xform_xml_,
+            json=xform_json(version_uid, media_question=RENAMED_MEDIA_QUESTION),
+        )
+        return version_uid
+
+    def _submit(self, xml: str, media_files: list | None = None) -> Instance:
+        return create_instance(
+            self.user.username,
+            io.BytesIO(xml.encode()),
+            media_files=media_files or [],
+            request=self.request,
+            check_usage_limits=False,
+        )
+
+    def _submit_with_photo(self, media_question: str, filename: str) -> Instance:
+        return self._submit(
+            submission_xml(
+                version_uid=self.version_1,
+                media_question=media_question,
+                filename=filename,
+            ),
+            media_files=[
+                SimpleUploadedFile(filename, b'jpeg', content_type='image/jpeg')
+            ],
         )

--- a/kobo/apps/openrosa/libs/utils/logger_tools.py
+++ b/kobo/apps/openrosa/libs/utils/logger_tools.py
@@ -1033,30 +1033,38 @@ def get_soft_deleted_attachments(instance: Instance) -> list[Attachment]:
     """
     Soft delete replaced attachments when editing a submission
     """
-    # Retrieve all media questions of Xform
-    media_question_xpaths = get_xform_media_question_xpaths(instance.xform)
 
-    # If XForm does not have any media fields, do not go further
-    if not media_question_xpaths:
+    # Retrieve all media questions of the XForm. This runs for every single
+    # submission, so leave before parsing anything when the form has no media
+    # field: an empty list soft deletes nothing, which is also the right answer
+    # for a form that dropped its only media question in a later version
+    xform_media_question_xpaths = get_xform_media_question_xpaths(instance.xform)
+
+    if not xform_media_question_xpaths:
         return []
 
     # Parse instance XML to get the basename of each file of the updated
-    # submission
+    # submission, and the form versions it has been through
     xml_parsed = fromstring_preserve_root_xmlns(instance.xml)
+
+    # Add the media questions of the other form versions the submission has
+    # been through
+    media_question_xpaths = _get_submission_media_question_xpaths(
+        instance, xml_parsed, xform_media_question_xpaths
+    )
+
+    if not media_question_xpaths:
+        # Stripping the root node off the XForm's `ref` attributes left nothing
+        # usable. Leaving now matters: an empty list would let the loop below
+        # soft delete every attachment of the submission
+        return []
+
     basenames = []
 
     for media_question_xpath in media_question_xpaths:
-        root_name, xpath_without_root = media_question_xpath.split('/', 1)
-        try:
-            assert root_name == xml_parsed.tag
-        except AssertionError:
-            logging.warning(
-                'Instance XML root tag name does not match with its form'
-            )
-
         # With repeat groups, several nodes can have the same XPath. We
         # need to retrieve all of them
-        questions = xml_parsed.findall(xpath_without_root)
+        questions = xml_parsed.findall(media_question_xpath)
         for question in questions:
             try:
                 basename = question.text
@@ -1280,6 +1288,32 @@ def _get_instance_from_deprecated_id(
     return instance, old_uuid
 
 
+def _get_other_form_version_uids(
+    instance: Instance, xml_parsed: ET.Element
+) -> list[str]:
+    """
+    Return the uids of the form versions a submission has been through, minus
+    the one currently deployed, which the XForm already describes.
+    """
+
+    form_versions, submission_version = _get_form_versions(xml_parsed)
+    if submission_version and submission_version not in form_versions:
+        form_versions.append(submission_version)
+
+    if not form_versions:
+        # A submission carrying no version at all, collected before KPI started
+        # stamping `__version__`. Nothing places it in time
+        return []
+
+    deployed_version_uid = instance.xform.deployed_version_uid
+
+    return [
+        version_uid
+        for version_uid in form_versions
+        if version_uid != deployed_version_uid
+    ]
+
+
 def _get_submission_field_paths(xml: str) -> set:
     """
     Return a submission's field XPaths, relative to its root node, with the
@@ -1289,6 +1323,58 @@ def _get_submission_field_paths(xml: str) -> set:
     root = clean_and_parse_xml(xml).documentElement
 
     return _exclude_common_paths(_collect_element_paths(root))
+
+
+def _get_submission_media_question_xpaths(
+    instance: Instance,
+    xml_parsed: ET.Element,
+    xform_media_question_xpaths: list[str],
+) -> list[str]:
+    """
+    Return the media question XPaths a submission may hold a file under,
+    relative to its root node.
+
+    `get_xform_media_question_xpaths()` only describes the deployed version. A
+    submission collected with an older one holds its files under names that
+    version may no longer know, and an unmatched attachment is soft deleted
+    right after being saved. The versions recorded by `add_form_versions()`
+    close that gap; they are added, never substituted, so a wider list can only
+    spare attachments.
+    """
+
+    xpaths = []
+
+    for media_question_xpath in xform_media_question_xpaths:
+        # A `ref` attribute carries the root node, e.g. `myform/group/photo`,
+        # whereas the submission tree is searched from under the root. The
+        # XPaths coming from KPI below already have that shape
+        root_name, _, xpath_without_root = media_question_xpath.partition('/')
+        if root_name != xml_parsed.tag:
+            logging.warning('Instance XML root tag name does not match with its form')
+
+        if xpath_without_root and xpath_without_root not in xpaths:
+            xpaths.append(xpath_without_root)
+
+    version_uids = _get_other_form_version_uids(instance, xml_parsed)
+    if not version_uids:
+        # Nothing the XForm has not already described, which is the case for
+        # the vast majority of submissions. Neither the asset nor its cache is
+        # touched
+        return xpaths
+
+    asset = instance.xform.asset
+    if asset.pk is None:
+        # Every XForm belongs to an asset, but `XForm.asset` hands back an
+        # unsaved placeholder when `kpi_asset_uid` does not resolve, and
+        # querying its versions would raise. Keep the XForm's own answer rather
+        # than fail a submission over it
+        return xpaths
+
+    for xpath in asset.get_attachment_xpaths_from_version_uids(version_uids):
+        if xpath not in xpaths:
+            xpaths.append(xpath)
+
+    return xpaths
 
 
 def _get_xform_template_field_paths(xform_xml: str) -> set:

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -629,16 +629,22 @@ class Asset(
         """
 
         if version:
-            content = version.to_formpack_schema()['content']
             cache_key = f'attachment_xpaths:{self.uid}:{version.uid}'
         else:
-            content = self.content
             cache_key = f'attachment_xpaths:{self.uid}:no-version'
 
         cached_xpaths = cache.get(cache_key)
 
         if cached_xpaths is not None:
             return cached_xpaths
+
+        # Read the content only once the cache has been given its chance:
+        # expanding a version's content is the expensive part of this method,
+        # and `self.content` may be a deferred field
+        if version:
+            content = version.to_formpack_schema()['content']
+        else:
+            content = self.content
 
         survey = content['survey']
 
@@ -672,6 +678,31 @@ class Asset(
         cache.set(cache_key, xpaths_list, timeout=settings.ATTACHMENT_XPATHS_CACHE_TTL)
 
         return xpaths_list
+
+    def get_attachment_xpaths_from_version_uids(self, version_uids: list[str]) -> list:
+        """
+        Get the attachment xpaths of several form versions, merged.
+
+        Takes uids, where `get_attachment_xpaths_from_version()` takes an
+        `AssetVersion` and holds the per-version Redis cache both share.
+
+        Versions are merged, never superseded: a question renamed between two
+        of them lives at both xpaths, and keeping only the newest is what makes
+        an attachment collected under the older name unreachable.
+        """
+
+        # A `version_content` weighs several megabytes on a large form.
+        # `iterator()` keeps one version at a time in memory, where iterating
+        # the queryset itself would fill its result cache with all of them
+        versions = self.asset_versions.filter(
+            uid__in=version_uids, deployed=True
+        ).iterator()
+
+        xpaths = set()
+        for version in versions:
+            xpaths.update(self.get_attachment_xpaths_from_version(version) or [])
+
+        return list(xpaths)
 
     def get_filters_for_partial_perm(
         self, user_id: int, perm: str = PERM_VIEW_SUBMISSIONS

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -600,6 +600,10 @@ class Asset(
         cached_xpaths = cache.get(cache_key)
 
         if cached_xpaths is not None:
+            # Memoize the hit too, otherwise every call on this instance pays a
+            # Redis round-trip and the query behind
+            # `latest_deployed_version_uid`
+            setattr(self, '_all_attachment_xpaths', cached_xpaths)
             return cached_xpaths
         elif only_cached_data:
             return None
@@ -625,23 +629,26 @@ class Asset(
         """
         Get attachment xpaths from a specific version.
 
-        Results are cached in Redis for 24 hours.
+        Results are cached in Redis for 24 hours, but only when a version is
+        given. A version's content never changes, so its uid alone says what
+        the entry holds and that entry can never go stale. `self.content`
+        offers no such marker: it changes on every save, and nothing
+        invalidates these keys. Reading it is also the cheap case, with no
+        `to_formpack_schema()` to pay for.
         """
+
+        cache_key = None
 
         if version:
             cache_key = f'attachment_xpaths:{self.uid}:{version.uid}'
-        else:
-            cache_key = f'attachment_xpaths:{self.uid}:no-version'
+            cached_xpaths = cache.get(cache_key)
 
-        cached_xpaths = cache.get(cache_key)
+            if cached_xpaths is not None:
+                return cached_xpaths
 
-        if cached_xpaths is not None:
-            return cached_xpaths
-
-        # Read the content only once the cache has been given its chance:
-        # expanding a version's content is the expensive part of this method,
-        # and `self.content` may be a deferred field
-        if version:
+            # Read the content only once the cache has been given its chance:
+            # expanding a version's content is the expensive part of this method,
+            # and `self.content` may be a deferred field
             content = version.to_formpack_schema()['content']
         else:
             content = self.content
@@ -666,16 +673,21 @@ class Asset(
 
             return xpaths
 
-        if xpaths := _get_xpaths(survey):
-            return xpaths
-
-        # Inject missing `$xpath` properties
-        self._insert_xpath(content)
-
         xpaths_list = _get_xpaths(survey)
 
+        if xpaths_list is None:
+            # Versions predating the NLP feature carry no `$xpath`. Inject the
+            # missing properties and read them again. An empty list needs no
+            # such treatment: a survey without a single question that takes an
+            # attachment has no xpath to offer either way
+            self._insert_xpath(content)
+            xpaths_list = _get_xpaths(survey)
+
         # Store in Redis cache
-        cache.set(cache_key, xpaths_list, timeout=settings.ATTACHMENT_XPATHS_CACHE_TTL)
+        if cache_key:
+            cache.set(
+                cache_key, xpaths_list, timeout=settings.ATTACHMENT_XPATHS_CACHE_TTL
+            )
 
         return xpaths_list
 

--- a/kpi/models/asset.py
+++ b/kpi/models/asset.py
@@ -999,6 +999,11 @@ class Asset(
         *args,
         **kwargs,
     ):
+        # Deploying a version changes which ones the xpaths are read from, and
+        # `deploy()` ends up saving the asset. Drop the memo rather than let it
+        # outlive its answer; refilling it costs a Redis lookup at worst
+        self._all_attachment_xpaths = None
+
         is_new = self.pk is None
 
         if is_new:

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -7,11 +7,13 @@ from functools import reduce
 from unittest.mock import patch
 
 from django.conf import settings
+from django.core.cache import cache
 from django.test import TestCase
 from model_bakery import baker
 
 from kpi.constants import ATTACHMENT_QUESTION_TYPES
 from kpi.models import Asset
+from kpi.models.asset_version import AssetVersion
 from kpi.utils.sluggify import sluggify_label
 
 
@@ -917,6 +919,59 @@ class TestAssetContent(TestCase):
         # Validate XPaths can still be retrieved even on old versions
         xpaths = asset.get_all_attachment_xpaths()
         assert sorted(xpaths) == ['Image', 'group_kq1rd43/Image']
+
+    def test_get_attachment_xpaths_from_version_caches_populated_result(self):
+        """
+        The case worth caching is the one that costs something: a version that
+        does have media questions, whose xpaths are read back from an expanded
+        `to_formpack_schema()`.
+        """
+
+        version = self.asset.asset_versions.filter(deployed=True).first()
+        cache_key = f'attachment_xpaths:{self.asset.uid}:{version.uid}'
+        cache.delete(cache_key)
+
+        with patch.object(
+            AssetVersion,
+            'to_formpack_schema',
+            side_effect=AssetVersion.to_formpack_schema,
+            autospec=True,
+        ) as expand:
+            assert self.asset.get_attachment_xpaths_from_version(version) == ['Image']
+            assert cache.get(cache_key) == ['Image']
+            assert self.asset.get_attachment_xpaths_from_version(version) == ['Image']
+
+        assert expand.call_count == 1
+
+    def test_get_attachment_xpaths_without_version_follow_the_content(self):
+        """
+        Without a version the xpaths come from `self.content`, which changes on
+        every save while nothing invalidates the cache. Reading it must
+        therefore answer for the content as it stands, which no cache entry
+        keyed on the asset alone could do.
+        """
+
+        assert self.asset.get_attachment_xpaths_from_version() == ['Image']
+
+        self.asset.content['survey'][0]['name'] = 'Image_renamed'
+        self.asset.save()
+
+        assert self.asset.get_attachment_xpaths_from_version() == ['Image_renamed']
+
+    def test_get_all_attachment_xpaths_memoizes_a_cache_hit(self):
+        """
+        A hit used to return before the instance memo was set, so each call paid
+        a Redis round-trip and the query behind `latest_deployed_version_uid`.
+        """
+
+        self.asset.get_all_attachment_xpaths()
+        asset = Asset.objects.get(pk=self.asset.pk)
+
+        with patch('kpi.models.asset.cache.get', side_effect=cache.get) as cache_get:
+            assert asset.get_all_attachment_xpaths() == ['Image']
+            assert asset.get_all_attachment_xpaths() == ['Image']
+
+        assert cache_get.call_count == 1
 
     def test_get_attachment_xpaths_from_version_uids_merges_versions(self):
         """

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -918,6 +918,52 @@ class TestAssetContent(TestCase):
         xpaths = asset.get_all_attachment_xpaths()
         assert sorted(xpaths) == ['Image', 'group_kq1rd43/Image']
 
+    def test_get_attachment_xpaths_from_version_uids_merges_versions(self):
+        """
+        A question renamed between two versions lives at both xpaths, and a
+        submission carries whichever one was deployed when its file arrived.
+        """
+
+        asset = self.asset
+        first_version_uid = asset.latest_deployed_version_uid
+
+        asset.content['survey'][0]['name'] = 'Image_renamed'
+        asset.save()
+        asset.deploy(backend='mock')
+        second_version_uid = asset.latest_deployed_version_uid
+
+        assert sorted(
+            asset.get_attachment_xpaths_from_version_uids(
+                [first_version_uid, second_version_uid]
+            )
+        ) == ['Image', 'Image_renamed']
+
+        assert asset.get_attachment_xpaths_from_version_uids([first_version_uid]) == [
+            'Image'
+        ]
+
+    def test_get_attachment_xpaths_from_version_uids_skips_unknown_uids(self):
+        version_uid = self.asset.latest_deployed_version_uid
+        unknown = 'v' + 'z' * 21
+
+        assert self.asset.get_attachment_xpaths_from_version_uids(
+            [unknown, version_uid]
+        ) == ['Image']
+        assert self.asset.get_attachment_xpaths_from_version_uids([unknown]) == []
+        assert self.asset.get_attachment_xpaths_from_version_uids([]) == []
+
+    def test_get_attachment_xpaths_from_version_uids_ignores_undeployed(self):
+        """
+        Only a deployed version can have produced a submission.
+        """
+
+        self.asset.content['survey'][0]['name'] = 'Image_renamed'
+        self.asset.save()
+        draft = self.asset.asset_versions.filter(deployed=False).first()
+
+        assert draft is not None
+        assert self.asset.get_attachment_xpaths_from_version_uids([draft.uid]) == []
+
     @patch('kpi.models.asset.Asset.get_attachment_xpaths_from_version')
     def test_xpath_method_called_once_for_single_version(
         self, mock_get_xpaths_from_version

--- a/kpi/tests/test_asset_content.py
+++ b/kpi/tests/test_asset_content.py
@@ -973,6 +973,24 @@ class TestAssetContent(TestCase):
 
         assert cache_get.call_count == 1
 
+    def test_get_all_attachment_xpaths_memo_does_not_outlive_a_deployment(self):
+        """
+        The memo answers for a set of deployed versions. Deploying another one
+        makes it wrong, and `save()` is what both a deployment and an edit go
+        through.
+        """
+
+        assert self.asset.get_all_attachment_xpaths() == ['Image']
+
+        self.asset.content['survey'][0]['name'] = 'Image_renamed'
+        self.asset.save()
+        self.asset.deploy(backend='mock')
+
+        assert sorted(self.asset.get_all_attachment_xpaths()) == [
+            'Image',
+            'Image_renamed',
+        ]
+
     def test_get_attachment_xpaths_from_version_uids_merges_versions(self):
         """
         A question renamed between two versions lives at both xpaths, and a


### PR DESCRIPTION
### 📣 Summary

Files attached to a submission are no longer dropped when the form's question was renamed while the form was open.

### 📖 Description

Attaching a file to a form that was renamed or reorganised in the meantime used to lose that file. The submission went through, the filename stayed in the data, but the file itself was gone with no error shown anywhere. It happened whenever the question moved between the moment the form was loaded and the moment the record reached the server: a form edited and redeployed in another tab, or a record filled in offline and sent days later.

Those files are kept now. A submission is matched against every version of the form it has been through, not only against the one deployed today.

### 💭 Notes

`get_soft_deleted_attachments()` built its list of accepted media questions from the currently deployed XForm alone, while the submission's nodes carry the names of the version the client actually rendered. Nothing matched, so every attachment of the record was soft deleted moments after being saved, with a 201 still returned to the client. The versions recorded in `meta/formVersions` by #7543 are now resolved through KPI and added to the XForm's own. `soft_delete_orphan_attachments` goes through the same function and is fixed along with it. Nothing to run, no migration, no backfill; records already soft deleted stay that way, that is DEV-2804.

**Known limitation, worth knowing before testing.** When a question's XPath changes, whether a rename or a move in or out of a group, and the record is then edited, Enketo posts back both shapes: the deployed one it renders, and the record's original nodes, which it appends at the end of the document. Nothing on the server ties two names of the same question together across a rename, so the file the edit has just replaced cannot be told apart from a file that simply has no home in the current form. Both are kept, and the stale one stays visible on the submission and has to be deleted by hand. It behaves like other questions, but this could be improved with another PR if we implement a specific unique identifier per question. (`$kuid` is not). 

That is a deliberate choice rather than an oversight. The alternative is to ignore the older names as soon as the deployed ones are answered, which is what release does. It retires the replaced file correctly, but it also retires any other file whose own question changed XPath in the same redeployment and whose deployed node comes back empty because Enketo could not carry the old value over. That second file was never touched by anyone, and it is not hypothetical: it is the shape of the record this was reproduced on, where `second_image` came back empty and the original `image_2` survived only as a leftover node. Neither behaviour is right and no rule can be, since the pairing is undecidable. Keeping is the safer of the two, since a stale file stays visible and can be removed while a file that vanishes is never noticed. Ordinary edits are unaffected either way: a replaced file is retired and the others are left alone. The Enketo behaviour behind all of this deserves its own ticket, it is not introduced here.


### 👀 Preview steps

1. ℹ️ have a deployed form with an image question named `upload_image`
2. open the form in Enketo, online-offline mode, and attach an image
3. in another tab, open the same form in the form builder, rename the question to `upload_image_edited`, save and deploy
4. go back to the Enketo tab and press submit
5. 🔴 [on release] open the submission in the API: the filename is in the data but `_attachments` is empty, the file is gone
6. 🟢 [on PR] the attachment is there, with a `question_xpath` of `upload_image`
7. edit the submission and replace the file on a question that was **not** renamed
8. 🟢 the replaced file is soft deleted as before, the others are untouched
