### PR TITLE
feat(frontend): rename data related labels DEV-2228

### DIFF
--- a/jsapp/js/components/projectDownloads/exportsConstants.ts
+++ b/jsapp/js/components/projectDownloads/exportsConstants.ts
@@ -41,7 +41,7 @@ export const EXPORT_FORMATS: {
 } = Object.freeze({
   // Unchecked wisdom from old component:
   // > The value of `formpack.constants.UNTRANSLATED` is `null` which is the same as `_default`
-  _default: { value: '_default', label: t('Labels') },
+  _default: { value: '_default', label: t('Question & choice labels') },
   // Unchecked wisdom from old component:
   // > The value of `formpack.constants.UNSPECIFIED_TRANSLATION` is `false` which is the same as `_xml`
   //
@@ -49,7 +49,7 @@ export const EXPORT_FORMATS: {
   // > Exports previously used `xml` (no underscore) for this, which works so
   // > long as the form has no language called `xml`. We shouldn't bank on that:
   // > https://en.wikipedia.org/wiki/Malaysian_Sign_Language
-  _xml: { value: '_xml', label: t('XML values and headers') },
+  _xml: { value: '_xml', label: t('Question & choice names') },
 })
 
 export type ExportMultiOptionName = 'details' | 'summary' | 'both'

--- a/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/DataTableCell.stories.tsx
@@ -256,7 +256,7 @@ export const SelectMultipleAsXmlValues: Story = {
     docs: {
       description: {
         story:
-          'Same data with the "Display XML Values" table setting, which arrives here as a negative translation index. No labels are looked up, so the response shows exactly as stored: "a b c".',
+          'Same data with the "Question & choice names" table setting, which arrives here as a negative translation index. No labels are looked up, so the response shows exactly as stored: "a b c".',
       },
     },
   },

--- a/jsapp/js/components/submissions/DataTableCell/index.tsx
+++ b/jsapp/js/components/submissions/DataTableCell/index.tsx
@@ -30,8 +30,8 @@ interface DataTableCellProps {
 }
 
 export default function DataTableCell(props: DataTableCellProps) {
-  // Table settings encode the "XML Values" display option as a negative
-  // translation index (see `TableSettings`).
+  // Table settings encode the "Question & choice names" display option as
+  // a negative translation index (see `TableSettings`).
   const shouldShowSelectLabels = props.translationIndex > -1
   const submission = props.reactTableRow.original
   const submissionIndex = props.reactTableRow.index + 1

--- a/jsapp/js/components/submissions/TableSettings.tsx
+++ b/jsapp/js/components/submissions/TableSettings.tsx
@@ -63,7 +63,7 @@ export default function TableSettings(props: TableSettingsProps) {
     const options: TableSettingsOption[] = [
       {
         value: '-1',
-        label: t('XML Values'),
+        label: t('Question & choice names'),
       },
     ]
 
@@ -140,7 +140,7 @@ export default function TableSettings(props: TableSettingsProps) {
   return (
     <Stack gap='md'>
       <Radio.Group
-        label={t('Display labels or XML values?')}
+        label={t('Column headers')}
         value={String(translationIndex)}
         onChange={(value) => setTranslationIndex(Number.parseInt(value, 10))}
       >
@@ -154,7 +154,7 @@ export default function TableSettings(props: TableSettingsProps) {
       <Checkbox
         checked={showGroupName}
         onChange={(event) => setShowGroupName(event.currentTarget.checked)}
-        label={t('Show group names in table headers')}
+        label={t('Show parent group in column headers')}
       />
 
       <Checkbox

--- a/jsapp/js/components/submissions/submissionModal.tsx
+++ b/jsapp/js/components/submissions/submissionModal.tsx
@@ -584,7 +584,7 @@ export default class SubmissionModal extends React.Component<SubmissionModalProp
           <Checkbox
             checked={this.state.showXMLNames}
             onChange={this.onShowXMLNamesChange.bind(this)}
-            label={t('Display XML names')}
+            label={t('Display question names')}
           />
 
           {this.renderEditButton()}

--- a/jsapp/js/components/submissions/tableUtils.ts
+++ b/jsapp/js/components/submissions/tableUtils.ts
@@ -668,8 +668,8 @@ export interface SelectResponseLabelOptions {
   /** All of the form's choices, not just the ones of this question's list. */
   choices: SurveyChoice[]
   /**
-   * Index into a choice `label` array. A negative one (the "Display XML Values"
-   * setting) matches no label, so every value comes back raw — but
+   * Index into a choice `label` array. A negative one (the "Question & choice
+   * names" setting) matches no label, so every value comes back raw — but
    * `select_multiple` values still get re-joined with commas, so callers that
    * need the response exactly as stored don't come here.
    */

--- a/jsapp/js/formbuild/containers/KoboMatrix.tsx
+++ b/jsapp/js/formbuild/containers/KoboMatrix.tsx
@@ -688,7 +688,7 @@ class KoboMatrix extends React.Component<KoboMatrixProps, KoboMatrixState> {
                 />
               </label>
               <label>
-                <span>{t('Data Column Suffix')}</span>
+                <span>{t('Question Name Suffix')}</span>
                 <input
                   type='text'
                   value={this.getCol(expandedCol, 'name')}
@@ -709,7 +709,7 @@ class KoboMatrix extends React.Component<KoboMatrixProps, KoboMatrixState> {
                 <div className='matrix-cols__options'>
                   <div className='matrix-cols__options--row-head'>
                     <span>{t('Label')}</span>
-                    <span>{t('Data Column Name')}</span>
+                    <span>{t('Choice Name')}</span>
                   </div>
                   {orderedChoices.map((choice) => {
                     if (choice.get('list_name') === this.getCol(expandedCol, 'select_from_list_name')) {
@@ -817,7 +817,7 @@ class KoboMatrix extends React.Component<KoboMatrixProps, KoboMatrixState> {
                       />
                     </label>
                     <label>
-                      <span>{t('Data Column Prefix')}</span>
+                      <span>{t('Question Name Prefix')}</span>
                       <input
                         type='text'
                         value={item.name}

--- a/jsapp/xlform/src/view.rowDetail.coffee
+++ b/jsapp/xlform/src/view.rowDetail.coffee
@@ -303,7 +303,11 @@ module.exports = do ->
     html: ->
       @fieldTab = "active"
       @$el.addClass("card__settings__fields--#{@fieldTab}")
-      viewRowDetail.Templates.textbox @cid, @model.key, t("Data column name"), 'text'
+      # A `kobomatrix` question is a `Group` under the hood, but it is presented
+      # to the user as a question, so it keeps the question wording
+      isGroup = @model._parent.isGroup() and @model._parent.getValue('type') isnt 'kobomatrix'
+      label = if isGroup then t("Group name") else t("Question name")
+      viewRowDetail.Templates.textbox @cid, @model.key, label, 'text'
     afterRender: ->
       @listenForInputChange(transformFn: (value)=>
         value_chars = value.split('')

--- a/test/xlform/survey.tests.coffee
+++ b/test/xlform/survey.tests.coffee
@@ -455,7 +455,7 @@ do ->
 
     it 'names library questions that only carry a label', () ->
       # A library question saved without a name only has one in `$autoname`, which
-      # is not where the "Data column name" field reads from
+      # is not where the "Question name" field reads from
       unnamedQuestion = -> $model.Survey.loadDict({
         survey: [
           {type: 'text', $autoname: 'choose_a_fruit', label: 'Choose a fruit'}


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary

Renamed the labels that used to talk about "data columns" and "XML values" so they now say question, group, and choice names — in Formbuilder, the data table settings, the single submission modal, and the downloads form.

### 💭 Notes

Changes in multiple files, simple things.

### 👀 Preview steps

1. ℹ️ have an account and a project with a few submissions
2. open the project in Formbuilder, expand a question's settings, go to the **Question Options** tab
3. 🔴 [on main] the name field is labelled **Data Column Name**
4. 🟢 [on PR] it says **Question Name**
5. group two questions together, open the group's settings → **Question Options**
6. 🟢 the same field says **Group Name**
7. add a **Question Matrix**, open a column's ⚙️ settings
8. 🟢 **Question Name Suffix** instead of **Data Column Suffix**
9. set that column's Response Type to **Select One**, so the choice list appears below
10. 🟢 the column above the choice values reads **Choice Name**
11. open a matrix row's ⚙️ settings
12. 🟢 **Question Name Prefix** instead of **Data Column Prefix**
13. go to Project → Data → Table and open **Table display options**
14. 🟢 the radio group is titled **Column headers**, the first option is **Question & choice names**, and the checkbox below reads **Show parent group in column headers**
15. pick **Question & choice names**, save, and confirm the table still shows raw names in the headers and cells — the rename is cosmetic, no behaviour was harmed in the making of this PR
16. open any submission from the table
17. 🟢 the checkbox at the bottom says **Display question names**; tick it and the question names still show up
18. go to Project → Data → Downloads and look at **Value and header format**
19. 🟢 the options are **Question & choice labels** and **Question & choice names**
20. run an export with each and confirm the files come out the same as before
