### PR TITLE
feat(formbuilder): allow filtering by multiple tags DEV-1967

### DIFF
--- a/jsapp/js/editorMixins/AssetNavigator.tsx
+++ b/jsapp/js/editorMixins/AssetNavigator.tsx
@@ -27,6 +27,16 @@ const SORTABLE_ITEM_CLASS_NAME = 'asset-navigator-sortable-item'
 // `QUERY_PARSER_MAX_TO_MANY_FILTERS`
 const MAX_SELECTED_TAGS = 10
 
+/**
+ * Wraps a tag name in quotes for the `q` search. Only spaces get normalized out of tag names (see
+ * `cleanupTags`), so a name may well contain a quote character, and the query grammar has no working
+ * escape sequence — so we quote with whichever character the name itself doesn't use. A name using
+ * both is unrepresentable, and would make the whole query fail to parse.
+ */
+function quoteTagName(tagName: string) {
+  return tagName.includes('"') ? `'${tagName}'` : `"${tagName}"`
+}
+
 export default function AssetNavigator() {
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedSearch] = useDebouncedValue(searchQuery, 500)
@@ -41,10 +51,11 @@ export default function AssetNavigator() {
 
   let tagsOptions: string[] = []
   if (tagsListQuery.data?.status === 200) {
-    const tagsOptionsRaw = tagsListQuery.data?.data?.results.map((t: TagListResponse) => t.name)
+    const tagsOptionsRaw = tagsListQuery.data?.data?.results.map((tag: TagListResponse) => tag.name)
     // Because tags API has a bug we need to ensure only unique results are returned:
     // https://linear.app/kobotoolbox/issue/DEV-1576/duplicated-values-in-apiv2tags-endpoint
-    tagsOptions = [...new Set(tagsOptionsRaw)]
+    // The endpoint has no `ordering` parameter, so we sort here to keep the picker browsable
+    tagsOptions = [...new Set(tagsOptionsRaw)].sort((a, b) => a.localeCompare(b))
   }
 
   useEffect(() => {
@@ -79,9 +90,16 @@ export default function AssetNavigator() {
       queryParts.push(`(${debouncedSearch})`)
     }
 
-    // Include tags filtering
+    // Include tags filtering.
+    //
+    // `iexact`, not `icontains`: the names come from a list of tags that already exist, so a partial
+    // match would silently pull in assets carrying a *different*, longer tag (picking "health" would
+    // also match "health-services").
+    //
+    // Multiple tags are joined with `AND`, which the back end reads as "has every one of these" —
+    // each to-many leaf becomes its own subquery (see DEV-1581).
     if (selectedTags.length > 0) {
-      const tagQuery = selectedTags.map((t) => `tags__name__icontains:"${t}"`).join(' AND ')
+      const tagQuery = selectedTags.map((tagName) => `tags__name__iexact:${quoteTagName(tagName)}`).join(' AND ')
       queryParts.push(`(${tagQuery})`)
     }
 
@@ -104,6 +122,7 @@ export default function AssetNavigator() {
     limit: 200,
     ordering: '-date_modified',
   })
+  const assetsFoundCount = assetsResponse?.data.count || 0
 
   // Step 4. Setup drag and drop for library assets
   //
@@ -140,9 +159,11 @@ export default function AssetNavigator() {
 
   return (
     <Stack gap='sm' h='100%'>
-      {/* Searchbox */}
+      {/* Searchbox. These filters are labelled only by `aria-label`, as the aside is too narrow to
+      spend a row per visible label on, and the panel heading already says this is a library search */}
       <TextInput
-        placeholder='Search…'
+        aria-label={t('Search library')}
+        placeholder={t('Search…')}
         leftSection={<Icon name='search' />}
         value={searchQuery}
         onChange={(event) => setSearchQuery(event.currentTarget.value)}
@@ -153,11 +174,18 @@ export default function AssetNavigator() {
         data={tagsOptions}
         value={selectedTags}
         onChange={setSelectedTags}
-        placeholder='Filter by tags'
+        aria-label={t('Filter by tags')}
+        placeholder={t('Filter by tags')}
         maxValues={MAX_SELECTED_TAGS}
+        // `maxValues` silently stops accepting picks, so say why once the limit is in reach
+        description={
+          selectedTags.length === MAX_SELECTED_TAGS
+            ? t('You can filter by up to ##count## tags at a time').replace('##count##', String(MAX_SELECTED_TAGS))
+            : undefined
+        }
         searchable
         clearable
-        nothingFoundMessage='No tags found'
+        nothingFoundMessage={t('No tags found')}
         hidePickedOptions
         size='md'
         selectFirstOptionOnChange
@@ -168,7 +196,8 @@ export default function AssetNavigator() {
         data={collectionOptions}
         value={selectedCollection}
         onChange={setSelectedCollection}
-        placeholder='Select collection'
+        aria-label={t('Filter by collection')}
+        placeholder={t('Select collection')}
         searchable
         clearable
         size='md'
@@ -178,11 +207,14 @@ export default function AssetNavigator() {
       {/* Total count & toggle expanded info */}
       <Group justify='space-between' align='center'>
         <Text size='sm' fw={500}>
-          {assetsResponse?.data.results?.length || 0} assets found
+          {/* `count` (not the length of `results`) so the total isn't cut down to the page `limit` */}
+          {assetsFoundCount === 1
+            ? t('1 asset found')
+            : t('##count## assets found').replace('##count##', String(assetsFoundCount))}
         </Text>
 
         <Checkbox
-          label='Expand details'
+          label={t('Expand details')}
           checked={isExpanded}
           onChange={(event) => setIsExpanded(event.currentTarget.checked)}
           size='sm'
@@ -197,12 +229,12 @@ export default function AssetNavigator() {
       ) : isError ? (
         <Center py='xl'>
           <Text c='red' size='sm'>
-            Error loading assets
+            {t('Error loading assets')}
           </Text>
         </Center>
       ) : assetsResponse?.data.results?.length === 0 ? (
         <Center py='xl'>
-          <Text size='sm'>No assets found</Text>
+          <Text size='sm'>{t('No assets found')}</Text>
         </Center>
       ) : (
         <Stack gap='xs' ref={assetsListRef}>

--- a/jsapp/js/editorMixins/AssetNavigator.tsx
+++ b/jsapp/js/editorMixins/AssetNavigator.tsx
@@ -28,10 +28,7 @@ const SORTABLE_ITEM_CLASS_NAME = 'asset-navigator-sortable-item'
 const MAX_SELECTED_TAGS = 10
 
 /**
- * Wraps a tag name in quotes for the `q` search. Only spaces get normalized out of tag names (see
- * `cleanupTags`), so a name may well contain a quote character, and the query grammar has no working
- * escape sequence — so we quote with whichever character the name itself doesn't use. A name using
- * both is unrepresentable, and would make the whole query fail to parse.
+ * Wraps a tag name in quotes for the `q` search to avoid potential query failure.
  */
 function quoteTagName(tagName: string) {
   return tagName.includes('"') ? `'${tagName}'` : `"${tagName}"`
@@ -75,10 +72,12 @@ export default function AssetNavigator() {
   })
   let collectionOptions: LabelValuePair[] = []
   if (collectionListQuery.data?.status === 200 && collectionListQuery.data?.data.results) {
-    collectionOptions = collectionListQuery.data.data.results.map((c: Asset) => ({
-      value: c.uid,
-      label: c.name || t('Unnamed collection'),
-    }))
+    collectionOptions = collectionListQuery.data.data.results.map((c: Asset) => {
+      return {
+        value: c.uid,
+        label: c.name || t('Unnamed collection'),
+      }
+    })
   }
 
   // Step 3. Fetch Main Assets List
@@ -92,12 +91,11 @@ export default function AssetNavigator() {
 
     // Include tags filtering.
     //
-    // `iexact`, not `icontains`: the names come from a list of tags that already exist, so a partial
-    // match would silently pull in assets carrying a *different*, longer tag (picking "health" would
+    // Uses `iexact`, not `icontains`: the names come from a list of tags that already exist,
+    // so a partial match would silently pull in assets carrying a *different*, longer tag (picking "health" would
     // also match "health-services").
     //
-    // Multiple tags are joined with `AND`, which the back end reads as "has every one of these" —
-    // each to-many leaf becomes its own subquery (see DEV-1581).
+    // Multiple tags are joined with `AND`, which the back end reads as "has every one of these".
     if (selectedTags.length > 0) {
       const tagQuery = selectedTags.map((tagName) => `tags__name__iexact:${quoteTagName(tagName)}`).join(' AND ')
       queryParts.push(`(${tagQuery})`)
@@ -159,8 +157,7 @@ export default function AssetNavigator() {
 
   return (
     <Stack gap='sm' h='100%'>
-      {/* Searchbox. These filters are labelled only by `aria-label`, as the aside is too narrow to
-      spend a row per visible label on, and the panel heading already says this is a library search */}
+      {/* Searchbox */}
       <TextInput
         aria-label={t('Search library')}
         placeholder={t('Search…')}
@@ -207,7 +204,6 @@ export default function AssetNavigator() {
       {/* Total count & toggle expanded info */}
       <Group justify='space-between' align='center'>
         <Text size='sm' fw={500}>
-          {/* `count` (not the length of `results`) so the total isn't cut down to the page `limit` */}
           {assetsFoundCount === 1
             ? t('1 asset found')
             : t('##count## assets found').replace('##count##', String(assetsFoundCount))}

--- a/jsapp/js/editorMixins/AssetNavigator.tsx
+++ b/jsapp/js/editorMixins/AssetNavigator.tsx
@@ -1,14 +1,18 @@
-import { Center, Checkbox, Group, Loader, MultiSelect, Select, Stack, Text, TextInput } from '@mantine/core'
+import { Center, Checkbox, Group, Loader, Stack, Text } from '@mantine/core'
 import { useDebouncedValue } from '@mantine/hooks'
 import * as Sentry from '@sentry/react'
 import React, { useState, useRef, useEffect } from 'react'
 import type { Asset } from '#/api/models/asset'
 import type { TagListResponse } from '#/api/models/tagListResponse'
 import { useAssetsList, useTagsList } from '#/api/react-query/manage-projects-and-library-content'
+import MultiSelect from '#/components/common/MultiSelect'
+import Select from '#/components/common/Select'
+import TextInput from '#/components/common/TextInput'
 import Icon from '#/components/common/icon'
 import { COMMON_QUERIES } from '#/constants'
 import type { LabelValuePair } from '#/dataInterface'
 import AssetNavigatorCard from './AssetNavigatorCard'
+import { formatTagValue } from './assetNavigatorUtils'
 
 // A stub types for sortable
 declare global {
@@ -26,13 +30,6 @@ const SORTABLE_ITEM_CLASS_NAME = 'asset-navigator-sortable-item'
 // Past this the `q` search rejects the query; mirrors the back end's
 // `QUERY_PARSER_MAX_TO_MANY_FILTERS`
 const MAX_SELECTED_TAGS = 10
-
-/**
- * Wraps a tag name in quotes for the `q` search to avoid potential query failure.
- */
-function quoteTagName(tagName: string) {
-  return tagName.includes('"') ? `'${tagName}'` : `"${tagName}"`
-}
 
 export default function AssetNavigator() {
   const [searchQuery, setSearchQuery] = useState('')
@@ -97,7 +94,7 @@ export default function AssetNavigator() {
     //
     // Multiple tags are joined with `AND`, which the back end reads as "has every one of these".
     if (selectedTags.length > 0) {
-      const tagQuery = selectedTags.map((tagName) => `tags__name__iexact:${quoteTagName(tagName)}`).join(' AND ')
+      const tagQuery = selectedTags.map((tagName) => `tags__name__iexact:${formatTagValue(tagName)}`).join(' AND ')
       queryParts.push(`(${tagQuery})`)
     }
 

--- a/jsapp/js/editorMixins/assetNavigatorUtils.tests.ts
+++ b/jsapp/js/editorMixins/assetNavigatorUtils.tests.ts
@@ -1,0 +1,34 @@
+import { formatTagValue } from './assetNavigatorUtils'
+
+// Every test here must match Backend's query parser logic
+describe('formatTagValue', () => {
+  it('quotes an ordinary tag name', () => {
+    chai.expect(formatTagValue('health')).to.equal('"health"')
+  })
+
+  it('double-quotes a name holding an apostrophe', () => {
+    chai.expect(formatTagValue("o'brien")).to.equal('"o\'brien"')
+  })
+
+  it('single-quotes a name holding a double quote', () => {
+    chai.expect(formatTagValue('say "hi"')).to.equal('\'say "hi"\'')
+  })
+
+  it('drops the quotes for a name holding both', () => {
+    chai.expect(formatTagValue('a"b\'c')).to.equal('a"b\'c')
+  })
+
+  it('quotes names holding characters that would end a bare value', () => {
+    chai.expect(formatTagValue('has(paren)')).to.equal('"has(paren)"')
+    chai.expect(formatTagValue('has:colon')).to.equal('"has:colon"')
+    chai.expect(formatTagValue('has space')).to.equal('"has space"')
+  })
+
+  it('gives up on a name that rules out every form, rather than breaking the query', () => {
+    // Both quote characters, so it can't be quoted, plus something that ends a bare value
+    chai.expect(formatTagValue('a"b\'c(d)')).to.equal('""')
+    chai.expect(formatTagValue('a"b\'c:d')).to.equal('""')
+    // A leading quote would open a quoted value and swallow the query up to the next one
+    chai.expect(formatTagValue('"a\'b')).to.equal('""')
+  })
+})

--- a/jsapp/js/editorMixins/assetNavigatorUtils.ts
+++ b/jsapp/js/editorMixins/assetNavigatorUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Renders a tag name as a `q` search value, in a form that won't break the API call. See tests for examples
+ */
+export function formatTagValue(tagName: string) {
+  if (!tagName.includes('"')) {
+    return `"${tagName}"`
+  }
+  if (!tagName.includes("'")) {
+    return `'${tagName}'`
+  }
+  if (!/^["']|[\s():]/.test(tagName)) {
+    return tagName
+  }
+  return '""'
+}

--- a/jsapp/js/theme/kobo/SelectBase.module.css
+++ b/jsapp/js/theme/kobo/SelectBase.module.css
@@ -70,6 +70,12 @@
   color: var(--mantine-color-gray-2);
 }
 
+/* Same `--mantine-color-dimmed` problem as `.empty`: 1.28:1 against a white
+   background, i.e. all but invisible. */
+.description {
+  color: var(--mantine-color-gray-2);
+}
+
 .groupLabel {
   color: var(--mantine-color-gray-4);
 }

--- a/jsapp/js/theme/kobo/SelectBase.module.css
+++ b/jsapp/js/theme/kobo/SelectBase.module.css
@@ -64,14 +64,8 @@
   stroke-width: 0.5;
 }
 
-/* Mantine dims this with `--mantine-color-dimmed`, which resolves to `gray-6` -
-   a divider grey in our inverted scale, so it barely shows on the dropdown. */
-.empty {
-  color: var(--mantine-color-gray-2);
-}
-
-/* Same `--mantine-color-dimmed` problem as `.empty`: 1.28:1 against a white
-   background, i.e. all but invisible. */
+/* Mantine dims these with `--mantine-color-dimmed`, which resolves to a very light gray, making it hard to read */
+.empty,
 .description {
   color: var(--mantine-color-gray-2);
 }


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [ ] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Filtering by multiple tags in Formbuilder → Add from Library.

### 💭 Notes

Changes here:

- **`jsapp/js/editorMixins/assetNavigatorUtils.ts`** (new, with unit tests)
  - `formatTagValue` renders a tag name as a `q` value that is fail safe
- **`jsapp/js/editorMixins/AssetNavigator.tsx`**
  - changed from `tags__name__icontains` → `tags__name__iexact`
  - Result count reads `data.count` instead of `results.length`
  - Tag options are sorted client-side; `/api/v2/tags/` has no `ordering` param
  - `aria-label` on the three filter inputs
- **`jsapp/js/theme/kobo/SelectBase.module.css`** — `.description` uses Mantine's `--mantine-color-dimmed`, same fix as the `.empty` rule

### 👀 Preview steps

1. ℹ️ have an account, a project, and at least three library items (questions and/or blocks)
2. in Library, tag one item `health`, another `health-services`, and a third with both `health` and `nutrition`
3. open the project → Form → Edit, then click **Add from Library** in the top bar
4. pick `health` under "Filter by tags"
5. 🔴 [on main] notice the `health-services` item is listed too, even though you never asked for it
6. 🟢 [on PR] notice only the items actually tagged `health` are listed
7. add `nutrition` as a second tag
8. 🟢 notice only the item carrying both tags is left
9. clear the tags, then pick `health` and `health-services` together
10. 🔴 [on main] notice the `health-services` item shows up, despite not having the `health` tag
11. 🟢 [on PR] notice nothing matches, since no item has both
12. 🟢 notice the tag dropdown lists tags alphabetically
13. clear the tags and keep picking until ten are selected, then try an eleventh
14. 🔴 [on main] notice the field quietly stops accepting tags
15. 🟢 [on PR] notice the hint under the field explaining the ten-tag limit
16. in Library, tag an item `it's-a-"test"` (both quote characters, no spaces), then filter by it
17. 🔴 [on main] notice the panel says "Error loading assets"
18. 🟢 [on PR] notice the item is found

