### PR TITLE
feat(usage): project usage breakdown search DEV-2701

### DIFF
--- a/jsapp/js/account/organization/MembersRoute.stories.tsx
+++ b/jsapp/js/account/organization/MembersRoute.stories.tsx
@@ -2,12 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5'
 import { http, HttpResponse } from 'msw'
 import { toast } from 'react-hot-toast'
 import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { TOO_SHORT_SEARCH_WARNING } from '#/components/common/searchPhrase.constants'
 import organizationMock from '#/endpoints/organization.mocks'
 import organizationMembersMock from '#/endpoints/organizationMembers.mocks'
 import { queryClientDecorator } from '#/query/queryClient.mocks'
 import { RequireOrg } from '#/router/RequireOrg'
 import ToasterConfig from '#/toasterConfig'
-import MembersRoute, { TOO_SHORT_WARNING } from './MembersRoute'
+import MembersRoute from './MembersRoute'
 
 /**
  * Nothing on this route asks for in-app messages, but `helpBubbleStore` does on load, and unmocked it 404s against the
@@ -94,7 +95,7 @@ export const SearchPhraseTooShort: Story = {
     // Nothing was filtered out, and crucially neither an error nor a nag surfaced.
     expect(canvas.getByText('bob')).toBeInTheDocument()
     expect(canvas.getByText('alice')).toBeInTheDocument()
-    expect(canvas.queryByText(TOO_SHORT_WARNING)).not.toBeInTheDocument()
+    expect(canvas.queryByText(TOO_SHORT_SEARCH_WARNING)).not.toBeInTheDocument()
   },
 }
 
@@ -107,7 +108,7 @@ export const SearchPhraseTooShortWarnsOnEnter: Story = {
     const input = await search(canvas, 'al')
     await userEvent.type(input, '{enter}')
 
-    await canvas.findByText(TOO_SHORT_WARNING)
+    await canvas.findByText(TOO_SHORT_SEARCH_WARNING)
     // The list is still all of them - the warning explains the lack of filtering, it isn't an error.
     expect(canvas.getByText('bob')).toBeInTheDocument()
   },

--- a/jsapp/js/account/organization/MembersRoute.tsx
+++ b/jsapp/js/account/organization/MembersRoute.tsx
@@ -26,6 +26,7 @@ import KoboIcon from '#/components/common/KoboIcon'
 import Alert from '#/components/common/alert'
 import Avatar from '#/components/common/avatar'
 import Badge from '#/components/common/badge'
+import { MIN_SEARCH_PHRASE_LENGTH, TOO_SHORT_SEARCH_WARNING } from '#/components/common/searchPhrase.constants'
 import envStore from '#/envStore'
 import SortableProjectColumnHeader, {
   type SortableColumnOrder,
@@ -55,17 +56,6 @@ function renderStatusBadge(isEnabled: boolean | null | undefined) {
 type MembersTableOrderableField = 'user__username' | 'status' | 'date_joined' | 'role'
 
 const ORDERABLE_FIELDS: MembersTableOrderableField[] = ['user__username', 'status', 'date_joined', 'role']
-
-/**
- * We hold short phrase back instead of firing a request we already know fails on Backend.
- */
-export const MIN_SEARCH_PHRASE_LENGTH = 3
-
-/** Interpolated here rather than at the call site, so importers (stories) get the string the user actually sees. */
-export const TOO_SHORT_WARNING = t('Type at least ##CHARACTER_COUNT## characters to search').replace(
-  '##CHARACTER_COUNT##',
-  String(MIN_SEARCH_PHRASE_LENGTH),
-)
 
 function MembersRoute() {
   const [organization] = useOrganizationAssumed()
@@ -130,7 +120,7 @@ function MembersRoute() {
 
     const enteredPhrase = event.currentTarget.value.trim()
     if (enteredPhrase.length > 0 && enteredPhrase.length < MIN_SEARCH_PHRASE_LENGTH) {
-      notify.warning(TOO_SHORT_WARNING)
+      notify.warning(TOO_SHORT_SEARCH_WARNING)
     }
   }
 

--- a/jsapp/js/account/usage/usageProjectBreakdown.module.scss
+++ b/jsapp/js/account/usage/usageProjectBreakdown.module.scss
@@ -2,8 +2,8 @@
 
 .root {
   width: auto;
-  padding-bottom: 40px;
-  padding-top: 15px;
+  // Added padding to ensure no highlight clipping of the search input
+  padding: 15px 10px 40px 10px;
   height: 100%;
   overflow-x: auto;
 }

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 
 import { Text } from '@mantine/core'
+import { Group } from '@mantine/core'
+import { IconSearch } from '@tabler/icons-react'
 import { keepPreviousData } from '@tanstack/react-query'
 import prettyBytes from 'pretty-bytes'
 import { Link } from 'react-router-dom'
@@ -14,22 +16,37 @@ import {
 } from '#/api/react-query/user-team-organization-usage'
 import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
 import AssetStatusBadge from '#/components/common/assetStatusBadge'
+import Button from '#/components/common/button'
+import DebouncedTextInput from '#/components/common/DebouncedTextInput'
+import Icon from '#/components/common/icon'
+import KoboIcon from '#/components/common/KoboIcon'
 import type { ProjectFieldDefinition } from '#/projects/projectViews/constants'
 import type { ProjectsTableOrder } from '#/projects/projectsTable/projectsTable'
 import SortableProjectColumnHeader from '#/projects/projectsTable/sortableProjectColumnHeader'
 import { ROUTES } from '#/router/routerConstants'
-import { convertSecondsToMinutes } from '#/utils'
+import { convertSecondsToMinutes, notify } from '#/utils'
 import styles from './usageProjectBreakdown.module.scss'
 import { useBillingPeriod } from './useBillingPeriod'
+
+const MIN_SEARCH_PHRASE_LENGTH = 3
+const TOO_SHORT_SEARCH_WARNING = t('Type at least ##CHARACTER_COUNT## characters to search').replace(
+  '##CHARACTER_COUNT##',
+  String(MIN_SEARCH_PHRASE_LENGTH),
+)
 
 const ProjectBreakdown = () => {
   const [organization] = useOrganizationAssumed()
   const { billingPeriod, hasActivePlan } = useBillingPeriod()
   const [order, setOrder] = useState<ProjectsTableOrder>({})
+  const [searchPhrase, setSearchPhrase] = useState('')
   const [pagination, setPagination] = useState({
     limit: DEFAULT_PAGE_SIZE,
     start: 0,
   })
+
+  const trimmedSearchPhrase = searchPhrase.trim()
+  const isSearchPhraseTooShort = trimmedSearchPhrase.length > 0 && trimmedSearchPhrase.length < MIN_SEARCH_PHRASE_LENGTH
+  const appliedSearchPhrase = isSearchPhraseTooShort ? '' : trimmedSearchPhrase
 
   function getQueryParams() {
     // TODO: align props with backend pagination params to simplify away this helper
@@ -38,6 +55,9 @@ const ProjectBreakdown = () => {
       const orderPrefix = order.direction === 'descending' ? '-' : ''
       const fieldName = order.fieldName === 'status' ? '_deployment_status' : order.fieldName
       queryParams.ordering = orderPrefix + fieldName
+    }
+    if (appliedSearchPhrase) {
+      queryParams.q = appliedSearchPhrase
     }
     return queryParams
   }
@@ -69,6 +89,22 @@ const ProjectBreakdown = () => {
 
   const updateOrder = (newOrder: ProjectsTableOrder) => {
     setOrder(newOrder)
+  }
+
+  const updateSearchPhrase = (newSearchPhrase: string) => {
+    setSearchPhrase(newSearchPhrase)
+    setPagination((currentPagination) => ({ ...currentPagination, start: 0 }))
+  }
+
+  function onSearchKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== 'Enter') {
+      return
+    }
+
+    const enteredPhrase = event.currentTarget.value.trim()
+    if (enteredPhrase.length > 0 && enteredPhrase.length < MIN_SEARCH_PHRASE_LENGTH) {
+      notify.warning(TOO_SHORT_SEARCH_WARNING)
+    }
   }
 
   const columns: Array<UniversalTableColumn<CustomAssetUsage>> = [
@@ -147,12 +183,23 @@ const ProjectBreakdown = () => {
   return (
     <div className={styles.root}>
       {/* Margin bottom to match the padding top of parent */}
-      <Text mb={15}>
+      <Group justify='space-between' mb='md'>
+      <Text>
         {t('Track usage for the current ##INTERVAL## across your projects').replace(
           '##INTERVAL##',
           billingPeriod === 'year' ? t('year') : hasActivePlan ? t('billing period') : t('month'),
         )}
       </Text>
+        <DebouncedTextInput
+          value={searchPhrase}
+          onChange={updateSearchPhrase}
+          onKeyDown={onSearchKeyDown}
+          placeholder={t('Search projects')}
+          leftSection={<KoboIcon icon={IconSearch} size='sm' />}
+          aria-label={t('Search projects')}
+          w={260}
+        />
+      </Group>
       <UniversalTable<CustomAssetUsage, ErrorDetail>
         pagination={pagination}
         setPagination={setPagination}

--- a/jsapp/js/account/usage/usageProjectBreakdown.tsx
+++ b/jsapp/js/account/usage/usageProjectBreakdown.tsx
@@ -15,11 +15,10 @@ import {
   useOrganizationsAssetUsageList,
 } from '#/api/react-query/user-team-organization-usage'
 import { useOrganizationAssumed } from '#/api/useOrganizationAssumed'
-import AssetStatusBadge from '#/components/common/assetStatusBadge'
-import Button from '#/components/common/button'
 import DebouncedTextInput from '#/components/common/DebouncedTextInput'
-import Icon from '#/components/common/icon'
 import KoboIcon from '#/components/common/KoboIcon'
+import AssetStatusBadge from '#/components/common/assetStatusBadge'
+import { MIN_SEARCH_PHRASE_LENGTH, TOO_SHORT_SEARCH_WARNING } from '#/components/common/searchPhrase.constants'
 import type { ProjectFieldDefinition } from '#/projects/projectViews/constants'
 import type { ProjectsTableOrder } from '#/projects/projectsTable/projectsTable'
 import SortableProjectColumnHeader from '#/projects/projectsTable/sortableProjectColumnHeader'
@@ -28,15 +27,9 @@ import { convertSecondsToMinutes, notify } from '#/utils'
 import styles from './usageProjectBreakdown.module.scss'
 import { useBillingPeriod } from './useBillingPeriod'
 
-const MIN_SEARCH_PHRASE_LENGTH = 3
-const TOO_SHORT_SEARCH_WARNING = t('Type at least ##CHARACTER_COUNT## characters to search').replace(
-  '##CHARACTER_COUNT##',
-  String(MIN_SEARCH_PHRASE_LENGTH),
-)
-
 const ProjectBreakdown = () => {
   const [organization] = useOrganizationAssumed()
-  const { billingPeriod, hasActivePlan } = useBillingPeriod()
+  const { intervalLabel } = useBillingPeriod()
   const [order, setOrder] = useState<ProjectsTableOrder>({})
   const [searchPhrase, setSearchPhrase] = useState('')
   const [pagination, setPagination] = useState({
@@ -184,12 +177,9 @@ const ProjectBreakdown = () => {
     <div className={styles.root}>
       {/* Margin bottom to match the padding top of parent */}
       <Group justify='space-between' mb='md'>
-      <Text>
-        {t('Track usage for the current ##INTERVAL## across your projects').replace(
-          '##INTERVAL##',
-          billingPeriod === 'year' ? t('year') : hasActivePlan ? t('billing period') : t('month'),
-        )}
-      </Text>
+        <Text>
+          {t('Track usage for the current ##INTERVAL## across your projects').replace('##INTERVAL##', intervalLabel)}
+        </Text>
         <DebouncedTextInput
           value={searchPhrase}
           onChange={updateSearchPhrase}

--- a/jsapp/js/account/usage/usageTopTabs.tsx
+++ b/jsapp/js/account/usage/usageTopTabs.tsx
@@ -23,7 +23,7 @@ const usageTopTabs: React.FC<UsageTopTabsProps> = ({ activeRoute }) => {
   return (
     <>
       <Tabs size='lg' value={activeTab} onChange={handleTabChange} pt={20} ml={40} mr={40} keepMounted={false}>
-        <Tabs.List>
+        <Tabs.List ml={10} mr={10}>
           <Tabs.Tab value={ACCOUNT_ROUTES.USAGE}> {t('Account Total')} </Tabs.Tab>
           <Tabs.Tab value={ACCOUNT_ROUTES.USAGE_PROJECT_BREAKDOWN}> {t('Per Project Total')} </Tabs.Tab>
         </Tabs.List>

--- a/jsapp/js/account/usage/useBillingPeriod.tsx
+++ b/jsapp/js/account/usage/useBillingPeriod.tsx
@@ -7,14 +7,13 @@ import type { RecurringInterval } from '../stripe.types'
 import subscriptionStore from '../subscriptionStore'
 
 /**
- * Get the subscription interval (`'month'` or `'year'`) for the logged-in user, along with whether
- * they have an active plan at all.
+ * Get the subscription interval (`'month'` or `'year'`) for the logged-in user, plus whether that
+ * interval came from an active plan.
  *
- * Returns `{interval: 'month', hasActivePlan: false}` for users on the free plan (and on deployments
- * without Stripe). This is so we can give a more accurate 'billing period' description for users that
- * have active monthly plans.
+ * Returns `{interval: 'month', hasActivePlan: false}` for users on the free plan, and on deployments
+ * without Stripe.
  */
-export async function getSubscriptionInfo(): Promise<{
+async function getSubscriptionInfo(): Promise<{
   interval: RecurringInterval
   hasActivePlan: boolean
 }> {
@@ -38,7 +37,7 @@ export async function getSubscriptionInfo(): Promise<{
 
 export const useBillingPeriod = (): {
   billingPeriod: RecurringInterval
-  hasActivePlan: boolean
+  intervalLabel: string
   isLoading: boolean
 } => {
   const { data, isLoading } = useQuery({
@@ -46,11 +45,13 @@ export const useBillingPeriod = (): {
     queryFn: getSubscriptionInfo,
   })
 
+  // Default to 'month'/no plan while the query is still loading
+  const billingPeriod = data?.interval || 'month'
+  const hasActivePlan = data?.hasActivePlan ?? false
+
   return {
-    // Default to 'month'/no plan while the query is still loading.
-    // This ensures that the hook always returns a valid billing period
-    billingPeriod: data?.interval || 'month',
-    hasActivePlan: data?.hasActivePlan ?? false,
+    billingPeriod,
+    intervalLabel: billingPeriod === 'year' ? t('year') : hasActivePlan ? t('billing period') : t('month'),
     isLoading,
   }
 }

--- a/jsapp/js/components/common/searchPhrase.constants.ts
+++ b/jsapp/js/components/common/searchPhrase.constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Mirrors `settings.MINIMUM_DEFAULT_SEARCH_CHARACTERS` on the backend. A handful of views lower their own
+ * `min_search_characters`, - this is the default, not a universal truth.
+ */
+export const MIN_SEARCH_PHRASE_LENGTH = 3
+
+export const TOO_SHORT_SEARCH_WARNING = t('Type at least ##CHARACTER_COUNT## characters to search').replace(
+  '##CHARACTER_COUNT##',
+  String(MIN_SEARCH_PHRASE_LENGTH),
+)


### PR DESCRIPTION
### 🗒️ Checklist

1. [x] run linter locally
2. [x] update developer docs (API, README, inline, etc.), if any
3. [x] for user-facing doc changes create a Zulip thread at `#Support Docs Updates`, if any
4. [x] draft PR with a title `<type>(<scope>)<!>: <title> DEV-1234`
5. [x] assign yourself, tag PR: at least `Front end` and/or `Back end` or `workflow`
6. [x] fill in the template below and delete template comments
7. [x] review thyself: read the diff and repro the preview as written
8. [x] open PR & confirm that CI passes & request reviewers, if needed
9. [x] act on any greptile review below a 5/5 score or leave comment explaining why you won't
10. [ ] delete this checklist section from the final squash commit before merging

### 📣 Summary
Adds a search box to the project usage breakdown page to filter by project name

### 💭 Notes
The way margins + padding were done on the usage page created horizontal clipping onto the new search box. To fix this, I tried to mimic MembersRoute.tsx but the usage page is broken down into two steps via its top tabs. I introduced some padding to both the tabs and the table itself to avoid the clipping as well as keeping everything lined up.

MembersRoute.tsx also has the same search box with the same timeout and warning logic. We may even want to refactor the entire search phrase hook but I left it as just the constants. These constants represent the default expectation from the backend

### 👀 Preview steps

1. ℹ️ have an account and many projects (rest of steps taken from #7523)
2. go to Account Settings → Usage → Per Project Total tab
1. type at least three characters of a member's name → 🟢 notice the list narrows to matches
1. clear the field → 🟢 notice the full list comes back
1. go to page 2, then type a search that matches someone on page 1 → 🟢 notice you land on page 1 rather than an empty page
1. type one or two characters → 🟢 notice nothing happens and the full list stays put
1. leaving those one or two characters in the field, press Enter → 🟢 notice a warning explaining the three character minimum
1. search for project that doesn't exist, e.g. voldemort → 🟢 notice the table explains there is no data to display
