### PR TITLE
fix(processing): keep audio files and NLP data reachable after a question moves into a group DEV-158

### DIFF
--- a/jsapp/js/components/submissions/submissionUtils.tests.ts
+++ b/jsapp/js/components/submissions/submissionUtils.tests.ts
@@ -370,7 +370,33 @@ describe('getSubmissionDisplayData for a question moved into a group', () => {
       .expect(groupResponses.find((response) => response.data === 'This is french transcript text.'))
       .to.not.equal(undefined)
   })
+
+  it('should keep the NLP rows of a submission made before the move', () => {
+    // A submission made before the move stores both the answer and its
+    // `_supplementalDetails` under the pre-move flat name. The current form
+    // only knows the grouped path, so the answer surfaces through the
+    // unaccounted-answers path - which must bring the NLP rows along, or the
+    // transcript silently vanishes from the single-submission view.
+    const asset = withRowMovedIntoGroup(assetWithSupplementalDetails, 'Secret_password_as_an_audio_file', 'grp')
+    const submission: SubmissionResponse = JSON.parse(JSON.stringify(submissionWithSupplementalDetails))
+
+    const allResponses = getAllResponses(getSubmissionDisplayData(asset, 0, submission))
+
+    // (a) the audio answer itself, kept visible under its submission-era path.
+    chai
+      .expect(allResponses.find((response) => response.data === '8BP076-09-rushjet1-unknown_sector-12_42_20.mp3'))
+      .to.not.equal(undefined)
+    // (b) the transcript row, attached next to the unaccounted answer.
+    chai
+      .expect(allResponses.find((response) => response.data === 'This is french transcript text.'))
+      .to.not.equal(undefined)
+  })
 })
+
+/** Every response in the display tree, from all groups at all depths. */
+function getAllResponses(group: DisplayGroup): DisplayResponse[] {
+  return group.children.flatMap((child) => (child instanceof DisplayGroup ? getAllResponses(child) : [child]))
+}
 
 describe('getRowData', () => {
   it('should find the answer of a question moved from one group to another', () => {

--- a/jsapp/js/components/submissions/submissionUtils.tests.ts
+++ b/jsapp/js/components/submissions/submissionUtils.tests.ts
@@ -1,10 +1,11 @@
 import { getRowName } from '#/assetUtils'
-import { QuestionTypeName } from '#/constants'
+import { GroupTypeBeginName, GroupTypeEndName, QuestionTypeName } from '#/constants'
 import assetDataFactory from '#/endpoints/assetData.factory'
 import {
   DisplayGroup,
   DisplayResponse,
   getMediaAttachment,
+  getRowData,
   getSubmissionDisplayData,
   getSupplementalDetailsContent,
   hasAnyUnacceptedAutomaticContent,
@@ -62,7 +63,7 @@ chai.use(chaiExclude)
 // After a recent chai / deep-eql update, tests relying on this behavior would
 // fail. Hence, use this looser comparison function.
 import chaiDeepEqualIgnoreUndefined from 'chai-deep-equal-ignore-undefined'
-import type { AssetResponse, SubmissionSupplementalDetails } from '#/dataInterface'
+import type { AssetResponse, SubmissionResponse, SubmissionSupplementalDetails, SurveyRow } from '#/dataInterface'
 chai.use(chaiDeepEqualIgnoreUndefined)
 
 describe('getSubmissionDisplayData', () => {
@@ -159,6 +160,42 @@ function withRenamedRow(asset: AssetResponse, oldName: string, newName: string):
     row.$xpath = [...row.$xpath.split('/').slice(0, -1), newName].join('/')
   }
   return renamedAsset
+}
+
+/**
+ * Wraps one existing question in a new group, the way redeploying a form with the
+ * question moved into a group would - changing the path the current form expects
+ * without rewriting how earlier eras were stored.
+ */
+function withRowMovedIntoGroup(asset: AssetResponse, rowName: string, groupName: string): AssetResponse {
+  const movedAsset: AssetResponse = JSON.parse(JSON.stringify(asset))
+  const survey = movedAsset.content?.survey
+  if (!survey) {
+    throw new Error('There is no survey to move a row in')
+  }
+  const index = survey.findIndex((surveyRow) => getRowName(surveyRow) === rowName)
+  if (index === -1) {
+    throw new Error(`There is no row named "${rowName}" to move`)
+  }
+
+  const [row] = survey.splice(index, 1)
+  if (row.$xpath !== undefined) {
+    row.$xpath = `${groupName}/${rowName}`
+  }
+  survey.splice(
+    index,
+    0,
+    {
+      name: groupName,
+      type: GroupTypeBeginName.begin_group,
+      $kuid: `${groupName}_kuid`,
+      $autoname: groupName,
+      label: [groupName],
+    } as SurveyRow,
+    row,
+    { type: GroupTypeEndName.end_group, $kuid: `/${groupName}_kuid` } as SurveyRow,
+  )
+  return movedAsset
 }
 
 /** The responses displayed directly in a group, i.e. without its subgroups. */
@@ -306,6 +343,48 @@ describe('getSubmissionDisplayData for answers the current form does not account
 
     chai.expect(groupResponses.map((response) => response.name)).to.deep.equal(['Favourite_color', 'Favourite_number'])
     chai.expect(groupResponses[1].data).to.equal(0)
+  })
+})
+
+describe('getSubmissionDisplayData for a question moved into a group', () => {
+  it('should keep the audio answer and its NLP rows when the question was moved after NLP was configured', () => {
+    // The question was moved into a group after transcript/translation were
+    // enabled, so its current path (`grp/...`) no longer equals the NLP source
+    // (the pre-move flat name kept in `analysis_form_json`). A submission made
+    // after the move stores the answer under the grouped path.
+    const asset = withRowMovedIntoGroup(assetWithSupplementalDetails, 'Secret_password_as_an_audio_file', 'grp')
+    const submission: SubmissionResponse = JSON.parse(JSON.stringify(submissionWithSupplementalDetails))
+    submission['grp/Secret_password_as_an_audio_file'] = submission.Secret_password_as_an_audio_file
+    delete submission.Secret_password_as_an_audio_file
+
+    const groupResponses = getGroupResponses(getSubmissionDisplayData(asset, 0, submission), 'grp')
+
+    // (a) the audio answer itself, found under the new grouped path.
+    chai
+      .expect(groupResponses.find((response) => response.data === '8BP076-09-rushjet1-unknown_sector-12_42_20.mp3'))
+      .to.not.equal(undefined)
+    // (b) the transcript row, which without the leaf-name fallback silently
+    // vanishes because the source path recorded at NLP-config time no longer
+    // matches the moved question's current path.
+    chai
+      .expect(groupResponses.find((response) => response.data === 'This is french transcript text.'))
+      .to.not.equal(undefined)
+  })
+})
+
+describe('getRowData', () => {
+  it('should find the answer of a question moved from one group to another', () => {
+    // The current form has the question in `new_grp`, but the submission was made
+    // when it lived in `old_grp`. Neither the current path nor the bare name
+    // matches the stored key, so without the leaf-name fallback this returns null.
+    const survey = [
+      { name: 'new_grp', type: GroupTypeBeginName.begin_group, $kuid: 'g', $autoname: 'new_grp', label: ['New'] },
+      { name: 'q', type: QuestionTypeName.audio, $kuid: 'q', $autoname: 'q', label: ['Q'] },
+      { type: GroupTypeEndName.end_group, $kuid: '/g' },
+    ] as unknown as SurveyRow[]
+    const data = { 'old_grp/q': 'clip.mp3' } as unknown as SubmissionResponse
+
+    chai.expect(getRowData('q', survey, data)).to.equal('clip.mp3')
   })
 })
 

--- a/jsapp/js/components/submissions/submissionUtils.tsx
+++ b/jsapp/js/components/submissions/submissionUtils.tsx
@@ -169,6 +169,44 @@ function sortAnalysisFormJsonKeys(additionalFields: AnalysisFormJsonField[]) {
   return sortedBySource
 }
 
+/** The last `/`-segment of a path, or the whole string when it has no `/`. */
+function getLeafName(path: string): string {
+  return path.includes('/') ? path.split('/').at(-1)! : path
+}
+
+/**
+ * Supplemental (NLP) keys recorded for a question's source path. The source is
+ * the xpath captured when the feature was enabled, so a question moved into or
+ * out of a group no longer matches it directly. Leaf names are unique per
+ * XLSForm, so fall back to every source sharing this leaf and return all their
+ * keys (deduped) - a question may carry keys from several eras.
+ */
+function getSupplementalKeysForSource(
+  supplementalDetailKeys: { [key: string]: string[] },
+  sourceKey: string,
+): string[] {
+  const direct = supplementalDetailKeys[sourceKey]
+  if (direct) {
+    return direct
+  }
+
+  const wantedLeaf = getLeafName(sourceKey)
+  const collected: string[] = []
+  const seen = new Set<string>()
+  for (const key of Object.keys(supplementalDetailKeys)) {
+    if (getLeafName(key) !== wantedLeaf) {
+      continue
+    }
+    for (const sdKey of supplementalDetailKeys[key]) {
+      if (!seen.has(sdKey)) {
+        seen.add(sdKey)
+        collected.push(sdKey)
+      }
+    }
+  }
+  return collected
+}
+
 function addXpathNode(parentGroup: DisplayGroup, repeatIndex: number | null, currentRowData: any) {
   const nodePath = []
   let childIndex = null
@@ -368,7 +406,7 @@ export function getSubmissionDisplayData(
          * Recursively add qual related rows to output. Looks for the source key in the list of all possible keys.
          */
         const addSupplementalDetails = (sourceKey: string) => {
-          supplementalDetailKeys[sourceKey]?.forEach((sdKey: string) => {
+          getSupplementalKeysForSource(supplementalDetailKeys, sourceKey).forEach((sdKey: string) => {
             // Create a unique xpath for the analysis/verification question
             const specificXpath = sdKey.replace('_supplementalDetails/', '')
 
@@ -686,6 +724,22 @@ export function getRowData(
     const rowData = getRegularGroupAnswers(data, path)
     if (recordKeys(rowData).length >= 1) {
       return rowData
+    }
+  }
+
+  // Question moved between groups: the submission stores its answer under the
+  // xpath of the form version it was made against, which no longer matches the
+  // current path or bare name. Leaf names are unique per XLSForm, so match the
+  // first flat key sharing this leaf (skipping back end and metadata keys).
+  for (const key of recordKeys(data)) {
+    if (typeof key !== 'string' || key.startsWith('_')) {
+      continue
+    }
+    if (key.startsWith('formhub/') || key.startsWith('meta/')) {
+      continue
+    }
+    if (getLeafName(key) === name && isAnswered(data[key])) {
+      return data[key]
     }
   }
   return null

--- a/jsapp/js/components/submissions/submissionUtils.tsx
+++ b/jsapp/js/components/submissions/submissionUtils.tsx
@@ -207,6 +207,45 @@ function getSupplementalKeysForSource(
   return collected
 }
 
+/**
+ * Appends one row per supplemental (NLP) key recorded for a question's source
+ * path - transcript, translations, analysis questions - including nested ones
+ * (e.g. qualVerification for a qual question).
+ */
+function addSupplementalDetailRows(
+  asset: AssetResponse,
+  submissionData: DataResponse | SubmissionResponse,
+  supplementalDetailKeys: { [key: string]: string[] },
+  sourceKey: string,
+  children: Array<DisplayResponse | DisplayGroup>,
+) {
+  getSupplementalKeysForSource(supplementalDetailKeys, sourceKey).forEach((sdKey: string) => {
+    // Create a unique xpath for the analysis/verification question
+    const specificXpath = sdKey.replace('_supplementalDetails/', '')
+
+    children.push(
+      new DisplayResponse(
+        // type
+        // TODO: should we aim at this being analysis question type name?
+        null,
+        // label
+        getColumnLabel(asset, sdKey, false),
+        // name
+        sdKey,
+        // xpath
+        specificXpath,
+        // listName
+        undefined,
+        // data
+        getSupplementalDetailsContent(submissionData, sdKey),
+      ),
+    )
+
+    // Check for nested supplemental details (e.g. qualVerification for a qual question)
+    addSupplementalDetailRows(asset, submissionData, supplementalDetailKeys, specificXpath, children)
+  })
+}
+
 function addXpathNode(parentGroup: DisplayGroup, repeatIndex: number | null, currentRowData: any) {
   const nodePath = []
   let childIndex = null
@@ -402,38 +441,7 @@ export function getSubmissionDisplayData(
 
         const rowxpath = flatPaths[rowName]
 
-        /**
-         * Recursively add qual related rows to output. Looks for the source key in the list of all possible keys.
-         */
-        const addSupplementalDetails = (sourceKey: string) => {
-          getSupplementalKeysForSource(supplementalDetailKeys, sourceKey).forEach((sdKey: string) => {
-            // Create a unique xpath for the analysis/verification question
-            const specificXpath = sdKey.replace('_supplementalDetails/', '')
-
-            parentGroup.children.push(
-              new DisplayResponse(
-                // type
-                // TODO: should we aim at this being analysis question type name?
-                null,
-                // label
-                getColumnLabel(asset, sdKey, false),
-                // name
-                sdKey,
-                // xpath
-                specificXpath,
-                // listName
-                undefined,
-                // data
-                getSupplementalDetailsContent(submissionData, sdKey),
-              ),
-            )
-
-            // Check for nested supplemental details (e.g. qualVerification for a qual question)
-            addSupplementalDetails(specificXpath)
-          })
-        }
-
-        addSupplementalDetails(rowxpath)
+        addSupplementalDetailRows(asset, submissionData, supplementalDetailKeys, rowxpath, parentGroup.children)
       }
     }
   }
@@ -481,6 +489,7 @@ function addUnaccountedAnswers(
   }
 
   const flatPaths = getSurveyFlatPaths(assetContent.survey ?? [], true)
+  const supplementalDetailKeys = sortAnalysisFormJsonKeys(asset.analysis_form_json?.additional_fields || [])
 
   for (const [key, value] of Object.entries(submissionData)) {
     if (displayedKeys.has(key) || NON_RESPONSE_SUBMISSION_KEYS.has(key)) {
@@ -509,6 +518,11 @@ function addUnaccountedAnswers(
 
     // Name and xpath are both the key - the path that finds the file too.
     group.children.push(new DisplayResponse(type, label, key, key, getRowListName(row), value))
+
+    // A submission made before its question moved into a group keeps both the
+    // answer and its NLP data under the pre-move path, so the NLP rows have to
+    // ride along here or they'd vanish with the moved answer.
+    addSupplementalDetailRows(asset, submissionData, supplementalDetailKeys, key, group.children)
   }
 }
 

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -80,7 +80,11 @@ from kpi.utils.files import ExtendedContentFile
 from kpi.utils.log import logging
 from kpi.utils.mongo_helper import MongoHelper
 from kpi.utils.object_permission import get_anonymous_user, get_database_user
-from kpi.utils.xml import fromstring_preserve_root_xmlns, xml_tostring
+from kpi.utils.xml import (
+    find_element_by_leaf_name,
+    fromstring_preserve_root_xmlns,
+    xml_tostring,
+)
 from ..exceptions import AttachmentUidMismatchException, BadFormatException
 from .base_backend import BaseDeploymentBackend
 from .kc_access.utils import kc_transaction_atomic
@@ -567,20 +571,9 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
 
             if element is None:
                 # Submissions keep the xpath of the form version they were made
-                # against, so a current-version xpath may not exist in an older
-                # submission's XML (and vice versa) when a question moves into
-                # or out of a group. XLSForm names are unique form-wide, so the
-                # first leaf-name match is deterministic.
-                leaf = xpath.rsplit('/', 1)[-1]
-                for candidate in submission_root.iter():
-                    if candidate is submission_root:
-                        continue
-                    tag = candidate.tag
-                    if isinstance(tag, str) and '}' in tag:
-                        tag = tag.rsplit('}', 1)[-1]
-                    if tag == leaf and candidate.text:
-                        element = candidate
-                        break
+                # against, so a path from another version may not exist in the
+                # XML when the question moved into or out of a group
+                element = find_element_by_leaf_name(submission_root, xpath)
 
             if element is None:
                 raise XPathNotFoundException

--- a/kpi/deployment_backends/openrosa_backend.py
+++ b/kpi/deployment_backends/openrosa_backend.py
@@ -566,6 +566,23 @@ class OpenRosaDeploymentBackend(BaseDeploymentBackend):
                 raise InvalidXPathException
 
             if element is None:
+                # Submissions keep the xpath of the form version they were made
+                # against, so a current-version xpath may not exist in an older
+                # submission's XML (and vice versa) when a question moves into
+                # or out of a group. XLSForm names are unique form-wide, so the
+                # first leaf-name match is deterministic.
+                leaf = xpath.rsplit('/', 1)[-1]
+                for candidate in submission_root.iter():
+                    if candidate is submission_root:
+                        continue
+                    tag = candidate.tag
+                    if isinstance(tag, str) and '}' in tag:
+                        tag = tag.rsplit('}', 1)[-1]
+                    if tag == leaf and candidate.text:
+                        element = candidate
+                        break
+
+            if element is None:
                 raise XPathNotFoundException
             attachment_filename = element.text
             # Legacy DB rows may store the basename in either normalization

--- a/kpi/tests/api/v2/test_api_attachments.py
+++ b/kpi/tests/api/v2/test_api_attachments.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import patch
 
+import pytest
 from django.http import QueryDict
 from django.test import override_settings
 from django.urls import reverse
@@ -10,6 +11,7 @@ from kobo.apps.kobo_auth.shortcuts import User
 from kpi.deployment_backends.kc_access.storage import (
     default_kobocat_storage as default_storage,
 )
+from kpi.exceptions import XPathNotFoundException
 from kpi.models import Asset
 from kpi.tests.base_test_case import BaseAssetTestCase
 from kpi.tests.utils.mock import guess_type_mock
@@ -331,3 +333,117 @@ class AttachmentApiTests(BaseAssetTestCase):
         self.client.get(thumb_url)
         # Thumbs should exist
         self.assertTrue(default_storage.exists(thumbnail))
+
+    def test_get_attachment_resolves_xpath_across_form_versions(self):
+        """
+        Keep an attachment reachable by both the pre-move and the post-move
+        xpath once a question is moved into a group and the form is redeployed.
+
+        Submissions keep the xpath of the version they were made against, so
+        without the leaf-name fallback a current-version xpath misses an older
+        submission's XML (and vice versa), which is the DEV-158 break.
+        """
+        clip = 'audio_conversion_test_clip.3gp'
+
+        def _make_submission(version_uid, audio_key):
+            _uuid = str(uuid.uuid4())
+            return {
+                '__version__': version_uid,
+                audio_key: clip,
+                '_uuid': _uuid,
+                'meta/instanceID': f'uuid:{_uuid}',
+                'meta/rootUuid': f'uuid:{_uuid}',
+                '_attachments': [
+                    {
+                        'download_url': f'http://testserver/someuser/{clip}',
+                        'filename': f'someuser/{clip}',
+                        'mimetype': 'video/3gpp',
+                    },
+                ],
+                '_submitted_by': 'someuser',
+            }
+
+        asset = Asset.objects.create(
+            content={
+                'survey': [
+                    {
+                        'type': 'audio',
+                        'name': 'Tell_me_a_story',
+                        'label': 'q',
+                        '$kuid': 'aud1',
+                    },
+                ]
+            },
+            owner=self.someuser,
+            asset_type='survey',
+        )
+        asset.deploy(backend='mock', active=True)
+        asset.save()
+
+        # A submission made before the move stores the answer at the root xpath.
+        old_submission = _make_submission(
+            asset.latest_deployed_version.uid, 'Tell_me_a_story'
+        )
+        with patch('mimetypes.guess_type') as guess_mock:
+            guess_mock.side_effect = guess_type_mock
+            asset.deployment.mock_submissions([old_submission])
+
+        # Move the question into a group and redeploy, as a new version would.
+        # The content is already normalized, so labels must stay translated lists.
+        asset.content['survey'] = [
+            {'type': 'begin_group', 'name': 'grp', 'label': ['grp'], '$kuid': 'grp1'},
+            {
+                'type': 'audio',
+                'name': 'Tell_me_a_story',
+                'label': ['q'],
+                '$kuid': 'aud1',
+            },
+            {'type': 'end_group', '$kuid': '/grp1'},
+        ]
+        asset.save()
+        asset.deploy(backend='mock', active=True)
+        asset.save()
+
+        # A submission made after the move stores it at the grouped xpath.
+        new_submission = _make_submission(
+            asset.latest_deployed_version.uid, 'grp/Tell_me_a_story'
+        )
+        with patch('mimetypes.guess_type') as guess_mock:
+            guess_mock.side_effect = guess_type_mock
+            asset.deployment.mock_submissions([new_submission])
+
+        deployment = asset.deployment
+        old_id = old_submission['_id']
+        new_id = new_submission['_id']
+        old_att_id = old_submission['_attachments'][0]['id']
+        new_att_id = new_submission['_attachments'][0]['id']
+
+        # Old submission: native root xpath, plus the current grouped xpath by
+        # leaf-name fallback.
+        assert (
+            deployment.get_attachment(old_id, self.someuser, xpath='Tell_me_a_story').pk
+            == old_att_id
+        )
+        assert (
+            deployment.get_attachment(
+                old_id, self.someuser, xpath='grp/Tell_me_a_story'
+            ).pk
+            == old_att_id
+        )
+
+        # New submission: native grouped xpath, plus the pre-move root xpath by
+        # leaf-name fallback.
+        assert (
+            deployment.get_attachment(
+                new_id, self.someuser, xpath='grp/Tell_me_a_story'
+            ).pk
+            == new_att_id
+        )
+        assert (
+            deployment.get_attachment(new_id, self.someuser, xpath='Tell_me_a_story').pk
+            == new_att_id
+        )
+
+        # A leaf that never existed in either era still raises.
+        with pytest.raises(XPathNotFoundException):
+            deployment.get_attachment(old_id, self.someuser, xpath='no_such_question')

--- a/kpi/tests/test_utils.py
+++ b/kpi/tests/test_utils.py
@@ -34,6 +34,7 @@ from kpi.utils.submission import get_attachment_filenames_and_xpaths
 from kpi.utils.urls import versioned_reverse
 from kpi.utils.xml import (
     edit_submission_xml,
+    find_element_by_leaf_name,
     fromstring_preserve_root_xmlns,
     get_or_create_element,
     strip_nodes,
@@ -824,6 +825,41 @@ class XmlUtilsTestCase(TestCase):
         re_source = re.sub(pattern, r'\1', source)
         re_target = re.sub(pattern, r'\1', target)
         self.assertEqual(re_source, re_target)
+
+    def test_find_element_by_leaf_name(self):
+        """
+        Paths from another form version resolve by question name, and repeat
+        occurrences follow the `[n]` indexes instead of collapsing to the
+        first match.
+        """
+        root = fromstring_preserve_root_xmlns(
+            '<root xmlns="http://openrosa.org/formats">'
+            '<story>old.mp3</story>'
+            '<rpt><clip>first.mp3</clip></rpt>'
+            '<rpt><clip>second.mp3</clip></rpt>'
+            '<outer><inner><note>a</note></inner><inner><note>b</note></inner></outer>'
+            '<outer><inner><note>c</note></inner></outer>'
+            '</root>'
+        )
+
+        def text_at(xpath):
+            element = find_element_by_leaf_name(root, xpath)
+            return None if element is None else element.text
+
+        # A question moved into a group since the submission was made
+        assert text_at('grp/story') == 'old.mp3'
+        # A renamed repeat: the requested occurrence, not the first match
+        assert text_at('renamed[2]/clip') == 'second.mp3'
+        assert text_at('renamed[1]/clip') == 'first.mp3'
+        # No index behaves like `find()`: first occurrence
+        assert text_at('renamed/clip') == 'first.mp3'
+        # Nested repeats keep every level's position
+        assert text_at('x[1]/y[2]/note') == 'b'
+        assert text_at('x[2]/y[1]/note') == 'c'
+        # Nothing invented for missing questions or occurrences
+        assert text_at('renamed[3]/clip') is None
+        assert text_at('x[2]/y[2]/note') is None
+        assert text_at('nope') is None
 
 
 class AttachmentFilenamesAndXpathsTestCase(TestCase):

--- a/kpi/utils/xml.py
+++ b/kpi/utils/xml.py
@@ -62,6 +62,45 @@ def edit_submission_xml(
     element.text = value
 
 
+def find_element_by_leaf_name(root: ET.Element, xpath: str) -> Optional[ET.Element]:
+    """
+    Return the element `xpath` points at by its last segment (the question
+    name) rather than its full path, or None when no such element exists.
+
+    A submission keeps the paths of the form version it was made against, so
+    a path from another version may not exist in its XML once a question or
+    group was moved or renamed. XLSForm names are unique form-wide, which
+    makes the leaf a safe identity across versions.
+
+    Repeat occurrences are honoured: the `[n]` indexes carried by `xpath` are
+    matched, in order, against the candidate's position among same-named
+    siblings at each level (see `_positions_match()`). Without any index the
+    first match wins, like `Element.find()`.
+    """
+    leaf = re.sub(r'\[\d+\]$', '', xpath.rsplit('/', 1)[-1])
+    wanted_positions = [int(index) for index in re.findall(r'\[(\d+)\]', xpath)]
+    parents = {child: parent for parent in root.iter() for child in parent}
+
+    for candidate in root.iter():
+        if candidate is root or _local_tag(candidate.tag) != leaf:
+            continue
+        if not wanted_positions:
+            return candidate
+
+        levels = []
+        node = candidate
+        while (parent := parents.get(node)) is not None:
+            siblings = [sibling for sibling in parent if sibling.tag == node.tag]
+            levels.append((siblings.index(node) + 1, len(siblings) > 1))
+            node = parent
+        levels.reverse()
+
+        if _positions_match(levels, wanted_positions):
+            return candidate
+
+    return None
+
+
 def fromstring_preserve_root_xmlns(
     text: Union[str, bytes],
 ) -> ET.Element:
@@ -250,6 +289,33 @@ def _filter_nodes_by_xpaths(root: etree._Element, xpath_matches: list) -> None:
             parent.remove(node)
         else:
             stack.extend((child, node, node_path) for child in node)
+
+
+def _local_tag(tag: str) -> str:
+    """
+    Return an element tag without its `{namespace}` prefix, if any.
+    """
+    return tag.rsplit('}', 1)[-1] if isinstance(tag, str) else tag
+
+
+def _positions_match(levels: list[tuple[int, bool]], wanted: list[int]) -> bool:
+    """
+    Tell whether the `[n]` indexes of a requested path (`wanted`) describe an
+    element whose ancestry is `levels`, each level being its 1-based position
+    among same-named siblings and whether that name has several instances.
+
+    Requested indexes are consumed top-down and every multi-instance level
+    must consume one. A single-instance level may consume a `1` or be skipped,
+    because a plain group and a repeat with one instance look the same in
+    the XML.
+    """
+    if not levels:
+        return not wanted
+
+    (position, is_multi), rest = levels[0], levels[1:]
+    if wanted and wanted[0] == position and _positions_match(rest, wanted[1:]):
+        return True
+    return not is_multi and _positions_match(rest, wanted)
 
 
 class OmitDefaultNamespacePrefixTreeBuilder(ET.TreeBuilder):


### PR DESCRIPTION
### 📣 Summary

Audio recordings and their transcripts, translations and analysis answers stay visible after an audio question is moved into a group.

### 📖 Description

Moving a question into or out of a group changes its path in the form. Older submissions keep the path of the version they were made with, so their audio and NLP data used to disappear from the single-submission view, and automatic transcription could fail to find the recording. Both now resolve the question by its name when the path changed.

### 💭 Notes

- `GET .../attachments/?xpath=` now accepts either the pre-move or the current path of a question. When the exact path is missing from the submission XML, the candidates come from the form versions the submission spans, its `__version__` plus `meta/formVersions` (#7543), through `Asset.get_attachment_xpaths_from_version_uids()` (#7567): the media xpaths of those versions sharing the requested last segment, with the `[n]` repeat indexes of the request applied by group name. The XML itself is never searched, since on edits Enketo keeps the record's original nodes and a file referenced only by such a leftover may have been replaced. `__version__` is enough for the pre-move case, so this works on existing submissions with no backfill. Automatic transcription and translation use the same lookup, so they work across form versions too. No API shape changes, no migrations.
- `get_submission_form_version_uids()` is the public half of `_get_other_form_version_uids()` in `logger_tools`, extracted so the deployment backend reads the lineage through the same code as the soft-delete rule.

- most of the ticket as written was already covered by DEV-2345 / DEV-2407 (processing view and data table read old submissions by their submission-era path). This PR closes the three spots still comparing paths strictly: the attachment lookup by xpath in the deployment backend, the NLP rows in the single-submission view, and the row lookup for a question moved from one group to another.
- the frontend half follows #7187 and #7521: stored keys are never rewritten, and the browser, which has no version definitions, falls back on the question name.
- in the single-submission view a pre-move submission surfaces its answer through the "unaccounted answers" path (plain groups don't recurse when nothing is stored under the group), so the NLP rows are attached there as well.
- still open, tracked in DEV-2821 because it needs a design decision rather than a fix: advanced-feature rows stay pinned to the xpath they were enabled at, so submissions made after the move need the features re-enabled at the new path, which forks config and analysis questions per era.
- each new test was run against the unfixed code first and fails there.

### 👀 Preview steps

1. ℹ️ have a project with one audio question at the root, deployed, with NLP languages loaded on the instance
2. submit one audio response, open it in the processing view, add a transcript, save
3. in the form builder select the question, click "Create group with selected questions", save, redeploy
4. in DATA, open that submission's record view (eye icon)
5. 🔴 [on main] the audio row shows but no transcript row anywhere
6. 🟢 [on PR] the transcript row appears right under the audio answer
7. 🟢 [on PR] `GET /api/v2/assets/<uid>/data/<id>/attachments/?xpath=<group>/<question>` returns the pre-move recording instead of a 404

