### PR TITLE
perf(attachments): parse form media xpaths with ElementTree DEV-2824

### DIFF
--- a/kobo/apps/openrosa/apps/logger/tests/test_parsing.py
+++ b/kobo/apps/openrosa/apps/logger/tests/test_parsing.py
@@ -2,6 +2,7 @@
 import os
 import re
 
+from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.openrosa.apps.logger.models import XForm
 from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
     XFormInstanceParser,
@@ -15,7 +16,6 @@ from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
 )
 from kobo.apps.openrosa.apps.main.tests.test_base import TestBase
 from kobo.apps.openrosa.libs.utils.common_tags import XFORM_ID_STRING
-from kobo.apps.kobo_auth.shortcuts import User
 from kpi.utils.xml import minidom_parsestring
 
 XML = 'xml'
@@ -243,3 +243,49 @@ class TestXFormInstanceParser(TestBase):
                 f'{id_string}/signature',
             ]
             assert sorted(expected) == sorted(get_xform_media_question_xpaths(xf))
+
+    def test_get_xform_media_question_xpaths_ignores_a_node_without_ref(self):
+        bob = User.objects.get(username='bob')
+        xml_path = self._fixture_path('signature', 'project_with_ref_before.xml')
+        with open(xml_path) as f:
+            xml_str = f.read()
+
+        # A `mediatype` pointing at nothing used to raise a `KeyError`, which
+        # failed the submission being saved
+        xml_str = xml_str.replace(
+            '<upload ref="/project_with_ref_before/image" mediatype="image/*">',
+            '<upload mediatype="image/*">',
+        )
+        xform = XForm.objects.create(
+            xml=xml_str, user=bob, id_string='project_with_ref_before'
+        )
+
+        with self.assertLogs('console_logger', level='WARNING') as logs:
+            assert get_xform_media_question_xpaths(xform) == [
+                'project_with_ref_before/signature'
+            ]
+
+        assert 'media node with no usable `ref`' in logs.output[0]
+
+    def test_get_xform_media_question_xpaths_keeps_accents_of_a_latin1_form(self):
+        bob = User.objects.get(username='bob')
+        xml_path = self._fixture_path('signature', 'project_with_ref_before.xml')
+        with open(xml_path) as f:
+            xml_str = f.read()
+
+        # A form is held as text, so its declaration only says what it was
+        # encoded with on the way in. Handing those characters to a parser as
+        # UTF-8 bytes would have expat decode them as declared instead, and
+        # `signature_é` would come back as `signature_Ã©`
+        xml_str = xml_str.replace(
+            '<?xml version="1.0" encoding="utf-8"?>',
+            '<?xml version="1.0" encoding="ISO-8859-1"?>',
+        ).replace('/signature', '/signature_é')
+        xform = XForm.objects.create(
+            xml=xml_str, user=bob, id_string='project_with_ref_before'
+        )
+
+        assert sorted(get_xform_media_question_xpaths(xform)) == [
+            'project_with_ref_before/image',
+            'project_with_ref_before/signature_é',
+        ]

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import sys
+import xml.etree.ElementTree as ET
 from datetime import datetime
 from typing import Optional, Union
 from xml.dom import Node
@@ -416,18 +417,6 @@ def _get_all_attributes(node):
             yield pair
 
 
-def _get_attributes_by_node(node):
-    """
-    Traverse the XML tree and yield each node with its attributes as a dictionary.
-    Only yields nodes that have attributes.
-    """
-    if hasattr(node, 'hasAttributes') and node.hasAttributes():
-        attrs = {key: node.getAttribute(key) for key in node.attributes.keys()}
-        yield node, attrs
-    for child in getattr(node, 'childNodes', []):
-        yield from _get_attributes_by_node(child)
-
-
 class XFormInstanceParser:
 
     def __init__(self, xml_str, data_dictionary, delay_parse=False):
@@ -524,14 +513,28 @@ def parse_xform_instance(xml_str, data_dictionary):
 
 
 def get_xform_media_question_xpaths(xform: 'logger.XForm') -> list:
-    parser = XFormInstanceParser(xform.xml, xform.data_dictionary(use_cache=True))
-    attributes_by_node = _get_attributes_by_node(parser.get_root_node())
+    """
+    Return the XPaths of the questions that hold a file, read from the `ref`
+    attribute of every node carrying a `mediatype`.
+    """
+
     media_field_xpaths = []
 
-    for node, attributes in attributes_by_node:
-        if 'mediatype' in attributes:
-            # We are returning XPaths, leading slash should be removed
-            media_field_xpaths.append(attributes['ref'][1:])
+    # `fromstring_preserve_root_xmlns()`, used everywhere else, is deliberately not
+    # used here: nothing here writes the tree back, and it's almost 4x faster for the
+    # same XPaths.
+    for element in ET.fromstring(xform.xml).iter():
+        if 'mediatype' not in element.attrib:
+            continue
+
+        if not (ref := element.attrib.get('ref')):
+            logging.warning(
+                f'XForm #{xform.pk} holds a media node with no usable `ref`'
+            )
+            continue
+
+        # We are returning XPaths, leading slash should be removed
+        media_field_xpaths.append(ref[1:])
 
     return media_field_xpaths
 

--- a/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
+++ b/kobo/apps/openrosa/apps/logger/xform_instance_parser.py
@@ -534,7 +534,7 @@ def get_xform_media_question_xpaths(xform: 'logger.XForm') -> list:
             continue
 
         # We are returning XPaths, leading slash should be removed
-        media_field_xpaths.append(ref[1:])
+        media_field_xpaths.append(ref.lstrip('/'))
 
     return media_field_xpaths
 


### PR DESCRIPTION
### 📣 Summary

Submitting to a large project is faster, and a malformed form no longer fails the submission it was carrying.

### 📖 Description

Every submission that arrives has its form read to find out which questions can hold a file. That reading was rebuilding the whole form each time, work that was thrown away immediately afterwards. It now reads only what it needs, which takes about a tenth of the time on a big project.

### 💭 Notes

`get_soft_deleted_attachments()` calls `get_xform_media_question_xpaths()` on every submission, so this cost was paid on every POST. Measured on production, 40 forms spread by size, and again locally against the implementation being replaced:

| XForm size | before | after |
| -- | -- | -- |
| < 50 kB | 5.8 ms | 0.5 ms |
| 50-200 kB | 18.3 ms | 1.9 ms |
| 200-500 kB | 53.7 ms | 5.4 ms |
| > 500 kB | 262.8 ms | 33.8 ms |

The function reads two attributes, `mediatype` and `ref`. It went through `XFormInstanceParser`, whose constructor calls `parse()`, which builds `dd.get_survey_elements_of_type('repeat')`, i.e. the entire pyxform survey, then `_xml_node_to_dict()` over the whole tree. Neither is used. The parse itself went through `clean_and_parse_xml()`, so minidom. The pyxform survey was half the cost and minidom the other half.

`clean_and_parse_xml()` is left alone: a dozen callers rely on the minidom API and on mutating the DOM before serialising it back.

`fromstring_preserve_root_xmlns()` is not used here, and the comment in the diff says why. It exists to hand a tree back with the root's default namespace intact, for code that writes the document back out. Nothing here reads a tag name or serialises anything, and it builds the tree in Python rather than through the C accelerator: 127 ms against 37 ms on a 2.6 MB form, for the same XPaths.

One behaviour change. The old code read `attributes['ref']` unguarded, so a node carrying `mediatype` without a `ref` raised a `KeyError` and failed the submission being saved. Such a node is now skipped and logged as a warning, since there is nothing useful to do with a media question that points at nothing.

`_get_attributes_by_node()` had no caller left and is removed.

### 👀 Preview steps

The script below runs both implementations side by side on real forms and compares their output, so a single run on this branch shows the difference. It is read-only: it parses XML and writes nothing.

1. ℹ️ have an instance with forms in it, the bigger the better
2. save the script below as `compare_xpaths.py`
3. run `./manage.py shell < compare_xpaths.py`
4. 🟢 notice the `differences` column is `0` on every bucket, and the closing line reads `Both implementations returned the same XPaths on every form sampled.`
5. 🟢 notice the `gain` column, around 10x, and larger on the bigger buckets
6. ℹ️ `SAMPLE_PER_BUCKET` at the top sets how many forms are taken from each size bucket

```python
"""
Compare `get_xform_media_question_xpaths()` against the implementation it
replaces, on real forms, and time both.

Read-only: it parses XML and touches nothing. Run it with

    ./manage.py shell < compare_xpaths.py
"""

import time
from statistics import median

from django.db.models.functions import Length

from kobo.apps.openrosa.apps.logger.models import XForm
from kobo.apps.openrosa.apps.logger.xform_instance_parser import (
    XFormInstanceParser,
    get_xform_media_question_xpaths,
)

SAMPLE_PER_BUCKET = 10
BUCKETS = (
    ('small   < 50 kB', 0, 50_000),
    ('medium  50-200 kB', 50_000, 200_000),
    ('large   200-500 kB', 200_000, 500_000),
    ('huge    > 500 kB', 500_000, 1_000_000_000),
)


def _get_attributes_by_node(node):
    """
    Traverse the XML tree and yield each node with its attributes as a dictionary.
    Only yields nodes that have attributes.
    """
    if hasattr(node, 'hasAttributes') and node.hasAttributes():
        attrs = {key: node.getAttribute(key) for key in node.attributes.keys()}
        yield node, attrs
    for child in getattr(node, 'childNodes', []):
        yield from _get_attributes_by_node(child)


def old_get_xform_media_question_xpaths(xform):
    parser = XFormInstanceParser(xform.xml, xform.data_dictionary(use_cache=True))
    attributes_by_node = _get_attributes_by_node(parser.get_root_node())
    media_field_xpaths = []

    for node, attributes in attributes_by_node:
        if 'mediatype' in attributes:
            # We are returning XPaths, leading slash should be removed
            media_field_xpaths.append(attributes['ref'][1:])

    return media_field_xpaths


def timed(fn, xform, rounds=3):
    timings = []
    result = None
    for _ in range(rounds):
        started_at = time.perf_counter()
        try:
            result = fn(xform)
        except Exception as e:  # noqa
            return None, f'{type(e).__name__}: {e}'
        timings.append((time.perf_counter() - started_at) * 1000)

    return median(timings), result


print(f'{"bucket":<20}{"n":>4}{"old":>12}{"new":>10}{"gain":>7}{"differences":>13}')

total_differences = []

for label, low, high in BUCKETS:
    xforms = (
        XForm.objects.annotate(xml_length=Length('xml'))
        .filter(xml_length__gte=low, xml_length__lt=high)
        .order_by('-pk')[:SAMPLE_PER_BUCKET]
    )

    old_timings, new_timings, differences = [], [], 0

    for xform in xforms:
        old_ms, old_result = timed(old_get_xform_media_question_xpaths, xform)
        new_ms, new_result = timed(get_xform_media_question_xpaths, xform)

        if old_result != new_result:
            differences += 1
            total_differences.append((xform.pk, old_result, new_result))

        if old_ms is not None:
            old_timings.append(old_ms)
        if new_ms is not None:
            new_timings.append(new_ms)

    if not new_timings:
        print(f'{label:<20}{0:>4}{"-":>12}{"-":>10}{"-":>7}{"-":>13}')
        continue

    old_median = median(old_timings) if old_timings else 0
    new_median = median(new_timings)
    gain = f'{old_median / new_median:.1f}x' if new_median else '-'
    print(
        f'{label:<20}{len(new_timings):>4}{old_median:>10.1f}ms'
        f'{new_median:>8.1f}ms{gain:>7}{differences:>13}'
    )

print()
if total_differences:
    print(f'{len(total_differences)} form(s) disagree:')
    for pk, old_result, new_result in total_differences[:20]:
        print(f'  XForm #{pk}')
        print(f'    old: {old_result}')
        print(f'    new: {new_result}')
else:
    print('Both implementations returned the same XPaths on every form sampled.')
```

Run on the development stack, thirteen forms:

```
bucket                 n         old       new   gain  differences
small   < 50 kB       10       0.3ms     0.0ms  12.0x            0
medium  50-200 kB      2      15.2ms     1.4ms  10.7x            0
large   200-500 kB     0           -         -      -            -
huge    > 500 kB       1     429.3ms    39.9ms  10.8x            0

Both implementations returned the same XPaths on every form sampled.
```
