### PR TITLE
feat(csrf): allow distinct origin config

### DIFF
--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -62,7 +62,12 @@ if SESSION_COOKIE_DOMAIN:
     trusted_domains = [
         f'{public_request_scheme}://*{SESSION_COOKIE_DOMAIN}',
     ]
-    CSRF_TRUSTED_ORIGINS = trusted_domains
+else:
+    trusted_domains = []
+CSRF_TRUSTED_ORIGINS = env.list(
+    # Separate multiple origins with commas, and do not use spaces
+    'DJANGO_CSRF_TRUSTED_ORIGINS', default=trusted_domains
+)
 ENKETO_CSRF_COOKIE_NAME = env.str('ENKETO_CSRF_COOKIE_NAME', '__csrf')
 
 # Limit sessions to 1 week (the default is 2 weeks)

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -66,7 +66,8 @@ else:
     trusted_domains = []
 CSRF_TRUSTED_ORIGINS = env.list(
     # Separate multiple origins with commas, and do not use spaces
-    'DJANGO_CSRF_TRUSTED_ORIGINS', default=trusted_domains
+    'DJANGO_CSRF_TRUSTED_ORIGINS',
+    default=trusted_domains,
 )
 ENKETO_CSRF_COOKIE_NAME = env.str('ENKETO_CSRF_COOKIE_NAME', '__csrf')
 


### PR DESCRIPTION
### 👷 Description for instance maintainers

Allow CSRF_TRUSTED_ORIGINS to be configured distinctly from SESSION_COOKIE_DOMAIN via the new environment variable DJANGO_CSRF_TRUSTED_ORIGINS