### PR TITLE
fix(sso): handle toggling of sso-exempt DEV-2818

### DIFF
--- a/hub/models/extra_user_detail.py
+++ b/hub/models/extra_user_detail.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 
 from django.conf import settings
 from django.db import models
@@ -32,6 +33,10 @@ class ExtraUserDetail(StandardizeSearchableFieldMixin, models.Model):
 
     def __str__(self):
         return "{}'s data: {}".format(self.user.__str__(), repr(self.data))
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._initial_sso_exempt = self.sso_exempt
 
     def save(
         self,
@@ -71,6 +76,7 @@ class ExtraUserDetail(StandardizeSearchableFieldMixin, models.Model):
                 self.user.id,
                 self.validated_password,
             )
+        self._initial_sso_exempt = self.sso_exempt
 
     @classmethod
     def update_last_project_activity(cls, user_ids: set[int]) -> None:

--- a/kobo/apps/accounts/forms.py
+++ b/kobo/apps/accounts/forms.py
@@ -18,9 +18,9 @@ from django.utils.translation import gettext_lazy as t
 
 from hub.models.sitewide_message import SitewideMessage
 from hub.utils.i18n import I18nUtils
-from kobo.apps.accounts.utils import get_normalized_domain, user_is_managed_by_sso
+from kobo.apps.accounts.utils import user_is_managed_by_sso
 from kobo.static_lists import COUNTRIES, USER_METADATA_DEFAULT_LABELS
-from .models import SocialAppManagedDomain
+from .models import SocialAppManagedDomain, get_normalized_domain
 
 # Only these fields can be controlled by constance.config.USER_METADATA_FIELDS
 CONFIGURABLE_METADATA_FIELDS = (

--- a/kobo/apps/accounts/models.py
+++ b/kobo/apps/accounts/models.py
@@ -162,7 +162,24 @@ class SocialAppManagedDomain(models.Model):
             domain__iexact=domain, social_app__managed=True
         ).exists()
 
+    @classmethod
+    def get_managing_sso(cls, user):
+        domain = get_normalized_domain(user.email)
+        managed_domain = cls.objects.filter(
+            domain__iexact=domain, social_app__managed=True
+        ).first()
+        if managed_domain:
+            return managed_domain.social_app.social_app
+        return None
+
     def save(self, *args, **kwargs):
         if self.domain:
             self.domain = self.domain.strip().lower()
         super().save(*args, **kwargs)
+
+
+def get_normalized_domain(email):
+    _, separator, domain = email.rpartition('@')
+    if not separator:
+        return ''
+    return domain.strip().lower()

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -172,6 +172,7 @@ def handle_sso_exempt_toggle(sender=None, instance=None, raw=None, **kwargs):
                 ' but no message to send. Cannot create'
                 f' managed SSO notification for new SSO user {user.username}'
             )
+            return
         InAppMessageUsers.objects.create(user=user, in_app_message=message)
         message.valid_until = timezone.now() + timedelta(days=365)
         message.save()

--- a/kobo/apps/accounts/signals.py
+++ b/kobo/apps/accounts/signals.py
@@ -1,16 +1,21 @@
+from datetime import timedelta
+
 import constance
 from allauth.account.models import EmailAddress
 from allauth.account.signals import email_confirmed
 from allauth.account.utils import cleanup_email_addresses
-from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.signals import social_account_added
 from django.contrib.auth import update_session_auth_hash
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
+from hub.models import ExtraUserDetail
+from kpi.utils.log import logging
 from ..help.models import InAppMessage, InAppMessageUsers, MessageType
 from .models import SocialAppCustomData, SocialAppManagedDomain
+from .tasks import update_linked_user
 from .utils import (
     SOCIAL_APP_IDENTIFIER,
     remove_managed_sso_reminders,
@@ -133,3 +138,40 @@ def enforce_managed_sso(sender=None, **kwargs):
         user.set_unusable_password()
         user.save()
         update_session_auth_hash(request, user)
+
+
+@receiver(post_save, sender=ExtraUserDetail)
+def handle_sso_exempt_toggle(sender=None, instance=None, raw=None, **kwargs):
+    if raw or instance.sso_exempt == instance._initial_sso_exempt:
+        return
+    user = instance.user
+    if instance.sso_exempt:
+        # clean up any reminders to link SSO for this user
+        InAppMessageUsers.objects.filter(
+            user=user, in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).delete()
+        InAppMessage.objects.filter(
+            message_type=MessageType.MANAGED_SSO_REMINDER,
+            inappmessageusers__isnull=True,
+        ).update(valid_until=timezone.now())
+        return
+    social_app = SocialAppManagedDomain.get_managing_sso(user)
+    if not social_app:
+        return
+    custom_data = social_app.custom_data
+    if SocialAccount.objects.filter(
+        user=user, provider=social_app.provider_id
+    ).exists():
+        update_linked_user(user, social_app.provider_id)
+    elif custom_data.send_in_app_message:
+        message = social_app.custom_data.in_app_message
+        if not message:
+            logging.error(
+                f'[Managed SSO] Custom data for {social_app.name}'
+                f' has send_in_app_message'
+                ' but no message to send. Cannot create'
+                f' managed SSO notification for new SSO user {user.username}'
+            )
+        InAppMessageUsers.objects.create(user=user, in_app_message=message)
+        message.valid_until = timezone.now() + timedelta(days=365)
+        message.save()

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -18,6 +18,7 @@ from kobo.apps.accounts.models import SocialAppCustomData, SocialAppManagedDomai
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kpi.tests.utils import baker_generators  # noqa
+from kpi.utils.log import logging
 from ..adapter import AccountAdapter
 from ..forms import UserTokenForm
 from ..tasks import (
@@ -906,3 +907,16 @@ class TestManagedSsoWithdrawal(TestCase):
         assert not InAppMessageUsers.objects.filter(
             user=self.bob, in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
         ).exists()
+
+    def test_disabling_sso_exempt_does_not_error_if_message_missing(self):
+        self.custom_data.in_app_message.delete()
+        InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).delete()
+        with self.assertLogs(logger=logging.name, level='ERROR') as logs:
+            self.bob.extra_details.sso_exempt = True
+            self.bob.extra_details.save()
+            self.bob.extra_details.sso_exempt = False
+            self.bob.extra_details.save()
+
+        assert 'no message to send' in logs.output[0]

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -892,3 +892,17 @@ class TestManagedSsoWithdrawal(TestCase):
         ).exists()
         self.custom_data.in_app_message.refresh_from_db()
         assert self.custom_data.in_app_message.valid_until > timezone.now()
+
+    def test_disabling_sso_exempt_does_not_send_reminder_if_none_configured(self):
+        self.custom_data.send_in_app_message = False
+        self.custom_data.save()
+        InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).delete()
+        self.bob.extra_details.sso_exempt = True
+        self.bob.extra_details.save()
+        self.bob.extra_details.sso_exempt = False
+        self.bob.extra_details.save()
+        assert not InAppMessageUsers.objects.filter(
+            user=self.bob, in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).exists()

--- a/kobo/apps/accounts/tests/test_managed_sso.py
+++ b/kobo/apps/accounts/tests/test_managed_sso.py
@@ -239,7 +239,7 @@ class TestManagedSsoUsers(TestCase):
                 in form.errors['user']
             )
 
-    @data('managed_off', 'domain_deleted', 'app_deleted')
+    @data('managed_off', 'domain_deleted', 'app_deleted', 'sso_exempt')
     def test_restrictions_lift_when_no_longer_managed(self, change):
         """
         Every SSO-managed enforcement point must release once the domain is
@@ -331,6 +331,9 @@ class TestManagedSsoUsers(TestCase):
             SocialAppManagedDomain.objects.get(domain='example.com').delete()
         elif change == 'app_deleted':
             self.social_app.delete()
+        elif change == 'sso_exempt':
+            self.user.extra_details.sso_exempt = True
+            self.user.extra_details.save()
 
 
 class TestManagedSsoCelery(TestCase):
@@ -847,3 +850,45 @@ class TestManagedSsoWithdrawal(TestCase):
         self.client.force_login(self.alice)
         response = self.client.get('/help/in_app_messages/')
         assert response.json()['count'] == 1
+
+    def test_enabling_sso_exempt_withdraws_reminder(self):
+        assert InAppMessageUsers.objects.filter(user=self.bob).exists()
+        assert InAppMessageUsers.objects.filter(user=self.alice).exists()
+        self.bob.extra_details.sso_exempt = True
+        self.bob.extra_details.save()
+        # Bob's reminder has been withdrawn
+        assert not InAppMessageUsers.objects.filter(user=self.bob).exists()
+
+        # message should not be expired since Alice still has a reminder
+        message = self.custom_data.in_app_message
+        message.refresh_from_db()
+        assert message.valid_until > timezone.now()
+        assert InAppMessageUsers.objects.filter(user=self.alice).exists()
+
+        # make Alice sso exempt
+        self.alice.extra_details.sso_exempt = True
+        self.alice.extra_details.save()
+
+        # Alice's notification has been withdrawn, message should be expired
+        assert not InAppMessageUsers.objects.filter(user=self.alice).exists()
+        message.refresh_from_db()
+        assert message.valid_until < timezone.now()
+
+    def test_disabling_sso_exempt_sends_reminder(self):
+        # all previous reminders removed, message is expired
+        InAppMessageUsers.objects.filter(
+            in_app_message__message_type=MessageType.MANAGED_SSO_REMINDER
+        ).delete()
+        self.custom_data.in_app_message.valid_until = timezone.now()
+        self.custom_data.in_app_message.save()
+
+        self.bob.extra_details.sso_exempt = True
+        self.bob.extra_details.save()
+        # Bob is no longer exempt
+        self.bob.extra_details.sso_exempt = False
+        self.bob.extra_details.save()
+        assert InAppMessageUsers.objects.filter(
+            user=self.bob, in_app_message=self.custom_data.in_app_message
+        ).exists()
+        self.custom_data.in_app_message.refresh_from_db()
+        assert self.custom_data.in_app_message.valid_until > timezone.now()

--- a/kobo/apps/accounts/utils.py
+++ b/kobo/apps/accounts/utils.py
@@ -9,7 +9,7 @@ from django.db.models.functions import Lower
 from django.utils import timezone
 from django.utils.translation import gettext_noop as t
 
-from kobo.apps.accounts.models import SocialAppManagedDomain
+from kobo.apps.accounts.models import SocialAppManagedDomain, get_normalized_domain
 from kobo.apps.help.models import InAppMessage, InAppMessageUsers, MessageType
 from kobo.apps.kobo_auth.shortcuts import User
 from kobo.apps.stripe.constants import ACTIVE_STRIPE_STATUSES
@@ -65,13 +65,6 @@ def user_has_paid_subscription(username):
         organizations_organization__djstripe_customers__subscriptions__status__in=ACTIVE_STRIPE_STATUSES,
         organizations_organization__djstripe_customers__subscriptions__items__price__unit_amount__gt=0,
     ).exists()
-
-
-def get_normalized_domain(email):
-    _, separator, domain = email.rpartition('@')
-    if not separator:
-        return ''
-    return domain.strip().lower()
 
 
 def remove_managed_sso_reminders(social_app_pk: int, domain: str | None = None):


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Enforce managed SSO restrictions on users who lose their sso-exempt status, and remove restrictions/notifications when the exemption is re/instated. 

### 📖 Description
If previously non-exempt users received a notification advising them to link their SSO account, setting them to sso-exempt will remove the notification. If previously exempt users are made non-exempt, they will receive a notification if they do not have a linked account. If they have a linked account, their password and any other SSO logins will be disabled.


### 👀 Preview steps
Ensure SSO is enabled

1. ℹ️ have an admin account and an account that can be linked to SSO (do not link it yet)
2. In Django admin, set the SocialAppCustomData to manage the appropriate domain
3. Login as the other user
4. 🟢 [on PR] notice there is a notification prompting you to link your SSO account
5. In Django admin > Extra user details, mark the user as SSO exempt
6. 🟢 [on PR] (as other user) Notice the notification is gone
7. In Django admin > Extra user details, uncheck 'SSO exempt'
8. 🟢 [on PR] (as other user) Notice the notification is back

