### PR TITLE
feat(singleSubmissionView): add Translate & analyze action for text responses DEV-2373

### DIFF
--- a/jsapp/js/attachments/AttachmentActionsDropdown.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.tsx
@@ -3,13 +3,14 @@ import { useState } from 'react'
 import type { _DataResponseAttachmentsItem } from '#/api/models/_dataResponseAttachmentsItem'
 import type { DataResponse } from '#/api/models/dataResponse'
 import { useAssetsAttachmentsDestroy } from '#/api/react-query/survey-data'
-import ActionIcon from '#/components/common/ActionIcon'
 import Button from '#/components/common/ButtonNew'
+import MoreActionsMenu from '#/components/common/MoreActionsMenu'
 import Icon from '#/components/common/icon'
 import { userHasPermForSubmission } from '#/components/permissions/utils'
+import { isNlpSupported } from '#/components/processing/common/utils'
 import { QuestionTypeName } from '#/constants'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
-import { notify } from '#/utils'
+import { getSubmissionRootUuid, notify } from '#/utils'
 import styles from './AttachmentActionsDropdown.module.scss'
 
 interface AttachmentActionsDropdownProps {
@@ -22,6 +23,13 @@ interface AttachmentActionsDropdownProps {
    * possibly in other places in UI.
    */
   onDeleted?: () => void
+  /**
+   * Also offer a "Translate & analyze" entry that opens Processing for this
+   * response's question, when NLP processing supports its type. Off by
+   * default: some callers of this dropdown (e.g. inside Processing itself)
+   * already are the Processing view, where the entry would be redundant.
+   */
+  showProcessingAction?: boolean
 }
 
 /**
@@ -72,35 +80,34 @@ export default function AttachmentActionsDropdown(props: AttachmentActionsDropdo
   }
 
   const userCanChangeSubmission = userHasPermForSubmission('change_submissions', props.asset, props.submission)
+  const isProcessingActionShown = props.showProcessingAction && isNlpSupported(questionType)
 
   return (
     <span className={styles.attachmentActionsDropdown}>
       {/* We don't use portal here, as opening this inside SubmissionModal causes the menu to open in weird place */}
-      <Menu withinPortal={false} closeOnClickOutside closeOnItemClick position='bottom-end'>
-        <Menu.Target>
-          <span style={{ position: 'relative' }}>
-            <ActionIcon size='md' variant='transparent' iconName='more' />
-          </span>
-        </Menu.Target>
-
-        <Menu.Dropdown>
-          <Menu.Item component='a' href={attachment!.download_url} leftSection={<Icon name='download' />}>
-            {t('Download')}
-          </Menu.Item>
-          {userCanChangeSubmission && (
-            <>
-              <Menu.Divider />
-              <Menu.Item
-                variant='danger'
-                onClick={() => setIsDeleteModalOpen(true)}
-                leftSection={<Icon name='trash' />}
-              >
-                {t('Delete')}
-              </Menu.Item>
-            </>
-          )}
-        </Menu.Dropdown>
-      </Menu>
+      <MoreActionsMenu
+        processingAction={
+          isProcessingActionShown
+            ? {
+                assetUid: props.asset.uid,
+                xpath: attachment.question_xpath,
+                submissionEditId: getSubmissionRootUuid(props.submission),
+              }
+            : undefined
+        }
+      >
+        <Menu.Item component='a' href={attachment!.download_url} leftSection={<Icon name='download' />}>
+          {t('Download')}
+        </Menu.Item>
+        {userCanChangeSubmission && (
+          <>
+            <Menu.Divider />
+            <Menu.Item variant='danger' onClick={() => setIsDeleteModalOpen(true)} leftSection={<Icon name='trash' />}>
+              {t('Delete')}
+            </Menu.Item>
+          </>
+        )}
+      </MoreActionsMenu>
 
       <Modal
         opened={isDeleteModalOpen}

--- a/jsapp/js/attachments/AttachmentActionsDropdown.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.tsx
@@ -8,6 +8,7 @@ import MoreActionsMenu from '#/components/common/MoreActionsMenu'
 import Icon from '#/components/common/icon'
 import { userHasPermForSubmission } from '#/components/permissions/utils'
 import { isNlpSupported } from '#/components/processing/common/utils'
+import { stripRepeatIndices } from '#/components/submissions/submissionMediaUtils'
 import { QuestionTypeName } from '#/constants'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
 import { getSubmissionRootUuid, notify } from '#/utils'
@@ -65,8 +66,9 @@ export default function AttachmentActionsDropdown(props: AttachmentActionsDropdo
     }
   }
 
-  // We find the question that the attachment belongs to, to determine the text to display in the modal.
-  const questionType = props.asset.content?.survey?.find((row) => row.$xpath === attachment.question_xpath)?.type
+  // Strip any repeat-instance index so this matches the survey row's static xpath.
+  const questionXpath = stripRepeatIndices(attachment.question_xpath)
+  const questionType = props.asset.content?.survey?.find((row) => row.$xpath === questionXpath)?.type
   let attachmentTypeName = t('attachment')
   if (questionType === QuestionTypeName.audio) {
     attachmentTypeName = t('audio recording')
@@ -89,7 +91,7 @@ export default function AttachmentActionsDropdown(props: AttachmentActionsDropdo
           isProcessingActionShown
             ? {
                 assetUid: props.asset.uid,
-                xpath: attachment.question_xpath,
+                xpath: questionXpath,
                 submissionEditId: getSubmissionRootUuid(props.submission),
               }
             : undefined

--- a/jsapp/js/attachments/AttachmentActionsDropdown.tsx
+++ b/jsapp/js/attachments/AttachmentActionsDropdown.tsx
@@ -25,9 +25,8 @@ interface AttachmentActionsDropdownProps {
   onDeleted?: () => void
   /**
    * Also offer a "Translate & analyze" entry that opens Processing for this
-   * response's question, when NLP processing supports its type. Off by
-   * default: some callers of this dropdown (e.g. inside Processing itself)
-   * already are the Processing view, where the entry would be redundant.
+   * response's question, when NLP processing supports its type.
+   * Off by default.
    */
   showProcessingAction?: boolean
 }

--- a/jsapp/js/components/common/MoreActionsMenu.tsx
+++ b/jsapp/js/components/common/MoreActionsMenu.tsx
@@ -1,0 +1,47 @@
+import { Menu } from '@mantine/core'
+import { IconPencilStar } from '@tabler/icons-react'
+import type { ReactNode } from 'react'
+import ActionIcon from '#/components/common/ActionIcon'
+import KoboIcon from '#/components/common/KoboIcon'
+import { goToProcessing } from '#/components/processing/routes.utils'
+
+interface MoreActionsMenuProps {
+  children?: ReactNode
+  className?: string
+  processingAction?: {
+    assetUid: string
+    xpath: string
+    submissionEditId: string
+  }
+}
+
+/** A "…" button that opens a dropdown menu of actions. */
+export default function MoreActionsMenu({ children, className, processingAction }: MoreActionsMenuProps) {
+  return (
+    <Menu withinPortal={false} closeOnClickOutside closeOnItemClick position='bottom-end'>
+      <Menu.Target>
+        <span className={className} style={{ position: 'relative' }}>
+          <ActionIcon size='md' variant='transparent' iconName='more' />
+        </span>
+      </Menu.Target>
+
+      <Menu.Dropdown>
+        {processingAction && (
+          <>
+            <Menu.Item
+              leftSection={<KoboIcon icon={IconPencilStar} size={16} />}
+              onClick={() =>
+                goToProcessing(processingAction.assetUid, processingAction.xpath, processingAction.submissionEditId)
+              }
+            >
+              {t('Translate & analyze')}
+            </Menu.Item>
+            {children && <Menu.Divider />}
+          </>
+        )}
+
+        {children}
+      </Menu.Dropdown>
+    </Menu>
+  )
+}

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -8,15 +8,14 @@ import { findRow, getRowName, renderQuestionTypeIcon } from '#/assetUtils'
 import AttachmentActionsDropdown from '#/attachments/AttachmentActionsDropdown'
 import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
+import MoreActionsMenu from '#/components/common/MoreActionsMenu'
 import SimpleTable from '#/components/common/SimpleTable'
-import Button from '#/components/common/button'
-import { goToProcessing } from '#/components/processing/routes.utils'
+import { isNlpSupported } from '#/components/processing/common/utils'
 import {
   DISPLAY_GROUP_TYPES,
   DisplayGroup,
   getMediaAttachment,
   getSubmissionDisplayData,
-  shouldProcessingBeAccessible,
 } from '#/components/submissions/submissionUtils'
 import type { DisplayResponse } from '#/components/submissions/submissionUtils'
 import { METADATA_COLUMN_LABELS } from '#/components/submissions/tableConstants'
@@ -24,7 +23,7 @@ import { getMetadataColumns } from '#/components/submissions/tableUtils'
 import { QUESTION_TYPES, RANK_LEVEL_TYPE, SCORE_ROW_TYPE } from '#/constants'
 import type { AnyRowTypeName, MetaQuestionTypeName } from '#/constants'
 import type { AssetResponse, SubmissionResponse } from '#/dataInterface'
-import { formatDate, formatTimeDate } from '#/utils'
+import { formatDate, formatTimeDate, getSubmissionRootUuid } from '#/utils'
 import AudioPlayer from '../common/audioPlayer'
 
 bem.SubmissionDataTable = makeBem(null, 'submission-data-table')
@@ -49,18 +48,6 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
   constructor(props: SubmissionDataTableProps) {
     super(props)
     autoBind(this)
-  }
-
-  /**
-   * Opens Single Processing for one response. With no row left to ask for the xpath,
-   * the path the response arrived under gets us there - files are found by xpath.
-   */
-  openProcessing(name: string, xpath: string) {
-    if (!this.props.asset?.content) {
-      return
-    }
-    const processingXpath = findRow(this.props.asset.content, name)?.$xpath ?? xpath
-    goToProcessing(this.props.asset.uid, processingXpath, this.props.submissionData._uuid)
   }
 
   renderGroup(item: DisplayGroup, itemIndex?: number) {
@@ -189,7 +176,9 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       case QUESTION_TYPES.audio.id:
       case QUESTION_TYPES.video.id:
       case QUESTION_TYPES.file.id:
-        return this.renderAttachment(item.type, item.data, item.name, item.xpath)
+        return this.renderAttachment(item.type, item.data, item.xpath)
+      case QUESTION_TYPES.text.id:
+        return this.renderTextResponse(item.data, item.name)
       case QUESTION_TYPES.geopoint.id:
       case QUESTION_TYPES.geotrace.id:
       case QUESTION_TYPES.geoshape.id:
@@ -223,7 +212,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     )
   }
 
-  renderAttachment(type: AnyRowTypeName | null, filename: string, name: string, xpath: string) {
+  renderAttachment(type: AnyRowTypeName | null, filename: string, xpath: string) {
     const attachment = getMediaAttachment(this.props.submissionData, filename, xpath)
 
     // In the case that an attachment is missing, don't crash the page
@@ -244,21 +233,10 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     return (
       <>
         {type === QUESTION_TYPES.audio.id && (
-          <Group>
+          <Group w='100%'>
             <AudioPlayer mediaURL={attachment?.download_url} />
 
             <span className='print-only'>{attachmentShortFilename}</span>
-
-            {shouldProcessingBeAccessible(this.props.submissionData, attachment) && (
-              <Button
-                className='hide-on-print'
-                type='primary'
-                size='s'
-                endIcon='arrow-up-right'
-                label={t('Open')}
-                onClick={this.openProcessing.bind(this, name, xpath)}
-              />
-            )}
           </Group>
         )}
 
@@ -289,12 +267,38 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
             asset={this.props.asset}
             submission={this.props.submissionData}
             attachmentUid={attachment.uid}
+            showProcessingAction
             onDeleted={() => {
               this.props.onAttachmentDeleted(attachment.uid)
             }}
           />
         )}
       </>
+    )
+  }
+
+  renderTextResponse(text: string, name: string) {
+    // `item.xpath` (passed to `renderAttachment`) is built for matching media attachments and gets a repeat-instance
+    // index baked in inside repeat groups (e.g. `group[2]/question`), which Processing's routing doesn't understand -
+    // it wants the question's static survey xpath, so we look that up by name instead, same as `renderAttachment`'s
+    // audio button does implicitly (its xpath comes from a `row.$xpath === attachment.question_xpath` match).
+    const questionXpath = this.props.asset.content && findRow(this.props.asset.content, name)?.$xpath
+
+    return (
+      <Group wrap='nowrap' align='flex-start'>
+        <bem.SubmissionDataTable__value style={{ flex: 1, minWidth: 0 }}>{text}</bem.SubmissionDataTable__value>
+
+        {text && questionXpath !== undefined && isNlpSupported(QUESTION_TYPES.text.id) && (
+          <MoreActionsMenu
+            className='hide-on-print'
+            processingAction={{
+              assetUid: this.props.asset.uid,
+              xpath: questionXpath,
+              submissionEditId: getSubmissionRootUuid(this.props.submissionData),
+            }}
+          />
+        )}
+      </Group>
     )
   }
 

--- a/jsapp/js/components/submissions/submissionDataTable.tsx
+++ b/jsapp/js/components/submissions/submissionDataTable.tsx
@@ -4,13 +4,14 @@ import React from 'react'
 
 import { Group } from '@mantine/core'
 import autoBind from 'react-autobind'
-import { findRow, getRowName, renderQuestionTypeIcon } from '#/assetUtils'
+import { getRowName, renderQuestionTypeIcon } from '#/assetUtils'
 import AttachmentActionsDropdown from '#/attachments/AttachmentActionsDropdown'
 import DeletedAttachment from '#/attachments/deletedAttachment.component'
 import bem, { makeBem } from '#/bem'
 import MoreActionsMenu from '#/components/common/MoreActionsMenu'
 import SimpleTable from '#/components/common/SimpleTable'
 import { isNlpSupported } from '#/components/processing/common/utils'
+import { stripRepeatIndices } from '#/components/submissions/submissionMediaUtils'
 import {
   DISPLAY_GROUP_TYPES,
   DisplayGroup,
@@ -178,7 +179,7 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
       case QUESTION_TYPES.file.id:
         return this.renderAttachment(item.type, item.data, item.xpath)
       case QUESTION_TYPES.text.id:
-        return this.renderTextResponse(item.data, item.name)
+        return this.renderTextResponse(item.data, item.xpath)
       case QUESTION_TYPES.geopoint.id:
       case QUESTION_TYPES.geotrace.id:
       case QUESTION_TYPES.geoshape.id:
@@ -277,18 +278,15 @@ class SubmissionDataTable extends React.Component<SubmissionDataTableProps> {
     )
   }
 
-  renderTextResponse(text: string, name: string) {
-    // `item.xpath` (passed to `renderAttachment`) is built for matching media attachments and gets a repeat-instance
-    // index baked in inside repeat groups (e.g. `group[2]/question`), which Processing's routing doesn't understand -
-    // it wants the question's static survey xpath, so we look that up by name instead, same as `renderAttachment`'s
-    // audio button does implicitly (its xpath comes from a `row.$xpath === attachment.question_xpath` match).
-    const questionXpath = this.props.asset.content && findRow(this.props.asset.content, name)?.$xpath
+  renderTextResponse(text: string, xpath: string) {
+    // Strip any repeat-instance index to get the question's static survey xpath.
+    const questionXpath = stripRepeatIndices(xpath)
 
     return (
       <Group wrap='nowrap' align='flex-start'>
         <bem.SubmissionDataTable__value style={{ flex: 1, minWidth: 0 }}>{text}</bem.SubmissionDataTable__value>
 
-        {text && questionXpath !== undefined && isNlpSupported(QUESTION_TYPES.text.id) && (
+        {text && isNlpSupported(QUESTION_TYPES.text.id) && (
           <MoreActionsMenu
             className='hide-on-print'
             processingAction={{

--- a/jsapp/js/components/submissions/submissionMediaUtils.tests.ts
+++ b/jsapp/js/components/submissions/submissionMediaUtils.tests.ts
@@ -1,7 +1,25 @@
 import { QuestionTypeName } from '#/constants'
 import type { SubmissionAttachment } from '#/dataInterface'
 import assetDataFactory from '#/endpoints/assetData.factory'
-import { findAttachmentByQuestionXpath, inferAttachmentQuestionType } from './submissionMediaUtils'
+import { findAttachmentByQuestionXpath, inferAttachmentQuestionType, stripRepeatIndices } from './submissionMediaUtils'
+
+describe('stripRepeatIndices', () => {
+  it('should leave a static xpath unchanged', () => {
+    chai.expect(stripRepeatIndices('outer_group/inner_group/question')).to.equal('outer_group/inner_group/question')
+  })
+
+  it('should strip a single repeat-instance index', () => {
+    chai.expect(stripRepeatIndices('children[1]/audio')).to.equal('children/audio')
+  })
+
+  it('should strip multiple repeat-instance indices from nested repeats', () => {
+    chai.expect(stripRepeatIndices('outer[2]/inner[10]/question')).to.equal('outer/inner/question')
+  })
+
+  it('should leave a bare question name unchanged', () => {
+    chai.expect(stripRepeatIndices('question')).to.equal('question')
+  })
+})
 
 function buildAttachment(overrides: Partial<SubmissionAttachment> = {}): SubmissionAttachment {
   return {

--- a/jsapp/js/components/submissions/submissionMediaUtils.ts
+++ b/jsapp/js/components/submissions/submissionMediaUtils.ts
@@ -3,6 +3,11 @@ import type { DataResponse } from '#/api/models/dataResponse'
 import { type AnyRowTypeName, QuestionTypeName } from '#/constants'
 import type { SubmissionAttachment, SubmissionResponse } from '#/dataInterface'
 
+/** Strips repeat-instance indices (e.g. `[2]`) to get the static survey xpath. */
+export function stripRepeatIndices(xpath: string): string {
+  return xpath.replace(/\[\d+\]/g, '')
+}
+
 /**
  * Finds the attachment a submission stored for the given question path. Matches on
  * `question_xpath`, the path recorded when the submission came in, so the file is


### PR DESCRIPTION
### 📣 Summary

Text responses in the Single Submission Modal now have a "..." menu with a "Translate & analyze" action, opening Processing for that response — same as audio already offers.

### 💭 Notes

- Audio's existing "Open" button in this same dialog was replaced by the same "Translate & analyze" menu entry, in its own existing "..." attachment menu, so both response types now share one consistent action, icon, and label.
- Extracted the shared "..." menu (`MoreActionsMenu`) and its optional "Translate & analyze" entry (`processingAction` prop) so both the attachment dropdown and the new text menu use the same implementation, rather than duplicating the trigger/label wiring.
- The audio player in this dialog now fills the row's full width, matching the layout of other response types.
- The text menu resolves the question's static survey xpath by name rather than using the repeat-instance-aware path used for matching media attachments, so the action opens Processing at the correct route even for a text question inside a repeat group.
- Depends on `isNlpSupported`/`isAudioQuestionType`/`isTextQuestionType` from DEV-2288, which this branch is stacked on top of (this PR's base is that branch, not `main`).

### 👀 Preview steps

1. ℹ️ have a project deployed with at least one audio question and one text question, and a submission answering both
2. append `?ff_nlpTextActionsEnabled=true` to the URL and reload
3. open a submission from the table to bring up the Single Submission Modal
4. 🔴 [on main] the text response has no "..." menu at all; the audio response has a separate "Open" button next to its "..." menu
5. 🟢 [on PR] both the audio and the text response show a "..." menu with a "Translate & analyze" item (pencil + star icon)
6. click "Translate & analyze" on the text response and confirm it opens Processing for that exact question
7. do the same for the audio response, and confirm the audio player now spans the full row width
8. reload without the `ff_nlpTextActionsEnabled` param (or use a private window) and confirm the text response's menu no longer appears (audio's "..." menu, with Download/Delete, still does)
