### PR TITLE
feat(accounts): support custom signup fields on headless API DEV-2807

### DIFF
--- a/jsapp/js/api/models/baseSignup.ts
+++ b/jsapp/js/api/models/baseSignup.ts
@@ -23,5 +23,5 @@ export interface BaseSignup {
   sector?: string
   country?: string
   newsletter_subscription?: boolean
-  terms_of_service: boolean
+  terms_of_service?: boolean
 }

--- a/jsapp/js/api/models/baseSignup.ts
+++ b/jsapp/js/api/models/baseSignup.ts
@@ -15,4 +15,13 @@ import type { Username } from './username'
 export interface BaseSignup {
   email: Email
   username: Username
+  name?: string
+  organization?: string
+  organization_website?: string
+  organization_type?: string
+  gender?: string
+  sector?: string
+  country?: string
+  newsletter_subscription?: boolean
+  terms_of_service: boolean
 }

--- a/kobo/apps/accounts/adapter.py
+++ b/kobo/apps/accounts/adapter.py
@@ -1,5 +1,4 @@
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.forms import SignupForm
 from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.helpers import render_authentication_error
@@ -13,6 +12,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as t
 
 from .models import SocialAppManagedDomain
+from .signup_fields import SignupExtraFieldsForm
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -25,9 +25,14 @@ class AccountAdapter(DefaultAccountAdapter):
         super().login(request, user)
 
     def save_user(self, request, user, form, commit=True):
-        # Compare allauth SignupForm with our custom field
-        standard_fields = set(SignupForm().fields.keys())
-        extra_fields = set(form.fields.keys()).difference(standard_fields)
+        # Our extra fields are the ones `SignupExtraFieldsForm` declares, minus
+        # any this server disabled via `USER_METADATA_FIELDS` and hence the
+        # intersection with what was actually submitted
+        extra_fields = [
+            field_name
+            for field_name in SignupExtraFieldsForm.base_fields
+            if field_name in form.cleaned_data
+        ]
         with transaction.atomic():
             user = super().save_user(request, user, form, commit)
             extra_data = {k: form.cleaned_data[k] for k in extra_fields}

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -14,7 +14,6 @@ from django import forms
 from django.utils.translation import gettext_lazy as t
 
 from kobo.apps.accounts.utils import get_normalized_domain, user_is_managed_by_sso
-
 from .models import SocialAppManagedDomain
 from .signup_fields import validate_email_domain
 

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -1,4 +1,3 @@
-import constance
 from allauth.account import app_settings
 from allauth.account.adapter import get_adapter
 from allauth.account.forms import LoginForm as BaseLoginForm
@@ -12,27 +11,12 @@ from allauth.account.utils import (
 )
 from allauth.socialaccount.forms import SignupForm as BaseSocialSignupForm
 from django import forms
-from django.utils.safestring import mark_safe
-from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as t
 
-from hub.models.sitewide_message import SitewideMessage
-from hub.utils.i18n import I18nUtils
 from kobo.apps.accounts.utils import get_normalized_domain, user_is_managed_by_sso
-from kobo.static_lists import COUNTRIES, USER_METADATA_DEFAULT_LABELS
-from .models import SocialAppManagedDomain
 
-# Only these fields can be controlled by constance.config.USER_METADATA_FIELDS
-CONFIGURABLE_METADATA_FIELDS = (
-    'name',
-    'organization',
-    'organization_type',
-    'organization_website',
-    'gender',
-    'sector',
-    'country',
-    'newsletter_subscription',
-)
+from .models import SocialAppManagedDomain
+from .signup_fields import validate_email_domain
 
 
 class LoginForm(BaseLoginForm):
@@ -43,223 +27,33 @@ class LoginForm(BaseLoginForm):
         self.label_suffix = ''
 
 
-class KoboSignupMixin(forms.Form):
-    # NOTE: Fields that are not part of django's contrib.auth.User model
-    #       are saved to ExtraUserDetail, via django-allauth internals
-    # SEE:
-    #     - AccountAdapter (save_user) in kobo/apps/accounts/adapter.py
-    #     - https://docs.allauth.org/en/latest/account/advanced.html#creating-and-populating-user-instances
-    name = forms.CharField(
-        label=USER_METADATA_DEFAULT_LABELS['name'],
-        required=False,
-    )
-    organization = forms.CharField(
-        label=USER_METADATA_DEFAULT_LABELS['organization'],
-        required=False,
-    )
-    organization_website = forms.CharField(
-        label=USER_METADATA_DEFAULT_LABELS['organization_website'],
-        required=False,
-        widget=forms.URLInput,
-    )
-    organization_website.widget.attrs['pattern'] = (
-        # Use r'' so we can copy-paste the literal without escaping backslashes
-        r'\s*(https?:\/\/)?([^\s.:\/]+\.)+([^\s.:\/]){2,}(:\d{1,5})?(\/.*)?\s*'
-    )
-    organization_website.widget.attrs['title'] = t(
-        'Please enter a valid URL'
-    )
+class KoboSignupMixin:
+    """
+    Validation shared by the HTML and SSO signup forms
 
-    organization_type = forms.ChoiceField(
-        label=USER_METADATA_DEFAULT_LABELS['organization_type'],
-        required=False,
-        choices=(
-            ('', ''),
-            ('non-profit', t('Non-profit organization')),
-            ('government', t('Government institution')),
-            ('educational', t('Educational organization')),
-            ('commercial', t('A commercial/for-profit company')),
-            ('none', t('I am not associated with any organization')),
-        ),
-    )
-    gender = forms.ChoiceField(
-        label=USER_METADATA_DEFAULT_LABELS['gender'],
-        required=False,
-        widget=forms.RadioSelect,
-        choices=(
-            ('male', t('Male')),
-            ('female', t('Female')),
-            ('other', t('Other')),
-        ),
-    )
-    sector = forms.ChoiceField(
-        label=USER_METADATA_DEFAULT_LABELS['sector'],
-        required=False,
-        # Don't set choices here; set them in the constructor so that changes
-        # made in the Django admin interface do not require a server restart
-    )
-    country = forms.ChoiceField(
-        label=USER_METADATA_DEFAULT_LABELS['country'],
-        required=False,
-        choices=(('', ''),) + COUNTRIES,
-    )
-    newsletter_subscription = forms.BooleanField(
-        label=USER_METADATA_DEFAULT_LABELS['newsletter_subscription'],
-        required=False,
-    )
-    terms_of_service = forms.BooleanField(
-        # Label is dynamic; see constructor
-        required=True,
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.label_suffix = ''
-
-        # Set dynamic label for terms of service checkbox
-        if constance.config.TERMS_OF_SERVICE_URL:
-            terms_of_service_link = (
-                f'<a href="{constance.config.TERMS_OF_SERVICE_URL}"'
-                f' target="_blank">{t("Terms of Service")}</a>'
-            )
-        else:
-            terms_of_service_link = gettext('Terms of Service')
-        if constance.config.PRIVACY_POLICY_URL:
-            privacy_policy_link = (
-                f'<a href="{constance.config.PRIVACY_POLICY_URL}"'
-                f' target="_blank">{t("Privacy Policy")}</a>'
-            )
-        else:
-            privacy_policy_link = gettext('Privacy Policy')
-        self.fields['terms_of_service'].label = mark_safe(
-            t('I agree with the ##terms_of_service## and ##privacy_policy##')
-            .replace('##terms_of_service##', terms_of_service_link)
-            .replace('##privacy_policy##', privacy_policy_link)
-        )
-
-        # Remove upstream placeholders
-        for field_name in ['username', 'email', 'password1', 'password2']:
-            if field_name in self.fields:
-                self.fields[field_name].widget.attrs['placeholder'] = ''
-        if 'password1' in self.fields:
-            # Remove `help_text` on purpose since some guidance is provided by
-            # Constance setting. Moreover it is redundant with error messages.
-            self.fields['password1'].help_text = ''
-        if 'password2' in self.fields:
-            self.fields['password2'].label = t('Password confirmation')
-        if 'email' in self.fields:
-            self.fields['email'].widget.attrs['placeholder'] = t('name@organization.org')
-
-        # Intentional t() call on dynamic string because the default choices
-        # are translated (see static_lists.py)
-        # Strip "\r" for legacy data created prior to django-constance 2.7.
-        self.fields['sector'].choices = (('', ''),) + tuple(
-            (s.strip('\r'), t(s.strip('\r')))
-            for s in constance.config.SECTOR_CHOICES.split('\n')
-        )
-
-        # It's easier to _remove_ unwanted fields here in the constructor
-        # than to add a new fields *shrug*
-        desired_metadata_fields = I18nUtils.get_metadata_fields('user')
-        desired_metadata_fields = {
-            field['name']: field for field in desired_metadata_fields
-        }
-        for field_name in list(self.fields.keys()):
-            if field_name not in CONFIGURABLE_METADATA_FIELDS:
-                # This field is not allowed to be configured
-                continue
-
-            try:
-                desired_field = desired_metadata_fields[field_name]
-            except KeyError:
-                # This field is unwanted
-                self.fields.pop(field_name)
-                continue
-
-            field = self.fields[field_name]
-            # Part of 'skip logic' for organization fields
-            #     The 'Organization Type' dropdown hides 'Organization' and
-            # 'Organization Website' inputs if the user has selected
-            # 'I am not associated with an organization'. In that case the
-            # back end accepts omitted or blank values for organization and
-            # organization_website, even if they're 'required'.
-            #     Adding errors is easier than removing errors we don't want.
-            # So make these fields 'not required', remember we did, and add
-            # 'required' errors in the clean() function.
-            if (
-                desired_metadata_fields.get('organization_type')
-                and desired_field.get('required')
-                and field_name in ['organization', 'organization_website']
-            ):
-                # Potentially 'skippable' organization-related field
-                field.required = False
-                # Add a [data-required] attribute, used by
-                #   1. JS to replicate the 'required' appearance, and
-                #   2. clean() to remember these are conditionally required
-                field.widget.attrs.update({'data-required': True})
-            else:
-                # Any other field, require based on metadata
-                field.required = desired_field.get('required', False)
-            self.fields[field_name].label = desired_field['label']
-        if not SitewideMessage.objects.filter(slug='terms_of_service').exists():
-            self.fields.pop('terms_of_service')
+    The fields live in `signup_fields.SignupExtraFieldsForm` so the headless API
+    gets them too. Only behaviour that must override allauth's stays here, since
+    that requires sitting above allauth's classes in the MRO.
+    """
 
     def clean(self):
         """
         Override parent form to pass extra user's attributes to validation.
         """
+        # Skips every allauth `clean()` below this mixin. `SignupForm.clean()`
+        # already redoes allauth's password checks, and running both would show
+        # each error twice
         super(forms.Form, self).clean()
 
-        # Part of 'skip logic' for organization fields.
-        # Add 'Field is required' errors for organization and organization_website,
-        # since we un-required them in case 'organization_type' is 'none'.
-        if 'organization_type' in self.fields:
-            for field_name in ['organization', 'organization_website']:
-                if (
-                    field_name in self.fields
-                    and self.fields[field_name].widget.attrs.get(
-                        'data-required'
-                    )
-                    and self.cleaned_data.get('organization_type') != 'none'
-                ):
-                    if not self.cleaned_data.get(field_name):
-                        self.add_error(field_name, t('This field is required.'))
+        self.validate_conditionally_required_organization_fields()
 
         return self.cleaned_data
 
     def clean_email(self, allow_managed_domains=False):
-        email = self.cleaned_data['email']
-        domain = email.split('@')[1].lower()
-        if not allow_managed_domains:
-            managed = SocialAppManagedDomain.objects.filter(
-                domain__iexact=domain, social_app__managed=True
-            ).exists()
-            if managed:
-                raise forms.ValidationError(
-                    'Your organization has restricted the use of passwords. '
-                    'Please sign up using SSO instead.'
-                )
-        blacklist_domains = constance.config.REGISTRATION_BLACKLIST_EMAIL_DOMAINS
-        blacklist_domain_set = {
-            d.strip().lower()
-            for d in blacklist_domains.splitlines()
-            if d.strip()
-        }
-
-        if domain.strip().lower() in blacklist_domain_set:
-            raise forms.ValidationError(
-                constance.config.REGISTRATION_BLACKLIST_ERROR_MESSAGE
-            )
-
-        allowed_domains = constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
-        allowed_domain_list = [domain.lower() for domain in allowed_domains.split('\n')]
-        # An empty domain list means all domains are allowed
-        if domain in allowed_domain_list or not allowed_domains:
-            return email
-        else:
-            raise forms.ValidationError(
-                constance.config.REGISTRATION_DOMAIN_NOT_ALLOWED_ERROR_MESSAGE
-            )
+        return validate_email_domain(
+            self.cleaned_data['email'],
+            allow_managed_domains=allow_managed_domains,
+        )
 
 
 class SocialSignupForm(KoboSignupMixin, BaseSocialSignupForm):
@@ -280,6 +74,10 @@ class SocialSignupForm(KoboSignupMixin, BaseSocialSignupForm):
         super().__init__(*args, **kwargs)
         self.fields['email'].widget.attrs['readonly'] = True
         self.label_suffix = ''
+        # Remove upstream placeholders (see `SignupForm.__init__`)
+        for field_name in ['username', 'email']:
+            if field_name in self.fields:
+                self.fields[field_name].widget.attrs['placeholder'] = ''
 
     def clean_email(self):
         # do not allow any other email besides the one retrieved from the SSO server
@@ -302,6 +100,27 @@ class SignupForm(KoboSignupMixin, BaseSignupForm):
         'gender',
         'newsletter_subscription',
     ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Presentation only. Kept here, not in `SignupExtraFieldsForm`, because
+        # that class runs before allauth adds the password fields
+
+        # Remove upstream placeholders
+        for field_name in ['username', 'email', 'password1', 'password2']:
+            if field_name in self.fields:
+                self.fields[field_name].widget.attrs['placeholder'] = ''
+        if 'password1' in self.fields:
+            # Remove `help_text` on purpose since some guidance is provided by
+            # Constance setting. Moreover it is redundant with error messages.
+            self.fields['password1'].help_text = ''
+        if 'password2' in self.fields:
+            self.fields['password2'].label = t('Password confirmation')
+        if 'email' in self.fields:
+            self.fields['email'].widget.attrs['placeholder'] = t(
+                'name@organization.org'
+            )
 
     def clean(self):
         """

--- a/kobo/apps/accounts/signup_fields.py
+++ b/kobo/apps/accounts/signup_fields.py
@@ -1,0 +1,286 @@
+"""
+KoboToolbox's extra signup fields.
+
+Wired up through `ACCOUNT_SIGNUP_FORM_CLASS`, which allauth injects as a base
+class of every signup form: the HTML page, the SSO page, and the headless JSON
+API. Declaring the fields here is what makes them work on
+`POST /api/v2/allauth/browser/v1/auth/signup` and what puts them in the OpenAPI
+schema that orval generates types from.
+
+Do not import `allauth.account.forms` here, even indirectly. allauth reads this
+setting while that module is still being imported, so importing it back raises
+`ImproperlyConfigured`. Models, constance and `I18nUtils` are imported inside the
+methods for the same reason: this module loads before the app registry is ready.
+"""
+
+import constance
+from django import forms
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as t
+
+from kobo.static_lists import COUNTRIES, USER_METADATA_DEFAULT_LABELS
+
+# Only these fields can be controlled by constance.config.USER_METADATA_FIELDS
+CONFIGURABLE_METADATA_FIELDS = (
+    'name',
+    'organization',
+    'organization_type',
+    'organization_website',
+    'gender',
+    'sector',
+    'country',
+    'newsletter_subscription',
+)
+
+
+def validate_email_domain(email, allow_managed_domains=False):
+    """
+    Apply KoboToolbox's email domain rules, raising ValidationError on rejection.
+    Shared so the HTML form and the API enforce the same policy.
+    """
+    from .models import SocialAppManagedDomain
+
+    domain = email.split('@')[1].lower()
+
+    if not allow_managed_domains:
+        managed = SocialAppManagedDomain.objects.filter(
+            domain__iexact=domain, social_app__managed=True
+        ).exists()
+        if managed:
+            raise forms.ValidationError(
+                'Your organization has restricted the use of passwords. '
+                'Please sign up using SSO instead.'
+            )
+
+    blacklist_domains = constance.config.REGISTRATION_BLACKLIST_EMAIL_DOMAINS
+    blacklist_domain_set = {
+        d.strip().lower() for d in blacklist_domains.splitlines() if d.strip()
+    }
+    if domain.strip().lower() in blacklist_domain_set:
+        raise forms.ValidationError(
+            constance.config.REGISTRATION_BLACKLIST_ERROR_MESSAGE
+        )
+
+    allowed_domains = constance.config.REGISTRATION_ALLOWED_EMAIL_DOMAINS.strip()
+    allowed_domain_list = [d.lower() for d in allowed_domains.split('\n')]
+    # An empty domain list means all domains are allowed
+    if domain in allowed_domain_list or not allowed_domains:
+        return email
+
+    raise forms.ValidationError(
+        constance.config.REGISTRATION_DOMAIN_NOT_ALLOWED_ERROR_MESSAGE
+    )
+
+
+class SignupExtraFieldsForm(forms.Form):
+    # NOTE: Fields that are not part of django's contrib.auth.User model
+    #       are saved to ExtraUserDetail, via django-allauth internals
+    # SEE:
+    #     - AccountAdapter (save_user) in kobo/apps/accounts/adapter.py
+    #     - https://docs.allauth.org/en/latest/account/advanced.html#creating-and-populating-user-instances
+    name = forms.CharField(
+        label=USER_METADATA_DEFAULT_LABELS['name'],
+        required=False,
+    )
+    organization = forms.CharField(
+        label=USER_METADATA_DEFAULT_LABELS['organization'],
+        required=False,
+    )
+    organization_website = forms.CharField(
+        label=USER_METADATA_DEFAULT_LABELS['organization_website'],
+        required=False,
+        widget=forms.URLInput,
+    )
+    organization_website.widget.attrs['pattern'] = (
+        # Use r'' so we can copy-paste the literal without escaping backslashes
+        r'\s*(https?:\/\/)?([^\s.:\/]+\.)+([^\s.:\/]){2,}(:\d{1,5})?(\/.*)?\s*'
+    )
+    organization_website.widget.attrs['title'] = t('Please enter a valid URL')
+
+    organization_type = forms.ChoiceField(
+        label=USER_METADATA_DEFAULT_LABELS['organization_type'],
+        required=False,
+        choices=(
+            ('', ''),
+            ('non-profit', t('Non-profit organization')),
+            ('government', t('Government institution')),
+            ('educational', t('Educational organization')),
+            ('commercial', t('A commercial/for-profit company')),
+            ('none', t('I am not associated with any organization')),
+        ),
+    )
+    gender = forms.ChoiceField(
+        label=USER_METADATA_DEFAULT_LABELS['gender'],
+        required=False,
+        widget=forms.RadioSelect,
+        choices=(
+            ('male', t('Male')),
+            ('female', t('Female')),
+            ('other', t('Other')),
+        ),
+    )
+    sector = forms.ChoiceField(
+        label=USER_METADATA_DEFAULT_LABELS['sector'],
+        required=False,
+        # Don't set choices here; set them in the constructor so that changes
+        # made in the Django admin interface do not require a server restart
+    )
+    country = forms.ChoiceField(
+        label=USER_METADATA_DEFAULT_LABELS['country'],
+        required=False,
+        choices=(('', ''),) + COUNTRIES,
+    )
+    newsletter_subscription = forms.BooleanField(
+        label=USER_METADATA_DEFAULT_LABELS['newsletter_subscription'],
+        required=False,
+    )
+    terms_of_service = forms.BooleanField(
+        # Label is dynamic; see constructor
+        required=True,
+    )
+
+    def signup(self, request, user):
+        """
+        allauth requires this method to exist. Nothing to do here: the fields are
+        saved by `AccountAdapter.save_user`.
+        """
+        pass
+
+    def __init__(self, *args, **kwargs):
+        from hub.models.sitewide_message import SitewideMessage
+        from hub.utils.i18n import I18nUtils
+
+        super().__init__(*args, **kwargs)
+        self.label_suffix = ''
+
+        # Set dynamic label for terms of service checkbox
+        if constance.config.TERMS_OF_SERVICE_URL:
+            terms_of_service_link = (
+                f'<a href="{constance.config.TERMS_OF_SERVICE_URL}"'
+                f' target="_blank">{t("Terms of Service")}</a>'
+            )
+        else:
+            terms_of_service_link = gettext('Terms of Service')
+        if constance.config.PRIVACY_POLICY_URL:
+            privacy_policy_link = (
+                f'<a href="{constance.config.PRIVACY_POLICY_URL}"'
+                f' target="_blank">{t("Privacy Policy")}</a>'
+            )
+        else:
+            privacy_policy_link = gettext('Privacy Policy')
+        self.fields['terms_of_service'].label = mark_safe(
+            t('I agree with the ##terms_of_service## and ##privacy_policy##')
+            .replace('##terms_of_service##', terms_of_service_link)
+            .replace('##privacy_policy##', privacy_policy_link)
+        )
+
+        # Intentional t() call on dynamic string because the default choices
+        # are translated (see static_lists.py)
+        # Strip "\r" for legacy data created prior to django-constance 2.7.
+        self.fields['sector'].choices = (('', ''),) + tuple(
+            (s.strip('\r'), t(s.strip('\r')))
+            for s in constance.config.SECTOR_CHOICES.split('\n')
+        )
+
+        # It's easier to _remove_ unwanted fields here in the constructor
+        # than to add a new fields *shrug*
+        desired_metadata_fields = I18nUtils.get_metadata_fields('user')
+        desired_metadata_fields = {
+            field['name']: field for field in desired_metadata_fields
+        }
+        for field_name in list(self.fields.keys()):
+            if field_name not in CONFIGURABLE_METADATA_FIELDS:
+                # This field is not allowed to be configured
+                continue
+
+            try:
+                desired_field = desired_metadata_fields[field_name]
+            except KeyError:
+                # This field is unwanted
+                self.fields.pop(field_name)
+                continue
+
+            field = self.fields[field_name]
+            # Part of 'skip logic' for organization fields
+            #     The 'Organization Type' dropdown hides 'Organization' and
+            # 'Organization Website' inputs if the user has selected
+            # 'I am not associated with an organization'. In that case the
+            # back end accepts omitted or blank values for organization and
+            # organization_website, even if they're 'required'.
+            #     Adding errors is easier than removing errors we don't want.
+            # So make these fields 'not required', remember we did, and add
+            # 'required' errors in the clean() function.
+            if (
+                desired_metadata_fields.get('organization_type')
+                and desired_field.get('required')
+                and field_name in ['organization', 'organization_website']
+            ):
+                # Potentially 'skippable' organization-related field
+                field.required = False
+                # Add a [data-required] attribute, used by
+                #   1. JS to replicate the 'required' appearance, and
+                #   2. clean() to remember these are conditionally required
+                field.widget.attrs.update({'data-required': True})
+            else:
+                # Any other field, require based on metadata
+                field.required = desired_field.get('required', False)
+            self.fields[field_name].label = desired_field['label']
+
+        if not SitewideMessage.objects.filter(slug='terms_of_service').exists():
+            self.fields.pop('terms_of_service')
+
+    def validate_conditionally_required_organization_fields(self):
+        """
+        Part of 'skip logic' for organization fields. Add 'Field is required'
+        errors for organization and organization_website, since we un-required
+        them in case 'organization_type' is 'none'.
+        """
+        if 'organization_type' not in self.fields:
+            return
+
+        for field_name in ['organization', 'organization_website']:
+            if (
+                field_name in self.fields
+                and self.fields[field_name].widget.attrs.get('data-required')
+                and self.cleaned_data.get('organization_type') != 'none'
+            ):
+                if not self.cleaned_data.get(field_name):
+                    self.add_error(field_name, t('This field is required.'))
+
+    def clean(self):
+        """
+        Only runs on the headless API. `KoboSignupMixin.clean()` sits above
+        allauth's classes on the HTML and SSO forms and skips this method, so
+        these checks cannot run twice there.
+        """
+        from allauth.account.adapter import get_adapter
+        from django.contrib.auth import get_user_model
+
+        cleaned_data = super().clean()
+
+        self.validate_conditionally_required_organization_fields()
+
+        email = self.cleaned_data.get('email')
+        if email and '@' in email:
+            try:
+                validate_email_domain(email)
+            except forms.ValidationError as e:
+                self.add_error('email', e)
+
+        # allauth validates the password without a user, so attribute-similarity
+        # rules never fire. Repeat the check with the same stand-in user
+        # `SignupForm.clean()` builds for the HTML page.
+        password = self.cleaned_data.get('password')
+        if password:
+            dummy_user = get_user_model()()
+            dummy_user.username = self.cleaned_data.get('username', '')
+            dummy_user.email = email or ''
+            dummy_user.organization_name = self.cleaned_data.get('organization', '')
+            dummy_user.full_name = self.cleaned_data.get('name', '')
+            try:
+                get_adapter().clean_password(password, user=dummy_user)
+            except forms.ValidationError as e:
+                self.add_error('password', e)
+
+        return cleaned_data

--- a/kobo/apps/accounts/signup_fields.py
+++ b/kobo/apps/accounts/signup_fields.py
@@ -1,18 +1,3 @@
-"""
-KoboToolbox's extra signup fields.
-
-Wired up through `ACCOUNT_SIGNUP_FORM_CLASS`, which allauth injects as a base
-class of every signup form: the HTML page, the SSO page, and the headless JSON
-API. Declaring the fields here is what makes them work on
-`POST /api/v2/allauth/browser/v1/auth/signup` and what puts them in the OpenAPI
-schema that orval generates types from.
-
-Do not import `allauth.account.forms` here, even indirectly. allauth reads this
-setting while that module is still being imported, so importing it back raises
-`ImproperlyConfigured`. Models, constance and `I18nUtils` are imported inside the
-methods for the same reason: this module loads before the app registry is ready.
-"""
-
 import constance
 from django import forms
 from django.utils.safestring import mark_safe
@@ -49,8 +34,10 @@ def validate_email_domain(email, allow_managed_domains=False):
         ).exists()
         if managed:
             raise forms.ValidationError(
-                'Your organization has restricted the use of passwords. '
-                'Please sign up using SSO instead.'
+                t(
+                    'Your organization has restricted the use of passwords. '
+                    'Please sign up using SSO instead.'
+                )
             )
 
     blacklist_domains = constance.config.REGISTRATION_BLACKLIST_EMAIL_DOMAINS
@@ -136,8 +123,11 @@ class SignupExtraFieldsForm(forms.Form):
         required=False,
     )
     terms_of_service = forms.BooleanField(
-        # Label is dynamic; see constructor
-        required=True,
+        # Label is dynamic, and so is requiredness: servers without a
+        # `terms_of_service` sitewide message drop the field entirely, so the
+        # published schema must not advertise it as always required. The
+        # constructor requires it on servers that do have one.
+        required=False,
     )
 
     def signup(self, request, user):
@@ -227,7 +217,9 @@ class SignupExtraFieldsForm(forms.Form):
                 field.required = desired_field.get('required', False)
             self.fields[field_name].label = desired_field['label']
 
-        if not SitewideMessage.objects.filter(slug='terms_of_service').exists():
+        if SitewideMessage.objects.filter(slug='terms_of_service').exists():
+            self.fields['terms_of_service'].required = True
+        else:
             self.fields.pop('terms_of_service')
 
     def validate_conditionally_required_organization_fields(self):

--- a/kobo/apps/accounts/signup_fields.py
+++ b/kobo/apps/accounts/signup_fields.py
@@ -65,7 +65,7 @@ class SignupExtraFieldsForm(forms.Form):
     #       are saved to ExtraUserDetail, via django-allauth internals
     # SEE:
     #     - AccountAdapter (save_user) in kobo/apps/accounts/adapter.py
-    #     - https://docs.allauth.org/en/latest/account/advanced.html#creating-and-populating-user-instances
+    #     - https://docs.allauth.org/en/latest/account/advanced.html#creating-and-populating-user-instances    # noqa
     name = forms.CharField(
         label=USER_METADATA_DEFAULT_LABELS['name'],
         required=False,

--- a/kobo/apps/accounts/tests/test_headless_signup.py
+++ b/kobo/apps/accounts/tests/test_headless_signup.py
@@ -1,12 +1,3 @@
-"""
-The headless signup endpoint is a separate code path from the templated signup
-page: allauth builds its own `SignupInput` rather than using
-`ACCOUNT_FORMS['signup']`. These tests pin down that both paths accept the same
-fields, enforce the same rules and store the same data.
-
-See `kobo/apps/accounts/signup_fields.py` for how the two are kept in sync.
-"""
-
 from constance.test import override_config
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase

--- a/kobo/apps/accounts/tests/test_headless_signup.py
+++ b/kobo/apps/accounts/tests/test_headless_signup.py
@@ -1,0 +1,189 @@
+"""
+The headless signup endpoint is a separate code path from the templated signup
+page: allauth builds its own `SignupInput` rather than using
+`ACCOUNT_FORMS['signup']`. These tests pin down that both paths accept the same
+fields, enforce the same rules and store the same data.
+
+See `kobo/apps/accounts/signup_fields.py` for how the two are kept in sync.
+"""
+
+from constance.test import override_config
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from hub.models.sitewide_message import SitewideMessage
+
+HEADLESS_SIGNUP_URL = '/api/v2/allauth/browser/v1/auth/signup'
+
+
+class HeadlessSignupExtraFieldsTestCase(TestCase):
+    """
+    `POST /api/v2/allauth/browser/v1/auth/signup` must accept the same extra
+    fields as the templated form and persist them to `ExtraUserDetail`
+    """
+
+    def setUp(self):
+        self.client = Client()
+        SitewideMessage.objects.create(slug='terms_of_service', body='tos agreement')
+
+    def test_extra_fields_are_persisted(self):
+        self._post_expecting_success(self._payload())
+
+        user = get_user_model().objects.get(username='headless_user')
+        extra_data = user.extra_details.data
+        assert extra_data['name'] == 'Headless Tester'
+        assert extra_data['organization'] == 'Ministry of Love'
+        assert extra_data['organization_type'] == 'non-profit'
+        assert extra_data['organization_website'] == 'https://minilove.test'
+        assert extra_data['newsletter_subscription'] is True
+        # `terms_of_service` is recorded as a timestamp, not stored verbatim
+        assert 'terms_of_service' not in extra_data
+        assert user.extra_details.private_data['last_tos_accept_time']
+
+    def test_terms_of_service_is_required(self):
+        response = self._post(
+            self._payload(username='tos_reluctant', terms_of_service=False)
+        )
+
+        assert response.status_code == 400
+        assert not get_user_model().objects.filter(username='tos_reluctant').exists()
+
+    def test_terms_of_service_not_required_when_no_sitewide_message(self):
+        SitewideMessage.objects.filter(slug='terms_of_service').delete()
+
+        payload = self._payload(username='no_tos_for_me')
+        del payload['terms_of_service']
+        self._post_expecting_success(payload)
+
+        user = get_user_model().objects.get(username='no_tos_for_me')
+        assert 'last_tos_accept_time' not in user.extra_details.private_data
+
+    @override_config(REGISTRATION_BLACKLIST_EMAIL_DOMAINS='example.com')
+    def test_blacklisted_email_domain_is_rejected(self):
+        response = self._post(self._payload(username='blacklisted'))
+
+        assert response.status_code == 400
+        assert not get_user_model().objects.filter(username='blacklisted').exists()
+
+    @override_config(
+        ENABLE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATION=True,
+        PASSWORD_USER_ATTRIBUTES='username\nemail\nfull_name\norganization',
+    )
+    def test_password_is_checked_against_user_attributes(self):
+        # allauth calls the password validators without a user, so the
+        # similarity rules would never fire on this path without our own check
+        response = self._post(
+            self._payload(username='similar_pw', password='Ministry of Love')
+        )
+
+        assert response.status_code == 400, response.content
+        assert not get_user_model().objects.filter(username='similar_pw').exists()
+
+    @override_config(USER_METADATA_FIELDS=[{'name': 'name', 'required': True}])
+    def test_fields_disabled_for_this_server_are_not_stored(self):
+        # `organization` is not in USER_METADATA_FIELDS, so the field is removed
+        # from the form and any submitted value must be ignored
+        self._post_expecting_success(self._payload(username='minimal_metadata'))
+
+        user = get_user_model().objects.get(username='minimal_metadata')
+        assert user.extra_details.data['name'] == 'Headless Tester'
+        # `ExtraUserDetail` normalises `organization` into a string of its own
+        # accord, so assert the submitted value was discarded rather than
+        # asserting the key is absent
+        assert user.extra_details.data.get('organization') != 'Ministry of Love'
+        assert 'sector' not in user.extra_details.data
+
+    @override_config(
+        USER_METADATA_FIELDS=[
+            {'name': 'organization', 'required': True},
+            {'name': 'organization_type', 'required': True},
+        ]
+    )
+    def test_conditionally_required_organization_fields_are_enforced(self):
+        # `organization` is required unless `organization_type` is 'none'
+        response = self._post(
+            self._payload(
+                username='no_org', organization='', organization_type='government'
+            )
+        )
+        assert response.status_code == 400
+        assert not get_user_model().objects.filter(username='no_org').exists()
+
+        # ...and the 'none' escape hatch still works over the API
+        self._post_expecting_success(
+            self._payload(
+                username='org_less', organization='', organization_type='none'
+            )
+        )
+        assert get_user_model().objects.filter(username='org_less').exists()
+
+    def _payload(self, username='headless_user', **overrides):
+        payload = {
+            'username': username,
+            'email': f'{username}@example.com',
+            'password': 'a-Sufficiently-Long-Passphrase-42',
+            'name': 'Headless Tester',
+            'organization': 'Ministry of Love',
+            'organization_type': 'non-profit',
+            'organization_website': 'https://minilove.test',
+            'sector': 'Public Administration',
+            'country': 'FRA',
+            'newsletter_subscription': True,
+            'terms_of_service': True,
+        }
+        payload.update(overrides)
+        return payload
+
+    def _post(self, payload):
+        return self.client.post(
+            HEADLESS_SIGNUP_URL, payload, content_type='application/json'
+        )
+
+    def _post_expecting_success(self, payload):
+        response = self._post(payload)
+        # `ACCOUNT_EMAIL_VERIFICATION = 'mandatory'` means a successful signup
+        # leaves the session unauthenticated pending verification, which allauth
+        # reports as 401 rather than 2xx
+        assert response.status_code == 401, response.content
+        return response
+
+
+class TemplatedSignupRegressionTestCase(TestCase):
+    """
+    `AccountAdapter.save_user` no longer identifies our extra fields by diffing
+    against allauth's own `SignupForm`, because `ACCOUNT_SIGNUP_FORM_CLASS` puts
+    them on that form too. Getting this wrong drops every extra value silently
+    while still creating the account, so pin the templated path down as well
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse('account_signup')
+
+    def test_extra_fields_are_persisted(self):
+        SitewideMessage.objects.create(slug='terms_of_service', body='tos agreement')
+        username = 'templated_user'
+        response = self.client.post(
+            self.url,
+            {
+                'username': username,
+                'email': f'{username}@example.com',
+                'password1': 'a-Sufficiently-Long-Passphrase-42',
+                'password2': 'a-Sufficiently-Long-Passphrase-42',
+                'name': 'Templated Tester',
+                'organization': 'Ministry of Peace',
+                'organization_type': 'non-profit',
+                'organization_website': 'https://minipax.test',
+                'newsletter_subscription': True,
+                'terms_of_service': True,
+            },
+        )
+
+        assert response.status_code == 302
+        user = get_user_model().objects.get(username=username)
+        extra_data = user.extra_details.data
+        assert extra_data['name'] == 'Templated Tester'
+        assert extra_data['organization'] == 'Ministry of Peace'
+        assert extra_data['newsletter_subscription'] is True
+        assert user.extra_details.private_data['last_tos_accept_time']

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1830,6 +1830,10 @@ CELERY_BEAT_RELOAD_INTERVAL = env.int('CELERY_BEAT_RELOAD_INTERVAL', 15)  # 15 s
 ACCOUNT_ADAPTER = 'kobo.apps.accounts.adapter.AccountAdapter'
 ACCOUNT_USERNAME_VALIDATORS = 'kobo.apps.accounts.validators.username_validators'
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'username*', 'password1*', 'password2*']
+# Adds our extra fields to every signup form, including the headless API's
+ACCOUNT_SIGNUP_FORM_CLASS = (
+    'kobo.apps.accounts.signup_fields.SignupExtraFieldsForm'
+)
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 ACCOUNT_EMAIL_VERIFICATION = env.str('ACCOUNT_EMAIL_VERIFICATION', 'mandatory')
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = env.int(

--- a/kobo/settings/base.py
+++ b/kobo/settings/base.py
@@ -1830,10 +1830,9 @@ CELERY_BEAT_RELOAD_INTERVAL = env.int('CELERY_BEAT_RELOAD_INTERVAL', 15)  # 15 s
 ACCOUNT_ADAPTER = 'kobo.apps.accounts.adapter.AccountAdapter'
 ACCOUNT_USERNAME_VALIDATORS = 'kobo.apps.accounts.validators.username_validators'
 ACCOUNT_SIGNUP_FIELDS = ['email*', 'username*', 'password1*', 'password2*']
-# Adds our extra fields to every signup form, including the headless API's
-ACCOUNT_SIGNUP_FORM_CLASS = (
-    'kobo.apps.accounts.signup_fields.SignupExtraFieldsForm'
-)
+# Adds our extra fields to every signup form, including the headless API's;
+# must point to a module that does not import `allauth.account.forms`
+ACCOUNT_SIGNUP_FORM_CLASS = 'kobo.apps.accounts.signup_fields.SignupExtraFieldsForm'
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 ACCOUNT_EMAIL_VERIFICATION = env.str('ACCOUNT_EMAIL_VERIFICATION', 'mandatory')
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = env.int(

--- a/kpi/password_validation.py
+++ b/kpi/password_validation.py
@@ -114,6 +114,11 @@ class UserAttributeSimilarityValidator(BaseUserAttributeSimilarityValidator):
         if not config.ENABLE_PASSWORD_USER_ATTRIBUTE_SIMILARITY_VALIDATION:
             return
 
+        # Nothing to compare against. Django's own validator returns early
+        # here too; without this, callers passing no user crash below
+        if user is None:
+            return
+
         # needs to set `self.min_length` here because if it is set in the
         # constructor, it won't be refresh if constance value is changed.
         self.user_attributes = config.PASSWORD_USER_ATTRIBUTES.splitlines()

--- a/static/openapi/schema_openrosa.json
+++ b/static/openapi/schema_openrosa.json
@@ -5415,8 +5415,7 @@
                 },
                 "required": [
                     "email",
-                    "username",
-                    "terms_of_service"
+                    "username"
                 ]
             },
             "Signup": {

--- a/static/openapi/schema_openrosa.json
+++ b/static/openapi/schema_openrosa.json
@@ -5384,11 +5384,39 @@
                     },
                     "username": {
                         "$ref": "#/components/schemas/Username"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization": {
+                        "type": "string"
+                    },
+                    "organization_website": {
+                        "type": "string"
+                    },
+                    "organization_type": {
+                        "type": "string"
+                    },
+                    "gender": {
+                        "type": "string"
+                    },
+                    "sector": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "newsletter_subscription": {
+                        "type": "boolean"
+                    },
+                    "terms_of_service": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
                     "email",
-                    "username"
+                    "username",
+                    "terms_of_service"
                 ]
             },
             "Signup": {

--- a/static/openapi/schema_openrosa.yaml
+++ b/static/openapi/schema_openrosa.yaml
@@ -3911,7 +3911,6 @@ components:
       required:
       - email
       - username
-      - terms_of_service
     Signup:
       allOf:
       - $ref: '#/components/schemas/BaseSignup'

--- a/static/openapi/schema_openrosa.yaml
+++ b/static/openapi/schema_openrosa.yaml
@@ -3890,9 +3890,28 @@ components:
           $ref: '#/components/schemas/Email'
         username:
           $ref: '#/components/schemas/Username'
+        name:
+          type: string
+        organization:
+          type: string
+        organization_website:
+          type: string
+        organization_type:
+          type: string
+        gender:
+          type: string
+        sector:
+          type: string
+        country:
+          type: string
+        newsletter_subscription:
+          type: boolean
+        terms_of_service:
+          type: boolean
       required:
       - email
       - username
+      - terms_of_service
     Signup:
       allOf:
       - $ref: '#/components/schemas/BaseSignup'

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -35150,8 +35150,7 @@
                 },
                 "required": [
                     "email",
-                    "username",
-                    "terms_of_service"
+                    "username"
                 ]
             },
             "Signup": {

--- a/static/openapi/schema_v2.json
+++ b/static/openapi/schema_v2.json
@@ -35119,11 +35119,39 @@
                     },
                     "username": {
                         "$ref": "#/components/schemas/Username"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization": {
+                        "type": "string"
+                    },
+                    "organization_website": {
+                        "type": "string"
+                    },
+                    "organization_type": {
+                        "type": "string"
+                    },
+                    "gender": {
+                        "type": "string"
+                    },
+                    "sector": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "newsletter_subscription": {
+                        "type": "boolean"
+                    },
+                    "terms_of_service": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
                     "email",
-                    "username"
+                    "username",
+                    "terms_of_service"
                 ]
             },
             "Signup": {

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -25203,9 +25203,28 @@ components:
           $ref: '#/components/schemas/Email'
         username:
           $ref: '#/components/schemas/Username'
+        name:
+          type: string
+        organization:
+          type: string
+        organization_website:
+          type: string
+        organization_type:
+          type: string
+        gender:
+          type: string
+        sector:
+          type: string
+        country:
+          type: string
+        newsletter_subscription:
+          type: boolean
+        terms_of_service:
+          type: boolean
       required:
       - email
       - username
+      - terms_of_service
     Signup:
       allOf:
       - $ref: '#/components/schemas/BaseSignup'

--- a/static/openapi/schema_v2.yaml
+++ b/static/openapi/schema_v2.yaml
@@ -25224,7 +25224,6 @@ components:
       required:
       - email
       - username
-      - terms_of_service
     Signup:
       allOf:
       - $ref: '#/components/schemas/BaseSignup'


### PR DESCRIPTION
### 📣 Summary
Adds the two signup fields allauth doesn't know about, `newsletter_subscription` and `terms_of_service`, to its headless signup endpoint so the SPA registration screen can collect

### 📖 Description
Registration collects two things beyond `username`/`email`/`password` that have to be recorded when the account is created: `newsletter_subscription` and `terms_of_service`. Both were declared only on the form used by the Django HTML page (`ACCOUNT_FORMS['signup']`), which allauth's headless API does not use.

`POST /api/v2/allauth/browser/v1/auth/signup` therefore accepted only three fields, and because Django forms ignore unknown keys, anything else was silently discarded with a success response. The SPA registration screen needs both fields, and consent in particular cannot be deferred until after signup.

This PR moves those two declarations to `ACCOUNT_SIGNUP_FORM_CLASS`, the hook allauth provides for this: it injects the class as a base of every signup form, so the HTML page, the SSO page and the headless API all get the fields. allauth's own schema generator reads the same class, so they land in the OpenAPI schema and the generated orval types with no manual schema work. 

The rest of the profile metadata (`name`, `organization`, `sector`, `country`, `gender`) is deliberately left off the API. As agreed with the frontend team, the SPA collects it after login through `PATCH /me/`, which already validates required fields against `USER_METADATA_FIELDS`. That also covers SSO users, who never see a signup form at all, so both kinds of  user end up completing their profile in the same place. Those fields stay on `KoboSignupMixin`, which only the HTML and SSO forms use, so the Django registration page is unchanged and keeps collecting everything until future work removes it. 

The new class lives in `signup_fields.py` rather than `forms.py` because allauth resolves the setting while `allauth.account.forms` is still importing; pointing it at `forms.py` is a circular import and the app will not boot. `KoboSignupMixin` stays above allauth's classes on the two form classes it is mixed into, which is what lets its `clean_email()` and organization skip-logic keep overriding allauth's behaviour exactly as before.

### 👀 Preview steps
<!-- Delete this section if behavior can't change. -->
<!-- If behavior changes or merely may change, add a preview of a minimal happy path. -->

1. ℹ️ From `/api/v1/docs`, try hitting `POST /api/v2/allauth/app/v1/auth/signup` with the two new fields: `newsletter_subscription` and `terms_of_service`
2. 🔴 [on main] notice that this endpoint doesn't exist.
3. 🟢 [on PR] notice that this will create a new user. You'll get a 401 response since the email is not yet verified, but you can see the newly created user in the admin.
4. 🟢 Try the validations for these fields; they should all work as expected.
5. 🟢 Try testing the existing HTML-templated flow; it should not be broken.

NOTE: We get a 401 response from the API because we have set `ACCOUNT_EMAIL_VERIFICATION = 'mandatory'`. This means that after a successful signup, the session remains unauthenticated pending email verification, which allauth reports as 401 rather than 2xx.